### PR TITLE
[iOS] Add Maestro SSL error page acceptance tests

### DIFF
--- a/.maestro/privacy_tests/10_expired_certificate.yaml
+++ b/.maestro/privacy_tests/10_expired_certificate.yaml
@@ -5,16 +5,25 @@ tags:
 
 ---
 
-# Set up 
-- runFlow: 
+# Set up
+- runFlow:
     file: ../shared/setup.yaml
 
 - assertVisible:
     id: "searchEntry"
 
-# Test 1 - Leave the dangerous site
-- tapOn: 
+# Load a normal site first so the SSL error page has back history to return to.
+- tapOn:
     id: "searchEntry"
+- eraseText
+- inputText: "https://www.search-company.site/#ad-id-5"
+- pressKey: Enter
+- assertVisible: "[Ad 5] SERP Ad (heuristic)"
+
+# Test 1 - Leave the dangerous site and verify back/forward navigation
+- tapOn:
+    id: "searchEntry"
+- eraseText
 - inputText: "https://expired.badssl.com"
 - pressKey: Enter
 - assertVisible: "Warning: This site may be insecure"
@@ -22,19 +31,42 @@ tags:
     id: "Globe-24"
 - tapOn: "Leave This Site"
 - assertNotVisible: "Warning: This site may be insecure"
+- assertVisible: "[Ad 5] SERP Ad (heuristic)"
+# Forward returns to the SSL error page, back returns to the safe site
+- tapOn: "Browse Forward"
+- assertVisible: "Warning: This site may be insecure"
+- tapOn: "Browse Back"
+- assertVisible: "[Ad 5] SERP Ad (heuristic)"
+- assertNotVisible: "Warning: This site may be insecure"
 
-# Test 2 - Visit the dangerous site
-- tapOn: 
-    id: "searchEntry"
-- inputText: "https://expired.badssl.com"
-- pressKey: Enter
+# Test 2 - Visit the dangerous site and verify back/forward navigation.
+# Reuse the SSL error page still held in forward history instead of reloading it.
+- tapOn: "Browse Forward"
+- assertVisible: "Warning: This site may be insecure"
 - assertVisible:
     id: "Globe-24"
 - tapOn: "Advanced"
-- scroll
+- scrollUntilVisible:
+    element:
+      text: ".*is expired.*"
+    direction: DOWN
+- scrollUntilVisible:
+    element:
+      text: "Accept Risk and Visit Site"
+    direction: DOWN
 - tapOn: "Accept Risk and Visit Site"
-- assertVisible: 
-    id: "privacy-icon-shield.button"
+# Wait for the real site to load over the network before checking the shield
+- extendedWaitUntil:
+    visible:
+      id: "privacy-icon-shield.button"
+    timeout: 20000
 - assertVisible: "expired.badssl.com"
-
-
+# Back returns to the safe site, forward returns to the accepted SSL site
+- tapOn: "Browse Back"
+- assertVisible: "[Ad 5] SERP Ad (heuristic)"
+- tapOn: "Browse Forward"
+- extendedWaitUntil:
+    visible:
+      id: "privacy-icon-shield.button"
+    timeout: 20000
+- assertVisible: "expired.badssl.com"

--- a/.maestro/privacy_tests/13_ssl_wrong_host_certificate.yaml
+++ b/.maestro/privacy_tests/13_ssl_wrong_host_certificate.yaml
@@ -1,0 +1,29 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - privacy
+
+---
+
+# Set up
+- runFlow:
+    file: ../shared/setup.yaml
+
+- assertVisible:
+    id: "searchEntry"
+
+# Navigate to a site whose certificate does not match its host
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://wrong.host.badssl.com"
+- pressKey: Enter
+
+# Verify the SSL warning page and the wrong-host specific messaging
+- assertVisible: "Warning: This site may be insecure"
+- assertVisible:
+    id: "Globe-24"
+- tapOn: "Advanced"
+- scrollUntilVisible:
+    element:
+      text: ".*does not match.*"
+    direction: DOWN

