### PR TITLE
Remove iPadPageContext feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -524,9 +524,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables deleting recent AI chats from the New Tab Page omnibar
     case ntpSuggestionsDeletion
 
-    /// Enables page context feature on iPad
-    case iPadPageContext
-
     /// Enables voice chat shortcut in the focused address bar
     case voiceShortcut
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -310,9 +310,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213433942918287?focus=true
     case multiplePageContexts
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213608678718359?focus=true
-    case iPadPageContext
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212980785692847?focus=true
     case aiChatSync
 
@@ -751,8 +748,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.autoAttachContextByDefault))
         case .multiplePageContexts:
             Config(source: .remoteReleasable(AIChatSubfeature.multiplePageContexts))
-        case .iPadPageContext:
-            Config(source: .remoteReleasable(AIChatSubfeature.iPadPageContext))
         case .aiChatSync:
             Config(source: .remoteReleasable(SyncSubfeature.aiChatSync))
         case .aiChatSyncPromo:

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualModeFeature.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualModeFeature.swift
@@ -31,7 +31,7 @@ protocol AIChatContextualModeFeatureProviding {
     /// - The `contextualDuckAIMode` sub-feature flag is enabled
     /// - The AI Chat URL domain is `duck.ai`
     /// - On iPhone: the `pageContextFeature` flag is enabled
-    /// - On iPad: the `iPadPageContext` flag is enabled
+    /// - On iPad: always enabled
     var isAvailable: Bool { get }
 }
 
@@ -61,6 +61,6 @@ struct AIChatContextualModeFeature: AIChatContextualModeFeatureProviding {
         if devicePlatform.isIphone {
             return featureFlagger.isFeatureOn(.pageContextFeature)
         }
-        return featureFlagger.isFeatureOn(.iPadPageContext)
+        return true
     }
 }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualModeFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualModeFeatureTests.swift
@@ -73,35 +73,19 @@ final class AIChatContextualModeFeatureTests: XCTestCase {
         XCTAssertFalse(feature.isAvailable)
     }
 
-    func testWhenIphoneAndOnlyIPadPageContextEnabledThenIsNotAvailable() {
-        let feature = makeFeature(
-            enabledFlags: [.contextualDuckAIMode, .iPadPageContext],
-            isIphone: true
-        )
-        XCTAssertFalse(feature.isAvailable)
-    }
-
     // MARK: - iPad Tests
 
-    func testWhenIPadAndIpadPageContextEnabledThenIsAvailable() {
+    func testWhenIPadAndContextualDuckAIModeEnabledThenIsAvailable() {
         let feature = makeFeature(
-            enabledFlags: [.contextualDuckAIMode, .iPadPageContext],
+            enabledFlags: [.contextualDuckAIMode],
             isIphone: false
         )
         XCTAssertTrue(feature.isAvailable)
     }
 
-    func testWhenIPadAndIpadPageContextDisabledThenIsNotAvailable() {
+    func testWhenIPadAndContextualDuckAIModeDisabledThenIsNotAvailable() {
         let feature = makeFeature(
-            enabledFlags: [.contextualDuckAIMode],
-            isIphone: false
-        )
-        XCTAssertFalse(feature.isAvailable)
-    }
-
-    func testWhenIPadAndOnlyIphonePageContextEnabledThenIsNotAvailable() {
-        let feature = makeFeature(
-            enabledFlags: [.contextualDuckAIMode, .pageContextFeature],
+            enabledFlags: [],
             isIphone: false
         )
         XCTAssertFalse(feature.isAvailable)
@@ -109,7 +93,7 @@ final class AIChatContextualModeFeatureTests: XCTestCase {
 
     func testWhenIPadAndURLDomainIsNotDuckAIThenIsNotAvailable() {
         let feature = makeFeature(
-            enabledFlags: [.contextualDuckAIMode, .iPadPageContext],
+            enabledFlags: [.contextualDuckAIMode],
             isIphone: false,
             aiChatURL: Self.nonDuckAIURL
         )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1213608678718359

### Description
The `iPadPageContext` feature flag was approved, so the conditional code is removed and the enabled behavior (page context available on iPad) is now permanent.

### Testing Steps
1. On an **iPad**, open Duck.ai in a browser tab and start a contextual Duck AI chat → page context is available.
2. On an **iPhone**, start a contextual Duck AI chat → behavior is unchanged (still gated by the existing `pageContextFeature` flag).

### Impact
Low — iPad page context was already rolled out via the approved flag; this only removes the now-redundant gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wjPAq5ho9joE23nrE3sJp

---
_Generated by [Claude Code](https://claude.ai/code/session_013wjPAq5ho9joE23nrE3sJp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small flag cleanup after an approved rollout; iPad behavior matches the flag-on state and iPhone still uses pageContextFeature.
> 
> **Overview**
> Removes the approved **`iPadPageContext`** rollout flag from privacy config (`AIChatSubfeature`), iOS **`FeatureFlag`**, and its remote mapping.
> 
> **Contextual Duck AI** on iPad no longer checks that flag: `AIChatContextualModeFeature` treats page context as always on for iPad while iPhone still requires **`pageContextFeature`**. Tests are updated to match (iPad availability depends on **`contextualDuckAIMode`** and duck.ai URL only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e162c380192d78f1b346606a5045641f3aff218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->