### PR TITLE
iOS: Update 7.230.0 release notes

### DIFF
--- a/iOS/fastlane/metadata/default/release_notes.txt
+++ b/iOS/fastlane/metadata/default/release_notes.txt
@@ -1,2 +1,2 @@
-• On iPad, if you have the Duck.ai address bar toggle enabled, you can now switch models directly from the address bar. Simply tap the model name to open the model picker menu.
-• This update includes various improvements and fixes a few bugs.
+• The new “Copy Clean Link” option lets you copy a version of the page URL without unnecessary parameters added by the site. Find “Copy Clean Link” in the browser menu.
+• This update includes various other improvements and bug fixes, including a few address bar usability improvements.


### PR DESCRIPTION
### Description
Update the iOS 7.230.0 App Store release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to App Store copy with no app code or runtime behavior impact.
> 
> **Overview**
> Updates **default App Store release notes** for iOS **7.230.0** in `release_notes.txt`.
> 
> The user-facing bullets now lead with **Copy Clean Link** (strip tracking/extra URL parameters via the browser menu) instead of the previous iPad Duck.ai address-bar model-picker note. The closing bullet still mentions general improvements and bug fixes, and now explicitly calls out **address bar usability** improvements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06fbd1aae057c343c0ce1f1797dc85a2fe7fc02e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->