### PR TITLE
iOS: Name the UTI display-state questions once (part 1 — predicates + call-site migration)

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2256,6 +2256,7 @@
 		CB781CDA30113EEE008DCD60 /* UTIKeyboardMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB781CD930113EEE008DCD60 /* UTIKeyboardMonitor.swift */; };
 		CB781CDC30138F32008DCD60 /* UTIPixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB781CDB30138F32008DCD60 /* UTIPixelReporter.swift */; };
 		CB781CDE30138F52008DCD60 /* UTIPixelReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB781CDD30138F52008DCD60 /* UTIPixelReporterTests.swift */; };
+		CB781CE030138F52008DCD70 /* UTIStateMachineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB781CDF30138F52008DCD70 /* UTIStateMachineTests.swift */; };
 		CB781CE0301392B6008DCD60 /* UTIWideEventReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB781CDF301392B6008DCD60 /* UTIWideEventReporter.swift */; };
 		CB781CE23013AB54008DCD60 /* UTIModelSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB781CE13013AB54008DCD60 /* UTIModelSelector.swift */; };
 		CB781CE43013BA7A008DCD60 /* UnifiedToggleInputDisplayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB781CE33013BA7A008DCD60 /* UnifiedToggleInputDisplayState.swift */; };
@@ -5012,6 +5013,7 @@
 		CB781CD930113EEE008DCD60 /* UTIKeyboardMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIKeyboardMonitor.swift; sourceTree = "<group>"; };
 		CB781CDB30138F32008DCD60 /* UTIPixelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIPixelReporter.swift; sourceTree = "<group>"; };
 		CB781CDD30138F52008DCD60 /* UTIPixelReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIPixelReporterTests.swift; sourceTree = "<group>"; };
+		CB781CDF30138F52008DCD70 /* UTIStateMachineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIStateMachineTests.swift; sourceTree = "<group>"; };
 		CB781CDF301392B6008DCD60 /* UTIWideEventReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIWideEventReporter.swift; sourceTree = "<group>"; };
 		CB781CE13013AB54008DCD60 /* UTIModelSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIModelSelector.swift; sourceTree = "<group>"; };
 		CB781CE33013BA7A008DCD60 /* UnifiedToggleInputDisplayState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputDisplayState.swift; sourceTree = "<group>"; };
@@ -9882,6 +9884,7 @@
 				CB781CCE30112EC9008DCD60 /* UTISessionMonitorTests.swift */,
 				CB781CD3301135BE008DCD60 /* UTITextModelTests.swift */,
 				CB781CDD30138F52008DCD60 /* UTIPixelReporterTests.swift */,
+				CB781CDF30138F52008DCD70 /* UTIStateMachineTests.swift */,
 			);
 			path = UnifiedToggleInput;
 			sourceTree = "<group>";
@@ -14410,6 +14413,7 @@
 				8565A34D1FC8DFE400239327 /* LaunchTabNotificationTests.swift in Sources */,
 				BB1D99D92EB9F3710050D8CF /* MockWinBackOfferPresenter.swift in Sources */,
 				CB781CDE30138F52008DCD60 /* UTIPixelReporterTests.swift in Sources */,
+				CB781CE030138F52008DCD70 /* UTIStateMachineTests.swift in Sources */,
 				9FCCC09F2FB59F16001F2670 /* DuckAIDestinationHandlerTests.swift in Sources */,
 				CB27DAF730063B9100EEEADB /* ToolbarVisibilityDecisionTests.swift in Sources */,
 				9FA0AF1A2EB4855000713387 /* MockRemoteMessagingPixelReporter.swift in Sources */,

