### PR TITLE
Update styling of CookiePopupProtectionOptInView for rebranding

### DIFF
--- a/SharedPackages/UIComponents/Sources/UIComponents/iOS/RadioButtonView.swift
+++ b/SharedPackages/UIComponents/Sources/UIComponents/iOS/RadioButtonView.swift
@@ -43,6 +43,9 @@ public struct RadioButtonConfiguration {
     public var selectedBorderColor: Color
     public var unselectedBorderColor: Color
     public var selectedCheckboxColor: Color?
+    /// Colour of the fill drawn behind the selected checkbox image.
+    /// Used when the checkbox image contains a knocked out transparent glyph, allowing the background to show through.
+    public var selectedCheckboxBackgroundColor: Color?
     public var unselectedCheckboxColor: Color?
     public var selectedCheckboxImage: Image
     public var unselectedCheckboxImage: Image
@@ -63,9 +66,10 @@ public struct RadioButtonConfiguration {
         unselectedBackgroundColor: Color = .clear,
         selectedBorderColor: Color = .init(designSystemColor: .accentPrimary),
         unselectedBorderColor: Color = .init(designSystemColor: .lines),
-        selectedCheckboxColor: Color? = nil,
+        selectedCheckboxColor: Color? = .init(designSystemColor: .accentPrimary),
+        selectedCheckboxBackgroundColor: Color? = .white,
         unselectedCheckboxColor: Color? = .gray.opacity(0.6),
-        selectedCheckboxImage: Image = Image(uiImage: DesignSystemImages.Glyphs.Size24.checkAccent),
+        selectedCheckboxImage: Image = Image(uiImage: DesignSystemImages.Glyphs.Size24.checkSolid),
         unselectedCheckboxImage: Image = Image(uiImage: DesignSystemImages.Glyphs.Size24.shapeCircle),
         borderWidth: CGFloat = 1,
         cornerRadius: CGFloat = 12,
@@ -84,6 +88,7 @@ public struct RadioButtonConfiguration {
         self.selectedBorderColor = selectedBorderColor
         self.unselectedBorderColor = unselectedBorderColor
         self.selectedCheckboxColor = selectedCheckboxColor
+        self.selectedCheckboxBackgroundColor = selectedCheckboxBackgroundColor
         self.unselectedCheckboxColor = unselectedCheckboxColor
         self.selectedCheckboxImage = selectedCheckboxImage
         self.unselectedCheckboxImage = unselectedCheckboxImage
@@ -244,6 +249,30 @@ private struct RadioButtonRow: View {
     }
 
     @ViewBuilder
+    private var checkbox: some View {
+        if isSelected, let backgroundColor = configuration.selectedCheckboxBackgroundColor {
+            ZStack {
+                // The fill shows through any knocked-out areas in the checkbox image, inset so it stays within the tinted disc.
+                Circle()
+                    .fill(backgroundColor)
+                    .padding(configuration.checkboxSize * 0.125)
+                configuration.selectedCheckboxImage
+                    .resizable()
+                    .conditionalTemplateMode(checkboxColor)
+                    .scaledToFit()
+            }
+            .frame(width: configuration.checkboxSize, height: configuration.checkboxSize)
+        } else {
+            (isSelected ? configuration.selectedCheckboxImage : configuration.unselectedCheckboxImage)
+                .resizable()
+                .conditionalTemplateMode(checkboxColor)
+                .font(.system(size: configuration.checkboxSize))
+                .frame(width: configuration.checkboxSize, height: configuration.checkboxSize)
+                .flexibleFrame(horizontal: false, vertical: false)
+        }
+    }
+
+    @ViewBuilder
     private var verticalRowContent: some View {
         Text(item.text)
             .font(configuration.font)
@@ -251,24 +280,14 @@ private struct RadioButtonRow: View {
             .multilineTextAlignment(.leading)
             .frame(maxWidth: .infinity, alignment: .leading)
 
-        (isSelected ? configuration.selectedCheckboxImage : configuration.unselectedCheckboxImage)
-            .resizable()
-            .conditionalTemplateMode(checkboxColor)
-            .font(.system(size: configuration.checkboxSize))
-            .frame(width: configuration.checkboxSize, height: configuration.checkboxSize)
-            .flexibleFrame(horizontal: false, vertical: false)
+        checkbox
     }
 
     @ViewBuilder
     private var horizontalRowContent: some View {
         Spacer()
 
-        (isSelected ? configuration.selectedCheckboxImage : configuration.unselectedCheckboxImage)
-            .resizable()
-            .conditionalTemplateMode(checkboxColor)
-            .font(.system(size: configuration.checkboxSize))
-            .frame(width: configuration.checkboxSize, height: configuration.checkboxSize)
-            .flexibleFrame(horizontal: false, vertical: false)
+        checkbox
 
         Text(item.text)
             .minimumScaleFactor(0.8)
@@ -463,6 +482,7 @@ private class CallbackRadioButtonViewModel: RadioButtonViewModel {
                 selectedBackgroundColor: .pink.opacity(0.1),
                 selectedBorderColor: .pink,
                 selectedCheckboxColor: .pink,
+                selectedCheckboxBackgroundColor: nil,
                 unselectedCheckboxColor: .gray.opacity(0.5),
                 selectedCheckboxImage: Image(systemName: "heart.fill"),
                 unselectedCheckboxImage: Image(systemName: "heart"),
@@ -519,6 +539,7 @@ private class CallbackRadioButtonViewModel: RadioButtonViewModel {
                         selectedBackgroundColor: .purple,
                         selectedBorderColor: .purple,
                         selectedCheckboxColor: .white,
+                        selectedCheckboxBackgroundColor: nil,
                         selectedCheckboxImage: Image(systemName: "star.fill"),
                         unselectedCheckboxImage: Image(systemName: "star"),
                         cornerRadius: 16

--- a/iOS/DuckDuckGo/Autoconsent/CookiePopupProtectionOptInView.swift
+++ b/iOS/DuckDuckGo/Autoconsent/CookiePopupProtectionOptInView.swift
@@ -21,6 +21,7 @@ import SwiftUI
 import DuckUI
 import DesignResourcesKit
 import DesignResourcesKitIcons
+import MetricBuilder
 import UIComponents
 
 enum CookiePopupProtectionOptInVariant {
@@ -71,6 +72,7 @@ struct CookiePopupProtectionOptInView: View {
     private let onConfirm: (CookiePopupProtectionOptInOption) -> Void
     @StateObject private var optionsModel: RadioButtonViewModel
 
+    @MainActor
     init(variant: CookiePopupProtectionOptInVariant, onConfirm: @escaping (CookiePopupProtectionOptInOption) -> Void) {
         self.variant = variant
         self.onConfirm = onConfirm
@@ -86,7 +88,7 @@ struct CookiePopupProtectionOptInView: View {
                 selectedTextColor: Color(designSystemColor: .textPrimary),
                 unselectedTextColor: Color(designSystemColor: .textPrimary),
                 unselectedCheckboxColor: Color(designSystemColor: .iconsSecondary),
-                cornerRadius: 16,
+                cornerRadius: ContainerMetrics.cornerRadius,
                 horizontalPadding: 16,
                 verticalPadding: 16,
                 checkboxSize: 28,
@@ -195,11 +197,11 @@ struct CookiePopupProtectionOptInView: View {
         }
         .padding(.horizontal, 16)
         .background(
-            RoundedRectangle(cornerRadius: 16)
+            RoundedRectangle(cornerRadius: 34)
                 .fill(Color(designSystemColor: .backgroundSheets))
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 16)
+            RoundedRectangle(cornerRadius: 34)
                 .stroke(Color(designSystemColor: .accentPrimary).opacity(0.3), lineWidth: 1)
         )
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211264967278501/task/1216723779214871?focus=true
Tech Design URL:
CC:

### Description
This PR makes some tweaks to the styling of CookiePopupProtectionOptInView for the recent app rebranding:

- Updates corner radius of radio button rows and the outline of the inner card area
- Updates the tint color of the checkmark symbol. I had to switch out the glyph used for this, as the old glyph had a baked in white checkmark so couldn't be tinted.

| Before | After |
|--------|--------|
| <img alt="Simulator Screenshot - iPhone 17 - 2026-07-03 at 16 58 14" src="https://github.com/user-attachments/assets/1156a6cb-9a31-4856-b7cb-f119998524bb" /> | <img alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-22 at 16 13 23" src="https://github.com/user-attachments/assets/eefac59d-e8e8-4ebd-88dc-0c5b9c48a59d" /> | 

(Note the header is different in the "after" because I displayed this from debug settings.

### Testing Steps

1. Build and run the app.
2. View the cookie prompt via Settings > Debug > CPM > Show opt-in dialog and check it looks good.

### Impact

Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and shared UI-component default changes only; default radio styling may shift elsewhere that relies on implicit `RadioButtonConfiguration`, but no auth, data, or business-logic paths change.
> 
> **Overview**
> **`RadioButtonView`** gains **`selectedCheckboxBackgroundColor`** and a shared **`checkbox`** renderer that layers a circular fill under the selected glyph so knocked-out assets can show a background while the mark stays template-tinted. Defaults now use **`checkSolid`**, **accent** selected checkbox tint, and **white** behind the check; previews that use SF Symbol images set the new background to **`nil`** to keep prior behavior.
> 
> **`CookiePopupProtectionOptInView`** aligns with rebranding: radio row corners use **`ContainerMetrics.cornerRadius`**, the inner sheet outline uses **34pt** radius (was 16), plus **`MetricBuilder`** import and **`@MainActor`** on the initializer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc2a1ce36a99a731830b9a2239205cd705be5346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->