### PR TITLE
macOS: add Prompt Bar duck.ai menu bar icon

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -4654,6 +4654,10 @@
 		FB07BAD00000000000000025 /* PromptBarPreferencesPersistorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD00000000000000007 /* PromptBarPreferencesPersistorTests.swift */; };
 		FB07BAD00000000000000023 /* PromptBarPreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD00000000000000008 /* PromptBarPreferencesTests.swift */; };
 		FB07BAD00000000000000026 /* PromptBarPreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD00000000000000008 /* PromptBarPreferencesTests.swift */; };
+		FB07BAD00000000000000027 /* PromptBarMenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD00000000000000009 /* PromptBarMenuBarController.swift */; };
+		FB07BAD00000000000000028 /* PromptBarMenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD00000000000000009 /* PromptBarMenuBarController.swift */; };
+		FB07BAD00000000000000029 /* PromptBarMenuBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD00000000000000010 /* PromptBarMenuBarControllerTests.swift */; };
+		FB07BAD00000000000000034 /* PromptBarMenuBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD00000000000000010 /* PromptBarMenuBarControllerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -7130,6 +7134,8 @@
 		FB07BAD00000000000000006 /* PromptBarShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarShortcutTests.swift; sourceTree = "<group>"; };
 		FB07BAD00000000000000007 /* PromptBarPreferencesPersistorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPreferencesPersistorTests.swift; sourceTree = "<group>"; };
 		FB07BAD00000000000000008 /* PromptBarPreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPreferencesTests.swift; sourceTree = "<group>"; };
+		FB07BAD00000000000000009 /* PromptBarMenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarMenuBarController.swift; sourceTree = "<group>"; };
+		FB07BAD00000000000000010 /* PromptBarMenuBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarMenuBarControllerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -13349,6 +13355,7 @@
 			children = (
 				FB07BAD00000000000000005 /* PromptBarPreferencesView.swift */,
 				FB07BAD00000000000000004 /* PromptBarShortcutRecorderView.swift */,
+				FB07BAD00000000000000009 /* PromptBarMenuBarController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -13359,6 +13366,7 @@
 				FB07BAD00000000000000007 /* PromptBarPreferencesPersistorTests.swift */,
 				FB07BAD00000000000000008 /* PromptBarPreferencesTests.swift */,
 				FB07BAD00000000000000006 /* PromptBarShortcutTests.swift */,
+				FB07BAD00000000000000010 /* PromptBarMenuBarControllerTests.swift */,
 			);
 			path = PromptBar;
 			sourceTree = "<group>";
@@ -15606,6 +15614,7 @@
 				FB07BAD00000000000000018 /* PromptBarPreferences.swift in Sources */,
 				FB07BAD00000000000000019 /* PromptBarShortcutRecorderView.swift in Sources */,
 				FB07BAD00000000000000020 /* PromptBarPreferencesView.swift in Sources */,
+				FB07BAD00000000000000028 /* PromptBarMenuBarController.swift in Sources */,
 				84537A032C998C28008723BC /* FireWindowSession.swift in Sources */,
 				BB470EBC2C5A66D6002EE91D /* BookmarkManagementDetailViewModel.swift in Sources */,
 				3706FB65293F65D500E42796 /* PrivacyDashboardWebView.swift in Sources */,
@@ -16892,6 +16901,7 @@
 				FB07BAD00000000000000024 /* PromptBarShortcutTests.swift in Sources */,
 				FB07BAD00000000000000025 /* PromptBarPreferencesPersistorTests.swift in Sources */,
 				FB07BAD00000000000000026 /* PromptBarPreferencesTests.swift in Sources */,
+				FB07BAD00000000000000034 /* PromptBarMenuBarControllerTests.swift in Sources */,
 				3706FE7A293F661700E42796 /* FireDialogViewModelTests.swift in Sources */,
 				7B09CBAA2BA4BE8200CF245B /* NetworkProtectionPixelEventTests.swift in Sources */,
 				3706FE7B293F661700E42796 /* HistoryStoringMock.swift in Sources */,
@@ -17762,6 +17772,7 @@
 				FB07BAD00000000000000013 /* PromptBarPreferences.swift in Sources */,
 				FB07BAD00000000000000014 /* PromptBarShortcutRecorderView.swift in Sources */,
 				FB07BAD00000000000000015 /* PromptBarPreferencesView.swift in Sources */,
