### PR TITLE
[iOS] update tab switcher to match figma and support ios 18

### DIFF
--- a/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
+++ b/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
@@ -27,9 +27,7 @@ import DesignResourcesKitIcons
 /// renders liquid glass automatically on iOS 26+. Below iOS 26 the same layout is used with a
 /// solid bar background as a fallback.
 ///
-/// Floating UI is iPhone-only and does not support the bottom address bar position, so this
-/// chrome only ever handles the `regularSize` / `editingRegularSize` interface modes and always
-/// pins the top bar to the top and the bottom bar to the bottom.
+/// The floating tab switcher is iPhone-only and pins its bars to the top and bottom.
 @MainActor
 final class FloatingTabSwitcherChrome: TabSwitcherChrome {
 
@@ -37,6 +35,8 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         static let estimatedNavBarHeight: CGFloat = 50
         static let estimatedToolbarHeight: CGFloat = 49
         static let bottomFloatingInset: CGFloat = 8
+        static let fallbackToolbarHorizontalPadding: CGFloat = 20
+        static let fallbackAIButtonSpacing: CGFloat = 12
     }
 
     private let navigationBar = UINavigationBar()
@@ -51,7 +51,6 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
     private weak var centerView: UIView?
     private var glassCenterContainer: UIVisualEffectView?
     private var layoutConstraints: [NSLayoutConstraint] = []
-    private var title: String?
     private var isFireModeEnabled = false
 
     var actions = TabSwitcherChromeActions()
@@ -69,24 +68,38 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         menu: UIMenu(children: []))
 
     private lazy var doneItem: UIBarButtonItem = {
-        let item = UIBarButtonItem(title: nil,
-                                   image: UIImage(systemName: "checkmark"),
-                                   primaryAction: UIAction { [weak self] _ in self?.actions.onDoneTapped?() },
-                                   menu: nil)
-        item.accessibilityLabel = UserText.navigationTitleDone
-        // Prominent style gives an accent-filled glass capsule (with a contrasting white
-        // checkmark) sized like the other glass bar buttons. The fill colour comes from
-        // `tintColor`, set in `decorate(theme:)`.
+        let action = UIAction { [weak self] _ in self?.actions.onDoneTapped?() }
+        let item: UIBarButtonItem
         if #available(iOS 26.0, *) {
+            item = UIBarButtonItem(title: nil,
+                                   image: UIImage(systemName: "checkmark"),
+                                   primaryAction: action,
+                                   menu: nil)
             item.style = .prominent
+        } else {
+            item = UIBarButtonItem(systemItem: .done,
+                                   primaryAction: action,
+                                   menu: nil)
         }
+        item.accessibilityLabel = UserText.navigationTitleDone
         return item
     }()
 
-    private lazy var closeItem = UIBarButtonItem(
-        systemItem: .close,
-        primaryAction: UIAction { [weak self] _ in self?.actions.onDoneTapped?() },
-        menu: nil)
+    private lazy var selectionTitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.daxHeadline()
+        label.textColor = UIColor(designSystemColor: .textPrimary)
+        return label
+    }()
+
+    private lazy var selectionTitleItem: UIBarButtonItem = {
+        let item = UIBarButtonItem(customView: selectionTitleLabel)
+        if #available(iOS 26.0, *) {
+            item.sharesBackground = false
+            item.hidesSharedBackground = true
+        }
+        return item
+    }()
 
     private lazy var selectAllItem = UIBarButtonItem(
         title: UserText.selectAllTabs,
@@ -102,13 +115,13 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
 
     private lazy var editMenuItem = UIBarButtonItem(
         title: nil,
-        image: DesignSystemImages.Glyphs.Size24.menuDotsHorizontal,
+        image: menuImage,
         primaryAction: nil,
         menu: UIMenu(children: []))
 
     private lazy var multiSelectMenuItem = UIBarButtonItem(
         title: nil,
-        image: DesignSystemImages.Glyphs.Size24.menuDotsHorizontal,
+        image: menuImage,
         primaryAction: nil,
         menu: UIMenu(children: []))
 
@@ -224,7 +237,7 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
     }
 
     func setTitle(_ title: String?) {
-        self.title = title
+        selectionTitleLabel.text = title
     }
 
     func configurePlusButtonLongPressMenu(isFireModeEnabled: Bool) {
@@ -263,7 +276,11 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         let tint = UIColor(singleUseColor: .toolbarButton)
         navigationBar.tintColor = tint
         toolbar.tintColor = tint
-        doneItem.tintColor = UIColor(designSystemColor: .accentPrimary)
+        if #available(iOS 26.0, *) {
+            doneItem.tintColor = UIColor(designSystemColor: .accentPrimary)
+        } else {
+            doneItem.tintColor = theme.navigationBarTintColor
+        }
         configureBarMaterials()
     }
 
