### PR TITLE
macOS: Limit tab attachments to three in the native omnibar

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -521,6 +521,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables attaching content from multiple open tabs to the New Tab Page omnibar Duck.ai chat.
     case ntpAttachMoreTabs
 
+    /// Enables the cap on how many open tabs can be attached (native omnibar and NTP). Kill switch.
+    case tabAttachmentLimit
+
     /// Enables deleting recent AI chats from the New Tab Page omnibar
     case ntpSuggestionsDeletion
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -306,10 +306,12 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         omnibarController.selectedModelSupportsFileUpload && hasExcessFileAttachments
     }
 
-    /// Tab-side analogue of `hasVisibleImageExcess` — over the tab cap and the tab picker is on,
-    /// so the over-limit cards are actually rendered for the error label to anchor against.
+    /// Tab-side analogue of `hasVisibleImageExcess`. Unlike images/files, tab cards always render
+    /// (they're page content, not model-typed — see `applyPanelAttachmentsFromSharedState`), so this
+    /// isn't gated on the picker flag: whenever the excess exists, its cards are on screen for the
+    /// error label to anchor against, and the cap must hold even if the picker flag flipped off.
     private var hasVisibleTabExcess: Bool {
-        omnibarController.isOmnibarTabPickerEnabled && omnibarController.hasExcessTabAttachments
+        omnibarController.hasExcessTabAttachments
     }
 
     required init?(coder: NSCoder) {
@@ -423,7 +425,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         let canSendImages = omnibarController.isImageGenerationMode || omnibarController.selectedModelSupportsImageUpload
         let imageBlockingExcess = canSendImages && omnibarController.hasExcessActiveTabImageAttachments
         let fileBlockingExcess = omnibarController.selectedModelSupportsFileUpload && hasExcessFileAttachments
-        let tabBlockingExcess = omnibarController.isOmnibarTabPickerEnabled && omnibarController.hasExcessTabAttachments
+        let tabBlockingExcess = omnibarController.hasExcessTabAttachments
         let hasBlockingExcess = imageBlockingExcess || fileBlockingExcess || tabBlockingExcess
 
         // Voice-chat mode only kicks in when the input is empty, the feature flag is on, and we

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -1484,17 +1484,25 @@ final class AIChatOmnibarContainerViewController: NSViewController {
                 isAttached: isAttached,
                 isCurrentTab: candidate.id == currentTabId,
                 isDisabled: !isAttached && atCap,
-                onToggle: { [weak omnibarController, weak observer] in
-                    guard let omnibarController else { return }
-                    // Read state BEFORE toggle so we know which pixel to fire — the toggle
-                    // flips it, so post-toggle we'd see the opposite of "what just happened".
-                    let wasAttached = omnibarController.activeTabAttachments.contains(where: { $0.id == candidate.id })
-                    omnibarController.toggleTabAttachment(candidate)
-                    let pixel: AIChatPixel = wasAttached
-                        ? .aiChatAddressBarAttachTabRemoved
-                        : .aiChatAddressBarAttachTabChosen
-                    PixelKit.fire(pixel, frequency: .dailyAndCount, includeAppVersionParameter: true)
-                    observer?.markDidMutate()
+                onToggle: { [weak self, weak observer, weak menu] in
+                    guard let self else { return }
+                    // Compare the real attachment state before and after: the toggle no-ops at the
+                    // display cap, so we must only fire a pixel / count a mutation when it actually
+                    // changed — otherwise an over-cap click would fire a bogus "chosen" pixel.
+                    let wasAttached = self.omnibarController.activeTabAttachments.contains(where: { $0.id == candidate.id })
+                    self.omnibarController.toggleTabAttachment(candidate)
+                    let nowAttached = self.omnibarController.activeTabAttachments.contains(where: { $0.id == candidate.id })
+                    if nowAttached != wasAttached {
+                        let pixel: AIChatPixel = wasAttached
+                            ? .aiChatAddressBarAttachTabRemoved
+                            : .aiChatAddressBarAttachTabChosen
+                        PixelKit.fire(pixel, frequency: .dailyAndCount, includeAppVersionParameter: true)
+                        observer?.markDidMutate()
+                    }
+                    // The submenu stays open for multi-toggle and never rebuilds, so refresh every
+                    // row from the authoritative attachment list — otherwise checkmarks and the
+                    // disabled appearance go stale once the cap is reached.
+                    self.refreshAttachTabsRows(in: menu)
                 }
             )
             item.view = row
@@ -1502,6 +1510,19 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         }
 
         return menu
+    }
+
+    /// Re-applies each attach-tabs row's checkmark and enabled/disabled state from the current
+    /// attachment list. Runs after every toggle because the submenu stays open for multi-toggle.
+    private func refreshAttachTabsRows(in menu: NSMenu?) {
+        guard let menu else { return }
+        let attachedIds = Set(omnibarController.activeTabAttachments.map(\.id))
+        let atCap = attachedIds.count >= omnibarController.tabAttachmentsDisplayCap
+        for item in menu.items {
+            guard let row = item.view as? AIChatTabPickerMenuRowView else { continue }
+            let isAttached = attachedIds.contains(row.tabId)
+            row.applyState(isAttached: isAttached, isDisabled: !isAttached && atCap)
+        }
     }
 
     @objc private func attachMenuImageOrFileClicked() {

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -1495,6 +1495,10 @@ final class AIChatOmnibarContainerViewController: NSViewController {
                     }
                     // The submenu stays open and never rebuilds, so refresh rows from the attachment list.
                     self.refreshAttachTabsRows(in: menu)
+                    // Going over the cap: close the menu so the over-limit error below the field is visible.
+                    if self.omnibarController.hasExcessTabAttachments {
+                        menu?.cancelTrackingWithoutAnimation()
+                    }
                 }
             )
             item.view = row

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -306,10 +306,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         omnibarController.selectedModelSupportsFileUpload && hasExcessFileAttachments
     }
 
-    /// Tab-side analogue of `hasVisibleImageExcess`. Unlike images/files, tab cards always render
-    /// (they're page content, not model-typed — see `applyPanelAttachmentsFromSharedState`), so this
-    /// isn't gated on the picker flag: whenever the excess exists, its cards are on screen for the
-    /// error label to anchor against, and the cap must hold even if the picker flag flipped off.
+    /// Tab-side analogue of `hasVisibleImageExcess`. Not picker-flag-gated: tab cards always render.
     private var hasVisibleTabExcess: Bool {
         omnibarController.hasExcessTabAttachments
     }
@@ -1470,8 +1467,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         header.isEnabled = false
         menu.addItem(header)
 
-        // Once the display cap is reached, unattached rows are disabled so the user can't push
-        // further over the limit; attached rows stay interactive so they can remove one.
+        // Disable unattached rows once at the display cap; attached rows stay interactive.
         let atCap = attachedIds.count >= omnibarController.tabAttachmentsDisplayCap
 
         // `openTabsForOmnibarPicker()` returns the current tab first, so the menu shows
