### PR TITLE
[macOS] Fix favicon flicker in Bookmarks Manager

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkManagementDetailViewController.swift
@@ -353,7 +353,7 @@ final class BookmarkManagementDetailViewController: NSViewController, NSMenuItem
     }
 
     /// Bookmark favicons are lazy-loaded: `Bookmark.favicon(.small)` may return `nil` on a cache miss and the
-    /// cell falls back to a default icon. When the image is decoded later, `.faviconCacheUpdated` is posted; reload
+    /// cell falls back to a default icon. When the image is decoded later, `.faviconCacheUpdated` is posted; refresh
     /// the table when the update relates to a host currently displayed in the list (or defensively if no payload).
     private func subscribeToFaviconCacheUpdates() {
         NotificationCenter.default.publisher(for: .faviconCacheUpdated)
@@ -363,7 +363,7 @@ final class BookmarkManagementDetailViewController: NSViewController, NSMenuItem
                 if let update = notification.faviconsCacheUpdate, update.hosts.isDisjoint(with: self.displayedBookmarkHosts) {
                     return
                 }
-                self.reloadData()
+                self.refreshFavicons()
             }
             .store(in: &cancellables)
     }
@@ -371,6 +371,18 @@ final class BookmarkManagementDetailViewController: NSViewController, NSMenuItem
     /// Hosts of the bookmarks currently visible in the list, used to filter favicon-cache updates.
     private var displayedBookmarkHosts: Set<String> {
         Set(managementDetailViewModel.visibleBookmarks.compactMap { ($0 as? Bookmark)?.urlObject?.host })
+    }
+
+    /// Refreshes favicons in place on the currently-visible rows instead of `reloadData()`. Rebuilding every
+    /// cell on each favicon-cache update would flicker the icons (blank/placeholder during the decode window).
+    private func refreshFavicons() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        let visibleRows = tableView.rows(in: tableView.visibleRect)
+        guard visibleRows.length > 0 else { return }
+        for row in visibleRows.location..<(visibleRows.location + visibleRows.length) {
+            guard let cell = tableView.view(atColumn: 0, row: row, makeIfNecessary: false) as? BookmarkTableCellView else { continue }
+            cell.refreshDisplayedFavicon()
+        }
     }
 
     override func keyDown(with event: NSEvent) {

--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkTableCellView.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkTableCellView.swift
@@ -233,6 +233,13 @@ final class BookmarkTableCellView: NSTableCellView {
         tertiaryTitleLabelValue = bookmark.url
     }
 
+    /// Upgrades the displayed favicon in place once it becomes available, without touching the rest of the
+    /// cell. Never falls back to the placeholder icon, so a transient cache miss doesn't blank a real favicon.
+    func refreshDisplayedFavicon() {
+        guard let bookmark = entity as? Bookmark, let favicon = bookmark.favicon(.small) else { return }
+        faviconImageView.image = favicon
+    }
+
     func update(from folder: BookmarkFolder) {
         self.entity = folder
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201621708115095/task/1216805871906308?focus=true

### Description
Same family of bug as the tab bar and bookmarks bar favicon flicker fixes (#5534, #5539). Bookmarks
Manager already filtered `.faviconCacheUpdated` notifications by displayed hosts, but still reloaded
the whole table on a match, which momentarily blanked favicons back to the placeholder icon while
the row was rebuilt. Now the list refreshes favicons in place on visible rows instead of reloading,
upgrading placeholder → real icon and never downgrading back.

### Testing Steps
Note that this is very rarely reproducible – the fix, however, is based on previous fixes to other views, that have proven helpful.
1. Open Bookmarks Manager with a list containing bookmarks whose real favicons differ from the default placeholder.
2. Scroll through / search the list to trigger favicon cache updates (decoding continues in the background).
3. Observe that correct favicons are displayed and there's no flickering.

### Impact
Low: visual bug fix only, no behavior change to bookmark data.

### Quality Considerations
Mirrors the established fix pattern from `BookmarksBarCollectionViewItem`/`BookmarksBarViewController` (#5534) and `BookmarkOutlineCellView`/`BookmarksBarMenuViewController` (#5539): in-place, upgrade-only favicon refresh instead of a full reload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to how favicons refresh; bookmark data and list behavior are unchanged.
> 
> **Overview**
> Fixes favicon flicker in **Bookmarks Manager** when lazy-loaded icons finish decoding. The list still filters `.faviconCacheUpdated` by displayed hosts, but on a match it no longer calls **`reloadData()`** (which rebuilt rows and briefly showed placeholders).
> 
> Instead, **`refreshFavicons()`** walks **visible** table rows and calls **`BookmarkTableCellView.refreshDisplayedFavicon()`**, which sets the image only when `bookmark.favicon(.small)` is non-nil—so icons upgrade from placeholder to real without downgrading an already-shown favicon. Same in-place, upgrade-only pattern as the bookmarks bar and outline fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e5c4d32341fbb4e7f36235923e49b749407fb39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->