### PR TITLE
[iOS] Add browsing-menu protection toggle to content blocking test

### DIFF
--- a/.maestro/release_tests/content-blocking.yaml
+++ b/.maestro/release_tests/content-blocking.yaml
@@ -40,8 +40,9 @@ tags:
 - assertVisible: "Don't Send"
 - tapOn: "Don't Send"
 
-- runFlow: ../shared/pull_to_refresh.yaml
-- extendedWaitUntil: 
+# Disabling protection makes the tab reload automatically (no manual refresh);
+# give that reload a moment to settle before checking the new state.
+- extendedWaitUntil:
     notVisible: "Nonsense text that won't exist"
     timeout: 2000
 
@@ -49,4 +50,70 @@ tags:
 
 - tapOn: "Privacy Icon"
 - assertVisible: "Protections are OFF for this site"
+- tapOn: "Done"
+
+# Toggling protection changes the unprotected-sites list, which makes the tab
+# reload automatically. We deliberately do NOT pull-to-refresh here: the
+# automatic reload is part of the behaviour under test, and the dashboard result
+# afterwards proves the new state was actually applied.
+
+# Re-enable protections from the browsing menu.
+# Protections are OFF, so the menu offers "Enable Privacy Protection".
+# Open the menu and scroll only until the item is visible (no centring, which
+# would keep scrolling an already-visible item).
+- tapOn: "Browsing menu"
+- scrollUntilVisible:
+    element:
+      text: "Enable Privacy Protection"
+- tapOn: "Enable Privacy Protection"
+# Confirmation toast with an Undo action
+- assertVisible: ".*Privacy Protection enabled for.*"
+- assertVisible: "Undo"
+# Wait for the toast to clear and the automatic reload to settle
+- extendedWaitUntil:
+    notVisible: "Undo"
+    timeout: 8000
+- tapOn: "Privacy Icon"
+- assertVisible: "Protections are ON for this site"
+# The page reloaded automatically, so the tracker is blocked again
+- assertVisible: "We blocked Google Ads (Google) from loading tracking requests on this page."
+- tapOn: "Done"
+
+# Disable protections from the browsing menu.
+# Protections are ON, so the menu offers "Disable Privacy Protection".
+# The "site not working?" report prompt was already shown and dismissed by the
+# dashboard toggle above (it is shown at most once per session), so no modal
+# appears here and the confirmation toast shows immediately after the tap.
+- tapOn: "Browsing menu"
+- scrollUntilVisible:
+    element:
+      text: "Disable Privacy Protection"
+- tapOn: "Disable Privacy Protection"
+- assertVisible: ".*Privacy Protection disabled for.*"
+- assertVisible: "Undo"
+- extendedWaitUntil:
+    notVisible: "Undo"
+    timeout: 8000
+- tapOn: "Privacy Icon"
+- assertVisible: "Protections are OFF for this site"
+# The page reloaded automatically, so nothing is blocked anymore
+- assertNotVisible: "We blocked Google Ads (Google) from loading tracking requests on this page."
+- tapOn: "Done"
+
+# Tapping Undo on the confirmation toast reverts the toggle.
+# Enable from the menu, then immediately tap Undo -> protections return to OFF.
+- tapOn: "Browsing menu"
+- scrollUntilVisible:
+    element:
+      text: "Enable Privacy Protection"
+- tapOn: "Enable Privacy Protection"
+- assertVisible: ".*Privacy Protection enabled for.*"
+- tapOn: "Undo"
+# Undo re-disables protection and the tab reloads again; confirm we are back OFF
+- extendedWaitUntil:
+    notVisible: "Undo"
+    timeout: 8000
+- tapOn: "Privacy Icon"
+- assertVisible: "Protections are OFF for this site"
+- assertNotVisible: "We blocked Google Ads (Google) from loading tracking requests on this page."
 

--- a/.maestro/release_tests/content-blocking.yaml
+++ b/.maestro/release_tests/content-blocking.yaml
@@ -40,8 +40,6 @@ tags:
 - assertVisible: "Don't Send"
 - tapOn: "Don't Send"
 
-# Disabling protection makes the tab reload automatically (no manual refresh);
-# give that reload a moment to settle before checking the new state.
 - extendedWaitUntil:
     notVisible: "Nonsense text that won't exist"
     timeout: 2000
@@ -52,38 +50,21 @@ tags:
 - assertVisible: "Protections are OFF for this site"
 - tapOn: "Done"
 