--- a/.maestro/privacy_tests/14_ssl_self_signed_certificate.yaml
+++ b/.maestro/privacy_tests/14_ssl_self_signed_certificate.yaml
@@ -1,0 +1,29 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - privacy
+
+---
+
+# Set up
+- runFlow:
+    file: ../shared/setup.yaml
+
+- assertVisible:
+    id: "searchEntry"
+
+# Navigate to a site with a self-signed certificate
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://self-signed.badssl.com"
+- pressKey: Enter
+
+# Verify the SSL warning page and the self-signed specific messaging
+- assertVisible: "Warning: This site may be insecure"
+- assertVisible:
+    id: "Globe-24"
+- tapOn: "Advanced"
+- scrollUntilVisible:
+    element:
+      text: ".*not trusted by your device.*"
+    direction: DOWN

--- a/.maestro/privacy_tests/15_ssl_untrusted_root_certificate.yaml
+++ b/.maestro/privacy_tests/15_ssl_untrusted_root_certificate.yaml
@@ -1,0 +1,29 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - privacy
+
+---
+
+# Set up
+- runFlow:
+    file: ../shared/setup.yaml
+
+- assertVisible:
+    id: "searchEntry"
+
+# Navigate to a site signed by an untrusted root certificate
+- tapOn:
+    id: "searchEntry"
+- inputText: "https://untrusted-root.badssl.com"
+- pressKey: Enter
+
+# Verify the SSL warning page and the untrusted-root specific messaging
+- assertVisible: "Warning: This site may be insecure"
+- assertVisible:
+    id: "Globe-24"
+- tapOn: "Advanced"
+- scrollUntilVisible:
+    element:
+      text: ".*not trusted by your device.*"
+    direction: DOWN


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211756057575863
CC:

### Description
Expands the iOS end-to-end coverage for SSL certificate error pages, which previously only exercised the expired-certificate case (leave + visit, no history navigation). Adds:
- Back/forward navigation checks after both leaving and visiting an SSL error site.
- Coverage for the wrong-host, self-signed and untrusted-root certificate error types, each asserting the warning page and its type-specific messaging.

These mirror the scenarios already covered by the macOS UI tests.

### Testing Steps
Set up the Maestro environment (`./.maestro/setup_ui_tests.sh`), then run each flow, expecting all steps to pass:
1. `maestro test -e ONBOARDING_COMPLETED=true -e APP_VARIANT= -e INTERNAL_USER_MODE=false .maestro/privacy_tests/10_expired_certificate.yaml`
2. `... .maestro/privacy_tests/13_ssl_wrong_host_certificate.yaml`
3. `... .maestro/privacy_tests/14_ssl_self_signed_certificate.yaml`
4. `... .maestro/privacy_tests/15_ssl_untrusted_root_certificate.yaml`

### Impact
None — test-only change, no production code touched.

### Quality Considerations
- Flows drive live `*.badssl.com` endpoints (as the existing flow already did), so they depend on those services being reachable.
- Verified locally on an iPhone 17 / iOS 26 simulator; CI runs iOS 18.x.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro YAML changes; no app or security logic is modified, though CI depends on live badssl.com reachability.
> 
> **Overview**
> **Expands iOS Maestro privacy coverage for SSL certificate error pages** with no production code changes.
> 
> The **`10_expired_certificate`** flow now seeds a normal page first, then exercises **leave site**, **accept risk**, and **back/forward** through the warning and loaded site. It uses **`scrollUntilVisible`** for Advanced details and **`extendedWaitUntil`** for the privacy shield after network loads.
> 
> **Three new flows** assert the shared warning UI plus type-specific Advanced copy for **`wrong.host`**, **`self-signed`**, and **`untrusted-root`** `*.badssl.com` endpoints, aligned with existing macOS UI test scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa667e663ebe50a80aea3453267cda368c948280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->