+				FB07BAD00000000000000027 /* PromptBarMenuBarController.swift in Sources */,
 				4B92928C26670D1700AD2C21 /* OutlineSeparatorViewCell.swift in Sources */,
 				8426108D2C9811F30070D5F9 /* KeyEquivalentView.swift in Sources */,
 				CC442CAD2F6C45B8002E8175 /* DockPreferencesModel.swift in Sources */,
@@ -19245,6 +19256,7 @@
 				FB07BAD00000000000000021 /* PromptBarShortcutTests.swift in Sources */,
 				FB07BAD00000000000000022 /* PromptBarPreferencesPersistorTests.swift in Sources */,
 				FB07BAD00000000000000023 /* PromptBarPreferencesTests.swift in Sources */,
+				FB07BAD00000000000000029 /* PromptBarMenuBarControllerTests.swift in Sources */,
 				EEF53E182950CED5002D78F4 /* JSAlertViewModelTests.swift in Sources */,
 				376C4DB928A1A48A00CC0F5B /* FireDialogViewModelTests.swift in Sources */,
 				AAEC74B62642CC6A00C2EFBC /* HistoryStoringMock.swift in Sources */,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -837,7 +837,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         contentScopePreferences = ContentScopePreferences(windowControllersManager: windowControllersManager)
         webTrackingProtectionPreferences = WebTrackingProtectionPreferences(persistor: WebTrackingProtectionPreferencesUserDefaultsPersistor(), windowControllersManager: windowControllersManager)
         cookiePopupProtectionPreferences = CookiePopupProtectionPreferences(persistor: CookiePopupProtectionPreferencesUserDefaultsPersistor(), windowControllersManager: windowControllersManager)
-        promptBarPreferences = PromptBarPreferences(persistor: PromptBarPreferencesUserDefaultsPersistor(keyValueStore: keyValueStore))
+        promptBarPreferences = PromptBarPreferences(persistor: PromptBarPreferencesUserDefaultsPersistor(keyValueStore: keyValueStore),
+                                                    aiChatMenuConfiguration: aiChatMenuConfiguration)
         aiChatPreferences = AIChatPreferences(
             storage: DefaultAIChatPreferencesStorage(),
             aiChatMenuConfiguration: aiChatMenuConfiguration,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -2441,14 +2441,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             promptBarMenuBarController = PromptBarMenuBarController()
         }
 
-        promptBarMenuBarCancellable = promptBarPreferences.$isMenuBarIconVisible
+        // Applied synchronously: a deferred first update lets the icon appear at
+        // launch before a hide lands.
+        promptBarMenuBarCancellable = promptBarPreferences.isMenuBarIconEffectivelyVisiblePublisher
             .sink { [weak self] isVisible in
-                Task { @MainActor in
-                    if isVisible {
-                        self?.promptBarMenuBarController?.show()
-                    } else {
-                        self?.promptBarMenuBarController?.hide()
-                    }
+                if isVisible {
+                    self?.promptBarMenuBarController?.show()
+                } else {
+                    self?.promptBarMenuBarController?.hide()
                 }
             }
     }

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -2441,8 +2441,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             promptBarMenuBarController = PromptBarMenuBarController()
         }
 