@@ -1486,9 +1482,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
                 isDisabled: !isAttached && atCap,
                 onToggle: { [weak self, weak observer, weak menu] in
                     guard let self else { return }
-                    // Compare the real attachment state before and after: the toggle no-ops at the
-                    // display cap, so we must only fire a pixel / count a mutation when it actually
-                    // changed — otherwise an over-cap click would fire a bogus "chosen" pixel.
+                    // Only fire a pixel / count a mutation on a real change — the toggle no-ops at the cap.
                     let wasAttached = self.omnibarController.activeTabAttachments.contains(where: { $0.id == candidate.id })
                     self.omnibarController.toggleTabAttachment(candidate)
                     let nowAttached = self.omnibarController.activeTabAttachments.contains(where: { $0.id == candidate.id })
@@ -1499,9 +1493,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
                         PixelKit.fire(pixel, frequency: .dailyAndCount, includeAppVersionParameter: true)
                         observer?.markDidMutate()
                     }
-                    // The submenu stays open for multi-toggle and never rebuilds, so refresh every
-                    // row from the authoritative attachment list — otherwise checkmarks and the
-                    // disabled appearance go stale once the cap is reached.
+                    // The submenu stays open and never rebuilds, so refresh rows from the attachment list.
                     self.refreshAttachTabsRows(in: menu)
                 }
             )
@@ -1512,8 +1504,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         return menu
     }
 
