### PR TITLE
[iOS] tab switcher ship review feedback

### DIFF
--- a/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
+++ b/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
@@ -248,6 +248,8 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
 
     func setTitle(_ title: String?) {
         selectionTitleLabel.text = title
+        selectionTitleLabel.sizeToFit()
+        navigationBar.setNeedsLayout()
     }
 
     func configurePlusButtonLongPressMenu(isFireModeEnabled: Bool) {

--- a/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
+++ b/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
@@ -400,11 +400,11 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         if #available(iOS 26, *), UIDevice.current.userInterfaceIdiom == .pad {
             topGuide = hostView.layoutGuide(for: .margins(cornerAdaptation: .vertical))
         } else {
-            topGuide = hostView.safeAreaLayoutGuide
+            topGuide = hostView.layoutMarginsGuide
         }
 
         var constraints = [
-            navigationBar.topAnchor.constraint(equalTo: topGuide.topAnchor),
+            navigationBar.topAnchor.constraint(equalTo: topGuide.topAnchor, constant: 8),
             navigationBar.leadingAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.leadingAnchor),
             navigationBar.trailingAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.trailingAnchor),
 

--- a/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
+++ b/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
@@ -55,6 +55,7 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
     private var glassCenterContainer: UIVisualEffectView?
     private var layoutConstraints: [NSLayoutConstraint] = []
     private var isFireModeEnabled = false
+    private var interfaceMode: TabSwitcherViewController.InterfaceMode = .regularSize
 
     var actions = TabSwitcherChromeActions()
 
@@ -87,6 +88,12 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         item.accessibilityLabel = UserText.navigationTitleDone
         return item
     }()
+
+    private lazy var doneTextItem = UIBarButtonItem(
+        title: UserText.navigationTitleDone,
+        image: nil,
+        primaryAction: UIAction { [weak self] _ in self?.actions.onDoneTapped?() },
+        menu: nil)
 
     private lazy var selectionTitleLabel: UILabel = {
         let label = UILabel()
@@ -292,16 +299,43 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
                 canShowSelectionMenu: Bool,
                 isEditing: Bool) {
         let params = Parameters(state: state)
+        interfaceMode = params.interfaceMode
 
         tabsStyleItem.image = tabsStyle.image
-        tabsStyleItem.menu = makeTabsStyleMenu(current: tabsStyle)
+        if params.interfaceMode.isLarge {
+            tabsStyleItem.primaryAction = UIAction { [weak self] _ in self?.actions.onToggleTabsStyle?() }
+            tabsStyleItem.menu = nil
+        } else {
+            tabsStyleItem.primaryAction = nil
+            tabsStyleItem.menu = makeTabsStyleMenu(current: tabsStyle)
+        }
         editMenuItem.menu = actions.onEditMenuRequested?()
         multiSelectMenuItem.menu = actions.onMultiSelectMenuRequested?()
         multiSelectMenuItem.isEnabled = canShowSelectionMenu
+        editMenuItem.isEnabled = params.totalCount > 1 || params.containsWebPages
 
-        doneItem.isEnabled = params.canDismissOnEmpty || params.totalCount > 0
+        let isDoneEnabled = params.canDismissOnEmpty || params.totalCount > 0
+        doneItem.isEnabled = isDoneEnabled
+        doneTextItem.isEnabled = isDoneEnabled
 
-        if isEditing {
+        if params.interfaceMode == .editingLargeSize {
+            navigationItem.title = nil
+            navigationItem.titleView = selectionTitleLabel
+            navigationItem.leftBarButtonItems = [doneTextItem]
+            navigationItem.rightBarButtonItems = [multiSelectMenuItem]
+            setToolbarItems([])
+        } else if params.interfaceMode == .largeSize {
+            navigationItem.title = nil
+            navigationItem.titleView = centerTitleView()
+            navigationItem.leftBarButtonItems = [editMenuItem, tabsStyleItem]
+
+            var items = [doneTextItem, fireItem, plusItem]
+            if params.showAIChat {
+                items.append(duckChatItem)
+            }
+            navigationItem.rightBarButtonItems = items
+            setToolbarItems([])
+        } else if isEditing {
             navigationItem.titleView = nil
             navigationItem.title = nil
             navigationItem.leftBarButtonItems = [selectionTitleItem]
@@ -325,13 +359,15 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
             }
             setToolbarItems(items)
         }
+
+        toolbar.isHidden = params.interfaceMode.isLarge
     }
 
     func applyCollectionContentInset(to collectionView: UICollectionView) {
         let navHeight = navigationBar.frame.height > 0 ? navigationBar.frame.height : Metrics.estimatedNavBarHeight
         let toolbarHeight = toolbar.frame.height > 0 ? toolbar.frame.height : Metrics.estimatedToolbarHeight
         collectionView.contentInset.top = navHeight
-        collectionView.contentInset.bottom = toolbarHeight + Metrics.bottomFloatingInset
+        collectionView.contentInset.bottom = interfaceMode.isLarge ? 0 : toolbarHeight + Metrics.bottomFloatingInset
     }
 
     func layout(addressBarPosition: AddressBarPosition,
@@ -341,7 +377,9 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
             return
         }
 
+        self.interfaceMode = interfaceMode
         contentView.translatesAutoresizingMaskIntoConstraints = false
