### PR TITLE
iOS: Native implementation of monthly free-trial experiment

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -736,6 +736,7 @@ public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {
     case subscriptionPromoForReinstallers
     case subscriptionExpirationReminderNotification
     case subscriptionPromoForExistingUsers
+    case monthlyFreeTrialExperiment
 }
 
 public enum DuckPlayerSubfeature: String, PrivacySubfeature {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/StorePurchaseManager/StorePurchaseManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/StorePurchaseManager/StorePurchaseManager.swift
@@ -269,8 +269,6 @@ public final class DefaultStorePurchaseManager: ObservableObject, StorePurchaseM
     public func subscriptionTierOptions(includeProTier: Bool) async -> Result<SubscriptionTierOptions, StoreError> {
         let tierProducts = await getAvailableProducts(includeProTier: includeProTier)
 
-        // Apply the monthly free-trial decision (e.g. experiment cohort) as the last step before
-        // building options, so only the cohort-appropriate monthly variant is offered to the user.
         let filteredProducts = monthlyFreeTrialDecider.filteringMonthlyFreeTrialPreference(from: tierProducts)
 
         guard !filteredProducts.isEmpty else {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/StorePurchaseManager/StorePurchaseManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/StorePurchaseManager/StorePurchaseManager.swift
@@ -186,6 +186,7 @@ public final class DefaultStorePurchaseManager: ObservableObject, StorePurchaseM
     private let subscriptionFeatureMappingCache: any SubscriptionFeatureMappingCache
     private let subscriptionFeatureFlagger: FeatureFlaggerMapping<SubscriptionFeatureFlags>?
     private let pendingTransactionHandler: PendingTransactionHandling?
+    private let monthlyFreeTrialDecider: any MonthlyFreeTrialDeciding
 
     @Published public private(set) var availableProducts: [any SubscriptionProduct] = []
     @Published public private(set) var purchasedProductIDs: [String] = []
@@ -213,7 +214,8 @@ public final class DefaultStorePurchaseManager: ObservableObject, StorePurchaseM
                 productFetcher: ProductFetching = DefaultProductFetcher(),
                 pendingTransactionHandler: PendingTransactionHandling? = nil,
                 monthlyFreeTrialDecider: any MonthlyFreeTrialDeciding) {
-        self.storeSubscriptionConfiguration = DefaultStoreSubscriptionConfiguration(monthlyFreeTrialDecider: monthlyFreeTrialDecider)
+        self.storeSubscriptionConfiguration = DefaultStoreSubscriptionConfiguration()
+        self.monthlyFreeTrialDecider = monthlyFreeTrialDecider
         self.subscriptionFeatureMappingCache = subscriptionFeatureMappingCache
         self.subscriptionFeatureFlagger = subscriptionFeatureFlagger
         self.productFetcher = productFetcher
@@ -266,13 +268,18 @@ public final class DefaultStorePurchaseManager: ObservableObject, StorePurchaseM
 
     public func subscriptionTierOptions(includeProTier: Bool) async -> Result<SubscriptionTierOptions, StoreError> {
         let tierProducts = await getAvailableProducts(includeProTier: includeProTier)
-        guard !tierProducts.isEmpty else {
+
+        // Apply the monthly free-trial decision (e.g. experiment cohort) as the last step before
+        // building options, so only the cohort-appropriate monthly variant is offered to the user.
+        let filteredProducts = monthlyFreeTrialDecider.filteringMonthlyFreeTrialPreference(from: tierProducts)
+
+        guard !filteredProducts.isEmpty else {
             Logger.subscriptionStorePurchaseManager.error("[Store Purchase Manager] No products available")
             return .failure(.tieredProductsNoProductsAvailable)
         }
-        let ids = tierProducts.map(\.self.id)
+        let ids = filteredProducts.map(\.self.id)
         Logger.subscriptionStorePurchaseManager.debug("[Store Purchase Manager] Returning SubscriptionTierOptions for products: \(ids)")
-        return await subscriptionTierOptions(for: tierProducts)
+        return await subscriptionTierOptions(for: filteredProducts)
     }
 
     @MainActor

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/StorePurchaseManager/StorePurchaseManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Managers/StorePurchaseManager/StorePurchaseManager.swift
@@ -211,8 +211,9 @@ public final class DefaultStorePurchaseManager: ObservableObject, StorePurchaseM
     public init(subscriptionFeatureMappingCache: any SubscriptionFeatureMappingCache,
                 subscriptionFeatureFlagger: FeatureFlaggerMapping<SubscriptionFeatureFlags>? = nil,
                 productFetcher: ProductFetching = DefaultProductFetcher(),
-                pendingTransactionHandler: PendingTransactionHandling? = nil) {
-        self.storeSubscriptionConfiguration = DefaultStoreSubscriptionConfiguration()
+                pendingTransactionHandler: PendingTransactionHandling? = nil,
+                monthlyFreeTrialDecider: any MonthlyFreeTrialDeciding) {
+        self.storeSubscriptionConfiguration = DefaultStoreSubscriptionConfiguration(monthlyFreeTrialDecider: monthlyFreeTrialDecider)
         self.subscriptionFeatureMappingCache = subscriptionFeatureMappingCache
         self.subscriptionFeatureFlagger = subscriptionFeatureFlagger
         self.productFetcher = productFetcher

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/MonthlyFreeTrialDeciding.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/MonthlyFreeTrialDeciding.swift
@@ -18,20 +18,12 @@
 
 import Foundation
 
-/// Decides whether the monthly subscription plans should be offered with a free trial.
-///
-/// The decision is queried at the point the paywall products are requested, so it can reflect
-/// experiment cohort assignment made at that moment rather than a value frozen earlier.
+/// Determines whether monthly subscriptions should include a free trial.
 public protocol MonthlyFreeTrialDeciding {
     func shouldOfferMonthlyFreeTrial() -> Bool
 }
 
-/// A decider that always offers the monthly free trial (the current, pre-experiment behavior).
-///
-/// Intended for contexts that never present the paywall — e.g. app extensions, or the shared
-/// subscription configuration used across many targets — which need to satisfy the API but never
-/// consult the decision. The cohort-aware deciders live in the app targets that actually run the
-/// experiment.
+/// Always offers the monthly free trial.
 public struct DefaultMonthlyFreeTrialDecider: MonthlyFreeTrialDeciding {
 
     public init() {}
@@ -43,21 +35,12 @@ public struct DefaultMonthlyFreeTrialDecider: MonthlyFreeTrialDeciding {
 
 extension MonthlyFreeTrialDeciding {
 
-    /// Filters products according to the current monthly free-trial decision.
-    ///
-    /// See the identifier-based overload for the filtering rule; this simply applies it to a set of
-    /// products, keeping only those whose identifier survives.
     func filteringMonthlyFreeTrialPreference(from products: [any SubscriptionProduct]) -> [any SubscriptionProduct] {
         let allowedIdentifiers = Set(filteringMonthlyFreeTrialPreference(from: products.map(\.id)))
         return products.filter { allowedIdentifiers.contains($0.id) }
     }
 
-    /// Filters product identifiers according to the current monthly free-trial decision.
-    ///
-    /// A monthly identifier is only filtered out when the opposite free-trial variant of the *same* plan
-    /// is also present. In that case only the variant matching `shouldOfferMonthlyFreeTrial()` survives.
-    /// A monthly identifier without a matching sibling, and every non-monthly identifier, passes through
-    /// unchanged — so a lone monthly plan is never hidden.
+    /// Filters paired monthly SKUs; unpaired and non-monthly identifiers remain unchanged.
     func filteringMonthlyFreeTrialPreference(from identifiers: [String]) -> [String] {
         let offerMonthlyFreeTrial = shouldOfferMonthlyFreeTrial()
 
@@ -90,9 +73,7 @@ private extension String {
         split(separator: ".").contains { $0 == StoreSubscriptionConstants.freeTrialIdentifer }
     }
 
-    /// The identifier with any free-trial marker removed, so a free-trial plan and its no-trial
-    /// counterpart resolve to the same key (e.g. `…monthly.renews.us.freetrial` and
-    /// `…monthly.renews.us`, or `…1month.freetrial.dev.pro` and `…1month.dev.pro`).
+    /// Removes the free-trial component for SKU matching.
     var trialAgnosticMonthlyIdentifier: String {
         split(separator: ".")
             .filter { $0 != StoreSubscriptionConstants.freeTrialIdentifer }

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/MonthlyFreeTrialDeciding.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/MonthlyFreeTrialDeciding.swift
@@ -1,0 +1,86 @@
+//
+//  MonthlyFreeTrialDeciding.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Decides whether the monthly subscription plans should be offered with a free trial.
+///
+/// The decision is queried at the point the paywall products are requested, so it can reflect
+/// experiment cohort assignment made at that moment rather than a value frozen earlier.
+public protocol MonthlyFreeTrialDeciding {
+    func shouldOfferMonthlyFreeTrial() -> Bool
+}
+
+extension MonthlyFreeTrialDeciding {
+
+    /// Filters products according to the current monthly free-trial decision.
+    ///
+    /// See the identifier-based overload for the filtering rule; this simply applies it to a set of
+    /// products, keeping only those whose identifier survives.
+    func filteringMonthlyFreeTrialPreference(from products: [any SubscriptionProduct]) -> [any SubscriptionProduct] {
+        let allowedIdentifiers = Set(filteringMonthlyFreeTrialPreference(from: products.map(\.id)))
+        return products.filter { allowedIdentifiers.contains($0.id) }
+    }
+
+    /// Filters product identifiers according to the current monthly free-trial decision.
+    ///
+    /// A monthly identifier is only filtered out when the opposite free-trial variant of the *same* plan
+    /// is also present. In that case only the variant matching `shouldOfferMonthlyFreeTrial()` survives.
+    /// A monthly identifier without a matching sibling, and every non-monthly identifier, passes through
+    /// unchanged — so a lone monthly plan is never hidden.
+    func filteringMonthlyFreeTrialPreference(from identifiers: [String]) -> [String] {
+        let offerMonthlyFreeTrial = shouldOfferMonthlyFreeTrial()
+
+        return identifiers.filter { identifier in
+            guard identifier.isMonthlySubscriptionIdentifier else { return true }
+
+            let planKey = identifier.trialAgnosticMonthlyIdentifier
+            let hasOppositeTrialSibling = identifiers.contains { other in
+                other != identifier
+                    && other.isMonthlySubscriptionIdentifier
+                    && other.trialAgnosticMonthlyIdentifier == planKey
+                    && other.includesFreeTrial != identifier.includesFreeTrial
+            }
+
+            guard hasOppositeTrialSibling else { return true }
+
+            return offerMonthlyFreeTrial ? identifier.includesFreeTrial : !identifier.includesFreeTrial
+        }
+    }
+}
+
+private extension String {
+
+    var isMonthlySubscriptionIdentifier: Bool {
+        let components = split(separator: ".")
+        return components.contains("monthly") || components.contains("1month")
+    }
+
+    var includesFreeTrial: Bool {
+        split(separator: ".").contains { $0 == StoreSubscriptionConstants.freeTrialIdentifer }
+    }
+
+    /// The identifier with any free-trial marker removed, so a free-trial plan and its no-trial
+    /// counterpart resolve to the same key (e.g. `…monthly.renews.us.freetrial` and
+    /// `…monthly.renews.us`, or `…1month.freetrial.dev.pro` and `…1month.dev.pro`).
+    var trialAgnosticMonthlyIdentifier: String {
+        split(separator: ".")
+            .filter { $0 != StoreSubscriptionConstants.freeTrialIdentifer }
+            .joined(separator: ".")
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/MonthlyFreeTrialDeciding.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/MonthlyFreeTrialDeciding.swift
@@ -26,6 +26,21 @@ public protocol MonthlyFreeTrialDeciding {
     func shouldOfferMonthlyFreeTrial() -> Bool
 }
 
+/// A decider that always offers the monthly free trial (the current, pre-experiment behavior).
+///
+/// Intended for contexts that never present the paywall — e.g. app extensions, or the shared
+/// subscription configuration used across many targets — which need to satisfy the API but never
+/// consult the decision. The cohort-aware deciders live in the app targets that actually run the
+/// experiment.
+public struct DefaultMonthlyFreeTrialDecider: MonthlyFreeTrialDeciding {
+
+    public init() {}
+
+    public func shouldOfferMonthlyFreeTrial() -> Bool {
+        true
+    }
+}
+
 extension MonthlyFreeTrialDeciding {
 
     /// Filters products according to the current monthly free-trial decision.

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/StoreSubscriptionConfiguration.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/StoreSubscriptionConfiguration.swift
@@ -32,11 +32,16 @@ protocol StoreSubscriptionConfiguration {
     func subscriptionIdentifiers(for region: SubscriptionRegion) -> [String]
 }
 
+public protocol MonthlyFreeTrialDeciding {
+    func shouldOfferMonthlyFreeTrial() -> Bool
+}
+
 final class DefaultStoreSubscriptionConfiguration: StoreSubscriptionConfiguration {
 
     private let subscriptions: [StoreSubscriptionDefinition]
+    private let monthlyFreeTrialDecider: any MonthlyFreeTrialDeciding
 
-    convenience init() {
+    convenience init(monthlyFreeTrialDecider: any MonthlyFreeTrialDeciding) {
         self.init(subscriptionDefinitions: [
             // Production shared for iOS and macOS
             .init(name: "DuckDuckGo Private Browser",
@@ -57,10 +62,12 @@ final class DefaultStoreSubscriptionConfiguration: StoreSubscriptionConfiguratio
                   identifiersByRegion: [.usa: ["ios.subscription.1month.freetrial.dev",
                                                "ios.subscription.1year.freetrial.dev",
                                                "ios.subscription.1month.freetrial.dev.\(StoreSubscriptionConstants.proTierIdentifier)",
+                                               "ios.subscription.1month.dev.\(StoreSubscriptionConstants.proTierIdentifier)",
                                                "ios.subscription.1year.freetrial.dev.\(StoreSubscriptionConstants.proTierIdentifier)"],
                                         .restOfWorld: ["ios.subscription.1month.row.freetrial.dev",
                                                        "ios.subscription.1year.row.freetrial.dev",
                                                        "ios.subscription.1month.row.freetrial.dev.\(StoreSubscriptionConstants.proTierIdentifier)",
+                                                       "ios.subscription.1month.row.dev.\(StoreSubscriptionConstants.proTierIdentifier)",
                                                        "ios.subscription.1year.row.freetrial.dev.\(StoreSubscriptionConstants.proTierIdentifier)"]]),
             // macOS debug build
             .init(name: "IAP debug - DDG for macOS",
@@ -99,11 +106,13 @@ final class DefaultStoreSubscriptionConfiguration: StoreSubscriptionConfiguratio
                                                        "tf.sandbox.subscription.1year.row.freetrial",
                                                        "tf.sandbox.subscription.1month.row.freetrial.\(StoreSubscriptionConstants.proTierIdentifier)",
                                                        "tf.sandbox.subscription.1year.row.freetrial.\(StoreSubscriptionConstants.proTierIdentifier)"]])
-        ])
+        ], monthlyFreeTrialDecider: monthlyFreeTrialDecider)
     }
 
-    init(subscriptionDefinitions: [StoreSubscriptionDefinition]) {
+    init(subscriptionDefinitions: [StoreSubscriptionDefinition],
+         monthlyFreeTrialDecider: any MonthlyFreeTrialDeciding) {
         self.subscriptions = subscriptionDefinitions
+        self.monthlyFreeTrialDecider = monthlyFreeTrialDecider
     }
 
     var allSubscriptionIdentifiers: [String] {
@@ -111,11 +120,15 @@ final class DefaultStoreSubscriptionConfiguration: StoreSubscriptionConfiguratio
     }
 
     func subscriptionIdentifiers(for country: String) -> [String] {
-        subscriptions.reduce([], { $0 + $1.identifiers(for: country) })
+        return subscriptions.reduce([], {
+            $0 + $1.identifiers(for: country, shouldOfferMonthlyFreeTrial: monthlyFreeTrialDecider.shouldOfferMonthlyFreeTrial())
+        })
     }
 
     func subscriptionIdentifiers(for region: SubscriptionRegion) -> [String] {
-        subscriptions.reduce([], { $0 + $1.identifiers(for: region) })
+        return subscriptions.reduce([], {
+            $0 + $1.identifiers(for: region, shouldOfferMonthlyFreeTrial: monthlyFreeTrialDecider.shouldOfferMonthlyFreeTrial())
+        })
     }
 }
 
@@ -129,12 +142,44 @@ struct StoreSubscriptionDefinition {
         identifiersByRegion.values.flatMap { $0 }
     }
 
-    func identifiers(for country: String) -> [String] {
-        identifiersByRegion.filter { region, _ in region.contains(country) }.flatMap { _, identifiers in identifiers }
+    func identifiers(for country: String, shouldOfferMonthlyFreeTrial: Bool) -> [String] {
+        identifiersByRegion
+            .filter { region, _ in region.contains(country) }
+            .flatMap { _, identifiers in
+                applyingMonthlyFreeTrialPreference(identifiers, shouldOfferMonthlyFreeTrial: shouldOfferMonthlyFreeTrial)
+            }
     }
 
-    func identifiers(for region: SubscriptionRegion) -> [String] {
-        identifiersByRegion[region] ?? []
+    func identifiers(for region: SubscriptionRegion, shouldOfferMonthlyFreeTrial: Bool) -> [String] {
+        applyingMonthlyFreeTrialPreference(identifiersByRegion[region] ?? [], shouldOfferMonthlyFreeTrial: shouldOfferMonthlyFreeTrial)
+    }
+
+    private func applyingMonthlyFreeTrialPreference(
+        _ identifiers: [String],
+        shouldOfferMonthlyFreeTrial: Bool
+    ) -> [String] {
+        identifiers.filter { identifier in
+            guard identifier.isMonthlySubscriptionIdentifier else {
+                return true
+            }
+
+            if shouldOfferMonthlyFreeTrial {
+                return identifier.includesFreeTrial
+            } else {
+                return !identifier.includesFreeTrial
+            }
+        }
+    }
+}
+
+private extension String {
+    var isMonthlySubscriptionIdentifier: Bool {
+        let components = split(separator: ".")
+        return components.contains("monthly") || components.contains("1month")
+    }
+
+    var includesFreeTrial: Bool {
+        split(separator: ".").contains { $0 == StoreSubscriptionConstants.freeTrialIdentifer }
     }
 }
 

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/StoreSubscriptionConfiguration.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/StoreSubscriptionConfiguration.swift
@@ -32,16 +32,11 @@ protocol StoreSubscriptionConfiguration {
     func subscriptionIdentifiers(for region: SubscriptionRegion) -> [String]
 }
 
-public protocol MonthlyFreeTrialDeciding {
-    func shouldOfferMonthlyFreeTrial() -> Bool
-}
-
 final class DefaultStoreSubscriptionConfiguration: StoreSubscriptionConfiguration {
 
     private let subscriptions: [StoreSubscriptionDefinition]
-    private let monthlyFreeTrialDecider: any MonthlyFreeTrialDeciding
 
-    convenience init(monthlyFreeTrialDecider: any MonthlyFreeTrialDeciding) {
+    convenience init() {
         self.init(subscriptionDefinitions: [
             // Production shared for iOS and macOS
             .init(name: "DuckDuckGo Private Browser",
@@ -106,13 +101,11 @@ final class DefaultStoreSubscriptionConfiguration: StoreSubscriptionConfiguratio
                                                        "tf.sandbox.subscription.1year.row.freetrial",
                                                        "tf.sandbox.subscription.1month.row.freetrial.\(StoreSubscriptionConstants.proTierIdentifier)",
                                                        "tf.sandbox.subscription.1year.row.freetrial.\(StoreSubscriptionConstants.proTierIdentifier)"]])
-        ], monthlyFreeTrialDecider: monthlyFreeTrialDecider)
+        ])
     }
 
-    init(subscriptionDefinitions: [StoreSubscriptionDefinition],
-         monthlyFreeTrialDecider: any MonthlyFreeTrialDeciding) {
+    init(subscriptionDefinitions: [StoreSubscriptionDefinition]) {
         self.subscriptions = subscriptionDefinitions
-        self.monthlyFreeTrialDecider = monthlyFreeTrialDecider
     }
 
     var allSubscriptionIdentifiers: [String] {
@@ -120,15 +113,11 @@ final class DefaultStoreSubscriptionConfiguration: StoreSubscriptionConfiguratio
     }
 
     func subscriptionIdentifiers(for country: String) -> [String] {
-        return subscriptions.reduce([], {
-            $0 + $1.identifiers(for: country, shouldOfferMonthlyFreeTrial: monthlyFreeTrialDecider.shouldOfferMonthlyFreeTrial())
-        })
+        subscriptions.reduce([], { $0 + $1.identifiers(for: country) })
     }
 
     func subscriptionIdentifiers(for region: SubscriptionRegion) -> [String] {
-        return subscriptions.reduce([], {
-            $0 + $1.identifiers(for: region, shouldOfferMonthlyFreeTrial: monthlyFreeTrialDecider.shouldOfferMonthlyFreeTrial())
-        })
+        subscriptions.reduce([], { $0 + $1.identifiers(for: region) })
     }
 }
 
@@ -142,44 +131,12 @@ struct StoreSubscriptionDefinition {
         identifiersByRegion.values.flatMap { $0 }
     }
 
-    func identifiers(for country: String, shouldOfferMonthlyFreeTrial: Bool) -> [String] {
-        identifiersByRegion
-            .filter { region, _ in region.contains(country) }
-            .flatMap { _, identifiers in
-                applyingMonthlyFreeTrialPreference(identifiers, shouldOfferMonthlyFreeTrial: shouldOfferMonthlyFreeTrial)
-            }
+    func identifiers(for country: String) -> [String] {
+        identifiersByRegion.filter { region, _ in region.contains(country) }.flatMap { _, identifiers in identifiers }
     }
 
-    func identifiers(for region: SubscriptionRegion, shouldOfferMonthlyFreeTrial: Bool) -> [String] {
-        applyingMonthlyFreeTrialPreference(identifiersByRegion[region] ?? [], shouldOfferMonthlyFreeTrial: shouldOfferMonthlyFreeTrial)
-    }
-
-    private func applyingMonthlyFreeTrialPreference(
-        _ identifiers: [String],
-        shouldOfferMonthlyFreeTrial: Bool
-    ) -> [String] {
-        identifiers.filter { identifier in
-            guard identifier.isMonthlySubscriptionIdentifier else {
-                return true
-            }
-
-            if shouldOfferMonthlyFreeTrial {
-                return identifier.includesFreeTrial
-            } else {
-                return !identifier.includesFreeTrial
-            }
-        }
-    }
-}
-
-private extension String {
-    var isMonthlySubscriptionIdentifier: Bool {
-        let components = split(separator: ".")
-        return components.contains("monthly") || components.contains("1month")
-    }
-
-    var includesFreeTrial: Bool {
-        split(separator: ".").contains { $0 == StoreSubscriptionConstants.freeTrialIdentifer }
+    func identifiers(for region: SubscriptionRegion) -> [String] {
+        identifiersByRegion[region] ?? []
     }
 }
 

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/MonthlyFreeTrialDecidingTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/MonthlyFreeTrialDecidingTests.swift
@@ -22,7 +22,6 @@ import Testing
 @Suite("Monthly Free Trial Deciding – identifier filtering")
 struct MonthlyFreeTrialDecidingTests {
 
-    // A paired plan: a monthly free-trial identifier and its no-trial sibling, plus yearly identifiers.
     private let pairedIdentifiers = [
         "ddg.privacy.pro.yearly.renews.us.freetrial",
         "ddg.privacy.pro.monthly.renews.us.freetrial",

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/MonthlyFreeTrialDecidingTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/MonthlyFreeTrialDecidingTests.swift
@@ -1,0 +1,130 @@
+//
+//  MonthlyFreeTrialDecidingTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Testing
+@testable import Subscription
+
+@Suite("Monthly Free Trial Deciding – identifier filtering")
+struct MonthlyFreeTrialDecidingTests {
+
+    // A paired plan: a monthly free-trial identifier and its no-trial sibling, plus yearly identifiers.
+    private let pairedIdentifiers = [
+        "ddg.privacy.pro.yearly.renews.us.freetrial",
+        "ddg.privacy.pro.monthly.renews.us.freetrial",
+        "ddg.privacy.pro.monthly.renews.us",
+        "ddg.subscription.yearly.renews.us.freetrial.pro",
+        "ddg.subscription.monthly.renews.us.freetrial.pro",
+        "ddg.subscription.monthly.renews.us.pro"
+    ]
+
+    @Test("When offering the trial, a paired monthly plan keeps only the free-trial variant")
+    func offeringTrialKeepsFreeTrialMonthlyOfAPair() {
+        let sut = MockMonthlyFreeTrialDecider(shouldOfferMonthlyFreeTrial: true)
+
+        let result = Set(sut.filteringMonthlyFreeTrialPreference(from: pairedIdentifiers))
+
+        #expect(result == [
+            "ddg.privacy.pro.yearly.renews.us.freetrial",
+            "ddg.privacy.pro.monthly.renews.us.freetrial",
+            "ddg.subscription.yearly.renews.us.freetrial.pro",
+            "ddg.subscription.monthly.renews.us.freetrial.pro"
+        ])
+    }
+
+    @Test("When not offering the trial, a paired monthly plan keeps only the no-trial variant")
+    func notOfferingTrialKeepsNoTrialMonthlyOfAPair() {
+        let sut = MockMonthlyFreeTrialDecider(shouldOfferMonthlyFreeTrial: false)
+
+        let result = Set(sut.filteringMonthlyFreeTrialPreference(from: pairedIdentifiers))
+
+        #expect(result == [
+            "ddg.privacy.pro.yearly.renews.us.freetrial",
+            "ddg.privacy.pro.monthly.renews.us",
+            "ddg.subscription.yearly.renews.us.freetrial.pro",
+            "ddg.subscription.monthly.renews.us.pro"
+        ])
+    }
+
+    @Test("A lone free-trial monthly plan is kept even when not offering the trial")
+    func loneFreeTrialMonthlyIsKeptWhenNotOffering() {
+        let identifiers = [
+            "ddg.privacy.pro.monthly.renews.us.freetrial",
+            "ddg.privacy.pro.yearly.renews.us.freetrial"
+        ]
+        let sut = MockMonthlyFreeTrialDecider(shouldOfferMonthlyFreeTrial: false)
+
+        let result = Set(sut.filteringMonthlyFreeTrialPreference(from: identifiers))
+
+        #expect(result == Set(identifiers), "A monthly plan with no no-trial sibling must never be hidden")
+    }
+
+    @Test("A lone no-trial monthly plan is kept even when offering the trial")
+    func loneNoTrialMonthlyIsKeptWhenOffering() {
+        let identifiers = [
+            "ddg.subscription.monthly.renews.us.pro",
+            "ddg.subscription.yearly.renews.us.freetrial.pro"
+        ]
+        let sut = MockMonthlyFreeTrialDecider(shouldOfferMonthlyFreeTrial: true)
+
+        let result = Set(sut.filteringMonthlyFreeTrialPreference(from: identifiers))
+
+        #expect(result == Set(identifiers), "A monthly plan with no free-trial sibling must never be hidden")
+    }
+
+    @Test("Dev-style 1month identifiers are paired correctly")
+    func devStyleMonthlyIdentifiersArePaired() {
+        let identifiers = [
+            "ios.subscription.1year.freetrial.dev.pro",
+            "ios.subscription.1month.freetrial.dev.pro",
+            "ios.subscription.1month.dev.pro"
+        ]
+        let sut = MockMonthlyFreeTrialDecider(shouldOfferMonthlyFreeTrial: false)
+
+        let result = Set(sut.filteringMonthlyFreeTrialPreference(from: identifiers))
+
+        #expect(result == [
+            "ios.subscription.1year.freetrial.dev.pro",
+            "ios.subscription.1month.dev.pro"
+        ])
+    }
+
+    @Test("Non-monthly identifiers always pass through untouched")
+    func nonMonthlyIdentifiersPassThrough() {
+        let identifiers = [
+            "ddg.privacy.pro.yearly.renews.us.freetrial",
+            "ddg.subscription.yearly.renews.us.freetrial.pro"
+        ]
+        let offering = MockMonthlyFreeTrialDecider(shouldOfferMonthlyFreeTrial: true)
+        let notOffering = MockMonthlyFreeTrialDecider(shouldOfferMonthlyFreeTrial: false)
+
+        #expect(Set(offering.filteringMonthlyFreeTrialPreference(from: identifiers)) == Set(identifiers))
+        #expect(Set(notOffering.filteringMonthlyFreeTrialPreference(from: identifiers)) == Set(identifiers))
+    }
+}
+
+private struct MockMonthlyFreeTrialDecider: MonthlyFreeTrialDeciding {
+    let value: Bool
+
+    init(shouldOfferMonthlyFreeTrial: Bool) {
+        self.value = shouldOfferMonthlyFreeTrial
+    }
+
+    func shouldOfferMonthlyFreeTrial() -> Bool {
+        value
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/StorePurchaseManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/StorePurchaseManagerTests.swift
@@ -563,15 +563,12 @@ final class StorePurchaseManagerTests: XCTestCase {
     }
 
     func testSubscriptionTierOptionsOffersOnlyFreeTrialMonthlyWhenTrialEnabled() async {
-        // Given – a paired monthly plan (free-trial + no-trial) and a yearly plan; decider offers the trial
         mockProductFetcher.mockProducts = makePairedMonthlyPlusProducts()
         await sut.updateAvailableProducts()
         mockCache.tierMapping = pairedMonthlyTierMapping()
 
-        // When
         let result = await sut.subscriptionTierOptions(includeProTier: false)
 
-        // Then – only the free-trial monthly variant is offered; the no-trial sibling is dropped
         guard case .success(let tierOptions) = result else {
             XCTFail("Expected success but got failure")
             return
@@ -583,7 +580,6 @@ final class StorePurchaseManagerTests: XCTestCase {
     }
 
     func testSubscriptionTierOptionsOffersOnlyNoTrialMonthlyWhenTrialDisabled() async {
-        // Given – the same paired plan, but the decider does not offer the monthly trial
         let sut = DefaultStorePurchaseManager(subscriptionFeatureMappingCache: mockCache,
                                               subscriptionFeatureFlagger: mockFeatureFlagger,
                                               productFetcher: mockProductFetcher,
@@ -592,10 +588,8 @@ final class StorePurchaseManagerTests: XCTestCase {
         await sut.updateAvailableProducts()
         mockCache.tierMapping = pairedMonthlyTierMapping()
 
-        // When
         let result = await sut.subscriptionTierOptions(includeProTier: false)
 
-        // Then – only the no-trial monthly variant is offered; the free-trial sibling is dropped
         guard case .success(let tierOptions) = result else {
             XCTFail("Expected success but got failure")
             return

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/StorePurchaseManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/StorePurchaseManagerTests.swift
@@ -562,6 +562,84 @@ final class StorePurchaseManagerTests: XCTestCase {
         XCTAssertTrue(yearlyOption?.offer?.isUserEligible ?? false)
     }
 
+    func testSubscriptionTierOptionsOffersOnlyFreeTrialMonthlyWhenTrialEnabled() async {
+        // Given – a paired monthly plan (free-trial + no-trial) and a yearly plan; decider offers the trial
+        mockProductFetcher.mockProducts = makePairedMonthlyPlusProducts()
+        await sut.updateAvailableProducts()
+        mockCache.tierMapping = pairedMonthlyTierMapping()
+
+        // When
+        let result = await sut.subscriptionTierOptions(includeProTier: false)
+
+        // Then – only the free-trial monthly variant is offered; the no-trial sibling is dropped
+        guard case .success(let tierOptions) = result else {
+            XCTFail("Expected success but got failure")
+            return
+        }
+        let optionIDs = Set(tierOptions.products.flatMap { $0.options.map(\.id) })
+        XCTAssertTrue(optionIDs.contains("com.test.monthly.freetrial"))
+        XCTAssertTrue(optionIDs.contains("com.test.yearly"))
+        XCTAssertFalse(optionIDs.contains("com.test.monthly"))
+    }
+
+    func testSubscriptionTierOptionsOffersOnlyNoTrialMonthlyWhenTrialDisabled() async {
+        // Given – the same paired plan, but the decider does not offer the monthly trial
+        let sut = DefaultStorePurchaseManager(subscriptionFeatureMappingCache: mockCache,
+                                              subscriptionFeatureFlagger: mockFeatureFlagger,
+                                              productFetcher: mockProductFetcher,
+                                              monthlyFreeTrialDecider: MockMonthlyFreeTrialDecider(shouldOffer: false))
+        mockProductFetcher.mockProducts = makePairedMonthlyPlusProducts()
+        await sut.updateAvailableProducts()
+        mockCache.tierMapping = pairedMonthlyTierMapping()
+
+        // When
+        let result = await sut.subscriptionTierOptions(includeProTier: false)
+
+        // Then – only the no-trial monthly variant is offered; the free-trial sibling is dropped
+        guard case .success(let tierOptions) = result else {
+            XCTFail("Expected success but got failure")
+            return
+        }
+        let optionIDs = Set(tierOptions.products.flatMap { $0.options.map(\.id) })
+        XCTAssertTrue(optionIDs.contains("com.test.monthly"))
+        XCTAssertTrue(optionIDs.contains("com.test.yearly"))
+        XCTAssertFalse(optionIDs.contains("com.test.monthly.freetrial"))
+    }
+
+    private func makePairedMonthlyPlusProducts() -> [MockSubscriptionProduct] {
+        let monthlyWithTrial = MockSubscriptionProduct(
+            id: "com.test.monthly.freetrial",
+            displayName: "Plus Monthly with Trial",
+            displayPrice: "$9.99",
+            isMonthly: true,
+            hasIntroductoryFreeTrialOffer: true,
+            introOffer: MockIntroductoryOffer(id: "trial1", displayPrice: "$0.00", periodInDays: 7, isFreeTrial: true),
+            isEligibleForFreeTrial: true
+        )
+        let monthlyWithoutTrial = MockSubscriptionProduct(
+            id: "com.test.monthly",
+            displayName: "Plus Monthly",
+            displayPrice: "$9.99",
+            isMonthly: true
+        )
+        let yearly = MockSubscriptionProduct(
+            id: "com.test.yearly",
+            displayName: "Plus Yearly",
+            displayPrice: "$99.99",
+            isYearly: true
+        )
+        return [monthlyWithTrial, monthlyWithoutTrial, yearly]
+    }
+
+    private func pairedMonthlyTierMapping() -> [String: [TierFeature]] {
+        let plusFeatures = [TierFeature(product: .networkProtection, name: .plus)]
+        return [
+            "com.test.monthly.freetrial": plusFeatures,
+            "com.test.monthly": plusFeatures,
+            "com.test.yearly": plusFeatures
+        ]
+    }
+
     func testSubscriptionTierOptionsExcludesProTierWhenNotRequested() async {
         // Given
         let plusMonthly = MockSubscriptionProduct(id: "com.test.monthly", isMonthly: true)
@@ -877,7 +955,9 @@ private class MockStoreSubscriptionConfiguration: StoreSubscriptionConfiguration
 }
 
 private struct MockMonthlyFreeTrialDecider: MonthlyFreeTrialDeciding {
+    var shouldOffer: Bool = true
+
     func shouldOfferMonthlyFreeTrial() -> Bool {
-        true
+        shouldOffer
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/StorePurchaseManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/StorePurchaseManagerTests.swift
@@ -36,7 +36,8 @@ final class StorePurchaseManagerTests: XCTestCase {
         mockFeatureFlagger = MockFeatureFlagger()
         sut = DefaultStorePurchaseManager(subscriptionFeatureMappingCache: mockCache,
                                           subscriptionFeatureFlagger: mockFeatureFlagger,
-                                          productFetcher: mockProductFetcher)
+                                          productFetcher: mockProductFetcher,
+                                          monthlyFreeTrialDecider: MockMonthlyFreeTrialDecider())
     }
 
     func testUpdateAvailableProductsSuccessfully() async {
@@ -872,5 +873,11 @@ private class MockStoreSubscriptionConfiguration: StoreSubscriptionConfiguration
         default:
             return rowIdentifiers
         }
+    }
+}
+
+private struct MockMonthlyFreeTrialDecider: MonthlyFreeTrialDeciding {
+    func shouldOfferMonthlyFreeTrial() -> Bool {
+        true
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/StoreSubscriptionConfigurationTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/StoreSubscriptionConfigurationTests.swift
@@ -22,7 +22,7 @@ import Testing
 @Suite("Store Subscription Configuration Tests")
 struct StoreSubscriptionConfigurationTests {
 
-    let sut = DefaultStoreSubscriptionConfiguration()
+    let sut = DefaultStoreSubscriptionConfiguration(monthlyFreeTrialDecider: MockMonthlyFreeTrialDecider(shouldOfferMonthlyFreeTrial: true))
 
     @Test("USA region returns expected product identifiers")
     func usaRegionReturnsExpectedProductIdentifiers() {
@@ -108,5 +108,89 @@ struct StoreSubscriptionConfigurationTests {
         // Then
         #expect(actualProducts == expectedROWProducts,
                 "ROW products should match expected list exactly")
+    }
+
+    // MARK: - Monthly free-trial filtering
+
+    @Test("USA region without monthly free trial returns expected product identifiers")
+    func usaRegionWithoutMonthlyFreeTrialReturnsExpectedProductIdentifiers() {
+        // Given
+        let sut = DefaultStoreSubscriptionConfiguration(monthlyFreeTrialDecider: MockMonthlyFreeTrialDecider(shouldOfferMonthlyFreeTrial: false))
+        let expectedUSAProducts: Set<String> = [
+            // Production
+            "ddg.privacy.pro.yearly.renews.us.freetrial",
+            "ddg.subscription.yearly.renews.us.freetrial.pro",
+
+            // iOS Alpha
+            "ios.subscription.1year.freetrial.dev",
+            "ios.subscription.1month.dev.pro",
+            "ios.subscription.1year.freetrial.dev.pro",
+
+            // macOS Debug
+            "subscription.1year.freetrial",
+            "subscription.1year.freetrial.pro",
+
+            // macOS Review
+            "review.subscription.1year.freetrial",
+            "review.subscription.1year.freetrial.pro",
+
+            // TestFlight
+            "tf.sandbox.subscription.1year.freetrial",
+            "tf.sandbox.subscription.1year.freetrial.pro"
+        ]
+
+        // When
+        let actualProducts = Set(sut.subscriptionIdentifiers(for: .usa))
+
+        // Then
+        #expect(actualProducts == expectedUSAProducts,
+                "USA products without monthly free trials should match expected list exactly")
+    }
+
+    @Test("ROW region without monthly free trial returns expected product identifiers")
+    func rowRegionWithoutMonthlyFreeTrialReturnsExpectedProductIdentifiers() {
+        // Given
+        let sut = DefaultStoreSubscriptionConfiguration(monthlyFreeTrialDecider: MockMonthlyFreeTrialDecider(shouldOfferMonthlyFreeTrial: false))
+        let expectedROWProducts: Set<String> = [
+            // Production
+            "ddg.privacy.pro.yearly.renews.row.freetrial",
+            "ddg.subscription.yearly.renews.row.freetrial.pro",
+
+            // iOS Alpha
+            "ios.subscription.1year.row.freetrial.dev",
+            "ios.subscription.1month.row.dev.pro",
+            "ios.subscription.1year.row.freetrial.dev.pro",
+
+            // macOS Debug
+            "subscription.1year.row.freetrial",
+            "subscription.1year.row.freetrial.pro",
+
+            // macOS Review
+            "review.subscription.1year.row.freetrial",
+            "review.subscription.1year.row.freetrial.pro",
+
+            // TestFlight
+            "tf.sandbox.subscription.1year.row.freetrial",
+            "tf.sandbox.subscription.1year.row.freetrial.pro"
+        ]
+
+        // When
+        let actualProducts = Set(sut.subscriptionIdentifiers(for: .restOfWorld))
+
+        // Then
+        #expect(actualProducts == expectedROWProducts,
+                "ROW products without monthly free trials should match expected list exactly")
+    }
+}
+
+private struct MockMonthlyFreeTrialDecider: MonthlyFreeTrialDeciding {
+    let shouldOfferMonthlyFreeTrialValue: Bool
+
+    init(shouldOfferMonthlyFreeTrial: Bool) {
+        self.shouldOfferMonthlyFreeTrialValue = shouldOfferMonthlyFreeTrial
+    }
+
+    func shouldOfferMonthlyFreeTrial() -> Bool {
+        shouldOfferMonthlyFreeTrialValue
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/StoreSubscriptionConfigurationTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/StoreSubscriptionConfigurationTests.swift
@@ -22,7 +22,7 @@ import Testing
 @Suite("Store Subscription Configuration Tests")
 struct StoreSubscriptionConfigurationTests {
 
-    let sut = DefaultStoreSubscriptionConfiguration(monthlyFreeTrialDecider: MockMonthlyFreeTrialDecider(shouldOfferMonthlyFreeTrial: true))
+    let sut = DefaultStoreSubscriptionConfiguration()
 
     @Test("USA region returns expected product identifiers")
     func usaRegionReturnsExpectedProductIdentifiers() {
@@ -38,6 +38,7 @@ struct StoreSubscriptionConfigurationTests {
             "ios.subscription.1month.freetrial.dev",
             "ios.subscription.1year.freetrial.dev",
             "ios.subscription.1month.freetrial.dev.pro",
+            "ios.subscription.1month.dev.pro",
             "ios.subscription.1year.freetrial.dev.pro",
 
             // macOS Debug
@@ -81,6 +82,7 @@ struct StoreSubscriptionConfigurationTests {
             "ios.subscription.1month.row.freetrial.dev",
             "ios.subscription.1year.row.freetrial.dev",
             "ios.subscription.1month.row.freetrial.dev.pro",
+            "ios.subscription.1month.row.dev.pro",
             "ios.subscription.1year.row.freetrial.dev.pro",
 
             // macOS Debug
@@ -108,89 +110,5 @@ struct StoreSubscriptionConfigurationTests {
         // Then
         #expect(actualProducts == expectedROWProducts,
                 "ROW products should match expected list exactly")
-    }
-
-    // MARK: - Monthly free-trial filtering
-
-    @Test("USA region without monthly free trial returns expected product identifiers")
-    func usaRegionWithoutMonthlyFreeTrialReturnsExpectedProductIdentifiers() {
-        // Given
-        let sut = DefaultStoreSubscriptionConfiguration(monthlyFreeTrialDecider: MockMonthlyFreeTrialDecider(shouldOfferMonthlyFreeTrial: false))
-        let expectedUSAProducts: Set<String> = [
-            // Production
-            "ddg.privacy.pro.yearly.renews.us.freetrial",
-            "ddg.subscription.yearly.renews.us.freetrial.pro",
-
-            // iOS Alpha
-            "ios.subscription.1year.freetrial.dev",
-            "ios.subscription.1month.dev.pro",
-            "ios.subscription.1year.freetrial.dev.pro",
-
-            // macOS Debug
-            "subscription.1year.freetrial",
-            "subscription.1year.freetrial.pro",
-
-            // macOS Review
-            "review.subscription.1year.freetrial",
-            "review.subscription.1year.freetrial.pro",
-
-            // TestFlight
-            "tf.sandbox.subscription.1year.freetrial",
-            "tf.sandbox.subscription.1year.freetrial.pro"
-        ]
-
-        // When
-        let actualProducts = Set(sut.subscriptionIdentifiers(for: .usa))
-
-        // Then
-        #expect(actualProducts == expectedUSAProducts,
-                "USA products without monthly free trials should match expected list exactly")
-    }
-
-    @Test("ROW region without monthly free trial returns expected product identifiers")
-    func rowRegionWithoutMonthlyFreeTrialReturnsExpectedProductIdentifiers() {
-        // Given
-        let sut = DefaultStoreSubscriptionConfiguration(monthlyFreeTrialDecider: MockMonthlyFreeTrialDecider(shouldOfferMonthlyFreeTrial: false))
-        let expectedROWProducts: Set<String> = [
-            // Production
-            "ddg.privacy.pro.yearly.renews.row.freetrial",
-            "ddg.subscription.yearly.renews.row.freetrial.pro",
-
-            // iOS Alpha
-            "ios.subscription.1year.row.freetrial.dev",
-            "ios.subscription.1month.row.dev.pro",
-            "ios.subscription.1year.row.freetrial.dev.pro",
-
-            // macOS Debug
-            "subscription.1year.row.freetrial",
-            "subscription.1year.row.freetrial.pro",
-
-            // macOS Review
-            "review.subscription.1year.row.freetrial",
-            "review.subscription.1year.row.freetrial.pro",
-
-            // TestFlight
-            "tf.sandbox.subscription.1year.row.freetrial",
-            "tf.sandbox.subscription.1year.row.freetrial.pro"
-        ]
-
-        // When
-        let actualProducts = Set(sut.subscriptionIdentifiers(for: .restOfWorld))
-
-        // Then
-        #expect(actualProducts == expectedROWProducts,
-                "ROW products without monthly free trials should match expected list exactly")
-    }
-}
-
-private struct MockMonthlyFreeTrialDecider: MonthlyFreeTrialDeciding {
-    let shouldOfferMonthlyFreeTrialValue: Bool
-
-    init(shouldOfferMonthlyFreeTrial: Bool) {
-        self.shouldOfferMonthlyFreeTrialValue = shouldOfferMonthlyFreeTrial
-    }
-
-    func shouldOfferMonthlyFreeTrial() -> Bool {
-        shouldOfferMonthlyFreeTrialValue
     }
 }

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -506,6 +506,11 @@ public enum FeatureFlag: String {
     /// NA Experiment: tailor the onboarding flow based on the user's download reason.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216491579842691?focus=true
     case onboardingFlowByDownloadReasonExperiment
+
+    /// Experiment: offer free trials on yearly plans only, removing the monthly free trial for the
+    /// treatment cohort. US-only; targeting is enforced via the remote configuration.
+    /// https://app.asana.com/1/137249556945/project/1202500774821704/task/1216172392115585
+    case monthlyFreeTrialExperiment
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -528,6 +533,13 @@ extension FeatureFlag: FeatureFlagDescribing {
 
     /// Cohorts for the onboarding-flow-by-download-reason experiment.
     public enum OnboardingFlowByDownloadReasonExperimentCohort: String, FeatureFlagCohortDescribing {
+        case control
+        case treatment
+    }
+
+    /// Cohorts for the monthly free-trial experiment. `treatment` removes the monthly free trial;
+    /// `control` keeps the current behavior (monthly free trial offered).
+    public enum MonthlyFreeTrialExperimentCohort: String, FeatureFlagCohortDescribing {
         case control
         case treatment
     }
@@ -781,6 +793,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.searchTokenExperiment), cohortType: SearchTokenExperimentCohort.self)
         case .onboardingFlowByDownloadReasonExperiment:
             Config(source: .disabled, cohortType: OnboardingFlowByDownloadReasonExperimentCohort.self)
+        case .monthlyFreeTrialExperiment:
+            Config(source: .remoteReleasable(PrivacyProSubfeature.monthlyFreeTrialExperiment), cohortType: MonthlyFreeTrialExperimentCohort.self)
         case .genericBackgroundTask:
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.genericBackgroundTask))
         case .crashCollectionLimitCallStackTreeDepth:

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -507,8 +507,7 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216491579842691?focus=true
     case onboardingFlowByDownloadReasonExperiment
 
-    /// Experiment: offer free trials on yearly plans only, removing the monthly free trial for the
-    /// treatment cohort. US-only; targeting is enforced via the remote configuration.
+    /// Annual-trials experiment. Treatment removes the monthly free trial.
     /// https://app.asana.com/1/137249556945/project/1202500774821704/task/1216172392115585
     case monthlyFreeTrialExperiment
 }
@@ -537,8 +536,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case treatment
     }
 
-    /// Cohorts for the monthly free-trial experiment. `treatment` removes the monthly free trial;
-    /// `control` keeps the current behavior (monthly free trial offered).
+    /// Treatment removes the monthly free trial.
     public enum MonthlyFreeTrialExperimentCohort: String, FeatureFlagCohortDescribing {
         case control
         case treatment

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1680,6 +1680,7 @@
 		9FCFCD802C6AF56D006EB7A0 /* LaunchOptionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCFCD7F2C6AF56D006EB7A0 /* LaunchOptionsHandlerTests.swift */; };
 		9FCFCD812C6B020D006EB7A0 /* LaunchOptionsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCFCD7D2C6AF52A006EB7A0 /* LaunchOptionsHandler.swift */; };
 		9FD1BDEC2D8C183C002F4EFE /* OnboardingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD1BDEB2D8C183C002F4EFE /* OnboardingManagerTests.swift */; };
+		FDEC1A2B30260001000000F1 /* IOSMonthlyFreeTrialDeciderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEC1A2B30260001000000F2 /* IOSMonthlyFreeTrialDeciderTests.swift */; };
 		9FD3DB3B2FB6E82700A7C56E /* OnboardingIntroFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD3DB3A2FB6E82000A7C56E /* OnboardingIntroFactory.swift */; };
 		9FD3DB3D2FB6EA5200A7C56E /* OnboardingIntroContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD3DB3C2FB6EA4F00A7C56E /* OnboardingIntroContext.swift */; };
 		9FD6E6052DF8226000C2B032 /* AudioSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD6E6042DF8225C00C2B032 /* AudioSessionManager.swift */; };
@@ -4388,6 +4389,7 @@
 		9FCFCD7D2C6AF52A006EB7A0 /* LaunchOptionsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchOptionsHandler.swift; sourceTree = "<group>"; };
 		9FCFCD7F2C6AF56D006EB7A0 /* LaunchOptionsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchOptionsHandlerTests.swift; sourceTree = "<group>"; };
 		9FD1BDEB2D8C183C002F4EFE /* OnboardingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManagerTests.swift; sourceTree = "<group>"; };
+		FDEC1A2B30260001000000F2 /* IOSMonthlyFreeTrialDeciderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSMonthlyFreeTrialDeciderTests.swift; sourceTree = "<group>"; };
 		9FD3DB3A2FB6E82000A7C56E /* OnboardingIntroFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingIntroFactory.swift; sourceTree = "<group>"; };
 		9FD3DB3C2FB6EA4F00A7C56E /* OnboardingIntroContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingIntroContext.swift; sourceTree = "<group>"; };
 		9FD6E6042DF8225C00C2B032 /* AudioSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionManager.swift; sourceTree = "<group>"; };
@@ -8534,6 +8536,7 @@
 				97EFB15A2EFAB2D600CF06E1 /* OnboardingSearchExperienceSettingsResolverTests.swift */,
 				9F5179D92D545D4300E40B40 /* DaxDialogsOnboardingMigratorTests.swift */,
 				9FD1BDEB2D8C183C002F4EFE /* OnboardingManagerTests.swift */,
+				FDEC1A2B30260001000000F2 /* IOSMonthlyFreeTrialDeciderTests.swift */,
 				9F3038F32F99C2840007310C /* OnboardingFlowEvaluatorTests.swift */,
 				3652B1D4CCA25401F948AB69 /* TabViewControllerSiteLoadingPixelTests.swift */,
 				6A30EF03B7EC51B89770CA36 /* NavigationPixelNavigationResponderTests.swift */,
@@ -14153,6 +14156,7 @@
 				850259682EC353EC004607A9 /* MobileCustomizationTests.swift in Sources */,
 				CBDD5DDF29A6736A00832877 /* APIHeadersTests.swift in Sources */,
 				9FD1BDEC2D8C183C002F4EFE /* OnboardingManagerTests.swift in Sources */,
+				FDEC1A2B30260001000000F1 /* IOSMonthlyFreeTrialDeciderTests.swift in Sources */,
 				986B45D0299E30A50089D2D7 /* BookmarkEntityTests.swift in Sources */,
 				BBFA34402F19286D0003CB58 /* SubscriptionPagesUseSubscriptionFeatureTests.swift in Sources */,
 				BBFA34412F19286D0003CB58 /* SubscriptionSettingsViewModelTests.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1680,7 +1680,6 @@
 		9FCFCD802C6AF56D006EB7A0 /* LaunchOptionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCFCD7F2C6AF56D006EB7A0 /* LaunchOptionsHandlerTests.swift */; };
 		9FCFCD812C6B020D006EB7A0 /* LaunchOptionsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCFCD7D2C6AF52A006EB7A0 /* LaunchOptionsHandler.swift */; };
 		9FD1BDEC2D8C183C002F4EFE /* OnboardingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD1BDEB2D8C183C002F4EFE /* OnboardingManagerTests.swift */; };
-		FDEC1A2B30260001000000F1 /* IOSMonthlyFreeTrialDeciderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEC1A2B30260001000000F2 /* IOSMonthlyFreeTrialDeciderTests.swift */; };
 		9FD3DB3B2FB6E82700A7C56E /* OnboardingIntroFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD3DB3A2FB6E82000A7C56E /* OnboardingIntroFactory.swift */; };
 		9FD3DB3D2FB6EA5200A7C56E /* OnboardingIntroContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD3DB3C2FB6EA4F00A7C56E /* OnboardingIntroContext.swift */; };
 		9FD6E6052DF8226000C2B032 /* AudioSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD6E6042DF8225C00C2B032 /* AudioSessionManager.swift */; };