-    /// Re-applies each attach-tabs row's checkmark and enabled/disabled state from the current
-    /// attachment list. Runs after every toggle because the submenu stays open for multi-toggle.
+    /// Re-applies every row's checkmark + disabled state from the attachment list after a toggle.
     private func refreshAttachTabsRows(in menu: NSMenu?) {
         guard let menu else { return }
         let attachedIds = Set(omnibarController.activeTabAttachments.map(\.id))

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -1484,6 +1484,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
                     guard let self else { return }
                     // Only fire a pixel / count a mutation on a real change — the toggle no-ops at the cap.
                     let wasAttached = self.omnibarController.activeTabAttachments.contains(where: { $0.id == candidate.id })
+                    let wasOverCap = self.omnibarController.hasExcessTabAttachments
                     self.omnibarController.toggleTabAttachment(candidate)
                     let nowAttached = self.omnibarController.activeTabAttachments.contains(where: { $0.id == candidate.id })
                     if nowAttached != wasAttached {
@@ -1495,8 +1496,10 @@ final class AIChatOmnibarContainerViewController: NSViewController {
                     }
                     // The submenu stays open and never rebuilds, so refresh rows from the attachment list.
                     self.refreshAttachTabsRows(in: menu)
-                    // Going over the cap: close the menu so the over-limit error below the field is visible.
-                    if self.omnibarController.hasExcessTabAttachments {
+                    // The panel reflow (error label + height) is deferred while the menu is open, so
+                    // crossing the cap boundary either way would leave a stale error. Close the menu so
+                    // `menuDidClose` reflows and the over-limit error appears / clears correctly.
+                    if self.omnibarController.hasExcessTabAttachments != wasOverCap {
                         menu?.cancelTrackingWithoutAnimation()
                     }
                 }

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -268,7 +268,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     /// Whether the attachments error label should be visible — either a sticky pick-time rejection
     /// or a live count-excess cue (one over the cap).
     private var shouldShowAttachmentError: Bool {
-        lastAttachmentError != nil || hasVisibleImageExcess || hasVisibleFileExcess
+        lastAttachmentError != nil || hasVisibleImageExcess || hasVisibleFileExcess || hasVisibleTabExcess
     }
 
     /// Extra height needed beyond text and suggestions for dynamic content like attachments.
@@ -304,6 +304,12 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     /// File-side analogue of `hasVisibleImageExcess`.
     private var hasVisibleFileExcess: Bool {
         omnibarController.selectedModelSupportsFileUpload && hasExcessFileAttachments
+    }
+
+    /// Tab-side analogue of `hasVisibleImageExcess` — over the tab cap and the tab picker is on,
+    /// so the over-limit cards are actually rendered for the error label to anchor against.
+    private var hasVisibleTabExcess: Bool {
+        omnibarController.isOmnibarTabPickerEnabled && omnibarController.hasExcessTabAttachments
     }
 
     required init?(coder: NSCoder) {
@@ -417,7 +423,8 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         let canSendImages = omnibarController.isImageGenerationMode || omnibarController.selectedModelSupportsImageUpload
         let imageBlockingExcess = canSendImages && omnibarController.hasExcessActiveTabImageAttachments
         let fileBlockingExcess = omnibarController.selectedModelSupportsFileUpload && hasExcessFileAttachments
-        let hasBlockingExcess = imageBlockingExcess || fileBlockingExcess
+        let tabBlockingExcess = omnibarController.isOmnibarTabPickerEnabled && omnibarController.hasExcessTabAttachments
+        let hasBlockingExcess = imageBlockingExcess || fileBlockingExcess || tabBlockingExcess
 
         // Voice-chat mode only kicks in when the input is empty, the feature flag is on, and we
         // aren't in image-generation mode (where the button must keep its image-flow semantics).
@@ -1461,14 +1468,20 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         header.isEnabled = false
         menu.addItem(header)
 
+        // Once the display cap is reached, unattached rows are disabled so the user can't push
+        // further over the limit; attached rows stay interactive so they can remove one.
+        let atCap = attachedIds.count >= omnibarController.tabAttachmentsDisplayCap
+
         // `openTabsForOmnibarPicker()` returns the current tab first, so the menu shows
         // "(Current Tab)" pinned on top.
         for candidate in candidates {
+            let isAttached = attachedIds.contains(candidate.id)
             let item = NSMenuItem()
             let row = AIChatTabPickerMenuRowView(
                 attachment: candidate,
-                isAttached: attachedIds.contains(candidate.id),
+                isAttached: isAttached,
                 isCurrentTab: candidate.id == currentTabId,
+                isDisabled: !isAttached && atCap,
                 onToggle: { [weak omnibarController, weak observer] in
                     guard let omnibarController else { return }
                     // Read state BEFORE toggle so we know which pixel to fire — the toggle
@@ -1611,10 +1624,11 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         // overlap the tools row below. Keeping the two decisions in sync prevents that.
         let visibleImageExcess = hasVisibleImageExcess
         let visibleFileExcess = hasVisibleFileExcess
+        let visibleTabExcess = hasVisibleTabExcess
         // A sticky pick-time rejection (size / pages / unsupported / count) takes priority — it
         // names the precise reason the file the user just chose wasn't added. Otherwise fall back
         // to the live count-excess copy; file excess wins over image excess as it's the more
-        // recently introduced and likely thing the user has just done.
+        // recently introduced and likely thing the user has just done, and tab excess falls last.
         attachmentsErrorLabel.isHidden = !shouldShowAttachmentError
         if let lastAttachmentError {
             attachmentsErrorLabel.stringValue = lastAttachmentError
@@ -1624,9 +1638,13 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             attachmentsErrorLabel.stringValue = UserText.aiChatAttachmentFileCountLimit(
                 maxFilesPerConversation: omnibarController.maxFileAttachments
             )
-        } else {
+        } else if visibleImageExcess {
             attachmentsErrorLabel.stringValue = UserText.aiChatAttachmentImageTurnLimit(
                 maxImagesPerTurn: omnibarController.maxImageAttachments
+            )
+        } else if visibleTabExcess {
+            attachmentsErrorLabel.stringValue = UserText.aiChatAttachmentTabCountLimit(
+                maxTabs: AIChatOmnibarController.maxTabAttachments
             )
         }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -515,15 +515,17 @@ final class AIChatOmnibarController {
 
     /// Hardcoded cap on tabs attached as page context (not backend-driven, unlike images/files).
     static let maxTabAttachments: Int = 3
-    /// One over the cap, mirroring the image/file display cap.
-    var tabAttachmentsDisplayCap: Int { Self.maxTabAttachments + 1 }
+    /// Kill switch (default on) for the whole tab-attachment cap. Off → no cap.
+    var isTabAttachmentLimitEnabled: Bool { featureFlagger.isFeatureOn(.aiChatTabAttachmentLimit) }
+    /// One over the cap, mirroring the image/file display cap; unbounded when the limit is disabled.
+    var tabAttachmentsDisplayCap: Int { isTabAttachmentLimitEnabled ? Self.maxTabAttachments + 1 : .max }
 
     var isActiveTabAttachmentsFull: Bool {
-        activeTabAttachments.count >= Self.maxTabAttachments
+        isTabAttachmentLimitEnabled && activeTabAttachments.count >= Self.maxTabAttachments
     }
 
     var hasExcessTabAttachments: Bool {
-        activeTabAttachments.count > Self.maxTabAttachments
+        isTabAttachmentLimitEnabled && activeTabAttachments.count > Self.maxTabAttachments
     }
 
     /// Whether the currently selected model supports file (PDF etc.) upload.

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -513,6 +513,23 @@ final class AIChatOmnibarController {
     }
     var fileAttachmentsDisplayCap: Int { maxFileAttachments + 1 }
 
+    /// Maximum open tabs the user can attach as page context. Hardcoded product constant (not
+    /// backend-driven, unlike images/files). Falls out to the same "+1 over → error → block" cue.
+    static let maxTabAttachments: Int = 3
+    /// One above the cap — `toggleTabAttachment` allows exactly one over so the error label has
+    /// something to anchor against and submit blocks while in that state. Mirrors the image/file cap.
+    var tabAttachmentsDisplayCap: Int { Self.maxTabAttachments + 1 }
+
+    /// At or above the tab cap.
+    var isActiveTabAttachmentsFull: Bool {
+        activeTabAttachments.count >= Self.maxTabAttachments
+    }
+
+    /// Strictly over the tab cap (one over, by `tabAttachmentsDisplayCap` design).
+    var hasExcessTabAttachments: Bool {
+        activeTabAttachments.count > Self.maxTabAttachments
+    }
+
     /// Whether the currently selected model supports file (PDF etc.) upload.
     /// Returns `false` conservatively when models are unavailable — file upload is opt-in per model
     /// and the file picker should stay hidden until we know the model can accept it.
@@ -794,6 +811,8 @@ final class AIChatOmnibarController {
         if let index = current.firstIndex(where: { $0.id == attachment.id }) {
             current.remove(at: index)
         } else {
+            // Allow reaching the display cap (one over) so the over-limit cue shows; block beyond.
+            guard current.count < tabAttachmentsDisplayCap else { return }
             current.append(attachment)
             prewarmAttachedTab(id: attachment.id)
         }
@@ -1089,6 +1108,12 @@ final class AIChatOmnibarController {
         // limit (`+1`) so the user gets a visible "you've gone over" cue; if they actually try to
         // submit while in that state, hold the submit until they remove the excess.
         if selectedModelSupportsFileUpload && activeFileAttachments.count > maxFileAttachments {
+            return
+        }
+
+        // Block submission if too many tabs are attached. Like files, the picker caps at one over
+        // the limit (+1) for a visible over-limit cue; hold submit until the excess is removed.
+        if isOmnibarTabPickerEnabled && hasExcessTabAttachments {
             return
         }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -1113,7 +1113,10 @@ final class AIChatOmnibarController {
 
         // Block submission if too many tabs are attached. Like files, the picker caps at one over
         // the limit (+1) for a visible over-limit cue; hold submit until the excess is removed.
-        if isOmnibarTabPickerEnabled && hasExcessTabAttachments {
+        // Not gated on `isOmnibarTabPickerEnabled`: tab cards always render (they're page content,
+        // not model-typed), and shared-state attachments persist if the picker flag flips off
+        // mid-session — so the cap must hold regardless of the flag to avoid shipping >3 contexts.
+        if hasExcessTabAttachments {
             return
         }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -513,19 +513,15 @@ final class AIChatOmnibarController {
     }
     var fileAttachmentsDisplayCap: Int { maxFileAttachments + 1 }
 
-    /// Maximum open tabs the user can attach as page context. Hardcoded product constant (not
-    /// backend-driven, unlike images/files). Falls out to the same "+1 over → error → block" cue.
+    /// Hardcoded cap on tabs attached as page context (not backend-driven, unlike images/files).
     static let maxTabAttachments: Int = 3
-    /// One above the cap — `toggleTabAttachment` allows exactly one over so the error label has
-    /// something to anchor against and submit blocks while in that state. Mirrors the image/file cap.
+    /// One over the cap, mirroring the image/file display cap.
     var tabAttachmentsDisplayCap: Int { Self.maxTabAttachments + 1 }
 
-    /// At or above the tab cap.
     var isActiveTabAttachmentsFull: Bool {
         activeTabAttachments.count >= Self.maxTabAttachments
     }
 
-    /// Strictly over the tab cap (one over, by `tabAttachmentsDisplayCap` design).
     var hasExcessTabAttachments: Bool {
         activeTabAttachments.count > Self.maxTabAttachments
     }
@@ -811,7 +807,7 @@ final class AIChatOmnibarController {
         if let index = current.firstIndex(where: { $0.id == attachment.id }) {
             current.remove(at: index)
         } else {
-            // Allow reaching the display cap (one over) so the over-limit cue shows; block beyond.
+            // Allow one over the cap (for the over-limit cue); block beyond.
             guard current.count < tabAttachmentsDisplayCap else { return }
             current.append(attachment)
             prewarmAttachedTab(id: attachment.id)
@@ -1111,11 +1107,7 @@ final class AIChatOmnibarController {
             return
         }
 
-        // Block submission if too many tabs are attached. Like files, the picker caps at one over
-        // the limit (+1) for a visible over-limit cue; hold submit until the excess is removed.
-        // Not gated on `isOmnibarTabPickerEnabled`: tab cards always render (they're page content,
-        // not model-typed), and shared-state attachments persist if the picker flag flips off
-        // mid-session — so the cap must hold regardless of the flag to avoid shipping >3 contexts.
+        // Hold submit while over the tab cap — unconditional, since tab cards render regardless of the picker flag.
         if hasExcessTabAttachments {
             return
         }

--- a/macOS/DuckDuckGo/AIChat/AIChatTabPickerMenuRowView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabPickerMenuRowView.swift
@@ -45,6 +45,7 @@ final class AIChatTabPickerMenuRowView: NSView {
         static let spacingAfterCheckmark: CGFloat = 6
         static let spacingAfterIcon: CGFloat = 4
         static let spacingBeforeAccessory: CGFloat = 6
+        static let disabledAlpha: CGFloat = 0.4
     }
 
     private let checkmarkView = NSImageView()
@@ -52,6 +53,10 @@ final class AIChatTabPickerMenuRowView: NSView {
     private let titleLabel = NSTextField(labelWithString: "")
     private let accessoryLabel = NSTextField(labelWithString: "")
     private var trackingArea: NSTrackingArea?
+
+    /// The attached tab's id. Lets the submenu refresh this row from the authoritative attachment
+    /// list after any toggle (the menu stays open for multi-toggle and never rebuilds).
+    let tabId: String
 
     private(set) var isAttached: Bool {
         didSet { checkmarkView.isHidden = !isAttached }
@@ -69,14 +74,22 @@ final class AIChatTabPickerMenuRowView: NSView {
 
     /// When true the row is inert (the tab cap is reached and this tab isn't attached): no hover
     /// highlight, no toggle, and the whole row is dimmed. Attached rows are never disabled so the
-    /// user can always remove one to get back under the cap.
-    private let isDisabled: Bool
+    /// user can always remove one to get back under the cap. Mutable because the submenu stays open
+    /// for multi-toggle, so it's refreshed on every row as the cap is reached / released.
+    private var isDisabled: Bool {
+        didSet {
+            guard oldValue != isDisabled else { return }
+            alphaValue = isDisabled ? Layout.disabledAlpha : 1.0
+            if isDisabled { isHovering = false }
+        }
+    }
 
     override var intrinsicContentSize: NSSize {
         NSSize(width: Layout.width, height: Layout.height)
     }
 
     init(attachment: AIChatTabAttachment, isAttached: Bool, isCurrentTab: Bool, isDisabled: Bool = false, onToggle: @escaping () -> Void) {
+        self.tabId = attachment.id
         self.isAttached = isAttached
         self.isDisabled = isDisabled
         self.onToggle = onToggle
@@ -177,10 +190,9 @@ final class AIChatTabPickerMenuRowView: NSView {
         }
 
         // Dim the whole row (favicon, title, reserved checkmark slot) when it can't be interacted
-        // with, matching how AppKit greys out unavailable menu items.
-        if isDisabled {
-            alphaValue = 0.4
-        }
+        // with, matching how AppKit greys out unavailable menu items. Set directly here because a
+        // `didSet` doesn't fire during initialization.
+        alphaValue = isDisabled ? Layout.disabledAlpha : 1.0
 
         updateColors()
     }
@@ -251,8 +263,17 @@ final class AIChatTabPickerMenuRowView: NSView {
         guard !isDisabled else { return }
         let pointInView = convert(event.locationInWindow, from: nil)
         guard bounds.contains(pointInView) else { return }
-        isAttached.toggle()
+        // Don't optimistically flip `isAttached` here — the toggle can no-op at the display cap.
+        // `onToggle` mutates the model and then refreshes this row (and its siblings) from the
+        // authoritative attachment list via `applyState`, so the checkmark always reflects reality.
         onToggle()
+    }
+
+    /// Re-applies attached + disabled state from the source of truth. Called on every row after any
+    /// toggle so the still-open submenu never shows a stale checkmark or a stale enabled appearance.
+    func applyState(isAttached: Bool, isDisabled: Bool) {
+        self.isAttached = isAttached
+        self.isDisabled = isDisabled
     }
 
     /// We override `mouseDown:` solely to consume the press half of the click. Without this,

--- a/macOS/DuckDuckGo/AIChat/AIChatTabPickerMenuRowView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabPickerMenuRowView.swift
@@ -54,8 +54,7 @@ final class AIChatTabPickerMenuRowView: NSView {
     private let accessoryLabel = NSTextField(labelWithString: "")
     private var trackingArea: NSTrackingArea?
 
-    /// The attached tab's id. Lets the submenu refresh this row from the authoritative attachment
-    /// list after any toggle (the menu stays open for multi-toggle and never rebuilds).
+    /// The tab's id, so the submenu can refresh this row from the attachment list after a toggle.
     let tabId: String
 
     private(set) var isAttached: Bool {
@@ -72,10 +71,7 @@ final class AIChatTabPickerMenuRowView: NSView {
 
     private let onToggle: () -> Void
 
-    /// When true the row is inert (the tab cap is reached and this tab isn't attached): no hover
-    /// highlight, no toggle, and the whole row is dimmed. Attached rows are never disabled so the
-    /// user can always remove one to get back under the cap. Mutable because the submenu stays open
-    /// for multi-toggle, so it's refreshed on every row as the cap is reached / released.
+    /// Inert + dimmed when the cap is reached and this tab isn't attached. Mutable so the still-open submenu can refresh it.
     private var isDisabled: Bool {
         didSet {
             guard oldValue != isDisabled else { return }
@@ -189,9 +185,7 @@ final class AIChatTabPickerMenuRowView: NSView {
             addSubview(accessoryLabel)
         }
 
-        // Dim the whole row (favicon, title, reserved checkmark slot) when it can't be interacted
-        // with, matching how AppKit greys out unavailable menu items. Set directly here because a
-        // `didSet` doesn't fire during initialization.
+        // Set directly (a `didSet` doesn't fire during init).
         alphaValue = isDisabled ? Layout.disabledAlpha : 1.0
 
         updateColors()
@@ -263,14 +257,11 @@ final class AIChatTabPickerMenuRowView: NSView {
         guard !isDisabled else { return }
         let pointInView = convert(event.locationInWindow, from: nil)
         guard bounds.contains(pointInView) else { return }
-        // Don't optimistically flip `isAttached` here — the toggle can no-op at the display cap.
-        // `onToggle` mutates the model and then refreshes this row (and its siblings) from the
-        // authoritative attachment list via `applyState`, so the checkmark always reflects reality.
+        // Don't flip `isAttached` here — the toggle can no-op at the cap; `onToggle` refreshes via `applyState`.
         onToggle()
     }
 
-    /// Re-applies attached + disabled state from the source of truth. Called on every row after any
-    /// toggle so the still-open submenu never shows a stale checkmark or a stale enabled appearance.
+    /// Re-applies attached + disabled state from the source of truth.
     func applyState(isAttached: Bool, isDisabled: Bool) {
         self.isAttached = isAttached
         self.isDisabled = isDisabled

--- a/macOS/DuckDuckGo/AIChat/AIChatTabPickerMenuRowView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabPickerMenuRowView.swift
@@ -67,12 +67,18 @@ final class AIChatTabPickerMenuRowView: NSView {
 
     private let onToggle: () -> Void
 
+    /// When true the row is inert (the tab cap is reached and this tab isn't attached): no hover
+    /// highlight, no toggle, and the whole row is dimmed. Attached rows are never disabled so the
+    /// user can always remove one to get back under the cap.
+    private let isDisabled: Bool
+
     override var intrinsicContentSize: NSSize {
         NSSize(width: Layout.width, height: Layout.height)
     }
 
-    init(attachment: AIChatTabAttachment, isAttached: Bool, isCurrentTab: Bool, onToggle: @escaping () -> Void) {
+    init(attachment: AIChatTabAttachment, isAttached: Bool, isCurrentTab: Bool, isDisabled: Bool = false, onToggle: @escaping () -> Void) {
         self.isAttached = isAttached
+        self.isDisabled = isDisabled
         self.onToggle = onToggle
         super.init(frame: NSRect(x: 0, y: 0, width: Layout.width, height: Layout.height))
 
@@ -170,6 +176,12 @@ final class AIChatTabPickerMenuRowView: NSView {
             addSubview(accessoryLabel)
         }
 
+        // Dim the whole row (favicon, title, reserved checkmark slot) when it can't be interacted
+        // with, matching how AppKit greys out unavailable menu items.
+        if isDisabled {
+            alphaValue = 0.4
+        }
+
         updateColors()
     }
 
@@ -209,6 +221,7 @@ final class AIChatTabPickerMenuRowView: NSView {
     }
 
     override func mouseEntered(with event: NSEvent) {
+        guard !isDisabled else { return }
         isHovering = true
     }
 
@@ -235,6 +248,7 @@ final class AIChatTabPickerMenuRowView: NSView {
     /// `NSMenu` would normally close on `mouseUp:` if we let the click bubble back as an item
     /// activation. Toggling locally here without chaining to `super` keeps the submenu open.
     override func mouseUp(with event: NSEvent) {
+        guard !isDisabled else { return }
         let pointInView = convert(event.locationInWindow, from: nil)
         guard bounds.contains(pointInView) else { return }
         isAttached.toggle()

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -865,6 +865,10 @@ struct UserText {
         let message = NSLocalizedString("aichat.attachment.file.count.limit", value: "You can only attach %d files per conversation.", comment: "Error message displayed when the user has attached more files than are allowed in a conversation. Parameter is the backend-provided maximum number of files.")
         return String(format: message, maxFilesPerConversation)
     }
+    static func aiChatAttachmentTabCountLimit(maxTabs: Int) -> String {
+        let message = NotLocalizedString("aichat.attachment.tab.count.limit", value: "You can only attach %d tabs at a time.", comment: "Error message displayed when the user has attached more open tabs than are allowed. Parameter is the maximum number of tabs.")
+        return String(format: message, maxTabs)
+    }
     static let aiChatAttachmentPromptTooLong = NSLocalizedString("aichat.attachment.prompt.too.long", value: "That message is too long to send with attachments.", comment: "Error message shown when an AI chat message exceeds the allowed length while attachments are included")
 
     static let aiChatReasoningEffortFastTitle = NSLocalizedString("aichat.reasoning-effort.fast.title", value: "Fast", comment: "Title of the 'Fast' option in the reasoning effort picker menu in AI chat omnibar")

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
@@ -239,7 +239,7 @@ extension NewTabPageActionsManager {
             NewTabPageOmnibarClient(configProvider: omnibarConfigProvider,
                                     suggestionsProvider: suggestionsProvider,
                                     aiChatsProvider: aiChatsProvider,
-                                    modelsProvider: NewTabPageOmnibarModelsProvider(),
+                                    modelsProvider: NewTabPageOmnibarModelsProvider(featureFlagger: featureFlagger),
                                     actionHandler: omnibarActionHandler,
                                     tabsProvider: NewTabPageOmnibarTabsProvider(windowControllersManager: windowControllersManager)),
             NewTabPageWinBackOfferClient(provider: winBackOfferBannerProvider)

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarModelsProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarModelsProvider.swift
@@ -79,20 +79,27 @@ final class NewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {
         }
     }
 
-    private func mapAttachmentLimits(_ limits: AIChatAttachmentTierLimits?) -> NewTabPageDataModel.AttachmentLimits? {
-        guard let limits else { return nil }
-        return NewTabPageDataModel.AttachmentLimits(
-            files: .init(
-                maxPerConversation: limits.files.maxPerConversation,
-                maxFileSizeMB: limits.files.maxFileSizeMB,
-                maxTotalFileSizeBytes: limits.files.maxTotalFileSizeBytes,
-                maxPagesPerFile: limits.files.maxPagesPerFile
-            ),
-            images: .init(
-                maxPerTurn: limits.images.maxPerTurn,
-                maxPerConversation: limits.images.maxPerConversation,
-                maxInputCharsWithAttachments: limits.images.maxInputCharsWithAttachments
-            )
+    /// Always returns a struct: `files`/`images` are populated from the backend when present (nil
+    /// otherwise), while `tabs` carries the hardcoded native cap unconditionally so the tab limit
+    /// survives a backend/network omission of the file/image limits.
+    private func mapAttachmentLimits(_ limits: AIChatAttachmentTierLimits?) -> NewTabPageDataModel.AttachmentLimits {
+        NewTabPageDataModel.AttachmentLimits(
+            files: limits.map {
+                .init(
+                    maxPerConversation: $0.files.maxPerConversation,
+                    maxFileSizeMB: $0.files.maxFileSizeMB,
+                    maxTotalFileSizeBytes: $0.files.maxTotalFileSizeBytes,
+                    maxPagesPerFile: $0.files.maxPagesPerFile
+                )
+            },
+            images: limits.map {
+                .init(
+                    maxPerTurn: $0.images.maxPerTurn,
+                    maxPerConversation: $0.images.maxPerConversation,
+                    maxInputCharsWithAttachments: $0.images.maxInputCharsWithAttachments
+                )
+            },
+            tabs: .init(maxAttached: AIChatOmnibarController.maxTabAttachments)
         )
     }
 

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarModelsProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarModelsProvider.swift
@@ -79,9 +79,7 @@ final class NewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {
         }
     }
 
-    /// Always returns a struct: `files`/`images` are populated from the backend when present (nil
-    /// otherwise), while `tabs` carries the hardcoded native cap unconditionally so the tab limit
-    /// survives a backend/network omission of the file/image limits.
+    /// `files`/`images` come from the backend when present; `tabs` always carries the hardcoded cap.
     private func mapAttachmentLimits(_ limits: AIChatAttachmentTierLimits?) -> NewTabPageDataModel.AttachmentLimits {
         NewTabPageDataModel.AttachmentLimits(
             files: limits.map {

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarModelsProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarModelsProvider.swift
@@ -20,6 +20,7 @@ import AIChat
 import FeatureFlags
 import NewTabPage
 import os.log
+import PrivacyConfig
 import Subscription
 
 /// Fetches AI models from the duck.ai API and builds sectioned model lists

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarModelsProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarModelsProvider.swift
@@ -17,6 +17,7 @@
 //
 
 import AIChat
+import FeatureFlags
 import NewTabPage
 import os.log
 import Subscription
@@ -30,13 +31,16 @@ final class NewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {
     private(set) var attachmentLimits: NewTabPageDataModel.AttachmentLimits?
     private let modelsService: AIChatModelsProviding
     private let subscriptionManager: any SubscriptionManager
+    private let featureFlagger: FeatureFlagger
 
     init(
         modelsService: AIChatModelsProviding = AIChatModelsService(),
-        subscriptionManager: any SubscriptionManager = Application.appDelegate.subscriptionManager
+        subscriptionManager: any SubscriptionManager = Application.appDelegate.subscriptionManager,
+        featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger
     ) {
         self.modelsService = modelsService
         self.subscriptionManager = subscriptionManager
+        self.featureFlagger = featureFlagger
     }
 
     func fetchAIModelSections() async -> [NewTabPageDataModel.AIModelSection] {
@@ -79,7 +83,7 @@ final class NewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {
         }
     }
 
-    /// `files`/`images` come from the backend when present; `tabs` always carries the hardcoded cap.
+    /// `files`/`images` come from the backend when present; `tabs` carries the hardcoded cap, omitted when the limit kill switch is off (web then applies no tab limit).
     private func mapAttachmentLimits(_ limits: AIChatAttachmentTierLimits?) -> NewTabPageDataModel.AttachmentLimits {
         NewTabPageDataModel.AttachmentLimits(
             files: limits.map {
@@ -97,7 +101,9 @@ final class NewTabPageOmnibarModelsProvider: NewTabPageOmnibarModelsProviding {
                     maxInputCharsWithAttachments: $0.images.maxInputCharsWithAttachments
                 )
             },
-            tabs: .init(maxAttached: AIChatOmnibarController.maxTabAttachments)
+            tabs: featureFlagger.isFeatureOn(.aiChatTabAttachmentLimit)
+                ? .init(maxAttached: AIChatOmnibarController.maxTabAttachments)
+                : nil
         )
     }
 

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -349,6 +349,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/task/1214804748957575?focus=true
     case aiChatOmnibarAttachMoreTabs
 
+    /// Kill switch for the tab-attachment limit (native omnibar and NTP). Default on.
+    case aiChatTabAttachmentLimit
+
     /// https://app.asana.com/1/137249556945/task/1213316822018797
     case aiChatSidebarResizable
 
@@ -709,6 +712,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.sidebarAttachMoreTabs), category: .duckAI)
         case .aiChatOmnibarAttachMoreTabs:
             Config(source: .remoteReleasable(AIChatSubfeature.omnibarAttachMoreTabs), category: .duckAI)
+        case .aiChatTabAttachmentLimit:
+            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.tabAttachmentLimit), category: .duckAI)
         case .aiChatSidebarResizable:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.sidebarResizable), category: .duckAI)
         case .aiChatNtpRecentChats:

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -350,6 +350,7 @@ public enum FeatureFlag: String, CaseIterable {
     case aiChatOmnibarAttachMoreTabs
 
     /// Kill switch for the tab-attachment limit (native omnibar and NTP). Default on.
+    /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1216831900874433?focus=true
     case aiChatTabAttachmentLimit
 
     /// https://app.asana.com/1/137249556945/task/1213316822018797

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
@@ -64,7 +64,7 @@ public extension NewTabPageDataModel {
         }
     }
 
-    /// Attachment limits forwarded to the web. `files`/`images` are backend-sourced + optional; `tabs` is a hardcoded native constant.
+    /// Attachment limits forwarded to the web. All optional: `files`/`images` are backend-sourced; `tabs` is a hardcoded native cap, omitted when the limit is disabled (web then applies no tab limit).
     struct AttachmentLimits: Codable, Equatable {
         public struct FileLimits: Codable, Equatable {
             let maxPerConversation: Int
@@ -102,9 +102,9 @@ public extension NewTabPageDataModel {
 
         let files: FileLimits?
         let images: ImageLimits?
-        let tabs: TabLimits
+        let tabs: TabLimits?
 
-        public init(files: FileLimits?, images: ImageLimits?, tabs: TabLimits) {
+        public init(files: FileLimits?, images: ImageLimits?, tabs: TabLimits?) {
             self.files = files
             self.images = images
             self.tabs = tabs

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
@@ -64,11 +64,7 @@ public extension NewTabPageDataModel {
         }
     }
 
-    /// Attachment limits forwarded to the web so the NTP omnibar can enforce them instead of
-    /// hardcoding defaults. `files`/`images` are sourced from the Duck.ai backend
-    /// (`/duckchat/v1/models`, field `attachmentLimits`), already tier-resolved, and are optional
-    /// because the backend may omit them (network failure, older backend). `tabs` is a hardcoded
-    /// native product constant and is always present.
+    /// Attachment limits forwarded to the web. `files`/`images` are backend-sourced + optional; `tabs` is a hardcoded native constant.
     struct AttachmentLimits: Codable, Equatable {
         public struct FileLimits: Codable, Equatable {
             let maxPerConversation: Int

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
@@ -64,10 +64,11 @@ public extension NewTabPageDataModel {
         }
     }
 
-    /// Attachment limits sourced from the Duck.ai backend (`/duckchat/v1/models`, field
-    /// `attachmentLimits`), already resolved for the user's tier. Forwarded to the web so the NTP
-    /// omnibar can enforce them instead of hardcoding defaults. Mirrors the resolved shape of
-    /// `AIChat.AIChatAttachmentTierLimits`.
+    /// Attachment limits forwarded to the web so the NTP omnibar can enforce them instead of
+    /// hardcoding defaults. `files`/`images` are sourced from the Duck.ai backend
+    /// (`/duckchat/v1/models`, field `attachmentLimits`), already tier-resolved, and are optional
+    /// because the backend may omit them (network failure, older backend). `tabs` is a hardcoded
+    /// native product constant and is always present.
     struct AttachmentLimits: Codable, Equatable {
         public struct FileLimits: Codable, Equatable {
             let maxPerConversation: Int
@@ -95,12 +96,22 @@ public extension NewTabPageDataModel {
             }
         }
 
-        let files: FileLimits
-        let images: ImageLimits
+        public struct TabLimits: Codable, Equatable {
+            let maxAttached: Int
 
-        public init(files: FileLimits, images: ImageLimits) {
+            public init(maxAttached: Int) {
+                self.maxAttached = maxAttached
+            }
+        }
+
+        let files: FileLimits?
+        let images: ImageLimits?
+        let tabs: TabLimits
+
+        public init(files: FileLimits?, images: ImageLimits?, tabs: TabLimits) {
             self.files = files
             self.images = images
+            self.tabs = tabs
         }
     }
 

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -610,6 +610,81 @@ final class AIChatOmnibarControllerTests: XCTestCase {
                        "Order matches the toggle-on order; the duck.ai web app preserves this on submit")
     }
 
+    func testWhenToggleTabAttachmentReachesDisplayCap_ThenOneOverIsAllowedButFurtherBlocked() {
+        // maxTabAttachments is 3; the picker allows exactly one over (displayCap 4) so the
+        // over-limit cue can show, then blocks further attaches — mirroring the image/file caps.
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-1"))
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-2"))
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-3"))
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-4"))
+
+        XCTAssertEqual(controller.activeTabAttachments.count, 4,
+                       "Attaching one over the cap (displayCap) is allowed to surface the over-limit cue")
+
+        // A fifth attach is a no-op — the list stays at the display cap.
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-5"))
+        XCTAssertEqual(controller.activeTabAttachments.map(\.id), ["tab-1", "tab-2", "tab-3", "tab-4"],
+                       "Attaching beyond the display cap is a no-op")
+    }
+
+    func testTabAttachmentFullAndExcessPredicates() {
+        XCTAssertFalse(controller.isActiveTabAttachmentsFull)
+        XCTAssertFalse(controller.hasExcessTabAttachments)
+
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-1"))
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-2"))
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-3"))
+
+        // At the cap (3): full, but not yet over.
+        XCTAssertTrue(controller.isActiveTabAttachmentsFull)
+        XCTAssertFalse(controller.hasExcessTabAttachments)
+
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-4"))
+
+        // One over (4): still full, and now in excess.
+        XCTAssertTrue(controller.isActiveTabAttachmentsFull)
+        XCTAssertTrue(controller.hasExcessTabAttachments)
+    }
+
+    func testWhenSubmitWithTabAttachmentsOverCap_ThenSubmitIsBlocked() {
+        // The submit guard is gated on the tab picker being enabled, so turn its flags on.
+        featureFlagger.enabledFeatureFlags = [.aiChatPageContext, .aiChatOmnibarAttachMoreTabs]
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-1"))
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-2"))
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-3"))
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-4"))
+        XCTAssertTrue(controller.hasExcessTabAttachments)
+        controller.updateText("summarize these")
+
+        // When
+        controller.submit()
+
+        // Then — submit returns early: no duck.ai tab opened, no prompt posted, attachments retained.
+        XCTAssertFalse(mockTabOpener.openAIChatTabCalled, "Submit is blocked while over the tab cap")
+        XCTAssertNil(AIChatPromptHandler.shared.consumeData(), "No prompt is posted while over the tab cap")
+        XCTAssertEqual(controller.activeTabAttachments.count, 4,
+                       "Over-cap attachments are retained so the user can remove one to unblock submit")
+    }
+
+    func testWhenSubmitWithTabAttachmentsAtCap_ThenSubmitProceeds() async {
+        // At exactly the cap (3, not over), submit must proceed even with the picker enabled.
+        featureFlagger.enabledFeatureFlags = [.aiChatPageContext, .aiChatOmnibarAttachMoreTabs]
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-1"))
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-2"))
+        controller.toggleTabAttachment(makeTabAttachment(id: "tab-3"))
+        XCTAssertTrue(controller.isActiveTabAttachmentsFull)
+        XCTAssertFalse(controller.hasExcessTabAttachments)
+        controller.updateText("summarize these")
+
+        // When — submit awaits per-tab page-context extraction; the brief sleep lets it settle
+        // (same rationale as `testWhenSubmitWithTabAttachments_ThenSubmitProceedsAndPixelFires`).
+        controller.submit()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        XCTAssertTrue(mockTabOpener.openAIChatTabCalled, "Submit proceeds when at (not over) the tab cap")
+    }
+
     func testWhenSubmitWithTabAttachments_ThenSharedStateClearsTabAttachments() async {
         // Given — a tab is attached and there's a prompt to submit
         let attachment = makeTabAttachment(id: "tab-1")

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -50,6 +50,8 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         mockDelegate = MockAIChatOmnibarControllerDelegate()
         mockTabOpener = MockAIChatTabOpener()
         featureFlagger = MockFeatureFlagger()
+        // The tab-attachment limit defaults on in production; reflect that baseline in the tests.
+        featureFlagger.enabledFeatureFlags = [.aiChatTabAttachmentLimit]
         searchPreferencesPersistor = AIChatMockSearchPreferencesPersistor()
         mockPreferences = MockAIChatPreferencesPersisting()
         mockModelsService = MockAIChatModelsProviding()
@@ -666,7 +668,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
 
     func testWhenSubmitWithTabAttachmentsAtCap_ThenSubmitProceeds() async {
         // At exactly the cap (3, not over), submit must proceed even with the picker enabled.
-        featureFlagger.enabledFeatureFlags = [.aiChatPageContext, .aiChatOmnibarAttachMoreTabs]
+        featureFlagger.enabledFeatureFlags = [.aiChatPageContext, .aiChatOmnibarAttachMoreTabs, .aiChatTabAttachmentLimit]
         controller.toggleTabAttachment(makeTabAttachment(id: "tab-1"))
         controller.toggleTabAttachment(makeTabAttachment(id: "tab-2"))
         controller.toggleTabAttachment(makeTabAttachment(id: "tab-3"))

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -646,9 +646,10 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         XCTAssertTrue(controller.hasExcessTabAttachments)
     }
 
-    func testWhenSubmitWithTabAttachmentsOverCap_ThenSubmitIsBlocked() {
-        // The submit guard is gated on the tab picker being enabled, so turn its flags on.
-        featureFlagger.enabledFeatureFlags = [.aiChatPageContext, .aiChatOmnibarAttachMoreTabs]
+    func testWhenSubmitWithTabAttachmentsOverCap_ThenSubmitIsBlockedEvenWithPickerFlagOff() {
+        // Regression: the cap must hold regardless of `isOmnibarTabPickerEnabled`. Tab cards always
+        // render and shared-state attachments persist if the picker flag flips off mid-session, so a
+        // flag-gated guard would let a prompt ship 4 page contexts. Flags are left OFF here on purpose.
         controller.toggleTabAttachment(makeTabAttachment(id: "tab-1"))
         controller.toggleTabAttachment(makeTabAttachment(id: "tab-2"))
         controller.toggleTabAttachment(makeTabAttachment(id: "tab-3"))

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -611,8 +611,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
     }
 
     func testWhenToggleTabAttachmentReachesDisplayCap_ThenOneOverIsAllowedButFurtherBlocked() {
-        // maxTabAttachments is 3; the picker allows exactly one over (displayCap 4) so the
-        // over-limit cue can show, then blocks further attaches — mirroring the image/file caps.
+        // Cap is 3; one over (displayCap 4) is allowed for the cue, then further attaches no-op.
         controller.toggleTabAttachment(makeTabAttachment(id: "tab-1"))
         controller.toggleTabAttachment(makeTabAttachment(id: "tab-2"))
         controller.toggleTabAttachment(makeTabAttachment(id: "tab-3"))
@@ -647,9 +646,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
     }
 
     func testWhenSubmitWithTabAttachmentsOverCap_ThenSubmitIsBlockedEvenWithPickerFlagOff() {
-        // Regression: the cap must hold regardless of `isOmnibarTabPickerEnabled`. Tab cards always
-        // render and shared-state attachments persist if the picker flag flips off mid-session, so a
-        // flag-gated guard would let a prompt ship 4 page contexts. Flags are left OFF here on purpose.
+        // Regression: the cap must hold with the picker flag OFF (left off here on purpose).
         controller.toggleTabAttachment(makeTabAttachment(id: "tab-1"))
         controller.toggleTabAttachment(makeTabAttachment(id: "tab-2"))
         controller.toggleTabAttachment(makeTabAttachment(id: "tab-3"))
@@ -677,8 +674,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         XCTAssertFalse(controller.hasExcessTabAttachments)
         controller.updateText("summarize these")
 
-        // When — submit awaits per-tab page-context extraction; the brief sleep lets it settle
-        // (same rationale as `testWhenSubmitWithTabAttachments_ThenSubmitProceedsAndPixelFires`).
+        // When — brief sleep lets the async page-context extraction settle (see sibling submit test).
         controller.submit()
         try? await Task.sleep(nanoseconds: 100_000_000)
 

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
@@ -28,15 +28,20 @@ final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
 
     private var mockModelsService: MockModelsService!
     private var mockSubscriptionManager: SubscriptionManagerMock!
+    private var mockFeatureFlagger: MockFeatureFlagger!
     private var provider: NewTabPageOmnibarModelsProvider!
 
     override func setUp() {
         super.setUp()
         mockModelsService = MockModelsService()
         mockSubscriptionManager = SubscriptionManagerMock()
+        // The tab-attachment limit defaults on, so enable it here; the off case has its own test.
+        mockFeatureFlagger = MockFeatureFlagger()
+        mockFeatureFlagger.enabledFeatureFlags = [.aiChatTabAttachmentLimit]
         provider = NewTabPageOmnibarModelsProvider(
             modelsService: mockModelsService,
-            subscriptionManager: mockSubscriptionManager
+            subscriptionManager: mockSubscriptionManager,
+            featureFlagger: mockFeatureFlagger
         )
     }
 
@@ -44,6 +49,7 @@ final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
         provider = nil
         mockModelsService = nil
         mockSubscriptionManager = nil
+        mockFeatureFlagger = nil
         super.tearDown()
     }
 
@@ -126,6 +132,17 @@ final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
             tabs: .init(maxAttached: AIChatOmnibarController.maxTabAttachments)
         )
         XCTAssertEqual(provider.attachmentLimits, expected)
+    }
+
+    func testWhenTabAttachmentLimitFlagOffThenTabsLimitIsOmitted() async {
+        mockFeatureFlagger.enabledFeatureFlags = []
+        mockModelsService.modelsToReturn = [makeRemoteModel(id: "free-model", accessTier: ["free"])]
+        mockModelsService.attachmentLimitsToReturn = makeAttachmentLimits()
+
+        _ = await provider.fetchAIModelSections()
+
+        // Kill switch off: files/images still mapped, but no tab cap is forwarded to the web.
+        XCTAssertEqual(provider.attachmentLimits, expectedAttachmentLimits(base: freeBase, tabsMaxAttached: nil))
     }
 
     func testWhenResponseHasAttachmentLimitsThenTheyAreMappedForFreeTier() async {
@@ -357,7 +374,7 @@ final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
         )
     }
 
-    private func expectedAttachmentLimits(base: Int) -> NewTabPageDataModel.AttachmentLimits {
+    private func expectedAttachmentLimits(base: Int, tabsMaxAttached: Int? = AIChatOmnibarController.maxTabAttachments) -> NewTabPageDataModel.AttachmentLimits {
         NewTabPageDataModel.AttachmentLimits(
             files: .init(
                 maxPerConversation: base + 1,
@@ -370,7 +387,7 @@ final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
                 maxPerConversation: base + 6,
                 maxInputCharsWithAttachments: base + 7
             ),
-            tabs: .init(maxAttached: AIChatOmnibarController.maxTabAttachments)
+            tabs: tabsMaxAttached.map { .init(maxAttached: $0) }
         )
     }
 

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
@@ -120,10 +120,14 @@ final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
         _ = await provider.fetchAIModelSections()
 
         // The backend-sourced file/image limits are absent, but the hardcoded tab cap is always
-        // forwarded so the NTP omnibar can still enforce it.
-        XCTAssertNil(provider.attachmentLimits?.files)
-        XCTAssertNil(provider.attachmentLimits?.images)
-        XCTAssertEqual(provider.attachmentLimits?.tabs.maxAttached, AIChatOmnibarController.maxTabAttachments)
+        // forwarded so the NTP omnibar can still enforce it. Asserted via Equatable (the struct's
+        // fields are internal to the NewTabPage package — only the public init is reachable here).
+        let expected = NewTabPageDataModel.AttachmentLimits(
+            files: nil,
+            images: nil,
+            tabs: .init(maxAttached: AIChatOmnibarController.maxTabAttachments)
+        )
+        XCTAssertEqual(provider.attachmentLimits, expected)
     }
 
     func testWhenResponseHasAttachmentLimitsThenTheyAreMappedForFreeTier() async {

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
@@ -113,13 +113,17 @@ final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
 
     // MARK: - Attachment Limits Tests
 
-    func testWhenResponseHasNoAttachmentLimitsThenProviderLimitsAreNil() async {
+    func testWhenResponseHasNoAttachmentLimitsThenFileAndImageLimitsAreNilButTabLimitIsPresent() async {
         mockModelsService.modelsToReturn = [makeRemoteModel(id: "free-model", accessTier: ["free"])]
         mockModelsService.attachmentLimitsToReturn = nil
 
         _ = await provider.fetchAIModelSections()
 
-        XCTAssertNil(provider.attachmentLimits)
+        // The backend-sourced file/image limits are absent, but the hardcoded tab cap is always
+        // forwarded so the NTP omnibar can still enforce it.
+        XCTAssertNil(provider.attachmentLimits?.files)
+        XCTAssertNil(provider.attachmentLimits?.images)
+        XCTAssertEqual(provider.attachmentLimits?.tabs.maxAttached, AIChatOmnibarController.maxTabAttachments)
     }
 
     func testWhenResponseHasAttachmentLimitsThenTheyAreMappedForFreeTier() async {
@@ -363,7 +367,8 @@ final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
                 maxPerTurn: base + 5,
                 maxPerConversation: base + 6,
                 maxInputCharsWithAttachments: base + 7
-            )
+            ),
+            tabs: .init(maxAttached: AIChatOmnibarController.maxTabAttachments)
         )
     }
 

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
@@ -19,6 +19,8 @@
 import XCTest
 import AIChat
 import FeatureFlags
+import PrivacyConfig
+import SharedTestUtilities
 import NewTabPage
 @testable import Subscription
 import SubscriptionTestingUtilities

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
@@ -119,9 +119,7 @@ final class NewTabPageOmnibarModelsProviderTests: XCTestCase {
 
         _ = await provider.fetchAIModelSections()
 
-        // The backend-sourced file/image limits are absent, but the hardcoded tab cap is always
-        // forwarded so the NTP omnibar can still enforce it. Asserted via Equatable (the struct's
-        // fields are internal to the NewTabPage package — only the public init is reachable here).
+        // File/image limits absent, tab cap still forwarded. Asserted via Equatable (fields are internal).
         let expected = NewTabPageDataModel.AttachmentLimits(
             files: nil,
             images: nil,

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarModelsProviderTests.swift
@@ -18,6 +18,7 @@
 
 import XCTest
 import AIChat
+import FeatureFlags
 import NewTabPage
 @testable import Subscription
 import SubscriptionTestingUtilities


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1216831900874433
Tech Design URL:
CC:

### Description

Caps attaching open tabs as page context at 3 in the native omnibar: a 4th attach surfaces the over-limit error label and blocks submit until one is removed, and the picker disables further rows — mirroring the image/file caps. Also forwards a hardcoded `attachmentLimits.tabs.maxAttached` to the NTP omnibar (`files`/`images` become optional so the cap survives a backend limits omission); the content-scope-scripts web side consumes it in a companion PR.

### Testing Steps
1. Internal build, enable the omnibar tab picker (`aiChatPageContext` + `aiChatOmnibarAttachMoreTabs`).
2. In the address-bar Duck.ai omnibar, attach 4 open tabs via "Attach Page Content" → error label appears, submit disabled, remaining picker rows disabled.
3. Remove one attachment → back to 3, error clears, submit enabled.

### Impact
Low. Behind internal flags; mirrors existing image/file cap behavior.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are scoped to Duck.ai attachment UX behind a default-on kill switch, mirroring established image/file cap patterns without touching auth or core browsing infrastructure.
> 
> **Overview**
> Introduces a **3-tab cap** for open-tab page context in the native Duck.ai omnibar, aligned with existing image/file attachment limits. A fourth tab can be selected to show an over-limit error and block submit until the user removes one; the attach-tabs submenu disables unattached rows at the cap and refreshes row state while the menu stays open.
> 
> Adds kill switch **`aiChatTabAttachmentLimit`** (default on) so the cap can be turned off remotely. **`AIChatOmnibarController`** exposes `maxTabAttachments`, display-cap / excess predicates, and submit blocking when over the cap.
> 
> For the **NTP omnibar**, `AttachmentLimits` now includes optional **`tabs.maxAttached`** (hardcoded 3 when the flag is on) and makes `files`/`images` optional so tab limits still apply when the models API omits backend attachment limits. Companion web work is expected to consume the forwarded limit.
> 
> Unit tests cover omnibar toggle/submit behavior and NTP limit mapping when the flag is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa033655c53ea63ad759b2a29fd2d469105bf15a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->