+        toolbar.isHidden = interfaceMode.isLarge
 
         NSLayoutConstraint.deactivate(layoutConstraints)
         layoutConstraints = []
@@ -356,8 +394,15 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         hostView.addSubview(toolbar)
         hostView.addSubview(navigationBar)
 
+        let topGuide: UILayoutGuide
+        if #available(iOS 26, *), UIDevice.current.userInterfaceIdiom == .pad {
+            topGuide = hostView.layoutGuide(for: .margins(cornerAdaptation: .vertical))
+        } else {
+            topGuide = hostView.safeAreaLayoutGuide
+        }
+
         var constraints = [
-            navigationBar.topAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.topAnchor),
+            navigationBar.topAnchor.constraint(equalTo: topGuide.topAnchor),
             navigationBar.leadingAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.leadingAnchor),
             navigationBar.trailingAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.trailingAnchor),
 
@@ -392,6 +437,11 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
     }
 
     private func setToolbarItems(_ items: [UIBarButtonItem]) {
+        if items.isEmpty {
+            toolbar.setItems([], animated: false)
+            return
+        }
+
         if #available(iOS 26.0, *) {
             toolbar.setItems(items, animated: false)
         } else {
@@ -442,15 +492,18 @@ private extension FloatingTabSwitcherChrome {
     struct Parameters {
         var selectedCount = 0
         var totalCount = 0
+        var containsWebPages = false
         var showAIChat = false
         var canDismissOnEmpty = true
+        var interfaceMode: TabSwitcherViewController.InterfaceMode = .regularSize
 
         init(state: TabSwitcherToolbarState) {
             switch state {
-            case .regularSize(let selectedCount, let totalCount, _, let showAIChat, let canDismissOnEmpty),
-                 .largeSize(let selectedCount, let totalCount, _, let showAIChat, let canDismissOnEmpty):
+            case .regularSize(let selectedCount, let totalCount, let containsWebPages, let showAIChat, let canDismissOnEmpty),
+                 .largeSize(let selectedCount, let totalCount, let containsWebPages, let showAIChat, let canDismissOnEmpty):
                 self.selectedCount = selectedCount
                 self.totalCount = totalCount
+                self.containsWebPages = containsWebPages
                 self.showAIChat = showAIChat
                 self.canDismissOnEmpty = canDismissOnEmpty
             case .editingRegularSize(let selectedCount, let totalCount),
@@ -458,6 +511,7 @@ private extension FloatingTabSwitcherChrome {
                 self.selectedCount = selectedCount
                 self.totalCount = totalCount
             }
+            self.interfaceMode = state.interfaceMode
         }
     }
 }

--- a/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
+++ b/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
@@ -154,7 +154,7 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         menu: nil)
 
     private lazy var closeTabsItem = UIBarButtonItem(
-        title: UserText.closeTabs(withCount: 0),
+        title: UserText.tabSwitcherCloseTabsButtonTitle(withCount: 0),
         image: nil,
         primaryAction: UIAction { [weak self] _ in self?.actions.onCloseTabsTapped?() },
         menu: nil)
@@ -341,7 +341,7 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
             navigationItem.leftBarButtonItems = [selectionTitleItem]
             navigationItem.rightBarButtonItems = [params.selectedCount == params.totalCount ? deselectAllItem : selectAllItem]
 
-            closeTabsItem.title = UserText.closeTabs(withCount: params.selectedCount)
+            closeTabsItem.title = UserText.tabSwitcherCloseTabsButtonTitle(withCount: params.selectedCount)
             closeTabsItem.isEnabled = params.selectedCount > 0
             setToolbarItems([doneItem, .flexibleSpace(), closeTabsItem, multiSelectMenuItem])
         } else {

--- a/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
+++ b/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
@@ -30,6 +30,7 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
     private enum Metrics {
         static let estimatedNavBarHeight: CGFloat = 50
         static let estimatedToolbarHeight: CGFloat = 49
+        static let topFloatingInset: CGFloat = 8
         static let bottomFloatingInset: CGFloat = 8
         static let fallbackToolbarHorizontalPadding: CGFloat = 20
         static let fallbackAIButtonSpacing: CGFloat = 12
@@ -368,7 +369,7 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
     func applyCollectionContentInset(to collectionView: UICollectionView) {
         let navHeight = navigationBar.frame.height > 0 ? navigationBar.frame.height : Metrics.estimatedNavBarHeight
         let toolbarHeight = toolbar.frame.height > 0 ? toolbar.frame.height : Metrics.estimatedToolbarHeight
-        collectionView.contentInset.top = navHeight
+        collectionView.contentInset.top = navHeight + Metrics.topFloatingInset
         collectionView.contentInset.bottom = interfaceMode.isLarge ? 0 : toolbarHeight + Metrics.bottomFloatingInset
     }
 
@@ -404,7 +405,7 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         }
 
         var constraints = [
-            navigationBar.topAnchor.constraint(equalTo: topGuide.topAnchor, constant: 8),
+            navigationBar.topAnchor.constraint(equalTo: topGuide.topAnchor, constant: Metrics.topFloatingInset),
             navigationBar.leadingAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.leadingAnchor),
             navigationBar.trailingAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.trailingAnchor),
 

--- a/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
+++ b/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
@@ -90,12 +90,6 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         return item
     }()
 
