### PR TITLE
Remove feature flag: aiChatOmnibarDefaultPosition

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -453,9 +453,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables the omnibar tools (customize, search toggle, image upload) for AI Chat
     case omnibarTools
 
-    /// Enables the default omnibar toggle position setting for AI Chat
-    case omnibarDefaultPosition
-
     case unifiedToggleInput
 
     /// Forward-only lever for the unified toggle input rollout. When disabled, *new* (un-granted)

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -427,9 +427,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1214749231578703/task/1213613180881406
     case fireButtonSingleTabDeleteAll
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213728968355833?focus=true
-    case aiChatOmnibarDefaultPosition
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213433942918287?focus=true
     case duckAIVoiceShortcut
 
@@ -826,8 +823,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.fireButtonRefinements))
         case .fireButtonSingleTabDeleteAll:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.fireButtonSingleTabDeleteAll))
-        case .aiChatOmnibarDefaultPosition:
-            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.omnibarDefaultPosition))
         case .duckAIVoiceShortcut:
             Config(source: .remoteReleasable(AIChatSubfeature.voiceShortcut))
         case .screenTimeCleaning:

--- a/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatSettings.swift
@@ -175,10 +175,6 @@ final class AIChatSettings: AIChatSettingsProvider {
     }
 
     var defaultOmnibarMode: DefaultOmnibarMode {
-        guard featureFlagger.isFeatureOn(.aiChatOmnibarDefaultPosition) else {
-            return .search
-        }
-
         guard let rawValue = keyValueStore.object(forKey: .defaultOmnibarModeKey) as? String,
               let mode = DefaultOmnibarMode(rawValue: rawValue) else {
             return .search
@@ -320,10 +316,6 @@ final class AIChatSettings: AIChatSettingsProvider {
     }
 
     func setDefaultOmnibarMode(_ mode: DefaultOmnibarMode) {
-        guard featureFlagger.isFeatureOn(.aiChatOmnibarDefaultPosition) else {
-            return
-        }
-
         keyValueStore.set(mode.rawValue, forKey: .defaultOmnibarModeKey)
         triggerSettingsChangedNotification()
         DailyPixel.fireDailyAndCount(pixel: .aiChatSettingsDefaultTogglePositionChanged,

--- a/iOS/DuckDuckGo/AppConfiguration/AppConfiguration.swift
+++ b/iOS/DuckDuckGo/AppConfiguration/AppConfiguration.swift
@@ -36,11 +36,9 @@ struct AppConfiguration {
     let persistentStoresConfiguration = PersistentStoresConfiguration()
     let onboardingConfiguration = OnboardingConfiguration()
     private let appKeyValueStore: ThrowingKeyValueStoring
-    private let featureFlagger: FeatureFlagger
 
-    init(appKeyValueStore: ThrowingKeyValueStoring, featureFlagger: FeatureFlagger) {
+    init(appKeyValueStore: ThrowingKeyValueStoring) {
         self.appKeyValueStore = appKeyValueStore
-        self.featureFlagger = featureFlagger
     }
 
     func start(isBookmarksDBFilePresent: Bool?) throws {
@@ -84,10 +82,6 @@ struct AppConfiguration {
         let store = UserDefaults(suiteName: Global.appConfigurationGroupName) ?? UserDefaults()
         let key = LegacyAiChatUserDefaultsKeys.defaultOmnibarModeKey
         guard store.object(forKey: key) == nil else { return }
-
-        guard featureFlagger.isFeatureOn(.aiChatOmnibarDefaultPosition) else {
-            return
-        }
 
         let isExistingUser = StatisticsUserDefaults().hasInstallStatistics
         let defaultMode: DefaultOmnibarMode = isExistingUser ? .search : .lastUsed

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -88,8 +88,7 @@ struct Launching: LaunchingHandling {
 
         // Initialize configuration with the key-value store
         configuration = AppConfiguration(
-            appKeyValueStore: appKeyValueFileStoreService.keyValueFilesStore,
-            featureFlagger: featureFlagger
+            appKeyValueStore: appKeyValueFileStoreService.keyValueFilesStore
         )
 
         var isBookmarksDBFilePresent: Bool?

--- a/iOS/DuckDuckGo/SettingsAIFeaturesView.swift
+++ b/iOS/DuckDuckGo/SettingsAIFeaturesView.swift
@@ -259,8 +259,7 @@ private extension AIFeaturesSettingsRowProviding {
                 pickerRow
             }
 
-            if viewModel.aiChatSearchInputEnabledBinding.wrappedValue,
-               viewModel.isDefaultOmnibarModeEnabled {
+            if viewModel.aiChatSearchInputEnabledBinding.wrappedValue {
                 SettingsPickerCellView(
                     label: UserText.settingsDefaultOmnibarModeHeader,
                     subtitle: UserText.settingsDefaultOmnibarModeFooter,

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -218,10 +218,6 @@ final class SettingsViewModel: ObservableObject {
         freemiumDBPUserStateManager.firstScanResult != nil
     }
 
-    var isDefaultOmnibarModeEnabled: Bool {
-        featureFlagger.isFeatureOn(.aiChatOmnibarDefaultPosition)
-    }
-
     var isAIFeaturesNativeControlsEnabled: Bool {
         featureFlagger.isFeatureOn(.aiFeaturesNativeControls)
     }

--- a/iOS/DuckDuckGoTests/OnboardingPersonalizationAITests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPersonalizationAITests.swift
@@ -102,8 +102,7 @@ struct OnboardingPersonalizationAIChatTests {
             privacyConfigurationManager: PrivacyConfigurationManagerMock(),
             debugSettings: MockAIChatDebugSettings(),
             keyValueStore: store,
-            notificationCenter: NotificationCenter(),
-            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.aiChatOmnibarDefaultPosition])
+            notificationCenter: NotificationCenter()
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1213728968355833
Tech Design URL:
CC:

### Description
Feature flag `aiChatOmnibarDefaultPosition` approved, removing conditional code. The "Toggle Position" setting under Settings → AI Features (which lets users choose the default omnibar toggle position) is now always available, and the underlying `defaultOmnibarMode` / `setDefaultOmnibarMode` logic in `AIChatSettings` no longer checks the flag. The first-launch default-mode migration in `AppConfiguration` also runs unconditionally now.

### Testing Steps
1. Go to Settings → AI Features → enable "Search & Duck.ai" input → verify the "Toggle Position" picker appears (no longer gated by a flag).
2. Set toggle position to "Duck.ai" → open a new tab → verify it opens in Duck.ai mode.
3. Fresh install → verify the default toggle position is "Last Used".
4. Upgrade from an existing install → verify the default toggle position is "Search".

### Impact
Low — this flag was already fully rolled out (Approved); this only removes the now-redundant remote gate. No user-facing behavior change.

### Quality Considerations
Removed the now-unused `featureFlagger` dependency from `AppConfiguration` (its only use was this flag check) and updated the one call site in `Launching.swift` accordingly. Did not touch the bundled `ios-config.json`, which is managed server-side.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ME8qd3CyYYmkwWshayyV2E)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cleanup after an approved rollout; behavior matches the previously enabled flag with no new remote kill switch for this setting.
> 
> **Overview**
> Removes the approved **`aiChatOmnibarDefaultPosition`** / **`omnibarDefaultPosition`** remote gates now that the omnibar default-toggle setting is fully shipped.
> 
> **Toggle Position** under Settings → AI Features (when Search & Duck.ai input is on) is no longer hidden behind a flag. **`AIChatSettings`** always reads and persists **`defaultOmnibarMode`**; **`AppConfiguration.setDefaultOmnibarModeIfNeeded()`** always seeds first-launch defaults (new installs → **Last Used**, upgrades → **Search**). **`SettingsViewModel.isDefaultOmnibarModeEnabled`** is deleted and the settings UI only checks that search input is enabled.
> 
> **`AppConfiguration`** drops its **`featureFlagger`** dependency (it was only used for this check); **`Launching`** passes the slimmer initializer. Privacy config and iOS **`FeatureFlag`** mappings for the subfeature are removed; an onboarding test no longer stubs the flag on **`AIChatSettings`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcc70c87281002e9249202cf4b4153b94562a20a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->