@@ -1839,6 +1838,8 @@
 		BB77957F2E9D4B4D00CF58F4 /* WinBackOfferService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB77957E2E9D4B4D00CF58F4 /* WinBackOfferService.swift */; };
 		BB7795812E9D532100CF58F4 /* WinBackOfferFeatureFlagger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7795802E9D532100CF58F4 /* WinBackOfferFeatureFlagger.swift */; };
 		BB8126B72EB8DC7900360AAF /* WinBackOfferModalPromptProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB8126B62EB8DC7900360AAF /* WinBackOfferModalPromptProviderTests.swift */; };
+		BB82616F30124E2200F8A80F /* MonthlyFreeTrialExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB82616E30124E2200F8A80F /* MonthlyFreeTrialExperiment.swift */; };
+		BB82617130124E5100F8A80F /* MonthlyFreeTrialExperimentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB82617030124E5100F8A80F /* MonthlyFreeTrialExperimentTests.swift */; };
 		BB88557B2FD1D04B007BDE10 /* SERPSettingsWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB88557A2FD1D04B007BDE10 /* SERPSettingsWebView.swift */; };
 		BBA0000000000000000A0002 /* TabInputState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA0000000000000000A0001 /* TabInputState.swift */; };
 		BBA0000000000000000A0004 /* TabInputStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA0000000000000000A0003 /* TabInputStateTests.swift */; };
