### PR TITLE
[iOS] Add voice search no-result pixels to close the funnel

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -2416,8 +2416,8 @@ extension Pixel.Event {
         case .voiceSearchAIChatDone: return "m_voice_search_aichat_done"
         case .openVoiceSearch: return "m_open_voice_search"
         case .voiceSearchCancelled: return "m_voice_search_cancelled"
-        case .voiceSearchError: return "m_voice_search_error"
-        case .voiceSearchNoSpeech: return "m_voice_search_no_speech"
+        case .voiceSearchError: return "voice_search_error"
+        case .voiceSearchNoSpeech: return "voice_search_no_speech"
             
         case .bookmarkImportSuccess: return "m_bi_s"
         case .bookmarkImportFailure: return "m_bi_e"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -375,6 +375,8 @@ extension Pixel {
         case voiceSearchAIChatDone
         case openVoiceSearch
         case voiceSearchCancelled
+        case voiceSearchError
+        case voiceSearchNoSpeech
 
         case bookmarkLaunchList
         case bookmarkLaunchScored
@@ -2414,6 +2416,8 @@ extension Pixel.Event {
         case .voiceSearchAIChatDone: return "m_voice_search_aichat_done"
         case .openVoiceSearch: return "m_open_voice_search"
         case .voiceSearchCancelled: return "m_voice_search_cancelled"
+        case .voiceSearchError: return "m_voice_search_error"
+        case .voiceSearchNoSpeech: return "m_voice_search_no_speech"
             
         case .bookmarkImportSuccess: return "m_bi_s"
         case .bookmarkImportFailure: return "m_bi_e"

--- a/iOS/DuckDuckGo/VoiceSearchFeedbackViewModel.swift
+++ b/iOS/DuckDuckGo/VoiceSearchFeedbackViewModel.swift
@@ -99,6 +99,14 @@ class VoiceSearchFeedbackViewModel: ObservableObject {
                 self.recognizedWords = text
 
                 if speechDidFinish || error != nil || self.hasReachedWordLimit(text) {
+                    if (text ?? "").isEmpty {
+                        // Session ended with no usable transcription: fires no done/cancelled pixel otherwise
+                        if let error {
+                            DailyPixel.fireDailyAndCount(pixel: .voiceSearchError, error: error)
+                        } else {
+                            DailyPixel.fireDailyAndCount(pixel: .voiceSearchNoSpeech)
+                        }
+                    }
                     self.finish()
                 }
             }

--- a/iOS/DuckDuckGo/VoiceSearchFeedbackViewModel.swift
+++ b/iOS/DuckDuckGo/VoiceSearchFeedbackViewModel.swift
@@ -59,6 +59,7 @@ class VoiceSearchFeedbackViewModel: ObservableObject {
     weak var delegate: VoiceSearchFeedbackViewModelDelegate?
     private let speechRecognizer: SpeechRecognizerProtocol
     private var isSilent = true
+    private var hasCompleted = false
     private let aiChatSettings: AIChatSettingsProvider
     private let maxWordsCount = 30
     private var recognizedWords: String? {
@@ -94,7 +95,7 @@ class VoiceSearchFeedbackViewModel: ObservableObject {
     func startSpeechRecognizer() {
         speechRecognizer.startRecording { [weak self] text, error, speechDidFinish in
             DispatchQueue.main.async {
-                guard let self = self else { return }
+                guard let self = self, !self.hasCompleted else { return }
 
                 self.recognizedWords = text
 
@@ -154,12 +155,18 @@ class VoiceSearchFeedbackViewModel: ObservableObject {
 
     func cancel() {
         assert(Thread.isMainThread)
+        guard !hasCompleted else { return }
+        hasCompleted = true
+        speechRecognizer.stopRecording()
         Pixel.fire(pixel: .voiceSearchCancelled)
         delegate?.voiceSearchFeedbackViewModel(self, didFinishQuery: nil, target: searchTarget)
     }
 
     func finish() {
         assert(Thread.isMainThread)
+        guard !hasCompleted else { return }
+        hasCompleted = true
+        speechRecognizer.stopRecording()
         delegate?.voiceSearchFeedbackViewModel(self, didFinishQuery: recognizedWords, target: searchTarget)
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/voice_search.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/voice_search.json5
@@ -5,13 +5,7 @@
         "owners": ["Bunn"],
         "triggers": ["exception"],
         "suffixes": ["daily_count"],
-        "parameters": [
-            "appVersion",
-            "errorDomain",
-            "errorCode",
-            "underlyingErrorDomain",
-            "underlyingErrorCode"
-        ]
+        "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode"]
     },
     "m_voice_search_no_speech": {
         "description": "Fires when a voice search session finishes on silence with no recognized words, so neither a done nor a cancelled pixel is sent. Completes the open->done funnel.",

--- a/iOS/PixelDefinitions/pixels/definitions/voice_search.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/voice_search.json5
@@ -1,13 +1,13 @@
 // Voice search session outcome pixels
 {
-    "m_voice_search_error": {
+    "voice_search_error": {
         "description": "Fires when a voice search session ends with a recognition or audio-session error and no usable transcription, so neither a done nor a cancelled pixel is sent. Signals recording/recognition failures behind the auto-close reports.",
         "owners": ["Bunn"],
         "triggers": ["exception"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode"]
     },
-    "m_voice_search_no_speech": {
+    "voice_search_no_speech": {
         "description": "Fires when a voice search session finishes on silence with no recognized words, so neither a done nor a cancelled pixel is sent. Completes the open->done funnel.",
         "owners": ["Bunn"],
         "triggers": ["other"],

--- a/iOS/PixelDefinitions/pixels/definitions/voice_search.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/voice_search.json5
@@ -1,0 +1,23 @@
+// Voice search session outcome pixels
+{
+    "m_voice_search_error": {
+        "description": "Fires when a voice search session ends with a recognition or audio-session error and no usable transcription, so neither a done nor a cancelled pixel is sent. Signals recording/recognition failures behind the auto-close reports.",
+        "owners": ["Bunn"],
+        "triggers": ["exception"],
+        "suffixes": ["daily_count"],
+        "parameters": [
+            "appVersion",
+            "errorDomain",
+            "errorCode",
+            "underlyingErrorDomain",
+            "underlyingErrorCode"
+        ]
+    },
+    "m_voice_search_no_speech": {
+        "description": "Fires when a voice search session finishes on silence with no recognized words, so neither a done nor a cancelled pixel is sent. Completes the open->done funnel.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion"]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1216825555627598?focus=true
Tech Design URL:
CC:

### Description
Add new error pixels for voice search

### Testing Steps
1. Trigger a recording failure (e.g. deny/occupy the mic via a call) and confirm `m_voice_search_error` fires with `e`/`d` error parameters.
2. Speak a normal query and confirm the existing `m_voice_search_serp_done` / `m_voice_search_aichat_done` still fire and the new pixels do not.

### Impact and Risks
Low

#### What could go wrong?
The new pixels fire on an existing dismissal path and touch no user-facing behavior, so worst case is an inaccurate count.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only on an existing dismissal path; no user-facing behavior changes beyond more accurate telemetry.
> 
> **Overview**
> Closes a gap in voice search analytics where sessions that auto-dismissed on **silence** or **recognition/recording errors** emitted no pixel, so opens outpaced done + cancelled.
> 
> When `VoiceSearchFeedbackViewModel` ends a session with **no usable transcription**, it now fires **`voice_search_no_speech`** (daily+count) or **`voice_search_error`** (daily+count with error domain/code). Successful queries still only fire the existing SERP/AIChat done pixels.
> 
> **`cancel()`** and **`finish()`** also set a **`hasCompleted`** flag and call **`stopRecording()`** so late recognizer callbacks cannot double-fire completion or the new outcome pixels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43f25d6800c918d6c405ab8a6c34ce58dd7b6a0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->