-# Toggling protection changes the unprotected-sites list, which makes the tab
-# reload automatically. We deliberately do NOT pull-to-refresh here: the
-# automatic reload is part of the behaviour under test, and the dashboard result
-# afterwards proves the new state was actually applied.
-
-# Re-enable protections from the browsing menu.
-# Protections are OFF, so the menu offers "Enable Privacy Protection".
-# Open the menu and scroll only until the item is visible (no centring, which
-# would keep scrolling an already-visible item).
 - tapOn: "Browsing menu"
 - scrollUntilVisible:
     element:
       text: "Enable Privacy Protection"
 - tapOn: "Enable Privacy Protection"
-# Confirmation toast with an Undo action
 - assertVisible: ".*Privacy Protection enabled for.*"
 - assertVisible: "Undo"
-# Wait for the toast to clear and the automatic reload to settle
 - extendedWaitUntil:
     notVisible: "Undo"
     timeout: 8000
 - tapOn: "Privacy Icon"
 - assertVisible: "Protections are ON for this site"
-# The page reloaded automatically, so the tracker is blocked again
 - assertVisible: "We blocked Google Ads (Google) from loading tracking requests on this page."
 - tapOn: "Done"
 
-# Disable protections from the browsing menu.
-# Protections are ON, so the menu offers "Disable Privacy Protection".
-# The "site not working?" report prompt was already shown and dismissed by the
-# dashboard toggle above (it is shown at most once per session), so no modal
-# appears here and the confirmation toast shows immediately after the tap.
 - tapOn: "Browsing menu"
 - scrollUntilVisible:
     element:
@@ -96,12 +77,9 @@ tags:
     timeout: 8000
 - tapOn: "Privacy Icon"
 - assertVisible: "Protections are OFF for this site"
-# The page reloaded automatically, so nothing is blocked anymore
 - assertNotVisible: "We blocked Google Ads (Google) from loading tracking requests on this page."
 - tapOn: "Done"
 
-# Tapping Undo on the confirmation toast reverts the toggle.
-# Enable from the menu, then immediately tap Undo -> protections return to OFF.
 - tapOn: "Browsing menu"
 - scrollUntilVisible:
     element:
@@ -109,7 +87,6 @@ tags:
 - tapOn: "Enable Privacy Protection"
 - assertVisible: ".*Privacy Protection enabled for.*"
 - tapOn: "Undo"
-# Undo re-disables protection and the tab reloads again; confirm we are back OFF
 - extendedWaitUntil:
     notVisible: "Undo"
     timeout: 8000

--- a/.maestro/release_tests/content-blocking.yaml
+++ b/.maestro/release_tests/content-blocking.yaml
@@ -15,11 +15,6 @@ tags:
     id: "searchEntry"
 - tapOn:
     id: "searchEntry"
-- inputText: "https://privacy-test-pages.site/"
-- pressKey: Enter
-
-- tapOn:
-    id: "searchEntry"
 - inputText: "https://privacy-test-pages.site/tracker-reporting/1major-via-script.html"
 - pressKey: Enter
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211756057575859
CC:

### Description
The content blocking acceptance test previously only toggled privacy protection from the Privacy Dashboard. This adds coverage for toggling protection from the **browsing menu** — the scenario named in the task — for both enable and disable, plus the toast's Undo action.

It also verifies real behaviour rather than just the on/off label: after each toggle the tab reloads automatically (no manual refresh), and the test confirms the tracker is actually blocked when protection is on and loads when it is off.

### Testing Steps
Set up Maestro (`./.maestro/setup_ui_tests.sh`), then run the flow, expecting all steps to pass:
1. `maestro test -e ONBOARDING_COMPLETED=true -e APP_VARIANT= -e INTERNAL_USER_MODE=false .maestro/release_tests/content-blocking.yaml`

### Impact
None — test-only change, no production code touched.

### Quality Considerations
- Drives the live `privacy-test-pages.site` tracker page (as the existing test already did).
- Relies on the automatic page reload that follows a protection toggle; the test waits for that reload to settle before asserting the new state instead of forcing a manual refresh.
- Verified locally on an iPhone 17 / iOS 26 simulator; CI runs iOS 18.x.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro YAML changes; no production code or release behavior is modified.
> 
> **Overview**
> Extends the **content-blocking** release Maestro flow so privacy protection is exercised from the **browsing menu**, not only the Privacy Dashboard.
> 
> After the existing dashboard disable path, the test opens the browsing menu to **enable** protection, waits for the auto-reload (replacing the old **pull-to-refresh** helper with a short `extendedWaitUntil`), and checks the dashboard shows protections ON and the Google Ads blocker message. It then **disables** from the menu with the same reload wait and asserts protections OFF and the blocker message is gone.
> 
> A third pass **enables** from the menu again and taps **Undo** on the toast, confirming protection stays off and trackers are not reported as blocked.
> 
> Initial navigation now loads the **1-major-via-script** tracker page directly instead of the privacy-test-pages home URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0994a7bbe5d0ec3ec1941d912999f3cd290508a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->