@@ -2625,6 +2626,7 @@
 		FBA1C0DE0000000000000007 /* IPadDuckAIControlsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000008 /* IPadDuckAIControlsFeatureTests.swift */; };
 		FBA1C0DE0000000000000009 /* IPadDuckAIControlValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE000000000000000A /* IPadDuckAIControlValues.swift */; };
 		FD555C0BE82E630360DC2E5A /* ToggleModeStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090D90640A2B1A529EDBAAB /* ToggleModeStorage.swift */; };
+		FDEC1A2B30260001000000F1 /* IOSMonthlyFreeTrialDeciderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEC1A2B30260001000000F2 /* IOSMonthlyFreeTrialDeciderTests.swift */; };
 		FE1A2B3C0001000100010001 /* AIChatRAGTool+ToolbarChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1A2B3C0001000100010002 /* AIChatRAGTool+ToolbarChip.swift */; };
 /* End PBXBuildFile section */
 
@@ -4389,7 +4391,6 @@
 		9FCFCD7D2C6AF52A006EB7A0 /* LaunchOptionsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchOptionsHandler.swift; sourceTree = "<group>"; };
 		9FCFCD7F2C6AF56D006EB7A0 /* LaunchOptionsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchOptionsHandlerTests.swift; sourceTree = "<group>"; };
 		9FD1BDEB2D8C183C002F4EFE /* OnboardingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManagerTests.swift; sourceTree = "<group>"; };
-		FDEC1A2B30260001000000F2 /* IOSMonthlyFreeTrialDeciderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSMonthlyFreeTrialDeciderTests.swift; sourceTree = "<group>"; };
 		9FD3DB3A2FB6E82000A7C56E /* OnboardingIntroFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingIntroFactory.swift; sourceTree = "<group>"; };
 		9FD3DB3C2FB6EA4F00A7C56E /* OnboardingIntroContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingIntroContext.swift; sourceTree = "<group>"; };
 		9FD6E6042DF8225C00C2B032 /* AudioSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionManager.swift; sourceTree = "<group>"; };
@@ -4537,6 +4538,8 @@
 		BB77957E2E9D4B4D00CF58F4 /* WinBackOfferService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinBackOfferService.swift; sourceTree = "<group>"; };
 		BB7795802E9D532100CF58F4 /* WinBackOfferFeatureFlagger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinBackOfferFeatureFlagger.swift; sourceTree = "<group>"; };
 		BB8126B62EB8DC7900360AAF /* WinBackOfferModalPromptProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinBackOfferModalPromptProviderTests.swift; sourceTree = "<group>"; };
+		BB82616E30124E2200F8A80F /* MonthlyFreeTrialExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyFreeTrialExperiment.swift; sourceTree = "<group>"; };
+		BB82617030124E5100F8A80F /* MonthlyFreeTrialExperimentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyFreeTrialExperimentTests.swift; sourceTree = "<group>"; };
 		BB88557A2FD1D04B007BDE10 /* SERPSettingsWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SERPSettingsWebView.swift; sourceTree = "<group>"; };
 		BBA0000000000000000A0001 /* TabInputState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabInputState.swift; sourceTree = "<group>"; };
 		BBA0000000000000000A0003 /* TabInputStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabInputStateTests.swift; sourceTree = "<group>"; };
@@ -5404,6 +5407,7 @@
 		FBA1C0DE0000000000000008 /* IPadDuckAIControlsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadDuckAIControlsFeatureTests.swift; sourceTree = "<group>"; };
 		FBA1C0DE000000000000000A /* IPadDuckAIControlValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadDuckAIControlValues.swift; sourceTree = "<group>"; };
 		FD63EDD2D1E5E97F3084B04F /* SearchTokenRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchTokenRequest.swift; sourceTree = "<group>"; };
+		FDEC1A2B30260001000000F2 /* IOSMonthlyFreeTrialDeciderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSMonthlyFreeTrialDeciderTests.swift; sourceTree = "<group>"; };
 		FE1A2B3C0001000100010002 /* AIChatRAGTool+ToolbarChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AIChatRAGTool+ToolbarChip.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -7693,6 +7697,7 @@
 		84E341A91E2F7EFB00BDBA6F /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				BB82617030124E5100F8A80F /* MonthlyFreeTrialExperimentTests.swift */,
 				5B941E702FA29A1600AF2CE7 /* Widgets */,
 				850259662EC353E1004607A9 /* Customization */,
 				9FB19C872E94CF2E00B651B1 /* RemoteMessaging */,
