### PR TITLE
Remove launch-path profile state reconcile from DBP provider (7.230.0 hotfix)

### DIFF
--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManagerProvider.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManagerProvider.swift
@@ -105,12 +105,6 @@ public class DataBrokerProtectionIOSManagerProvider {
                                                         optOutRetryErrorFeatureFlagger: featureFlagger)
 
         let database = DataBrokerProtectionDatabase(fakeBrokerFlag: fakeBroker, pixelHandler: sharedPixelsHandler, vault: vault, localBrokerService: localBrokerService)
-        do {
-            profileStateManager.reconcileProfileState(hasSavedProfile: try database.fetchProfile() != nil)
-        } catch {
-            profileStateManager.recordProfileStateUnknown()
-            Logger.dataBrokerProtection.error("Error reconciling profile state, error: \(error.localizedDescription, privacy: .public)")
-        }
 
         let operationQueue = OperationQueue()
         let jobProvider = BrokerProfileJobProvider()


### PR DESCRIPTION
Task/Issue URL: TBD (7.229.0 launch-time regression / SQLCipher crash triage)
CC:

### Description

7.229.0 introduced a profile-state reconcile that reads the PIR secure vault (SQLCipher read + keychain L2 decrypt) synchronously on the main thread during launch, for all users with `pirRollout` enabled (~100%). This removes that launch-path read, returning launch to the 7.228 baseline. The cache writers (profile save/delete) remain, and all cache consumers (RMF matcher, Settings) already handle the `.unknown` state by falling back to pre-7.229 behavior.

### Testing Steps

1. Launch the app with PIR enabled → no DBP vault query on the main thread during launch (Instruments / os_log).
2. As an existing PIR user: Settings → PIR row shows correct status (cached state from 7.229 persists).
3. Open PIR dashboard, run a scan, delete profile data → cache updates via save/delete writers.

### Impact

Low

#### What could go wrong?

- Users updating directly from ≤7.228 keep `.unknown` state → RMF falls back to full vault validation on refresh (exact pre-7.229 behavior) and Settings shows no status indicator → by design; heals on first profile save/delete or on 7.231's deferred-init reconcile.
- ⚠️ **Merge-back hazard**: merging this branch into main auto-transplants the deletion into `makeVaultResources` (where #5734 moved the reconcile, load-bearing for deferred vault init) **with no conflict**. Land #6012 (helper extraction on main) first — it turns that silent transplant into a loud merge conflict. When the first post-hotfix merge-back conflicts on this file, resolve by keeping main's side.
