### PR TITLE
Delay web-extension unloads to avoid a WebKit declarativeNetRequest crash

### DIFF
--- a/SharedPackages/WebExtensions/Package.resolved
+++ b/SharedPackages/WebExtensions/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "c83b04d371e1c66148dd4d9771e4262264e9cf9c0f52cc062b940e7336600002",
+  "originHash" : "ac2a9945ad19c7da6daf61472649344613332f0fa77e9b4e44a6ce545a90bea6",
   "pins" : [
     {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "dc9b1280951a22359aac33d07ffd410cbbae2b94",
-        "version" : "15.12.0"
+        "revision" : "3011e9e06cc68d3f9c2cd7b00aadabcd34d2869a",
+        "version" : "15.19.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
       "state" : {
-        "revision" : "40a8c752fb73a15738899dc0edb5e17e33302a37",
-        "version" : "9.10.1"
+        "revision" : "88a028fe9e4aa53941cb49dfc93bbcf62bd46f3b",
+        "version" : "9.10.2"
       }
     },
     {

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager+EmbeddedExtensions.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager+EmbeddedExtensions.swift
@@ -43,6 +43,12 @@ extension WebExtensionManager {
             if enabledTypes.contains(descriptor.type) {
                 await syncEmbeddedExtension(descriptor)
             } else {
+                // A launch loads every installed extension before this sync runs, so a type that is
+                // disabled gets unloaded seconds after loading — the same window the upgrade branch
+                // above waits out.
+                if let installed = installedEmbeddedExtension(for: descriptor.type) {
+                    await unloadGuard.awaitSettled(context(for: installed.uniqueIdentifier))
+                }
                 uninstallEmbeddedExtension(type: descriptor.type)
             }
         }

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager+EmbeddedExtensions.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager+EmbeddedExtensions.swift
@@ -85,6 +85,7 @@ extension WebExtensionManager {
                 if shouldUpgrade(installed: installed, bundledVersion: bundledMetadata.version) {
                     Logger.webExtensions.info("⬆️ Upgrading embedded extension \(descriptor.type.rawValue): \(installed.version ?? "?") → \(bundledMetadata.version ?? "?")")
                     let oldVersion = installed.version
+                    await awaitDNRSettleWindow(for: installed.uniqueIdentifier)
                     try uninstallExtension(identifier: installed.uniqueIdentifier)
                     try await installEmbeddedExtension(from: bundledURL, type: descriptor.type, requiresExtraction: bundledMetadata.requiresExtraction)
                     pixelFiring.fire(.embeddedUpgraded(type: descriptor.type, fromVersion: oldVersion, toVersion: bundledMetadata.version))
@@ -139,6 +140,7 @@ extension WebExtensionManager {
 
         do {
             let loadResult = try await loader.loadWebExtension(identifier: identifier, into: controller)
+            recordLoadDate(for: identifier)
 
             let installedExtension = InstalledWebExtension(
                 uniqueIdentifier: identifier,

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager+EmbeddedExtensions.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager+EmbeddedExtensions.swift
@@ -85,7 +85,7 @@ extension WebExtensionManager {
                 if shouldUpgrade(installed: installed, bundledVersion: bundledMetadata.version) {
                     Logger.webExtensions.info("⬆️ Upgrading embedded extension \(descriptor.type.rawValue): \(installed.version ?? "?") → \(bundledMetadata.version ?? "?")")
                     let oldVersion = installed.version
-                    await awaitDNRSettleWindow(for: installed.uniqueIdentifier)
+                    await unloadGuard.awaitSettled(context(for: installed.uniqueIdentifier))
                     try uninstallExtension(identifier: installed.uniqueIdentifier)
                     try await installEmbeddedExtension(from: bundledURL, type: descriptor.type, requiresExtraction: bundledMetadata.requiresExtraction)
                     pixelFiring.fire(.embeddedUpgraded(type: descriptor.type, fromVersion: oldVersion, toVersion: bundledMetadata.version))
@@ -140,7 +140,7 @@ extension WebExtensionManager {
 
         do {
             let loadResult = try await loader.loadWebExtension(identifier: identifier, into: controller)
-            recordLoadDate(for: identifier)
+            unloadGuard.recordLoad(of: identifier)
 
             let installedExtension = InstalledWebExtension(
                 uniqueIdentifier: identifier,

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager.swift
@@ -65,6 +65,14 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
     /// consumed by a reload.
     private var unloadedExtensionsCache: [String: WKWebExtension] = [:]
 
+    /// Most recent successful load time per extension identifier. Drives `awaitDNRSettleWindow(for:)`.
+    @MainActor
+    private var lastLoadDates: [String: Date] = [:]
+
+    private let dnrSettleWindow: TimeInterval
+    private let now: () -> Date
+    private let sleeper: (TimeInterval) async -> Void
+
     /// Pixel firing for analytics.
     let pixelFiring: WebExtensionPixelFiring
 
@@ -89,7 +97,10 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
                 pixelFiring: WebExtensionPixelFiring = NoOpWebExtensionPixelFiring(),
                 messageRouter: WebExtensionMessageRouting? = nil,
                 handlerProvider: WebExtensionHandlerProviding? = nil,
-                scriptletConfiguration: ScriptletConfiguration? = nil) {
+                scriptletConfiguration: ScriptletConfiguration? = nil,
+                dnrSettleWindow: TimeInterval = WebExtensionManager.defaultDNRSettleWindow,
+                now: @escaping () -> Date = Date.init,
+                sleeper: @escaping (TimeInterval) async -> Void = { try? await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000)) }) {
         let controllerConfiguration = WKWebExtensionController.Configuration.default()
         controllerConfiguration.webViewConfiguration.applicationNameForUserAgent = configuration.applicationNameForUserAgent
         self.controller = WKWebExtensionController(configuration: controllerConfiguration)
@@ -105,6 +116,9 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
         self.messageRouter = messageRouter ?? WebExtensionMessageRouter()
         self.handlerProvider = handlerProvider
         self.scriptletConfiguration = scriptletConfiguration
+        self.dnrSettleWindow = dnrSettleWindow
+        self.now = now
+        self.sleeper = sleeper
 
         super.init()
 
@@ -165,6 +179,7 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
 
         do {
             let loadResult = try await loader.loadWebExtension(identifier: identifier, into: controller)
+            await recordLoadDate(for: identifier)
 
             let installedExtension = InstalledWebExtension(
                 uniqueIdentifier: identifier,
@@ -321,13 +336,62 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
     public func reloadExtension(identifier: String) async throws {
         Logger.webExtensions.debug("🔄 Reloading extension '\(identifier)'")
 
+        await awaitDNRSettleWindow(for: identifier)
+
         try loader.unloadExtension(identifier: identifier, from: controller)
         unregisterHandlers(for: identifier)
 
         _ = try await loader.loadWebExtension(identifier: identifier, into: controller)
+        recordLoadDate(for: identifier)
 
         Logger.webExtensions.info("✅ Reloaded extension '\(identifier)'")
         notifyUpdate()
+    }
+
+    // MARK: - DNR Settle Window
+
+    /// Minimum time an extension that requests `declarativeNetRequest` must stay loaded before it
+    /// may be unloaded again. Works around a WebKit crash present up to WebKit 7624.x (macOS
+    /// 26.0–26.4): loading a context starts a fire-and-forget declarativeNetRequest rules load on a
+    /// background queue, and unloading the context destroys the SQLite stores that load reads from;
+    /// a store torn down with the read still queued delivers a null rules array that WebKit then
+    /// dereferences (https://bugs.webkit.org/show_bug.cgi?id=305585, fixed upstream in 305661@main).
+    /// Remove this workaround once the minimum supported macOS ships the fix.
+    ///
+    /// Value: maximum observed load-to-crash window was ~1.5s (perf-CI crash reports, Jul 2026),
+    /// doubled as a safety factor.
+    public static let defaultDNRSettleWindow: TimeInterval = 3
+
+    private static let dnrPermissions: Set<WKWebExtension.Permission> = [
+        WKWebExtension.Permission("declarativeNetRequest"),
+        WKWebExtension.Permission("declarativeNetRequestWithHostAccess"),
+    ]
+
+    /// Records a successful load of the extension so `awaitDNRSettleWindow(for:)` can measure
+    /// how long it has been loaded.
+    @MainActor
+    func recordLoadDate(for identifier: String) {
+        lastLoadDates[identifier] = now()
+    }
+
+    /// Suspends until the extension has been loaded for at least `dnrSettleWindow`. Only applies
+    /// to loaded extensions that request declarativeNetRequest — no other extension triggers the
+    /// WebKit rules load that makes unloading unsafe (see `defaultDNRSettleWindow`).
+    ///
+    /// Deliberately not applied to the synchronous unload paths (`unloadAllExtensions`,
+    /// user-initiated `uninstallExtension`): those cannot await, and in practice they run long
+    /// after the extension was loaded.
+    @MainActor
+    func awaitDNRSettleWindow(for identifier: String) async {
+        guard let context = context(for: identifier),
+              !Self.dnrPermissions.isDisjoint(with: context.webExtension.requestedPermissions),
+              let loadDate = lastLoadDates[identifier] else { return }
+
+        let remaining = dnrSettleWindow - now().timeIntervalSince(loadDate)
+        guard remaining > 0 else { return }
+
+        Logger.webExtensions.debug("⏸️ Delaying unload of '\(identifier)' by \(remaining)s for WebKit's in-flight declarativeNetRequest load")
+        await sleeper(remaining)
     }
 
     // MARK: - Loading
@@ -353,6 +417,7 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
             switch result {
             case .success:
                 Logger.webExtensions.debug("✅ Loaded extension `\(installedExtension.name ?? "")` v\(installedExtension.version ?? "unknown") | \(installedExtension.filename) | \(installedExtension.uniqueIdentifier)")
+                recordLoadDate(for: installedExtension.uniqueIdentifier)
                 successCount += 1
             case .failure(let failure):
                 Logger.webExtensions.error("❌ Failed to load web extension \(installedExtension.filename) (\(installedExtension.uniqueIdentifier)): \(failure.localizedDescription)")
@@ -430,6 +495,7 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
             await Task.yield()
             do {
                 try await loader.reloadWebExtension(webExtension, identifier: identifier, into: controller)
+                recordLoadDate(for: identifier)
                 successCount += 1
             } catch {
                 Logger.webExtensions.error("❌ Failed to reload web extension '\(identifier)': \(error.localizedDescription)")

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager.swift
@@ -65,13 +65,9 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
     /// consumed by a reload.
     private var unloadedExtensionsCache: [String: WKWebExtension] = [:]
 
-    /// Most recent successful load time per extension identifier. Drives `awaitDNRSettleWindow(for:)`.
-    @MainActor
-    private var lastLoadDates: [String: Date] = [:]
-
-    private let dnrSettleWindow: TimeInterval
-    private let now: () -> Date
-    private let sleeper: (TimeInterval) async -> Void
+    /// Guards unload/reload paths against a WebKit declarativeNetRequest crash — see
+    /// `WebExtensionUnloadGuard`. `var` only so tests can inject a guard with a controlled clock.
+    var unloadGuard: WebExtensionUnloadGuard
 
     /// Pixel firing for analytics.
     let pixelFiring: WebExtensionPixelFiring
@@ -97,10 +93,7 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
                 pixelFiring: WebExtensionPixelFiring = NoOpWebExtensionPixelFiring(),
                 messageRouter: WebExtensionMessageRouting? = nil,
                 handlerProvider: WebExtensionHandlerProviding? = nil,
-                scriptletConfiguration: ScriptletConfiguration? = nil,
-                dnrSettleWindow: TimeInterval = WebExtensionManager.defaultDNRSettleWindow,
-                now: @escaping () -> Date = Date.init,
-                sleeper: @escaping (TimeInterval) async -> Void = { try? await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000)) }) {
+                scriptletConfiguration: ScriptletConfiguration? = nil) {
         let controllerConfiguration = WKWebExtensionController.Configuration.default()
         controllerConfiguration.webViewConfiguration.applicationNameForUserAgent = configuration.applicationNameForUserAgent
         self.controller = WKWebExtensionController(configuration: controllerConfiguration)
@@ -116,9 +109,7 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
         self.messageRouter = messageRouter ?? WebExtensionMessageRouter()
         self.handlerProvider = handlerProvider
         self.scriptletConfiguration = scriptletConfiguration
-        self.dnrSettleWindow = dnrSettleWindow
-        self.now = now
-        self.sleeper = sleeper
+        self.unloadGuard = WebExtensionUnloadGuard()
 
         super.init()
 
@@ -179,7 +170,7 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
 
         do {
             let loadResult = try await loader.loadWebExtension(identifier: identifier, into: controller)
-            await recordLoadDate(for: identifier)
+            await unloadGuard.recordLoad(of: identifier)
 
             let installedExtension = InstalledWebExtension(
                 uniqueIdentifier: identifier,
@@ -336,62 +327,16 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
     public func reloadExtension(identifier: String) async throws {
         Logger.webExtensions.debug("🔄 Reloading extension '\(identifier)'")
 
-        await awaitDNRSettleWindow(for: identifier)
+        await unloadGuard.awaitSettled(context(for: identifier))
 
         try loader.unloadExtension(identifier: identifier, from: controller)
         unregisterHandlers(for: identifier)
 
         _ = try await loader.loadWebExtension(identifier: identifier, into: controller)
-        recordLoadDate(for: identifier)
+        unloadGuard.recordLoad(of: identifier)
 
         Logger.webExtensions.info("✅ Reloaded extension '\(identifier)'")
         notifyUpdate()
-    }
-
-    // MARK: - DNR Settle Window
-
-    /// Minimum time an extension that requests `declarativeNetRequest` must stay loaded before it
-    /// may be unloaded again. Works around a WebKit crash present up to WebKit 7624.x (macOS
-    /// 26.0–26.4): loading a context starts a fire-and-forget declarativeNetRequest rules load on a
-    /// background queue, and unloading the context destroys the SQLite stores that load reads from;
-    /// a store torn down with the read still queued delivers a null rules array that WebKit then
-    /// dereferences (https://bugs.webkit.org/show_bug.cgi?id=305585, fixed upstream in 305661@main).
-    /// Remove this workaround once the minimum supported macOS ships the fix.
-    ///
-    /// Value: maximum observed load-to-crash window was ~1.5s (perf-CI crash reports, Jul 2026),
-    /// doubled as a safety factor.
-    public static let defaultDNRSettleWindow: TimeInterval = 3
-
-    private static let dnrPermissions: Set<WKWebExtension.Permission> = [
-        WKWebExtension.Permission("declarativeNetRequest"),
-        WKWebExtension.Permission("declarativeNetRequestWithHostAccess"),
-    ]
-
-    /// Records a successful load of the extension so `awaitDNRSettleWindow(for:)` can measure
-    /// how long it has been loaded.
-    @MainActor
-    func recordLoadDate(for identifier: String) {
-        lastLoadDates[identifier] = now()
-    }
-
-    /// Suspends until the extension has been loaded for at least `dnrSettleWindow`. Only applies
-    /// to loaded extensions that request declarativeNetRequest — no other extension triggers the
-    /// WebKit rules load that makes unloading unsafe (see `defaultDNRSettleWindow`).
-    ///
-    /// Deliberately not applied to the synchronous unload paths (`unloadAllExtensions`,
-    /// user-initiated `uninstallExtension`): those cannot await, and in practice they run long
-    /// after the extension was loaded.
-    @MainActor
-    func awaitDNRSettleWindow(for identifier: String) async {
-        guard let context = context(for: identifier),
-              !Self.dnrPermissions.isDisjoint(with: context.webExtension.requestedPermissions),
-              let loadDate = lastLoadDates[identifier] else { return }
-
-        let remaining = dnrSettleWindow - now().timeIntervalSince(loadDate)
-        guard remaining > 0 else { return }
-
-        Logger.webExtensions.debug("⏸️ Delaying unload of '\(identifier)' by \(remaining)s for WebKit's in-flight declarativeNetRequest load")
-        await sleeper(remaining)
     }
 
     // MARK: - Loading
@@ -417,7 +362,7 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
             switch result {
             case .success:
                 Logger.webExtensions.debug("✅ Loaded extension `\(installedExtension.name ?? "")` v\(installedExtension.version ?? "unknown") | \(installedExtension.filename) | \(installedExtension.uniqueIdentifier)")
-                recordLoadDate(for: installedExtension.uniqueIdentifier)
+                unloadGuard.recordLoad(of: installedExtension.uniqueIdentifier)
                 successCount += 1
             case .failure(let failure):
                 Logger.webExtensions.error("❌ Failed to load web extension \(installedExtension.filename) (\(installedExtension.uniqueIdentifier)): \(failure.localizedDescription)")
@@ -495,7 +440,7 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
             await Task.yield()
             do {
                 try await loader.reloadWebExtension(webExtension, identifier: identifier, into: controller)
-                recordLoadDate(for: identifier)
+                unloadGuard.recordLoad(of: identifier)
                 successCount += 1
             } catch {
                 Logger.webExtensions.error("❌ Failed to reload web extension '\(identifier)': \(error.localizedDescription)")

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionManager.swift
@@ -65,8 +65,7 @@ open class WebExtensionManager: NSObject, WebExtensionManaging, WebExtensionInst
     /// consumed by a reload.
     private var unloadedExtensionsCache: [String: WKWebExtension] = [:]
 
-    /// Guards unload/reload paths against a WebKit declarativeNetRequest crash — see
-    /// `WebExtensionUnloadGuard`. `var` only so tests can inject a guard with a controlled clock.
+    /// See `WebExtensionUnloadGuard`. Settable only so tests can inject a controlled clock.
     var unloadGuard: WebExtensionUnloadGuard
 
     /// Pixel firing for analytics.

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionUnloadGuard.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionUnloadGuard.swift
@@ -38,6 +38,8 @@ import WebKit
 ///
 /// Remove this type (and its call sites in `WebExtensionManager`) once the minimum supported
 /// macOS ships the WebKit fix.
+///
+/// Tracked in https://app.asana.com/1/137249556945/project/1201037661562251/task/1216821343663926
 @available(macOS 15.4, iOS 18.4, *)
 @MainActor
 final class WebExtensionUnloadGuard {

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionUnloadGuard.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionUnloadGuard.swift
@@ -49,9 +49,19 @@ final class WebExtensionUnloadGuard {
     /// Most recent successful load time per extension identifier.
     private var lastLoadDates: [String: Date] = [:]
 
+    /// Deliberately not `Task.sleep`: cancellation would skip the wait and unload inside the danger
+    /// window, and teardown — the very thing that cancels — is when unloads happen.
+    private static func sleep(for seconds: TimeInterval) async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.asyncAfter(deadline: .now() + seconds) {
+                continuation.resume()
+            }
+        }
+    }
+
     init(settleWindow: TimeInterval = WebExtensionUnloadGuard.defaultSettleWindow,
          now: @escaping () -> Date = Date.init,
-         sleeper: @escaping (TimeInterval) async -> Void = { try? await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000)) }) {
+         sleeper: @escaping (TimeInterval) async -> Void = { await WebExtensionUnloadGuard.sleep(for: $0) }) {
         self.settleWindow = settleWindow
         self.now = now
         self.sleeper = sleeper

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionUnloadGuard.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionUnloadGuard.swift
@@ -20,33 +20,21 @@ import Foundation
 import os.log
 import WebKit
 
-/// Workaround for a WebKit crash when unloading a web extension that uses declarativeNetRequest
-/// (https://bugs.webkit.org/show_bug.cgi?id=305585).
+/// Delays unloading a declarativeNetRequest extension until shortly after it loads, to avoid a
+/// WebKit crash: unloading one while WebKit is still reading its rules dereferences a null and
+/// crashes the app. Fixed upstream but not yet in any shipping macOS 26.x.
 ///
-/// Loading an extension context starts a fire-and-forget read of its declarativeNetRequest rules
-/// on a background queue. Unloading the context destroys the SQLite store that read uses, and a
-/// store torn down while the read is still queued invokes the completion callback with a null
-/// rules array, which WebKit dereferences — crashing the app. The bug is fixed upstream
-/// (https://commits.webkit.org/305661@main) but the fix has not shipped in any macOS 26.x WebKit.
+/// Callers record each load with `recordLoad(of:)`, then call `awaitSettled(_:)` before unloading.
 ///
-/// The guard closes the race with a "settle window": callers record every successful extension
-/// load (`recordLoad(of:)`) and, before unloading or reloading an extension that requests
-/// declarativeNetRequest, wait until at least `settleWindow` has passed since that extension's
-/// load (`awaitSettled(_:)`). Extensions without the permission never trigger the vulnerable
-/// rules read, so the guard lets them pass immediately — as it does any extension loaded longer
-/// than the window.
-///
-/// Remove this type (and its call sites in `WebExtensionManager`) once the minimum supported
-/// macOS ships the WebKit fix.
-///
-/// Tracked in https://app.asana.com/1/137249556945/project/1201037661562251/task/1216821343663926
+/// Remove once the minimum supported macOS ships the fix.
+/// - WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=305585 (fix: https://commits.webkit.org/305661@main)
+/// - Tracked in: https://app.asana.com/1/137249556945/project/1201037661562251/task/1216821343663926
 @available(macOS 15.4, iOS 18.4, *)
 @MainActor
 final class WebExtensionUnloadGuard {
 
-    /// How long an extension that requests declarativeNetRequest must stay loaded before it may
-    /// be unloaded. The largest load-to-crash gap observed in crash reports was ~1.5s (perf-CI,
-    /// Jul 2026); doubled as a safety factor.
+    /// Minimum time a declarativeNetRequest extension must stay loaded before it may be unloaded.
+    /// The largest load-to-crash gap seen in crash reports was ~1.5s; doubled for safety.
     nonisolated static let defaultSettleWindow: TimeInterval = 3
 
     private static let dnrPermissions: Set<WKWebExtension.Permission> = [
@@ -69,28 +57,30 @@ final class WebExtensionUnloadGuard {
         self.sleeper = sleeper
     }
 
-    /// Records a successful load of the extension so `awaitSettled(_:)` can measure how long it
-    /// has been loaded.
+    /// Records when the extension finished loading, so `awaitSettled(_:)` can tell how long ago.
     func recordLoad(of identifier: String) {
         lastLoadDates[identifier] = now()
     }
 
-    /// Suspends until the extension behind `context` has been loaded for at least `settleWindow`.
-    /// Returns immediately when the extension doesn't request declarativeNetRequest, isn't loaded
-    /// (`context` is nil), or has no recorded load.
+    /// Waits until the extension has been loaded for at least `settleWindow`. Returns immediately
+    /// when it doesn't use declarativeNetRequest, isn't loaded, or loaded long enough ago.
     ///
-    /// Deliberately not applied to the synchronous unload paths (`unloadAllExtensions`,
-    /// user-initiated `uninstallExtension`): those cannot await, and in practice they run long
-    /// after the extension was loaded.
+    /// Not applied to the synchronous unload paths (`unloadAllExtensions`, `uninstallExtension`):
+    /// they can't await, and in practice run long after the load.
     func awaitSettled(_ context: WKWebExtensionContext?) async {
-        guard let context,
-              !Self.dnrPermissions.isDisjoint(with: context.webExtension.requestedPermissions),
+        guard let context, usesDeclarativeNetRequest(context),
               let loadDate = lastLoadDates[context.uniqueIdentifier] else { return }
 
-        let remaining = settleWindow - now().timeIntervalSince(loadDate)
+        let elapsed = now().timeIntervalSince(loadDate)
+        let remaining = settleWindow - elapsed
         guard remaining > 0 else { return }
 
         Logger.webExtensions.debug("⏸️ Delaying unload of '\(context.uniqueIdentifier)' by \(remaining)s for WebKit's in-flight declarativeNetRequest load")
         await sleeper(remaining)
+    }
+
+    private func usesDeclarativeNetRequest(_ context: WKWebExtensionContext) -> Bool {
+        let requested = context.webExtension.requestedPermissions
+        return Self.dnrPermissions.contains { requested.contains($0) }
     }
 }

--- a/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionUnloadGuard.swift
+++ b/SharedPackages/WebExtensions/Sources/WebExtensions/Manager/WebExtensionUnloadGuard.swift
@@ -1,0 +1,94 @@
+//
+//  WebExtensionUnloadGuard.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import os.log
+import WebKit
+
+/// Workaround for a WebKit crash when unloading a web extension that uses declarativeNetRequest
+/// (https://bugs.webkit.org/show_bug.cgi?id=305585).
+///
+/// Loading an extension context starts a fire-and-forget read of its declarativeNetRequest rules
+/// on a background queue. Unloading the context destroys the SQLite store that read uses, and a
+/// store torn down while the read is still queued invokes the completion callback with a null
+/// rules array, which WebKit dereferences — crashing the app. The bug is fixed upstream
+/// (https://commits.webkit.org/305661@main) but the fix has not shipped in any macOS 26.x WebKit.
+///
+/// The guard closes the race with a "settle window": callers record every successful extension
+/// load (`recordLoad(of:)`) and, before unloading or reloading an extension that requests
+/// declarativeNetRequest, wait until at least `settleWindow` has passed since that extension's
+/// load (`awaitSettled(_:)`). Extensions without the permission never trigger the vulnerable
+/// rules read, so the guard lets them pass immediately — as it does any extension loaded longer
+/// than the window.
+///
+/// Remove this type (and its call sites in `WebExtensionManager`) once the minimum supported
+/// macOS ships the WebKit fix.
+@available(macOS 15.4, iOS 18.4, *)
+@MainActor
+final class WebExtensionUnloadGuard {
+
+    /// How long an extension that requests declarativeNetRequest must stay loaded before it may
+    /// be unloaded. The largest load-to-crash gap observed in crash reports was ~1.5s (perf-CI,
+    /// Jul 2026); doubled as a safety factor.
+    nonisolated static let defaultSettleWindow: TimeInterval = 3
+
+    private static let dnrPermissions: Set<WKWebExtension.Permission> = [
+        WKWebExtension.Permission("declarativeNetRequest"),
+        WKWebExtension.Permission("declarativeNetRequestWithHostAccess"),
+    ]
+
+    private let settleWindow: TimeInterval
+    private let now: () -> Date
+    private let sleeper: (TimeInterval) async -> Void
+
+    /// Most recent successful load time per extension identifier.
+    private var lastLoadDates: [String: Date] = [:]
+
+    init(settleWindow: TimeInterval = WebExtensionUnloadGuard.defaultSettleWindow,
+         now: @escaping () -> Date = Date.init,
+         sleeper: @escaping (TimeInterval) async -> Void = { try? await Task.sleep(nanoseconds: UInt64($0 * 1_000_000_000)) }) {
+        self.settleWindow = settleWindow
+        self.now = now
+        self.sleeper = sleeper
+    }
+
+    /// Records a successful load of the extension so `awaitSettled(_:)` can measure how long it
+    /// has been loaded.
+    func recordLoad(of identifier: String) {
+        lastLoadDates[identifier] = now()
+    }
+
+    /// Suspends until the extension behind `context` has been loaded for at least `settleWindow`.
+    /// Returns immediately when the extension doesn't request declarativeNetRequest, isn't loaded
+    /// (`context` is nil), or has no recorded load.
+    ///
+    /// Deliberately not applied to the synchronous unload paths (`unloadAllExtensions`,
+    /// user-initiated `uninstallExtension`): those cannot await, and in practice they run long
+    /// after the extension was loaded.
+    func awaitSettled(_ context: WKWebExtensionContext?) async {
+        guard let context,
+              !Self.dnrPermissions.isDisjoint(with: context.webExtension.requestedPermissions),
+              let loadDate = lastLoadDates[context.uniqueIdentifier] else { return }
+
+        let remaining = settleWindow - now().timeIntervalSince(loadDate)
+        guard remaining > 0 else { return }
+
+        Logger.webExtensions.debug("⏸️ Delaying unload of '\(context.uniqueIdentifier)' by \(remaining)s for WebKit's in-flight declarativeNetRequest load")
+        await sleeper(remaining)
+    }
+}

--- a/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionManagerTests.swift
+++ b/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionManagerTests.swift
@@ -31,6 +31,8 @@ final class WebExtensionManagerTests: XCTestCase {
     var lifecycleDelegateMock: WebExtensionLifecycleDelegateMock!
     var configurationMock: WebExtensionConfigurationProvidingMock!
     private var createdTestExtensionDirs: [URL] = []
+    private var recordedSleeps: [TimeInterval] = []
+    private var currentDate = Date()
 
     @MainActor
     override func setUp() {
@@ -43,6 +45,8 @@ final class WebExtensionManagerTests: XCTestCase {
         eventsListenerMock = WebExtensionEventsListenerMock()
         lifecycleDelegateMock = WebExtensionLifecycleDelegateMock()
         configurationMock = WebExtensionConfigurationProvidingMock()
+        recordedSleeps = []
+        currentDate = Date()
     }
 
     override func tearDown() {
@@ -73,7 +77,9 @@ final class WebExtensionManagerTests: XCTestCase {
             installationStore: installedExtensionStoringMock,
             loader: webExtensionLoadingMock,
             eventsListener: eventsListenerMock,
-            lifecycleDelegate: lifecycleDelegateMock
+            lifecycleDelegate: lifecycleDelegateMock,
+            now: { [unowned self] in currentDate },
+            sleeper: { [unowned self] in recordedSleeps.append($0) }
         )
     }
 
@@ -93,8 +99,10 @@ final class WebExtensionManagerTests: XCTestCase {
     /// `unloadAllExtensions()` has something to capture for the lightweight reload tests.
     @MainActor
     @discardableResult
-    private func loadRealContext(identifier: String, into controller: WKWebExtensionController) async throws -> WKWebExtensionContext {
-        let dir = try makeTestExtensionDirectory()
+    private func loadRealContext(identifier: String,
+                                 into controller: WKWebExtensionController,
+                                 permissions: [String] = []) async throws -> WKWebExtensionContext {
+        let dir = try makeTestExtensionDirectory(permissions: permissions)
         let webExtension = try await WKWebExtension(resourceBaseURL: dir)
         let context = WKWebExtensionContext(for: webExtension)
         context.uniqueIdentifier = identifier
@@ -102,14 +110,16 @@ final class WebExtensionManagerTests: XCTestCase {
         return context
     }
 
-    private func makeTestExtensionDirectory() throws -> URL {
+    private func makeTestExtensionDirectory(permissions: [String] = []) throws -> URL {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent("ReloadTestExtension-\(UUID().uuidString)")
+        let permissionsJSON = permissions.map { "\"\($0)\"" }.joined(separator: ", ")
         let manifest = """
         {
             "manifest_version": 3,
             "name": "Reload Test Extension",
             "version": "1.0.0",
-            "description": "Minimal backgroundless test extension for reload unit tests"
+            "description": "Minimal backgroundless test extension for reload unit tests",
+            "permissions": [\(permissionsJSON)]
         }
         """
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -374,6 +384,81 @@ final class WebExtensionManagerTests: XCTestCase {
         // The lightweight reload was attempted, failed, and recovery used the full load path.
         XCTAssertTrue(webExtensionLoadingMock.reloadWebExtensionCalled)
         XCTAssertTrue(webExtensionLoadingMock.loadWebExtensionsCalled)
+    }
+
+    // MARK: - DNR Settle Window Tests
+
+    /// Loads a real DNR-permission context into the manager's controller and records its load
+    /// date via `loadInstalledExtensions()`, so the settle window can be exercised.
+    @MainActor
+    private func makeManagerWithLoadedExtension(identifier: String, permissions: [String]) async throws -> WebExtensionManager {
+        installedExtensionStoringMock.installedExtensions = [makeInstalledWebExtension(uniqueIdentifier: identifier)]
+        webExtensionLoadingMock.mockLoadResults = [
+            .success(WebExtensionLoadResult(identifier: identifier, filename: "extension.zip", displayName: nil, version: "1.0.0"))
+        ]
+        let manager = makeManager()
+        try await loadRealContext(identifier: identifier, into: manager.controller, permissions: permissions)
+        await manager.loadInstalledExtensions()
+        return manager
+    }
+
+    @MainActor
+    func testWhenDNRExtensionIsReloadedWithinSettleWindow_ThenReloadSleepsForRemainder() async throws {
+        let manager = try await makeManagerWithLoadedExtension(identifier: "dnr-extension",
+                                                               permissions: ["declarativeNetRequest"])
+
+        currentDate = currentDate.addingTimeInterval(1)
+        try await manager.reloadExtension(identifier: "dnr-extension")
+
+        XCTAssertEqual(recordedSleeps.count, 1)
+        XCTAssertEqual(recordedSleeps[0], 2.0, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testWhenDNRExtensionIsReloadedAfterSettleWindow_ThenReloadDoesNotSleep() async throws {
+        let manager = try await makeManagerWithLoadedExtension(identifier: "dnr-extension",
+                                                               permissions: ["declarativeNetRequest"])
+
+        currentDate = currentDate.addingTimeInterval(3.5)
+        try await manager.reloadExtension(identifier: "dnr-extension")
+
+        XCTAssertTrue(recordedSleeps.isEmpty)
+    }
+
+    @MainActor
+    func testWhenNonDNRExtensionIsReloadedWithinSettleWindow_ThenReloadDoesNotSleep() async throws {
+        let manager = try await makeManagerWithLoadedExtension(identifier: "plain-extension",
+                                                               permissions: [])
+
+        currentDate = currentDate.addingTimeInterval(1)
+        try await manager.reloadExtension(identifier: "plain-extension")
+
+        XCTAssertTrue(recordedSleeps.isEmpty)
+    }
+
+    @MainActor
+    func testWhenEmbeddedDNRExtensionIsUpgradedWithinSettleWindow_ThenSyncSleepsBeforeUninstall() async throws {
+        installedExtensionStoringMock.installedExtensions = [
+            InstalledWebExtension(uniqueIdentifier: "old-adblock",
+                                  filename: "content-blocker-extension-apple.zip",
+                                  name: nil,
+                                  version: "0.0.1",
+                                  embeddedType: .adBlockingExtension)
+        ]
+        webExtensionLoadingMock.mockLoadResults = [
+            .success(WebExtensionLoadResult(identifier: "old-adblock", filename: "content-blocker-extension-apple.zip", displayName: nil, version: "0.0.1"))
+        ]
+        let manager = makeManager()
+        try await loadRealContext(identifier: "old-adblock", into: manager.controller, permissions: ["declarativeNetRequest"])
+        await manager.loadInstalledExtensions()
+
+        currentDate = currentDate.addingTimeInterval(1)
+        await manager.syncEmbeddedExtensions(enabledTypes: [.adBlockingExtension])
+
+        XCTAssertEqual(recordedSleeps.count, 1)
+        XCTAssertEqual(recordedSleeps[0], 2.0, accuracy: 0.001)
+        XCTAssertFalse(installedExtensionStoringMock.installedExtensions.contains { $0.uniqueIdentifier == "old-adblock" },
+                       "upgrade should have uninstalled the old extension after the settle window")
     }
 
     // MARK: - Computed Properties Tests

--- a/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionManagerTests.swift
+++ b/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionManagerTests.swift
@@ -70,17 +70,20 @@ final class WebExtensionManagerTests: XCTestCase {
 
     @MainActor
     private func makeManager() -> WebExtensionManager {
-        WebExtensionManager(
+        let manager = WebExtensionManager(
             configuration: configurationMock,
             windowTabProvider: windowTabProviderMock,
             storageProvider: storageProvidingMock,
             installationStore: installedExtensionStoringMock,
             loader: webExtensionLoadingMock,
             eventsListener: eventsListenerMock,
-            lifecycleDelegate: lifecycleDelegateMock,
+            lifecycleDelegate: lifecycleDelegateMock
+        )
+        manager.unloadGuard = WebExtensionUnloadGuard(
             now: { [unowned self] in currentDate },
             sleeper: { [unowned self] in recordedSleeps.append($0) }
         )
+        return manager
     }
 
     private func makeInstalledWebExtension(uniqueIdentifier: String,
@@ -386,7 +389,10 @@ final class WebExtensionManagerTests: XCTestCase {
         XCTAssertTrue(webExtensionLoadingMock.loadWebExtensionsCalled)
     }
 
-    // MARK: - DNR Settle Window Tests
+    // MARK: - Unload Guard Integration Tests
+
+    // The guard's windowing logic is covered in WebExtensionUnloadGuardTests; these prove the
+    // manager's unload/reload paths actually consult the guard and record loads with it.
 
     /// Loads a real DNR-permission context into the manager's controller and records its load
     /// date via `loadInstalledExtensions()`, so the settle window can be exercised.
@@ -412,28 +418,6 @@ final class WebExtensionManagerTests: XCTestCase {
 
         XCTAssertEqual(recordedSleeps.count, 1)
         XCTAssertEqual(recordedSleeps[0], 2.0, accuracy: 0.001)
-    }
-
-    @MainActor
-    func testWhenDNRExtensionIsReloadedAfterSettleWindow_ThenReloadDoesNotSleep() async throws {
-        let manager = try await makeManagerWithLoadedExtension(identifier: "dnr-extension",
-                                                               permissions: ["declarativeNetRequest"])
-
-        currentDate = currentDate.addingTimeInterval(3.5)
-        try await manager.reloadExtension(identifier: "dnr-extension")
-
-        XCTAssertTrue(recordedSleeps.isEmpty)
-    }
-
-    @MainActor
-    func testWhenNonDNRExtensionIsReloadedWithinSettleWindow_ThenReloadDoesNotSleep() async throws {
-        let manager = try await makeManagerWithLoadedExtension(identifier: "plain-extension",
-                                                               permissions: [])
-
-        currentDate = currentDate.addingTimeInterval(1)
-        try await manager.reloadExtension(identifier: "plain-extension")
-
-        XCTAssertTrue(recordedSleeps.isEmpty)
     }
 
     @MainActor

--- a/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionManagerTests.swift
+++ b/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionManagerTests.swift
@@ -420,8 +420,10 @@ final class WebExtensionManagerTests: XCTestCase {
         XCTAssertEqual(recordedSleeps[0], 2.0, accuracy: 0.001)
     }
 
+    /// Loads a real DNR context for the embedded ad blocker and records its load date, so the
+    /// settle window can be exercised through `syncEmbeddedExtensions()`.
     @MainActor
-    func testWhenEmbeddedDNRExtensionIsUpgradedWithinSettleWindow_ThenSyncSleepsBeforeUninstall() async throws {
+    private func makeManagerWithLoadedAdBlocker() async throws -> WebExtensionManager {
         installedExtensionStoringMock.installedExtensions = [
             InstalledWebExtension(uniqueIdentifier: "old-adblock",
                                   filename: "content-blocker-extension-apple.zip",
@@ -435,6 +437,28 @@ final class WebExtensionManagerTests: XCTestCase {
         let manager = makeManager()
         try await loadRealContext(identifier: "old-adblock", into: manager.controller, permissions: ["declarativeNetRequest"])
         await manager.loadInstalledExtensions()
+        return manager
+    }
+
+    @MainActor
+    func testWhenDisabledDNRExtensionIsUninstalledWithinSettleWindow_ThenSyncSleepsFirst() async throws {
+        let manager = try await makeManagerWithLoadedAdBlocker()
+
+        currentDate = currentDate.addingTimeInterval(1)
+        await manager.syncEmbeddedExtensions(enabledTypes: [])
+
+        XCTAssertEqual(recordedSleeps.count, 1)
+        XCTAssertEqual(recordedSleeps[0], 2.0, accuracy: 0.001)
+        XCTAssertFalse(installedExtensionStoringMock.installedExtensions.contains { $0.uniqueIdentifier == "old-adblock" },
+                       "disabling should have uninstalled the extension after the settle window")
+    }
+
+    // The upgrade branch resolves the bundled extension through `Bundle.module`, which traps on iOS.
+    // Gated for the same reason as DarkReaderBundlePatchTests.
+#if os(macOS)
+    @MainActor
+    func testWhenEmbeddedDNRExtensionIsUpgradedWithinSettleWindow_ThenSyncSleepsBeforeUninstall() async throws {
+        let manager = try await makeManagerWithLoadedAdBlocker()
 
         currentDate = currentDate.addingTimeInterval(1)
         await manager.syncEmbeddedExtensions(enabledTypes: [.adBlockingExtension])
@@ -444,6 +468,7 @@ final class WebExtensionManagerTests: XCTestCase {
         XCTAssertFalse(installedExtensionStoringMock.installedExtensions.contains { $0.uniqueIdentifier == "old-adblock" },
                        "upgrade should have uninstalled the old extension after the settle window")
     }
+#endif
 
     // MARK: - Computed Properties Tests
 

--- a/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionManagerTests.swift
+++ b/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionManagerTests.swift
@@ -32,6 +32,9 @@ final class WebExtensionManagerTests: XCTestCase {
     var configurationMock: WebExtensionConfigurationProvidingMock!
     private var createdTestExtensionDirs: [URL] = []
     private var recordedSleeps: [TimeInterval] = []
+    /// Whether the loader had already been asked to unload when each sleep began, so the tests can
+    /// tell a wait that precedes the unload from one that follows it.
+    private var unloadCalledAtSleepTime: [Bool] = []
     private var currentDate = Date()
 
     @MainActor
@@ -46,6 +49,7 @@ final class WebExtensionManagerTests: XCTestCase {
         lifecycleDelegateMock = WebExtensionLifecycleDelegateMock()
         configurationMock = WebExtensionConfigurationProvidingMock()
         recordedSleeps = []
+        unloadCalledAtSleepTime = []
         currentDate = Date()
     }
 
@@ -81,7 +85,10 @@ final class WebExtensionManagerTests: XCTestCase {
         )
         manager.unloadGuard = WebExtensionUnloadGuard(
             now: { [unowned self] in currentDate },
-            sleeper: { [unowned self] in recordedSleeps.append($0) }
+            sleeper: { [unowned self] in
+                recordedSleeps.append($0)
+                unloadCalledAtSleepTime.append(webExtensionLoadingMock.unloadExtensionCalled)
+            }
         )
         return manager
     }
@@ -89,12 +96,14 @@ final class WebExtensionManagerTests: XCTestCase {
     private func makeInstalledWebExtension(uniqueIdentifier: String,
                                            filename: String = "extension.zip",
                                            name: String? = nil,
-                                           version: String? = nil) -> InstalledWebExtension {
+                                           version: String? = nil,
+                                           embeddedType: DuckDuckGoWebExtensionType? = nil) -> InstalledWebExtension {
         InstalledWebExtension(
             uniqueIdentifier: uniqueIdentifier,
             filename: filename,
             name: name,
-            version: version
+            version: version,
+            embeddedType: embeddedType
         )
     }
 
@@ -394,50 +403,50 @@ final class WebExtensionManagerTests: XCTestCase {
     // The guard's windowing logic is covered in WebExtensionUnloadGuardTests; these prove the
     // manager's unload/reload paths actually consult the guard and record loads with it.
 
-    /// Loads a real DNR-permission context into the manager's controller and records its load
-    /// date via `loadInstalledExtensions()`, so the settle window can be exercised.
+    /// Loads a real DNR-permission context into the manager's controller and records its load date
+    /// via `loadInstalledExtensions()`, so the settle window can be exercised.
     @MainActor
-    private func makeManagerWithLoadedExtension(identifier: String, permissions: [String]) async throws -> WebExtensionManager {
-        installedExtensionStoringMock.installedExtensions = [makeInstalledWebExtension(uniqueIdentifier: identifier)]
+    private func makeManagerWithLoadedExtension(identifier: String,
+                                                filename: String = "extension.zip",
+                                                embeddedType: DuckDuckGoWebExtensionType? = nil) async throws -> WebExtensionManager {
+        installedExtensionStoringMock.installedExtensions = [
+            makeInstalledWebExtension(uniqueIdentifier: identifier, filename: filename, version: "0.0.1", embeddedType: embeddedType)
+        ]
         webExtensionLoadingMock.mockLoadResults = [
-            .success(WebExtensionLoadResult(identifier: identifier, filename: "extension.zip", displayName: nil, version: "1.0.0"))
+            .success(WebExtensionLoadResult(identifier: identifier, filename: filename, displayName: nil, version: "0.0.1"))
         ]
         let manager = makeManager()
-        try await loadRealContext(identifier: identifier, into: manager.controller, permissions: permissions)
+        try await loadRealContext(identifier: identifier, into: manager.controller, permissions: ["declarativeNetRequest"])
         await manager.loadInstalledExtensions()
         return manager
+    }
+
+    /// Loads the embedded ad blocker, the only bundled extension that requests declarativeNetRequest.
+    @MainActor
+    private func makeManagerWithLoadedAdBlocker() async throws -> WebExtensionManager {
+        try await makeManagerWithLoadedExtension(identifier: "old-adblock",
+                                                 filename: "content-blocker-extension-apple.zip",
+                                                 embeddedType: .adBlockingExtension)
+    }
+
+    /// The window is only useful if it elapses before the unload, so every path asserts both.
+    private func assertSleptForRemainderBeforeUnloading(file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(recordedSleeps.count, 1, "expected exactly one settle wait", file: file, line: line)
+        XCTAssertEqual(recordedSleeps.first ?? 0, 2.0, accuracy: 0.001, file: file, line: line)
+        XCTAssertEqual(unloadCalledAtSleepTime, [false],
+                       "the wait must happen before the unload, not after it", file: file, line: line)
+        XCTAssertTrue(webExtensionLoadingMock.unloadExtensionCalled,
+                      "the unload should still happen once the window elapses", file: file, line: line)
     }
 
     @MainActor
     func testWhenDNRExtensionIsReloadedWithinSettleWindow_ThenReloadSleepsForRemainder() async throws {
-        let manager = try await makeManagerWithLoadedExtension(identifier: "dnr-extension",
-                                                               permissions: ["declarativeNetRequest"])
+        let manager = try await makeManagerWithLoadedExtension(identifier: "dnr-extension")
 
         currentDate = currentDate.addingTimeInterval(1)
         try await manager.reloadExtension(identifier: "dnr-extension")
 
-        XCTAssertEqual(recordedSleeps.count, 1)
-        XCTAssertEqual(recordedSleeps[0], 2.0, accuracy: 0.001)
-    }
-
-    /// Loads a real DNR context for the embedded ad blocker and records its load date, so the
-    /// settle window can be exercised through `syncEmbeddedExtensions()`.
-    @MainActor
-    private func makeManagerWithLoadedAdBlocker() async throws -> WebExtensionManager {
-        installedExtensionStoringMock.installedExtensions = [
-            InstalledWebExtension(uniqueIdentifier: "old-adblock",
-                                  filename: "content-blocker-extension-apple.zip",
-                                  name: nil,
-                                  version: "0.0.1",
-                                  embeddedType: .adBlockingExtension)
-        ]
-        webExtensionLoadingMock.mockLoadResults = [
-            .success(WebExtensionLoadResult(identifier: "old-adblock", filename: "content-blocker-extension-apple.zip", displayName: nil, version: "0.0.1"))
-        ]
-        let manager = makeManager()
-        try await loadRealContext(identifier: "old-adblock", into: manager.controller, permissions: ["declarativeNetRequest"])
-        await manager.loadInstalledExtensions()
-        return manager
+        assertSleptForRemainderBeforeUnloading()
     }
 
     @MainActor
@@ -447,8 +456,7 @@ final class WebExtensionManagerTests: XCTestCase {
         currentDate = currentDate.addingTimeInterval(1)
         await manager.syncEmbeddedExtensions(enabledTypes: [])
 
-        XCTAssertEqual(recordedSleeps.count, 1)
-        XCTAssertEqual(recordedSleeps[0], 2.0, accuracy: 0.001)
+        assertSleptForRemainderBeforeUnloading()
         XCTAssertFalse(installedExtensionStoringMock.installedExtensions.contains { $0.uniqueIdentifier == "old-adblock" },
                        "disabling should have uninstalled the extension after the settle window")
     }
@@ -463,8 +471,7 @@ final class WebExtensionManagerTests: XCTestCase {
         currentDate = currentDate.addingTimeInterval(1)
         await manager.syncEmbeddedExtensions(enabledTypes: [.adBlockingExtension])
 
-        XCTAssertEqual(recordedSleeps.count, 1)
-        XCTAssertEqual(recordedSleeps[0], 2.0, accuracy: 0.001)
+        assertSleptForRemainderBeforeUnloading()
         XCTAssertFalse(installedExtensionStoringMock.installedExtensions.contains { $0.uniqueIdentifier == "old-adblock" },
                        "upgrade should have uninstalled the old extension after the settle window")
     }

--- a/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionUnloadGuardTests.swift
+++ b/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionUnloadGuardTests.swift
@@ -156,14 +156,15 @@ final class WebExtensionUnloadGuardTests: XCTestCase {
         let context = try await makeContext(identifier: "dnr-extension", permissions: ["declarativeNetRequest"])
         unloadGuard.recordLoad(of: "dnr-extension")
 
-        let task = Task { @MainActor in
+        let task = Task { @MainActor () -> (elapsed: TimeInterval, wasCancelled: Bool) in
             let start = Date()
             await unloadGuard.awaitSettled(context)
-            return Date().timeIntervalSince(start)
+            return (Date().timeIntervalSince(start), Task.isCancelled)
         }
         task.cancel()
 
-        let elapsed = await task.value
-        XCTAssertGreaterThan(elapsed, settleWindow * 0.8)
+        let result = await task.value
+        XCTAssertTrue(result.wasCancelled, "the task must really be cancelled, or this proves nothing")
+        XCTAssertGreaterThan(result.elapsed, settleWindow * 0.8)
     }
 }

--- a/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionUnloadGuardTests.swift
+++ b/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionUnloadGuardTests.swift
@@ -1,0 +1,149 @@
+//
+//  WebExtensionUnloadGuardTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import WebKit
+@testable import WebExtensions
+
+@available(macOS 15.4, iOS 18.4, *)
+final class WebExtensionUnloadGuardTests: XCTestCase {
+
+    private var recordedSleeps: [TimeInterval] = []
+    private var currentDate = Date()
+    private var createdTestExtensionDirs: [URL] = []
+
+    override func setUp() {
+        super.setUp()
+        recordedSleeps = []
+        currentDate = Date()
+    }
+
+    override func tearDown() {
+        for dir in createdTestExtensionDirs {
+            try? FileManager.default.removeItem(at: dir)
+        }
+        createdTestExtensionDirs.removeAll()
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func makeGuard(settleWindow: TimeInterval = 3) -> WebExtensionUnloadGuard {
+        WebExtensionUnloadGuard(
+            settleWindow: settleWindow,
+            now: { [unowned self] in currentDate },
+            sleeper: { [unowned self] in recordedSleeps.append($0) }
+        )
+    }
+
+    @MainActor
+    private func makeContext(identifier: String, permissions: [String]) async throws -> WKWebExtensionContext {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("UnloadGuardTestExtension-\(UUID().uuidString)")
+        let permissionsJSON = permissions.map { "\"\($0)\"" }.joined(separator: ", ")
+        let manifest = """
+        {
+            "manifest_version": 3,
+            "name": "Unload Guard Test Extension",
+            "version": "1.0.0",
+            "description": "Minimal backgroundless test extension for unload guard unit tests",
+            "permissions": [\(permissionsJSON)]
+        }
+        """
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try manifest.write(to: dir.appendingPathComponent("manifest.json"), atomically: true, encoding: .utf8)
+        createdTestExtensionDirs.append(dir)
+
+        let webExtension = try await WKWebExtension(resourceBaseURL: dir)
+        let context = WKWebExtensionContext(for: webExtension)
+        context.uniqueIdentifier = identifier
+        return context
+    }
+
+    // MARK: - Tests
+
+    @MainActor
+    func testWhenDNRExtensionWasLoadedWithinWindow_ThenAwaitSettledSleepsForRemainder() async throws {
+        let unloadGuard = makeGuard()
+        let context = try await makeContext(identifier: "dnr-extension", permissions: ["declarativeNetRequest"])
+        unloadGuard.recordLoad(of: "dnr-extension")
+
+        currentDate = currentDate.addingTimeInterval(1)
+        await unloadGuard.awaitSettled(context)
+
+        XCTAssertEqual(recordedSleeps.count, 1)
+        XCTAssertEqual(recordedSleeps[0], 2.0, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testWhenDNRExtensionWasLoadedBeyondWindow_ThenAwaitSettledDoesNotSleep() async throws {
+        let unloadGuard = makeGuard()
+        let context = try await makeContext(identifier: "dnr-extension", permissions: ["declarativeNetRequest"])
+        unloadGuard.recordLoad(of: "dnr-extension")
+
+        currentDate = currentDate.addingTimeInterval(3.5)
+        await unloadGuard.awaitSettled(context)
+
+        XCTAssertTrue(recordedSleeps.isEmpty)
+    }
+
+    @MainActor
+    func testWhenExtensionDoesNotRequestDNR_ThenAwaitSettledDoesNotSleep() async throws {
+        let unloadGuard = makeGuard()
+        let context = try await makeContext(identifier: "plain-extension", permissions: [])
+        unloadGuard.recordLoad(of: "plain-extension")
+
+        currentDate = currentDate.addingTimeInterval(1)
+        await unloadGuard.awaitSettled(context)
+
+        XCTAssertTrue(recordedSleeps.isEmpty)
+    }
+
+    @MainActor
+    func testWhenExtensionRequestsDNRWithHostAccess_ThenAwaitSettledSleeps() async throws {
+        let unloadGuard = makeGuard()
+        let context = try await makeContext(identifier: "dnr-extension", permissions: ["declarativeNetRequestWithHostAccess"])
+        unloadGuard.recordLoad(of: "dnr-extension")
+
+        currentDate = currentDate.addingTimeInterval(1)
+        await unloadGuard.awaitSettled(context)
+
+        XCTAssertEqual(recordedSleeps.count, 1)
+        XCTAssertEqual(recordedSleeps[0], 2.0, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testWhenNoLoadWasRecorded_ThenAwaitSettledDoesNotSleep() async throws {
+        let unloadGuard = makeGuard()
+        let context = try await makeContext(identifier: "dnr-extension", permissions: ["declarativeNetRequest"])
+
+        await unloadGuard.awaitSettled(context)
+
+        XCTAssertTrue(recordedSleeps.isEmpty)
+    }
+
+    @MainActor
+    func testWhenContextIsNil_ThenAwaitSettledDoesNotSleep() async {
+        let unloadGuard = makeGuard()
+        unloadGuard.recordLoad(of: "dnr-extension")
+
+        await unloadGuard.awaitSettled(nil)
+
+        XCTAssertTrue(recordedSleeps.isEmpty)
+    }
+}

--- a/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionUnloadGuardTests.swift
+++ b/SharedPackages/WebExtensions/Tests/WebExtensionsTests/WebExtensionUnloadGuardTests.swift
@@ -146,4 +146,24 @@ final class WebExtensionUnloadGuardTests: XCTestCase {
 
         XCTAssertTrue(recordedSleeps.isEmpty)
     }
+
+    /// Uses the real sleeper rather than the recording one: teardown cancels the tasks that unload,
+    /// so a cancellable wait would skip the window exactly when it is needed.
+    @MainActor
+    func testWhenTaskIsCancelled_ThenAwaitSettledStillWaitsOutTheWindow() async throws {
+        let settleWindow: TimeInterval = 0.3
+        let unloadGuard = WebExtensionUnloadGuard(settleWindow: settleWindow)
+        let context = try await makeContext(identifier: "dnr-extension", permissions: ["declarativeNetRequest"])
+        unloadGuard.recordLoad(of: "dnr-extension")
+
+        let task = Task { @MainActor in
+            let start = Date()
+            await unloadGuard.awaitSettled(context)
+            return Date().timeIntervalSince(start)
+        }
+        task.cancel()
+
+        let elapsed = await task.value
+        XCTAssertGreaterThan(elapsed, settleWindow * 0.8)
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1216849418420274?focus=true

### Description

Unloading a web extension while WebKit is still reading its declarativeNetRequest rules crashes the app. The bug is in WebKit ([305585](https://bugs.webkit.org/show_bug.cgi?id=305585)), fixed upstream but not in any shipping macOS 26. It also causes the macOS performance-test flakiness.

So an extension that uses declarativeNetRequest now stays loaded for 3 seconds before anything unloads or reloads it, double the longest load-to-crash gap in the crash reports. Three paths on launch would break that rule, and now wait instead:

- a scriptlet update, which reloads the extension
- an embedded upgrade, which replaces it
- the launch sync, which removes it when its type is disabled

The feature-flag handler and the fire button are synchronous, so they still unload immediately.

The wait ignores cancellation on purpose: teardown is both what cancels and when extensions unload. It suspends rather than blocking, so the UI stays responsive.

Remove this once the minimum supported macOS ships the WebKit fix.

### Testing Steps

1. Open Debug → Web Extensions → Uninstall all extensions.
2. Open Debug → Web Extensions → Clear Cached Scriptlets.
3. Run `log stream --level debug --predicate 'subsystem == "WebExtensions"'` in Terminal.
4. Relaunch the app.
5. Watch the stream for a few seconds.
   It prints `📦 Installing embedded extension`, then `⏸️ Delaying unload ...`, then `✅ Reloaded extension`, and the app does not crash.
6. Visit an ad-heavy page.
   Ads are blocked, so the extension still works after the delayed reload.

The embedded-upgrade path needs a bundled version bump, so unit tests cover it with an injected clock instead.

### Impact

Medium: a regression would delay or disrupt scriptlet updates and embedded upgrades.

#### What could go wrong?

If WebKit needs more than 3 seconds, the crash still happens. Nothing tells us when it finishes, so 3 seconds is an estimate that narrows the window rather than closing it.

A scriptlet update that arrives within 3 seconds of its extension loading applies up to 3 seconds later. Nothing else is delayed.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