-    private lazy var doneTextItem = UIBarButtonItem(
-        title: UserText.navigationTitleDone,
-        image: nil,
-        primaryAction: UIAction { [weak self] _ in self?.actions.onDoneTapped?() },
-        menu: nil)
-
     private lazy var selectionTitleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.daxHeadline()
@@ -305,26 +299,21 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         interfaceMode = params.interfaceMode
 
         tabsStyleItem.image = tabsStyle.image
-        if params.interfaceMode.isLarge {
-            tabsStyleItem.primaryAction = UIAction { [weak self] _ in self?.actions.onToggleTabsStyle?() }
-            tabsStyleItem.menu = nil
-        } else {
-            tabsStyleItem.primaryAction = nil
-            tabsStyleItem.menu = makeTabsStyleMenu(current: tabsStyle)
-        }
+        tabsStyleItem.primaryAction = nil
+        tabsStyleItem.menu = makeTabsStyleMenu(current: tabsStyle)
         editMenuItem.menu = actions.onEditMenuRequested?()
         multiSelectMenuItem.menu = actions.onMultiSelectMenuRequested?()
         multiSelectMenuItem.isEnabled = canShowSelectionMenu
         editMenuItem.isEnabled = params.totalCount > 1 || params.containsWebPages
+        configureBackgroundSharing(isLarge: params.interfaceMode.isLarge)
 
         let isDoneEnabled = params.canDismissOnEmpty || params.totalCount > 0
         doneItem.isEnabled = isDoneEnabled
-        doneTextItem.isEnabled = isDoneEnabled
 
         if params.interfaceMode == .editingLargeSize {
             navigationItem.title = nil
             navigationItem.titleView = selectionTitleLabel
-            navigationItem.leftBarButtonItems = [doneTextItem]
+            navigationItem.leftBarButtonItems = [doneItem]
             navigationItem.rightBarButtonItems = [multiSelectMenuItem]
             setToolbarItems([])
         } else if params.interfaceMode == .largeSize {
@@ -332,7 +321,7 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
             navigationItem.titleView = centerTitleView()
             navigationItem.leftBarButtonItems = [editMenuItem, tabsStyleItem]
 
-            var items = [doneTextItem, fireItem, plusItem]
+            var items = [doneItem, fireItem, plusItem]
             if params.showAIChat {
                 items.append(duckChatItem)
             }
@@ -466,6 +455,17 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
             self?.actions.onSelectTabsStyle?(.list)
         }
         return UIMenu(children: [grid, list])