@@ -10452,6 +10457,7 @@
 		D664C7922B289AA000CBFA76 /* Subscription */ = {
 			isa = PBXGroup;
 			children = (
+				BB82616E30124E2200F8A80F /* MonthlyFreeTrialExperiment.swift */,
 				BBA8EA4D30120A4600FE41CD /* IOSMonthlyFreeTrialDecider.swift */,
 				3666D84A30004E3E00B63F99 /* Onboarding */,
 				BB3F734C2F321F4000461429 /* FreeTrialPixelHandler.swift */,
@@ -13537,6 +13543,7 @@
 				CBAD0F102D0062A7006267B8 /* ScreenshotService.swift in Sources */,
 				8598D2E42CEB98B500C45685 /* FaviconSourcesProvider.swift in Sources */,
 				C18390C22F4F712A001939B9 /* AIChatBasicNativeInputViewController.swift in Sources */,
+				BB82616F30124E2200F8A80F /* MonthlyFreeTrialExperiment.swift in Sources */,
 				CBB4A8652FD31A0A00A65956 /* SuggestionsFavoritesView.swift in Sources */,
 				317DF60B2D01E7D600DE0145 /* RoundedPageSheetPresentationAnimator.swift in Sources */,
 				85AE6690209724120014CF04 /* NotificationView.swift in Sources */,
@@ -14576,6 +14583,7 @@
 				56940C752E0AA4F60007741D /* UnifiedFeedbackFormViewModelTests.swift in Sources */,
 				5651F5342EE887DD009C7490 /* SubscriptionFlowTypeTests.swift in Sources */,
 				8588026A24E424EE00C24AB6 /* AppWidthObserverTests.swift in Sources */,
+				BB82617130124E5100F8A80F /* MonthlyFreeTrialExperimentTests.swift in Sources */,
 				8504E9EA2D8883BA00FF1352 /* TabSwitcherBarsStateHandlerTests.swift in Sources */,
 				7A1B2C3D2E0000000000F001 /* TabsBarViewControllerSizingTests.swift in Sources */,
 				857229882BBEE74100E2E802 /* AppRatingPromptDatabaseMigrationTests.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		0ADDA22E21E33D1BA5126D53 /* SearchTokenExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E195E64C4FA98412110685 /* SearchTokenExperiment.swift */; };
 		0F7978C4A0677C699DE8CF19 /* IPadOmnibarAttachmentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57D32992B677C4C22600174 /* IPadOmnibarAttachmentController.swift */; };
 		18EB298166184F06B6A87190 /* OnboardingSearchAIToggleGrey.lottie in Resources */ = {isa = PBXBuildFile; fileRef = 17BA504D98D84DB79BDE168D /* OnboardingSearchAIToggleGrey.lottie */; };
+		1A2B3C4D5E6F708192A3B402 /* MainViewController+AIChatHistoryViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F708192A3B401 /* MainViewController+AIChatHistoryViewModelDelegate.swift */; };
 		1AD965E390AC1B7FDE09D956 /* OnboardingView+ComparisonContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8693FFCAC02CE4A85D0BD62C /* OnboardingView+ComparisonContent.swift */; };
 		1CB7B82123CEA1F800AA24EA /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB7B82023CEA1F800AA24EA /* DateExtension.swift */; };
 		1CB7B82323CEA28300AA24EA /* DateExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB7B82223CEA28300AA24EA /* DateExtensionTests.swift */; };
@@ -257,11 +258,11 @@
 		31F43E1F2F472F3C001BBCDA /* AIChatAddressBarExperience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F43E1E2F472F3C001BBCDA /* AIChatAddressBarExperience.swift */; };
 		31F43E212F4734B8001BBCDA /* AIChatAddressBarExperienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F43E202F4734B8001BBCDA /* AIChatAddressBarExperienceTests.swift */; };
 		31FD991B2DCE6AAB00AAC9C7 /* ExperimentalAIChatManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FD991A2DCE6AAB00AAC9C7 /* ExperimentalAIChatManager.swift */; };
+		35281034C485F1E15258BFD5 /* OnboardingView+IntroDialogContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9785D25DF2EA27126C8A33B8 /* OnboardingView+IntroDialogContent.swift */; };
 		36208F733005706900EB6335 /* SubscriptionOnboardingListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36208F723005706900EB6335 /* SubscriptionOnboardingListItemView.swift */; };
 		36208F753005707600EB6335 /* SubscriptionOnboardingShowcaseCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36208F743005707600EB6335 /* SubscriptionOnboardingShowcaseCard.swift */; };
 		36208F773005742400EB6335 /* SubscriptionOnboardingSetupCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36208F763005742400EB6335 /* SubscriptionOnboardingSetupCard.swift */; };
 		36208F793005916700EB6335 /* SubscriptionOnboardingVPNInfoCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36208F783005916700EB6335 /* SubscriptionOnboardingVPNInfoCard.swift */; };
-		35281034C485F1E15258BFD5 /* OnboardingView+IntroDialogContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9785D25DF2EA27126C8A33B8 /* OnboardingView+IntroDialogContent.swift */; };
 		362AB8382F69A33700E3F222 /* ActionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362AB8372F69A33700E3F222 /* ActionResult.swift */; };
 		365E900B2E566C2300BDB0E8 /* AIChatIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 365E900A2E566C2300BDB0E8 /* AIChatIntent.swift */; };
 		365E90132E5673DF00BDB0E8 /* SearchInAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 365E90122E5673DF00BDB0E8 /* SearchInAppIntent.swift */; };
@@ -313,6 +314,7 @@
 		37FCAABC2992F592000E420A /* MultilineScrollableTextFix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FCAABB2992F592000E420A /* MultilineScrollableTextFix.swift */; };
 		37FCAAC029930E26000E420A /* FailedAssertionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FCAABF29930E26000E420A /* FailedAssertionView.swift */; };
 		39BD5432CF6280442CDE88F0 /* DBPIOSContentBlockingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99D6557A506491EFDAD68A2 /* DBPIOSContentBlockingTests.swift */; };
+		39DD82B9D3CC259FF8CF5B13 /* FileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16393FE1ECCB9CC00DDD653 /* FileLoader.swift */; };
 		45865446DBAA91F852E4AEA1 /* SearchTokenExperimentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E893A63A6D9BB66F042D3770 /* SearchTokenExperimentTests.swift */; };
 		46DD3D5A2D0A29F600F33D49 /* CrashReportSenderExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46DD3D592D0A29F400F33D49 /* CrashReportSenderExtensions.swift */; };
 		4B0163D92F704AB60002E7FF /* MarketplaceAdPostbackStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317F5F972C94A9EB0081666F /* MarketplaceAdPostbackStorage.swift */; };
