### PR TITLE
Trigger performance tests on PRs only when their own workflow changes

### DIFF
--- a/.github/workflows/macos_performance_tests.yml
+++ b/.github/workflows/macos_performance_tests.yml
@@ -24,7 +24,7 @@ on:
     # We're also adding ready_for_review to run checks when a draft PR becomes ready for review.
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - '.github/**'
+      - '.github/workflows/macos_performance_tests.yml'
       - '.xcode-version'
 
 concurrency:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206580121312550/task/1216821343663944?focus=true

### Description

We want to prevent a flaky test from:
- Running when it doesn't need to run (~18 mins of CI time); and
- Blocking unrelated work due to the test's current flakiness

The flakiness issue is an actual crasher that will be resolved [in a separate task](https://app.asana.com/1/137249556945/project/1201037661562251/task/1216821343663926?focus=true), this PR is just preventing the test from blocking unrelated work.

### Important

I expect the flakey Performance test to be flakey and fail in this PR, but you can also easily see this PR isn't affecting Performance tests at all, it only affects when the test runs.

### Testing Steps

No testing steps.