+    }
+
+    private func configureBackgroundSharing(isLarge: Bool) {
+        guard #available(iOS 26.0, *) else { return }
+        let shouldShareBackground = !isLarge
+        editMenuItem.sharesBackground = shouldShareBackground
+        tabsStyleItem.sharesBackground = shouldShareBackground
+        fireItem.sharesBackground = shouldShareBackground
+        doneItem.sharesBackground = shouldShareBackground
+        plusItem.sharesBackground = true
+        duckChatItem.sharesBackground = true
     }
 
     private func configureBarMaterials() {

--- a/iOS/DuckDuckGo/TabSwitcherMenuBuilder.swift
+++ b/iOS/DuckDuckGo/TabSwitcherMenuBuilder.swift
@@ -28,9 +28,10 @@ struct TabSwitcherMultiSelectMenuState {
     let totalCount: Int
     let selectedContainsWebPages: Bool
     let allContainsWebPages: Bool
+    var shouldShowSelectionToggleActions = true
 
-    var canShowDeselectAll: Bool { selectedCount > 0 && selectedCount == totalCount }
-    var canShowSelectAll: Bool { selectedCount < totalCount }
+    var canShowDeselectAll: Bool { shouldShowSelectionToggleActions && selectedCount > 0 && selectedCount == totalCount }
+    var canShowSelectAll: Bool { shouldShowSelectionToggleActions && selectedCount < totalCount }
     var canShare: Bool { selectedContainsWebPages }
     var canAddBookmarks: Bool { selectedContainsWebPages }
     var canCloseOther: Bool { selectedCount > 0 && selectedCount < totalCount }

--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -300,11 +300,13 @@ extension TabSwitcherViewController {
     func createMultiSelectionMenu() -> UIMenu {
         let selectedIndexPaths = selectedTabs
         let selectedTabObjects = selectedIndexPaths.map { tabsModel.get(tabAt: $0.row) }.compactMap { $0 }
+        let shouldShowSelectionToggleActions = !featureFlagger.isFeatureOn(.tabSwitcherJuly2026) || UIDevice.current.userInterfaceIdiom != .phone
         let state = TabSwitcherMultiSelectMenuState(
             selectedCount: selectedTabObjects.count,
             totalCount: tabsModel.count,
             selectedContainsWebPages: selectedTabObjects.contains(where: { $0.link != nil }),
-            allContainsWebPages: tabsModel.tabs.contains(where: { $0.link != nil })
+            allContainsWebPages: tabsModel.tabs.contains(where: { $0.link != nil }),
+            shouldShowSelectionToggleActions: shouldShowSelectionToggleActions
         )
         canShowSelectionMenu = state.canShowSelectionMenu
         return menuBuilder.multiSelectionMenu(state: state, actions: TabSwitcherMultiSelectMenuActions(

--- a/iOS/DuckDuckGo/TabViewCell.swift
+++ b/iOS/DuckDuckGo/TabViewCell.swift
@@ -460,6 +460,7 @@ class TabViewCell: UICollectionViewCell {
     func updateSelectionIndicator(_ image: UIImageView) {
         if !isSelected {
             image.image = DesignSystemImages.Glyphs.Size24.shapeCircle
+            image.tintColor = UIColor(designSystemColor: .iconsTertiary)
         } else {
             image.image = DesignSystemImages.Recolorable.Size24.check.applyPalleteColorsToSymbol(
                 foreground: UIColor(designSystemColor: .accentContentPrimary),

--- a/iOS/DuckDuckGo/TabViewCell.swift
+++ b/iOS/DuckDuckGo/TabViewCell.swift
@@ -459,9 +459,12 @@ class TabViewCell: UICollectionViewCell {
 
     func updateSelectionIndicator(_ image: UIImageView) {
         if !isSelected {
+            image.preferredSymbolConfiguration = UIImage.SymbolConfiguration(pointSize: Constants.selectionIndicatorSize)
             image.image = DesignSystemImages.Glyphs.Size24.shapeCircle
             image.tintColor = UIColor(designSystemColor: .iconsTertiary)
         } else {
+            // Hack to fix image size.
+            image.preferredSymbolConfiguration = UIImage.SymbolConfiguration(pointSize: Constants.selectionIndicatorSize - 4)
             image.image = DesignSystemImages.Recolorable.Size24.check.applyPalleteColorsToSymbol(
                 foreground: UIColor(designSystemColor: .accentContentPrimary),
                 background: accentColor,

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -396,6 +396,11 @@ public struct UserText {
         return String.localizedStringWithFormat(format, count)
     }
 
+    public static func tabSwitcherCloseTabsButtonTitle(withCount count: Int) -> String {
+        let format = Bundle.main.localizedString(forKey: "tab.switcher.close-tabs.button.withCount", value: nil, table: nil)
+        return String.localizedStringWithFormat(format, count)
+    }
+
     public static let closeAllTabs: String = NSLocalizedString("close.all.tabs", value: "Close All Tabs", comment: "Close All Tabs")
 
     public static func closeAllTabs(withCount count: Int) -> String {

--- a/iOS/DuckDuckGo/bg.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/bg.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@
 			<string>Затваряне на разделите</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Затваряне на %1$d раздел</string>
+			<key>other</key>
+			<string>Затваряне на %1$d раздела</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/cs.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/cs.lproj/Localizable.stringsdict
@@ -476,6 +476,26 @@ Zablokovali jsme je.
 			<string>Zavřít karty</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Zavřít %1$d kartu</string>
+			<key>few</key>
+			<string>Zavřít %1$d karty</string>
+			<key>many</key>
+			<string>Zavřít %1$d karty</string>
+			<key>other</key>
+			<string>Zavřít %1$d karet</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/da.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/da.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@ Jeg blokerede dem!
 			<string>Luk faner</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Luk %1$d fane</string>
+			<key>other</key>
+			<string>Luk %1$d faner</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/de.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/de.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@ Ich habe sie blockiert!
 			<string>Tabs schließen</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Tab schließen</string>
+			<key>other</key>
+			<string>%1$d Tabs schließen</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/el.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/el.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@
 			<string>Κλείσιμο καρτελών</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Κλείσιμο %1$d καρτέλας</string>
+			<key>other</key>
+			<string>Κλείσιμο %1$d καρτελών</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/en.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.stringsdict
@@ -388,6 +388,24 @@ I blocked them!
 			<string>Close Tab</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>Close %d Tabs</string>
+			<key>one</key>
+			<string>Close %d Tab</string>
+			<key>zero</key>
+			<string>Close Tabs</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/es.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/es.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@
 			<string>Cerrar pestañas</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Cerrar %1$d pestaña</string>
+			<key>other</key>
+			<string>Cerrar %1$d pestañas</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/et.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/et.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@ Blokeerisin nad!
 			<string>Sule vahekaardid</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Sule %1$d vahekaart</string>
+			<key>other</key>
+			<string>Sule %1$d vahekaarti</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/fi.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/fi.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@
 			<string>Sulje välilehdet</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Sulje %1$d välilehti</string>
+			<key>other</key>
+			<string>Sulje %1$d välilehteä</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/fr.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/fr.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@ Je les ai bloqués !
 			<string>Fermer les onglets</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Fermer %1$d onglet</string>
+			<key>other</key>
+			<string>Fermer %1$d onglets</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/hr.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/hr.lproj/Localizable.stringsdict
@@ -476,6 +476,26 @@ Ja sam ih blokirao!
 			<string>Zatvori kartica</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Zatvori karticu</string>
+			<key>few</key>
+			<string>Zatvori %1$d kartice</string>
+			<key>many</key>
+			<string>Zatvori %1$d kartica</string>
+			<key>other</key>
+			<string>Zatvori %1$d kartica</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/hu.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/hu.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@ Blokkoltam őket!
 			<string>Lapok bezárása</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%1$d lap bezárása</string>
+			<key>other</key>
+			<string>%1$d lap bezárása</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/it.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/it.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@ Li ho bloccati!
 			<string>Chiudi schede</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Chiudi %1$d scheda</string>
+			<key>other</key>
+			<string>Chiudi %1$d schede</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/ja.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/ja.lproj/Localizable.stringsdict
@@ -320,6 +320,20 @@
 			<string>タブを閉じる</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%1$d件のタブを閉じる</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/lt.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/lt.lproj/Localizable.stringsdict
@@ -476,6 +476,26 @@ Užblokavau juos!
 			<string>Uždaryti skirtukus</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Uždaryti %1$d skirtuką</string>
+			<key>few</key>
+			<string>Uždaryti %1$d skirtukus</string>
+			<key>many</key>
+			<string>Uždaryti %1$d skirtuko</string>
+			<key>other</key>
+			<string>Uždaryti %1$d skirtukų</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/lv.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/lv.lproj/Localizable.stringsdict
@@ -424,6 +424,24 @@ Es tos nobloķēju!
 			<string>Aizvērt cilnes</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>Aizvērt %1$d cilnes</string>
+			<key>one</key>
+			<string>Aizvērt %1$d cilni</string>
+			<key>other</key>
+			<string>Aizvērt %1$d cilnes</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/nb.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/nb.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@ Jeg blokkerte dem!
 			<string>Lukk fanene</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Lukk %1$d fane</string>
+			<key>other</key>
+			<string>Lukk %1$d faner</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/nl.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/nl.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@ Ik heb ze geblokkeerd!
 			<string>Tabbladen sluiten</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%1$d tabblad sluiten</string>
+			<key>other</key>
+			<string>%1$d tabbladen sluiten</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/pl.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/pl.lproj/Localizable.stringsdict
@@ -476,6 +476,26 @@ Zablokowałem ich!
 			<string>Zamknij karty</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Zamknij %1$d kartę</string>
+			<key>few</key>
+			<string>Zamknij %1$d karty</string>
+			<key>many</key>
+			<string>Zamknij %1$d kart</string>
+			<key>other</key>
+			<string>Zamknij %1$d karty</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/pt.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/pt.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@ Bloqueei-os!
 			<string>Fechar separadores</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Fechar %1$d separador</string>
+			<key>other</key>
+			<string>Fechar %1$d separadores</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/ro.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/ro.lproj/Localizable.stringsdict
@@ -424,6 +424,24 @@ I-am blocat!
 			<string>Închide filele</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Închide %1$d filă</string>
+			<key>few</key>
+			<string>Închide %1$d file</string>
+			<key>other</key>
+			<string>Închide %1$d de file</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/ru.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/ru.lproj/Localizable.stringsdict
@@ -476,6 +476,26 @@
 			<string>Закрыть вкладки</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Закрыть %1$d вкладку</string>
+			<key>few</key>
+			<string>Закрыть %1$d вкладки</string>
+			<key>many</key>
+			<string>Закрыть %1$d вкладок</string>
+			<key>other</key>
+			<string>Закрыть вкладки (%1$d)</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/sk.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/sk.lproj/Localizable.stringsdict
@@ -476,6 +476,26 @@ Boli zablokovaní!
 			<string>Zatvoriť karty</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Zavrieť %1$d kartu</string>
+			<key>few</key>
+			<string>Zavrieť %1$d karty</string>
+			<key>many</key>
+			<string>Zavrieť %1$d karty</string>
+			<key>other</key>
+			<string>Zavrieť %1$d kariet</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/sl.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/sl.lproj/Localizable.stringsdict
@@ -476,6 +476,26 @@ Blokiral sem jih!
 			<string>Zapri zavihke</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Zapri %1$d zavihek</string>
+			<key>two</key>
+			<string>Zapri %1$d zavihka</string>
+			<key>few</key>
+			<string>Zapri %1$d zavihke</string>
+			<key>other</key>
+			<string>Zapri %1$d zavihkov</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/sv.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/sv.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@ Jag blockerade dem!
 			<string>Stäng flikar</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Stäng %1$d flik</string>
+			<key>other</key>
+			<string>Stäng %1$d flikar</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGo/tr.lproj/Localizable.stringsdict
+++ b/iOS/DuckDuckGo/tr.lproj/Localizable.stringsdict
@@ -372,6 +372,22 @@ Onları engelledim!
 			<string>Sekmeleri Kapat</string>
 		</dict>
 	</dict>
+	<key>tab.switcher.close-tabs.button.withCount</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@tabs@</string>
+		<key>tabs</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%1$d Sekmeyi Kapat</string>
+			<key>other</key>
+			<string>%1$d Sekmeyi Kapat</string>
+		</dict>
+	</dict>
 	<key>closeAllTabs.withCount</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
+++ b/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
@@ -150,7 +150,7 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
         XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.first?.title, UserText.deselectAllTabs)
     }
 
-    func testWhenLargeSizeThenMatchesProductionBarLayout() {
+    func testWhenLargeSizeThenMatchesIPhoneControlStyle() {
         let chrome = makeInstalledChrome()
         chrome.actions.onEditMenuRequested = { UIMenu(children: []) }
 
@@ -161,11 +161,17 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
 
         XCTAssertEqual(chrome.navigationItem.leftBarButtonItems?.count, 2)
         XCTAssertNotNil(chrome.navigationItem.leftBarButtonItems?.first?.menu)
-        XCTAssertNil(chrome.navigationItem.leftBarButtonItems?.last?.menu)
-        XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.first?.title, UserText.navigationTitleDone)
+        XCTAssertNotNil(chrome.navigationItem.leftBarButtonItems?.last?.menu)
+        XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.first?.accessibilityLabel, UserText.navigationTitleDone)
         XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.count, 3)
         XCTAssertTrue(chrome.toolbar.isHidden)
         XCTAssertTrue(chrome.toolbar.items?.isEmpty == true)
+
+        if #available(iOS 26.0, *) {
+            XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.first?.style, .prominent)
+            XCTAssertEqual(chrome.navigationItem.leftBarButtonItems?.map(\.sharesBackground), [false, false])
+            XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.map(\.sharesBackground), [false, false, true])
+        }
     }
 
     func testWhenLargeSizeWithAIChatThenDuckChatIsInTopBar() {
@@ -179,6 +185,10 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
         XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.count, 4)
         XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.last?.accessibilityIdentifier, "TabSwitcher.Button.DuckChat")
         XCTAssertTrue(chrome.toolbar.items?.isEmpty == true)
+
+        if #available(iOS 26.0, *) {
+            XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.map(\.sharesBackground), [false, false, true, true])
+        }
     }
 
     func testWhenEditingLargeSizeThenMatchesProductionBarLayout() {
@@ -191,11 +201,15 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
                       canShowSelectionMenu: true,
                       isEditing: true)
 
-        XCTAssertEqual(chrome.navigationItem.leftBarButtonItems?.first?.title, UserText.navigationTitleDone)
+        XCTAssertEqual(chrome.navigationItem.leftBarButtonItems?.first?.accessibilityLabel, UserText.navigationTitleDone)
         XCTAssertEqual((chrome.navigationItem.titleView as? UILabel)?.text, "2 Selected")
         XCTAssertNotNil(chrome.navigationItem.rightBarButtonItems?.first?.menu)
         XCTAssertTrue(chrome.toolbar.isHidden)
         XCTAssertTrue(chrome.toolbar.items?.isEmpty == true)
+
+        if #available(iOS 26.0, *) {
+            XCTAssertEqual(chrome.navigationItem.leftBarButtonItems?.first?.style, .prominent)
+        }
     }
 
     func testWhenLargeSizeThenCollectionHasNoBottomInset() {

--- a/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
+++ b/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
@@ -211,6 +211,15 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
         XCTAssertEqual(collectionView.contentInset.bottom, 0)
     }
 
+    func testWhenCollectionContentInsetIsAppliedThenTopIncludesFloatingMargin() {
+        let chrome = FloatingTabSwitcherChrome()
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+
+        chrome.applyCollectionContentInset(to: collectionView)
+
+        XCTAssertEqual(collectionView.contentInset.top, 58)
+    }
+
     func testWhenLargeSizeHasSingleEmptyTabThenEditMenuIsDisabled() {
         let chrome = makeInstalledChrome()
         chrome.actions.onEditMenuRequested = { UIMenu(children: []) }

--- a/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
+++ b/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
@@ -130,6 +130,76 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
         XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.first?.title, UserText.deselectAllTabs)
     }
 
+    func testWhenLargeSizeThenMatchesProductionBarLayout() {
+        let chrome = makeInstalledChrome()
+        chrome.actions.onEditMenuRequested = { UIMenu(children: []) }
+
+        chrome.update(state: .largeSize(selectedCount: 0, totalCount: 3, containsWebPages: true, showAIChat: false, canDismissOnEmpty: true),
+                      tabsStyle: .grid,
+                      canShowSelectionMenu: false,
+                      isEditing: false)
+
+        XCTAssertEqual(chrome.navigationItem.leftBarButtonItems?.count, 2)
+        XCTAssertNotNil(chrome.navigationItem.leftBarButtonItems?.first?.menu)
+        XCTAssertNil(chrome.navigationItem.leftBarButtonItems?.last?.menu)
+        XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.first?.title, UserText.navigationTitleDone)
+        XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.count, 3)
+        XCTAssertTrue(chrome.toolbar.isHidden)
+        XCTAssertTrue(chrome.toolbar.items?.isEmpty == true)
+    }
+
+    func testWhenLargeSizeWithAIChatThenDuckChatIsInTopBar() {
+        let chrome = makeInstalledChrome()
+
+        chrome.update(state: .largeSize(selectedCount: 0, totalCount: 3, containsWebPages: true, showAIChat: true, canDismissOnEmpty: true),
+                      tabsStyle: .grid,
+                      canShowSelectionMenu: false,
+                      isEditing: false)
+
+        XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.count, 4)
+        XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.last?.accessibilityIdentifier, "TabSwitcher.Button.DuckChat")
+        XCTAssertTrue(chrome.toolbar.items?.isEmpty == true)
+    }
+
+    func testWhenEditingLargeSizeThenMatchesProductionBarLayout() {
+        let chrome = makeInstalledChrome()
+        chrome.setTitle("2 Selected")
+        chrome.actions.onMultiSelectMenuRequested = { UIMenu(children: []) }
+
+        chrome.update(state: .editingLargeSize(selectedCount: 2, totalCount: 4),
+                      tabsStyle: .grid,
+                      canShowSelectionMenu: true,
+                      isEditing: true)
+
+        XCTAssertEqual(chrome.navigationItem.leftBarButtonItems?.first?.title, UserText.navigationTitleDone)
+        XCTAssertEqual((chrome.navigationItem.titleView as? UILabel)?.text, "2 Selected")
+        XCTAssertNotNil(chrome.navigationItem.rightBarButtonItems?.first?.menu)
+        XCTAssertTrue(chrome.toolbar.isHidden)
+        XCTAssertTrue(chrome.toolbar.items?.isEmpty == true)
+    }
+
+    func testWhenLargeSizeThenCollectionHasNoBottomInset() {
+        let chrome = makeInstalledChrome()
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+
+        chrome.layout(addressBarPosition: .top, interfaceMode: .largeSize)
+        chrome.applyCollectionContentInset(to: collectionView)
+
+        XCTAssertEqual(collectionView.contentInset.bottom, 0)
+    }
+
+    func testWhenLargeSizeHasSingleEmptyTabThenEditMenuIsDisabled() {
+        let chrome = makeInstalledChrome()
+        chrome.actions.onEditMenuRequested = { UIMenu(children: []) }
+
+        chrome.update(state: .largeSize(selectedCount: 0, totalCount: 1, containsWebPages: false, showAIChat: false, canDismissOnEmpty: true),
+                      tabsStyle: .grid,
+                      canShowSelectionMenu: false,
+                      isEditing: false)
+
+        XCTAssertEqual(chrome.navigationItem.leftBarButtonItems?.first?.isEnabled, false)
+    }
+
     func testWhenNoTabsSelectedWhileEditingThenCloseTabsDisabled() {
         let chrome = makeInstalledChrome()
 

--- a/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
+++ b/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
@@ -199,8 +199,11 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
     }
 
     func testWhenLargeSizeThenCollectionHasNoBottomInset() {
-        let chrome = makeInstalledChrome()
+        let chrome = FloatingTabSwitcherChrome()
+        let host = UIView()
+        let content = UIScrollView()
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        chrome.install(in: host, contentView: content)
 
         chrome.layout(addressBarPosition: .top, interfaceMode: .largeSize)
         chrome.applyCollectionContentInset(to: collectionView)
@@ -292,6 +295,21 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
         XCTAssertEqual(secondContentConstraints.count, 4)
         XCTAssertTrue(firstContentConstraints.allSatisfy { !$0.isActive })
         XCTAssertTrue(secondContentConstraints.allSatisfy(\.isActive))
+    }
+
+    func testWhenLayoutIsAppliedThenNavigationBarUsesPlatformTopMargin() {
+        guard UIDevice.current.userInterfaceIdiom != .pad else { return }
+        let chrome = FloatingTabSwitcherChrome()
+        let host = UIView()
+        let content = UIScrollView()
+        chrome.install(in: host, contentView: content)
+
+        chrome.layout(addressBarPosition: .top, interfaceMode: .regularSize)
+
+        let topConstraint = host.constraints.first {
+            $0.firstItem is UINavigationBar && $0.firstAttribute == .top
+        }
+        XCTAssertTrue((topConstraint?.secondItem as? UILayoutGuide) === host.layoutMarginsGuide)
     }
 
     func testWhenLayoutIsAppliedThenFallbackTopBackgroundCoversContentBeforeIOS26() {

--- a/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
+++ b/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
@@ -97,6 +97,26 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
         XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.first?.title, UserText.selectAllTabs)
     }
 
