### PR TITLE
Comments to indicate legacy non-PixelKit pixel systems are deprecated.

### DIFF
--- a/iOS/Core/DailyPixel.swift
+++ b/iOS/Core/DailyPixel.swift
@@ -30,6 +30,7 @@ import Persistence
 /// The 'onComplete' closure is always called - even when no pixel is fired.
 /// In those scenarios a 'DailyPixelError' is returned denoting the reason.
 /// 
+/// Deprecated. Use PixelKit (`.daily` frequency) for new pixels.
 public final class DailyPixel {
 
     public enum Error: Swift.Error {

--- a/iOS/Core/DailyPixel.swift
+++ b/iOS/Core/DailyPixel.swift
@@ -30,7 +30,7 @@ import Persistence
 /// The 'onComplete' closure is always called - even when no pixel is fired.
 /// In those scenarios a 'DailyPixelError' is returned denoting the reason.
 /// 
-/// Deprecated. Use PixelKit (`.daily` frequency) for new pixels.
+/// *** Deprecated. Use PixelKit (`.daily` frequency) for new pixels. ***
 public final class DailyPixel {
 
     public enum Error: Swift.Error {

--- a/iOS/Core/PersistentPixel.swift
+++ b/iOS/Core/PersistentPixel.swift
@@ -39,6 +39,7 @@ public protocol PersistentPixelFiring {
     func sendQueuedPixels(completion: @escaping (PersistentPixelStorageError?) -> Void)
 }
 
+/// Deprecated. Use PixelKit (which also has retry support) for new pixels.
 public final class PersistentPixel: PersistentPixelFiring {
 
     enum Constants {

--- a/iOS/Core/PersistentPixel.swift
+++ b/iOS/Core/PersistentPixel.swift
@@ -39,7 +39,7 @@ public protocol PersistentPixelFiring {
     func sendQueuedPixels(completion: @escaping (PersistentPixelStorageError?) -> Void)
 }
 
-/// Deprecated. Use PixelKit (which also has retry support) for new pixels.
+/// *** Deprecated. Use PixelKit (which also has retry support) for new pixels. ***
 public final class PersistentPixel: PersistentPixelFiring {
 
     enum Constants {

--- a/iOS/Core/Pixel.swift
+++ b/iOS/Core/Pixel.swift
@@ -24,6 +24,7 @@ import FoundationExtensions
 import Networking
 import os.log
 
+/// *** Deprecated.  Use PixelKit for new pixels. ***
 public struct PixelParameters {
     public static let url = "url"
     public static let duration = "dur"
@@ -225,7 +226,7 @@ public struct PixelValues {
     static let test = "1"
 }
 
-/// Deprecated. Use PixelKit for new pixels.
+/// *** Deprecated. Use PixelKit for new pixels. ***
 public class Pixel {
 
     private struct Constants {

--- a/iOS/Core/Pixel.swift
+++ b/iOS/Core/Pixel.swift
@@ -225,6 +225,7 @@ public struct PixelValues {
     static let test = "1"
 }
 
+/// Deprecated. Use PixelKit for new pixels.
 public class Pixel {
 
     private struct Constants {

--- a/iOS/Core/PixelFiring.swift
+++ b/iOS/Core/PixelFiring.swift
@@ -21,6 +21,7 @@ import Foundation
 import Networking
 import PixelKit
 
+/// Deprecated. Use PixelKit's `PixelFiring` for new pixels.
 public protocol PixelFiring {
 
     static func fire(_ pixel: Pixel.Event,

--- a/iOS/Core/PixelFiring.swift
+++ b/iOS/Core/PixelFiring.swift
@@ -21,7 +21,7 @@ import Foundation
 import Networking
 import PixelKit
 
-/// Deprecated. Use PixelKit's `PixelFiring` for new pixels.
+/// *** Deprecated. Use PixelKit's `PixelFiring` for new pixels. ***
 public protocol PixelFiring {
 
     static func fire(_ pixel: Pixel.Event,

--- a/iOS/Core/TimedPixel.swift
+++ b/iOS/Core/TimedPixel.swift
@@ -19,6 +19,7 @@
 
 import Foundation
 
+/// Deprecated. Use PixelKit for new pixels.  Consider WideEvents for measuring timeframes.
 public class TimedPixel {
 
     let pixel: Pixel.Event

--- a/iOS/Core/TimedPixel.swift
+++ b/iOS/Core/TimedPixel.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-/// Deprecated. Use PixelKit for new pixels.  Consider WideEvents for measuring timeframes.
+/// *** Deprecated. Use PixelKit for new pixels.  Consider WideEvents for measuring timeframes. ***
 public class TimedPixel {
 
     let pixel: Pixel.Event

--- a/iOS/Core/UniquePixel.swift
+++ b/iOS/Core/UniquePixel.swift
@@ -26,6 +26,7 @@ import Persistence
 /// The 'onComplete' closure is always called - even when no pixel is fired.
 /// In those scenarios a 'UniquePixelError' is returned denoting the reason.
 ///
+/// Deprecated. Use PixelKit (`.uniqueByName` frequency) for new pixels.
 public final class UniquePixel {
 
     public enum Error: Swift.Error {

--- a/iOS/Core/UniquePixel.swift
+++ b/iOS/Core/UniquePixel.swift
@@ -26,7 +26,7 @@ import Persistence
 /// The 'onComplete' closure is always called - even when no pixel is fired.
 /// In those scenarios a 'UniquePixelError' is returned denoting the reason.
 ///
-/// Deprecated. Use PixelKit (`.uniqueByName` frequency) for new pixels.
+/// *** Deprecated. Use PixelKit (`.uniqueByName` frequency) for new pixels. ***
 public final class UniquePixel {
 
     public enum Error: Swift.Error {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216800519699945?focus=true
Tech Design URL:
CC:

### Description
Follow-up from [All new pixels should use PixelKit](https://app.asana.com/1/137249556945/project/1200194497630846/task/1216768405353137?focus=true) proposal, this PR adds some comments to the legacy Pixel implementation to help remind folks to use PixelKit instead of the older system.

Q: Any other spots you think similar comments would be helpful?

### Testing Steps
N/A - Change is comments only.

### Impact
N/A

#### What could go wrong?
Compilation error if I somehow failed to write comments correctly 🤷‍♂️

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes with no logic, networking, or analytics behavior modifications.
> 
> **Overview**
> Adds **deprecation documentation** on the pre-PixelKit analytics stack so engineers see migration guidance at the type they might import.
> 
> **`Pixel`**, **`PixelParameters`**, and the legacy **`PixelFiring`** protocol are marked deprecated with a pointer to **PixelKit** (and PixelKit’s `PixelFiring`). Variant helpers get targeted replacements: **`DailyPixel`** → PixelKit `.daily`, **`UniquePixel`** → `.uniqueByName`, **`PersistentPixel`** → PixelKit (including retry), and **`TimedPixel`** → PixelKit with a note to consider **WideEvents** for duration-style measurement.
> 
> No runtime or API behavior changes—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c238092c196a83bde01521498870e3ddca2a751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->