### PR TITLE
Extract PIR profile state reconcile into a helper (merge guard for 7.230.0 hotfix)

### DIFF
--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManagerProvider.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManagerProvider.swift
@@ -178,12 +178,7 @@ public class DataBrokerProtectionIOSManagerProvider {
                                                         optOutRetryErrorFeatureFlagger: featureFlagger)
 
         let database = DataBrokerProtectionDatabase(fakeBrokerFlag: fakeBroker, pixelHandler: sharedPixelsHandler, vault: vault, localBrokerService: localBrokerService)
-        do {
-            profileStateManager.reconcileProfileState(hasSavedProfile: try database.fetchProfile() != nil)
-        } catch {
-            profileStateManager.recordProfileStateUnknown()
-            Logger.dataBrokerProtection.error("Error reconciling profile state, error: \(error.localizedDescription, privacy: .public)")
-        }
+        reconcileProfileState(from: database, using: profileStateManager)
 
         let operationQueue = OperationQueue()
         let jobProvider = BrokerProfileJobProvider()
@@ -245,5 +240,15 @@ public class DataBrokerProtectionIOSManagerProvider {
             },
             engagementPixelsRepository: DataBrokerProtectionEngagementPixelsUserDefaults(userDefaults: .dbp)
         )
+    }
+
+    /// Seeds/heals the cached profile state whenever vault resources are materialized.
+    private static func reconcileProfileState(from database: DataBrokerProtectionRepository, using profileStateManager: DBPProfileStateManaging) {
+        do {
+            profileStateManager.reconcileProfileState(hasSavedProfile: try database.fetchProfile() != nil)
+        } catch {
+            profileStateManager.recordProfileStateUnknown()
+            Logger.dataBrokerProtection.error("Error reconciling profile state, error: \(error.localizedDescription, privacy: .public)")
+        }
     }
 }


### PR DESCRIPTION
Task/Issue URL: TBD (same as #6011)
CC:

### Description

Pure refactor: extracts the profile-state reconcile in `makeVaultResources` into a private helper. No behavior change.

This doubles as a merge guard for the 7.230.0 hotfix (#6011): that PR deletes the reconcile block on the release branch, and because #5734 moved the identical block text into `makeVaultResources` on main, the automated release→main merge-back **silently deletes the reconcile from the deferred vault init flow with zero conflicts** (verified with `git merge-tree`). The deferred flow depends on it to seed/heal the cached profile state that gates vault-init skipping. With this extraction the block text no longer matches, so that merge **conflicts loudly** on this file instead — simulation-verified.

### Testing Steps

1. CI — no behavior change; reconcile still runs when vault resources are materialized.

### Impact

None (mechanical refactor)

#### What could go wrong?

- When the first post-#6011 release-branch merge-back to main runs, the bot's merge will fail with a content conflict on this file **by design**. Resolve by keeping main's side (the `reconcileProfileState(from:using:)` helper call). This must land on main before that merge-back happens.