+    func testWhenEditingTitleChangesThenLabelResizesToFitNewTitle() {
+        let chrome = makeInstalledChrome()
+        chrome.setTitle("2 Tabs")
+        chrome.update(state: .editingRegularSize(selectedCount: 0, totalCount: 2),
+                      tabsStyle: .grid,
+                      canShowSelectionMenu: true,
+                      isEditing: true)
+
+        guard let titleLabel = chrome.navigationItem.leftBarButtonItems?.first?.customView as? UILabel else {
+            XCTFail("Missing selection title label")
+            return
+        }
+        let initialWidth = titleLabel.frame.width
+
+        chrome.setTitle("5 Private Tabs")
+
+        XCTAssertGreaterThan(titleLabel.frame.width, initialWidth)
+        XCTAssertGreaterThanOrEqual(titleLabel.frame.width, titleLabel.intrinsicContentSize.width)
+    }
+
     func testWhenEditingThenBottomBarHasDoneCloseTabsAndMenu() {
         let chrome = makeInstalledChrome()
         chrome.actions.onMultiSelectMenuRequested = { UIMenu(children: []) }

--- a/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
+++ b/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
@@ -108,7 +108,7 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
 
         let items = chrome.toolbar.items ?? []
         let doneIndex = items.firstIndex { $0.accessibilityLabel == UserText.navigationTitleDone }
-        let closeTabsIndex = items.firstIndex { $0.title == UserText.closeTabs(withCount: 2) }
+        let closeTabsIndex = items.firstIndex { $0.title == UserText.tabSwitcherCloseTabsButtonTitle(withCount: 2) }
         let menuIndex = items.firstIndex { $0.menu != nil }
 
         guard let doneIndex, let closeTabsIndex, let menuIndex else {
@@ -208,8 +208,22 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
                       canShowSelectionMenu: false,
                       isEditing: true)
 
-        let closeTabsItem = chrome.toolbar.items?.first { $0.title == UserText.closeTabs(withCount: 0) }
+        let closeTabsItem = chrome.toolbar.items?.first { $0.title == UserText.tabSwitcherCloseTabsButtonTitle(withCount: 0) }
         XCTAssertEqual(closeTabsItem?.isEnabled, false)
+    }
+
+    func testWhenOneTabSelectedWhileEditingThenCloseTabsTitleIncludesCount() {
+        let chrome = makeInstalledChrome()
+
+        chrome.update(state: .editingRegularSize(selectedCount: 1, totalCount: 4),
+                      tabsStyle: .grid,
+                      canShowSelectionMenu: true,
+                      isEditing: true)
+
+        let closeTabsItem = chrome.toolbar.items?.first {
+            $0.title == UserText.tabSwitcherCloseTabsButtonTitle(withCount: 1)
+        }
+        XCTAssertNotNil(closeTabsItem)
     }
 
     func testWhenTabsSelectedWhileEditingThenCloseTabsEnabled() {
@@ -220,7 +234,7 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
                       canShowSelectionMenu: true,
                       isEditing: true)
 