@@ -283,13 +300,13 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
 
         if isEditing {
             navigationItem.titleView = nil
-            navigationItem.title = title
-            navigationItem.leftBarButtonItems = [closeItem]
+            navigationItem.title = nil
+            navigationItem.leftBarButtonItems = [selectionTitleItem]
             navigationItem.rightBarButtonItems = [params.selectedCount == params.totalCount ? deselectAllItem : selectAllItem]
 
             closeTabsItem.title = UserText.closeTabs(withCount: params.selectedCount)
             closeTabsItem.isEnabled = params.selectedCount > 0
-            toolbar.setItems([multiSelectMenuItem, .flexibleSpace(), closeTabsItem], animated: false)
+            setToolbarItems([doneItem, .flexibleSpace(), closeTabsItem, multiSelectMenuItem])
         } else {
             navigationItem.title = nil
             navigationItem.titleView = centerTitleView()
@@ -298,9 +315,12 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
 
             var items: [UIBarButtonItem] = [editMenuItem, .flexibleSpace(), fireItem, .flexibleSpace(), plusItem]
             if params.showAIChat {
+                if #unavailable(iOS 26.0) {
+                    items.append(.fixedSpace(Metrics.fallbackAIButtonSpacing))
+                }
                 items.append(duckChatItem)
             }
-            toolbar.setItems(items, animated: false)
+            setToolbarItems(items)
         }
     }
 
@@ -349,6 +369,23 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
     }
 
     // MARK: - Private