-        // `@Published` replays the current value on subscription, so this both
-        // applies the initial visibility and reacts to later toggle changes.
         promptBarMenuBarCancellable = promptBarPreferences.$isMenuBarIconVisible
             .sink { [weak self] isVisible in
                 Task { @MainActor in

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -124,6 +124,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private(set) var autofillPixelReporter: AutofillPixelReporter?
     private var passwordsStatusBarMenu: PasswordsStatusBarMenu?
     private var passwordsMenuBarCancellable: AnyCancellable?
+    private var promptBarMenuBarController: PromptBarMenuBarController?
+    private var promptBarMenuBarCancellable: AnyCancellable?
 
     private(set) var syncDataProviders: SyncDataProvidersSource?
     private(set) var syncService: DDGSyncing?
@@ -1495,6 +1497,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         setUpAutofillPixelReporter()
         setUpPasswordsMenuBarVisibility()
+        setUpPromptBarMenuBarVisibility()
 
         remoteMessagingClient?.startRefreshingRemoteMessages()
 
@@ -2420,6 +2423,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         self?.passwordsStatusBarMenu?.show()
                     } else {
                         self?.passwordsStatusBarMenu?.hide()
+                    }
+                }
+            }
+    }
+
+    @MainActor
+    private func setUpPromptBarMenuBarVisibility() {
+        guard featureFlagger.isFeatureOn(.macosPromptBar) else {
+            promptBarMenuBarController?.hide()
+            promptBarMenuBarController = nil
+            promptBarMenuBarCancellable = nil
+            return
+        }
+
+        if promptBarMenuBarController == nil {
+            promptBarMenuBarController = PromptBarMenuBarController()
+        }
+
+        // `@Published` replays the current value on subscription, so this both
+        // applies the initial visibility and reacts to later toggle changes.
+        promptBarMenuBarCancellable = promptBarPreferences.$isMenuBarIconVisible
+            .sink { [weak self] isVisible in
+                Task { @MainActor in
+                    if isVisible {
+                        self?.promptBarMenuBarController?.show()
+                    } else {
+                        self?.promptBarMenuBarController?.hide()
                     }
                 }
             }

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPreferences.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPreferences.swift
@@ -36,6 +36,19 @@ final class PromptBarPreferences: ObservableObject {
         didSet { persistor.isMenuBarIconVisible = isMenuBarIconVisible }
     }
 
+    /// The icon is a shortcut entry point, so it stays hidden while the shortcut
+    /// is off. `isMenuBarIconVisible` keeps its stored value so it can be restored.
+    var isMenuBarIconEffectivelyVisible: Bool {
+        isMenuBarIconVisible && isKeyboardShortcutEnabled
+    }
+
+    var isMenuBarIconEffectivelyVisiblePublisher: AnyPublisher<Bool, Never> {
+        Publishers.CombineLatest($isMenuBarIconVisible, $isKeyboardShortcutEnabled)
+            .map { $0 && $1 }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+
     private var persistor: PromptBarPreferencesPersistor
 
     init(persistor: PromptBarPreferencesPersistor = PromptBarPreferencesUserDefaultsPersistor(keyValueStore: NSApp.delegateTyped.keyValueStore)) {

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPreferences.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPreferences.swift
@@ -36,23 +36,33 @@ final class PromptBarPreferences: ObservableObject {
         didSet { persistor.isMenuBarIconVisible = isMenuBarIconVisible }
     }
 
-    /// The icon is a shortcut entry point, so it stays hidden while the shortcut
-    /// is off. `isMenuBarIconVisible` keeps its stored value so it can be restored.
+    /// The icon is a Duck.ai entry point behind the shortcut, so it stays hidden
+    /// unless both are on. Stored values are kept so they can be restored.
     var isMenuBarIconEffectivelyVisible: Bool {
-        isMenuBarIconVisible && isKeyboardShortcutEnabled
+        isMenuBarIconVisible && isKeyboardShortcutEnabled && aiChatMenuConfiguration.shouldDisplayAnyAIChatFeature
     }
 
     var isMenuBarIconEffectivelyVisiblePublisher: AnyPublisher<Bool, Never> {
-        Publishers.CombineLatest($isMenuBarIconVisible, $isKeyboardShortcutEnabled)
-            .map { $0 && $1 }
+        let aiChatMenuConfiguration = self.aiChatMenuConfiguration
+        let aiChatFeatureChanges = aiChatMenuConfiguration.valuesChangedPublisher
+            .map { _ in () }
+            .prepend(())
+
+        return Publishers.CombineLatest3($isMenuBarIconVisible, $isKeyboardShortcutEnabled, aiChatFeatureChanges)
+            .map { isMenuBarIconVisible, isKeyboardShortcutEnabled, _ in
+                isMenuBarIconVisible && isKeyboardShortcutEnabled && aiChatMenuConfiguration.shouldDisplayAnyAIChatFeature
+            }
             .removeDuplicates()
             .eraseToAnyPublisher()
     }
 
     private var persistor: PromptBarPreferencesPersistor
+    private let aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable
 
-    init(persistor: PromptBarPreferencesPersistor = PromptBarPreferencesUserDefaultsPersistor(keyValueStore: NSApp.delegateTyped.keyValueStore)) {
+    init(persistor: PromptBarPreferencesPersistor = PromptBarPreferencesUserDefaultsPersistor(keyValueStore: NSApp.delegateTyped.keyValueStore),
+         aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable) {
         self.persistor = persistor
+        self.aiChatMenuConfiguration = aiChatMenuConfiguration
         isKeyboardShortcutEnabled = persistor.isKeyboardShortcutEnabled
         keyboardShortcut = persistor.keyboardShortcut
         isMenuBarIconVisible = persistor.isMenuBarIconVisible

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarMenuBarController.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarMenuBarController.swift
@@ -33,16 +33,16 @@ extension NSStatusItem: PromptBarStatusItem {}
 @MainActor
 final class PromptBarMenuBarController: NSObject {
 
-    private let statusItem: PromptBarStatusItem
+    private let makeStatusItem: @MainActor () -> PromptBarStatusItem
+    private var statusItem: PromptBarStatusItem?
 
-    /// - Parameter statusItem: Injectable for testing; defaults to a real menu bar item.
-    init(statusItem: PromptBarStatusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)) {
-        self.statusItem = statusItem
+    /// - Parameter makeStatusItem: Injectable for testing; defaults to a real menu bar item.
+    init(makeStatusItem: @escaping @MainActor () -> PromptBarStatusItem = { NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength) }) {
+        self.makeStatusItem = makeStatusItem
         super.init()
-        configureStatusItem()
     }
 
-    private func configureStatusItem() {
+    private func configureStatusItem(_ statusItem: PromptBarStatusItem) {
         guard let button = statusItem.button else { return }
 
         button.image = DesignSystemImages.Glyphs.Size16.duckAi
@@ -58,11 +58,18 @@ final class PromptBarMenuBarController: NSObject {
         // Prompt Bar window is wired here in a later milestone.
     }
 
+    /// The item is created on first show: `NSStatusBar` puts it on screen as soon
+    /// as it exists, so it must not be created while the icon should be hidden.
     func show() {
-        statusItem.isVisible = true
+        if statusItem == nil {
+            let statusItem = makeStatusItem()
+            self.statusItem = statusItem
+            configureStatusItem(statusItem)
+        }
+        statusItem?.isVisible = true
     }
 
     func hide() {
-        statusItem.isVisible = false
+        statusItem?.isVisible = false
     }
 }

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarMenuBarController.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarMenuBarController.swift
@@ -1,0 +1,72 @@
+//
+//  PromptBarMenuBarController.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import DesignResourcesKitIcons
+
+/// The part of `NSStatusItem` this controller drives, so tests can substitute a
+/// detached item instead of installing one in the system menu bar.
+@MainActor
+protocol PromptBarStatusItem: AnyObject {
+    var button: NSStatusBarButton? { get }
+    var isVisible: Bool { get set }
+}
+
+extension NSStatusItem: PromptBarStatusItem {}
+
+/// Manages the Prompt Bar's duck.ai icon in the macOS menu bar.
+///
+/// Visibility is driven by `PromptBarPreferences.isMenuBarIconVisible`: the owner
+/// (`AppDelegate`) creates the controller behind the `macosPromptBar` flag and
+/// calls `show()` / `hide()` as the setting changes.
+@MainActor
+final class PromptBarMenuBarController: NSObject {
+
+    private let statusItem: PromptBarStatusItem
+
+    /// - Parameter statusItem: Injectable for testing; defaults to a real menu bar item.
+    init(statusItem: PromptBarStatusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)) {
+        self.statusItem = statusItem
+        super.init()
+        configureStatusItem()
+    }
+
+    private func configureStatusItem() {
+        guard let button = statusItem.button else { return }
+
+        button.image = DesignSystemImages.Glyphs.Size16.duckAi
+        button.image?.isTemplate = true
+        button.setAccessibilityIdentifier("PromptBar.menuBarIcon")
+        button.target = self
+        button.action = #selector(statusBarButtonTapped)
+    }
+
+    @objc
+    private func statusBarButtonTapped() {
+        // No-op for now: this milestone only places the icon. Opening the floating
+        // Prompt Bar window is wired here in a later milestone.
+    }
+
+    func show() {
+        statusItem.isVisible = true
+    }
+
+    func hide() {
+        statusItem.isVisible = false
+    }
+}

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarMenuBarController.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarMenuBarController.swift
@@ -30,10 +30,6 @@ protocol PromptBarStatusItem: AnyObject {
 extension NSStatusItem: PromptBarStatusItem {}
 
 /// Manages the Prompt Bar's duck.ai icon in the macOS menu bar.
-///
-/// Visibility is driven by `PromptBarPreferences.isMenuBarIconVisible`: the owner
-/// (`AppDelegate`) creates the controller behind the `macosPromptBar` flag and
-/// calls `show()` / `hide()` as the setting changes.
 @MainActor
 final class PromptBarMenuBarController: NSObject {
 

--- a/macOS/UnitTests/PromptBar/PromptBarMenuBarControllerTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarMenuBarControllerTests.swift
@@ -1,0 +1,63 @@
+//
+//  PromptBarMenuBarControllerTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+/// Detached stand-in: a real `NSStatusBar` item presents an `NSStatusBarWindow`,
+/// which unit tests are not allowed to do.
+@MainActor
+private final class MockPromptBarStatusItem: PromptBarStatusItem {
+    let button: NSStatusBarButton? = NSStatusBarButton()
+    var isVisible: Bool = true
+}
+
+final class PromptBarMenuBarControllerTests: XCTestCase {
+
+    @MainActor
+    func testWhenInitializedThenButtonShowsTemplateGlyph() {
+        let statusItem = MockPromptBarStatusItem()
+
+        _ = PromptBarMenuBarController(statusItem: statusItem)
+
+        XCTAssertNotNil(statusItem.button?.image)
+        XCTAssertEqual(statusItem.button?.image?.isTemplate, true)
+    }
+
+    @MainActor
+    func testWhenHideThenStatusItemIsNotVisible() {
+        let statusItem = MockPromptBarStatusItem()
+        let controller = PromptBarMenuBarController(statusItem: statusItem)
+
+        controller.hide()
+
+        XCTAssertFalse(statusItem.isVisible)
+    }
+
+    @MainActor
+    func testWhenShowThenStatusItemIsVisible() {
+        let statusItem = MockPromptBarStatusItem()
+        let controller = PromptBarMenuBarController(statusItem: statusItem)
+
+        controller.hide()
+        controller.show()
+
+        XCTAssertTrue(statusItem.isVisible)
+    }
+}

--- a/macOS/UnitTests/PromptBar/PromptBarMenuBarControllerTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarMenuBarControllerTests.swift
@@ -28,36 +28,79 @@ private final class MockPromptBarStatusItem: PromptBarStatusItem {
     var isVisible: Bool = true
 }
 
+@MainActor
+private final class StatusItemFactory {
+    let item = MockPromptBarStatusItem()
+    private(set) var createdCount = 0
+
+    func make() -> PromptBarStatusItem {
+        createdCount += 1
+        return item
+    }
+}
+
 final class PromptBarMenuBarControllerTests: XCTestCase {
 
     @MainActor
-    func testWhenInitializedThenButtonShowsTemplateGlyph() {
-        let statusItem = MockPromptBarStatusItem()
+    func testWhenInitializedThenStatusItemIsNotCreated() {
+        let factory = StatusItemFactory()
 
-        _ = PromptBarMenuBarController(statusItem: statusItem)
+        _ = PromptBarMenuBarController(makeStatusItem: factory.make)
 
-        XCTAssertNotNil(statusItem.button?.image)
-        XCTAssertEqual(statusItem.button?.image?.isTemplate, true)
+        XCTAssertEqual(factory.createdCount, 0)
     }
 
     @MainActor
-    func testWhenHideThenStatusItemIsNotVisible() {
-        let statusItem = MockPromptBarStatusItem()
-        let controller = PromptBarMenuBarController(statusItem: statusItem)
+    func testWhenHiddenBeforeBeingShownThenStatusItemIsNotCreated() {
+        let factory = StatusItemFactory()
+        let controller = PromptBarMenuBarController(makeStatusItem: factory.make)
 
         controller.hide()
 
-        XCTAssertFalse(statusItem.isVisible)
+        XCTAssertEqual(factory.createdCount, 0)
     }
 
     @MainActor
-    func testWhenShowThenStatusItemIsVisible() {
-        let statusItem = MockPromptBarStatusItem()
-        let controller = PromptBarMenuBarController(statusItem: statusItem)
+    func testWhenShownThenButtonShowsTemplateGlyph() {
+        let factory = StatusItemFactory()
+        let controller = PromptBarMenuBarController(makeStatusItem: factory.make)
 
-        controller.hide()
         controller.show()
 
-        XCTAssertTrue(statusItem.isVisible)
+        XCTAssertNotNil(factory.item.button?.image)
+        XCTAssertEqual(factory.item.button?.image?.isTemplate, true)
+    }
+
+    @MainActor
+    func testWhenShownThenStatusItemIsVisible() {
+        let factory = StatusItemFactory()
+        let controller = PromptBarMenuBarController(makeStatusItem: factory.make)
+
+        controller.show()
+
+        XCTAssertEqual(factory.createdCount, 1)
+        XCTAssertTrue(factory.item.isVisible)
+    }
+
+    @MainActor
+    func testWhenHiddenAfterBeingShownThenStatusItemIsNotVisible() {
+        let factory = StatusItemFactory()
+        let controller = PromptBarMenuBarController(makeStatusItem: factory.make)
+
+        controller.show()
+        controller.hide()
+
+        XCTAssertFalse(factory.item.isVisible)
+    }
+
+    @MainActor
+    func testWhenShownTwiceThenStatusItemIsCreatedOnce() {
+        let factory = StatusItemFactory()
+        let controller = PromptBarMenuBarController(makeStatusItem: factory.make)
+
+        controller.show()
+        controller.show()
+
+        XCTAssertEqual(factory.createdCount, 1)
     }
 }

--- a/macOS/UnitTests/PromptBar/PromptBarPreferencesTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarPreferencesTests.swift
@@ -27,7 +27,20 @@ private final class MockPromptBarPreferencesPersistor: PromptBarPreferencesPersi
     var isMenuBarIconVisible: Bool = true
 }
 
+private extension MockAIChatConfig {
+    static var enabled: MockAIChatConfig {
+        let configuration = MockAIChatConfig()
+        configuration.shouldDisplayAnyAIChatFeature = true
+        return configuration
+    }
+}
+
 final class PromptBarPreferencesTests: XCTestCase {
+
+    private func makePreferences(persistor: PromptBarPreferencesPersistor,
+                                 configuration: MockAIChatConfig = .enabled) -> PromptBarPreferences {
+        PromptBarPreferences(persistor: persistor, aiChatMenuConfiguration: configuration)
+    }
 
     func testWhenInitializedThenValuesAreSeededFromPersistor() {
         let persistor = MockPromptBarPreferencesPersistor()
@@ -35,7 +48,7 @@ final class PromptBarPreferencesTests: XCTestCase {
         persistor.isMenuBarIconVisible = false
         persistor.keyboardShortcut = PromptBarShortcut(keyCode: UInt16(kVK_ANSI_D), modifierFlags: [.control, .option])
 
-        let preferences = PromptBarPreferences(persistor: persistor)
+        let preferences = makePreferences(persistor: persistor)
 
         XCTAssertFalse(preferences.isKeyboardShortcutEnabled)
         XCTAssertFalse(preferences.isMenuBarIconVisible)
@@ -44,7 +57,7 @@ final class PromptBarPreferencesTests: XCTestCase {
 
     func testWhenValuesChangeThenTheyAreWrittenToPersistor() {
         let persistor = MockPromptBarPreferencesPersistor()
-        let preferences = PromptBarPreferences(persistor: persistor)
+        let preferences = makePreferences(persistor: persistor)
         let customShortcut = PromptBarShortcut(keyCode: UInt16(kVK_ANSI_D), modifierFlags: [.control, .option])
 
         preferences.isKeyboardShortcutEnabled = false
@@ -59,7 +72,7 @@ final class PromptBarPreferencesTests: XCTestCase {
     func testWhenResetKeyboardShortcutToDefaultThenDefaultShortcutIsAppliedAndPersisted() {
         let persistor = MockPromptBarPreferencesPersistor()
         persistor.keyboardShortcut = PromptBarShortcut(keyCode: UInt16(kVK_ANSI_D), modifierFlags: [.control, .option])
-        let preferences = PromptBarPreferences(persistor: persistor)
+        let preferences = makePreferences(persistor: persistor)
 
         preferences.resetKeyboardShortcutToDefault()
 
@@ -72,7 +85,7 @@ final class PromptBarPreferencesTests: XCTestCase {
         persistor.isMenuBarIconVisible = true
         persistor.isKeyboardShortcutEnabled = false
 
-        let preferences = PromptBarPreferences(persistor: persistor)
+        let preferences = makePreferences(persistor: persistor)
 
         XCTAssertFalse(preferences.isMenuBarIconEffectivelyVisible)
     }
@@ -82,7 +95,7 @@ final class PromptBarPreferencesTests: XCTestCase {
         persistor.isMenuBarIconVisible = true
         persistor.isKeyboardShortcutEnabled = true
 
-        let preferences = PromptBarPreferences(persistor: persistor)
+        let preferences = makePreferences(persistor: persistor)
 
         XCTAssertTrue(preferences.isMenuBarIconEffectivelyVisible)
     }
@@ -90,7 +103,7 @@ final class PromptBarPreferencesTests: XCTestCase {
     func testWhenKeyboardShortcutIsDisabledThenStoredMenuBarIconPreferenceIsUnchanged() {
         let persistor = MockPromptBarPreferencesPersistor()
         persistor.isMenuBarIconVisible = true
-        let preferences = PromptBarPreferences(persistor: persistor)
+        let preferences = makePreferences(persistor: persistor)
 
         preferences.isKeyboardShortcutEnabled = false
 
@@ -103,7 +116,7 @@ final class PromptBarPreferencesTests: XCTestCase {
         let persistor = MockPromptBarPreferencesPersistor()
         persistor.isMenuBarIconVisible = true
         persistor.isKeyboardShortcutEnabled = true
-        let preferences = PromptBarPreferences(persistor: persistor)
+        let preferences = makePreferences(persistor: persistor)
         var received: [Bool] = []
         let cancellable = preferences.isMenuBarIconEffectivelyVisiblePublisher.sink { received.append($0) }
 
@@ -117,12 +130,53 @@ final class PromptBarPreferencesTests: XCTestCase {
         let persistor = MockPromptBarPreferencesPersistor()
         persistor.isMenuBarIconVisible = true
         persistor.isKeyboardShortcutEnabled = false
-        let preferences = PromptBarPreferences(persistor: persistor)
+        let preferences = makePreferences(persistor: persistor)
         var received: [Bool] = []
 
         let cancellable = preferences.isMenuBarIconEffectivelyVisiblePublisher.sink { received.append($0) }
 
         XCTAssertEqual(received, [false])
         cancellable.cancel()
+    }
+
+    func testWhenAIFeaturesAreDisabledThenMenuBarIconIsNotEffectivelyVisible() {
+        let persistor = MockPromptBarPreferencesPersistor()
+        persistor.isMenuBarIconVisible = true
+        persistor.isKeyboardShortcutEnabled = true
+        let configuration = MockAIChatConfig()
+        configuration.shouldDisplayAnyAIChatFeature = false
+
+        let preferences = makePreferences(persistor: persistor, configuration: configuration)
+
+        XCTAssertFalse(preferences.isMenuBarIconEffectivelyVisible)
+    }
+
+    func testWhenAIFeaturesAreTurnedOffThenEffectiveVisibilityPublisherEmitsFalse() {
+        let persistor = MockPromptBarPreferencesPersistor()
+        persistor.isMenuBarIconVisible = true
+        persistor.isKeyboardShortcutEnabled = true
+        let configuration = MockAIChatConfig.enabled
+        let preferences = makePreferences(persistor: persistor, configuration: configuration)
+        var received: [Bool] = []
+        let cancellable = preferences.isMenuBarIconEffectivelyVisiblePublisher.sink { received.append($0) }
+
+        configuration.shouldDisplayAnyAIChatFeature = false
+        configuration.valuesChangedPublisher.send()
+
+        XCTAssertEqual(received, [true, false])
+        cancellable.cancel()
+    }
+
+    func testWhenAIFeaturesAreDisabledThenStoredMenuBarIconPreferenceIsUnchanged() {
+        let persistor = MockPromptBarPreferencesPersistor()
+        persistor.isMenuBarIconVisible = true
+        let configuration = MockAIChatConfig()
+        configuration.shouldDisplayAnyAIChatFeature = false
+
+        let preferences = makePreferences(persistor: persistor, configuration: configuration)
+
+        XCTAssertTrue(preferences.isMenuBarIconVisible)
+        XCTAssertTrue(persistor.isMenuBarIconVisible)
+        XCTAssertFalse(preferences.isMenuBarIconEffectivelyVisible)
     }
 }

--- a/macOS/UnitTests/PromptBar/PromptBarPreferencesTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarPreferencesTests.swift
@@ -17,6 +17,7 @@
 //
 
 import Carbon.HIToolbox
+import Combine
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 
@@ -64,5 +65,64 @@ final class PromptBarPreferencesTests: XCTestCase {
 
         XCTAssertEqual(preferences.keyboardShortcut, .defaultShortcut)
         XCTAssertEqual(persistor.keyboardShortcut, .defaultShortcut)
+    }
+
+    func testWhenKeyboardShortcutIsDisabledThenMenuBarIconIsNotEffectivelyVisible() {
+        let persistor = MockPromptBarPreferencesPersistor()
+        persistor.isMenuBarIconVisible = true
+        persistor.isKeyboardShortcutEnabled = false
+
+        let preferences = PromptBarPreferences(persistor: persistor)
+
+        XCTAssertFalse(preferences.isMenuBarIconEffectivelyVisible)
+    }
+
+    func testWhenKeyboardShortcutAndMenuBarIconAreEnabledThenIconIsEffectivelyVisible() {
+        let persistor = MockPromptBarPreferencesPersistor()
+        persistor.isMenuBarIconVisible = true
+        persistor.isKeyboardShortcutEnabled = true
+
+        let preferences = PromptBarPreferences(persistor: persistor)
+
+        XCTAssertTrue(preferences.isMenuBarIconEffectivelyVisible)
+    }
+
+    func testWhenKeyboardShortcutIsDisabledThenStoredMenuBarIconPreferenceIsUnchanged() {
+        let persistor = MockPromptBarPreferencesPersistor()
+        persistor.isMenuBarIconVisible = true
+        let preferences = PromptBarPreferences(persistor: persistor)
+
+        preferences.isKeyboardShortcutEnabled = false
+
+        XCTAssertTrue(preferences.isMenuBarIconVisible)
+        XCTAssertTrue(persistor.isMenuBarIconVisible)
+        XCTAssertFalse(preferences.isMenuBarIconEffectivelyVisible)
+    }
+
+    func testWhenKeyboardShortcutIsDisabledThenEffectiveVisibilityPublisherEmitsFalse() {
+        let persistor = MockPromptBarPreferencesPersistor()
+        persistor.isMenuBarIconVisible = true
+        persistor.isKeyboardShortcutEnabled = true
+        let preferences = PromptBarPreferences(persistor: persistor)
+        var received: [Bool] = []
+        let cancellable = preferences.isMenuBarIconEffectivelyVisiblePublisher.sink { received.append($0) }
+
+        preferences.isKeyboardShortcutEnabled = false
+
+        XCTAssertEqual(received, [true, false])
+        cancellable.cancel()
+    }
+
+    func testWhenSubscribedThenEffectiveVisibilityPublisherEmitsCurrentValueSynchronously() {
+        let persistor = MockPromptBarPreferencesPersistor()
+        persistor.isMenuBarIconVisible = true
+        persistor.isKeyboardShortcutEnabled = false
+        let preferences = PromptBarPreferences(persistor: persistor)
+        var received: [Bool] = []
+
+        let cancellable = preferences.isMenuBarIconEffectivelyVisiblePublisher.sink { received.append($0) }
+
+        XCTAssertEqual(received, [false])
+        cancellable.cancel()
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1213113444700279?focus=true
Tech Design URL:
CC:

### Description
Adds a duck.ai glyph to the macOS menu bar, driven by the existing "Show icon in the menu bar" AI Features setting and gated behind the `macosPromptBar` flag. 

### Testing Steps
1. Enable the `macosPromptBar` internal feature flag and open Settings → AI Features.
2. Toggle "Show icon in the menu bar" on → the duck.ai icon appears in the macOS menu bar; toggle off → it disappears.
3. Confirm the icon tints correctly in both light and dark menu bars.

### Impact and Risks
Low — isolated behind an internal feature flag; no behavior change when the flag is off.

#### What could go wrong?
The icon could fail to show/hide if the settings observation or flag gate regresses, affecting only internal builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are isolated behind the internal `macosPromptBar` flag with no user impact when off; risk is limited to incorrect show/hide of a non-functional menu bar icon in internal builds.
> 
> **Overview**
> Adds a **duck.ai** template icon to the macOS menu bar for the Prompt Bar, gated on the `macosPromptBar` feature flag and wired at launch like the passwords menu bar flow.
> 
> **`PromptBarMenuBarController`** lazily creates an `NSStatusItem` only when shown (so a hidden icon never flashes at startup), configures the Design System glyph, and toggles visibility; the button action is intentionally a no-op until a later milestone opens the floating Prompt Bar.
> 
> **`PromptBarPreferences`** now derives **effective** menu bar visibility: the icon appears only when the stored “show in menu bar” preference, the keyboard shortcut toggle, and `aiChatMenuConfiguration.shouldDisplayAnyAIChatFeature` are all true. User defaults for the menu bar toggle are **not** cleared when the icon is suppressed, so settings restore when AI/shortcut come back. A Combine publisher drives `AppDelegate` show/hide synchronously on subscribe.
> 
> Unit tests cover the controller lifecycle and effective visibility / publisher behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f814bfd0b3daa5347fb2df57ea8281bc046c00c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->