--- a/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
@@ -29,7 +29,6 @@ final class IPadOmnibarToolPickerController {
     private let store: UTIModelStore
     private let toolsController = UTIToolsController()
     private let menuFactory = UTIToolsMenuFactory()
-    private let displayState: UnifiedToggleInputDisplayState = .omnibar(.active)
     var onToolsUpdated: (() -> Void)?
 
     init(store: UTIModelStore) {
@@ -101,7 +100,7 @@ final class IPadOmnibarToolPickerController {
 
     private var presentation: UTIToolsController.Presentation {
         toolsController.presentation(
-            displayState: displayState,
+            isActive: true,
             modelStore: store,
             canShowCustomizeResponses: false
         )

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1896,9 +1896,7 @@ class MainViewController: UIViewController {
         configureUnifiedInputEscapeHatch(model)
     }
 
-    /// True when the address bar owns editing focus. Reads the persistent omnibar-session state, which
-    /// survives a card tap that dismisses the keyboard. Narrower than `isKeyboardOwnedByOmnibar`, which
-    /// also treats a first responder anywhere inside the omnibar view hierarchy as omnibar-owned.
+    /// True when the address bar owns editing focus; survives a card tap that dismisses the keyboard.
     private var isAddressBarFocused: Bool {
         omniBar.isTextFieldEditing || unifiedToggleInputCoordinator?.isOmnibarSession == true
     }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1635,7 +1635,7 @@ class MainViewController: UIViewController {
         updateUnifiedToggleInputKeyboardVisibility(keyboardVisible)
 
         let coordinator = unifiedToggleInputCoordinator
-        let isAITabCollapsed = coordinator?.displayState == .aiTab(.collapsed)
+        let isAITabCollapsed = coordinator?.isAITabCollapsed == true
         let isBottomExpandedUTIKeyboardAnchored = coordinator?.isInputEditing == true
             && coordinator?.cardPosition == .bottom
             && viewCoordinator.isNavigationBarContainerBottomKeyboardBased
@@ -1896,9 +1896,10 @@ class MainViewController: UIViewController {
         configureUnifiedInputEscapeHatch(model)
     }
 
-    /// True when an escape hatch action runs in focus mode (reads the persistent omnibar-session state, which
-    /// survives the card tap that dismisses the keyboard).
-    private var isEscapeHatchInFocusMode: Bool {
+    /// True when the address bar owns editing focus. Reads the persistent omnibar-session state, which
+    /// survives a card tap that dismisses the keyboard. Narrower than `isKeyboardOwnedByOmnibar`, which
+    /// also treats a first responder anywhere inside the omnibar view hierarchy as omnibar-owned.
+    private var isAddressBarFocused: Bool {
         omniBar.isTextFieldEditing || unifiedToggleInputCoordinator?.isOmnibarSession == true
     }
 
@@ -3172,7 +3173,7 @@ class MainViewController: UIViewController {
     /// no-op once correct — no loop, no per-frame work beyond the bool check.
     private func reanchorAITabCollapsedFooterIfNeeded() {
         guard let coordinator = unifiedToggleInputCoordinator,
-              coordinator.displayState == .aiTab(.collapsed),
+              coordinator.isAITabCollapsed,
               coordinator.cardPosition == .bottom,
               !viewCoordinator.isNavigationBarContainerBottomKeyboardBased else { return }
         viewCoordinator.setNavBarContainerBottomToKeyboard()
@@ -4154,7 +4155,7 @@ extension MainViewController: BrowserChromeDelegate {
         chromeMorphAnimator.cancel()
 
         if percent < 1 {
-            if omniBar.isTextFieldEditing || unifiedToggleInputCoordinator?.isOmnibarSession == true {
+            if isAddressBarFocused {
                 dismissOmniBar()
             }
             _ = findInPageView?.resignFirstResponder()
@@ -5726,7 +5727,7 @@ extension MainViewController: EscapeHatchActionRouter {
         }
 
         // Captured before the confirmation dialog steals focus, so we can restore the keyboard afterwards.
-        let wasInFocusMode = isEscapeHatchInFocusMode
+        let wasInFocusMode = isAddressBarFocused
         let tabViewModel = tabManager.viewModel(for: tab)
         let presenter = FireConfirmationPresenter()
         presenter.presentFireConfirmation(
@@ -5756,7 +5757,7 @@ extension MainViewController: EscapeHatchActionRouter {
             return
         }
 
-        let wasInFocusMode = isEscapeHatchInFocusMode
+        let wasInFocusMode = isAddressBarFocused
         let tabViewModel = tabManager.viewModel(for: tab)
         let request = FireRequest(
             options: .all,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIStateMachine.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIStateMachine.swift
@@ -58,8 +58,24 @@ final class UTIStateMachine {
         displayState == .aiTab(.expanded)
     }
 
+    var isAITabCollapsed: Bool {
+        displayState == .aiTab(.collapsed)
+    }
+
     var isContextualChatState: Bool {
         displayState == .contextualChat
+    }
+
+    /// The omnibar session is being edited. Distinct from `isOmnibarSession` (any omnibar state)
+    /// and from `isActive` (any state other than `.hidden`).
+    var isOmnibarEditing: Bool {
+        displayState == .omnibar(.active)
+    }
+
+    /// The omnibar sub-state, or `nil` when the current state isn't an omnibar one.
+    var omnibarState: UnifiedToggleInputDisplayState.OmnibarState? {
+        if case .omnibar(let state) = displayState { return state }
+        return nil
     }
 
     /// Folds contextual + Duck.ai tab into one "Duck.ai surface" bucket — used only for the funnel `origin`.
@@ -96,6 +112,13 @@ final class UTIStateMachine {
     /// Combines user setting + Duck.ai-tab hide flag; the kill-switch term drops out on non-AI tabs.
     func isToggleVisible(isToggleEnabled: Bool) -> Bool {
         isToggleEnabled && !(hidesToggleOnDuckAITab && isAITabState)
+    }
+
+    /// Search mode on an expanded Duck.ai tab — the state where the toggle has been flipped to Search
+    /// but the chat web view is still the tab's content. Requires `.aiTab(.expanded)`, not any AI-tab
+    /// state: on a collapsed AI tab there is no input pane for a mode to apply to.
+    func isSearchOnAITab(inputMode: TextEntryMode) -> Bool {
+        isAITabExpanded && inputMode == .search
     }
 
     // MARK: - Render
@@ -135,7 +158,7 @@ final class UTIStateMachine {
             isExpanded = true
             isInputVisible = true
             let isAIChatOnAITab = isAITabState && inputMode == .aiChat
-            let isSearchOnAITab = isAITabState && inputMode == .search
+            let isSearchOnAITab = self.isSearchOnAITab(inputMode: inputMode)
             // Toggling to Search on a chat tab without visible text is a mode switch — keep the
             // chat web view; `textState` (not `currentText`) excludes preserved drafts from
             // dismiss-cleanup.

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIStateMachine.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIStateMachine.swift
@@ -58,6 +58,7 @@ final class UTIStateMachine {
         displayState == .aiTab(.expanded)
     }
 
+    /// A Duck.ai tab showing the collapsed chat-input footer rather than the expanded input pane.
     var isAITabCollapsed: Bool {
         displayState == .aiTab(.collapsed)
     }
@@ -114,9 +115,8 @@ final class UTIStateMachine {
         isToggleEnabled && !(hidesToggleOnDuckAITab && isAITabState)
     }
 
-    /// Search mode on an expanded Duck.ai tab — the state where the toggle has been flipped to Search
-    /// but the chat web view is still the tab's content. Requires `.aiTab(.expanded)`, not any AI-tab
-    /// state: on a collapsed AI tab there is no input pane for a mode to apply to.
+    /// Search mode on an expanded Duck.ai tab — requires `.aiTab(.expanded)`, not any AI-tab state.
+    /// Not reachable with default behaviour: the mode toggle isn't shown on Duck.ai tabs today.
     func isSearchOnAITab(inputMode: TextEntryMode) -> Bool {
         isAITabExpanded && inputMode == .search
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -851,9 +851,8 @@ extension MainViewController {
         updateUnifiedInputContentVisibility(for: coordinator, renderState: coordinator.computeRenderState())
     }
 
-    /// The collapsed-AI-tab pose reads the coordinator's live display state, so a caller passing an
-    /// already-stale snapshot can't drive a pose the coordinator has moved past. Everything below it
-    /// still trusts `renderState` — every current caller computes that fresh from this same coordinator.
+    /// The collapsed-footer pose — how the Duck.ai chat input and its separator sit at the bottom of the
+    /// screen — reads the coordinator's live display state; the chrome below it still trusts `renderState`.
     func updateUnifiedInputContentVisibility(for coordinator: UnifiedToggleInputCoordinator, renderState: UTIRenderState) {
         let isOnAITab = currentTab?.isAITab == true
         coordinator.contentViewController.forceBottomBarLayout = coordinator.isAITabState

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -477,7 +477,7 @@ private extension MainViewController {
             .removeDuplicates()
             .sink { [weak self] _ in
                 guard let self, let coordinator = self.unifiedToggleInputCoordinator,
-                      coordinator.isAITabExpanded, coordinator.inputMode == .search else { return }
+                      coordinator.isSearchOnAITab else { return }
                 self.updateUnifiedInputContentVisibility(for: coordinator)
             }
             .store(in: &unifiedToggleInputCancellables)
@@ -851,11 +851,14 @@ extension MainViewController {
         updateUnifiedInputContentVisibility(for: coordinator, renderState: coordinator.computeRenderState())
     }
 
+    /// The collapsed-AI-tab pose reads the coordinator's live display state, so a caller passing an
+    /// already-stale snapshot can't drive a pose the coordinator has moved past. Everything below it
+    /// still trusts `renderState` — every current caller computes that fresh from this same coordinator.
     func updateUnifiedInputContentVisibility(for coordinator: UnifiedToggleInputCoordinator, renderState: UTIRenderState) {
         let isOnAITab = currentTab?.isAITab == true
         coordinator.contentViewController.forceBottomBarLayout = coordinator.isAITabState
 
-        let isAITabCollapsed = coordinator.isAITabState && !renderState.isExpanded
+        let isAITabCollapsed = coordinator.isAITabCollapsed
         coordinator.viewController.setAITabCollapsedFooterPoseActive(isAITabCollapsed)
         viewCoordinator.setAITabCollapsedTopSeparatorVisible(isAITabCollapsed)
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
@@ -43,7 +43,7 @@ extension MainViewController {
 
     func syncBottomOmnibarAnchorIfNeeded(for coordinator: UnifiedToggleInputCoordinator) {
         guard coordinator.cardPosition == .bottom,
-              case .omnibar(let state) = coordinator.displayState,
+              let state = coordinator.omnibarState,
               viewCoordinator.addressBarPosition.isBottom else {
             return
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputSwipeTabs.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputSwipeTabs.swift
@@ -59,7 +59,7 @@ extension MainViewController {
             return false
         }
 
-        if case .omnibar(.active) = coordinator.displayState {
+        if coordinator.isOmnibarEditing {
             return false
         }
         if coordinator.viewController.isInputFirstResponder {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIToolsController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIToolsController.swift
@@ -65,7 +65,7 @@ final class UTIToolsController {
     }
 
     func presentation(
-        displayState: UnifiedToggleInputDisplayState,
+        isActive: Bool,
         modelStore: UTIModelStore,
         canShowCustomizeResponses: Bool
     ) -> Presentation {
@@ -73,7 +73,7 @@ final class UTIToolsController {
             modelStore: modelStore,
             canShowCustomizeResponses: canShowCustomizeResponses
         )
-        guard canShowTools(displayState: displayState),
+        guard canShowTools(isActive: isActive),
               hasActionableMenuItem(modelStore: modelStore, toolsMenu: toolsMenu) else {
             return .hidden
         }
@@ -99,8 +99,8 @@ final class UTIToolsController {
 private extension UTIToolsController {
 
     // Mode-gating lives at the toolbar-container level; toggling `isHidden` per-button would step-vanish before the toolbar's alpha fade completes.
-    func canShowTools(displayState: UnifiedToggleInputDisplayState) -> Bool {
-        return displayState != .hidden
+    func canShowTools(isActive: Bool) -> Bool {
+        return isActive
     }
 
     func buildToolsMenu(modelStore: UTIModelStore, canShowCustomizeResponses: Bool) -> UTIToolsMenu {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -197,7 +197,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     var isOmnibarSession: Bool { stateMachine.isOmnibarSession }
     var isAITabState: Bool { stateMachine.isAITabState }
     var isAITabExpanded: Bool { stateMachine.isAITabExpanded }
+    var isAITabCollapsed: Bool { stateMachine.isAITabCollapsed }
     var isContextualChatState: Bool { stateMachine.isContextualChatState }
+    var isOmnibarEditing: Bool { stateMachine.isOmnibarEditing }
+    var omnibarState: UnifiedToggleInputDisplayState.OmnibarState? { stateMachine.omnibarState }
+    var isSearchOnAITab: Bool { stateMachine.isSearchOnAITab(inputMode: inputMode) }
     var isDuckAISurfaceForAttribution: Bool { stateMachine.isDuckAISurfaceForAttribution }
     var pixelSurface: UnifiedToggleInputPixelSurface { stateMachine.pixelSurface }
     var isInputPaneExpanded: Bool { stateMachine.isInputPaneExpanded }
@@ -217,7 +221,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
 
     private var usesFloatingReturnKey: Bool {
-        displayState == .omnibar(.active) && isInputVisibleForKeyboard && isOmnibarNewAIChatPrompt
+        isOmnibarEditing && isInputVisibleForKeyboard && isOmnibarNewAIChatPrompt
     }
 
     private var cancellables = Set<AnyCancellable>()
@@ -823,11 +827,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         }
 
         DispatchQueue.main.async { [weak self] in
-            guard let self, case .omnibar(.active) = displayState else { return }
+            guard let self, isOmnibarEditing else { return }
             viewController.activateInput()
             guard omnibarPrefilledText != nil else { return }
             DispatchQueue.main.async { [weak self] in
-                guard let self, case .omnibar(.active) = displayState else { return }
+                guard let self, isOmnibarEditing else { return }
                 if selectsAllText {
                     viewController.selectAllText()
                 } else {
@@ -992,7 +996,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         isInputVisibleForKeyboard = isInputVisible
         syncInputBehaviorToHandler()
         updateFloatingReturnKeyState()
-        let isAITabSearch = displayState == .aiTab(.expanded) && inputMode == .search
+        let isAITabSearch = isSearchOnAITab
 
         switch (displayState, isInputVisible) {
         case (.omnibar(.active), false) where keyboardMonitor.isAwaitingPresentation:
@@ -1039,12 +1043,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
 
     func dismissOmnibarKeyboard() {
-        switch displayState {
-        case .contextualChat, .omnibar(.active), .aiTab(.expanded):
-            viewController.deactivateInput()
-        default:
-            return
-        }
+        guard isInputPaneExpanded else { return }
+        viewController.deactivateInput()
     }
 
     func setEscapeHatch(_ model: EscapeHatchModel) {
@@ -1472,7 +1472,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
             }
             sessionMonitor.recordActivity(mode: .search)
             clearStoreEntryAfterSubmission()
-            if case .aiTab = displayState {
+            if isAITabState {
                 hide()
             } else if isContextualChatState {
                 hide()
@@ -1691,7 +1691,7 @@ private extension UnifiedToggleInputCoordinator {
     }
 
     func expandIfOnExpandedInputHost() {
-        if case .aiTab = displayState {
+        if isAITabState {
             showExpanded()
         } else if isContextualChatState {
             showExpanded()
@@ -2040,7 +2040,7 @@ private extension UnifiedToggleInputCoordinator {
 
     func refreshToolsPresentation() {
         let presentation = toolsController.presentation(
-            displayState: displayState,
+            isActive: isActive,
             modelStore: modelStore,
             canShowCustomizeResponses: canShowCustomizeResponsesMenuItem
         )

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIStateMachineTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIStateMachineTests.swift
@@ -1,0 +1,215 @@
+//
+//  UTIStateMachineTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+@MainActor
+final class UTIStateMachineTests: XCTestCase {
+
+    private func makeSUT(_ displayState: UnifiedToggleInputDisplayState,
+                         host: UnifiedToggleInputHost = .omnibar,
+                         hidesToggleOnDuckAITab: Bool = false) -> UTIStateMachine {
+        UTIStateMachine(displayState: displayState, host: host, hidesToggleOnDuckAITab: hidesToggleOnDuckAITab)
+    }
+
+    /// One row per display state, asserting the whole predicate vector. Adding a display state
+    /// should fail to compile here (the switch is exhaustive) and force a new row — that's the point.
+    private struct Expectation {
+        let isOmnibarSession: Bool
+        let isAITabState: Bool
+        let isAITabExpanded: Bool
+        let isAITabCollapsed: Bool
+        let isContextualChatState: Bool
+        let isOmnibarEditing: Bool
+        let isDuckAISurfaceForAttribution: Bool
+        let isInputPaneExpanded: Bool
+        let isInputEditing: Bool
+        let isActive: Bool
+        let omnibarState: UnifiedToggleInputDisplayState.OmnibarState?
+        let pixelSurface: UnifiedToggleInputPixelSurface
+    }
+
+    private func expectation(for displayState: UnifiedToggleInputDisplayState) -> Expectation {
+        switch displayState {
+        case .hidden:
+            return Expectation(isOmnibarSession: false, isAITabState: false, isAITabExpanded: false,
+                               isAITabCollapsed: false, isContextualChatState: false, isOmnibarEditing: false,
+                               isDuckAISurfaceForAttribution: false, isInputPaneExpanded: false,
+                               isInputEditing: false, isActive: false, omnibarState: nil, pixelSurface: .addressBar)
+        case .contextualChat:
+            return Expectation(isOmnibarSession: false, isAITabState: false, isAITabExpanded: false,
+                               isAITabCollapsed: false, isContextualChatState: true, isOmnibarEditing: false,
+                               isDuckAISurfaceForAttribution: true, isInputPaneExpanded: true,
+                               isInputEditing: true, isActive: true, omnibarState: nil, pixelSurface: .contextualChat)
+        case .aiTab(.collapsed):
+            return Expectation(isOmnibarSession: false, isAITabState: true, isAITabExpanded: false,
+                               isAITabCollapsed: true, isContextualChatState: false, isOmnibarEditing: false,
+                               isDuckAISurfaceForAttribution: true, isInputPaneExpanded: false,
+                               isInputEditing: false, isActive: true, omnibarState: nil, pixelSurface: .duckAI)
+        case .aiTab(.expanded):
+            return Expectation(isOmnibarSession: false, isAITabState: true, isAITabExpanded: true,
+                               isAITabCollapsed: false, isContextualChatState: false, isOmnibarEditing: false,
+                               isDuckAISurfaceForAttribution: true, isInputPaneExpanded: true,
+                               isInputEditing: true, isActive: true, omnibarState: nil, pixelSurface: .duckAI)
+        case .omnibar(.active):
+            return Expectation(isOmnibarSession: true, isAITabState: false, isAITabExpanded: false,
+                               isAITabCollapsed: false, isContextualChatState: false, isOmnibarEditing: true,
+                               isDuckAISurfaceForAttribution: false, isInputPaneExpanded: true,
+                               isInputEditing: true, isActive: true, omnibarState: .active, pixelSurface: .addressBar)
+        case .omnibar(.inactive):
+            return Expectation(isOmnibarSession: true, isAITabState: false, isAITabExpanded: false,
+                               isAITabCollapsed: false, isContextualChatState: false, isOmnibarEditing: false,
+                               isDuckAISurfaceForAttribution: false, isInputPaneExpanded: false,
+                               isInputEditing: true, isActive: true, omnibarState: .inactive, pixelSurface: .addressBar)
+        }
+    }
+
+    private static let allDisplayStates: [UnifiedToggleInputDisplayState] = [
+        .hidden, .contextualChat, .aiTab(.collapsed), .aiTab(.expanded), .omnibar(.active), .omnibar(.inactive)
+    ]
+
+    // MARK: - Full predicate vector
+
+    func test_predicateVector_forEveryDisplayState() {
+        for displayState in Self.allDisplayStates {
+            let sut = makeSUT(displayState)
+            let expected = expectation(for: displayState)
+            let context = "\(displayState)"
+
+            XCTAssertEqual(sut.isOmnibarSession, expected.isOmnibarSession, "isOmnibarSession — \(context)")
+            XCTAssertEqual(sut.isAITabState, expected.isAITabState, "isAITabState — \(context)")
+            XCTAssertEqual(sut.isAITabExpanded, expected.isAITabExpanded, "isAITabExpanded — \(context)")
+            XCTAssertEqual(sut.isAITabCollapsed, expected.isAITabCollapsed, "isAITabCollapsed — \(context)")
+            XCTAssertEqual(sut.isContextualChatState, expected.isContextualChatState, "isContextualChatState — \(context)")
+            XCTAssertEqual(sut.isOmnibarEditing, expected.isOmnibarEditing, "isOmnibarEditing — \(context)")
+            XCTAssertEqual(sut.isDuckAISurfaceForAttribution, expected.isDuckAISurfaceForAttribution, "isDuckAISurfaceForAttribution — \(context)")
+            XCTAssertEqual(sut.isInputPaneExpanded, expected.isInputPaneExpanded, "isInputPaneExpanded — \(context)")
+            XCTAssertEqual(sut.isInputEditing, expected.isInputEditing, "isInputEditing — \(context)")
+            XCTAssertEqual(sut.isActive, expected.isActive, "isActive — \(context)")
+            XCTAssertEqual(sut.omnibarState, expected.omnibarState, "omnibarState — \(context)")
+            XCTAssertEqual(sut.pixelSurface, expected.pixelSurface, "pixelSurface — \(context)")
+        }
+    }
+
+    func test_transition_movesToTheNewStateAndItsPredicates() {
+        let sut = makeSUT(.hidden)
+        XCTAssertFalse(sut.isActive)
+
+        sut.transition(to: .aiTab(.collapsed))
+
+        XCTAssertTrue(sut.isAITabCollapsed)
+        XCTAssertFalse(sut.isAITabExpanded)
+        XCTAssertTrue(sut.isActive)
+    }
+
+    // MARK: - isSearchOnAITab
+
+    /// Deliberately requires `.aiTab(.expanded)`, not any AI-tab state: a collapsed Duck.ai tab has no
+    /// input pane for a mode to apply to. Widening this to `isAITabState` would make consumers fire on
+    /// collapsed tabs, so the collapsed rows below are the ones that matter.
+    func test_isSearchOnAITab_isTrueOnlyForExpandedAITabInSearchMode() {
+        for displayState in Self.allDisplayStates {
+            for inputMode in TextEntryMode.allCases {
+                let sut = makeSUT(displayState)
+                let expected = displayState == .aiTab(.expanded) && inputMode == .search
+
+                XCTAssertEqual(sut.isSearchOnAITab(inputMode: inputMode), expected,
+                               "isSearchOnAITab — \(displayState) / \(inputMode)")
+            }
+        }
+    }
+
+    func test_isSearchOnAITab_isFalseOnCollapsedAITabEvenInSearchMode() {
+        let sut = makeSUT(.aiTab(.collapsed))
+
+        XCTAssertFalse(sut.isSearchOnAITab(inputMode: .search))
+    }
+
+    // MARK: - isToggleVisible
+
+    func test_isToggleVisible_matrix() {
+        let cases: [(displayState: UnifiedToggleInputDisplayState, hidesOnDuckAITab: Bool, isToggleEnabled: Bool, expected: Bool)] = [
+            (.omnibar(.active), false, true, true),
+            (.omnibar(.active), true, true, true),
+            (.omnibar(.active), true, false, false),
+            (.aiTab(.expanded), false, true, true),
+            (.aiTab(.expanded), true, true, false),
+            (.aiTab(.collapsed), true, true, false),
+            (.contextualChat, true, true, true)
+        ]
+
+        for testCase in cases {
+            let sut = makeSUT(testCase.displayState, hidesToggleOnDuckAITab: testCase.hidesOnDuckAITab)
+
+            XCTAssertEqual(sut.isToggleVisible(isToggleEnabled: testCase.isToggleEnabled), testCase.expected,
+                           "\(testCase.displayState) / hidesOnDuckAITab \(testCase.hidesOnDuckAITab) / enabled \(testCase.isToggleEnabled)")
+        }
+    }
+
+    // MARK: - Disjointness relied on by call sites
+
+    /// `MainViewController.adjustUI` ANDs `!isAITabCollapsed` with `isOmnibarSession`; that term is only
+    /// redundant (rather than wrong) because the two can never be true at once.
+    func test_isAITabCollapsed_andIsOmnibarSession_areNeverBothTrue() {
+        for displayState in Self.allDisplayStates {
+            let sut = makeSUT(displayState)
+
+            XCTAssertFalse(sut.isAITabCollapsed && sut.isOmnibarSession, "\(displayState)")
+        }
+    }
+
+    func test_aiTabCollapsedAndExpanded_areMutuallyExclusive() {
+        for displayState in Self.allDisplayStates {
+            let sut = makeSUT(displayState)
+
+            XCTAssertFalse(sut.isAITabCollapsed && sut.isAITabExpanded, "\(displayState)")
+            if sut.isAITabCollapsed || sut.isAITabExpanded {
+                XCTAssertTrue(sut.isAITabState, "\(displayState)")
+            }
+        }
+    }
+
+    /// `dismissOmnibarKeyboard` replaced a three-case switch with `guard isInputPaneExpanded`, so this
+    /// set is now load-bearing for keyboard dismissal.
+    func test_isInputPaneExpanded_coversExactlyContextualChatExpandedAITabAndOmnibarEditing() {
+        let expectedTrue: [UnifiedToggleInputDisplayState] = [.contextualChat, .aiTab(.expanded), .omnibar(.active)]
+
+        for displayState in Self.allDisplayStates {
+            let sut = makeSUT(displayState)
+
+            XCTAssertEqual(sut.isInputPaneExpanded, expectedTrue.contains(displayState), "\(displayState)")
+        }
+    }
+
+    // MARK: - omnibarState
+
+    func test_omnibarState_isNilForEveryNonOmnibarState() {
+        for displayState in Self.allDisplayStates where sutIsNotOmnibar(displayState) {
+            let sut = makeSUT(displayState)
+
+            XCTAssertNil(sut.omnibarState, "\(displayState)")
+        }
+    }
+
+    private func sutIsNotOmnibar(_ displayState: UnifiedToggleInputDisplayState) -> Bool {
+        if case .omnibar = displayState { return false }
+        return true
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216878797836710

### Description

The unified toggle input describes what it's showing with a small enum, and code all over the app opened that enum up inline to ask questions of it — so the same question was re-derived in several places, each free to drift.

- Names four of those questions once each, next to the state they read, and points every caller at the name — so only the state's owner and its own file now look inside the enum.
- Stops handing a whole display state to the tools menu, which only needed "is the input showing at all". That removes a state the iPad tool picker was inventing to satisfy the signature.
- Renames an address-bar-focus check to say what it tests, and folds an identical copy of it in the same file into it.
- No behaviour change: every replacement swaps an expression for a provably equal one.
- Adds the first tests for the state owner, which had none — a table over all six display states plus the invariants call sites now depend on.

Part 1 of 4. Later parts add a test suite for the state owner, split an overgrown test file, and run the Maestro verification.

### Testing Steps

Internal build with the unified toggle input enabled. iPhone, address bar at bottom, except the last step.

**On a Duck.ai tab**
1. On a duck.ai tab submit a prompt → the input collapses to the chat-input footer: centred placeholder, fire and menu buttons either side.
2. Tap the collapsed footer → it expands to the full input; the fire/menu buttons and the separator above it go away.
3. Tap the chat web view while the input is expanded → the input collapses back to the footer.
4. Rotate to landscape and back while collapsed → the footer stays pinned to the bottom in both orientations.
5. On a web page focus the address bar, then dismiss it → it is expanded when focused and returns to rest with no jump.
6. Focus the address bar and swipe down over the area below the input → the keyboard drops and the input stays expanded.
7. On iPad open the omnibar tool picker → the tools button appears, the menu opens, tool selection works.

### Impact

**Low** — a naming and ownership refactor behind an internal-only feature, with no intended behaviour change. It does touch keyboard and layout paths, which is why the steps above concentrate there.

#### What could go wrong?

- One call site now reads live state where it previously read a snapshot passed in by its caller. All ten callers were traced and each computes that snapshot immediately beforehand from the same source → mitigated by tracing every caller, and by a doc comment recording which half of the function still reads the snapshot.
- A predicate could be defined slightly wider or narrower than the expression it replaced, changing when a branch fires → mitigated by checking each of the 13 substitutions against its original individually, including the deliberately narrow search-on-Duck.ai-tab definition, which must not match collapsed tabs.

### Quality Considerations

**Left raw** wherever one question doesn't capture the original test: the composite that also reads card position, a comparison against a previously captured state, the transition-pair matches, and three multi-case dispatch switches.

**Verified**: clean build, no new warnings; 9 new state-machine tests plus 342 existing unit tests pass across the coordinator, render-state, per-tab-state and fire-onboarding suites; no test referenced a changed signature.

**Rebased onto #6010** after it merged. That PR moved the enum into its own file and split the coordinator further; its new pieces consume derived booleans through their environment rather than the raw state, so the two reinforce each other.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with equivalence checks and new unit tests; touches keyboard and layout branches but does not change intended UTI behavior.
> 
> **Overview**
> Centralizes repeated questions about unified toggle input **display state** into `UTIStateMachine` and routes callers through `UnifiedToggleInputCoordinator` instead of inline enum pattern matching.
> 
> New predicates include **`isAITabCollapsed`**, **`isOmnibarEditing`**, **`omnibarState`**, and **`isSearchOnAITab`** (intentionally tied to expanded Duck.ai tab + search mode, not any AI-tab state). **`dismissOmnibarKeyboard`** now keys off **`isInputPaneExpanded`** instead of a three-case switch. The iPad tool picker and tools presentation API take **`isActive`** instead of a fabricated omnibar display state or full **`displayState`**.
> 
> **`MainViewController`** renames the escape-hatch focus check to **`isAddressBarFocused`** and reuses it where chrome morph and burn flows duplicated the same condition. Collapsed-footer layout reads live **`isAITabCollapsed`** rather than deriving collapse from render **`isExpanded`**.
> 
> Adds **`UTIStateMachineTests`** with an exhaustive predicate matrix, transition checks, and disjointness tests that document assumptions at call sites. No intended behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b546ac5dc1dc52471224dca07df8c20c9ccbe132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->