### PR TITLE
Remove feature flag: aiChatContextualFireButton

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -533,9 +533,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables removing individual AI chat suggestions
     case removeSuggestion
 
-    /// Enables the fire button in the contextual AI chat sheet
-    case contextualFireButton
-
     /// Enables the Duck.ai top-level main menu shortcut (macOS only)
     case mainMenuShortcut
 

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -436,9 +436,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213813585476250?focus=true
     case screenTimeCleaning
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213763338305579?focus=true
-    case aiChatContextualFireButton
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215448831345663?focus=true
     case bottomBarViewportFixedElementsWorkaround
 
@@ -832,8 +829,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.voiceShortcut))
         case .screenTimeCleaning:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.screenTimeCleaning))
-        case .aiChatContextualFireButton:
-            Config(source: .remoteReleasable(AIChatSubfeature.contextualFireButton))
         case .bottomBarViewportFixedElementsWorkaround:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.bottomBarViewportFixedElementsWorkaround))
         case .aiChatNativeStorage:

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -1102,14 +1102,12 @@ private extension AIChatContextualSheetViewController {
 
         headerView.addSubview(rightButtonContainer)
         rightButtonContainer.addSubview(rightButtonStack)
-        if featureFlagger.isFeatureOn(for: FeatureFlag.aiChatContextualFireButton) {
-            rightButtonStack.addArrangedSubview(fireButton)
-            fireButton.isHidden = true
-            NSLayoutConstraint.activate([
-                fireButton.widthAnchor.constraint(equalToConstant: Constants.headerButtonSize),
-                fireButton.heightAnchor.constraint(equalToConstant: Constants.headerButtonSize),
-            ])
-        }
+        rightButtonStack.addArrangedSubview(fireButton)
+        fireButton.isHidden = true
+        NSLayoutConstraint.activate([
+            fireButton.widthAnchor.constraint(equalToConstant: Constants.headerButtonSize),
+            fireButton.heightAnchor.constraint(equalToConstant: Constants.headerButtonSize),
+        ])
         rightButtonStack.addArrangedSubview(closeButton)
 
         view.addSubview(contentContainerView)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1213763338305579
Tech Design URL:
CC:

### Description
Feature flag `aiChatContextualFireButton` approved, removing conditional code. The fire button in the contextual AI chat sheet is now always shown, and the associated `FeatureFlag`/`AIChatSubfeature` cases are removed.

### Testing Steps
1. Open the contextual AI chat sheet → fire button appears in the header (as it did while the flag was enabled).

### Impact
Low: removes a fully-enabled feature flag, no behavior change.

### Quality Considerations
Pixel event names `aiChatContextualFireButtonTapped`/`aiChatContextualFireButtonConfirmed` are unrelated telemetry identifiers and were left untouched, as was the bundled `ios-config.json` (managed server-side).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012PNhLpzCaCADRaBaU1bJ6F)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag cleanup only; behavior matches the previously enabled rollout, with visibility still gated by existing sheet state rather than remote config.
> 
> **Overview**
> Removes the approved **`aiChatContextualFireButton`** / **`contextualFireButton`** rollout flag and makes the contextual AI chat sheet **fire button** part of the header unconditionally.
> 
> **Privacy config & iOS flags:** Drops `AIChatSubfeature.contextualFireButton`, `FeatureFlag.aiChatContextualFireButton`, and its remote-releasable mapping.
> 
> **UI:** In `AIChatContextualSheetViewController`, the header always adds the fire button to the right stack (still hidden until web-view state warrants it via existing `fireButton.isHidden` logic). Telemetry pixel names for fire taps/confirm are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9efb1b517206591195986897e3037df69c99cbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->