@@ -814,7 +816,6 @@
 		85058370219F424500ED4EDB /* SearchBarExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F143C3451E4AA32D00CFDE3A /* SearchBarExtension.swift */; };
 		8508931F2EA7AF04005F84FD /* MobileCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8508931E2EA7AEFE005F84FD /* MobileCustomization.swift */; };
 		850ABD012AC3961100A733DF /* MainViewController+Segues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850ABD002AC3961100A733DF /* MainViewController+Segues.swift */; };
-		1A2B3C4D5E6F708192A3B402 /* MainViewController+AIChatHistoryViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F708192A3B401 /* MainViewController+AIChatHistoryViewModelDelegate.swift */; };
 		850F93DB2B594AB800823EEA /* ZippedPassKitPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850F93DA2B594AB800823EEA /* ZippedPassKitPreviewHelper.swift */; };
 		8512EA4F24ED30D20073EE19 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8512EA4E24ED30D20073EE19 /* WidgetKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		8512EA5124ED30D20073EE19 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8512EA5024ED30D20073EE19 /* SwiftUI.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -1845,6 +1846,7 @@
 		BBA0000000000000000D0004 /* UnifiedInputStateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA0000000000000000D0003 /* UnifiedInputStateStoreTests.swift */; };
 		BBA0000000000000000E0002 /* Logger+UnifiedInputState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA0000000000000000E0001 /* Logger+UnifiedInputState.swift */; };
 		BBA0000000000000000F0002 /* UnifiedInputTabState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA0000000000000000F0001 /* UnifiedInputTabState.swift */; };
+		BBA8EA4E30120A4600FE41CD /* IOSMonthlyFreeTrialDecider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA8EA4D30120A4600FE41CD /* IOSMonthlyFreeTrialDecider.swift */; };
 		BBAFF02D2F6A93F900029537 /* SubscriptionPromoPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBAFF02B2F6A93F900029537 /* SubscriptionPromoPresenter.swift */; };
 		BBAFF02E2F6A93F900029537 /* SubscriptionPromoCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBAFF0292F6A93F900029537 /* SubscriptionPromoCoordinator.swift */; };
 		BBAFF02F2F6A93F900029537 /* SubscriptionPromoLaunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBAFF02A2F6A93F900029537 /* SubscriptionPromoLaunchView.swift */; };
@@ -1891,6 +1893,7 @@
 		BDFF031D2BA3D2BD00F324C9 /* DefaultNetworkProtectionVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFF031C2BA3D2BD00F324C9 /* DefaultNetworkProtectionVisibility.swift */; };
 		BDFF03222BA3D8E200F324C9 /* NetworkProtectionFeatureVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFF03192BA39C5A00F324C9 /* NetworkProtectionFeatureVisibility.swift */; };
 		BDFF03232BA3D8E300F324C9 /* NetworkProtectionFeatureVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFF03192BA39C5A00F324C9 /* NetworkProtectionFeatureVisibility.swift */; };
+		BE645AAB1B563BF912B09749 /* FileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16393FE1ECCB9CC00DDD653 /* FileLoader.swift */; };
 		BE83A575896316C700B212FA /* DuckAISubscriptionUpsellPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E71D2723FF8B5622E2904F40 /* DuckAISubscriptionUpsellPresenterTests.swift */; };
 		BEC5B10A1F9E4CF5A889BBDC /* EscapeHatchModelBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98109F19E7F142578C327237 /* EscapeHatchModelBuilder.swift */; };
 		BFA000022F90000000FEEE01 /* FreemiumPIREligibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA000012F90000000FEEE01 /* FreemiumPIREligibility.swift */; };
@@ -1912,7 +1915,6 @@
 		C11F41152F2CCBE900C126C3 /* AIChatContextualChatSessionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11F41142F2CCBE900C126C3 /* AIChatContextualChatSessionStateTests.swift */; };
 		C12324C32C4697C900FBB26B /* AutofillBreakageReportTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1836CE42C35A0EA0016D057 /* AutofillBreakageReportTableViewCell.swift */; };
 		C124027C2F2922E700F87332 /* AIChatContextualModePixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C124027B2F2922E700F87332 /* AIChatContextualModePixelHandler.swift */; };
-		FB90C0DE0000000000000A01 /* PageContextExtractionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB90C0DE0000000000000A02 /* PageContextExtractionPixelHandler.swift */; };
 		C124027E2F2935F600F87332 /* AIChatContextualModePixelHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C124027D2F2935F600F87332 /* AIChatContextualModePixelHandlerTests.swift */; };
 		C124F0532E686CBB008D0F49 /* SwitchBarFunnel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C124F0522E686CBB008D0F49 /* SwitchBarFunnel.swift */; };
 		C124F0562E6879E7008D0F49 /* SwitchBarFunnelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C124F0552E6879E7008D0F49 /* SwitchBarFunnelTests.swift */; };
@@ -2155,6 +2157,8 @@
 		C1FA13762ECFDB72001392FA /* AutofillExtensionEnableCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FA13752ECFDB72001392FA /* AutofillExtensionEnableCoordinatorTests.swift */; };
 		C1FFBD462C761BE20073622B /* SyncPromoManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FFBD452C761BE20073622B /* SyncPromoManagerTests.swift */; };
 		C1FFBD482C7749A90073622B /* SyncSettingsViewController+PlatformLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FFBD472C7749A90073622B /* SyncSettingsViewController+PlatformLinks.swift */; };
+		C2920E700F7D448614155BC5 /* FileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16393FE1ECCB9CC00DDD653 /* FileLoader.swift */; };
+		C51DE2491C1278EF27899BB1 /* FileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16393FE1ECCB9CC00DDD653 /* FileLoader.swift */; };
 		C590E41C21CD46E99C4A5B2E /* AIChatContextualWebViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7971E90992B46FABF42A908 /* AIChatContextualWebViewControllerTests.swift */; };
 		CB1143DE2AF6D4B600C1CCD3 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = CB1143DC2AF6D4B600C1CCD3 /* InfoPlist.strings */; };
 		CB14D5832E269A7F002E897E /* UserAgentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB14D5822E269A73002E897E /* UserAgentConfiguration.swift */; };
@@ -2215,8 +2219,8 @@
 		CB6D17A42FA3983100ECD5AE /* UnifiedToggleInputPageContextChipViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17A32FA3983100ECD5AE /* UnifiedToggleInputPageContextChipViewModel.swift */; };
 		CB6D17A82FA39FC900ECD5AE /* AIChatContextualUTIHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17A72FA39FC900ECD5AE /* AIChatContextualUTIHost.swift */; };
 		CB6D17AA2FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17A92FA4B57900ECD5AE /* AIChatContextualUTIHostTests.swift */; };
-		CB6D17B12FA4B57900ECD5AE /* AIChatContextualSheetViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B02FA4B57900ECD5AE /* AIChatContextualSheetViewControllerTests.swift */; };
 		CB6D17B02FA2138200ECD5AE /* AIChatSyncPromoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B12FA2138200ECD5AE /* AIChatSyncPromoView.swift */; };
+		CB6D17B12FA4B57900ECD5AE /* AIChatContextualSheetViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B02FA4B57900ECD5AE /* AIChatContextualSheetViewControllerTests.swift */; };
 		CB6D17B22FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B32FA2138200ECD5AE /* AIChatSyncIntroSheetView.swift */; };
 		CB6D17B42FB000000ECD5AE /* AIChatSyncPromoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B52FB000000ECD5AE /* AIChatSyncPromoViewModel.swift */; };
 		CB6D17B72FB000000ECD5AE /* AIChatSyncPromoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6D17B62FB000000ECD5AE /* AIChatSyncPromoViewModelTests.swift */; };
@@ -2342,6 +2346,8 @@
 		D1A2B3C4E5F60001AABB0003 /* PostIdleSessionWideEventDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60001AABB0004 /* PostIdleSessionWideEventDataTests.swift */; };
 		D1A2B3C4E5F60001AABB0005 /* PostIdleSessionInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60001AABB0006 /* PostIdleSessionInstrumentation.swift */; };
 		D1A2B3C4E5F60001AABB0007 /* PostIdleSessionInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60001AABB0008 /* PostIdleSessionInstrumentationTests.swift */; };
+		D1A4C0DE2F210002004E5001 /* NetworkProtectionStatusViewTintSpecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A4C0DE2F210001004E5001 /* NetworkProtectionStatusViewTintSpecTests.swift */; };
+		D1A4C0DE2F210004004E5001 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = D1A4C0DE2F210003004E5001 /* Lottie */; };
 		D2D2D2D200000000000000F1 /* CookiePopupProtectionOptInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D2D2D200000000000000F0 /* CookiePopupProtectionOptInView.swift */; };
 		D4F72864A16A77A0907EBA57 /* OnboardingView+Landing.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD503EBD506182525F5E8107 /* OnboardingView+Landing.swift */; };
 		D60170BD2BA34CE8001911B5 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60170BB2BA32DD6001911B5 /* Subscription.swift */; };
@@ -2463,8 +2469,6 @@
 		EEF7091F2DDE77B000BA3C36 /* SyncExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF7091E2DDE77B000BA3C36 /* SyncExtensions.swift */; };
 		EEFC6A602AC0F2F80065027D /* UserText.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFC6A5F2AC0F2F80065027D /* UserText.swift */; };
 		EEFE9C732A603CE9005B0A26 /* NetworkProtectionStatusViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFE9C722A603CE9005B0A26 /* NetworkProtectionStatusViewModelTests.swift */; };
-		D1A4C0DE2F210002004E5001 /* NetworkProtectionStatusViewTintSpecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A4C0DE2F210001004E5001 /* NetworkProtectionStatusViewTintSpecTests.swift */; };
-		D1A4C0DE2F210004004E5001 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = D1A4C0DE2F210003004E5001 /* Lottie */; };
 		F0A100012F30200100BAD001 /* NewBadgeVisibilityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A100002F30200100BAD001 /* NewBadgeVisibilityManager.swift */; };
 		F0A1B2C3D4E5F60718293B01 /* FloatingUIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A1B2C3D4E5F60718293A01 /* FloatingUIManager.swift */; };
 		F0A1B2C3D4E5F60718293B02 /* FloatingUIChromeStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A1B2C3D4E5F60718293A02 /* FloatingUIChromeStyler.swift */; };
@@ -2512,10 +2516,6 @@
 		F1617C151E57336D00DEDCAF /* TabManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1617C141E57336D00DEDCAF /* TabManager.swift */; };
 		F1617C191E573EA800DEDCAF /* TabSwitcherDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1617C181E573EA800DEDCAF /* TabSwitcherDelegate.swift */; };
 		F16393FF1ECCB9CC00DDD653 /* FileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16393FE1ECCB9CC00DDD653 /* FileLoader.swift */; };
-		39DD82B9D3CC259FF8CF5B13 /* FileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16393FE1ECCB9CC00DDD653 /* FileLoader.swift */; };
-		BE645AAB1B563BF912B09749 /* FileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16393FE1ECCB9CC00DDD653 /* FileLoader.swift */; };
-		C51DE2491C1278EF27899BB1 /* FileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16393FE1ECCB9CC00DDD653 /* FileLoader.swift */; };
-		C2920E700F7D448614155BC5 /* FileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16393FE1ECCB9CC00DDD653 /* FileLoader.swift */; };
 		F164BCD42E3CFAF9001DF95A /* AdAttributionPixelReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F164BCD12E3CFAF9001DF95A /* AdAttributionPixelReporterTests.swift */; };
 		F164BCD52E3CFAF9001DF95A /* AdAttributionFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F164BCD02E3CFAF9001DF95A /* AdAttributionFetcherTests.swift */; };
 		F164BCD62E3CFAF9001DF95A /* AdClickExternalOpenDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F164BCD22E3CFAF9001DF95A /* AdClickExternalOpenDetectorTests.swift */; };
@@ -2617,6 +2617,7 @@
 		FADE0001C0FFEE00A5311003 /* PageSuggestionsCatalog.json in Resources */ = {isa = PBXBuildFile; fileRef = FADE0001C0FFEE00A5311004 /* PageSuggestionsCatalog.json */; };
 		FADE0001C0FFEE00A5311005 /* ContextualSuggestionUserText.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADE0001C0FFEE00A5311006 /* ContextualSuggestionUserText.swift */; };
 		FADE0001C0FFEE00A5311007 /* ContextualSuggestionsMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADE0001C0FFEE00A5311008 /* ContextualSuggestionsMatcherTests.swift */; };
+		FB90C0DE0000000000000A01 /* PageContextExtractionPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB90C0DE0000000000000A02 /* PageContextExtractionPixelHandler.swift */; };
 		FBA1C0DE0000000000000001 /* IPadOmnibarModelPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000002 /* IPadOmnibarModelPickerController.swift */; };
 		FBA1C0DE0000000000000003 /* IPadOmnibarModelPickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000004 /* IPadOmnibarModelPickerControllerTests.swift */; };
 		FBA1C0DE0000000000000005 /* IPadDuckAIControlsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000006 /* IPadDuckAIControlsFeature.swift */; };
@@ -2798,6 +2799,7 @@
 		114B20D6843A4D239C58435F /* SearchExperienceToggleAnimationView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchExperienceToggleAnimationView.swift; sourceTree = "<group>"; };
 		136D952152194AD431654F8D /* RemoteMessagingUIPreviewsDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMessagingUIPreviewsDebugView.swift; sourceTree = "<group>"; };
 		17BA504D98D84DB79BDE168D /* OnboardingSearchAIToggleGrey.lottie */ = {isa = PBXFileReference; lastKnownFileType = file; path = OnboardingSearchAIToggleGrey.lottie; sourceTree = "<group>"; };
