### PR TITLE
[macOS] Skip check for AMP URL when bot detection interrupts test

### DIFF
--- a/macOS/UITests/NavigationProtectionUITests.swift
+++ b/macOS/UITests/NavigationProtectionUITests.swift
@@ -79,6 +79,8 @@ class NavigationProtectionUITests: UITestCase {
             let label = allLabelsInOrder[index]
             // not working: handled in testNavigationProtection_AMPLinks_GuardianDotAmp_RedirectsToCanonical
             if label == "amp. link" { continue }
+            // Destination bot protection can interrupt canonical URL redirect; handled in testNavigationProtection_AMPLinks_NonStandardTLD_RedirectsToCanonical
+            if label == "*Non Standard TLD (Google Domain)" { continue }
 
             let expectedURL = expectedTexts[index]
             let link = webView.links[label].firstMatch
@@ -132,6 +134,39 @@ class NavigationProtectionUITests: UITestCase {
 
         // Should be redirected to the exact expected canonical URL from the test page
         XCTAssertEqual(finalURL, expectedURL, "Should be redirected to exact canonical URL specified in test page")
+    }
+
+    func testNavigationProtection_AMPLinks_NonStandardTLD_RedirectsToCanonical() throws {
+        // Navigate to AMP protection test page
+        let ampTestURL = URL(string: "https://privacy-test-pages.site/privacy-protections/amp/")!
+        addressBarTextField.pasteURL(ampTestURL, pressingEnter: true)
+
+        // Find the Non Standard TLD test link
+        let nonStandardTLDAmpLink = webView.links["*Non Standard TLD (Google Domain)"].firstMatch
+        XCTAssertTrue(nonStandardTLDAmpLink.waitForExistence(timeout: UITests.Timeouts.elementExistence), "*Non Standard TLD (Google Domain) test link should be available")
+
+        // Get the expected URL from the test page instead of hardcoding
+        let expectedURLElement = webView.staticTexts.containing(\.value, containing: "Expected: https://www.brookings.edu").firstMatch
+        XCTAssertTrue(expectedURLElement.waitForExistence(timeout: UITests.Timeouts.elementExistence), "Expected URL element should be found on the test page")
+
+        let expectedURLText = expectedURLElement.value as? String ?? ""
+        let expectedURL = expectedURLText.replacingOccurrences(of: "Expected: ", with: "")
+
+        // Click the AMP link to test protection
+        nonStandardTLDAmpLink.click()
+
+        // Wait for navigation to complete
+        let newPageContent = webView.staticTexts.firstMatch
+        XCTAssertTrue(newPageContent.waitForExistence(timeout: UITests.Timeouts.navigation), "Navigation should complete after AMP link click")
+
+        // Verify AMP protection redirected to the expected canonical URL.
+        // Skip test if bot protection is triggered, as the canonical URL cannot be verified in that case.
+        let finalURL = app.addressBarValueActivatingIfNeeded() ?? ""
+        guard finalURL == expectedURL else {
+            XCTAssertTrue(app.staticTexts["Performing security verification"].exists,
+                          "Should be redirected to exact canonical URL \(expectedURL) or bot detection page; actual: \(finalURL)")
+            throw XCTSkip("Bot detection prevented redirect to canonical URL")
+        }
     }
 
     // MARK: - Click-to-Load Social Media Tests


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1216844934315983?focus=true
Tech Design URL:
CC:

### Description

Mitigates a failing UI test for AMP URL redirects due to bot detection interrupting the test. A longer term solution could involve using an AMP URL we control, but for now the test is skipped if bot detection prevents the test from completing.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Confirm UI test run passes: https://github.com/duckduckgo/apple-browsers/actions/runs/30088480001

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling (UI tests)

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only macOS UI test logic; no user-facing or production navigation behavior is modified.
> 
> **Overview**
> Stabilizes macOS AMP navigation UI tests when the destination site shows bot protection instead of completing the canonical redirect.
> 
> The bulk AMP loop in `testNavigationProtection_AMPLinks_RedirectsToCanonical` now **skips** the **\*Non Standard TLD (Google Domain)** case (same pattern as `amp. link`), with a dedicated test owning that scenario.
> 
> A new **`testNavigationProtection_AMPLinks_NonStandardTLD_RedirectsToCanonical`** exercises only that link, reads the expected Brookings URL from the test page, and **passes** if the address bar matches. If not, it accepts a **"Performing security verification"** interstitial and **`XCTSkip`**s so CI does not fail when third-party bot detection blocks the redirect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 133c3ed94a593894a640f320d463f291ad468a2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->