### PR TITLE
[iOS] fix fire mode toggle in tab switcher in floating ui

### DIFF
--- a/iOS/DuckDuckGo/TabSwitcherPageViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherPageViewController.swift
@@ -67,6 +67,7 @@ class TabSwitcherPageViewController: UIViewController {
     private weak var previewsSource: TabPreviewsSource?
     private let tabSwitcherSettings: TabSwitcherSettings
     private var isFireModeEnabled: Bool
+    private let isFloatingUIEnabled: Bool
     private var tabObserverCancellable: AnyCancellable?
     private var trackerCountViewModel: TabSwitcherTrackerCountViewModel?
     private var trackerCountCancellable: AnyCancellable?
@@ -89,6 +90,7 @@ class TabSwitcherPageViewController: UIViewController {
          tabSwitcherSettings: TabSwitcherSettings,
          trackerCountViewModel: TabSwitcherTrackerCountViewModel?,
          isFireModeEnabled: Bool,
+         isFloatingUIEnabled: Bool = false,
          duckAIGridContentProvider: DuckAIGridContentProviding?,
          duckAIVoiceSessionTracker: DuckAIVoiceSessionTracking?) {
         self.browsingMode = browsingMode
@@ -97,6 +99,7 @@ class TabSwitcherPageViewController: UIViewController {
         self.tabSwitcherSettings = tabSwitcherSettings
         self.trackerCountViewModel = trackerCountViewModel
         self.isFireModeEnabled = isFireModeEnabled
+        self.isFloatingUIEnabled = isFloatingUIEnabled
         self.currentSelection = tabsModel.currentIndex
         self.duckAIGridContentProvider = duckAIGridContentProvider
         self.duckAIVoiceSessionTracker = duckAIVoiceSessionTracker
@@ -198,14 +201,23 @@ class TabSwitcherPageViewController: UIViewController {
         view.addSubview(hostingController.view)
         hostingController.didMove(toParent: self)
 
+        let topConstraint = isFloatingUIEnabled
+            ? hostingController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor,
+                                                          constant: FireModeEmptyStateMetrics.floatingNavigationBarClearance)
+            : hostingController.view.topAnchor.constraint(equalTo: view.topAnchor)
+
         NSLayoutConstraint.activate([
-            hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            topConstraint,
             hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
 
         fireModeEmptyStateHostingController = hostingController
+    }
+
+    private enum FireModeEmptyStateMetrics {
+        static let floatingNavigationBarClearance: CGFloat = 60
     }
 
     func updateEmptyStateVisibility() {

--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -306,6 +306,7 @@ class TabSwitcherViewController: UIViewController {
 
     private func setupPagingScrollView() {
         let isFireModeEnabled = fireModeCapability.isFireModeEnabled
+        let isFloatingUIEnabled = floatingUIManaging.isFloatingUIEnabled
 
         pagingScrollView = UIScrollView()
         pagingScrollView.isPagingEnabled = isFireModeEnabled
@@ -367,6 +368,7 @@ class TabSwitcherViewController: UIViewController {
                 tabSwitcherSettings: tabSwitcherSettings,
                 trackerCountViewModel: nil,
                 isFireModeEnabled: isFireModeEnabled,
+                isFloatingUIEnabled: isFloatingUIEnabled,
                 duckAIGridContentProvider: duckAIGridContentProvider,
                 duckAIVoiceSessionTracker: duckAIVoiceSessionTracker)
             firePageController?.pageDelegate = self


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1216791771246089?focus=true
Tech Design URL:
CC:

### Description
Update the tab switcher to fix layout of fire mode toggle.

### Testing Steps

1. Validate no feature flag leakage
2. Go to tab switcher
3. Check fire mode icon is now in right position.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Tab switcher UI could break

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only change gated on the existing floating UI flag; default initializer keeps prior behavior for the normal tabs page.
> 
> **Overview**
> When **floating tab switcher UI** is on, the fire-mode **empty state** was pinned to the page’s top edge, so it sat under the floating nav and the **fire mode toggle** looked misaligned.
> 
> This change threads `isFloatingUIEnabled` from `TabSwitcherViewController` into the fire `TabSwitcherPageViewController` and, only when that flag is true, anchors the empty state below the safe area with a **60pt** top inset (`FireModeEmptyStateMetrics.floatingNavigationBarClearance`). Non-floating layout is unchanged (still `view.topAnchor`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e694004cdd792a372033d5cf424ae28a1cd75d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->