### PR TITLE
[macOS] Add experiment for Chrome extension install during onboarding

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/FeatureFlagger/Mock/MockFeatureFlagger.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/FeatureFlagger/Mock/MockFeatureFlagger.swift
@@ -39,7 +39,8 @@ public final class MockFeatureFlagger: FeatureFlagger {
 
     public var allActiveExperiments: Experiments = [:]
 
-    private(set) var didCallResolveCohort: Bool = false
+    public private(set) var didCallResolveCohort: Bool = false
+    public private(set) var didCallAssignedCohort: Bool = false
 
     public var internalUserDecider: InternalUserDecider = DefaultInternalUserDecider(store: MockInternalUserStoring())
     public var localOverrides: FeatureFlagLocalOverriding?
@@ -68,10 +69,12 @@ public final class MockFeatureFlagger: FeatureFlagger {
 
     var resolveCohortStub: (any FeatureFlagCohortDescribing)?
     public func resolveCohort<Flag>(for featureFlag: Flag, allowOverride: Bool) -> (any FeatureFlagCohortDescribing)? where Flag: FeatureFlagDescribing {
-        resolveCohortStub
+        didCallResolveCohort = true
+        return resolveCohortStub
     }
 
     public func assignedCohort<Flag: FeatureFlagDescribing>(for featureFlag: Flag, allowOverride: Bool) -> (any FeatureFlagCohortDescribing)? {
-        resolveCohortStub
+        didCallAssignedCohort = true
+        return resolveCohortStub
     }
 }

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1900,6 +1900,7 @@
 		4BF97ADD2B43C5FC00EB4240 /* KeychainType+ClientDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD3AF5C2A8E7AF1006F9F56 /* KeychainType+ClientDefault.swift */; };
 		4D18EEA2197C40AD97C4B1A7 /* RebrandedContextualOnboardingDialogs+SearchCompleted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E776DE170ED47F4B3E992DF /* RebrandedContextualOnboardingDialogs+SearchCompleted.swift */; };
 		4D5E6F708192A3B4C5D6E7F8 /* BookmarksBarMenuCustomPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2C3D4E5F60718293A4B5C6 /* BookmarksBarMenuCustomPopover.swift */; };
+		4EEDB43A93254D5D80927F59 /* MockExperimentActionPixelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FCC743A88243F0AEF8B22D /* MockExperimentActionPixelStore.swift */; };
 		4F25DAF90625497DB96B6E8D /* ContextualDaxDialogsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B63E5D7F5349E0ADA3EDEA /* ContextualDaxDialogsProvider.swift */; };
 		4FC6164C23014DAAAD077E74 /* SubscriptionPromoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC1AE4AED1E4A4C95A36533 /* SubscriptionPromoView.swift */; };
 		5093DFC4902349B9A5AF8683 /* AIChatDeleteChatsDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E61483DDA440CEAD33A5C5 /* AIChatDeleteChatsDialog.swift */; };
@@ -2741,6 +2742,7 @@
 		98A95D88299A2DF900B9B81A /* BookmarkMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A95D87299A2DF900B9B81A /* BookmarkMigrationTests.swift */; };
 		98EB5D1027516A4800681FE6 /* AppPrivacyConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98EB5D0F27516A4800681FE6 /* AppPrivacyConfigurationTests.swift */; };
 		9BF66A3171D59EB4B55171ED /* AutoplayPolicyTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FEBFD485D01E6666551201 /* AutoplayPolicyTabExtensionTests.swift */; };
+		9CA57666309146C3A9EA7C63 /* OnboardingChromeExtensionExperimentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E1C6F6843A455BA63258FB /* OnboardingChromeExtensionExperimentTests.swift */; };
 		9D84E42C2CD4E66F0046CD8B /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 9D84E4072CD4E66F0046CD8B /* Common */; };
 		9D84E42D2CD4E66F0046CD8B /* PixelKitTestingUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = 9D84E4042CD4E66F0046CD8B /* PixelKitTestingUtilities */; };
 		9D84E42E2CD4E66F0046CD8B /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 9D84E4022CD4E66F0046CD8B /* SnapshotTesting */; };
@@ -2957,6 +2959,7 @@
 		A1B2C3D42F16000000000001 /* AIChatSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D32F16000000000001 /* AIChatSession.swift */; };
 		A1B2C3D52F16000000000001 /* AIChatSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D32F16000000000001 /* AIChatSession.swift */; };
 		A2386B5C129943ED88670FBE /* AIChatFloatingWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12E99106CCA4281998533BC /* AIChatFloatingWindow.swift */; };
+		A331475E95F24FB5A6DE869C /* OnboardingChromeExtensionExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D48634AE4C346D2A58138C1 /* OnboardingChromeExtensionExperiment.swift */; };
 		A370E7706B30748FF9DEAD3F /* TabSuspensionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F16A73746AF35E5F7248523 /* TabSuspensionExtension.swift */; };
 		A73FF53A415CF3340D986951 /* SafariVersionReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACF6FD526BC366D00CF09F9 /* SafariVersionReader.swift */; };
 		A79433C7FCB2CA08F8782A94 /* UnloadedTabViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BC7E0753A96C3B81E3BCB2 /* UnloadedTabViewModelTests.swift */; };
@@ -3986,6 +3989,7 @@
 		C1F142DC2CB93AED003DA518 /* FreemiumDBPPromotionViewCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F142DA2CB93AED003DA518 /* FreemiumDBPPromotionViewCoordinatorTests.swift */; };
 		C3A357144DFF4A47914A933D /* ContextMenuSubfeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BBCD4E443448C19C16F91E /* ContextMenuSubfeatureTests.swift */; };
 		C5965506B4FA4A4E92FD11C9 /* ContextMenuSubfeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BBCD4E443448C19C16F91E /* ContextMenuSubfeatureTests.swift */; };
+		C86DEF76F90A416C936E54CD /* OnboardingChromeExtensionExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D48634AE4C346D2A58138C1 /* OnboardingChromeExtensionExperiment.swift */; };
 		C8C8050EED40EF171CC2784D /* QuickFeedbackDiagnosticsCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F511D9CB8F68D9D9B0341314 /* QuickFeedbackDiagnosticsCollector.swift */; };
 		C8E4E6A94A9FA76E5ABF3A2A /* QuickFeedbackTipController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C76403F87E9F53E2C9FFA007 /* QuickFeedbackTipController.swift */; };
 		C8F1A3D52B6E4C7091D4E8F0 /* DDGChromeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E7C4B12D8F4A6C93E5F1B0 /* DDGChromeExtension.swift */; };