+
+    private var menuImage: UIImage {
+        if #available(iOS 26.0, *) {
+            return DesignSystemImages.Glyphs.Size24.menuDotsHorizontal
+        }
+        return DesignSystemImages.Glyphs.Size24.moreApple
+    }
+
+    private func setToolbarItems(_ items: [UIBarButtonItem]) {
+        if #available(iOS 26.0, *) {
+            toolbar.setItems(items, animated: false)
+        } else {
+            toolbar.setItems([.fixedSpace(Metrics.fallbackToolbarHorizontalPadding)] + items
+                             + [.fixedSpace(Metrics.fallbackToolbarHorizontalPadding)],
+                             animated: false)
+        }
+    }
 
     private func makeTabsStyleMenu(current: TabSwitcherViewController.TabsStyle) -> UIMenu {
         let grid = UIAction(title: UserText.tabSwitcherGridViewMenuTitle,

--- a/iOS/DuckDuckGo/FloatingUI/FloatingUIManager.swift
+++ b/iOS/DuckDuckGo/FloatingUI/FloatingUIManager.swift
@@ -24,6 +24,7 @@ import PrivacyConfig
 
 protocol FloatingUIManaging {
     var isFloatingUIEnabled: Bool { get }
+    var isFloatingTabSwitcherEnabled: Bool { get }
 }
 
 final class FloatingUIManager: FloatingUIManaging {
@@ -32,14 +33,17 @@ final class FloatingUIManager: FloatingUIManaging {
     private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
     private let isPad: () -> Bool
     private let isSupportedOS: () -> Bool
+    private let isTabSwitcherSupportedOS: () -> Bool
 
     init(featureFlagger: any FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
          isPadProvider: @escaping () -> Bool = { DevicePlatform.isIpad },
          isSupportedOSProvider: @escaping () -> Bool = { if #available(iOS 26, *) { true } else { false } },
+         isTabSwitcherSupportedOSProvider: @escaping () -> Bool = { if #available(iOS 18, *) { true } else { false } },
          unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature()) {
         self.featureFlagger = featureFlagger
         self.isPad = isPadProvider
         self.isSupportedOS = isSupportedOSProvider
+        self.isTabSwitcherSupportedOS = isTabSwitcherSupportedOSProvider
         self.unifiedToggleInputFeature = unifiedToggleInputFeature
     }
 
@@ -47,5 +51,9 @@ final class FloatingUIManager: FloatingUIManaging {
         // iPhone-only, iOS 26+ (for obscuredContentInsets), and requires Unified Toggle Input.
         guard featureFlagger.isFeatureOn(.floatingUI), !isPad(), isSupportedOS() else { return false }
         return unifiedToggleInputFeature.isAvailable
+    }
+
+    var isFloatingTabSwitcherEnabled: Bool {
+        featureFlagger.isFeatureOn(.floatingUI) && !isPad() && isTabSwitcherSupportedOS()
     }
 }

--- a/iOS/DuckDuckGo/TabSwitcherChrome.swift
+++ b/iOS/DuckDuckGo/TabSwitcherChrome.swift
@@ -88,13 +88,13 @@ extension TabSwitcherChrome {
     func trackScrollEdge(of scrollView: UIScrollView) {}
 }
 
-/// Selects the chrome implementation based on whether floating UI is enabled.
+/// Selects the tab switcher chrome implementation.
 enum TabSwitcherChromeFactory {
 
     @MainActor
-    static func makeChrome(isFloatingUIEnabled: Bool,
+    static func makeChrome(isFloatingTabSwitcherEnabled: Bool,
                            appSettings: AppSettings) -> TabSwitcherChrome {
-        if isFloatingUIEnabled {
+        if isFloatingTabSwitcherEnabled {
             return FloatingTabSwitcherChrome()
         }
         return LegacyTabSwitcherChrome(appSettings: appSettings)

--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -298,8 +298,7 @@ class TabSwitcherViewController: UIViewController {
     }
 
     private func makeChrome() -> TabSwitcherChrome {
-        let isFloating = floatingUIManaging.isFloatingUIEnabled
-        let chrome = TabSwitcherChromeFactory.makeChrome(isFloatingUIEnabled: isFloating,
+        let chrome = TabSwitcherChromeFactory.makeChrome(isFloatingTabSwitcherEnabled: floatingUIManaging.isFloatingTabSwitcherEnabled,
                                                          appSettings: appSettings)
         return chrome
     }

--- a/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
+++ b/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
@@ -100,6 +100,7 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
 
     func testWhenEditingThenBottomBarHasDoneCloseTabsAndMenu() {
         let chrome = makeInstalledChrome()
+        chrome.actions.onMultiSelectMenuRequested = { UIMenu(children: []) }
 
         chrome.update(state: .editingRegularSize(selectedCount: 2, totalCount: 4),
                       tabsStyle: .grid,

--- a/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
+++ b/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
@@ -44,6 +44,9 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
         XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.count, 1)
         XCTAssertNil(chrome.navigationItem.title)
         XCTAssertNotNil(chrome.navigationItem.leftBarButtonItems?.first?.menu)
+        if #unavailable(iOS 26.0) {
+            XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.first?.title, UserText.navigationTitleDone)
+        }
     }
 
     func testWhenRegularSizeWithoutAIChatThenBottomBarHasNoDuckChat() {
@@ -54,8 +57,13 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
                       canShowSelectionMenu: false,
                       isEditing: false)
 
-        // editMenu, flex, fire, flex, plus
-        XCTAssertEqual(chrome.toolbar.items?.count, 5)
+        if #available(iOS 26.0, *) {
+            XCTAssertEqual(chrome.toolbar.items?.count, 5)
+        } else {
+            XCTAssertEqual(chrome.toolbar.items?.count, 7)
+            XCTAssertEqual(chrome.toolbar.items?.first?.width, 20)
+            XCTAssertEqual(chrome.toolbar.items?.last?.width, 20)
+        }
     }
 
     func testWhenRegularSizeWithAIChatThenBottomBarHasDuckChat() {
@@ -66,11 +74,15 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
                       canShowSelectionMenu: false,
                       isEditing: false)
 
-        // editMenu, flex, fire, flex, plus, duckChat
-        XCTAssertEqual(chrome.toolbar.items?.count, 6)
+        if #available(iOS 26.0, *) {
+            XCTAssertEqual(chrome.toolbar.items?.count, 6)
+        } else {
+            XCTAssertEqual(chrome.toolbar.items?.count, 9)
+            XCTAssertEqual(chrome.toolbar.items?[6].width, 12)
+        }
     }
 
-    func testWhenEditingThenTopBarHasCloseAndSelectAll() {
+    func testWhenEditingThenTopBarHasLeadingTitleAndSelectAll() {
         let chrome = makeInstalledChrome()
         chrome.setTitle("2 Selected")
 
@@ -79,9 +91,32 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
                       canShowSelectionMenu: true,
                       isEditing: true)
 
-        XCTAssertEqual(chrome.navigationItem.title, "2 Selected")
+        XCTAssertEqual((chrome.navigationItem.leftBarButtonItems?.first?.customView as? UILabel)?.text, "2 Selected")
+        XCTAssertEqual(chrome.navigationItem.leftBarButtonItems?.count, 1)
+        XCTAssertNil(chrome.navigationItem.title)
         XCTAssertNil(chrome.navigationItem.titleView)
         XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.first?.title, UserText.selectAllTabs)
+    }
+
+    func testWhenEditingThenBottomBarHasDoneCloseTabsAndMenu() {
+        let chrome = makeInstalledChrome()
+
+        chrome.update(state: .editingRegularSize(selectedCount: 2, totalCount: 4),
+                      tabsStyle: .grid,
+                      canShowSelectionMenu: true,
+                      isEditing: true)
+
+        let items = chrome.toolbar.items ?? []
+        let doneIndex = items.firstIndex { $0.accessibilityLabel == UserText.navigationTitleDone }
+        let closeTabsIndex = items.firstIndex { $0.title == UserText.closeTabs(withCount: 2) }
+        let menuIndex = items.firstIndex { $0.menu != nil }
+
+        guard let doneIndex, let closeTabsIndex, let menuIndex else {
+            XCTFail("Missing selection toolbar items")
+            return
+        }
+        XCTAssertLessThan(doneIndex, closeTabsIndex)
+        XCTAssertLessThan(closeTabsIndex, menuIndex)
     }
 
     func testWhenAllSelectedWhileEditingThenShowsDeselectAll() {
@@ -103,7 +138,8 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
                       canShowSelectionMenu: false,
                       isEditing: true)
 
-        XCTAssertEqual(chrome.toolbar.items?.last?.isEnabled, false)
+        let closeTabsItem = chrome.toolbar.items?.first { $0.title == UserText.closeTabs(withCount: 0) }
+        XCTAssertEqual(closeTabsItem?.isEnabled, false)
     }
 
     func testWhenTabsSelectedWhileEditingThenCloseTabsEnabled() {
@@ -114,7 +150,8 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
                       canShowSelectionMenu: true,
                       isEditing: true)
 
-        XCTAssertEqual(chrome.toolbar.items?.last?.isEnabled, true)
+        let closeTabsItem = chrome.toolbar.items?.first { $0.title == UserText.closeTabs(withCount: 2) }
+        XCTAssertEqual(closeTabsItem?.isEnabled, true)
     }
 
     func testWhenStyleMenuBuiltThenItHasGridAndListActions() {

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -78,6 +78,49 @@ final class FloatingUIManagerTests: XCTestCase {
 
         XCTAssertFalse(manager.isFloatingUIEnabled)
     }
+
+    func testWhenFloatingUIIsEnabledOnSupportedIPhoneThenFloatingTabSwitcherIsEnabled() {
+        let manager = FloatingUIManager(
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.floatingUI]),
+            isPadProvider: { false },
+            isSupportedOSProvider: { false },
+            isTabSwitcherSupportedOSProvider: { true },
+            unifiedToggleInputFeature: MockUnifiedToggleInputFeatureProvider(isAvailable: false)
+        )
+
+        XCTAssertFalse(manager.isFloatingUIEnabled)
+        XCTAssertTrue(manager.isFloatingTabSwitcherEnabled)
+    }
+
+    func testWhenFloatingUIIsDisabledThenFloatingTabSwitcherIsDisabled() {
+        let manager = FloatingUIManager(
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: []),
+            isPadProvider: { false },
+            isTabSwitcherSupportedOSProvider: { true }
+        )
+
+        XCTAssertFalse(manager.isFloatingTabSwitcherEnabled)
+    }
+
+    func testWhenFloatingUIIsEnabledOnIPadThenFloatingTabSwitcherIsDisabled() {
+        let manager = FloatingUIManager(
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.floatingUI]),
+            isPadProvider: { true },
+            isTabSwitcherSupportedOSProvider: { true }
+        )
+
+        XCTAssertFalse(manager.isFloatingTabSwitcherEnabled)
+    }
+
+    func testWhenTabSwitcherOSIsUnsupportedThenFloatingTabSwitcherIsDisabled() {
+        let manager = FloatingUIManager(
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.floatingUI]),
+            isPadProvider: { false },
+            isTabSwitcherSupportedOSProvider: { false }
+        )
+
+        XCTAssertFalse(manager.isFloatingTabSwitcherEnabled)
+    }
 }
 
 final class FloatingUILayoutPolicyTests: XCTestCase {

--- a/iOS/DuckDuckGoTests/TabSwitcherChromeFactoryTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherChromeFactoryTests.swift
@@ -23,14 +23,14 @@ import XCTest
 @MainActor
 final class TabSwitcherChromeFactoryTests: XCTestCase {
 
-    func testWhenFloatingUIEnabledThenFloatingChromeIsCreated() {
-        let chrome = TabSwitcherChromeFactory.makeChrome(isFloatingUIEnabled: true,
+    func testWhenFloatingTabSwitcherEnabledThenFloatingChromeIsCreated() {
+        let chrome = TabSwitcherChromeFactory.makeChrome(isFloatingTabSwitcherEnabled: true,
                                                          appSettings: AppSettingsMock())
         XCTAssertTrue(chrome is FloatingTabSwitcherChrome)
     }
 
-    func testWhenFloatingUIDisabledThenLegacyChromeIsCreated() {
-        let chrome = TabSwitcherChromeFactory.makeChrome(isFloatingUIEnabled: false,
+    func testWhenFloatingTabSwitcherDisabledThenLegacyChromeIsCreated() {
+        let chrome = TabSwitcherChromeFactory.makeChrome(isFloatingTabSwitcherEnabled: false,
                                                          appSettings: AppSettingsMock())
         XCTAssertTrue(chrome is LegacyTabSwitcherChrome)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1216791771254388?focus=true
Tech Design URL:
CC:

### Description
Updates the flagged tab switcher on iPhone to support iOS 18 and match the platform-specific toolbar designs. Selection mode now uses the revised control layout.

### Testing Steps

1. Ensure no feature flag leakage. 
1. Enable the Floating UI feature flag on an iOS 18 iPhone.
2. Open the tab switcher → standard Done button and correctly spaced toolbar controls appear.
3. Choose Select Tabs → tab count appears top-left and Done, Close Tabs, and menu controls appear along the bottom.
4. Select one or more tabs → the selected count and Close Tabs button update correctly.
5. Repeat on iOS 26 → Liquid Glass controls and the blue checkmark Done button remain intact.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The revised tab switcher could appear on unsupported devices → mitigated by iPhone and iOS 18 availability guards.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only tab switcher chrome and feature gating on iPhone/iOS 18+; no auth, data, or core browsing logic changes.
> 
> **Overview**
> **Decouples the floating tab switcher from full Floating UI** so it can show on **iPhone + iOS 18+** when the Floating UI flag is on, without requiring iOS 26 or Unified Toggle Input. `TabSwitcherViewController` now uses `isFloatingTabSwitcherEnabled` instead of `isFloatingUIEnabled` when picking chrome.
> 
> **`FloatingTabSwitcherChrome` adds pre–iOS 26 fallback behavior** while keeping liquid-glass layout on iOS 26+: standard **Done** in the nav bar (prominent checkmark only on 26+), **more**-style overflow icons, and extra toolbar fixed spacing (including before AI chat). **Selection mode** matches the revised design: selected count as a **leading custom title** in the top bar, and the bottom bar is **Done → Close Tabs → menu** (replacing top close + bottom-only close/menu).
> 
> Tests cover the new gating and OS-specific toolbar item counts/layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28fa31691f0ad83a8e4935197d6344ba9e1b07d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->