### PR TITLE
iOS: Change UTI card background color to red

### DIFF
--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
@@ -333,7 +333,7 @@ struct DefaultColorPalette: ColorPaletteDefinition {
         case .duckAIWebViewBackground:
             return DynamicColor(lightColor: .white, darkColor: .x111111)
         case .unifiedToggleInputCardBackground:
-            return DynamicColor(lightColor: .white, darkColor: x3D3D3D)
+            return DynamicColor(lightColor: .red50, darkColor: .red50)
         case .unifiedToggleInputStopButtonBackground:
             return DynamicColor(lightColor: .shade(0.06), darkColor: .tint(0.12))
         case .floatingAddressBarBackground:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1216816016174734
Tech Design URL:
CC:

### Description
Changes the Unified Toggle Input (UTI) card background single-use color token (`unifiedToggleInputCardBackground`) to use the design system's `red50` color for both light and dark appearances, instead of white/dark-gray.

### Testing Steps
1. Open the app and view the Unified Toggle Input bar → background renders red in both light and dark mode.

### Impact
Low: Visual-only change to a single background color token.

### Quality Considerations
None — single-line design token change, no logic affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MGe2WxtpXYYrV7PvoHGkKG)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single design-token color swap with no logic changes; visual-only impact on the unified toggle input chrome.
> 
> **Overview**
> Updates the **`unifiedToggleInputCardBackground`** single-use color in `DefaultColorPalette` so the Unified Toggle Input (UTI) card uses **`red50`** in both light and dark mode, replacing white (light) and `#3D3D3D` (dark).
> 
> Any UI that resolves this token—e.g. the UTI card and legacy AI tab accessory button in `UnifiedToggleInputView`—will show the new red background; fire-tab cards still use `.fireModeCardBackground` and are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 269c4c77042dbf98dca09a5efa4266e91ec89a2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->