@@ -4244,6 +4248,7 @@
 		CD34F0C22C886482006826BE /* MaliciousSiteProtectionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD34F0BF2C886482006826BE /* MaliciousSiteProtectionMocks.swift */; };
 		CD89DD612C89E08D0080F9AF /* MaliciousSiteProtectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89DD5D2C89E08D0080F9AF /* MaliciousSiteProtectionTests.swift */; };
 		CD89DD622C89E08D0080F9AF /* MaliciousSiteProtectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89DD5D2C89E08D0080F9AF /* MaliciousSiteProtectionTests.swift */; };
+		CEEFFD0D8BD04439ACBED3AA /* OnboardingChromeExtensionExperimentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E1C6F6843A455BA63258FB /* OnboardingChromeExtensionExperimentTests.swift */; };
 		CFCB0D03ADA84A06A1B05235 /* ContextualDaxDialogsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B63E5D7F5349E0ADA3EDEA /* ContextualDaxDialogsProvider.swift */; };
 		D16140583C0346C5BE2D9B96 /* QuickFeedbackWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6323C46A8F7693E56A2AD5F8 /* QuickFeedbackWindowController.swift */; };
 		D1A7B0010000000000000002 /* NewTabPageOmnibarTabsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000001 /* NewTabPageOmnibarTabsProvider.swift */; };
@@ -4281,6 +4286,7 @@
 		DA0001012F5B000000000002 /* PasswordManagerCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0001012F5B000000000000 /* PasswordManagerCoordinatorTests.swift */; };
 		DBDE0002000000000000BDE0 /* NavigationPixelNavigationResponderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDE0001000000000000BDE0 /* NavigationPixelNavigationResponderTests.swift */; };
 		DBDE0003000000000000BDE0 /* NavigationPixelNavigationResponderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDE0001000000000000BDE0 /* NavigationPixelNavigationResponderTests.swift */; };
+		DD64C09B3FB444E5878C0D31 /* MockExperimentActionPixelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FCC743A88243F0AEF8B22D /* MockExperimentActionPixelStore.swift */; };
 		DDBB9E343D3A8AA3C0A9FBF7 /* AIChatDebugServer in Frameworks */ = {isa = PBXBuildFile; productRef = 30EF23C27554D957E2FCC6EE /* AIChatDebugServer */; };
 		DE5427713AC642CE9E29303C /* TabContentDisplayTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6308141E2A1B48C8B5FC059A /* TabContentDisplayTitleTests.swift */; };
 		DFE9DC288642264669587656 /* WebViewUserAgentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAAA013D5BF54C0C260E784E /* WebViewUserAgentProvider.swift */; };
@@ -4872,6 +4878,7 @@
 		1430DFF424D0580F00B8978C /* TabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewController.swift; sourceTree = "<group>"; };
 		14505A07256084EF00272CC6 /* UserAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgent.swift; sourceTree = "<group>"; };
 		1456D6E024EFCBC300775049 /* TabBarCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarCollectionView.swift; sourceTree = "<group>"; };
+		17FCC743A88243F0AEF8B22D /* MockExperimentActionPixelStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockExperimentActionPixelStore.swift; sourceTree = "<group>"; };
 		1812146DE841448CA4CE3FD1 /* AIChatFloatingWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatFloatingWindowController.swift; sourceTree = "<group>"; };
 		18B63E5D7F5349E0ADA3EDEA /* ContextualDaxDialogsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDaxDialogsProvider.swift; sourceTree = "<group>"; };
 		1A77VST00000000000000001 /* VoiceSessionTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSessionTracker.swift; sourceTree = "<group>"; };
@@ -4910,6 +4917,7 @@
 		1D3DCCEF2F6A9EEE00388752 /* NewTabPageOmnibarModelsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageOmnibarModelsProvider.swift; sourceTree = "<group>"; };
 		1D4071AD2BD64266002D4537 /* DockCustomizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DockCustomizer.swift; sourceTree = "<group>"; };
 		1D43EB3329297D760065E5D6 /* BWNotRespondingAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BWNotRespondingAlert.swift; sourceTree = "<group>"; };
+		1D48634AE4C346D2A58138C1 /* OnboardingChromeExtensionExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingChromeExtensionExperiment.swift; sourceTree = "<group>"; };
 		1D4B03D52CA4431C00224E99 /* BookmarkUrlExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkUrlExtension.swift; sourceTree = "<group>"; };
 		1D4B03D82CA55DDF00224E99 /* BookmarkUrlExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarkUrlExtensionTests.swift; sourceTree = "<group>"; };
 		1D5072052F3A41AE005BE196 /* AIChatModelPickerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatModelPickerButton.swift; sourceTree = "<group>"; };
@@ -5623,6 +5631,7 @@
 		4BF4EA4F27C71F26004E57C4 /* PasswordManagementListSectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordManagementListSectionTests.swift; sourceTree = "<group>"; };
 		4BF6961F28BEEE8B00D402D4 /* LocalPinningManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalPinningManagerTests.swift; sourceTree = "<group>"; };
 		51FEBFD485D01E6666551201 /* AutoplayPolicyTabExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoplayPolicyTabExtensionTests.swift; sourceTree = "<group>"; };
+		53E1C6F6843A455BA63258FB /* OnboardingChromeExtensionExperimentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingChromeExtensionExperimentTests.swift; sourceTree = "<group>"; };
 		5601FECC29B7973D00068905 /* TabBarViewItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewItemTests.swift; sourceTree = "<group>"; };
 		5603D90529B7B746007F9F01 /* MockTabViewItemDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabViewItemDelegate.swift; sourceTree = "<group>"; };
 		560419432DD49BB600818414 /* PreferencesThreatProtectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesThreatProtectionView.swift; sourceTree = "<group>"; };
@@ -9655,6 +9664,7 @@
 				56A0542A2C201D64007D8FAB /* MockContentBlocking.swift */,
 				56A054462C22536A007D8FAB /* CapturingOnboardingActionsManager.swift */,
 				B1F2A3D52B6E4C7091D4E902 /* MockThirdPartyBrowserExtensionInstalling.swift */,
+				17FCC743A88243F0AEF8B22D /* MockExperimentActionPixelStore.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -10429,6 +10439,7 @@
 				56A054062C1B4772007D8FAB /* Mocks */,
 				A9E7C4B12D8F4A6C93E5F1B3 /* ChromeExtensionInstallerTests.swift */,
 				56A053FE2C1AEFA1007D8FAB /* OnboardingManagerTests.swift */,
