### PR TITLE
iOS: Test - change unified toggle input color to pink

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
@@ -72,7 +72,7 @@ final class UnifiedToggleInputToggleView: UIView {
 
     private lazy var indicator: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor(designSystemColor: .controlsRaisedFillPrimary)
+        view.backgroundColor = UIColor.systemPink
         view.layer.cornerRadius = Constants.innerCornerRadius
         view.layer.shadowColor = UIColor(designSystemColor: .shadowSecondary).cgColor
         view.layer.shadowOpacity = 1.0


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1216816016174736
Tech Design URL:
CC:

### Description
Changes the Unified Toggle Input's indicator (pill) background color to pink, scoped to this one component only.

### Testing Steps
1. Open any settings screen using the Unified Toggle Input control → the toggle's indicator pill renders pink instead of the previous design-system fill color.

### Impact
Low: Minor visual change to a single UI control.

### Quality Considerations
This is a test task for validating the automated task pipeline; the color change intentionally uses `UIColor.systemPink` locally rather than introducing a new shared design-system token, since it only affects this one component.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NB2bxvMF7q1g3uj1gaS264)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component cosmetic color swap with no logic, auth, or data changes.
> 
> **Overview**
> Updates the **Unified Toggle Input** sliding indicator pill in `UnifiedToggleInputToggleView` so its background uses **`UIColor.systemPink`** instead of the design-system token **`.controlsRaisedFillPrimary`**.
> 
> Scope is limited to that indicator view; backdrop, shadows, and segment buttons are unchanged. Intended as a pipeline test, not a new shared design token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31f4baf2cd3f48e993a66e6651fcffe48f1088bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->