-        let closeTabsItem = chrome.toolbar.items?.first { $0.title == UserText.closeTabs(withCount: 2) }
+        let closeTabsItem = chrome.toolbar.items?.first { $0.title == UserText.tabSwitcherCloseTabsButtonTitle(withCount: 2) }
         XCTAssertEqual(closeTabsItem?.isEnabled, true)
     }
 

--- a/iOS/DuckDuckGoTests/TabSwitcherMenuBuilderTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherMenuBuilderTests.swift
@@ -62,6 +62,30 @@ class DefaultTabSwitcherMenuBuilderTests: XCTestCase {
         XCTAssertFalse(actions.contains(title: UserText.tabSwitcherBookmarkAllTabs))
     }
 
+    func testMultiSelectMenu_whenSelectionToggleActionsAreHidden_doesNotShowSelectAll() {
+        let state = TabSwitcherMultiSelectMenuState(
+            selectedCount: 0, totalCount: 3,
+            selectedContainsWebPages: false, allContainsWebPages: false,
+            shouldShowSelectionToggleActions: false
+        )
+        let items = builder.multiSelectionMenuItems(state: state, actions: noopMultiSelectActions)
+        let actions = flatActions(items)
+
+        XCTAssertFalse(actions.contains(title: UserText.selectAllTabs))
+    }
+
+    func testMultiSelectMenu_whenSelectionToggleActionsAreHidden_doesNotShowDeselectAll() {
+        let state = TabSwitcherMultiSelectMenuState(
+            selectedCount: 3, totalCount: 3,
+            selectedContainsWebPages: false, allContainsWebPages: false,
+            shouldShowSelectionToggleActions: false
+        )
+        let items = builder.multiSelectionMenuItems(state: state, actions: noopMultiSelectActions)
+        let actions = flatActions(items)
+
+        XCTAssertFalse(actions.contains(title: UserText.deselectAllTabs))
+    }
+
     func testMultiSelectMenu_whenAllSelected_showsDeselectAllAndClose() {
         let state = TabSwitcherMultiSelectMenuState(
             selectedCount: 3, totalCount: 3,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1216898657210012?focus=true
Tech Design URL:
CC:

### Description
Addressed following feedback:
* [Multi-Select: checked icon appears smaller than unchecked](https://app.asana.com/1/137249556945/task/1216854623859737)
* [Multi-Select: title showing cropped after closing some tabs](https://app.asana.com/1/137249556945/task/1216854795649362)
* [Multi-Select: remove “Select All” from options menu](https://app.asana.com/1/137249556945/task/1216854795649360)
* [Multi-Select: fix color for unchecked icon](https://app.asana.com/1/137249556945/task/1216854795649357)
* [iPadOS: adopt liquid glass but keep existing toolbar button arrangement](https://app.asana.com/1/137249556945/task/1216854795649355)
* [Multi-Select: show count of selected tabs in “Close Tabs” button](https://app.asana.com/1/137249556945/task/1216854795649361)
* [Landscape: missing margin in top-toolbar](https://app.asana.com/1/137249556945/task/1216854623859734)

### Testing Steps
1. Validate all above items addressed correctly.
2. Smoke test tabswitcher still working as expected.

### Impact
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Could break tab switcher.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tab switcher chrome layout across iPhone/iPad and feature-flagged multi-select menus; regressions could break tab management UX but changes are UI-focused with added tests.
> 
> **Overview**
> Addresses tab switcher ship-review feedback across **multi-select**, **floating chrome**, and **localization**.
> 
> **Multi-select:** Tab cells use tertiary tint and adjusted symbol sizing for unchecked vs checked indicators. The selection title label resizes when the title changes so it doesn’t crop after closing tabs. On iPhone with the July 2026 tab switcher flag, **Select All** / **Deselect All** are removed from the overflow menu (toolbar still offers select/deselect where applicable). The bottom **Close Tabs** action uses a new pluralized string that includes the selected count.
> 
> **Floating tab switcher chrome:** Large iPad-style `interfaceMode` now mirrors the production top-bar: edit, tabs style, Done, fire, plus, and optional Duck Chat in the navigation bar with the bottom toolbar hidden; editing large size uses Done, title, and multi-select menu in the top bar. iOS 26 liquid-glass `sharesBackground` is configured per mode. Top inset adds an 8pt floating margin (landscape margin fix); large size drops bottom collection inset. Navigation bar top anchor uses layout margins on phone and vertical margin adaptation on iPad. Edit menu is disabled when there is only one empty tab.
> 
> **Tests:** Expanded `FloatingTabSwitcherChromeTests` and menu builder tests for the above behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b3cde2cdacab36b012ee41c2989836f5e79eb02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->