+				53E1C6F6843A455BA63258FB /* OnboardingChromeExtensionExperimentTests.swift */,
 				56A054432C2252CE007D8FAB /* OnboardingUserScriptTests.swift */,
 			);
 			path = Onboarding;
@@ -10678,6 +10689,7 @@
 				A9E7C4B12D8F4A6C93E5F1B0 /* DDGChromeExtension.swift */,
 				A9E7C4B12D8F4A6C93E5F1B1 /* ThirdPartyBrowserExtensionInstalling.swift */,
 				A9E7C4B12D8F4A6C93E5F1B2 /* ChromeExtensionInstaller.swift */,
+				1D48634AE4C346D2A58138C1 /* OnboardingChromeExtensionExperiment.swift */,
 			);
 			path = ThirdPartyBrowserExtensions;
 			sourceTree = "<group>";
@@ -15696,6 +15708,7 @@
 				7BA64F682EE1E86B00289E30 /* ContentScopeExperimentsMenu.swift in Sources */,
 				37E13B8F2D54B03D002ECD62 /* HistoryViewDataProvider.swift in Sources */,
 				56A053FD2C1A0AC9007D8FAB /* OnboardingActionsManager.swift in Sources */,
+				C86DEF76F90A416C936E54CD /* OnboardingChromeExtensionExperiment.swift in Sources */,
 				C8F1A3D52B6E4C7091D4E8F1 /* DDGChromeExtension.swift in Sources */,
 				C8F1A3D52B6E4C7091D4E8F3 /* ThirdPartyBrowserExtensionInstalling.swift in Sources */,
 				C8F1A3D52B6E4C7091D4E8F5 /* ChromeExtensionInstaller.swift in Sources */,
@@ -16601,6 +16614,7 @@
 				FB0C0800000000000000CE05 /* PageContextExtractionPixelHandlerTests.swift in Sources */,
 				1DFAB5232A8983E100A0F7F6 /* SetExtensionTests.swift in Sources */,
 				56A054002C1AEFA1007D8FAB /* OnboardingManagerTests.swift in Sources */,
+				CEEFFD0D8BD04439ACBED3AA /* OnboardingChromeExtensionExperimentTests.swift in Sources */,
 				C1C257142ECD178400C4AEAD /* SafariArchiveImporterTests.swift in Sources */,
 				3706FE36293F661700E42796 /* FirefoxFaviconsReaderTests.swift in Sources */,
 				3706FE37293F661700E42796 /* TabCollectionViewModelTests+WithoutPinnedTabsManager.swift in Sources */,
@@ -16631,6 +16645,7 @@
 				1A77VST00000000000000006 /* VoiceSessionTrackerTests.swift in Sources */,
 				56A054482C22536A007D8FAB /* CapturingOnboardingActionsManager.swift in Sources */,
 				B1F2A3D52B6E4C7091D4E901 /* MockThirdPartyBrowserExtensionInstalling.swift in Sources */,
+				DD64C09B3FB444E5878C0D31 /* MockExperimentActionPixelStore.swift in Sources */,
 				C8F1A3D52B6E4C7091D4E8F7 /* ChromeExtensionInstallerTests.swift in Sources */,
 				3706FE3D293F661700E42796 /* DataEncryptionTests.swift in Sources */,
 				1D39F7292DCA2C9200F258F0 /* InitialWindowFrameProviderTests.swift in Sources */,
@@ -18500,6 +18515,7 @@
 				B65E6B9E26D9EC0800095F96 /* CircularProgressView.swift in Sources */,
 				BB3229052D08644400DA92E9 /* TabBarRemoteMessageView.swift in Sources */,
 				56A053FC2C19E8F7007D8FAB /* OnboardingActionsManager.swift in Sources */,
+				A331475E95F24FB5A6DE869C /* OnboardingChromeExtensionExperiment.swift in Sources */,
 				C8F1A3D52B6E4C7091D4E8F0 /* DDGChromeExtension.swift in Sources */,
 				C8F1A3D52B6E4C7091D4E8F2 /* ThirdPartyBrowserExtensionInstalling.swift in Sources */,
 				C8F1A3D52B6E4C7091D4E8F4 /* ChromeExtensionInstaller.swift in Sources */,
@@ -18698,6 +18714,7 @@
 				CC8E70D72F0EC71E008C8070 /* MockNewTabPageNextStepsCardsPersistor.swift in Sources */,
 				56A054472C22536A007D8FAB /* CapturingOnboardingActionsManager.swift in Sources */,
 				B1F2A3D52B6E4C7091D4E900 /* MockThirdPartyBrowserExtensionInstalling.swift in Sources */,
+				4EEDB43A93254D5D80927F59 /* MockExperimentActionPixelStore.swift in Sources */,
 				EE1886592EB8D83600A46272 /* NewImportSummaryViewModelTests.swift in Sources */,
 				C13909F42B85FD79001626ED /* AutofillDeleteAllPasswordsExecutorTests.swift in Sources */,
 				37534C9E28104D9B002621E7 /* TabLazyLoaderTests.swift in Sources */,
@@ -18913,6 +18930,7 @@
 				1D8C2FED2B70F5D0005E4BBD /* MockViewSnapshotRenderer.swift in Sources */,
 				B6106BAF26A7C6180013B453 /* PermissionStoreMock.swift in Sources */,
 				4B98D27A28D95F1A003C2B6F /* ChromiumFaviconsReaderTests.swift in Sources */,
+				9CA57666309146C3A9EA7C63 /* OnboardingChromeExtensionExperimentTests.swift in Sources */,
 				84C1007F2ECC75350083AB11 /* MockWKNavigationAction.swift in Sources */,
 				9F0660732BECC71200B8EEF1 /* SubscriptionAttributionPixelHandlerTests.swift in Sources */,
 				986189E62A7CFB3E001B4519 /* LocalBookmarkStoreSavingTests.swift in Sources */,

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -19,6 +19,7 @@
 import AIChat
 import Combine
 import Common
+import FeatureFlags
 import DuckPlayer
 import FoundationExtensions
 import Foundation
@@ -121,6 +122,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     private var aiChatPreferencesStorage: AIChatPreferencesStorage
     private let homepageSearchModeSeedPersistor: HomepageSearchModeSeedPersistor
     private let featureFlagger: FeatureFlagger
+    private let chromeExtensionExperiment: OnboardingChromeExtensionExperiment
     private let onboardingSharedPixelHandler: OnboardingSharedPixelHandling
     private let chromeExtensionInstaller: ThirdPartyBrowserExtensionInstalling
     private var cancellables = Set<AnyCancellable>()
