### PR TITLE
iOS: Test - change unified toggle input color to pink

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToggleView.swift
@@ -72,7 +72,7 @@ final class UnifiedToggleInputToggleView: UIView {
 
     private lazy var indicator: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor(designSystemColor: .controlsRaisedFillPrimary)
+        view.backgroundColor = UIColor.systemPink
         view.layer.cornerRadius = Constants.innerCornerRadius
         view.layer.shadowColor = UIColor(designSystemColor: .shadowSecondary).cgColor
         view.layer.shadowOpacity = 1.0


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1216816016174736
Tech Design URL:
CC:

### Description
Changes the Unified Toggle Input's sliding indicator background color to pink (`UIColor.systemPink`), isolated to this component's usage site only. The shared `.controlsRaisedFillPrimary` design system token (used by other components) is left untouched.

### Testing Steps
1. Open the address bar / Unified Toggle Input on iOS → the sliding indicator behind the Search/Duck.ai segments is pink.

### Impact
Low: visual-only change to a single component, for pipeline verification purposes.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

---
_Generated by [Claude Code](https://claude.ai/code/session_014wMc8PsUNRw7PaPHcUmtQb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line UI color change with no logic, auth, or data impact; intended for pipeline verification.
> 
> **Overview**
> **Visual-only change** to the address bar **Unified Toggle Input**: the sliding pill behind Search / Duck.ai now uses **`UIColor.systemPink`** instead of the design token **`.controlsRaisedFillPrimary`**.
> 
> The swap is **local to `UnifiedToggleInputToggleView`**’s `indicator` view only; shared design system tokens used elsewhere are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c606aabb53a5aa9bbf94c40099e9e8ed087b872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->