### PR TITLE
iOS: Test - change unified toggle input color to pink

### DIFF
--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
@@ -52,6 +52,7 @@ struct DefaultColorPalette: ColorPaletteDefinition {
     private static let xF6CDD1 = Color(0xF6CDD1)
     private static let x5A2A2A = Color(0x5A2A2A)
     private static let xD4452F = Color(0xD4452F)
+    private static let xFFC0CB = Color(0xFFC0CB)
 
     // URL bar
     private static let urlBar = DynamicColor(lightColor: .white, darkColor: x474747)
@@ -333,7 +334,7 @@ struct DefaultColorPalette: ColorPaletteDefinition {
         case .duckAIWebViewBackground:
             return DynamicColor(lightColor: .white, darkColor: .x111111)
         case .unifiedToggleInputCardBackground:
-            return DynamicColor(lightColor: .white, darkColor: x3D3D3D)
+            return DynamicColor(lightColor: xFFC0CB, darkColor: xFFC0CB)
         case .unifiedToggleInputStopButtonBackground:
             return DynamicColor(lightColor: .shade(0.06), darkColor: .tint(0.12))
         case .floatingAddressBarBackground:

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
@@ -44,7 +44,7 @@ public enum SingleUseColor {
     /// Duck.ai web view background color (#FFFFFF light / #111111 dark)
     case duckAIWebViewBackground
 
-    /// Card background for the unified toggle input bar (white in light, #3D3D3D in dark)
+    /// Card background for the unified toggle input bar (pink)
     case unifiedToggleInputCardBackground
     case unifiedToggleInputAttachmentErrorBannerBackground
     case unifiedToggleInputAttachmentErrorText


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1216816016174736
Tech Design URL:
CC:

### Description
Changed the `unifiedToggleInputCardBackground` single-use color to pink (`#FFC0CB`) for both light and dark mode.

### Testing Steps
1. Open the unified toggle input (e.g. via the address bar / fire button entry point) in both light and dark mode → the card background renders pink.

### Impact
Low: cosmetic color change to a single-use design token, no logic changes.

Co-Authored-By: Claude <noreply@anthropic.com>