+		1A2B3C4D5E6F708192A3B401 /* MainViewController+AIChatHistoryViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewController+AIChatHistoryViewModelDelegate.swift"; sourceTree = "<group>"; };
 		1CB7B82023CEA1F800AA24EA /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		1CB7B82223CEA28300AA24EA /* DateExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensionTests.swift; sourceTree = "<group>"; };
 		1D200C962BA3157A00108701 /* SettingsNextStepsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsNextStepsView.swift; sourceTree = "<group>"; };
@@ -3137,8 +3139,8 @@
 		4C0B70EF2418A35A5D863506 /* AIChatRecentChatsPopupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatRecentChatsPopupViewController.swift; sourceTree = "<group>"; };
 		4C8AD06BCB81EA991F22DD66 /* DefaultTogglePositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTogglePositionTests.swift; sourceTree = "<group>"; };
 		4CBE907E9CAC75F8561B75D4 /* SearchTokenRequestTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchTokenRequestTests.swift; sourceTree = "<group>"; };
-		4DF9CB391BF7042CDB857788 /* SearchTokenExperimentSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchTokenExperimentSettings.swift; sourceTree = "<group>"; };
 		4D434F523CEFF1B86C75ECC6 /* OnboardingView+AddToDockContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "OnboardingView+AddToDockContent.swift"; sourceTree = "<group>"; };
+		4DF9CB391BF7042CDB857788 /* SearchTokenExperimentSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchTokenExperimentSettings.swift; sourceTree = "<group>"; };
 		52CC2F8B19BA4ED5AAB32605 /* OnboardingSearchAIToggleGrey_dark.lottie */ = {isa = PBXFileReference; lastKnownFileType = file; path = OnboardingSearchAIToggleGrey_dark.lottie; sourceTree = "<group>"; };
 		56038D5E2E0E97B20001419D /* SubscriptionURLNavigationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionURLNavigationHandler.swift; sourceTree = "<group>"; };
 		5608B5122F2125CC00ABC3F4 /* UITestOverridesDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestOverridesDebugView.swift; sourceTree = "<group>"; };
@@ -3501,7 +3503,6 @@
 		85058365219AE9EA00ED4EDB /* HomePageConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageConfiguration.swift; sourceTree = "<group>"; };
 		8508931E2EA7AEFE005F84FD /* MobileCustomization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileCustomization.swift; sourceTree = "<group>"; };
 		850ABD002AC3961100A733DF /* MainViewController+Segues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewController+Segues.swift"; sourceTree = "<group>"; };
-		1A2B3C4D5E6F708192A3B401 /* MainViewController+AIChatHistoryViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewController+AIChatHistoryViewModelDelegate.swift"; sourceTree = "<group>"; };
 		850F93DA2B594AB800823EEA /* ZippedPassKitPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZippedPassKitPreviewHelper.swift; sourceTree = "<group>"; };
 		8512BCBF2061B6110085E862 /* global.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = global.swift; sourceTree = "<group>"; };
 		8512EA4D24ED30D20073EE19 /* WidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -4542,6 +4543,7 @@
 		BBA0000000000000000D0003 /* UnifiedInputStateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedInputStateStoreTests.swift; sourceTree = "<group>"; };
 		BBA0000000000000000E0001 /* Logger+UnifiedInputState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+UnifiedInputState.swift"; sourceTree = "<group>"; };
 		BBA0000000000000000F0001 /* UnifiedInputTabState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedInputTabState.swift; sourceTree = "<group>"; };
+		BBA8EA4D30120A4600FE41CD /* IOSMonthlyFreeTrialDecider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSMonthlyFreeTrialDecider.swift; sourceTree = "<group>"; };
 		BBAFF0292F6A93F900029537 /* SubscriptionPromoCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPromoCoordinator.swift; sourceTree = "<group>"; };
 		BBAFF02A2F6A93F900029537 /* SubscriptionPromoLaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPromoLaunchView.swift; sourceTree = "<group>"; };
 		BBAFF02B2F6A93F900029537 /* SubscriptionPromoPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPromoPresenter.swift; sourceTree = "<group>"; };
@@ -4601,7 +4603,6 @@
 		C11F41122F2CCBD800C126C3 /* AIChatContextualChatSessionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualChatSessionState.swift; sourceTree = "<group>"; };
 		C11F41142F2CCBE900C126C3 /* AIChatContextualChatSessionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualChatSessionStateTests.swift; sourceTree = "<group>"; };
 		C124027B2F2922E700F87332 /* AIChatContextualModePixelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualModePixelHandler.swift; sourceTree = "<group>"; };
-		FB90C0DE0000000000000A02 /* PageContextExtractionPixelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageContextExtractionPixelHandler.swift; sourceTree = "<group>"; };
 		C124027D2F2935F600F87332 /* AIChatContextualModePixelHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualModePixelHandlerTests.swift; sourceTree = "<group>"; };
 		C124F0522E686CBB008D0F49 /* SwitchBarFunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchBarFunnel.swift; sourceTree = "<group>"; };
 		C124F0552E6879E7008D0F49 /* SwitchBarFunnelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchBarFunnelTests.swift; sourceTree = "<group>"; };
@@ -5079,6 +5080,7 @@
 		D1A2B3C4E5F60001AABB0004 /* PostIdleSessionWideEventDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostIdleSessionWideEventDataTests.swift; sourceTree = "<group>"; };
 		D1A2B3C4E5F60001AABB0006 /* PostIdleSessionInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostIdleSessionInstrumentation.swift; sourceTree = "<group>"; };
 		D1A2B3C4E5F60001AABB0008 /* PostIdleSessionInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostIdleSessionInstrumentationTests.swift; sourceTree = "<group>"; };
+		D1A4C0DE2F210001004E5001 /* NetworkProtectionStatusViewTintSpecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionStatusViewTintSpecTests.swift; sourceTree = "<group>"; };
 		D2870028D8D7FA19512B7FD0 /* NavigationPixelNavigationResponder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationPixelNavigationResponder.swift; sourceTree = "<group>"; };
 		D2D2D2D200000000000000F0 /* CookiePopupProtectionOptInView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CookiePopupProtectionOptInView.swift; sourceTree = "<group>"; };
 		D60170BB2BA32DD6001911B5 /* Subscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
@@ -5248,7 +5250,6 @@
 		EEF7091E2DDE77B000BA3C36 /* SyncExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncExtensions.swift; sourceTree = "<group>"; };
 		EEFC6A5F2AC0F2F80065027D /* UserText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserText.swift; sourceTree = "<group>"; };
 		EEFE9C722A603CE9005B0A26 /* NetworkProtectionStatusViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionStatusViewModelTests.swift; sourceTree = "<group>"; };
-		D1A4C0DE2F210001004E5001 /* NetworkProtectionStatusViewTintSpecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionStatusViewTintSpecTests.swift; sourceTree = "<group>"; };
 		EFDD2F8A58E59142D8FDD931 /* CalendarEventPreviewHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEventPreviewHelperTests.swift; sourceTree = "<group>"; };
 		F0A100002F30200100BAD001 /* NewBadgeVisibilityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBadgeVisibilityManager.swift; sourceTree = "<group>"; };
 		F0A1B2C3D4E5F60718293A01 /* FloatingUIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingUIManager.swift; sourceTree = "<group>"; };
@@ -5394,6 +5395,7 @@
 		FADE0001C0FFEE00A5311004 /* PageSuggestionsCatalog.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = PageSuggestionsCatalog.json; sourceTree = "<group>"; };
 		FADE0001C0FFEE00A5311006 /* ContextualSuggestionUserText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualSuggestionUserText.swift; sourceTree = "<group>"; };
 		FADE0001C0FFEE00A5311008 /* ContextualSuggestionsMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualSuggestionsMatcherTests.swift; sourceTree = "<group>"; };
+		FB90C0DE0000000000000A02 /* PageContextExtractionPixelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageContextExtractionPixelHandler.swift; sourceTree = "<group>"; };
 		FBA1C0DE0000000000000002 /* IPadOmnibarModelPickerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadOmnibarModelPickerController.swift; sourceTree = "<group>"; };
 		FBA1C0DE0000000000000004 /* IPadOmnibarModelPickerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadOmnibarModelPickerControllerTests.swift; sourceTree = "<group>"; };
 		FBA1C0DE0000000000000006 /* IPadDuckAIControlsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadDuckAIControlsFeature.swift; sourceTree = "<group>"; };
@@ -10447,6 +10449,7 @@
 		D664C7922B289AA000CBFA76 /* Subscription */ = {
 			isa = PBXGroup;
 			children = (
+				BBA8EA4D30120A4600FE41CD /* IOSMonthlyFreeTrialDecider.swift */,
 				3666D84A30004E3E00B63F99 /* Onboarding */,
 				BB3F734C2F321F4000461429 /* FreeTrialPixelHandler.swift */,
 				56D60AA42EE33EA600652ABB /* SubscriptionUserScriptFeatureFlagAdapter.swift */,
@@ -13673,6 +13676,7 @@
 				310C4B47281B60E300BA79A9 /* AutofillLoginDetailsViewModel.swift in Sources */,
 				5BF65FD42F58C01F00BCC9F4 /* SettingsAutoplayView.swift in Sources */,
 				C1F9D9122EEAE70400E35AD5 /* AIChatContextualSheetViewController.swift in Sources */,
+				BBA8EA4E30120A4600FE41CD /* IOSMonthlyFreeTrialDecider.swift in Sources */,
 				A06E1D600618608596891F29 /* AIChatRecentChatsPopupViewController.swift in Sources */,
 				B7A3E1F20A1B2C3D4E5F6A70 /* AIChatRecentChatsPopupViewModel.swift in Sources */,
 				C1F9D91D2EF6400000E35AD5 /* AIChatContextualInputViewController.swift in Sources */,
@@ -18838,11 +18842,6 @@
 			package = 9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */;
 			productName = Lottie;
 		};
-		D1A4C0DE2F210003004E5001 /* Lottie */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */;
-			productName = Lottie;
-		};
 		9F909E382EEA6BD00057F518 /* UIKitExtensions */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = UIKitExtensions;
@@ -18943,6 +18942,11 @@
 		CCBA04E92EE2DF5700A70114 /* Networking */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Networking;
+		};
+		D1A4C0DE2F210003004E5001 /* Lottie */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9F8FE9472BAE50E50071E372 /* XCRemoteSwiftPackageReference "lottie-spm" */;
+			productName = Lottie;
 		};
 		D61CDA172B7CF78300A0FBB9 /* ZIPFoundation */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
@@ -258,9 +258,11 @@ final class AppDependencyProvider: DependencyProvider {
 
         let pendingTransactionHandler = DefaultPendingTransactionHandler(userDefaults: subscriptionUserDefaults,
                                                                          pixelHandler: pixelHandler)
+        let monthlyFreeTrialDecider = IOSMonthlyFreeTrialDecider(featureFlagger: featureFlagger)
         let storePurchaseManager = DefaultStorePurchaseManager(subscriptionFeatureMappingCache: subscriptionEndpointService,
                                                                subscriptionFeatureFlagger: subscriptionFeatureFlagger,
-                                                               pendingTransactionHandler: pendingTransactionHandler)
+                                                               pendingTransactionHandler: pendingTransactionHandler,
+                                                               monthlyFreeTrialDecider: monthlyFreeTrialDecider)
         let subscriptionManager = DefaultSubscriptionManager(storePurchaseManager: storePurchaseManager,
                                                                oAuthClient: authClient,
                                                                userDefaults: subscriptionUserDefaults,

--- a/iOS/DuckDuckGo/Subscription/IOSMonthlyFreeTrialDecider.swift
+++ b/iOS/DuckDuckGo/Subscription/IOSMonthlyFreeTrialDecider.swift
@@ -1,0 +1,34 @@
+//
+//  IOSMonthlyFreeTrialDecider.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import PrivacyConfig
+import Subscription
+
+struct IOSMonthlyFreeTrialDecider: MonthlyFreeTrialDeciding {
+
+    private let featureFlagger: FeatureFlagger
+
+    init(featureFlagger: FeatureFlagger) {
+        self.featureFlagger = featureFlagger
+    }
+
+    func shouldOfferMonthlyFreeTrial() -> Bool {
+        true
+    }
+}

--- a/iOS/DuckDuckGo/Subscription/IOSMonthlyFreeTrialDecider.swift
+++ b/iOS/DuckDuckGo/Subscription/IOSMonthlyFreeTrialDecider.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+import Core
 import PrivacyConfig
 import Subscription
 
@@ -29,6 +30,16 @@ struct IOSMonthlyFreeTrialDecider: MonthlyFreeTrialDeciding {
     }
 
     func shouldOfferMonthlyFreeTrial() -> Bool {
-        true
+        // Resolving the cohort here (at the paywall/tier-options request) enrolls the user at the
+        // moment the decision is needed. `treatment` removes the monthly free trial; `control` and
+        // unenrolled users keep the current behavior.
+        let cohort = featureFlagger.resolveCohort(for: FeatureFlag.monthlyFreeTrialExperiment) as? FeatureFlag.MonthlyFreeTrialExperimentCohort
+
+        switch cohort {
+        case .treatment:
+            return false
+        case .control, .none:
+            return true
+        }
     }
 }

--- a/iOS/DuckDuckGo/Subscription/IOSMonthlyFreeTrialDecider.swift
+++ b/iOS/DuckDuckGo/Subscription/IOSMonthlyFreeTrialDecider.swift
@@ -30,10 +30,8 @@ struct IOSMonthlyFreeTrialDecider: MonthlyFreeTrialDeciding {
     }
 
     func shouldOfferMonthlyFreeTrial() -> Bool {
-        // Resolving the cohort here (at the paywall/tier-options request) enrolls the user at the
-        // moment the decision is needed. `treatment` removes the monthly free trial; `control` and
-        // unenrolled users keep the current behavior.
-        let cohort = featureFlagger.resolveCohort(for: FeatureFlag.monthlyFreeTrialExperiment) as? FeatureFlag.MonthlyFreeTrialExperimentCohort
+        // Product filtering must not enroll users.
+        let cohort = featureFlagger.assignedCohort(for: FeatureFlag.monthlyFreeTrialExperiment) as? FeatureFlag.MonthlyFreeTrialExperimentCohort
 
         switch cohort {
         case .treatment:

--- a/iOS/DuckDuckGo/Subscription/MonthlyFreeTrialExperiment.swift
+++ b/iOS/DuckDuckGo/Subscription/MonthlyFreeTrialExperiment.swift
@@ -1,0 +1,38 @@
+//
+//  MonthlyFreeTrialExperiment.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Common
+import Core
+import Foundation
+import PrivacyConfig
+
+enum MonthlyFreeTrialExperiment {
+
+    /// iOS-specific cohort override; Android uses the unsuffixed parameter.
+    static let cohortParameterName = "experiment_mobileannualtrials_ios"
+
+    /// Enrolls eligible users and appends the resulting frontend cohort override.
+    static func appendingCohortParameter(to url: URL, resolvedBy featureFlagger: FeatureFlagger) -> URL {
+        guard let cohort = featureFlagger.resolveCohort(for: FeatureFlag.monthlyFreeTrialExperiment)
+            as? FeatureFlag.MonthlyFreeTrialExperimentCohort else {
+            return url
+        }
+        return url.appendingParameter(name: cohortParameterName, value: cohort.rawValue)
+    }
+}

--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
@@ -372,13 +372,20 @@ final class SubscriptionFlowViewModel: ObservableObject {
         DispatchQueue.main.async {
             self.resetState()
         }
+
+        // Only initial-purchase offer screens participate in the experiment.
+        let isInitialPurchaseOfferScreen = flowType.impressionPixel != nil
+            && initialURL.forComparison() != subscriptionManager.url(for: .welcome).forComparison()
+
         if webViewModel.url != subscriptionManager.url(for: currentSubscriptionURL).forComparison() {
-            self.webViewModel.navigationCoordinator.navigateTo(url: initialURL)
+            let urlToLoad = isInitialPurchaseOfferScreen
+                ? MonthlyFreeTrialExperiment.appendingCohortParameter(to: initialURL, resolvedBy: featureFlagger)
+                : initialURL
+            self.webViewModel.navigationCoordinator.navigateTo(url: urlToLoad)
         }
         await self.setupTransactionObserver()
         await self.setupWebViewObservers()
-        if let pixel = flowType.impressionPixel,
-           initialURL.forComparison() != subscriptionManager.url(for: .welcome).forComparison() {
+        if isInitialPurchaseOfferScreen, let pixel = flowType.impressionPixel {
             let origin = URLComponents(url: initialURL, resolvingAgainstBaseURL: false)?
                 .queryItems?
                 .first(where: { $0.name == AttributionParameter.origin })?

--- a/iOS/DuckDuckGoTests/IOSMonthlyFreeTrialDeciderTests.swift
+++ b/iOS/DuckDuckGoTests/IOSMonthlyFreeTrialDeciderTests.swift
@@ -1,0 +1,54 @@
+//
+//  IOSMonthlyFreeTrialDeciderTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import PrivacyConfig
+import Testing
+@testable import Core
+@testable import DuckDuckGo
+
+@Suite("iOS Monthly Free Trial Decider")
+struct IOSMonthlyFreeTrialDeciderTests {
+
+    @Test("Control cohort keeps the monthly free trial (current behavior)")
+    func controlCohortOffersMonthlyFreeTrial() {
+        let sut = IOSMonthlyFreeTrialDecider(
+            featureFlagger: PrivacyConfig.MockFeatureFlagger(resolveCohortStub: FeatureFlag.MonthlyFreeTrialExperimentCohort.control)
+        )
+
+        #expect(sut.shouldOfferMonthlyFreeTrial() == true)
+    }
+
+    @Test("Treatment cohort removes the monthly free trial")
+    func treatmentCohortDoesNotOfferMonthlyFreeTrial() {
+        let sut = IOSMonthlyFreeTrialDecider(
+            featureFlagger: PrivacyConfig.MockFeatureFlagger(resolveCohortStub: FeatureFlag.MonthlyFreeTrialExperimentCohort.treatment)
+        )
+
+        #expect(sut.shouldOfferMonthlyFreeTrial() == false)
+    }
+
+    @Test("A user not enrolled in the experiment keeps the monthly free trial")
+    func unenrolledUserOffersMonthlyFreeTrial() {
+        let sut = IOSMonthlyFreeTrialDecider(
+            featureFlagger: PrivacyConfig.MockFeatureFlagger(resolveCohortStub: nil)
+        )
+
+        #expect(sut.shouldOfferMonthlyFreeTrial() == true)
+    }
+}

--- a/iOS/DuckDuckGoTests/MonthlyFreeTrialExperimentTests.swift
+++ b/iOS/DuckDuckGoTests/MonthlyFreeTrialExperimentTests.swift
@@ -1,0 +1,65 @@
+//
+//  MonthlyFreeTrialExperimentTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import PrivacyConfig
+import Testing
+@testable import Core
+@testable import DuckDuckGo
+
+@Suite("Monthly Free Trial Experiment – purchase URL cohort parameter")
+struct MonthlyFreeTrialExperimentTests {
+
+    private let baseURL = URL(string: "https://duckduckgo.com/subscriptions?origin=funnel_appsettings_ios")!
+
+    private func cohortValue(in url: URL) -> String? {
+        URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first { $0.name == "experiment_mobileannualtrials_ios" }?
+            .value
+    }
+
+    @Test("Control cohort is appended as experiment_mobileannualtrials_ios=control")
+    func controlCohortAppendedToURL() {
+        let featureFlagger = PrivacyConfig.MockFeatureFlagger(resolveCohortStub: FeatureFlag.MonthlyFreeTrialExperimentCohort.control)
+
+        let result = MonthlyFreeTrialExperiment.appendingCohortParameter(to: baseURL, resolvedBy: featureFlagger)
+
+        #expect(cohortValue(in: result) == "control")
+    }
+
+    @Test("Treatment cohort is appended as experiment_mobileannualtrials_ios=treatment")
+    func treatmentCohortAppendedToURL() {
+        let featureFlagger = PrivacyConfig.MockFeatureFlagger(resolveCohortStub: FeatureFlag.MonthlyFreeTrialExperimentCohort.treatment)
+
+        let result = MonthlyFreeTrialExperiment.appendingCohortParameter(to: baseURL, resolvedBy: featureFlagger)
+
+        #expect(cohortValue(in: result) == "treatment")
+    }
+
+    @Test("An unenrolled user gets no experiment parameter and the URL is unchanged")
+    func unenrolledUserLeavesURLUnchanged() {
+        let featureFlagger = PrivacyConfig.MockFeatureFlagger(resolveCohortStub: nil)
+
+        let result = MonthlyFreeTrialExperiment.appendingCohortParameter(to: baseURL, resolvedBy: featureFlagger)
+
+        #expect(cohortValue(in: result) == nil)
+        #expect(result == baseURL)
+    }
+}

--- a/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -606,7 +606,9 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
 
         let subscriptionEndpointService = DefaultSubscriptionEndpointService(apiService: APIServiceFactory.makeAPIServiceForSubscription(withUserAgent: DefaultUserAgentManager.duckDuckGoUserAgent),
                                                                              baseURL: subscriptionEnvironment.serviceEnvironment.url)
-        let storePurchaseManager = DefaultStorePurchaseManager(subscriptionFeatureMappingCache: subscriptionEndpointService)
+        let monthlyFreeTrialDecider = IOSMonthlyFreeTrialDecider(featureFlagger: featureFlagger)
+        let storePurchaseManager = DefaultStorePurchaseManager(subscriptionFeatureMappingCache: subscriptionEndpointService,
+                                                               monthlyFreeTrialDecider: monthlyFreeTrialDecider)
         let subscriptionManager = DefaultSubscriptionManager(storePurchaseManager: storePurchaseManager,
                                                              oAuthClient: authClient,
                                                              userDefaults: UserDefaults.standard,

--- a/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -606,8 +606,7 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
 
         let subscriptionEndpointService = DefaultSubscriptionEndpointService(apiService: APIServiceFactory.makeAPIServiceForSubscription(withUserAgent: DefaultUserAgentManager.duckDuckGoUserAgent),
                                                                              baseURL: subscriptionEnvironment.serviceEnvironment.url)
-        // The tunnel never presents the paywall, so the monthly free-trial decision is never consulted;
-        // use the trivial default rather than the app-only cohort-aware decider.
+        // The tunnel never presents subscription offers.
         let storePurchaseManager = DefaultStorePurchaseManager(subscriptionFeatureMappingCache: subscriptionEndpointService,
                                                                monthlyFreeTrialDecider: DefaultMonthlyFreeTrialDecider())
         let subscriptionManager = DefaultSubscriptionManager(storePurchaseManager: storePurchaseManager,

--- a/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
+++ b/iOS/PacketTunnelProvider/NetworkProtection/NetworkProtectionPacketTunnelProvider.swift
@@ -606,9 +606,10 @@ final class NetworkProtectionPacketTunnelProvider: PacketTunnelProvider {
 
         let subscriptionEndpointService = DefaultSubscriptionEndpointService(apiService: APIServiceFactory.makeAPIServiceForSubscription(withUserAgent: DefaultUserAgentManager.duckDuckGoUserAgent),
                                                                              baseURL: subscriptionEnvironment.serviceEnvironment.url)
-        let monthlyFreeTrialDecider = IOSMonthlyFreeTrialDecider(featureFlagger: featureFlagger)
+        // The tunnel never presents the paywall, so the monthly free-trial decision is never consulted;
+        // use the trivial default rather than the app-only cohort-aware decider.
         let storePurchaseManager = DefaultStorePurchaseManager(subscriptionFeatureMappingCache: subscriptionEndpointService,
-                                                               monthlyFreeTrialDecider: monthlyFreeTrialDecider)
+                                                               monthlyFreeTrialDecider: DefaultMonthlyFreeTrialDecider())
         let subscriptionManager = DefaultSubscriptionManager(storePurchaseManager: storePurchaseManager,
                                                              oAuthClient: authClient,
                                                              userDefaults: UserDefaults.standard,

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -428,9 +428,7 @@
 		31BFDB702ECA46DD00ADFABD /* AIChatOmnibarTextContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BFDB6F2ECA46DD00ADFABD /* AIChatOmnibarTextContainerViewController.swift */; };
 		31BFDB712ECA46DD00ADFABD /* AIChatOmnibarTextContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BFDB6F2ECA46DD00ADFABD /* AIChatOmnibarTextContainerViewController.swift */; };
 		31BFDB792ECA5FCD00ADFABD /* AIChatOmnibarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BFDB782ECA5FCD00ADFABD /* AIChatOmnibarController.swift */; };
-		68670FD3ABCC454881CDD750 /* AIChatOmnibarSubscriptionUpsellPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D273972C6794EFFACE867AD /* AIChatOmnibarSubscriptionUpsellPresenter.swift */; };
 		31BFDB7A2ECA5FCD00ADFABD /* AIChatOmnibarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BFDB782ECA5FCD00ADFABD /* AIChatOmnibarController.swift */; };
-		BEFCBA41EF1340FBA6D21F2C /* AIChatOmnibarSubscriptionUpsellPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D273972C6794EFFACE867AD /* AIChatOmnibarSubscriptionUpsellPresenter.swift */; };
 		31C26A0A2CBE9D2700FFF462 /* PreferencesAIChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C26A092CBE9D2200FFF462 /* PreferencesAIChat.swift */; };
 		31C26A0B2CBE9D2700FFF462 /* PreferencesAIChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C26A092CBE9D2200FFF462 /* PreferencesAIChat.swift */; };
 		31C26A0D2CBE9DFE00FFF462 /* AIChatPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C26A0C2CBE9DFA00FFF462 /* AIChatPreferences.swift */; };
