### PR TITLE
Add deferred secure vault init success pixel

### DIFF
--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
@@ -477,6 +477,7 @@ public final class DataBrokerProtectionIOSManager {
                 do {
                     let resources = try await loadVaultResources()
                     publishVaultResources(resources)
+                    iOSPixelsHandler.fire(.deferredSecureVaultInitSucceeded(trigger: reason.rawValue))
                     return resources
                 } catch {
                     clearVaultResourcesInitAttempt()

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/Pixels/IOSPixels.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/Pixels/IOSPixels.swift
@@ -30,6 +30,13 @@ public enum IOSPixels {
     case backgroundTaskExpired(duration: Double)
     case backgroundTaskEndedHavingCompletedAllJobs(duration: Double)
     case backgroundTaskSchedulingFailed(error: Error?)
+
+    // Deferred Secure Vault initialization
+    case deferredSecureVaultInitSucceeded(trigger: String)
+
+    enum Consts {
+        static let trigger = "trigger"
+    }
 }
 
 extension IOSPixels: PixelKitEvent {
@@ -39,6 +46,7 @@ extension IOSPixels: PixelKitEvent {
         case .backgroundTaskExpired: return "m_ios_dbp_background-task_expired"
         case .backgroundTaskEndedHavingCompletedAllJobs: return "m_ios_dbp_background-task_ended-having-completed-all-jobs"
         case .backgroundTaskSchedulingFailed: return "m_ios_dbp_background-task_scheduling-failed"
+        case .deferredSecureVaultInitSucceeded: return "m_ios_dbp_secure-vault_deferred-init-succeeded"
         }
     }
 
@@ -54,6 +62,8 @@ extension IOSPixels: PixelKitEvent {
         case .backgroundTaskExpired(let duration),
                 .backgroundTaskEndedHavingCompletedAllJobs(let duration):
             return [DataBrokerProtectionSharedPixels.Consts.durationInMs: String(duration)]
+        case .deferredSecureVaultInitSucceeded(let trigger):
+            return [Consts.trigger: trigger]
         }
     }
 
@@ -62,7 +72,8 @@ extension IOSPixels: PixelKitEvent {
         case .backgroundTaskStarted,
                 .backgroundTaskExpired,
                 .backgroundTaskEndedHavingCompletedAllJobs,
-                .backgroundTaskSchedulingFailed:
+                .backgroundTaskSchedulingFailed,
+                .deferredSecureVaultInitSucceeded:
             return [.pixelSource]
         }
     }
@@ -81,6 +92,8 @@ public class IOSPixelsHandler: EventMapping<IOSPixels> {
                     .backgroundTaskExpired,
                     .backgroundTaskEndedHavingCompletedAllJobs:
                 pixelKit.fire(event)
+            case .deferredSecureVaultInitSucceeded:
+                pixelKit.fire(event, frequency: .dailyAndCount)
             case .backgroundTaskSchedulingFailed(let error):
                 pixelKit.fire(DebugEvent(event, error: error))
             }

--- a/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -1,4 +1,20 @@
 {
+    "m_ios_dbp_secure-vault_deferred-init-succeeded": {
+        "description": "Fired daily and count when deferred secure vault initialization completes successfully.",
+        "owners": ["quanganhdo"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "trigger",
+                "description": "The app lifecycle entry point that triggered deferred secure vault initialization",
+                "type": "string",
+                "enum": ["launch", "appActive", "dashboard", "backgroundTask"]
+            }
+        ]
+    },
     "m_ios_dbp_optout_stage_start": {
         "description": "Fired at the start stage of an opt-out attempt.",
         "owners": ["quanganhdo", "THISISDINOSAUR"],


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216389800185774?focus=true
Tech Design URL:
CC:

### Description

Adds success pixels for deferred secure vault init. Errors are already covered by existing secure vault pixels.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Smoke test PIR, make sure to override deferred vault init to true
2. Expect to see PixelKit logs

```
👾[Daily and Count-Fired] m_ios_dbp_secure-vault_deferred-init-succeeded_daily ["appVersion": "7.230.0", "pixelSource": "phone", "trigger": "appActive"]
👾[Daily and Count-Fired] m_ios_dbp_secure-vault_deferred-init-succeeded_count ["appVersion": "7.230.0", "pixelSource": "phone", "trigger": "appActive”]
```

### Impact

Low

#### What could go wrong?

### Quality Considerations

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only instrumentation on an existing success path; no changes to vault init behavior or data handling.
> 
> **Overview**
> Adds **success telemetry** for deferred secure vault initialization on iOS PIR, complementing existing secure-vault error pixels.
> 
> After `loadVaultResources()` completes and resources are published, `DataBrokerProtectionIOSManager` fires `deferredSecureVaultInitSucceeded` with the **`VaultInitReason`** (`launch`, `appActive`, `dashboard`, `backgroundTask`). The new `IOSPixels` case maps to `m_ios_dbp_secure-vault_deferred-init-succeeded` and is sent via PixelKit with **daily and count** frequency. Pixel definitions document `trigger`, `appVersion`, and `pixelSource`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f5f836d279765e045b6ffce57a4687deab8c865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->