@@ -184,8 +186,16 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
 
     private var didRequestDefaultBrowser: Bool = false
 
+    // MARK: Chrome extension install
+
+    private var isEligibleForChromeExtensionInstall: Bool {
+        featureFlagger.isFeatureOn(.onboardingRebranding)
+            && chromeExtensionInstaller.canInstallDDGExtension
+    }
+
     private var shouldShowChromeInstallOption: Bool {
-        featureFlagger.isFeatureOn(.onboardingChromeExtension) && chromeExtensionInstaller.canInstallDDGExtension
+        isEligibleForChromeExtensionInstall
+            && chromeExtensionExperiment.cohort == .treatment
     }
 
     convenience init(
@@ -201,7 +211,6 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         installDateProvider: @escaping () -> Date
     ) {
         let chromeExtensionInstaller = ChromeExtensionInstaller(
-            featureFlagger: featureFlagger,
             buildType: StandardApplicationBuildType(),
             isChromeInstalled: { ThirdPartyBrowser.chrome.isInstalled },
             applicationSupportURL: .nonSandboxApplicationSupportDirectoryURL,
@@ -250,6 +259,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
         self.aiChatPreferencesStorage = aiChatPreferencesStorage
         self.homepageSearchModeSeedPersistor = homepageSearchModeSeedPersistor
         self.featureFlagger = featureFlagger
+        self.chromeExtensionExperiment = OnboardingChromeExtensionExperiment(featureFlagger: featureFlagger)
         self.onboardingSharedPixelHandler = onboardingSharedPixelHandler
         self.chromeExtensionInstaller = chromeExtensionInstaller
     }
@@ -257,6 +267,9 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     func onboardingStarted() {
         navigation.updatePreventUserInteraction(prevent: true)
         stepShown(step: .welcome)
+        if isEligibleForChromeExtensionInstall {
+            chromeExtensionExperiment.enroll()
+        }
     }
 
     @MainActor
@@ -305,6 +318,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     func setAsDefault() {
         try? defaultBrowserProvider.presentDefaultBrowserPrompt()
         onboardingSharedPixelHandler.fire(.setDefault(.clicked(.engage)))
+        chromeExtensionExperiment.fireMetric(.setAsDefault)
         didRequestDefaultBrowser = true
     }
 
@@ -504,6 +518,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     private func fireOnboardingFinishedPixels(userSawToggleOnboarding: Bool) {
         PixelKit.fire(GeneralPixel.onboardingFinalStepComplete, frequency: .dailyAndCount)
         fireSharedPixelForFinalStep(userSawToggleOnboarding)
+        chromeExtensionExperiment.fireMetric(.onboardingCompleted)
 
         guard userSawToggleOnboarding else { return }
 

--- a/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ChromeExtensionInstaller.swift
+++ b/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ChromeExtensionInstaller.swift
@@ -16,7 +16,6 @@
 //  limitations under the License.
 //
 
-import FeatureFlags
 import Foundation
 import PixelKit
 import PrivacyConfig
@@ -52,7 +51,6 @@ final class ChromeExtensionInstaller: ThirdPartyBrowserExtensionInstalling {
         static let profileExtensionsPath = "Extensions"
     }
 
-    private let featureFlagger: FeatureFlagger
     private let buildType: ApplicationBuildType
     private let isChromeInstalled: () -> Bool
     private let applicationSupportURL: URL
@@ -60,14 +58,12 @@ final class ChromeExtensionInstaller: ThirdPartyBrowserExtensionInstalling {
     private let pixelFiring: PixelFiring?
 
     init(
-        featureFlagger: FeatureFlagger,
         buildType: ApplicationBuildType,
         isChromeInstalled: @escaping () -> Bool,
         applicationSupportURL: URL,
         fileManager: FileManager,
         pixelFiring: PixelFiring?
     ) {
-        self.featureFlagger = featureFlagger
         self.buildType = buildType
         self.isChromeInstalled = isChromeInstalled
         self.applicationSupportURL = applicationSupportURL
@@ -83,7 +79,6 @@ final class ChromeExtensionInstaller: ThirdPartyBrowserExtensionInstalling {
     /// Whether the Chrome extension can be staged for the user.
     ///
     /// Returns `true` only when all of the following hold:
-    /// - The `onboardingChromeExtension` feature flag is enabled
     /// - The app is a Sparkle (DMG) build
     /// - Chrome is installed and has been launched before
     /// - None of the DDG extension variants are already installed in any Chrome channel or profile
@@ -92,8 +87,7 @@ final class ChromeExtensionInstaller: ThirdPartyBrowserExtensionInstalling {
     var canInstallDDGExtension: Bool {
         let channelRoots = installedChannelRoots
 
-        guard featureFlagger.isFeatureOn(.onboardingChromeExtension),
-              buildType.isSparkleBuild,
+        guard buildType.isSparkleBuild,
               isChromeInstalled(),
               !channelRoots.isEmpty else {
             return false

--- a/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/OnboardingChromeExtensionExperiment.swift
+++ b/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/OnboardingChromeExtensionExperiment.swift
@@ -1,0 +1,67 @@
+//
+//  OnboardingChromeExtensionExperiment.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import FeatureFlags
+import Foundation
+import PixelKit
+import PrivacyConfig
+
+struct OnboardingChromeExtensionExperiment {
+
+    private let featureFlagger: FeatureFlagger
+
+    private static let subfeatureID = MacOSBrowserConfigSubfeature.onboardingChromeExtension.rawValue
+
+    enum Metric: String {
+        case setAsDefault = "setAsDefault"
+        case onboardingCompleted = "onboardingCompleted"
+    }
+
+    private enum ConversionWindows {
+        static let oneDay = 0...1
+        static let fiveDays = 0...5
+        static let sevenDays = 0...7
+        static let all = [oneDay, fiveDays, sevenDays]
+    }
+
+    init(featureFlagger: FeatureFlagger) {
+        self.featureFlagger = featureFlagger
+    }
+
+    /// Assigns a cohort via `resolveCohort`. Caller must only invoke when install-eligible.
+    func enroll() {
+        _ = featureFlagger.resolveCohort(for: FeatureFlag.onboardingChromeExtension)
+    }
+
+    /// Already-assigned cohort, or `nil` when not enrolled. Never assigns.
+    var cohort: FeatureFlag.OnboardingChromeExtensionCohort? {
+        featureFlagger.assignedCohort(for: FeatureFlag.onboardingChromeExtension) as? FeatureFlag.OnboardingChromeExtensionCohort
+    }
+
+    func fireMetric(_ metric: Metric) {
+        guard cohort != nil else { return }
+        for window in ConversionWindows.all {
+            PixelKit.fireExperimentPixel(
+                for: Self.subfeatureID,
+                metric: metric.rawValue,
+                conversionWindowDays: window,
+                value: "true"
+            )
+        }
+    }
+}

--- a/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/OnboardingChromeExtensionExperiment.swift
+++ b/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/OnboardingChromeExtensionExperiment.swift
@@ -28,8 +28,8 @@ struct OnboardingChromeExtensionExperiment {
     private static let subfeatureID = MacOSBrowserConfigSubfeature.onboardingChromeExtension.rawValue
 
     enum Metric: String {
-        case setAsDefault = "setAsDefault"
-        case onboardingCompleted = "onboardingCompleted"
+        case setAsDefault
+        case onboardingCompleted
     }
 
     private enum ConversionWindows {

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -485,6 +485,12 @@ extension FeatureFlag: FeatureFlagDescribing {
         case treatment
     }
 
+    /// Cohorts for the onboarding Chrome extension install experiment
+    public enum OnboardingChromeExtensionCohort: String, FeatureFlagCohortDescribing {
+        case control
+        case treatment
+    }
+
     private struct Config {
         let defaultValue: FeatureFlagDefaultValue
         let source: FeatureFlagSource
@@ -524,7 +530,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .newTabPageRebranding:
             Config(defaultValue: .disabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.appRebranding))
         case .onboardingChromeExtension:
-            Config(defaultValue: .disabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.onboardingChromeExtension))
+            Config(defaultValue: .disabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.onboardingChromeExtension), cohortType: OnboardingChromeExtensionCohort.self)
         case .fireDialogSimplified:
             Config(defaultValue: .disabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.fireDialogSimplified))
         case .unknownUsernameCategorization:

--- a/macOS/PixelDefinitions/pixels/native_experiments.json5
+++ b/macOS/PixelDefinitions/pixels/native_experiments.json5
@@ -22,6 +22,19 @@
                     "enum": ["true"]
                 }
             }
+        },
+        "onboardingChromeExtension": {
+            "cohorts": ["control", "treatment"],
+            "metrics": {
+                "setAsDefault": {
+                    "description": "User clicked the Set as Default call to action during onboarding",
+                    "enum": ["true"]
+                },
+                "onboardingCompleted": {
+                    "description": "User completed the full onboarding flow",
+                    "enum": ["true"]
+                }
+            }
         }
     }
 }

--- a/macOS/UnitTests/Onboarding/ChromeExtensionInstallerTests.swift
+++ b/macOS/UnitTests/Onboarding/ChromeExtensionInstallerTests.swift
@@ -16,11 +16,9 @@
 //  limitations under the License.
 //
 
-import FeatureFlags
 import Foundation
 import PixelKit
 import PixelKitTestingUtilities
-import PrivacyConfig
 import XCTest
 
 @testable import DuckDuckGo_Privacy_Browser
@@ -43,12 +41,6 @@ final class ChromeExtensionInstallerTests: XCTestCase {
         }
         applicationSupportURL = nil
         try super.tearDownWithError()
-    }
-
-    func testWhenFeatureFlagIsOffThenCanInstallIsFalse() {
-        let installer = makeSUT(enableOnboardingChromeExtensionFlag: false)
-
-        XCTAssertFalse(installer.canInstallDDGExtension)
     }
 
     func testWhenBuildIsNotSparkleThenCanInstallIsFalse() throws {
@@ -159,7 +151,6 @@ final class ChromeExtensionInstallerTests: XCTestCase {
     // MARK: - Helpers
 
     private func makeSUT(
-        enableOnboardingChromeExtensionFlag: Bool = true,
         buildType: ApplicationBuildTypeMock = {
             let buildType = ApplicationBuildTypeMock()
             buildType.isSparkleBuild = true
@@ -169,13 +160,7 @@ final class ChromeExtensionInstallerTests: XCTestCase {
         fileManager: FileManager = .default,
         pixelFiring: PixelFiring? = nil
     ) -> ChromeExtensionInstaller {
-        let featureFlagger = MockFeatureFlagger()
-        if enableOnboardingChromeExtensionFlag {
-            featureFlagger.enableFeatures([.onboardingChromeExtension])
-        }
-
-        return ChromeExtensionInstaller(
-            featureFlagger: featureFlagger,
+        ChromeExtensionInstaller(
             buildType: buildType,
             isChromeInstalled: isChromeInstalled,
             applicationSupportURL: applicationSupportURL,

--- a/macOS/UnitTests/Onboarding/Mocks/MockExperimentActionPixelStore.swift
+++ b/macOS/UnitTests/Onboarding/Mocks/MockExperimentActionPixelStore.swift
@@ -1,0 +1,26 @@
+//
+//  MockExperimentActionPixelStore.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import PixelExperimentKit
+
+final class MockExperimentActionPixelStore: ExperimentActionPixelStore {
+    var store: [String: Int] = [:]
+    func removeObject(forKey defaultName: String) { store.removeValue(forKey: defaultName) }
+    func integer(forKey defaultName: String) -> Int { store[defaultName] ?? 0 }
+    func set(_ value: Int, forKey defaultName: String) { store[defaultName] = value }
+}

--- a/macOS/UnitTests/Onboarding/OnboardingChromeExtensionExperimentTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingChromeExtensionExperimentTests.swift
@@ -1,0 +1,111 @@
+//
+//  OnboardingChromeExtensionExperimentTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import FeatureFlags
+import PixelExperimentKit
+import PixelKit
+import PrivacyConfig
+import XCTest
+
+@testable import DuckDuckGo_Privacy_Browser
+
+final class OnboardingChromeExtensionExperimentTests: XCTestCase {
+
+    private var firedEvents: [PixelKitEvent]!
+
+    override func setUp() {
+        firedEvents = []
+    }
+
+    override func tearDown() {
+        firedEvents = nil
+    }
+
+    func testEnrollCallsResolveCohort() {
+        let cohort = FeatureFlag.OnboardingChromeExtensionCohort.treatment
+        let featureFlagger = MockFeatureFlagger(resolveCohortStub: cohort)
+        let experiment = OnboardingChromeExtensionExperiment(featureFlagger: featureFlagger)
+
+        experiment.enroll()
+
+        XCTAssertEqual(experiment.cohort, cohort)
+        XCTAssertTrue(featureFlagger.didCallResolveCohort)
+    }
+
+    func testCohortReadsAssignedCohortWithoutResolving() {
+        let cohort = FeatureFlag.OnboardingChromeExtensionCohort.control
+        let featureFlagger = MockFeatureFlagger(resolveCohortStub: cohort)
+        let experiment = OnboardingChromeExtensionExperiment(featureFlagger: featureFlagger)
+
+        XCTAssertEqual(experiment.cohort, cohort)
+        XCTAssertTrue(featureFlagger.didCallAssignedCohort)
+        XCTAssertFalse(featureFlagger.didCallResolveCohort)
+    }
+
+    func testCohortIsNilWhenNotAssigned() {
+        let featureFlagger = MockFeatureFlagger()
+        let experiment = OnboardingChromeExtensionExperiment(featureFlagger: featureFlagger)
+
+        XCTAssertNil(experiment.cohort)
+    }
+
+    func testFireMetricDoesNotFireWhenNotEnrolled() {
+        let featureFlagger = MockFeatureFlagger()
+        let experiment = OnboardingChromeExtensionExperiment(featureFlagger: featureFlagger)
+        configureExperimentKit(cohort: nil, featureFlagger: featureFlagger)
+
+        experiment.fireMetric(.setAsDefault)
+
+        XCTAssertTrue(firedEvents.isEmpty)
+        XCTAssertFalse(featureFlagger.didCallResolveCohort)
+    }
+
+    func testFireMetricFiresWhenEnrolled() {
+        let cohort = FeatureFlag.OnboardingChromeExtensionCohort.control
+        let featureFlagger = MockFeatureFlagger(resolveCohortStub: cohort)
+        let experiment = OnboardingChromeExtensionExperiment(featureFlagger: featureFlagger)
+        configureExperimentKit(cohort: cohort, featureFlagger: featureFlagger)
+
+        experiment.fireMetric(.setAsDefault)
+
+        XCTAssertTrue(firedEvents.contains(where: { $0.parameters?["metric"] == "setAsDefault" }))
+    }
+}
+
+private extension OnboardingChromeExtensionExperimentTests {
+    func configureExperimentKit(cohort: FeatureFlag.OnboardingChromeExtensionCohort?,
+                                featureFlagger: MockFeatureFlagger) {
+        if let cohort {
+            let subfeatureID = MacOSBrowserConfigSubfeature.onboardingChromeExtension.rawValue
+            featureFlagger.allActiveExperiments = [
+                subfeatureID: ExperimentData(
+                    parentID: PrivacyFeature.macOSBrowserConfig.rawValue,
+                    cohortID: cohort.rawValue,
+                    enrollmentDate: Date()
+                )
+            ]
+        } else {
+            featureFlagger.allActiveExperiments = [:]
+        }
+        PixelKit.configureExperimentKit(
+            featureFlagger: featureFlagger,
+            eventTracker: ExperimentEventTracker(store: MockExperimentActionPixelStore()),
+            fire: { event, _, _ in self.firedEvents.append(event) }
+        )
+    }
+}

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -17,10 +17,13 @@
 //
 
 import AIChat
+import Combine
 import FeatureFlags
 import Onboarding
 import Persistence
 import PersistenceTestingUtils
+import PixelExperimentKit
+import PixelKit
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 import SharedTestUtilities
@@ -116,28 +119,16 @@ class OnboardingManagerTests: XCTestCase {
         XCTAssertEqual(manager.configuration, expectedConfig)
     }
 
-    func testReturnsExpectedOnboardingConfig_WhenChromeExtensionCanBeInstalled_AndFlagIsEnabled_IncludesChromeExtensionInstallOption() {
+    func testReturnsExpectedOnboardingConfig_WhenChromeExtensionCanBeInstalled_AndTreatmentCohortAssigned_IncludesChromeExtensionInstallOption() {
         // Given
-        chromeExtensionInstaller.canInstallDDGExtension = true
-        let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = [.onboardingChromeExtension]
-        let managerWithFlagOn = OnboardingActionsManager(
-            navigationDelegate: navigationDelegate,
-            dockCustomization: dockCustomization,
-            defaultBrowserProvider: defaultBrowserProvider,
-            appearancePreferences: appearancePreferences,
-            startupPreferences: startupPreferences,
-            dataImportProvider: importProvider,
-            featureFlagger: featureFlagger,
-            onboardingSharedPixelHandler: onboardingSharedPixelHandler,
-            chromeExtensionInstaller: chromeExtensionInstaller
-        )
+        let featureFlagger = makeFeatureFlagger(cohort: .treatment)
+        let managerWithFlagOn = makeExperimentManager(featureFlagger: featureFlagger)
 
         // Then
         XCTAssertEqual(managerWithFlagOn.configuration.stepDefinitions.getStarted.options, ["chrome-extension-install"])
     }
 
-    func testReturnsExpectedOnboardingConfig_WhenChromeExtensionCanBeInstalled_AndFlagIsDisabled_DoesNotIncludeChromeExtensionInstallOption() {
+    func testReturnsExpectedOnboardingConfig_WhenNotEnrolledInExperiment_DoesNotIncludeChromeExtensionInstallOption() {
         // Given
         chromeExtensionInstaller.canInstallDDGExtension = true
 
@@ -147,23 +138,11 @@ class OnboardingManagerTests: XCTestCase {
 
     func testReturnsExpectedOnboardingConfig_WhenChromeExtensionCannotBeInstalled_DoesNotIncludeChromeExtensionInstallOption() {
         // Given
-        chromeExtensionInstaller.canInstallDDGExtension = false
-        let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = [.onboardingChromeExtension]
-        let managerWithFlagOn = OnboardingActionsManager(
-            navigationDelegate: navigationDelegate,
-            dockCustomization: dockCustomization,
-            defaultBrowserProvider: defaultBrowserProvider,
-            appearancePreferences: appearancePreferences,
-            startupPreferences: startupPreferences,
-            dataImportProvider: importProvider,
-            featureFlagger: featureFlagger,
-            onboardingSharedPixelHandler: onboardingSharedPixelHandler,
-            chromeExtensionInstaller: chromeExtensionInstaller
-        )
+        let featureFlagger = makeFeatureFlagger(cohort: .treatment)
+        let managerWithTreatment = makeExperimentManager(featureFlagger: featureFlagger, canInstall: false)
 
         // Then
-        XCTAssertTrue(managerWithFlagOn.configuration.stepDefinitions.getStarted.options.isEmpty)
+        XCTAssertTrue(managerWithTreatment.configuration.stepDefinitions.getStarted.options.isEmpty)
     }
 
     func testReturnsExpectedOnboardingConfig_WhenDockCustomization_DoesNotSupportAddingToDock() {
@@ -458,26 +437,159 @@ class OnboardingManagerTests: XCTestCase {
 
     func testExpectedShownPixelsFired_WhenGetStartedStepShown_AndChromeOptionCanBeShown() {
         // Given
-        chromeExtensionInstaller.canInstallDDGExtension = true
-        let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = [.onboardingChromeExtension]
-        let managerWithFlagOn = OnboardingActionsManager(
-            navigationDelegate: navigationDelegate,
-            dockCustomization: dockCustomization,
-            defaultBrowserProvider: defaultBrowserProvider,
-            appearancePreferences: appearancePreferences,
-            startupPreferences: startupPreferences,
-            dataImportProvider: importProvider,
-            featureFlagger: featureFlagger,
-            onboardingSharedPixelHandler: onboardingSharedPixelHandler,
-            chromeExtensionInstaller: chromeExtensionInstaller
-        )
+        let featureFlagger = makeFeatureFlagger(cohort: .treatment)
+        let managerWithTreatment = makeExperimentManager(featureFlagger: featureFlagger)
 
         // When
-        managerWithFlagOn.stepShown(step: .getStarted)
+        managerWithTreatment.stepShown(step: .getStarted)
 
         // Then
         XCTAssertEqual(onboardingSharedPixelHandler.eventsReceived, [.chromeExtensionInstall(.shown)])
+    }
+
+    func testChromeExtensionInstallShownPixelNotFired_WhenGetStartedStepShown_AndControlCohort() {
+        // Given
+        let featureFlagger = makeFeatureFlagger(cohort: .control)
+        let managerWithControl = makeExperimentManager(featureFlagger: featureFlagger)
+
+        // When
+        managerWithControl.stepShown(step: .getStarted)
+
+        // Then
+        XCTAssertTrue(onboardingSharedPixelHandler.eventsReceived.isEmpty)
+    }
+
+    func testWhenEligibleAndTreatmentCohortThenConfigIncludesChromeExtensionInstallOption() {
+        // Given
+        let featureFlagger = makeFeatureFlagger(cohort: .treatment)
+        let managerWithTreatment = makeExperimentManager(featureFlagger: featureFlagger)
+
+        // When
+        managerWithTreatment.onboardingStarted()
+
+        // Then
+        XCTAssertEqual(
+            managerWithTreatment.configuration.stepDefinitions.getStarted.options,
+            [OnboardingOption.chromeExtensionInstall.rawValue]
+        )
+        XCTAssertTrue(featureFlagger.didCallResolveCohort)
+    }
+
+    func testWhenEligibleAndControlCohortThenConfigDoesNotIncludeChromeExtensionInstallOption() {
+        // Given
+        let featureFlagger = makeFeatureFlagger(cohort: .control)
+        let managerWithControl = makeExperimentManager(featureFlagger: featureFlagger)
+
+        // When
+        managerWithControl.onboardingStarted()
+
+        // Then
+        XCTAssertTrue(managerWithControl.configuration.stepDefinitions.getStarted.options.isEmpty)
+        XCTAssertTrue(featureFlagger.didCallResolveCohort)
+    }
+
+    func testWhenNotV4ThenDoesNotResolveCohortOrIncludeChromeExtensionInstallOption() {
+        // Given
+        let featureFlagger = makeFeatureFlagger(cohort: .treatment, isOnboardingRebrandingEnabled: false)
+        chromeExtensionInstaller.canInstallDDGExtension = true
+        let managerWithTreatment = makeExperimentManager(featureFlagger: featureFlagger)
+
+        // When
+        managerWithTreatment.onboardingStarted()
+
+        // Then
+        XCTAssertTrue(managerWithTreatment.configuration.stepDefinitions.getStarted.options.isEmpty)
+        XCTAssertFalse(featureFlagger.didCallResolveCohort)
+    }
+
+    func testWhenChromeCannotBeInstalledThenDoesNotResolveCohortOrIncludeOption() {
+        // Given
+        let featureFlagger = makeFeatureFlagger(cohort: .treatment)
+        let managerWithTreatment = makeExperimentManager(featureFlagger: featureFlagger, canInstall: false)
+
+        // When
+        managerWithTreatment.onboardingStarted()
+
+        // Then
+        XCTAssertTrue(managerWithTreatment.configuration.stepDefinitions.getStarted.options.isEmpty)
+        XCTAssertFalse(featureFlagger.didCallResolveCohort)
+    }
+
+    func testWhenCohortResolutionReturnsNilThenDoesNotEnrollOrIncludeOption() {
+        // Given
+        let featureFlagger = makeFeatureFlagger(cohort: nil)
+        chromeExtensionInstaller.canInstallDDGExtension = true
+        let experimentManager = makeExperimentManager(featureFlagger: featureFlagger)
+
+        // When
+        experimentManager.onboardingStarted()
+
+        // Then
+        XCTAssertTrue(experimentManager.configuration.stepDefinitions.getStarted.options.isEmpty)
+        XCTAssertTrue(featureFlagger.didCallResolveCohort)
+    }
+
+    func testWhenEligibilityBecomesTrueOnSecondOnboardingStartThenResolvesCohort() {
+        // Given
+        let featureFlagger = makeFeatureFlagger(cohort: .treatment)
+        let experimentManager = makeExperimentManager(featureFlagger: featureFlagger, canInstall: false)
+
+        // First access: not install-eligible → must not enroll
+        experimentManager.onboardingStarted()
+        XCTAssertTrue(experimentManager.configuration.stepDefinitions.getStarted.options.isEmpty)
+        XCTAssertFalse(featureFlagger.didCallResolveCohort)
+
+        // Later access: now install-eligible → must enroll and show treatment option
+        chromeExtensionInstaller.canInstallDDGExtension = true
+        experimentManager.onboardingStarted()
+        XCTAssertEqual(
+            experimentManager.configuration.stepDefinitions.getStarted.options,
+            [OnboardingOption.chromeExtensionInstall.rawValue]
+        )
+        XCTAssertTrue(featureFlagger.didCallResolveCohort)
+    }
+
+    func testSetDefaultCompletedExperimentMetricFiredWhenEnrolled() {
+        // Given
+        var firedEvents: [PixelKitEvent] = []
+        let featureFlagger = makeFeatureFlagger(cohort: .control)
+        let subfeatureID = MacOSBrowserConfigSubfeature.onboardingChromeExtension.rawValue
+        featureFlagger.allActiveExperiments = [
+            subfeatureID: ExperimentData(
+                parentID: PrivacyFeature.macOSBrowserConfig.rawValue,
+                cohortID: FeatureFlag.OnboardingChromeExtensionCohort.control.rawValue,
+                enrollmentDate: Date()
+            )
+        ]
+        PixelKit.configureExperimentKit(
+            featureFlagger: featureFlagger,
+            eventTracker: ExperimentEventTracker(store: MockExperimentActionPixelStore()),
+            fire: { event, _, _ in firedEvents.append(event) }
+        )
+        let experimentManager = makeExperimentManager(featureFlagger: featureFlagger)
+        experimentManager.onboardingStarted()
+
+        // When
+        experimentManager.setAsDefault()
+
+        // Then
+        XCTAssertTrue(firedEvents.contains(where: { $0.parameters?["metric"] == "setAsDefault" }))
+    }
+
+    func testSetDefaultCompletedExperimentMetricNotFiredWhenNotEnrolled() {
+        // Given
+        var firedEvents: [PixelKitEvent] = []
+        PixelKit.configureExperimentKit(
+            featureFlagger: MockFeatureFlagger(),
+            eventTracker: ExperimentEventTracker(store: MockExperimentActionPixelStore()),
+            fire: { event, _, _ in firedEvents.append(event) }
+        )
+
+        // When
+        manager.setAsDefault()
+
+        // Then
+        XCTAssertTrue(firedEvents.isEmpty)
     }
 
     func testExpectedShownPixelsFired_WhenRowShownTelemetryEventReported() {
@@ -715,4 +827,38 @@ class OnboardingManagerTests: XCTestCase {
         )
     }
 
+}
+
+// MARK: - Chrome extension experiment test helpers
+
+private extension OnboardingManagerTests {
+
+    func makeExperimentManager(
+        featureFlagger: MockFeatureFlagger,
+        canInstall: Bool = true
+    ) -> OnboardingActionsManager {
+        chromeExtensionInstaller.canInstallDDGExtension = canInstall
+        return OnboardingActionsManager(
+            navigationDelegate: navigationDelegate,
+            dockCustomization: dockCustomization,
+            defaultBrowserProvider: defaultBrowserProvider,
+            appearancePreferences: appearancePreferences,
+            startupPreferences: startupPreferences,
+            dataImportProvider: importProvider,
+            featureFlagger: featureFlagger,
+            onboardingSharedPixelHandler: onboardingSharedPixelHandler,
+            chromeExtensionInstaller: chromeExtensionInstaller
+        )
+    }
+
+    func makeFeatureFlagger(
+        cohort: FeatureFlag.OnboardingChromeExtensionCohort?,
+        isOnboardingRebrandingEnabled: Bool = true
+    ) -> MockFeatureFlagger {
+        let featureFlagger = MockFeatureFlagger(resolveCohortStub: cohort)
+        if isOnboardingRebrandingEnabled {
+            featureFlagger.enabledFeatureFlags = [.onboardingRebranding]
+        }
+        return featureFlagger
+    }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201621853593513/task/1216006558410871?focus=true
Experiment Design URL: https://app.asana.com/1/137249556945/project/1201621853593513/task/1215237652741235?focus=true
CC:

### Description

Implements the experiment design for the options to install the Chrome search extension during macOS onboarding (DMG only):
* Eligible users are enrolled in the experiment when onboarding starts.
* Users in the treatment cohort see the option to install the extension on the first step of onboarding.
* Experiment metrics are fired for enrolled users when Set as Default is requested (next step in onboarding) and when onboarding is completed.

This also removes the feature flag check from the Chrome extension installer, since the experiment cohort now determines whether the install option can be shown.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->

1. Make sure you are eligible for the option to install the Chrome extension:
   - Install Chrome if needed.
   - Check the Chrome search extension is not installed for you: Go to ~/Library/Application Support/Google/Chrome/External Extensions. If the file jhagicoeeifaamcacdeifbjacnbgbeip.json is in that folder, delete it.
   - Check no Chrome extension is installed in a Chrome profile: Open the Chrome app, open each Chrome profile, and go to chrome://extensions. If a DuckDuckGo extension is installed there, remove it.
   - Close Chrome.
2. Build and run the app (DMG build).
3. Go to Debug → Set Internal User State (if it isn't already set).
4. Go to Debug → Reset Data → Reset Onboarding.
5. Go to Debug → Feature Flag Overrides → onboardingChromeExtension (under Experiments) → Cohort: control.
6. Close the window and reopen it to start onboarding.
7. Confirm onboarding starts with no Chrome extension install option on the "Hi there!" screen.
8. Go to Debug → Feature Flag Overrides → onboardingChromeExtension (under Experiments) → Cohort: treatment.
9. Close the window and reopen it to restart onboarding.
10. On the "Hi there!" screen, check the box to install the Chrome search extension and click "Start browser setup."
11. Relaunch the Chrome app, select a profile, and use the prompt to enable the extension.

### Impact
Medium: Could disrupt the first step of onboarding (if install option is shown to wrong set of users)

#### What could go wrong?
* Unit tests cover expected user-facing behavior, e.g. install option being included or not
* Unit tests cover expected experiment setup, e.g. enrolling users and firing metrics when expected

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-step onboarding UX for eligible DMG users and depends on correct cohort enrollment; mis-assignment could show or hide the install option for the wrong users, though behavior is covered by unit tests.
> 
> **Overview**
> Adds a **control/treatment experiment** for offering the DuckDuckGo Chrome search extension on the first onboarding step, replacing the previous “feature flag on = show option” behavior.
> 
> **Enrollment and UI:** When onboarding rebranding (v4) is on and the user can install (DMG/Sparkle, Chrome present, extension not already installed), `onboardingStarted()` enrolls via `resolveCohort`. Only the **treatment** cohort gets the `chrome-extension-install` option on Get Started; control sees the same step without that checkbox.
> 
> **Metrics:** Enrolled users fire experiment pixels for **set as default** and **onboarding completed** (1-, 5-, and 7-day conversion windows), registered in `native_experiments.json5`. `onboardingChromeExtension` is wired with `OnboardingChromeExtensionCohort` in FeatureFlags.
> 
> **Installer:** `ChromeExtensionInstaller` no longer checks `onboardingChromeExtension`; eligibility for staging is environmental only. Gating the UI is handled by onboarding + cohort.
> 
> **Tests:** `MockFeatureFlagger` tracks cohort resolution/assignment; new unit tests cover the experiment helper and expanded onboarding manager scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d2b7a1f78886160e63a57e76780f201e56cfb9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->