### PR TITLE
PIR: Guard operation errors behind lock

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/QueueManaging/JobQueueManager.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/QueueManaging/JobQueueManager.swift
@@ -114,6 +114,7 @@ public final class JobQueueManager: JobQueueManaging {
     private let pixelHandler: EventMapping<DataBrokerProtectionSharedPixels>
 
     private var mode = BrokerProfileJobQueueMode.idle
+    private let operationErrorsLock = NSLock()
     private var operationErrors: [Error] = []
 
     public var debugRunningStatusString: String {
@@ -304,7 +305,7 @@ private extension JobQueueManager {
 
     func resetMode() {
         mode = .idle
-        operationErrors = []
+        operationErrorsLock.withLock { operationErrors = [] }
     }
 
     func addJobs(for jobType: JobType,
@@ -346,7 +347,9 @@ private extension JobQueueManager {
     }
 
     func operationErrorsForCurrentOperations() -> [Error]? {
-        return operationErrors.count != 0 ? operationErrors : nil
+        operationErrorsLock.withLock {
+            operationErrors.isEmpty ? nil : operationErrors
+        }
     }
 }
 
@@ -357,7 +360,7 @@ extension JobQueueManager: BrokerProfileJobStatusReportingDelegate {
                                             identifier: CompletedJobIdentifier?,
                                             dataBrokerParent: String?,
                                             isFreeScan: Bool?) {
-        operationErrors.append(error)
+        operationErrorsLock.withLock { operationErrors.append(error) }
         delegate?.queueManagerDidCompleteIndividualJob(self, identifier: identifier)
 
         guard let error = error as? DataBrokerProtectionError, let brokerURL, let version else { return }
@@ -389,7 +392,7 @@ extension JobQueueManager: BrokerProfileJobStatusReportingDelegate {
 
 extension JobQueueManager: EmailConfirmationErrorDelegate {
     public func emailConfirmationOperationDidError(_ error: Error, withBrokerURL brokerURL: String?, version: String?) {
-        operationErrors.append(error)
+        operationErrorsLock.withLock { operationErrors.append(error) }
 
         guard let error = error as? DataBrokerProtectionError, let brokerURL, let version else {
             return

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/JobQueueManagerTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/JobQueueManagerTests.swift
@@ -569,6 +569,39 @@ final class JobQueueManagerTests: XCTestCase {
         XCTAssertEqual(receivedIdentifier.stepType, .scan)
     }
 
+    func testMultipleErrorOperationsConcurrently() async throws {
+        // Given
+        sut = JobQueueManager(jobQueue: mockQueue,
+                              jobProvider: mockOperationsCreator,
+                              emailConfirmationJobProvider: mockEmailConfirmationJobProvider,
+                              mismatchCalculator: mockMismatchCalculator,
+                              pixelHandler: mockPixelHandler)
+        let errorCount = 50
+        let expectation = expectation(description: "Expected completion to be called")
+        var errorCollection: DataBrokerProtectionJobsErrorCollection!
+
+        sut.startImmediateScanOperationsIfPermitted(showWebView: false, isAuthenticatedUser: true, jobDependencies: mockDependencies) { errors in
+            errorCollection = errors
+        } completion: {
+            expectation.fulfill()
+        }
+
+        // When
+        DispatchQueue.concurrentPerform(iterations: errorCount) { _ in
+            sut.dataBrokerOperationDidError(DataBrokerProtectionError.actionFailed(actionID: "action", message: "failed"),
+                                            withBrokerURL: nil,
+                                            version: nil,
+                                            identifier: nil,
+                                            dataBrokerParent: nil,
+                                            isFreeScan: nil)
+        }
+        mockQueue.completeAllOperations()
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 5)
+        XCTAssertEqual(errorCollection.operationErrors?.count, errorCount)
+    }
+
     func testWhenStartImmediateOptOut_andCurrentModeIsScheduled_thenCurrentOperationsAreInterrupted() {
         sut = JobQueueManager(jobQueue: mockQueue,
                               jobProvider: mockOperationsCreator,


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1216650120602129?focus=true
Tech Design URL:
CC:

### Description

Adds `operationErrorsLock` to guard access.

### Testing Steps

1. CI passes
2.

### Impact

Low

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized synchronization around error aggregation in the PIR job queue; behavior should match prior semantics with fewer data races.
> 
> **Overview**
> **`JobQueueManager`** now protects the in-memory **`operationErrors`** list with an **`operationErrorsLock`** (`NSLock`) so concurrent broker and email-confirmation jobs can report failures without racing on append, read, or reset.
> 
> All mutations and reads go through **`withLock`**: errors are appended in **`dataBrokerOperationDidError`** and **`emailConfirmationOperationDidError`**, cleared in **`resetMode`**, and snapshotted in **`operationErrorsForCurrentOperations`** (empty check simplified to **`isEmpty`**). A new test **`testMultipleErrorOperationsConcurrently`** hammers **`dataBrokerOperationDidError`** from 50 parallel iterations and expects the completion handler to receive all errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b53abfb70613eef6cdab2b36be9b3de9f01ad51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->