@@ -1532,6 +1530,7 @@
 		37FC2A192CF903080048E226 /* MockPrivacyStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FC2A172CF903060048E226 /* MockPrivacyStats.swift */; };
 		37FD78112A29EBD100B36DB1 /* SyncErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD78102A29EBD100B36DB1 /* SyncErrorHandler.swift */; };
 		37FD78122A29EBD100B36DB1 /* SyncErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD78102A29EBD100B36DB1 /* SyncErrorHandler.swift */; };
+		38935B87BCB54456BFEBB274 /* AIChatSubscriptionUpsellDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F8268B7F214B78ABBD3CAB /* AIChatSubscriptionUpsellDialog.swift */; };
 		3BB9000FD0E24C33A8E285DF /* RebrandedContextualOnboardingDialogs+Trackers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 486DE4DF1E7F43229D062937 /* RebrandedContextualOnboardingDialogs+Trackers.swift */; };
 		3C4D5E6F708192A3B4C5D6E7 /* BookmarksBarMenuCustomPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2C3D4E5F60718293A4B5C6 /* BookmarksBarMenuCustomPopover.swift */; };
 		3CB3A2D4D123A64803F4E2EE /* TabSuspensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 642A608704E4BE38779B6162 /* TabSuspensionTests.swift */; };
@@ -1901,7 +1900,6 @@
 		4F25DAF90625497DB96B6E8D /* ContextualDaxDialogsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B63E5D7F5349E0ADA3EDEA /* ContextualDaxDialogsProvider.swift */; };
 		4FC6164C23014DAAAD077E74 /* SubscriptionPromoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC1AE4AED1E4A4C95A36533 /* SubscriptionPromoView.swift */; };
 		5093DFC4902349B9A5AF8683 /* AIChatDeleteChatsDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E61483DDA440CEAD33A5C5 /* AIChatDeleteChatsDialog.swift */; };
-		822F3701CD2748E0BF8F7F89 /* AIChatSubscriptionUpsellDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F8268B7F214B78ABBD3CAB /* AIChatSubscriptionUpsellDialog.swift */; };
 		517D1CC5BBC997B1D17DA1AC /* (null) in Sources */ = {isa = PBXBuildFile; };
 		53C5FDE635F54E86A44EF5C6 /* DuckAIChromeButtonsPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E090D60EAB41E8BB22CA88 /* DuckAIChromeButtonsPreferences.swift */; };
 		541B2C4D448B4C109EF580A3 /* AIChatFloatingWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1812146DE841448CA4CE3FD1 /* AIChatFloatingWindowController.swift */; };
@@ -1940,9 +1938,7 @@
 		5641734B2CFE168700F4B716 /* PixelExperimentKit in Frameworks */ = {isa = PBXBuildFile; productRef = 5641734A2CFE168700F4B716 /* PixelExperimentKit */; };
 		5641734D2CFE169400F4B716 /* PixelExperimentKit in Frameworks */ = {isa = PBXBuildFile; productRef = 5641734C2CFE169400F4B716 /* PixelExperimentKit */; };
 		56504F0C2E0D900300333A1E /* SubscriptionNavigationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56504F0B2E0D900300333A1E /* SubscriptionNavigationCoordinatorTests.swift */; };
-		F1396E92FC2749888523B2FD /* AIChatOmnibarSubscriptionUpsellPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D82828FB034DE7BCB7BB91 /* AIChatOmnibarSubscriptionUpsellPresenterTests.swift */; };
 		56504F0D2E0D900300333A1E /* SubscriptionNavigationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56504F0B2E0D900300333A1E /* SubscriptionNavigationCoordinatorTests.swift */; };
-		968FC19A13C54CE4981CBD7A /* AIChatOmnibarSubscriptionUpsellPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D82828FB034DE7BCB7BB91 /* AIChatOmnibarSubscriptionUpsellPresenterTests.swift */; };
 		56504F0F2E0D9A8C00333A1E /* MockSubscriptionTabsShowing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56504F0E2E0D9A8C00333A1E /* MockSubscriptionTabsShowing.swift */; };
 		56504F102E0D9A8C00333A1E /* MockSubscriptionTabsShowing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56504F0E2E0D9A8C00333A1E /* MockSubscriptionTabsShowing.swift */; };
 		5650E3732D3FDC8900D41ECF /* PageRefreshMonitorExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5650E3722D3FDC8900D41ECF /* PageRefreshMonitorExtensionTests.swift */; };
@@ -2067,8 +2063,8 @@
 		6590DB562DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6590DB542DB7D59F007D6046 /* DuckPlayerTabExtensionTests.swift */; };
 		65EE7C622E3297A5009FD83B /* DuckPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EE7C612E3297A0009FD83B /* DuckPlayerTests.swift */; };
 		6719D31C9C755E42C73B81A4 /* WebKitVersionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFE068226C7082D005434CC /* WebKitVersionProvider.swift */; };
+		68670FD3ABCC454881CDD750 /* AIChatOmnibarSubscriptionUpsellPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D273972C6794EFFACE867AD /* AIChatOmnibarSubscriptionUpsellPresenter.swift */; };
 		6994C93E8D134666A5772C83 /* AIChatDeleteChatsDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E61483DDA440CEAD33A5C5 /* AIChatDeleteChatsDialog.swift */; };
-		38935B87BCB54456BFEBB274 /* AIChatSubscriptionUpsellDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F8268B7F214B78ABBD3CAB /* AIChatSubscriptionUpsellDialog.swift */; };
 		6994F07EA8764AE186F8353E /* AdBlockingAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86EE9A7B2E24D47BACF8241 /* AdBlockingAvailability.swift */; };
 		6A06A7E014E04F60B399531F /* AIChatTabOpenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DF815DCDE34CFBA7F38DFA /* AIChatTabOpenerTests.swift */; };
 		6F2449E6DE7EE721370575B9 /* QuickFeedbackDiagnosticsCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD3D561804AB2C73BB789AC /* QuickFeedbackDiagnosticsCollectorTests.swift */; };
@@ -2401,6 +2397,7 @@
 		7BFF35732C10D75000F89673 /* IPCServiceLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFF35722C10D75000F89673 /* IPCServiceLauncher.swift */; };
 		7BFF35742C10D75000F89673 /* IPCServiceLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFF35722C10D75000F89673 /* IPCServiceLauncher.swift */; };
 		7BFF850F2B0C09DA00ECACA2 /* DuckDuckGo Personal Information Removal.app in Embed Login Items */ = {isa = PBXBuildFile; fileRef = 9D9AE8D12AAA39A70026E7DC /* DuckDuckGo Personal Information Removal.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		822F3701CD2748E0BF8F7F89 /* AIChatSubscriptionUpsellDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F8268B7F214B78ABBD3CAB /* AIChatSubscriptionUpsellDialog.swift */; };
 		826DE2AF36B745189B120C74 /* AdBlockingDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E98EDA7AE9931D95CEA01E /* AdBlockingDebugMenu.swift */; };
 		8400DC4B2C6E26AE006509D2 /* BookmarksBarCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400DC4A2C6E26AE006509D2 /* BookmarksBarCollectionView.swift */; };
 		8400DC4C2C6E26AE006509D2 /* BookmarksBarCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400DC4A2C6E26AE006509D2 /* BookmarksBarCollectionView.swift */; };
@@ -2716,6 +2713,7 @@
 		92351A6719194A9F4DD19D56 /* AIChatSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72808BE3E5BF485C31627B8 /* AIChatSettingsTests.swift */; };
 		9264F7AF4D4841749D18B650 /* RebrandedContextualOnboardingDialogs+TrySearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 228E1D6E1E824085A874C175 /* RebrandedContextualOnboardingDialogs+TrySearch.swift */; };
 		93BD7FEAF65A45E5AF6465EE /* TabSuspensionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 590E11956C6E4C788AF09F9A /* TabSuspensionServiceTests.swift */; };
+		968FC19A13C54CE4981CBD7A /* AIChatOmnibarSubscriptionUpsellPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D82828FB034DE7BCB7BB91 /* AIChatOmnibarSubscriptionUpsellPresenterTests.swift */; };
 		9812D895276CEDA5004B6181 /* ContentBlockerRulesLists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9812D894276CEDA5004B6181 /* ContentBlockerRulesLists.swift */; };
 		981E20B6299A39B8002B68CD /* BookmarkMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A95D87299A2DF900B9B81A /* BookmarkMigrationTests.swift */; };
 		9826B0A02747DF3D0092F683 /* ContentBlocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9826B09F2747DF3D0092F683 /* ContentBlocking.swift */; };
@@ -3701,6 +3699,8 @@
 		BB9BDD492D09BAA80069E9EF /* TabBarRemoteMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9BDD482D09BA9D0069E9EF /* TabBarRemoteMessageViewModel.swift */; };
 		BB9BDD4A2D09BAA80069E9EF /* TabBarRemoteMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9BDD482D09BA9D0069E9EF /* TabBarRemoteMessageViewModel.swift */; };
 		BBA6DA1E2F5B05570031D76C /* AutoplayPreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1380633D7A4C9CA3AD18CD /* AutoplayPreferencesTests.swift */; };
+		BBA8EA4B3012091700FE41CD /* MacOSMonthlyFreeTrialDecider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA8EA4A3012091700FE41CD /* MacOSMonthlyFreeTrialDecider.swift */; };
+		BBA8EA4C3012091700FE41CD /* MacOSMonthlyFreeTrialDecider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA8EA4A3012091700FE41CD /* MacOSMonthlyFreeTrialDecider.swift */; };
 		BBA9A8572E40E23D00FB29A1 /* VPNPopoverPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA9A8562E40E23D00FB29A1 /* VPNPopoverPresenterTests.swift */; };
 		BBA9A8582E40E23D00FB29A1 /* VPNPopoverPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA9A8562E40E23D00FB29A1 /* VPNPopoverPresenterTests.swift */; };
 		BBB3F1F12E302143009E77AF /* ReportProblemFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB3F1F02E302143009E77AF /* ReportProblemFormView.swift */; };
@@ -3866,6 +3866,7 @@
 		BDE981D92BBD10D600645880 /* vpn-dark-mode.json in Resources */ = {isa = PBXBuildFile; fileRef = BD384AC82BBC821100EF3735 /* vpn-dark-mode.json */; };
 		BDE981DA2BBD10D600645880 /* vpn-light-mode.json in Resources */ = {isa = PBXBuildFile; fileRef = BD384AC72BBC821100EF3735 /* vpn-light-mode.json */; };
 		BE52EBAD30CF498897B80160 /* SubscriptionPromoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B077E3CB7B47349C4BD72C /* SubscriptionPromoViewModel.swift */; };
