### PR TITLE
PIR: Forward extras on extracted profiles

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -274,6 +274,7 @@ public enum DBPSubfeature: String, Equatable, PrivacySubfeature {
     case freemiumPIR
     case optOutRetryError96Hours
     case deferredSecureVaultInit
+    case extractedProfileRefresh
 }
 
 public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Features/DBPFeatureFlagging.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Features/DBPFeatureFlagging.swift
@@ -22,6 +22,7 @@ public typealias DBPFeatureFlagging = ForegroundRunningFeatureFlagging
     & ContinuedProcessingFeatureFlagging
     & WebViewUserAgentFeatureFlagging
     & OptOutRetryErrorFeatureFlagging
+    & ExtractedProfileRefreshFeatureFlagging
 
 public protocol ForegroundRunningFeatureFlagging {
     var isForegroundRunningOnAppActiveFeatureOn: Bool { get }
@@ -37,6 +38,10 @@ public protocol WebViewUserAgentFeatureFlagging {
 
 public protocol OptOutRetryErrorFeatureFlagging {
     var isOptOutRetryErrorFrequencyExperimentOn: Bool { get }
+}
+
+public protocol ExtractedProfileRefreshFeatureFlagging {
+    var isExtractedProfileRefreshOn: Bool { get }
 }
 
 public struct DisabledOptOutRetryErrorFeatureFlagger: OptOutRetryErrorFeatureFlagging {

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Model/ExtractedProfile.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Model/ExtractedProfile.swift
@@ -56,17 +56,35 @@ public struct ExtractProfileSelectors: Codable, Sendable {
     }
 }
 
+/// Open map of config-defined fields with no dedicated property on the model. C-S-S extracts these
+/// during a scan and reads them back during opt out; we store and forward them verbatim, so a new
+/// broker field can ship as a config change alone. String values only, omitted when empty.
+public typealias ProfileExtras = [String: String]
+
 public struct AddressCityState: Codable, Hashable, Sendable {
     public let city: String
     public let state: String
+    public let extras: ProfileExtras?
 
-    public init(city: String, state: String) {
+    public init(city: String, state: String, extras: ProfileExtras? = nil) {
         self.city = city
         self.state = state
+        self.extras = extras
     }
 
     public var fullAddress: String {
         "\(city), \(state)"
+    }
+
+    /// Extras are opaque passthrough data, so two addresses for the same place remain equal
+    /// regardless of which extras the broker config happened to scrape for each.
+    public static func == (lhs: AddressCityState, rhs: AddressCityState) -> Bool {
+        lhs.city == rhs.city && lhs.state == rhs.state
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(city)
+        hasher.combine(state)
     }
 }
 
@@ -85,6 +103,7 @@ public struct ExtractedProfile: Codable, Sendable {
     public var removedDate: Date?
     public let fullName: String?
     public let identifier: String?
+    public let extras: ProfileExtras?
 
     enum CodingKeys: CodingKey {
         case id
@@ -101,6 +120,7 @@ public struct ExtractedProfile: Codable, Sendable {
         case removedDate
         case fullName
         case identifier
+        case extras
     }
 
     public init(id: Int64? = nil,
@@ -115,7 +135,8 @@ public struct ExtractedProfile: Codable, Sendable {
                 age: String? = nil,
                 email: String? = nil,
                 removedDate: Date? = nil,
-                identifier: String? = nil) {
+                identifier: String? = nil,
+                extras: ProfileExtras? = nil) {
         self.id = id
         self.name = name
         self.alternativeNames = alternativeNames
@@ -130,6 +151,7 @@ public struct ExtractedProfile: Codable, Sendable {
         self.removedDate = removedDate
         self.fullName = name
         self.identifier = identifier
+        self.extras = extras
     }
 
     public init(from decoder: Decoder) throws {
@@ -147,6 +169,7 @@ public struct ExtractedProfile: Codable, Sendable {
         email = try container.decodeIfPresent(String.self, forKey: .email)
         removedDate = try container.decodeIfPresent(Date.self, forKey: .removedDate)
         fullName = try container.decodeIfPresent(String.self, forKey: .fullName)
+        extras = try container.decodeIfPresent(ProfileExtras.self, forKey: .extras)
         if let identifier = try container.decodeIfPresent(String.self, forKey: .identifier) {
             self.identifier = identifier
         } else {
@@ -168,7 +191,8 @@ public struct ExtractedProfile: Codable, Sendable {
             age: self.age ?? String(profile.age),
             email: self.email,
             removedDate: self.removedDate,
-            identifier: self.identifier
+            identifier: self.identifier,
+            extras: self.extras
         )
     }
 
@@ -220,7 +244,45 @@ extension ExtractedProfile {
                          age: age,
                          email: email,
                          removedDate: removedDate,
-                         identifier: identifier)
+                         identifier: identifier,
+                         extras: extras)
+    }
+
+    /// Returns this stored record brought up to date with a re-scrape of the same profile, keeping
+    /// the state the broker doesn't own (`id`, `email`, `removedDate`).
+    ///
+    /// Extras the re-scrape didn't return keep their stored value, so a broker changing its markup
+    /// before we update the config doesn't strip fields the pending opt out still needs.
+    func refreshed(from scrapedProfile: ExtractedProfile) -> ExtractedProfile {
+        ExtractedProfile(id: id,
+                         name: scrapedProfile.name,
+                         alternativeNames: scrapedProfile.alternativeNames,
+                         addressFull: scrapedProfile.addressFull,
+                         addresses: scrapedProfile.addresses?.map { $0.mergingExtras(storedIn: addresses) },
+                         phoneNumbers: scrapedProfile.phoneNumbers,
+                         relatives: scrapedProfile.relatives,
+                         profileUrl: scrapedProfile.profileUrl,
+                         reportId: scrapedProfile.reportId,
+                         age: scrapedProfile.age,
+                         email: email,
+                         removedDate: removedDate,
+                         identifier: identifier,
+                         extras: extras.merging(scrapedProfile.extras))
+    }
+}
+
+private extension AddressCityState {
+    func mergingExtras(storedIn storedAddresses: [AddressCityState]?) -> AddressCityState {
+        let storedExtras = storedAddresses?.first { $0 == self }?.extras
+        return AddressCityState(city: city, state: state, extras: storedExtras.merging(extras))
+    }
+}
+
+private extension Optional where Wrapped == ProfileExtras {
+    func merging(_ scrapedExtras: ProfileExtras?) -> ProfileExtras? {
+        guard let storedExtras = self else { return scrapedExtras }
+        guard let scrapedExtras else { return storedExtras }
+        return storedExtras.merging(scrapedExtras) { _, scrapedValue in scrapedValue }
     }
 }
 

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/BrokerProfileScanSubJob.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/BrokerProfileScanSubJob.swift
@@ -408,7 +408,8 @@ struct BrokerProfileScanSubJob {
                     try database.add(reAppearanceEvent)
                     try database.updateRemovedDate(nil, on: id)
                 }
-                if let identifier = extractedProfile.identifier, !identifier.isEmpty {
+                if dependencies.featureFlagger.isExtractedProfileRefreshOn,
+                   let identifier = extractedProfile.identifier, !identifier.isEmpty {
                     try database.updateExtractedProfile(existingProfile.refreshed(from: extractedProfile), on: id)
                 }
                 Logger.dataBrokerProtection.log("Extracted profile already exists in database: \(id.description)")

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/BrokerProfileScanSubJob.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/BrokerProfileScanSubJob.swift
@@ -408,7 +408,9 @@ struct BrokerProfileScanSubJob {
                     try database.add(reAppearanceEvent)
                     try database.updateRemovedDate(nil, on: id)
                 }
-                try database.updateExtractedProfile(existingProfile.refreshed(from: extractedProfile), on: id)
+                if let identifier = extractedProfile.identifier, !identifier.isEmpty {
+                    try database.updateExtractedProfile(existingProfile.refreshed(from: extractedProfile), on: id)
+                }
                 Logger.dataBrokerProtection.log("Extracted profile already exists in database: \(id.description)")
             } else {
                 try scheduleNewOptOutJob(from: extractedProfile,

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/BrokerProfileScanSubJob.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/BrokerProfileScanSubJob.swift
@@ -408,6 +408,7 @@ struct BrokerProfileScanSubJob {
                     try database.add(reAppearanceEvent)
                     try database.updateRemovedDate(nil, on: id)
                 }
+                try database.updateExtractedProfile(existingProfile.refreshed(from: extractedProfile), on: id)
                 Logger.dataBrokerProtection.log("Extracted profile already exists in database: \(id.description)")
             } else {
                 try scheduleNewOptOutJob(from: extractedProfile,

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/DataBrokerProtectionDatabase.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/DataBrokerProtectionDatabase.swift
@@ -75,6 +75,7 @@ public protocol DataBrokerProtectionRepository: EmailConfirmationSupporting {
                                                   profileQueryId: Int64,
                                                   extractedProfileId: Int64) throws
     func updateRemovedDate(_ date: Date?, on extractedProfileId: Int64) throws
+    func updateExtractedProfile(_ extractedProfile: ExtractedProfile, on extractedProfileId: Int64) throws
 
     func add(_ historyEvent: HistoryEvent) throws
     func fetchLastEvent(brokerId: Int64, profileQueryId: Int64) throws -> HistoryEvent?
@@ -389,6 +390,15 @@ public final class DataBrokerProtectionDatabase: DataBrokerProtectionRepository 
             try vault.updateRemovedDate(for: extractedProfileId, with: date)
         } catch {
             handleError(error, context: "DataBrokerProtectionDatabase.updateRemovedDate date on extractedProfileId")
+            throw error
+        }
+    }
+
+    public func updateExtractedProfile(_ extractedProfile: ExtractedProfile, on extractedProfileId: Int64) throws {
+        do {
+            try vault.updateExtractedProfile(extractedProfile, for: extractedProfileId)
+        } catch {
+            handleError(error, context: "DataBrokerProtectionDatabase.updateExtractedProfile on extractedProfileId")
             throw error
         }
     }

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/DataBrokerProtectionDatabaseProvider.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/DataBrokerProtectionDatabaseProvider.swift
@@ -126,6 +126,7 @@ public protocol DataBrokerProtectionDatabaseProvider: SecureStorageDatabaseProvi
     func fetchExtractedProfiles(for brokerId: Int64, with profileQueryId: Int64) throws -> [ExtractedProfileDB]
     func fetchExtractedProfiles(for brokerId: Int64) throws -> [ExtractedProfileDB]
     func updateRemovedDate(for extractedProfileId: Int64, with date: Date?) throws
+    func updateProfileData(for extractedProfileId: Int64, with profileData: Data) throws
 
     func hasMatches() throws -> Bool
 
@@ -804,6 +805,17 @@ public final class DefaultDataBrokerProtectionDatabaseProvider: GRDBSecureStorag
         try db.write { db in
             if var extractedProfile = try ExtractedProfileDB.fetchOne(db, key: extractedProfileId) {
                 extractedProfile.removedDate = date
+                try extractedProfile.update(db)
+            } else {
+                throw DataBrokerProtectionDatabaseErrors.elementNotFound
+            }
+        }
+    }
+
+    public func updateProfileData(for extractedProfileId: Int64, with profileData: Data) throws {
+        try db.write { db in
+            if var extractedProfile = try ExtractedProfileDB.fetchOne(db, key: extractedProfileId) {
+                extractedProfile.profile = profileData
                 try extractedProfile.update(db)
             } else {
                 throw DataBrokerProtectionDatabaseErrors.elementNotFound

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/DataBrokerProtectionSecureVault.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/DataBrokerProtectionSecureVault.swift
@@ -112,6 +112,7 @@ public protocol DataBrokerProtectionSecureVault: SecureVault {
     func fetchExtractedProfiles(for brokerId: Int64, with profileQueryId: Int64) throws -> [ExtractedProfile]
     func fetchExtractedProfiles(for brokerId: Int64) throws -> [ExtractedProfile]
     func updateRemovedDate(for extractedProfileId: Int64, with date: Date?) throws
+    func updateExtractedProfile(_ extractedProfile: ExtractedProfile, for extractedProfileId: Int64) throws
 
     func hasMatches() throws -> Bool
 
@@ -501,6 +502,12 @@ public final class DefaultDataBrokerProtectionSecureVault<T: DataBrokerProtectio
 
     public func updateRemovedDate(for extractedProfileId: Int64, with date: Date?) throws {
         try self.providers.database.updateRemovedDate(for: extractedProfileId, with: date)
+    }
+
+    public func updateExtractedProfile(_ extractedProfile: ExtractedProfile, for extractedProfileId: Int64) throws {
+        let mapper = MapperToDB(mechanism: l2Encrypt(data:))
+
+        try self.providers.database.updateProfileData(for: extractedProfileId, with: mapper.mapToDB(extractedProfile))
     }
 
     public func hasMatches() throws -> Bool {

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/Mappers.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/Mappers.swift
@@ -93,15 +93,17 @@ public struct MapperToDB {
     }
 
     func mapToDB(_ extractedProfile: ExtractedProfile, brokerId: Int64, profileQueryId: Int64) throws -> ExtractedProfileDB {
-        let encodedProfile = try jsonEncoder.encode(extractedProfile)
-
-        return .init(
+        .init(
             id: nil,
             brokerId: brokerId,
             profileQueryId: profileQueryId,
-            profile: try mechanism(encodedProfile),
+            profile: try mapToDB(extractedProfile),
             removedDate: nil // Removed data is initialized as empty when created.
         )
+    }
+
+    func mapToDB(_ extractedProfile: ExtractedProfile) throws -> Data {
+        try mechanism(jsonEncoder.encode(extractedProfile))
     }
 
     func mapToDB(_ historyEvent: HistoryEvent, brokerId: Int64, profileQueryId: Int64) throws -> ScanHistoryEventDB {
@@ -291,7 +293,8 @@ struct MapperToModel {
                      age: extractedProfile.age,
                      email: extractedProfile.email,
                      removedDate: extractedProfileDB.removedDate,
-                     identifier: extractedProfile.identifier)
+                     identifier: extractedProfile.identifier,
+                     extras: extractedProfile.extras)
     }
 
     func mapToModel(_ scanEvent: ScanHistoryEventDB) throws -> HistoryEvent {

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/SchedulerSchema.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/SchedulerSchema.swift
@@ -404,7 +404,7 @@ public struct ExtractedProfileDB: Codable {
     let id: Int64?
     let brokerId: Int64
     let profileQueryId: Int64
-    let profile: Data // Stored as Data JSON
+    var profile: Data // Stored as Data JSON
     var removedDate: Date?
 }
 

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -2156,17 +2156,20 @@ public final class MockDBPFeatureFlagger: DBPFeatureFlagging, FreemiumPIRFeature
     public let isWebViewUserAgentOn: Bool
     public let isOptOutRetryErrorFrequencyExperimentOn: Bool
     public let isFreemiumPIREnabled: Bool
+    public let isExtractedProfileRefreshOn: Bool
 
     public init(isForegroundRunningOnAppActiveFeatureOn: Bool = true,
                 isContinuedProcessingFeatureOn: Bool = true,
                 isWebViewUserAgentOn: Bool = false,
                 isOptOutRetryErrorFrequencyExperimentOn: Bool = false,
-                isFreemiumPIREnabled: Bool = false) {
+                isFreemiumPIREnabled: Bool = false,
+                isExtractedProfileRefreshOn: Bool = true) {
         self.isForegroundRunningOnAppActiveFeatureOn = isForegroundRunningOnAppActiveFeatureOn
         self.isContinuedProcessingFeatureOn = isContinuedProcessingFeatureOn
         self.isWebViewUserAgentOn = isWebViewUserAgentOn
         self.isOptOutRetryErrorFrequencyExperimentOn = isOptOutRetryErrorFrequencyExperimentOn
         self.isFreemiumPIREnabled = isFreemiumPIREnabled
+        self.isExtractedProfileRefreshOn = isExtractedProfileRefreshOn
     }
 }
 

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -916,6 +916,9 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
     public func updateRemovedDate(for extractedProfileId: Int64, with date: Date?) throws {
     }
 
+    public func updateExtractedProfile(_ extractedProfile: ExtractedProfile, for extractedProfileId: Int64) throws {
+    }
+
     public func hasMatches() throws -> Bool {
         false
     }
@@ -1084,6 +1087,7 @@ public final class MockDatabase: DataBrokerProtectionRepository {
     public var submittedSuccessfullyDate: Date?
     public var extractedProfileRemovedDate: Date?
     public var extractedProfilesFromBroker = [ExtractedProfile]()
+    public var updatedExtractedProfiles = [(profile: ExtractedProfile, id: Int64)]()
     public var childBrokers = [DataBroker]()
     public var lastParentBrokerWhereChildSitesWhereFetched: String?
     public var lastProfileQueryIdOnScanUpdatePreferredRunDate: Int64?
@@ -1347,6 +1351,10 @@ public final class MockDatabase: DataBrokerProtectionRepository {
         wasUpdateRemoveDateCalled = true
     }
 
+    public func updateExtractedProfile(_ extractedProfile: ExtractedProfile, on extractedProfileId: Int64) throws {
+        updatedExtractedProfiles.append((profile: extractedProfile, id: extractedProfileId))
+    }
+
     public func add(_ historyEvent: HistoryEvent) throws {
         wasAddHistoryEventCalled = true
         lastAddedHistoryEvent = historyEvent
@@ -1481,6 +1489,7 @@ public final class MockDatabase: DataBrokerProtectionRepository {
         lastPreferredRunDateOnOptOut = nil
         extractedProfileRemovedDate = nil
         extractedProfilesFromBroker.removeAll()
+        updatedExtractedProfiles.removeAll()
         childBrokers.removeAll()
         lastParentBrokerWhereChildSitesWhereFetched = nil
         lastProfileQueryIdOnScanUpdatePreferredRunDate = nil

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/ActionRequestEncodingTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/ActionRequestEncodingTests.swift
@@ -214,6 +214,36 @@ final class ActionRequestEncodingTests: XCTestCase {
         XCTAssertNil(data["emailData"])
     }
 
+    func testWhenExtractedProfileHasExtras_thenTheyAreForwardedToFillForm() throws {
+        let action = FillFormAction(id: "fill-jane-smith", actionType: .fillForm, elements: [.init(type: "county")])
+        let extractedProfile = ExtractedProfile(name: "Jane Smith",
+                                                addresses: [AddressCityState(city: "Springfield", state: "IL", extras: ["zip": "62701"])],
+                                                extras: ["county": "Sangamon"])
+        let params = Params(state: ActionRequest(action: action, data: .userData(makeProfileQuery(), extractedProfile, nil, [:])))
+
+        let state = try XCTUnwrap(try params.toDictionary()["state"] as? [String: Any])
+        let data = try XCTUnwrap(state["data"] as? [String: Any])
+        let encodedProfile = try XCTUnwrap(data["extractedProfile"] as? [String: Any])
+        let encodedAddress = try XCTUnwrap((encodedProfile["addresses"] as? [[String: Any]])?.first)
+
+        XCTAssertEqual(encodedProfile["extras"] as? [String: String], ["county": "Sangamon"])
+        XCTAssertEqual(encodedAddress["extras"] as? [String: String], ["zip": "62701"])
+    }
+
+    func testWhenExtractedProfileHasNoExtras_thenTheKeyIsOmittedFromTheFillFormPayload() throws {
+        let action = FillFormAction(id: "fill-jane-smith", actionType: .fillForm, elements: [.init(type: "city")])
+        let extractedProfile = ExtractedProfile(name: "Jane Smith", addresses: [AddressCityState(city: "Springfield", state: "IL")])
+        let params = Params(state: ActionRequest(action: action, data: .userData(makeProfileQuery(), extractedProfile, nil, [:])))
+
+        let state = try XCTUnwrap(try params.toDictionary()["state"] as? [String: Any])
+        let data = try XCTUnwrap(state["data"] as? [String: Any])
+        let encodedProfile = try XCTUnwrap(data["extractedProfile"] as? [String: Any])
+        let encodedAddress = try XCTUnwrap((encodedProfile["addresses"] as? [[String: Any]])?.first)
+
+        XCTAssertNil(encodedProfile["extras"])
+        XCTAssertNil(encodedAddress["extras"])
+    }
+
     func testWhenActionElementsContainBooleans_thenTheyEncodeAsJSONBooleansNotNumbers() throws {
         // Regression: booleans decoded from JSON bridge to NSNumber. When the custom encoder
         // (CodableExtension) matched `Int` before `Bool`, `NSNumber(true) as? Int` succeeded and

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileScanSubJobTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileScanSubJobTests.swift
@@ -1329,6 +1329,31 @@ final class BrokerProfileScanSubJobTests: XCTestCase {
         }
     }
 
+    func testWhenScannedProfileHasNoIdentifier_thenNoStoredProfileIsRefreshed() async {
+        do {
+            let storedProfile = ExtractedProfile(id: 1, name: "Some name", extras: ["county": "Sangamon"])
+            let scrapedProfile = ExtractedProfile(name: "Some other name")
+            mockDatabase.extractedProfilesFromBroker = [storedProfile]
+            mockScanRunner.scanResults = [scrapedProfile]
+
+            _ = try await sut.runScan(
+                brokerProfileQueryData: .init(
+                    dataBroker: .mock,
+                    profileQuery: .mock,
+                    scanJobData: .mock,
+                    optOutJobData: [OptOutJobData.mock(with: storedProfile)]
+                ),
+                showWebView: false,
+                isManual: false,
+                shouldRunNextStep: { true }
+            )
+
+            XCTAssertTrue(mockDatabase.updatedExtractedProfiles.isEmpty)
+        } catch {
+            XCTFail("Should not throw")
+        }
+    }
+
     func testWhenScannedProfileIsAlreadyInTheDatabaseAndWasRemoved_thenTheRemovedDateIsSetBackToNil() async {
         do {
             mockDatabase.extractedProfilesFromBroker = [.mockWithRemovedDate]

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileScanSubJobTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileScanSubJobTests.swift
@@ -1311,6 +1311,39 @@ final class BrokerProfileScanSubJobTests: XCTestCase {
         }
     }
 
+    func testWhenExtractedProfileRefreshIsOff_thenTheStoredProfileIsNotRefreshed() async {
+        do {
+            mockDependencies.featureFlagger = MockDBPFeatureFlagger(isExtractedProfileRefreshOn: false)
+            let storedProfile = ExtractedProfile(id: 1,
+                                                 name: "Some name",
+                                                 profileUrl: "someURL",
+                                                 identifier: "someURL",
+                                                 extras: ["county": "Sangamon"])
+            let scrapedProfile = ExtractedProfile(name: "Some name",
+                                                  profileUrl: "someURL",
+                                                  identifier: "someURL",
+                                                  extras: ["zip": "62701"])
+            mockDatabase.extractedProfilesFromBroker = [storedProfile]
+            mockScanRunner.scanResults = [scrapedProfile]
+
+            _ = try await sut.runScan(
+                brokerProfileQueryData: .init(
+                    dataBroker: .mock,
+                    profileQuery: .mock,
+                    scanJobData: .mock,
+                    optOutJobData: [OptOutJobData.mock(with: storedProfile)]
+                ),
+                showWebView: false,
+                isManual: false,
+                shouldRunNextStep: { true }
+            )
+
+            XCTAssertTrue(mockDatabase.updatedExtractedProfiles.isEmpty)
+        } catch {
+            XCTFail("Should not throw")
+        }
+    }
+
     func testWhenScannedProfileIsNotYetInTheDatabase_thenNoStoredProfileIsRefreshed() async {
         do {
             mockScanRunner.scanResults = [.mockWithoutRemovedDate]

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileScanSubJobTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileScanSubJobTests.swift
@@ -1274,6 +1274,61 @@ final class BrokerProfileScanSubJobTests: XCTestCase {
         }
     }
 
+    func testWhenScannedProfileIsAlreadyInTheDatabase_thenTheStoredProfileIsRefreshedFromTheScrape() async {
+        do {
+            let storedProfile = ExtractedProfile(id: 1,
+                                                 name: "Some name",
+                                                 addresses: [AddressCityState(city: "Springfield", state: "IL", extras: ["street": "100 Sample Dr"])],
+                                                 profileUrl: "someURL",
+                                                 identifier: "someURL",
+                                                 extras: ["county": "Sangamon"])
+            let scrapedProfile = ExtractedProfile(name: "Some name",
+                                                  addresses: [AddressCityState(city: "Springfield", state: "IL", extras: ["zip": "62701"])],
+                                                  profileUrl: "someURL",
+                                                  identifier: "someURL")
+            mockDatabase.extractedProfilesFromBroker = [storedProfile]
+            mockScanRunner.scanResults = [scrapedProfile]
+
+            _ = try await sut.runScan(
+                brokerProfileQueryData: .init(
+                    dataBroker: .mock,
+                    profileQuery: .mock,
+                    scanJobData: .mock,
+                    optOutJobData: [OptOutJobData.mock(with: storedProfile)]
+                ),
+                showWebView: false,
+                isManual: false,
+                shouldRunNextStep: { true }
+            )
+
+            XCTAssertEqual(mockDatabase.updatedExtractedProfiles.count, 1)
+            let update = try XCTUnwrap(mockDatabase.updatedExtractedProfiles.first)
+            XCTAssertEqual(update.id, 1)
+            XCTAssertEqual(update.profile.extras, ["county": "Sangamon"])
+            XCTAssertEqual(update.profile.addresses?.first?.extras, ["street": "100 Sample Dr", "zip": "62701"])
+        } catch {
+            XCTFail("Should not throw")
+        }
+    }
+
+    func testWhenScannedProfileIsNotYetInTheDatabase_thenNoStoredProfileIsRefreshed() async {
+        do {
+            mockScanRunner.scanResults = [.mockWithoutRemovedDate]
+
+            _ = try await sut.runScan(
+                brokerProfileQueryData: .init(dataBroker: .mock, profileQuery: .mock, scanJobData: .mock),
+                showWebView: false,
+                isManual: false,
+                shouldRunNextStep: { true }
+            )
+
+            XCTAssertTrue(mockDatabase.updatedExtractedProfiles.isEmpty)
+            XCTAssertTrue(mockDatabase.wasSaveOptOutOperationCalled)
+        } catch {
+            XCTFail("Should not throw")
+        }
+    }
+
     func testWhenScannedProfileIsAlreadyInTheDatabaseAndWasRemoved_thenTheRemovedDateIsSetBackToNil() async {
         do {
             mockDatabase.extractedProfilesFromBroker = [.mockWithRemovedDate]

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionDatabaseProviderTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionDatabaseProviderTests.swift
@@ -503,6 +503,29 @@ final class DataBrokerProtectionDatabaseProviderTests: XCTestCase {
         try? FileManager.default.removeItem(at: url)
     }
 
+    func testUpdateProfileDataReplacesTheStoredProfileAndLeavesTheRemovedDateAlone() throws {
+        // Given
+        let brokerIds = try sut.fetchAllBrokers().compactMap(\.id)
+        let extractedProfileId = try XCTUnwrap(brokerIds.flatMap { try sut.fetchExtractedProfiles(for: $0) }.first?.id)
+        let removedDate = Date(timeIntervalSince1970: 1_000_000)
+        try sut.updateRemovedDate(for: extractedProfileId, with: removedDate)
+
+        // When
+        let refreshedProfileData = Data("refreshed".utf8)
+        try sut.updateProfileData(for: extractedProfileId, with: refreshedProfileData)
+
+        // Then
+        let updated = try XCTUnwrap(sut.fetchExtractedProfile(with: extractedProfileId))
+        XCTAssertEqual(updated.profile, refreshedProfileData)
+        XCTAssertEqual(try XCTUnwrap(updated.removedDate).timeIntervalSince1970, removedDate.timeIntervalSince1970, accuracy: 0.001)
+    }
+
+    func testUpdateProfileDataThrowsWhenTheProfileDoesNotExist() throws {
+        XCTAssertThrowsError(try sut.updateProfileData(for: -1, with: Data())) { error in
+            XCTAssertEqual(error as? DataBrokerProtectionDatabaseErrors, .elementNotFound)
+        }
+    }
+
     private func createFreshTestVault() throws -> (DefaultDataBrokerProtectionDatabaseProvider, URL) {
         let freshVaultURL = DefaultDataBrokerProtectionDatabaseProvider.databaseFilePath(
             directoryName: "DBP",

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionFeatureTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionFeatureTests.swift
@@ -77,6 +77,30 @@ final class DataBrokerProtectionFeatureTests: XCTestCase {
         XCTAssertEqual(mockCSSDelegate.profiles?.count, 2)
     }
 
+    func testWhenExtractActionCarriesExtras_thenDelegateSendsThemOnTheProfile() async {
+        let profiles = NSArray(objects: ["name": "Jane Smith",
+                                         "addresses": [["city": "Springfield", "state": "IL", "extras": ["zip": "62701"]]],
+                                         "extras": ["county": "Sangamon"]])
+        let params = ["result": ["success": ["actionID": "1", "actionType": "extract", "response": profiles] as [String: Any]]]
+        let sut = DataBrokerProtectionFeature(delegate: mockCSSDelegate, executionConfig: BrokerJobExecutionConfig(), shouldContinueActionHandler: { true })
+
+        await sut.parseActionCompleted(params: params)
+
+        XCTAssertNil(mockCSSDelegate.lastError)
+        XCTAssertEqual(mockCSSDelegate.profiles?.first?.extras, ["county": "Sangamon"])
+        XCTAssertEqual(mockCSSDelegate.profiles?.first?.addresses?.first?.extras, ["zip": "62701"])
+    }
+
+    func testWhenExtrasAreMalformed_thenDelegateSendsParsingError() async {
+        let profiles = NSArray(objects: ["name": "Jane Smith", "extras": ["county": 42]])
+        let params = ["result": ["success": ["actionID": "1", "actionType": "extract", "response": profiles] as [String: Any]]]
+        let sut = DataBrokerProtectionFeature(delegate: mockCSSDelegate, executionConfig: BrokerJobExecutionConfig(), shouldContinueActionHandler: { true })
+
+        await sut.parseActionCompleted(params: params)
+
+        XCTAssertEqual(mockCSSDelegate.lastError as? DataBrokerProtectionError, DataBrokerProtectionError.parsingErrorObjectFailed)
+    }
+
     func testWhenUnknownActionIsParsed_thenDelegateSendsParsingError() async {
         let params = ["result": ["success": ["actionID": "1", "actionType": "unknown"] as [String: Any]]]
         let sut = DataBrokerProtectionFeature(delegate: mockCSSDelegate, executionConfig: BrokerJobExecutionConfig(), shouldContinueActionHandler: { true })

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/ExtractedProfileTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/ExtractedProfileTests.swift
@@ -63,6 +63,157 @@ final class ExtractedProfileTests: XCTestCase {
         XCTAssertEqual(sut.age, "52")
     }
 
+    func testWhenExtractedProfileHasExtras_thenMergeKeepsThem() {
+        let profileQuery = ProfileQuery(firstName: "John", lastName: "Doe", city: "Los Angeles", state: "CA", birthYear: 1980)
+        let extractedProfile = ExtractedProfile(addresses: [AddressCityState(city: "Springfield", state: "IL", extras: ["zip": "62701"])],
+                                                extras: ["county": "Sangamon"])
+
+        let sut = extractedProfile.merge(with: profileQuery)
+
+        XCTAssertEqual(sut.extras, ["county": "Sangamon"])
+        XCTAssertEqual(sut.addresses?.first?.extras, ["zip": "62701"])
+    }
+
+    func testWhenExtractedProfileHasExtras_thenWithIdKeepsThem() {
+        let extractedProfile = ExtractedProfile(addresses: [AddressCityState(city: "Springfield", state: "IL", extras: ["zip": "62701"])],
+                                                extras: ["county": "Sangamon"])
+
+        let sut = extractedProfile.with(id: 1)
+
+        XCTAssertEqual(sut.extras, ["county": "Sangamon"])
+        XCTAssertEqual(sut.addresses?.first?.extras, ["zip": "62701"])
+    }
+
+    // MARK: - Extras coding
+
+    func testWhenExtractResponseContainsExtras_thenTheyAreDecodedAtProfileAndAddressLevel() throws {
+        let json = """
+            [
+                {
+                    "name": "Jane Smith",
+                    "age": "38",
+                    "addresses": [
+                        { "city": "Springfield", "state": "IL", "extras": { "street": "100 Sample Dr", "zip": "62701" } }
+                    ],
+                    "profileUrl": "https://broker.example/id/jane-smith",
+                    "identifier": "https://broker.example/id/jane-smith",
+                    "extras": { "county": "Sangamon" }
+                }
+            ]
+            """
+
+        let profiles = try JSONDecoder().decode([ExtractedProfile].self, from: Data(json.utf8))
+
+        XCTAssertEqual(profiles.first?.extras, ["county": "Sangamon"])
+        XCTAssertEqual(profiles.first?.addresses?.first?.extras, ["street": "100 Sample Dr", "zip": "62701"])
+    }
+
+    func testWhenExtractResponseOmitsExtras_thenTheyDecodeAsNil() throws {
+        let json = """
+            [{ "name": "Jane Smith", "addresses": [{ "city": "Springfield", "state": "IL" }] }]
+            """
+
+        let profiles = try JSONDecoder().decode([ExtractedProfile].self, from: Data(json.utf8))
+
+        XCTAssertNil(profiles.first?.extras)
+        XCTAssertNil(profiles.first?.addresses?.first?.extras)
+    }
+
+    func testWhenExtrasContainANonStringValue_thenDecodingFails() {
+        let json = """
+            [{ "name": "Jane Smith", "extras": { "county": 42 } }]
+            """
+
+        XCTAssertThrowsError(try JSONDecoder().decode([ExtractedProfile].self, from: Data(json.utf8)))
+    }
+
+    func testWhenProfileHasNoExtras_thenTheKeyIsOmittedFromTheEncodedProfile() throws {
+        let encoded = try JSONEncoder().encode(ExtractedProfile(name: "Jane Smith"))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+
+        XCTAssertNil(object["extras"])
+    }
+
+    func testWhenProfileHasExtras_thenTheyAreEncodedForFillForm() throws {
+        let profile = ExtractedProfile(name: "Jane Smith",
+                                       addresses: [AddressCityState(city: "Springfield", state: "IL", extras: ["zip": "62701"])],
+                                       extras: ["county": "Sangamon"])
+
+        let encoded = try JSONEncoder().encode(profile)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let address = try XCTUnwrap((object["addresses"] as? [[String: Any]])?.first)
+
+        XCTAssertEqual(object["extras"] as? [String: String], ["county": "Sangamon"])
+        XCTAssertEqual(address["extras"] as? [String: String], ["zip": "62701"])
+    }
+
+    func testWhenAddressesDifferOnlyByExtras_thenTheyAreEqual() {
+        let address = AddressCityState(city: "Springfield", state: "IL")
+        let addressWithExtras = AddressCityState(city: "Springfield", state: "IL", extras: ["zip": "62701"])
+
+        XCTAssertEqual(address, addressWithExtras)
+        XCTAssertEqual(Set([address, addressWithExtras]).count, 1)
+    }
+
+    // MARK: - Refreshing a stored profile from a re-scan
+
+    func testRefreshedTakesTheScrapedFieldsAndKeepsTheFieldsTheBrokerDoesNotOwn() {
+        let storedProfile = ExtractedProfile(id: 1,
+                                             name: "Jane Smith",
+                                             age: "38",
+                                             email: "duck@duck.com",
+                                             removedDate: Date(timeIntervalSince1970: 100),
+                                             identifier: "https://broker.example/id/jane-smith")
+        let scrapedProfile = ExtractedProfile(name: "Jane A Smith",
+                                              relatives: ["John Smith"],
+                                              age: "39",
+                                              identifier: "https://broker.example/id/jane-smith")
+
+        let sut = storedProfile.refreshed(from: scrapedProfile)
+
+        XCTAssertEqual(sut.name, "Jane A Smith")
+        XCTAssertEqual(sut.age, "39")
+        XCTAssertEqual(sut.relatives, ["John Smith"])
+        XCTAssertEqual(sut.id, 1)
+        XCTAssertEqual(sut.email, "duck@duck.com")
+        XCTAssertEqual(sut.removedDate, Date(timeIntervalSince1970: 100))
+        XCTAssertEqual(sut.identifier, "https://broker.example/id/jane-smith")
+    }
+
+    func testRefreshedOverwritesStoredExtrasWithScrapedOnesAndKeepsTheRest() {
+        let storedProfile = ExtractedProfile(id: 1, extras: ["county": "Sangamon", "middleName": "A"])
+        let scrapedProfile = ExtractedProfile(extras: ["county": "Cook"])
+
+        let sut = storedProfile.refreshed(from: scrapedProfile)
+
+        XCTAssertEqual(sut.extras, ["county": "Cook", "middleName": "A"])
+    }
+
+    func testRefreshedKeepsStoredExtrasWhenTheScrapeReturnsNone() {
+        let storedProfile = ExtractedProfile(id: 1, extras: ["county": "Sangamon"])
+
+        let sut = storedProfile.refreshed(from: ExtractedProfile())
+
+        XCTAssertEqual(sut.extras, ["county": "Sangamon"])
+    }
+
+    func testRefreshedMergesAddressExtrasForTheSameCityAndState() {
+        let storedProfile = ExtractedProfile(id: 1, addresses: [
+            AddressCityState(city: "Springfield", state: "IL", extras: ["street": "100 Sample Dr", "zip": "62701"]),
+            AddressCityState(city: "Chicago", state: "IL", extras: ["zip": "60601"])
+        ])
+        let scrapedProfile = ExtractedProfile(addresses: [
+            AddressCityState(city: "Springfield", state: "IL", extras: ["zip": "62702"]),
+            AddressCityState(city: "Peoria", state: "IL")
+        ])
+
+        let sut = storedProfile.refreshed(from: scrapedProfile)
+
+        XCTAssertEqual(sut.addresses?.count, 2)
+        XCTAssertEqual(sut.addresses?.first?.extras, ["street": "100 Sample Dr", "zip": "62702"])
+        XCTAssertNil(sut.addresses?.last?.extras)
+    }
+
     // MARK: - Test matching logic
 
     func testDoesMatchExtractedProfile_whenThereAnExactMatch_thenDoesMatchExtractedProfileIsTrue() {

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/MapperToModelTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/MapperToModelTests.swift
@@ -323,6 +323,23 @@ final class MapperToModelTests: XCTestCase {
         XCTAssertEqual((firstElement["parent"] as? [String: Any])?["selector"] as? String, "#email-wrapper")
     }
 
+    func testMapToModel_extractedProfileRoundTripsExtras() throws {
+        // Given
+        let extractedProfile = ExtractedProfile(name: "Jane Smith",
+                                                addresses: [AddressCityState(city: "Springfield", state: "IL", extras: ["zip": "62701"])],
+                                                identifier: "https://broker.example/id/jane-smith",
+                                                extras: ["county": "Sangamon"])
+        let profileData = try MapperToDB(mechanism: { $0 }).mapToDB(extractedProfile)
+        let extractedProfileDB = ExtractedProfileDB(id: 1, brokerId: 1, profileQueryId: 1, profile: profileData, removedDate: nil)
+
+        // When
+        let result = try MapperToModel(mechanism: { $0 }).mapToModel(extractedProfileDB)
+
+        // Then
+        XCTAssertEqual(result.extras, ["county": "Sangamon"])
+        XCTAssertEqual(result.addresses?.first?.extras, ["zip": "62701"])
+    }
+
     // MARK: - Helpers
 
     private func makeProfileQuery() -> ProfileQuery {

--- a/iOS/DuckDuckGo/AppServices/DBPService.swift
+++ b/iOS/DuckDuckGo/AppServices/DBPService.swift
@@ -204,6 +204,10 @@ final class DBPFeatureFlagger: DBPFeatureFlagging, FreemiumPIRFeatureFlagging {
         appDependencies.featureFlagger.isFeatureOn(.dbpOptOutRetryError96Hours)
     }
 
+    var isExtractedProfileRefreshOn: Bool {
+        appDependencies.featureFlagger.isFeatureOn(.dbpExtractedProfileRefresh)
+    }
+
     var isFreemiumPIREnabled: Bool {
         freemiumPIRDebugSettings.isEligibilityForced
             || appDependencies.featureFlagger.isFeatureOn(.dbpFreemiumPIR)

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -130,6 +130,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216731632905182
     case dbpDeferredSecureVaultInit
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217396600005661
+    case dbpExtractedProfileRefresh
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866711635701
     case crashReportOptInStatusResetting
 
@@ -660,6 +663,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(DBPSubfeature.optOutRetryError96Hours))
         case .dbpDeferredSecureVaultInit:
             Config(source: .remoteReleasable(DBPSubfeature.deferredSecureVaultInit), supportsLocalOverriding: true)
+        case .dbpExtractedProfileRefresh:
+            Config(defaultValue: .enabled, source: .remoteReleasable(DBPSubfeature.extractedProfileRefresh), supportsLocalOverriding: true)
         case .crashReportOptInStatusResetting:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(iOSBrowserConfigSubfeature.crashReportOptInStatusResetting), supportsLocalOverriding: false)
         case .syncSeamlessAccountSwitching:

--- a/macOS/DuckDuckGo/DBP/DBPFeatureFlagger.swift
+++ b/macOS/DuckDuckGo/DBP/DBPFeatureFlagger.swift
@@ -44,6 +44,10 @@ final class DBPFeatureFlagger: DBPFeatureFlagging {
         featureFlagger.isFeatureOn(.dbpOptOutRetryError96Hours)
     }
 
+    var isExtractedProfileRefreshOn: Bool {
+        featureFlagger.isFeatureOn(.dbpExtractedProfileRefresh)
+    }
+
     init(featureFlagger: FeatureFlagger) {
         self.featureFlagger = featureFlagger
     }

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/Debug/DataBrokerRunCustomJSONView.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/Debug/DataBrokerRunCustomJSONView.swift
@@ -138,6 +138,7 @@ struct DataBrokerRunCustomJSONView: View {
     private var dbpFeatureFlagLines: [(name: String, value: String)] {
         [
             (FeatureFlag.dbpWebViewUserAgent.rawValue, viewModel.featureFlagger.isWebViewUserAgentOn.description),
+            (FeatureFlag.dbpExtractedProfileRefresh.rawValue, viewModel.featureFlagger.isExtractedProfileRefreshOn.description),
         ]
     }
 

--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -119,6 +119,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212843034975366
     case dbpOptOutRetryError96Hours
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217396600005661
+    case dbpExtractedProfileRefresh
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866717382557
     case syncSetupBarcodeIsUrlBased
 
@@ -587,6 +590,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(DBPSubfeature.webViewUserAgent), supportsLocalOverriding: true, category: .dbp)
         case .dbpOptOutRetryError96Hours:
             Config(source: .remoteReleasable(DBPSubfeature.optOutRetryError96Hours), category: .dbp)
+        case .dbpExtractedProfileRefresh:
+            Config(defaultValue: .enabled, source: .remoteReleasable(DBPSubfeature.extractedProfileRefresh), supportsLocalOverriding: true, category: .dbp)
         case .syncSetupBarcodeIsUrlBased:
             Config(source: .remoteReleasable(SyncSubfeature.syncSetupBarcodeIsUrlBased), category: .sync)
         case .allowSingleDeviceOnConnectScreen:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216773212741751
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1216773212741757

### Description
Support `extras` in extracted profiles and addresses, pass tem along to `fillForm`, and update stored profiles with the freshly scraped profile. This lessens the need for an app release when an opt out form requires a new field we don’t have.

### Testing Steps
1. Point C-S-S to https://github.com/duckduckgo/content-scope-scripts/pull/2907 by modifying `Package.swift`:

```swift
.package(url: "https://github.com/duckduckgo/content-scope-scripts.git", branch: "pr-releases/randerson/pir-extras-open-field”)
```

2. Build and run.
4. Ensure DBP API is pointed to the staging URL.
5. Open PIR Debug Mode. 
6. Select `cyberbackgroundchecks.com` and replace the JSON on right: https://dub.duckduckgo.com/duckduckgo/dbp-api/blob/2fb2bb29f5d3f67bc6c70098ca36db7ca4a100b9/dbp-json/data/json/cyberbackgroundchecks.com.json
7. Complete a scan and opt out: Scan → Opt-out selected → Check for email confirmation → Continue opt-out.
8. The street and zip fields in the post-confirmation opt out form should be filled from data that was extracted during the scan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secure-vault persistence and the PIR scan/opt-out path for stored PII profiles, but the refresh behavior is feature-flagged with careful merge semantics and solid test coverage.
> 
> **Overview**
> Lets PIR ship new opt-out form fields via broker config alone by storing and forwarding opaque `extras` on `ExtractedProfile` and `AddressCityState`, then passing them through to fill-form.
> 
> When a re-scan finds an already-stored profile, **`extractedProfileRefresh`** (default on, remote-releasable) updates the vault record from the scrape via `refreshed(from:)`. Scraped fields overwrite stored ones, while `id`/`email`/`removedDate` are kept, and extras merge so fields missing from a scrape are not stripped from a pending opt-out.
> 
> Adds vault/database APIs to persist refreshed profile JSON, wires the flag on iOS and macOS, and covers encoding, merge/refresh, and scan behavior with tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e030080bdd22b871f0b4c086bc65a5d1310c5a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->