### PR TITLE
iOS: Test - change unified toggle input color to pink

### DIFF
--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
@@ -333,7 +333,7 @@ struct DefaultColorPalette: ColorPaletteDefinition {
         case .duckAIWebViewBackground:
             return DynamicColor(lightColor: .white, darkColor: .x111111)
         case .unifiedToggleInputCardBackground:
-            return DynamicColor(lightColor: .white, darkColor: x3D3D3D)
+            return DynamicColor(lightColor: .pink, darkColor: .pink)
         case .unifiedToggleInputStopButtonBackground:
             return DynamicColor(lightColor: .shade(0.06), darkColor: .tint(0.12))
         case .floatingAddressBarBackground:

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
@@ -44,7 +44,7 @@ public enum SingleUseColor {
     /// Duck.ai web view background color (#FFFFFF light / #111111 dark)
     case duckAIWebViewBackground
 
-    /// Card background for the unified toggle input bar (white in light, #3D3D3D in dark)
+    /// Card background for the unified toggle input bar (pink in light, pink in dark)
     case unifiedToggleInputCardBackground
     case unifiedToggleInputAttachmentErrorBannerBackground
     case unifiedToggleInputAttachmentErrorText


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1216816016174736
Tech Design URL:
CC:

### Description
Changes the background of the Unified Toggle Input card (the search/Duck.ai toggle input bar) to pink in both light and dark mode, via the `unifiedToggleInputCardBackground` single-use color token. This token is dedicated to this component only, so the change is isolated and doesn't affect the shared `DesignSystemColor` tokens used by the toggle pill itself.

### Testing Steps
1. Open the app and trigger the Unified Toggle Input bar (search/Duck.ai toggle) → card background renders pink in light mode.
2. Switch to dark mode → card background renders pink in dark mode.

### Impact
Low: cosmetic color-only change to a single test-designated component, no logic changes.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Brak7bD8LYE9WaZg2k548)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated UI color token change with no logic, auth, or data impact.
> 
> **Overview**
> **Test-only cosmetic change:** the Unified Toggle Input bar card background now uses **pink** in both light and dark mode via the `unifiedToggleInputCardBackground` single-use color token.
> 
> Previously this token mapped to white (light) and `#3D3D3D` (dark). The palette switch and the `SingleUseColor` doc comment were updated to match; no other design tokens or logic are touched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 088cee5bf3177406fcdba672f1d43dde060258e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->