+		BEFCBA41EF1340FBA6D21F2C /* AIChatOmnibarSubscriptionUpsellPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D273972C6794EFFACE867AD /* AIChatOmnibarSubscriptionUpsellPresenter.swift */; };
 		C0DE0071E018E1FA30000000 /* CookiePopupProtectionOptInPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE0071E018E1FE00000000 /* CookiePopupProtectionOptInPixel.swift */; };
 		C0DE0071E018E1FBF0000000 /* CookiePopupProtectionOptInPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE0071E018E1FE00000000 /* CookiePopupProtectionOptInPixel.swift */; };
 		C10529432C9CC18B0041E502 /* AutofillCredentialsDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10529422C9CC18B0041E502 /* AutofillCredentialsDebugView.swift */; };
@@ -4474,6 +4475,7 @@
 		F124E0ED2D6E123A0035C7BA /* PersistenceTestingUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0EC2D6E123A0035C7BA /* PersistenceTestingUtils */; };
 		F124E0EF2D6E123A0035C7BA /* PixelKitTestingUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0EE2D6E123A0035C7BA /* PixelKitTestingUtilities */; };
 		F124E0F12D6E123A0035C7BA /* SubscriptionTestingUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0F02D6E123A0035C7BA /* SubscriptionTestingUtilities */; };
+		F1396E92FC2749888523B2FD /* AIChatOmnibarSubscriptionUpsellPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D82828FB034DE7BCB7BB91 /* AIChatOmnibarSubscriptionUpsellPresenterTests.swift */; };
 		F1476FC02C1359FB00EAE46A /* SubscriptionUIHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1476FBF2C1359FB00EAE46A /* SubscriptionUIHandler.swift */; };
 		F1476FC12C1359FB00EAE46A /* SubscriptionUIHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1476FBF2C1359FB00EAE46A /* SubscriptionUIHandler.swift */; };
 		F14890852ECCCAA800B5239E /* AttributedMetricUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14890842ECCCAA800B5239E /* AttributedMetricUtils.swift */; };
@@ -5010,6 +5012,8 @@
 		2026FB0CABDEF00100AA00A3 /* YouTubeAdBlockPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeAdBlockPopover.swift; sourceTree = "<group>"; };
 		228E1D6E1E824085A874C175 /* RebrandedContextualOnboardingDialogs+TrySearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RebrandedContextualOnboardingDialogs+TrySearch.swift"; sourceTree = "<group>"; };
 		2644631CDBDA424A80C1127B /* AppUpdater */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = AppUpdater; path = LocalPackages/AppUpdater; sourceTree = SOURCE_ROOT; };
+		26F8268B7F214B78ABBD3CAB /* AIChatSubscriptionUpsellDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSubscriptionUpsellDialog.swift; sourceTree = "<group>"; };
+		2D273972C6794EFFACE867AD /* AIChatOmnibarSubscriptionUpsellPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarSubscriptionUpsellPresenter.swift; sourceTree = "<group>"; };
 		31031EB62CC94C6C00684340 /* AIChatRemoteSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatRemoteSettingsTests.swift; sourceTree = "<group>"; };
 		310E79BE294A19A8007C49E8 /* FireproofingReferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireproofingReferenceTests.swift; sourceTree = "<group>"; };
 		310E83F62ED79B1E006F80D2 /* KeyboardShortcutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutView.swift; sourceTree = "<group>"; };
@@ -5054,7 +5058,6 @@
 		31BFDB6C2ECA423900ADFABD /* MouseBlockingBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseBlockingBackgroundView.swift; sourceTree = "<group>"; };
 		31BFDB6F2ECA46DD00ADFABD /* AIChatOmnibarTextContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarTextContainerViewController.swift; sourceTree = "<group>"; };
 		31BFDB782ECA5FCD00ADFABD /* AIChatOmnibarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarController.swift; sourceTree = "<group>"; };
-		2D273972C6794EFFACE867AD /* AIChatOmnibarSubscriptionUpsellPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarSubscriptionUpsellPresenter.swift; sourceTree = "<group>"; };
 		31C26A092CBE9D2200FFF462 /* PreferencesAIChat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesAIChat.swift; sourceTree = "<group>"; };
 		31C26A0C2CBE9DFA00FFF462 /* AIChatPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatPreferences.swift; sourceTree = "<group>"; };
 		31C3CE0128EDC1E70002C24A /* CustomRoundedCornersShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRoundedCornersShape.swift; sourceTree = "<group>"; };
@@ -5388,6 +5391,7 @@
 		43A7F6C124DA119D76D5AC50 /* TabSuspensionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSuspensionService.swift; sourceTree = "<group>"; };
 		4620F01533744547AD4AE7FF /* TabSuspensionExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSuspensionExtensionTests.swift; sourceTree = "<group>"; };
 		467D16662D0C98D5007C020A /* CrashReportSenderExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportSenderExtensions.swift; sourceTree = "<group>"; };
+		47D82828FB034DE7BCB7BB91 /* AIChatOmnibarSubscriptionUpsellPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarSubscriptionUpsellPresenterTests.swift; sourceTree = "<group>"; };
 		486DE4DF1E7F43229D062937 /* RebrandedContextualOnboardingDialogs+Trackers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RebrandedContextualOnboardingDialogs+Trackers.swift"; sourceTree = "<group>"; };
 		49DF815DCDE34CFBA7F38DFA /* AIChatTabOpenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabOpenerTests.swift; sourceTree = "<group>"; };
 		4AC1AE4AED1E4A4C95A36533 /* SubscriptionPromoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPromoView.swift; sourceTree = "<group>"; };
@@ -5624,7 +5628,6 @@
 		563A3CF92D37AE2A001966FD /* ConfigurationManagerIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationManagerIntegrationTests.swift; sourceTree = "<group>"; };
 		56406D4A2C636A8900BF8FA2 /* SpecialPagesUserScriptExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialPagesUserScriptExtension.swift; sourceTree = "<group>"; };
 		56504F0B2E0D900300333A1E /* SubscriptionNavigationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionNavigationCoordinatorTests.swift; sourceTree = "<group>"; };
-		47D82828FB034DE7BCB7BB91 /* AIChatOmnibarSubscriptionUpsellPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarSubscriptionUpsellPresenterTests.swift; sourceTree = "<group>"; };
 		56504F0E2E0D9A8C00333A1E /* MockSubscriptionTabsShowing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSubscriptionTabsShowing.swift; sourceTree = "<group>"; };
 		5650E3722D3FDC8900D41ECF /* PageRefreshMonitorExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageRefreshMonitorExtensionTests.swift; sourceTree = "<group>"; };
 		56534DEC29DF252C00121467 /* CapturingDefaultBrowserProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturingDefaultBrowserProvider.swift; sourceTree = "<group>"; };
@@ -6141,7 +6144,6 @@
 		A1B2C3D42E5F600700000007 /* PromoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoService.swift; sourceTree = "<group>"; };
 		A1B2C3D42E5F600800000008 /* TimedFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimedFlag.swift; sourceTree = "<group>"; };
 		A3E61483DDA440CEAD33A5C5 /* AIChatDeleteChatsDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatDeleteChatsDialog.swift; sourceTree = "<group>"; };
-		26F8268B7F214B78ABBD3CAB /* AIChatSubscriptionUpsellDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSubscriptionUpsellDialog.swift; sourceTree = "<group>"; };
 		A5A7430C39C716A6A3A1F654 /* WebNotificationPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebNotificationPixel.swift; sourceTree = "<group>"; };
 		A7C3D1E82F4B5A000654B4E /* SERPInstallOrigin */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SERPInstallOrigin; path = ../SharedPackages/SERPInstallOrigin; sourceTree = SOURCE_ROOT; };
 		A86EE9A7B2E24D47BACF8241 /* AdBlockingAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdBlockingAvailability.swift; sourceTree = "<group>"; };
@@ -6666,6 +6668,7 @@
 		BB9BA2252D10C089009229F3 /* TabBarRemoteMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarRemoteMessage.swift; sourceTree = "<group>"; };
 		BB9BA2282D10C0A3009229F3 /* TabBarActiveRemoteMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarActiveRemoteMessage.swift; sourceTree = "<group>"; };
 		BB9BDD482D09BA9D0069E9EF /* TabBarRemoteMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarRemoteMessageViewModel.swift; sourceTree = "<group>"; };
+		BBA8EA4A3012091700FE41CD /* MacOSMonthlyFreeTrialDecider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSMonthlyFreeTrialDecider.swift; sourceTree = "<group>"; };
 		BBA9A8562E40E23D00FB29A1 /* VPNPopoverPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNPopoverPresenterTests.swift; sourceTree = "<group>"; };
 		BBB3F1F02E302143009E77AF /* ReportProblemFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportProblemFormView.swift; sourceTree = "<group>"; };
 		BBB819102EC493750064977E /* PreferencesPurchaseSubscriptionModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesPurchaseSubscriptionModelTests.swift; sourceTree = "<group>"; };
@@ -13200,6 +13203,7 @@
 				F118EA7C2BEA2B8700F77634 /* DefaultSubscriptionFeatureAvailability+DefaultInitializer.swift */,
 				F1DA51842BF607D200CF29FA /* SubscriptionAttributionPixelHandler.swift */,
 				F1D042982BFBABA100A31506 /* SubscriptionManager+StandardConfiguration.swift */,
+				BBA8EA4A3012091700FE41CD /* MacOSMonthlyFreeTrialDecider.swift */,
 				F1DA51852BF607D200CF29FA /* SubscriptionRedirectManager.swift */,
 				F1FDC9372BF51F41006B1435 /* VPNSettings+Environment.swift */,
 				C167D9022DAD561C00FA1E70 /* SubscriptionFunnelOrigin.swift */,
@@ -16289,6 +16293,7 @@
 				C1D3C5732E8ADB080086A2BD /* IdentitiesCleanupErrorHandling.swift in Sources */,
 				C1D3C5742E8ADB080086A2BD /* SyncIdentitiesAdapter.swift in Sources */,
 				3706FCA1293F65D500E42796 /* AdjacentItemEnumerator.swift in Sources */,
+				BBA8EA4C3012091700FE41CD /* MacOSMonthlyFreeTrialDecider.swift in Sources */,
 				9F9C49FA2BC7BC970099738D /* BookmarkAllTabsDialogView.swift in Sources */,
 				31ECDA122BED339600AE679F /* DataBrokerAuthenticationManagerBuilder.swift in Sources */,
 				3706FCA2293F65D500E42796 /* ChromiumKeychainPrompt.swift in Sources */,
@@ -18519,6 +18524,7 @@
 				B603FD9E2A02712E00F3FCA9 /* CIImageExtension.swift in Sources */,
 				AA7412B524D1536B00D22FE0 /* MainWindowController.swift in Sources */,
 				AA9FF95924A1ECF20039E328 /* Tab.swift in Sources */,
+				BBA8EA4B3012091700FE41CD /* MacOSMonthlyFreeTrialDecider.swift in Sources */,
 				BB7BAAC22DDBB096004A5A58 /* AddressBarStyleProviding.swift in Sources */,
 				4BBDEE9228FC14760092FAA6 /* ConnectBitwardenView.swift in Sources */,
 				850E8DFB2A6FEC5E00691187 /* BookmarksBarAppearance.swift in Sources */,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -776,7 +776,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                                          pixelHandler: pixelHandler)
         let defaultSubscriptionManager = DefaultSubscriptionManager(storePurchaseManager: DefaultStorePurchaseManager(subscriptionFeatureMappingCache: subscriptionEndpointService,
                                                                                                                       subscriptionFeatureFlagger: subscriptionFeatureFlagger,
-                                                                                                                      pendingTransactionHandler: pendingTransactionHandler),
+                                                                                                                      pendingTransactionHandler: pendingTransactionHandler,
+                                                                                                                      monthlyFreeTrialDecider: MacOSMonthlyFreeTrialDecider()),
                                                                     oAuthClient: authClient,
                                                                     userDefaults: subscriptionUserDefaults,
                                                                     subscriptionEndpointService: subscriptionEndpointService,

--- a/macOS/DuckDuckGo/Subscription/MacOSMonthlyFreeTrialDecider.swift
+++ b/macOS/DuckDuckGo/Subscription/MacOSMonthlyFreeTrialDecider.swift
@@ -1,0 +1,26 @@
+//
+//  MacOSMonthlyFreeTrialDecider.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Subscription
+
+struct MacOSMonthlyFreeTrialDecider: MonthlyFreeTrialDeciding {
+    func shouldOfferMonthlyFreeTrial() -> Bool {
+        true
+    }
+}

--- a/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
@@ -109,7 +109,7 @@ extension DefaultSubscriptionManager {
         self.init(storePurchaseManager: DefaultStorePurchaseManager(subscriptionFeatureMappingCache: subscriptionEndpointService,
                                                                     subscriptionFeatureFlagger: subscriptionFeatureFlagger,
                                                                     pendingTransactionHandler: pendingTransactionHandler,
-                                                                    monthlyFreeTrialDecider: MacOSMonthlyFreeTrialDecider()),
+                                                                    monthlyFreeTrialDecider: DefaultMonthlyFreeTrialDecider()),
                   oAuthClient: authClient,
                   userDefaults: userDefaults,
                   subscriptionEndpointService: subscriptionEndpointService,

--- a/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionManager+StandardConfiguration.swift
@@ -108,7 +108,8 @@ extension DefaultSubscriptionManager {
                                                                          pixelHandler: pixelHandler)
         self.init(storePurchaseManager: DefaultStorePurchaseManager(subscriptionFeatureMappingCache: subscriptionEndpointService,
                                                                     subscriptionFeatureFlagger: subscriptionFeatureFlagger,
-                                                                    pendingTransactionHandler: pendingTransactionHandler),
+                                                                    pendingTransactionHandler: pendingTransactionHandler,
+                                                                    monthlyFreeTrialDecider: MacOSMonthlyFreeTrialDecider()),
                   oAuthClient: authClient,
                   userDefaults: userDefaults,
                   subscriptionEndpointService: subscriptionEndpointService,


### PR DESCRIPTION
Task/Issue URL:
Tech Design URL:
CC:

### Description
Implements the iOS native side of the "free trials on yearly plans only" experiment. For the treatment cohort, the monthly plan no longer offers a free trial; the yearly plan keeps its trial. Control keeps both trials as today. The experiment is US-only and gated behind a remote-releasable feature flag with `control`/`treatment` cohorts.

The paywall is rendered by the frontend, so native drives cohort assignment and hands it off to the FE. Enrolment happens at a single point — the initial-purchase offer screen, gated by the same eligibility as the impression pixel — so plan-update and welcome flows don't enrol. The resolved cohort is appended to the purchase URL (`experiment_mobileannualtrials_ios=<control|treatment>`), and monthly SKU filtering reads the assigned cohort without ever enrolling.

Extensions and shared targets use the always-offer default decider; cohort-aware deciders live in the app targets. macOS uses the trivial default — the experiment is iOS-only.

### Testing Steps
1. With the flag off (or cohort `control`), open the subscription paywall → both monthly and yearly plans offer a free trial.
2. Enable the experiment / assign `treatment`, open the initial-purchase paywall → yearly still offers a free trial, monthly does not.
3. Re-open via a plan-update or welcome flow → no enrolment occurs (cohort not resolved on those entry points).

### Impact
Medium — affects the subscription purchase flow and trial availability for the treatment cohort. Guarded by a remote-releasable feature flag defaulting off, so it can be disabled remotely.

#### What could go wrong?
- Wrong cohort passed to FE → mitigated by single enrolment point + unit tests on the helper and decider.
- Monthly trial removed for control users → mitigated by cohort-gated filtering (read-only decider) and unit coverage of the tier-options path.

### Quality Considerations
- **Cross-repo contract (keep in sync):** subfeature key `monthlyFreeTrialExperiment` matches the privacy-config key; FE param is `experiment_mobileannualtrials_ios` (`control`/`treatment`). Targets **7.231.0**.
- The `onFirstAppear` enrolment wiring is not unit-tested (no VM test infra); unit tests cover the helper and decider. Final commit to be re-verified in FlowDeck before marking ready.
- **Not in scope / open:** no-trial monthly SKUs (App Store Connect + backend entitlement mappings) are deferred to ship review — only iOS Alpha dev config has them.
