### PR TITLE
iOS: Test - change unified toggle input color to pink

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
@@ -63,7 +63,7 @@ final class UnifiedToggleInputToggleView: UIView {
 
     private lazy var backgroundView: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor(designSystemColor: .controlsRaisedBackdrop)
+        view.backgroundColor = UIColor.systemPink
         view.alpha = 0.5
         view.layer.cornerRadius = Constants.cornerRadius
         view.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1216816016174736
Tech Design URL:
CC:

### Description
Changes the unified toggle input's pill background color to pink for a test task.

### Testing Steps
1. Open the unified toggle input (Search/Duck.ai segmented control) in the address bar → pill background renders in pink.

### Impact
Low: Minor visual/test-only change.


---
_Generated by [Claude Code](https://claude.ai/code/session_011X3pysSJG9WiZauYiWxQ6Z)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-off UI color swap with no logic, data, or auth impact; should be reverted before release if not intended for production.
> 
> **Overview**
> **Test-only visual tweak** for the address-bar Search / Duck.ai pill (`UnifiedToggleInputToggleView`).
> 
> The raised backdrop behind the segmented control no longer uses the design token `controlsRaisedFillPrimary` / `.controlsRaisedBackdrop`; it is set to **`UIColor.systemPink`** (still at 0.5 alpha). The sliding indicator and other styling are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba2e18ba17bb373e2c627e4d3e464f312d30aa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->