### PR TITLE
Fix stale titlebar strip color after playing a video in Full Screen

### DIFF
--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -418,6 +418,11 @@ extension MainWindowController: NSWindowDelegate {
               let mainWindow = self.window,
               keyWindow.isInHierarchy(of: mainWindow) else { return }
 
+        // This window may have been occluded (e.g. on a different Space while another window
+        // was in Full Screen) while the system appearance changed, missing the titlebar strip
+        // re-color from `subscribeToEffectiveAppearance()`. Re-apply now that it's on screen again.
+        applyThemeStyle()
+
         mainViewController.windowDidBecomeKey()
         lastWindowDidBecomeKeyTimestamp = CACurrentMediaTime()
         if !mainWindow.isPopUpWindow {

--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -418,11 +418,6 @@ extension MainWindowController: NSWindowDelegate {
               let mainWindow = self.window,
               keyWindow.isInHierarchy(of: mainWindow) else { return }
 
-        // This window may have been occluded (e.g. on a different Space while another window
-        // was in Full Screen) while the system appearance changed, missing the titlebar strip
-        // re-color from `subscribeToEffectiveAppearance()`. Re-apply now that it's on screen again.
-        applyThemeStyle()
-
         mainViewController.windowDidBecomeKey()
         lastWindowDidBecomeKeyTimestamp = CACurrentMediaTime()
         if !mainWindow.isPopUpWindow {
@@ -461,6 +456,17 @@ extension MainWindowController: NSWindowDelegate {
         }
 
         fullscreenController.resetFullscreenExitFlag()
+    }
+
+    func windowDidExitFullScreen(_ notification: Notification) {
+        // While this window was in Full Screen (on its own Space), the app's other windows were
+        // occluded on the background Space. If the system appearance changed during that time, their
+        // titlebar strip re-color from `subscribeToEffectiveAppearance()` didn't reliably reach the
+        // screen. Re-apply the theme to every window now that they're all visible again.
+        guard AppVersion.isLiquidGlassSupported else { return }
+        for windowController in Application.appDelegate.windowControllersManager.mainWindowControllers {
+            windowController.applyThemeStyle()
+        }
     }
 
     private func hideTabBarAndBookmarksBar() {

--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -90,6 +90,7 @@ final class MainWindowController: NSWindowController {
         subscribeToKeyWindow()
         subscribeToThemeChanges()
         subscribeToEffectiveAppearance()
+        subscribeToWindowOcclusion()
 
         applyThemeStyle()
 
@@ -188,6 +189,21 @@ final class MainWindowController: NSWindowController {
         NSApp.publisher(for: \.effectiveAppearance)
             .dropFirst()
             .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.applyThemeStyle()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func subscribeToWindowOcclusion() {
+        // A window occluded by a full screen Space — either another window's native Full Screen or a
+        // WKFullScreenWindowController video — doesn't reliably repaint its titlebar strip when the
+        // system appearance changes while it's off screen: subscribeToEffectiveAppearance() runs, but
+        // the layer color assignment doesn't stick until the window is on screen again. Re-apply the
+        // theme when the window becomes visible, when its effective appearance is guaranteed current.
+        guard AppVersion.isLiquidGlassSupported, let window else { return }
+        NotificationCenter.default.publisher(for: NSWindow.didChangeOcclusionStateNotification, object: window)
+            .filter { ($0.object as? NSWindow)?.occlusionState.contains(.visible) == true }
             .sink { [weak self] _ in
                 self?.applyThemeStyle()
             }
@@ -456,17 +472,6 @@ extension MainWindowController: NSWindowDelegate {
         }
 
         fullscreenController.resetFullscreenExitFlag()
-    }
-
-    func windowDidExitFullScreen(_ notification: Notification) {
-        // While this window was in Full Screen (on its own Space), the app's other windows were
-        // occluded on the background Space. If the system appearance changed during that time, their
-        // titlebar strip re-color from `subscribeToEffectiveAppearance()` didn't reliably reach the
-        // screen. Re-apply the theme to every window now that they're all visible again.
-        guard AppVersion.isLiquidGlassSupported else { return }
-        for windowController in Application.appDelegate.windowControllersManager.mainWindowControllers {
-            windowController.applyThemeStyle()
-        }
     }
 
     private func hideTabBarAndBookmarksBar() {

--- a/macOS/DuckDuckGo/Tab/View/WebViewContainerView.swift
+++ b/macOS/DuckDuckGo/Tab/View/WebViewContainerView.swift
@@ -54,6 +54,9 @@ final class WebViewContainerView: NSView {
 
     private var blurViewIsHiddenCancellable: AnyCancellable?
     private var cancellables = Set<AnyCancellable>()
+    // Kept separate from `cancellables`, which `observeFullScreenWindowWillExitFullScreen` empties as
+    // soon as the Full Screen window starts closing — before `didExitFullScreenNotification` arrives.
+    private var fullScreenExitThemeCancellable: AnyCancellable?
 
     override func layout() {
         super.layout()
@@ -99,6 +102,7 @@ final class WebViewContainerView: NSView {
 
                 self.observeTabMainWindow(fullScreenWindowController)
                 self.observeFullScreenWindowWillExitFullScreen(fullScreenWindowController)
+                self.observeFullScreenWindowDidExitFullScreen(fullScreenWindowController)
             }
             .store(in: &cancellables)
     }
@@ -183,6 +187,26 @@ final class WebViewContainerView: NSView {
                 }
             }
             .store(in: &cancellables)
+    }
+
+    /**
+
+     Fix a stale titlebar strip color on macOS 26 Liquid Glass UI after playing a Full Screen video.
+
+     The MainWindow is occluded by the WKFullScreenWindowController's own window while a video plays in
+     Full Screen, so if the system appearance changes during that time, `MainWindowController` re-colors
+     its (offscreen) titlebar strip but the change doesn't reliably make it onto screen. Once the video
+     Full Screen window closes and the MainWindow is shown again, re-apply the theme to guarantee the
+     strip matches the current appearance.
+    */
+    private func observeFullScreenWindowDidExitFullScreen(_ fullScreenWindowController: NSWindowController) {
+        // Note: stored in `fullScreenExitThemeCancellable`, not `cancellables` — see its declaration.
+        fullScreenExitThemeCancellable = NotificationCenter.default.publisher(for: NSWindow.didExitFullScreenNotification, object: fullScreenWindowController.window)
+            .first()
+            .sink { [weak self] _ in
+                guard let mainWindowController = self?.webView.tabContentView.window?.windowController as? MainWindowController else { return }
+                mainWindowController.applyThemeStyle()
+            }
     }
 
     private enum Selector {

--- a/macOS/DuckDuckGo/Tab/View/WebViewContainerView.swift
+++ b/macOS/DuckDuckGo/Tab/View/WebViewContainerView.swift
@@ -54,9 +54,6 @@ final class WebViewContainerView: NSView {
 
     private var blurViewIsHiddenCancellable: AnyCancellable?
     private var cancellables = Set<AnyCancellable>()
-    // Kept separate from `cancellables`, which `observeFullScreenWindowWillExitFullScreen` empties as
-    // soon as the Full Screen window starts closing — before `didExitFullScreenNotification` arrives.
-    private var fullScreenExitThemeCancellable: AnyCancellable?
 
     override func layout() {
         super.layout()
@@ -102,7 +99,6 @@ final class WebViewContainerView: NSView {
 
                 self.observeTabMainWindow(fullScreenWindowController)
                 self.observeFullScreenWindowWillExitFullScreen(fullScreenWindowController)
-                self.observeFullScreenWindowDidExitFullScreen(fullScreenWindowController)
             }
             .store(in: &cancellables)
     }
@@ -187,26 +183,6 @@ final class WebViewContainerView: NSView {
                 }
             }
             .store(in: &cancellables)
-    }
-
-    /**
-
-     Fix a stale titlebar strip color on macOS 26 Liquid Glass UI after playing a Full Screen video.
-
-     The MainWindow is occluded by the WKFullScreenWindowController's own window while a video plays in
-     Full Screen, so if the system appearance changes during that time, `MainWindowController` re-colors
-     its (offscreen) titlebar strip but the change doesn't reliably make it onto screen. Once the video
-     Full Screen window closes and the MainWindow is shown again, re-apply the theme to guarantee the
-     strip matches the current appearance.
-    */
-    private func observeFullScreenWindowDidExitFullScreen(_ fullScreenWindowController: NSWindowController) {
-        // Note: stored in `fullScreenExitThemeCancellable`, not `cancellables` — see its declaration.
-        fullScreenExitThemeCancellable = NotificationCenter.default.publisher(for: NSWindow.didExitFullScreenNotification, object: fullScreenWindowController.window)
-            .first()
-            .sink { [weak self] _ in
-                guard let mainWindowController = self?.webView.tabContentView.window?.windowController as? MainWindowController else { return }
-                mainWindowController.applyThemeStyle()
-            }
     }
 
     private enum Selector {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201621708115095/task/1215831775972379?focus=true

### Description
Follow-up to #5215. Fix multiple windows case when one of them is full-screen and another is occluded
(behind a full-screen window) and then the system theme change happens. Have each main window controller
observe its own window's occlusion state and re-apply the theme when the window becomes visible again.

### Testing Steps
Set system appearance to follow "System" in DuckDuckGo Settings > Appearance and start in macOS Dark Mode for each test.

**Video full screen:**
1. Open a YouTube video and enter native video full screen (this full screen window is a separate window from the app window).
2. While in full screen, switch the system appearance to Light Mode.
3. Exit full screen → the strip above the tab bar should be light, not dark. Any other open windows should also be correct.

**Multiple windows:**
1. Open two browser windows.
2. Put one window into native full screen (green traffic-light button).
3. While in full screen, switch the system appearance to Light Mode.
4. Exit full screen → both windows' titlebar strips should be light, not dark, without needing to click into them.

### Impact
Low: visual-only fix for a cosmetic titlebar strip glitch on macOS 26 Liquid Glass UI.

### Quality Considerations
No new tests added — this is a timing-dependent AppKit/WebKit rendering interaction that isn't practically unit-testable; verified manually per the repro steps above and by confirming the app builds cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only theme re-application on Liquid Glass when a window becomes visible; no auth, data, or security-sensitive paths.
> 
> **Overview**
> Fixes a **cosmetic titlebar strip** glitch on macOS 26 Liquid Glass when a browser window sits **behind full screen** (native window full screen or in-page video full screen) and the **system appearance changes** while that window is off-screen.
> 
> Each `MainWindowController` now **subscribes to its window’s occlusion state** (`NSWindow.didChangeOcclusionStateNotification`) and calls **`applyThemeStyle()` again when the window becomes visible**. That complements the existing effective-appearance subscription, which can run while the window is occluded but **doesn’t reliably persist the titlebar layer color** until the window is on screen again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd66e768d33e46a15e44acc7f8cf0d385c1128e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->