### PR TITLE
macOS: open the Prompt Bar from the global shortcut and menu bar icon

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -4658,7 +4658,27 @@
 		FB07BAD00000000000000028 /* PromptBarMenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD00000000000000009 /* PromptBarMenuBarController.swift */; };
 		FB07BAD00000000000000029 /* PromptBarMenuBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD00000000000000010 /* PromptBarMenuBarControllerTests.swift */; };
 		FB07BAD00000000000000034 /* PromptBarMenuBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD00000000000000010 /* PromptBarMenuBarControllerTests.swift */; };
-/* End PBXBuildFile section */
+		FB07BAD10000000000000002 /* PromptBarWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000001 /* PromptBarWindow.swift */; };
+				FB07BAD10000000000000003 /* PromptBarWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000001 /* PromptBarWindow.swift */; };
+				FB07BAD10000000000000005 /* PromptBarPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000004 /* PromptBarPlacement.swift */; };
+				FB07BAD10000000000000006 /* PromptBarPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000004 /* PromptBarPlacement.swift */; };
+				FB07BAD10000000000000008 /* PromptBarContentHosting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000007 /* PromptBarContentHosting.swift */; };
+				FB07BAD10000000000000009 /* PromptBarContentHosting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000007 /* PromptBarContentHosting.swift */; };
+				FB07BAD1000000000000000B /* PromptBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD1000000000000000A /* PromptBarViewController.swift */; };
+				FB07BAD1000000000000000C /* PromptBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD1000000000000000A /* PromptBarViewController.swift */; };
+				FB07BAD1000000000000000F /* PromptBarPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD1000000000000000E /* PromptBarPresenter.swift */; };
+				FB07BAD10000000000000010 /* PromptBarPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD1000000000000000E /* PromptBarPresenter.swift */; };
+				FB07BAD10000000000000012 /* PromptBarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000011 /* PromptBarCoordinator.swift */; };
+				FB07BAD10000000000000013 /* PromptBarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000011 /* PromptBarCoordinator.swift */; };
+				FB07BAD10000000000000016 /* GlobalShortcutRegistering.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000015 /* GlobalShortcutRegistering.swift */; };
+				FB07BAD10000000000000017 /* GlobalShortcutRegistering.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000015 /* GlobalShortcutRegistering.swift */; };
+				FB07BAD10000000000000019 /* CarbonGlobalShortcutRegistrar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000018 /* CarbonGlobalShortcutRegistrar.swift */; };
+				FB07BAD1000000000000001A /* CarbonGlobalShortcutRegistrar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000018 /* CarbonGlobalShortcutRegistrar.swift */; };
+				FB07BAD1000000000000001C /* PromptBarPlacementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD1000000000000001B /* PromptBarPlacementTests.swift */; };
+				FB07BAD1000000000000001D /* PromptBarPlacementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD1000000000000001B /* PromptBarPlacementTests.swift */; };
+				FB07BAD1000000000000001F /* PromptBarCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD1000000000000001E /* PromptBarCoordinatorTests.swift */; };
+				FB07BAD10000000000000020 /* PromptBarCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD1000000000000001E /* PromptBarCoordinatorTests.swift */; };
+		/* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		31C6E9AC2B0C07BA0086DC30 /* PBXContainerItemProxy */ = {
@@ -7136,7 +7156,17 @@
 		FB07BAD00000000000000008 /* PromptBarPreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPreferencesTests.swift; sourceTree = "<group>"; };
 		FB07BAD00000000000000009 /* PromptBarMenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarMenuBarController.swift; sourceTree = "<group>"; };
 		FB07BAD00000000000000010 /* PromptBarMenuBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarMenuBarControllerTests.swift; sourceTree = "<group>"; };
-/* End PBXFileReference section */
+		FB07BAD10000000000000001 /* PromptBarWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarWindow.swift; sourceTree = "<group>"; };
+				FB07BAD10000000000000004 /* PromptBarPlacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPlacement.swift; sourceTree = "<group>"; };
+				FB07BAD10000000000000007 /* PromptBarContentHosting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarContentHosting.swift; sourceTree = "<group>"; };
+				FB07BAD1000000000000000A /* PromptBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarViewController.swift; sourceTree = "<group>"; };
+				FB07BAD1000000000000000E /* PromptBarPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPresenter.swift; sourceTree = "<group>"; };
+				FB07BAD10000000000000011 /* PromptBarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarCoordinator.swift; sourceTree = "<group>"; };
+				FB07BAD10000000000000015 /* GlobalShortcutRegistering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalShortcutRegistering.swift; sourceTree = "<group>"; };
+				FB07BAD10000000000000018 /* CarbonGlobalShortcutRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbonGlobalShortcutRegistrar.swift; sourceTree = "<group>"; };
+				FB07BAD1000000000000001B /* PromptBarPlacementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPlacementTests.swift; sourceTree = "<group>"; };
+				FB07BAD1000000000000001E /* PromptBarCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarCoordinatorTests.swift; sourceTree = "<group>"; };
+		/* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		3706FCA6293F65D500E42796 /* Frameworks */ = {
@@ -13331,9 +13361,29 @@
 			path = Subscription;
 			sourceTree = "<group>";
 		};
+		FB07BAD1000000000000000D /* Controller */ = {
+			isa = PBXGroup;
+			children = (
+				FB07BAD10000000000000011 /* PromptBarCoordinator.swift */,
+				FB07BAD1000000000000000E /* PromptBarPresenter.swift */,
+			);
+			path = Controller;
+			sourceTree = "<group>";
+		};
+		FB07BAD10000000000000014 /* Shortcut */ = {
+			isa = PBXGroup;
+			children = (
+				FB07BAD10000000000000018 /* CarbonGlobalShortcutRegistrar.swift */,
+				FB07BAD10000000000000015 /* GlobalShortcutRegistering.swift */,
+			);
+			path = Shortcut;
+			sourceTree = "<group>";
+		};
 		FB07BAD00000000000000030 /* PromptBar */ = {
 			isa = PBXGroup;
 			children = (
+				FB07BAD10000000000000014 /* Shortcut */,
+				FB07BAD1000000000000000D /* Controller */,
 				FB07BAD00000000000000031 /* Model */,
 				FB07BAD00000000000000032 /* View */,
 			);
@@ -13353,6 +13403,10 @@
 		FB07BAD00000000000000032 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				FB07BAD1000000000000000A /* PromptBarViewController.swift */,
+				FB07BAD10000000000000007 /* PromptBarContentHosting.swift */,
+				FB07BAD10000000000000004 /* PromptBarPlacement.swift */,
+				FB07BAD10000000000000001 /* PromptBarWindow.swift */,
 				FB07BAD00000000000000005 /* PromptBarPreferencesView.swift */,
 				FB07BAD00000000000000004 /* PromptBarShortcutRecorderView.swift */,
 				FB07BAD00000000000000009 /* PromptBarMenuBarController.swift */,
@@ -13363,6 +13417,8 @@
 		FB07BAD00000000000000033 /* PromptBar */ = {
 			isa = PBXGroup;
 			children = (
+				FB07BAD1000000000000001E /* PromptBarCoordinatorTests.swift */,
+				FB07BAD1000000000000001B /* PromptBarPlacementTests.swift */,
 				FB07BAD00000000000000007 /* PromptBarPreferencesPersistorTests.swift */,
 				FB07BAD00000000000000008 /* PromptBarPreferencesTests.swift */,
 				FB07BAD00000000000000006 /* PromptBarShortcutTests.swift */,
@@ -15088,6 +15144,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FB07BAD1000000000000001A /* CarbonGlobalShortcutRegistrar.swift in Sources */,
+				FB07BAD10000000000000017 /* GlobalShortcutRegistering.swift in Sources */,
+				FB07BAD10000000000000013 /* PromptBarCoordinator.swift in Sources */,
+				FB07BAD10000000000000010 /* PromptBarPresenter.swift in Sources */,
+				FB07BAD1000000000000000C /* PromptBarViewController.swift in Sources */,
+				FB07BAD10000000000000009 /* PromptBarContentHosting.swift in Sources */,
+				FB07BAD10000000000000006 /* PromptBarPlacement.swift in Sources */,
+				FB07BAD10000000000000003 /* PromptBarWindow.swift in Sources */,
 				A1B2C3D42E5F601100000001 /* PromoType.swift in Sources */,
 				A1B2C3D42E5F601200000002 /* PromoHistoryRecord.swift in Sources */,
 				CC0816472FAC9FE9000F8217 /* PromoDelegate.swift in Sources */,
@@ -16447,6 +16511,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FB07BAD10000000000000020 /* PromptBarCoordinatorTests.swift in Sources */,
+				FB07BAD1000000000000001D /* PromptBarPlacementTests.swift in Sources */,
 				20AC3AA2FB956B8B11BCA072 /* DarkReaderFeatureSettingsTests.swift in Sources */,
 				BB35FFD52F742B160090410A /* QuitSurveyReturnUserHandlerTests.swift in Sources */,
 				9F0FFFB92BCCAE9C007C87DD /* AddEditBookmarkDialogViewModelMock.swift in Sources */,
@@ -17421,6 +17487,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FB07BAD10000000000000019 /* CarbonGlobalShortcutRegistrar.swift in Sources */,
+				FB07BAD10000000000000016 /* GlobalShortcutRegistering.swift in Sources */,
+				FB07BAD10000000000000012 /* PromptBarCoordinator.swift in Sources */,
+				FB07BAD1000000000000000F /* PromptBarPresenter.swift in Sources */,
+				FB07BAD1000000000000000B /* PromptBarViewController.swift in Sources */,
+				FB07BAD10000000000000008 /* PromptBarContentHosting.swift in Sources */,
+				FB07BAD10000000000000005 /* PromptBarPlacement.swift in Sources */,
+				FB07BAD10000000000000002 /* PromptBarWindow.swift in Sources */,
 				CC3967ED2F461D6700AE83F2 /* PromoType.swift in Sources */,
 				CC3967EE2F461D6B00AE83F2 /* PromoHistoryRecord.swift in Sources */,
 				CC0816482FAC9FE9000F8217 /* PromoDelegate.swift in Sources */,
@@ -18766,6 +18840,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FB07BAD1000000000000001F /* PromptBarCoordinatorTests.swift in Sources */,
+				FB07BAD1000000000000001C /* PromptBarPlacementTests.swift in Sources */,
 				365B217A2F64460D00DE0CB0 /* DataClearingWideEventServiceTests.swift in Sources */,
 				F076A1D953FD915AAA066DB2 /* DarkReaderFeatureSettingsTests.swift in Sources */,
 				9833913327AAAEEE00DAF119 /* EmbeddedTrackerDataTests.swift in Sources */,

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -4678,6 +4678,10 @@
 				FB07BAD1000000000000001D /* PromptBarPlacementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD1000000000000001B /* PromptBarPlacementTests.swift */; };
 				FB07BAD1000000000000001F /* PromptBarCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD1000000000000001E /* PromptBarCoordinatorTests.swift */; };
 				FB07BAD10000000000000020 /* PromptBarCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD1000000000000001E /* PromptBarCoordinatorTests.swift */; };
+				FB07BAD10000000000000022 /* PromptBarPromptSubmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000021 /* PromptBarPromptSubmitter.swift */; };
+				FB07BAD10000000000000023 /* PromptBarPromptSubmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000021 /* PromptBarPromptSubmitter.swift */; };
+				FB07BAD10000000000000025 /* PromptBarPromptSubmitterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000024 /* PromptBarPromptSubmitterTests.swift */; };
+				FB07BAD10000000000000026 /* PromptBarPromptSubmitterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD10000000000000024 /* PromptBarPromptSubmitterTests.swift */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -7166,6 +7170,8 @@
 				FB07BAD10000000000000018 /* CarbonGlobalShortcutRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbonGlobalShortcutRegistrar.swift; sourceTree = "<group>"; };
 				FB07BAD1000000000000001B /* PromptBarPlacementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPlacementTests.swift; sourceTree = "<group>"; };
 				FB07BAD1000000000000001E /* PromptBarCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarCoordinatorTests.swift; sourceTree = "<group>"; };
+				FB07BAD10000000000000021 /* PromptBarPromptSubmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPromptSubmitter.swift; sourceTree = "<group>"; };
+				FB07BAD10000000000000024 /* PromptBarPromptSubmitterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPromptSubmitterTests.swift; sourceTree = "<group>"; };
 		/* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -13364,6 +13370,7 @@
 		FB07BAD1000000000000000D /* Controller */ = {
 			isa = PBXGroup;
 			children = (
+				FB07BAD10000000000000021 /* PromptBarPromptSubmitter.swift */,
 				FB07BAD10000000000000011 /* PromptBarCoordinator.swift */,
 				FB07BAD1000000000000000E /* PromptBarPresenter.swift */,
 			);
@@ -13417,6 +13424,7 @@
 		FB07BAD00000000000000033 /* PromptBar */ = {
 			isa = PBXGroup;
 			children = (
+				FB07BAD10000000000000024 /* PromptBarPromptSubmitterTests.swift */,
 				FB07BAD1000000000000001E /* PromptBarCoordinatorTests.swift */,
 				FB07BAD1000000000000001B /* PromptBarPlacementTests.swift */,
 				FB07BAD00000000000000007 /* PromptBarPreferencesPersistorTests.swift */,
@@ -15144,6 +15152,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FB07BAD10000000000000023 /* PromptBarPromptSubmitter.swift in Sources */,
 				FB07BAD1000000000000001A /* CarbonGlobalShortcutRegistrar.swift in Sources */,
 				FB07BAD10000000000000017 /* GlobalShortcutRegistering.swift in Sources */,
 				FB07BAD10000000000000013 /* PromptBarCoordinator.swift in Sources */,
@@ -16511,6 +16520,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FB07BAD10000000000000026 /* PromptBarPromptSubmitterTests.swift in Sources */,
 				FB07BAD10000000000000020 /* PromptBarCoordinatorTests.swift in Sources */,
 				FB07BAD1000000000000001D /* PromptBarPlacementTests.swift in Sources */,
 				20AC3AA2FB956B8B11BCA072 /* DarkReaderFeatureSettingsTests.swift in Sources */,
@@ -17487,6 +17497,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FB07BAD10000000000000022 /* PromptBarPromptSubmitter.swift in Sources */,
 				FB07BAD10000000000000019 /* CarbonGlobalShortcutRegistrar.swift in Sources */,
 				FB07BAD10000000000000016 /* GlobalShortcutRegistering.swift in Sources */,
 				FB07BAD10000000000000012 /* PromptBarCoordinator.swift in Sources */,
@@ -18840,6 +18851,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FB07BAD10000000000000025 /* PromptBarPromptSubmitterTests.swift in Sources */,
 				FB07BAD1000000000000001F /* PromptBarCoordinatorTests.swift in Sources */,
 				FB07BAD1000000000000001C /* PromptBarPlacementTests.swift in Sources */,
 				365B217A2F64460D00DE0CB0 /* DataClearingWideEventServiceTests.swift in Sources */,

--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -107,13 +107,11 @@ protocol AIChatTabOpening {
     @MainActor
     func openVoiceSession(inSourceCollection sourceCollection: TabCollectionViewModel?, behavior: LinkOpenBehavior)
 
-    /// Opens an auto-submitted query in a new tab of a specific window, for window-less entry points
-    /// that resolve their own target rather than taking `lastKeyMainWindowController`.
+    /// For window-less entry points that resolve their own target rather than taking `lastKeyMainWindowController`.
     @MainActor
     func openAIChatTab(withQuery query: String, inNewTabOf windowController: MainWindowController)
 
-    /// Opens an auto-submitted query in a new window placed by its top-center point. Without one a
-    /// new window cascades off the last key window, possibly onto another display.
+    /// Placed by top-center point; without one a new window cascades off the last key window.
     @MainActor
     func openAIChatTab(withQuery query: String, inNewWindowAt droppingPoint: NSPoint)
 }
@@ -221,11 +219,9 @@ protocol AIChatTabManaging {
     @MainActor
     func openAIChat(_ url: URL, with behavior: LinkOpenBehavior, hasPrompt: Bool)
 
-    /// Bypasses last-key-window resolution.
     @MainActor
     func openAIChat(_ url: URL, inNewTabOf windowController: MainWindowController, hasPrompt: Bool)
 
-    /// Positioned by its top-center point rather than cascaded off the last key window.
     @MainActor
     func openAIChat(_ url: URL, inNewWindowAt droppingPoint: NSPoint, hasPrompt: Bool)
 

--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -107,19 +107,13 @@ protocol AIChatTabOpening {
     @MainActor
     func openVoiceSession(inSourceCollection sourceCollection: TabCollectionViewModel?, behavior: LinkOpenBehavior)
 
-    /// Opens a chat with a pre-filled, auto-submitted query in a new selected tab of a specific window.
-    ///
-    /// For entry points that own no window and so must resolve their own target — the Prompt Bar
-    /// picks the browser window on the screen and Space the user is actually looking at, which
-    /// `lastKeyMainWindowController` would not necessarily be.
+    /// Opens an auto-submitted query in a new tab of a specific window, for window-less entry points
+    /// that resolve their own target rather than taking `lastKeyMainWindowController`.
     @MainActor
     func openAIChatTab(withQuery query: String, inNewTabOf windowController: MainWindowController)
 
-    /// Opens a chat with a pre-filled, auto-submitted query in a new window whose top-center lands
-    /// at `droppingPoint`.
-    ///
-    /// Without an explicit point a new window cascades off the last key window, which for a
-    /// window-less entry point can be on a display the user isn't looking at.
+    /// Opens an auto-submitted query in a new window placed by its top-center point. Without one a
+    /// new window cascades off the last key window, possibly onto another display.
     @MainActor
     func openAIChatTab(withQuery query: String, inNewWindowAt droppingPoint: NSPoint)
 }
@@ -227,12 +221,11 @@ protocol AIChatTabManaging {
     @MainActor
     func openAIChat(_ url: URL, with behavior: LinkOpenBehavior, hasPrompt: Bool)
 
-    /// Opens the chat in a new selected tab of `windowController`, bypassing last-key-window resolution.
+    /// Bypasses last-key-window resolution.
     @MainActor
     func openAIChat(_ url: URL, inNewTabOf windowController: MainWindowController, hasPrompt: Bool)
 
-    /// Opens the chat in a new window positioned by its top-center point, rather than cascaded off
-    /// the last key window.
+    /// Positioned by its top-center point rather than cascaded off the last key window.
     @MainActor
     func openAIChat(_ url: URL, inNewWindowAt droppingPoint: NSPoint, hasPrompt: Bool)
 

--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -106,6 +106,22 @@ protocol AIChatTabOpening {
     ///   - behavior: The `LinkOpenBehavior` used when opening a fresh voice tab.
     @MainActor
     func openVoiceSession(inSourceCollection sourceCollection: TabCollectionViewModel?, behavior: LinkOpenBehavior)
+
+    /// Opens a chat with a pre-filled, auto-submitted query in a new selected tab of a specific window.
+    ///
+    /// For entry points that own no window and so must resolve their own target — the Prompt Bar
+    /// picks the browser window on the screen and Space the user is actually looking at, which
+    /// `lastKeyMainWindowController` would not necessarily be.
+    @MainActor
+    func openAIChatTab(withQuery query: String, inNewTabOf windowController: MainWindowController)
+
+    /// Opens a chat with a pre-filled, auto-submitted query in a new window whose top-center lands
+    /// at `droppingPoint`.
+    ///
+    /// Without an explicit point a new window cascades off the last key window, which for a
+    /// window-less entry point can be on a display the user isn't looking at.
+    @MainActor
+    func openAIChatTab(withQuery query: String, inNewWindowAt droppingPoint: NSPoint)
 }
 
 struct AIChatTabOpener: AIChatTabOpening {
@@ -169,6 +185,18 @@ struct AIChatTabOpener: AIChatTabOpening {
         openAIChatTab(with: .mode(AIChatNativePrompt.voiceMode), behavior: behavior)
     }
 
+    @MainActor
+    func openAIChatTab(withQuery query: String, inNewTabOf windowController: MainWindowController) {
+        promptHandler.setData(.queryPrompt(query, autoSubmit: true))
+        aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, inNewTabOf: windowController, hasPrompt: true)
+    }
+
+    @MainActor
+    func openAIChatTab(withQuery query: String, inNewWindowAt droppingPoint: NSPoint) {
+        promptHandler.setData(.queryPrompt(query, autoSubmit: true))
+        aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, inNewWindowAt: droppingPoint, hasPrompt: true)
+    }
+
     // MARK: - Private Helpers
 
     @MainActor
@@ -198,6 +226,15 @@ struct AIChatTabOpener: AIChatTabOpening {
 protocol AIChatTabManaging {
     @MainActor
     func openAIChat(_ url: URL, with behavior: LinkOpenBehavior, hasPrompt: Bool)
+
+    /// Opens the chat in a new selected tab of `windowController`, bypassing last-key-window resolution.
+    @MainActor
+    func openAIChat(_ url: URL, inNewTabOf windowController: MainWindowController, hasPrompt: Bool)
+
+    /// Opens the chat in a new window positioned by its top-center point, rather than cascaded off
+    /// the last key window.
+    @MainActor
+    func openAIChat(_ url: URL, inNewWindowAt droppingPoint: NSPoint, hasPrompt: Bool)
 
     @MainActor
     func insertAIChatTab(with url: URL, payload: AIChatPayload)
@@ -251,6 +288,14 @@ extension WindowControllersManager: AIChatTabManaging {
         default:
             open(url, with: linkOpenBehavior, source: .ui, target: nil)
         }
+    }
+
+    func openAIChat(_ url: URL, inNewTabOf windowController: MainWindowController, hasPrompt: Bool) {
+        open(url, with: .newTab(selected: true), source: .ui, target: windowController)
+    }
+
+    func openAIChat(_ url: URL, inNewWindowAt droppingPoint: NSPoint, hasPrompt: Bool) {
+        WindowsManager.openNewWindow(with: url, source: .ui, droppingPoint: droppingPoint)
     }
 
     func insertAIChatTab(with url: URL, payload: AIChat.AIChatPayload) {

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -2431,8 +2431,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
     }
 
-    /// Builds the Prompt Bar's window stack and registers its global shortcut. Must run before
-    /// `setUpPromptBarMenuBarVisibility()`, which hands the menu bar icon's click to the coordinator.
+    /// Must run before `setUpPromptBarMenuBarVisibility()`, which hands the icon's click to the coordinator.
     @MainActor
     private func setUpPromptBar() {
         guard featureFlagger.isFeatureOn(.macosPromptBar) else {

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -126,6 +126,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var passwordsMenuBarCancellable: AnyCancellable?
     private var promptBarMenuBarController: PromptBarMenuBarController?
     private var promptBarMenuBarCancellable: AnyCancellable?
+    private var promptBarCoordinator: PromptBarCoordinator?
 
     private(set) var syncDataProviders: SyncDataProvidersSource?
     private(set) var syncService: DDGSyncing?
@@ -1498,6 +1499,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         setUpAutofillPixelReporter()
         setUpPasswordsMenuBarVisibility()
+        setUpPromptBar()
         setUpPromptBarMenuBarVisibility()
 
         remoteMessagingClient?.startRefreshingRemoteMessages()
@@ -2429,6 +2431,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
     }
 
+    /// Builds the Prompt Bar's window stack and registers its global shortcut. Must run before
+    /// `setUpPromptBarMenuBarVisibility()`, which hands the menu bar icon's click to the coordinator.
+    @MainActor
+    private func setUpPromptBar() {
+        guard featureFlagger.isFeatureOn(.macosPromptBar) else {
+            promptBarCoordinator = nil
+            return
+        }
+
+        let coordinator = PromptBarCoordinator(
+            featureFlagger: featureFlagger,
+            preferences: promptBarPreferences,
+            shortcutRegistrar: CarbonGlobalShortcutRegistrar(),
+            presenter: PromptBarPresenter(content: PromptBarViewController(aiChatTabOpener: aiChatTabOpener))
+        )
+        coordinator.start()
+        promptBarCoordinator = coordinator
+    }
+
     @MainActor
     private func setUpPromptBarMenuBarVisibility() {
         guard featureFlagger.isFeatureOn(.macosPromptBar) else {
@@ -2440,6 +2461,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         if promptBarMenuBarController == nil {
             promptBarMenuBarController = PromptBarMenuBarController()
+        }
+        promptBarMenuBarController?.onClick = { [weak self] in
+            self?.promptBarCoordinator?.togglePromptBar()
         }
 
         // Applied synchronously: a deferred first update lets the icon appear at

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -2440,11 +2440,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        let promptSubmitter = PromptBarPromptSubmitter(aiChatTabOpener: aiChatTabOpener,
+                                                       windowControllersManager: windowControllersManager)
         let coordinator = PromptBarCoordinator(
             featureFlagger: featureFlagger,
             preferences: promptBarPreferences,
             shortcutRegistrar: CarbonGlobalShortcutRegistrar(),
-            presenter: PromptBarPresenter(content: PromptBarViewController(aiChatTabOpener: aiChatTabOpener))
+            presenter: PromptBarPresenter(content: PromptBarViewController(promptSubmitter: promptSubmitter))
         )
         coordinator.start()
         promptBarCoordinator = coordinator

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarCoordinator.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarCoordinator.swift
@@ -22,9 +22,6 @@ import FeatureFlags
 import PrivacyConfig
 
 /// Owns the Prompt Bar's entry points: the global shortcut and the menu bar icon click.
-///
-/// Keeps the registered shortcut in step with the user's preference, and unregisters it when the
-/// preference or Duck.ai itself is switched off.
 @MainActor
 final class PromptBarCoordinator {
 
@@ -45,8 +42,6 @@ final class PromptBarCoordinator {
         self.presenter = presenter
     }
 
-    /// Begins observing the shortcut preference. A no-op while the feature flag is off, so nothing
-    /// is registered and the menu bar click stays inert.
     func start() {
         guard featureFlagger.isFeatureOn(.macosPromptBar) else { return }
 
@@ -56,8 +51,6 @@ final class PromptBarCoordinator {
             }
     }
 
-    /// Shows the bar, or hides it when it is already up. Called by the global shortcut and the
-    /// menu bar icon.
     func togglePromptBar() {
         guard featureFlagger.isFeatureOn(.macosPromptBar) else { return }
         presenter.toggle()
@@ -70,7 +63,7 @@ final class PromptBarCoordinator {
         }
 
         shortcutRegistrar.register(shortcut) { [weak self] in
-            // The Carbon handler is not isolated, so hop to the main actor before touching UI.
+            // The Carbon handler is nonisolated.
             Task { @MainActor in
                 self?.togglePromptBar()
             }

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarCoordinator.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarCoordinator.swift
@@ -1,0 +1,79 @@
+//
+//  PromptBarCoordinator.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import Combine
+import FeatureFlags
+import PrivacyConfig
+
+/// Owns the Prompt Bar's entry points: the global shortcut and the menu bar icon click.
+///
+/// Keeps the registered shortcut in step with the user's preference, and unregisters it when the
+/// preference or Duck.ai itself is switched off.
+@MainActor
+final class PromptBarCoordinator {
+
+    private let featureFlagger: FeatureFlagger
+    private let preferences: PromptBarPreferences
+    private let shortcutRegistrar: GlobalShortcutRegistering
+    private let presenter: PromptBarPresenting
+
+    private var shortcutCancellable: AnyCancellable?
+
+    init(featureFlagger: FeatureFlagger,
+         preferences: PromptBarPreferences,
+         shortcutRegistrar: GlobalShortcutRegistering,
+         presenter: PromptBarPresenting) {
+        self.featureFlagger = featureFlagger
+        self.preferences = preferences
+        self.shortcutRegistrar = shortcutRegistrar
+        self.presenter = presenter
+    }
+
+    /// Begins observing the shortcut preference. A no-op while the feature flag is off, so nothing
+    /// is registered and the menu bar click stays inert.
+    func start() {
+        guard featureFlagger.isFeatureOn(.macosPromptBar) else { return }
+
+        shortcutCancellable = preferences.effectiveKeyboardShortcutPublisher
+            .sink { [weak self] shortcut in
+                self?.applyShortcut(shortcut)
+            }
+    }
+
+    /// Shows the bar, or hides it when it is already up. Called by the global shortcut and the
+    /// menu bar icon.
+    func togglePromptBar() {
+        guard featureFlagger.isFeatureOn(.macosPromptBar) else { return }
+        presenter.toggle()
+    }
+
+    private func applyShortcut(_ shortcut: PromptBarShortcut?) {
+        guard let shortcut else {
+            shortcutRegistrar.unregister()
+            return
+        }
+
+        shortcutRegistrar.register(shortcut) { [weak self] in
+            // The Carbon handler is not isolated, so hop to the main actor before touching UI.
+            Task { @MainActor in
+                self?.togglePromptBar()
+            }
+        }
+    }
+}

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPresenter.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPresenter.swift
@@ -28,8 +28,7 @@ protocol PromptBarPresenting: AnyObject {
     func toggle()
 }
 
-/// Owns the Prompt Bar window and the dismissal policy: Escape, submit, and losing key status —
-/// the last of which is suppressed while the content has a menu or file picker up.
+/// Owns the Prompt Bar window and its dismissal policy.
 @MainActor
 final class PromptBarPresenter: PromptBarPresenting {
 
@@ -44,8 +43,7 @@ final class PromptBarPresenter: PromptBarPresenting {
         window?.isVisible ?? false
     }
 
-    /// `screenProvider` is resolved in the body rather than as a default value: default parameter
-    /// values are evaluated in a nonisolated context, and the provider is main-actor isolated.
+    // `screenProvider` has no default value: defaults are evaluated nonisolated, and the provider is @MainActor.
     init(content: PromptBarContentHosting,
          screenProvider: PromptBarScreenProviding? = nil,
          makeWindow: @escaping (NSRect) -> PromptBarWindow = { PromptBarWindow(contentRect: $0) }) {
@@ -77,10 +75,9 @@ final class PromptBarPresenter: PromptBarPresenting {
                                                  in: screenProvider.targetVisibleFrame),
                         display: false)
 
-        // The bar is a keyboard-first surface, so the app has to come forward to receive typing.
         NSApp.activate(ignoringOtherApps: true)
         window.makeKeyAndOrderFront(nil)
-        // Only meaningful once the window is key, so it follows the ordering above.
+        // First responder only sticks once the window is key.
         content.focusPromptEditor()
     }
 
@@ -108,8 +105,7 @@ final class PromptBarPresenter: PromptBarPresenting {
         return window
     }
 
-    /// Clicking outside dismisses, but a tool menu or `NSOpenPanel` also takes key away — those
-    /// must not close the bar the user is still filling in.
+    /// Clicking outside dismisses — but a tool menu or `NSOpenPanel` also takes key away, and must not.
     private func subscribeToResignKey(of window: PromptBarWindow) {
         resignKeyCancellable = NotificationCenter.default
             .publisher(for: NSWindow.didResignKeyNotification, object: window)
@@ -122,7 +118,7 @@ final class PromptBarPresenter: PromptBarPresenting {
     private func resizeWindow(toContentSize size: NSSize) {
         guard let window, window.isVisible else { return }
 
-        // Keep the top edge pinned so the bar grows downwards as the prompt gets longer.
+        // Pin the top edge so the bar grows downwards.
         var frame = window.frame
         let top = frame.maxY
         frame.size.height = size.height

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPresenter.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPresenter.swift
@@ -75,10 +75,15 @@ final class PromptBarPresenter: PromptBarPresenting {
                                                  in: screenProvider.targetVisibleFrame),
                         display: false)
 
-        NSApp.activate(ignoringOtherApps: true)
-        window.makeKeyAndOrderFront(nil)
+        // Deliberately no `NSApp.activate`: that raises the browser's own windows above whatever the
+        // user has in front. `orderFrontRegardless` + the panel's `.nonactivatingPanel` style show
+        // and focus the bar while the app stays inactive; submitting is what brings the browser forward.
+        window.orderFrontRegardless()
+        window.makeKey()
         // First responder only sticks once the window is key.
         content.focusPromptEditor()
+        // Subscribed per presentation, not per window: `dismiss()` tears the subscription down.
+        subscribeToResignKey(of: window)
     }
 
     func dismiss() {
@@ -100,7 +105,6 @@ final class PromptBarPresenter: PromptBarPresenting {
         window.onCancel = { [weak self] in
             self?.dismiss()
         }
-        subscribeToResignKey(of: window)
         self.window = window
         return window
     }

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPresenter.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPresenter.swift
@@ -19,7 +19,6 @@
 import AppKit
 import Combine
 
-/// Shows and hides the floating Prompt Bar.
 @MainActor
 protocol PromptBarPresenting: AnyObject {
     var isVisible: Bool { get }
@@ -28,7 +27,6 @@ protocol PromptBarPresenting: AnyObject {
     func toggle()
 }
 
-/// Owns the Prompt Bar window and its dismissal policy.
 @MainActor
 final class PromptBarPresenter: PromptBarPresenting {
 
@@ -75,14 +73,12 @@ final class PromptBarPresenter: PromptBarPresenting {
                                                  in: screenProvider.targetVisibleFrame),
                         display: false)
 
-        // Deliberately no `NSApp.activate`: that raises the browser's own windows above whatever the
-        // user has in front. `orderFrontRegardless` + the panel's `.nonactivatingPanel` style show
-        // and focus the bar while the app stays inactive; submitting is what brings the browser forward.
+        // No `NSApp.activate`: it would raise the browser's windows above whatever the user has in front.
         window.orderFrontRegardless()
         window.makeKey()
         // First responder only sticks once the window is key.
         content.focusPromptEditor()
-        // Subscribed per presentation, not per window: `dismiss()` tears the subscription down.
+        // Per presentation, not per window: `dismiss()` tears this down.
         subscribeToResignKey(of: window)
     }
 
@@ -122,7 +118,6 @@ final class PromptBarPresenter: PromptBarPresenting {
     private func resizeWindow(toContentSize size: NSSize) {
         guard let window, window.isVisible else { return }
 
-        // Pin the top edge so the bar grows downwards.
         var frame = window.frame
         let top = frame.maxY
         frame.size.height = size.height

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPresenter.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPresenter.swift
@@ -1,0 +1,132 @@
+//
+//  PromptBarPresenter.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import Combine
+
+/// Shows and hides the floating Prompt Bar.
+@MainActor
+protocol PromptBarPresenting: AnyObject {
+    var isVisible: Bool { get }
+    func show()
+    func dismiss()
+    func toggle()
+}
+
+/// Owns the Prompt Bar window and the dismissal policy: Escape, submit, and losing key status —
+/// the last of which is suppressed while the content has a menu or file picker up.
+@MainActor
+final class PromptBarPresenter: PromptBarPresenting {
+
+    private let content: PromptBarContentHosting
+    private let screenProvider: PromptBarScreenProviding
+    private let makeWindow: (NSRect) -> PromptBarWindow
+
+    private var window: PromptBarWindow?
+    private var resignKeyCancellable: AnyCancellable?
+
+    var isVisible: Bool {
+        window?.isVisible ?? false
+    }
+
+    /// `screenProvider` is resolved in the body rather than as a default value: default parameter
+    /// values are evaluated in a nonisolated context, and the provider is main-actor isolated.
+    init(content: PromptBarContentHosting,
+         screenProvider: PromptBarScreenProviding? = nil,
+         makeWindow: @escaping (NSRect) -> PromptBarWindow = { PromptBarWindow(contentRect: $0) }) {
+        self.content = content
+        self.screenProvider = screenProvider ?? MouseLocationScreenProvider()
+        self.makeWindow = makeWindow
+
+        self.content.onSubmit = { [weak self] in
+            self?.dismiss()
+        }
+        self.content.onPreferredWindowContentSizeChanged = { [weak self] size in
+            self?.resizeWindow(toContentSize: size)
+        }
+    }
+
+    func toggle() {
+        if isVisible {
+            dismiss()
+        } else {
+            show()
+        }
+    }
+
+    func show() {
+        content.prepareForPresentation()
+
+        let window = existingWindowOrNew()
+        window.setFrame(PromptBarPlacement.frame(forContentHeight: content.preferredWindowContentSize.height,
+                                                 in: screenProvider.targetVisibleFrame),
+                        display: false)
+
+        // The bar is a keyboard-first surface, so the app has to come forward to receive typing.
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
+        // Only meaningful once the window is key, so it follows the ordering above.
+        content.focusPromptEditor()
+    }
+
+    func dismiss() {
+        guard let window else { return }
+        resignKeyCancellable = nil
+        window.orderOut(nil)
+        content.resetAfterDismissal()
+    }
+
+    private func existingWindowOrNew() -> PromptBarWindow {
+        if let window {
+            return window
+        }
+
+        let initialFrame = PromptBarPlacement.frame(forContentHeight: content.preferredWindowContentSize.height,
+                                                    in: screenProvider.targetVisibleFrame)
+        let window = makeWindow(initialFrame)
+        window.contentViewController = content.viewController
+        window.onCancel = { [weak self] in
+            self?.dismiss()
+        }
+        subscribeToResignKey(of: window)
+        self.window = window
+        return window
+    }
+
+    /// Clicking outside dismisses, but a tool menu or `NSOpenPanel` also takes key away — those
+    /// must not close the bar the user is still filling in.
+    private func subscribeToResignKey(of window: PromptBarWindow) {
+        resignKeyCancellable = NotificationCenter.default
+            .publisher(for: NSWindow.didResignKeyNotification, object: window)
+            .sink { [weak self] _ in
+                guard let self, !self.content.isPresentingAuxiliaryUI else { return }
+                self.dismiss()
+            }
+    }
+
+    private func resizeWindow(toContentSize size: NSSize) {
+        guard let window, window.isVisible else { return }
+
+        // Keep the top edge pinned so the bar grows downwards as the prompt gets longer.
+        var frame = window.frame
+        let top = frame.maxY
+        frame.size.height = size.height
+        frame.origin.y = top - size.height
+        window.setFrame(frame, display: true, animate: false)
+    }
+}

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPromptSubmitter.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPromptSubmitter.swift
@@ -1,0 +1,96 @@
+//
+//  PromptBarPromptSubmitter.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+
+/// Hands a Prompt Bar prompt to Duck.ai.
+@MainActor
+protocol PromptBarPromptSubmitting {
+
+    /// - Parameter screen: The screen the Prompt Bar is on. A browser window there is reused;
+    ///   otherwise a new window is opened, so the chat never appears on a display the user isn't looking at.
+    func submit(prompt: String, preferringWindowOn screen: NSScreen?)
+}
+
+/// The window properties that decide whether a browser window can host a submitted prompt.
+/// A protocol so the rule can be tested without real windows.
+@MainActor
+protocol PromptBarHostWindow {
+    var isVisible: Bool { get }
+    var isMiniaturized: Bool { get }
+
+    /// Whether the window is on the Space the user is currently viewing.
+    var isOnActiveSpace: Bool { get }
+
+    /// Frame of the display showing most of the window, or `nil` when the window is offscreen.
+    /// Frames identify displays: two screens can never share one in global coordinates.
+    var screenFrame: NSRect? { get }
+}
+
+extension NSWindow: PromptBarHostWindow {
+    var screenFrame: NSRect? { screen?.frame }
+}
+
+@MainActor
+final class PromptBarPromptSubmitter: PromptBarPromptSubmitting {
+
+    private let aiChatTabOpener: AIChatTabOpening
+    private let windowControllersManager: WindowControllersManagerProtocol
+
+    init(aiChatTabOpener: AIChatTabOpening, windowControllersManager: WindowControllersManagerProtocol) {
+        self.aiChatTabOpener = aiChatTabOpener
+        self.windowControllersManager = windowControllersManager
+    }
+
+    func submit(prompt: String, preferringWindowOn screen: NSScreen?) {
+        if let windowController = windowToReuse(on: screen) {
+            aiChatTabOpener.openAIChatTab(withQuery: prompt, inNewTabOf: windowController)
+        } else if let visibleFrame = screen?.visibleFrame {
+            // Placed explicitly: an unplaced new window cascades off the last key window, which is
+            // how it would end up back on the display the user just walked away from.
+            aiChatTabOpener.openAIChatTab(withQuery: prompt, inNewWindowAt: Self.newWindowDroppingPoint(in: visibleFrame))
+        } else {
+            aiChatTabOpener.openAIChatTab(with: .query(prompt, shouldAutoSubmit: true), behavior: .newWindow(selected: true))
+        }
+    }
+
+    /// Top-center point for a new window, which is what `droppingPoint` means: horizontally centered
+    /// on the target display and flush with the top of its visible area.
+    static func newWindowDroppingPoint(in visibleFrame: NSRect) -> NSPoint {
+        NSPoint(x: visibleFrame.midX, y: visibleFrame.maxY)
+    }
+
+    /// The most recently focused eligible window, so a screen showing several windows reuses the one
+    /// the user last worked in. `lastKeyMainWindowController(where:)` already excludes popups.
+    private func windowToReuse(on screen: NSScreen?) -> MainWindowController? {
+        let targetScreenFrame = screen?.frame
+        return windowControllersManager.lastKeyMainWindowController { windowController in
+            guard let window = windowController.window else { return false }
+            return Self.canHostPrompt(window, submittedFromScreenFrame: targetScreenFrame)
+        }
+    }
+
+    /// A window qualifies when it is actually on screen, on the Space being viewed, and on the
+    /// display the prompt came from. With an unknown source display, any on-screen window qualifies —
+    /// better to reuse a window than to open one the user may not have wanted.
+    static func canHostPrompt(_ window: PromptBarHostWindow, submittedFromScreenFrame screenFrame: NSRect?) -> Bool {
+        guard window.isVisible, !window.isMiniaturized, window.isOnActiveSpace else { return false }
+        guard let screenFrame else { return true }
+        return window.screenFrame == screenFrame
+    }
+}

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPromptSubmitter.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPromptSubmitter.swift
@@ -22,22 +22,19 @@ import AppKit
 @MainActor
 protocol PromptBarPromptSubmitting {
 
-    /// - Parameter screen: The screen the Prompt Bar is on. A browser window there is reused;
-    ///   otherwise a new window is opened, so the chat never appears on a display the user isn't looking at.
+    /// - Parameter screen: Reuses a browser window there, so the chat never opens on a display the
+    ///   user isn't looking at.
     func submit(prompt: String, preferringWindowOn screen: NSScreen?)
 }
 
-/// The window properties that decide whether a browser window can host a submitted prompt.
-/// A protocol so the rule can be tested without real windows.
+/// The window properties deciding whether a browser window can host a submitted prompt.
+/// A protocol so the rule tests without real windows.
 @MainActor
 protocol PromptBarHostWindow {
     var isVisible: Bool { get }
     var isMiniaturized: Bool { get }
-
-    /// Whether the window is on the Space the user is currently viewing.
     var isOnActiveSpace: Bool { get }
 
-    /// Frame of the display showing most of the window, or `nil` when the window is offscreen.
     /// Frames identify displays: two screens can never share one in global coordinates.
     var screenFrame: NSRect? { get }
 }
@@ -61,22 +58,20 @@ final class PromptBarPromptSubmitter: PromptBarPromptSubmitting {
         if let windowController = windowToReuse(on: screen) {
             aiChatTabOpener.openAIChatTab(withQuery: prompt, inNewTabOf: windowController)
         } else if let visibleFrame = screen?.visibleFrame {
-            // Placed explicitly: an unplaced new window cascades off the last key window, which is
-            // how it would end up back on the display the user just walked away from.
+            // Placed explicitly: an unplaced window cascades off the last key window, i.e. back onto its display.
             aiChatTabOpener.openAIChatTab(withQuery: prompt, inNewWindowAt: Self.newWindowDroppingPoint(in: visibleFrame))
         } else {
             aiChatTabOpener.openAIChatTab(with: .query(prompt, shouldAutoSubmit: true), behavior: .newWindow(selected: true))
         }
     }
 
-    /// Top-center point for a new window, which is what `droppingPoint` means: horizontally centered
-    /// on the target display and flush with the top of its visible area.
+    /// `droppingPoint` is a window's top-center: centered on the display, flush with its visible top.
     static func newWindowDroppingPoint(in visibleFrame: NSRect) -> NSPoint {
         NSPoint(x: visibleFrame.midX, y: visibleFrame.maxY)
     }
 
-    /// The most recently focused eligible window, so a screen showing several windows reuses the one
-    /// the user last worked in. `lastKeyMainWindowController(where:)` already excludes popups.
+    /// Most recently focused first, so a screen with several windows reuses the last one worked in.
+    /// `lastKeyMainWindowController(where:)` already excludes popups.
     private func windowToReuse(on screen: NSScreen?) -> MainWindowController? {
         let targetScreenFrame = screen?.frame
         return windowControllersManager.lastKeyMainWindowController { windowController in
@@ -85,9 +80,7 @@ final class PromptBarPromptSubmitter: PromptBarPromptSubmitting {
         }
     }
 
-    /// A window qualifies when it is actually on screen, on the Space being viewed, and on the
-    /// display the prompt came from. With an unknown source display, any on-screen window qualifies —
-    /// better to reuse a window than to open one the user may not have wanted.
+    /// With an unknown source display, any on-screen window qualifies — reusing beats opening one.
     static func canHostPrompt(_ window: PromptBarHostWindow, submittedFromScreenFrame screenFrame: NSRect?) -> Bool {
         guard window.isVisible, !window.isMiniaturized, window.isOnActiveSpace else { return false }
         guard let screenFrame else { return true }

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPromptSubmitter.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPromptSubmitter.swift
@@ -63,6 +63,10 @@ final class PromptBarPromptSubmitter: PromptBarPromptSubmitting {
         } else {
             aiChatTabOpener.openAIChatTab(with: .query(prompt, shouldAutoSubmit: true), behavior: .newWindow(selected: true))
         }
+
+        // The bar opens without activating the app, so reused windows are only reordered within it,
+        // not raised above other apps. Submitting is the point at which the browser should come forward.
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     /// `droppingPoint` is a window's top-center: centered on the display, flush with its visible top.

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPromptSubmitter.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPromptSubmitter.swift
@@ -18,17 +18,13 @@
 
 import AppKit
 
-/// Hands a Prompt Bar prompt to Duck.ai.
 @MainActor
 protocol PromptBarPromptSubmitting {
 
-    /// - Parameter screen: Reuses a browser window there, so the chat never opens on a display the
-    ///   user isn't looking at.
     func submit(prompt: String, preferringWindowOn screen: NSScreen?)
 }
 
-/// The window properties deciding whether a browser window can host a submitted prompt.
-/// A protocol so the rule tests without real windows.
+/// A protocol so the eligibility rule tests without real windows.
 @MainActor
 protocol PromptBarHostWindow {
     var isVisible: Bool { get }
@@ -64,8 +60,7 @@ final class PromptBarPromptSubmitter: PromptBarPromptSubmitting {
             aiChatTabOpener.openAIChatTab(with: .query(prompt, shouldAutoSubmit: true), behavior: .newWindow(selected: true))
         }
 
-        // The bar opens without activating the app, so reused windows are only reordered within it,
-        // not raised above other apps. Submitting is the point at which the browser should come forward.
+        // The bar never activates the app, so submitting is what brings the browser forward.
         NSApp.activate(ignoringOtherApps: true)
     }
 
@@ -74,8 +69,6 @@ final class PromptBarPromptSubmitter: PromptBarPromptSubmitting {
         NSPoint(x: visibleFrame.midX, y: visibleFrame.maxY)
     }
 
-    /// Most recently focused first, so a screen with several windows reuses the last one worked in.
-    /// `lastKeyMainWindowController(where:)` already excludes popups.
     private func windowToReuse(on screen: NSScreen?) -> MainWindowController? {
         let targetScreenFrame = screen?.frame
         return windowControllersManager.lastKeyMainWindowController { windowController in
@@ -84,7 +77,6 @@ final class PromptBarPromptSubmitter: PromptBarPromptSubmitting {
         }
     }
 
-    /// With an unknown source display, any on-screen window qualifies — reusing beats opening one.
     static func canHostPrompt(_ window: PromptBarHostWindow, submittedFromScreenFrame screenFrame: NSRect?) -> Bool {
         guard window.isVisible, !window.isMiniaturized, window.isOnActiveSpace else { return false }
         guard let screenFrame else { return true }

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPreferences.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPreferences.swift
@@ -56,6 +56,29 @@ final class PromptBarPreferences: ObservableObject {
             .eraseToAnyPublisher()
     }
 
+    /// The shortcut opens Duck.ai, so it stays unregistered while Duck.ai is off. The stored
+    /// combination is kept so it can be restored.
+    var isKeyboardShortcutEffectivelyEnabled: Bool {
+        isKeyboardShortcutEnabled && aiChatMenuConfiguration.shouldDisplayAnyAIChatFeature
+    }
+
+    /// The shortcut that should currently be registered with the OS, or `nil` for none. One channel
+    /// so registration doesn't have to combine the enabled flag, the combination and Duck.ai's state.
+    var effectiveKeyboardShortcutPublisher: AnyPublisher<PromptBarShortcut?, Never> {
+        let aiChatMenuConfiguration = self.aiChatMenuConfiguration
+        let aiChatFeatureChanges = aiChatMenuConfiguration.valuesChangedPublisher
+            .map { _ in () }
+            .prepend(())
+
+        return Publishers.CombineLatest3($isKeyboardShortcutEnabled, $keyboardShortcut, aiChatFeatureChanges)
+            .map { isEnabled, shortcut, _ -> PromptBarShortcut? in
+                guard isEnabled, aiChatMenuConfiguration.shouldDisplayAnyAIChatFeature else { return nil }
+                return shortcut
+            }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+
     private var persistor: PromptBarPreferencesPersistor
     private let aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable
 

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPreferences.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPreferences.swift
@@ -56,14 +56,12 @@ final class PromptBarPreferences: ObservableObject {
             .eraseToAnyPublisher()
     }
 
-    /// The shortcut opens Duck.ai, so it stays unregistered while Duck.ai is off. The stored
-    /// combination is kept so it can be restored.
+    /// The shortcut opens Duck.ai, so it stays unregistered while Duck.ai is off.
     var isKeyboardShortcutEffectivelyEnabled: Bool {
         isKeyboardShortcutEnabled && aiChatMenuConfiguration.shouldDisplayAnyAIChatFeature
     }
 
-    /// The shortcut that should currently be registered with the OS, or `nil` for none. One channel
-    /// so registration doesn't have to combine the enabled flag, the combination and Duck.ai's state.
+    /// The shortcut that should be registered with the OS, or `nil` for none.
     var effectiveKeyboardShortcutPublisher: AnyPublisher<PromptBarShortcut?, Never> {
         let aiChatMenuConfiguration = self.aiChatMenuConfiguration
         let aiChatFeatureChanges = aiChatMenuConfiguration.valuesChangedPublisher

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPreferences.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPreferences.swift
@@ -61,7 +61,7 @@ final class PromptBarPreferences: ObservableObject {
         isKeyboardShortcutEnabled && aiChatMenuConfiguration.shouldDisplayAnyAIChatFeature
     }
 
-    /// The shortcut that should be registered with the OS, or `nil` for none.
+    /// `nil` when no shortcut should be registered.
     var effectiveKeyboardShortcutPublisher: AnyPublisher<PromptBarShortcut?, Never> {
         let aiChatMenuConfiguration = self.aiChatMenuConfiguration
         let aiChatFeatureChanges = aiChatMenuConfiguration.valuesChangedPublisher

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPreferencesPersistor.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPreferencesPersistor.swift
@@ -40,7 +40,7 @@ struct PromptBarPreferencesUserDefaultsPersistor: PromptBarPreferencesPersistor 
     }
 
     var isKeyboardShortcutEnabled: Bool {
-        get { (try? keyValueStore.object(forKey: Key.keyboardShortcutIsEnabled.rawValue) as? Bool) ?? true }
+        get { (try? keyValueStore.object(forKey: Key.keyboardShortcutIsEnabled.rawValue) as? Bool) ?? false }
         set { try? keyValueStore.set(newValue, forKey: Key.keyboardShortcutIsEnabled.rawValue) }
     }
 
@@ -59,7 +59,7 @@ struct PromptBarPreferencesUserDefaultsPersistor: PromptBarPreferencesPersistor 
     }
 
     var isMenuBarIconVisible: Bool {
-        get { (try? keyValueStore.object(forKey: Key.menuBarIconIsVisible.rawValue) as? Bool) ?? true }
+        get { (try? keyValueStore.object(forKey: Key.menuBarIconIsVisible.rawValue) as? Bool) ?? false }
         set { try? keyValueStore.set(newValue, forKey: Key.menuBarIconIsVisible.rawValue) }
     }
 }

--- a/macOS/DuckDuckGo/PromptBar/Shortcut/CarbonGlobalShortcutRegistrar.swift
+++ b/macOS/DuckDuckGo/PromptBar/Shortcut/CarbonGlobalShortcutRegistrar.swift
@@ -20,8 +20,8 @@ import AppKit
 import Carbon.HIToolbox
 import os.log
 
-/// Global shortcut registration through Carbon's `RegisterEventHotKey` — the only route that needs
-/// no Accessibility permission; `NSEvent.addGlobalMonitorForEvents` drops key events until granted.
+/// Carbon's `RegisterEventHotKey` is the only global-hotkey route needing no Accessibility grant;
+/// `NSEvent.addGlobalMonitorForEvents` silently drops key events until one is given.
 final class CarbonGlobalShortcutRegistrar: GlobalShortcutRegistering {
 
     private enum Constants {
@@ -84,7 +84,6 @@ final class CarbonGlobalShortcutRegistrar: GlobalShortcutRegistering {
         handler?()
     }
 
-    /// One handler serves every hot key this registrar owns, so it is installed once.
     private func installEventHandlerIfNeeded() -> Bool {
         guard eventHandlerRef == nil else { return true }
 

--- a/macOS/DuckDuckGo/PromptBar/Shortcut/CarbonGlobalShortcutRegistrar.swift
+++ b/macOS/DuckDuckGo/PromptBar/Shortcut/CarbonGlobalShortcutRegistrar.swift
@@ -20,11 +20,8 @@ import AppKit
 import Carbon.HIToolbox
 import os.log
 
-/// Global shortcut registration through Carbon's `RegisterEventHotKey`.
-///
-/// Carbon is the only route to a system-wide hotkey that needs no Accessibility permission —
-/// `NSEvent.addGlobalMonitorForEvents` silently delivers nothing for key events until the user
-/// grants trust.
+/// Global shortcut registration through Carbon's `RegisterEventHotKey` — the only route that needs
+/// no Accessibility permission; `NSEvent.addGlobalMonitorForEvents` drops key events until granted.
 final class CarbonGlobalShortcutRegistrar: GlobalShortcutRegistering {
 
     private enum Constants {
@@ -83,12 +80,11 @@ final class CarbonGlobalShortcutRegistrar: GlobalShortcutRegistering {
         registeredShortcut = nil
     }
 
-    /// Called from the Carbon event handler on the main thread.
     fileprivate func handleHotKeyPressed() {
         handler?()
     }
 
-    /// One handler serves every hot key this registrar owns, so it is installed once and left in place.
+    /// One handler serves every hot key this registrar owns, so it is installed once.
     private func installEventHandlerIfNeeded() -> Bool {
         guard eventHandlerRef == nil else { return true }
 

--- a/macOS/DuckDuckGo/PromptBar/Shortcut/CarbonGlobalShortcutRegistrar.swift
+++ b/macOS/DuckDuckGo/PromptBar/Shortcut/CarbonGlobalShortcutRegistrar.swift
@@ -1,0 +1,129 @@
+//
+//  CarbonGlobalShortcutRegistrar.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import Carbon.HIToolbox
+import os.log
+
+/// Global shortcut registration through Carbon's `RegisterEventHotKey`.
+///
+/// Carbon is the only route to a system-wide hotkey that needs no Accessibility permission —
+/// `NSEvent.addGlobalMonitorForEvents` silently delivers nothing for key events until the user
+/// grants trust.
+final class CarbonGlobalShortcutRegistrar: GlobalShortcutRegistering {
+
+    private enum Constants {
+        /// Four-char signature ("DDGP") scoping our hot key IDs to this app.
+        static let signature = OSType(0x44_44_47_50)
+        static let promptBarHotKeyID: UInt32 = 1
+    }
+
+    private var hotKeyRef: EventHotKeyRef?
+    private var eventHandlerRef: EventHandlerRef?
+    private var handler: (() -> Void)?
+
+    private(set) var registeredShortcut: PromptBarShortcut?
+
+    deinit {
+        if let hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+        }
+        if let eventHandlerRef {
+            RemoveEventHandler(eventHandlerRef)
+        }
+    }
+
+    @discardableResult
+    func register(_ shortcut: PromptBarShortcut, handler: @escaping () -> Void) -> Bool {
+        unregister()
+
+        guard installEventHandlerIfNeeded() else { return false }
+
+        let hotKeyID = EventHotKeyID(signature: Constants.signature, id: Constants.promptBarHotKeyID)
+        var reference: EventHotKeyRef?
+        let status = RegisterEventHotKey(UInt32(shortcut.keyCode),
+                                        Self.carbonModifiers(from: shortcut.modifierFlags),
+                                        hotKeyID,
+                                        GetApplicationEventTarget(),
+                                        0,
+                                        &reference)
+
+        guard status == noErr, let reference else {
+            Logger.general.error("Prompt Bar: global shortcut registration failed with status \(status)")
+            return false
+        }
+
+        hotKeyRef = reference
+        self.handler = handler
+        registeredShortcut = shortcut
+        return true
+    }
+
+    func unregister() {
+        if let hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+        }
+        hotKeyRef = nil
+        handler = nil
+        registeredShortcut = nil
+    }
+
+    /// Called from the Carbon event handler on the main thread.
+    fileprivate func handleHotKeyPressed() {
+        handler?()
+    }
+
+    /// One handler serves every hot key this registrar owns, so it is installed once and left in place.
+    private func installEventHandlerIfNeeded() -> Bool {
+        guard eventHandlerRef == nil else { return true }
+
+        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+        var reference: EventHandlerRef?
+        let status = InstallEventHandler(GetApplicationEventTarget(),
+                                        promptBarHotKeyEventHandler,
+                                        1,
+                                        &eventType,
+                                        Unmanaged.passUnretained(self).toOpaque(),
+                                        &reference)
+
+        guard status == noErr else {
+            Logger.general.error("Prompt Bar: global shortcut event handler install failed with status \(status)")
+            return false
+        }
+
+        eventHandlerRef = reference
+        return true
+    }
+
+    private static func carbonModifiers(from flags: NSEvent.ModifierFlags) -> UInt32 {
+        var carbonFlags: UInt32 = 0
+        if flags.contains(.command) { carbonFlags |= UInt32(cmdKey) }
+        if flags.contains(.option) { carbonFlags |= UInt32(optionKey) }
+        if flags.contains(.control) { carbonFlags |= UInt32(controlKey) }
+        if flags.contains(.shift) { carbonFlags |= UInt32(shiftKey) }
+        return carbonFlags
+    }
+}
+
+/// C callback: Carbon can't carry a Swift closure, so the registrar is passed as `userData`.
+private let promptBarHotKeyEventHandler: EventHandlerUPP = { _, _, userData in
+    guard let userData else { return OSStatus(eventNotHandledErr) }
+    let registrar = Unmanaged<CarbonGlobalShortcutRegistrar>.fromOpaque(userData).takeUnretainedValue()
+    registrar.handleHotKeyPressed()
+    return noErr
+}

--- a/macOS/DuckDuckGo/PromptBar/Shortcut/GlobalShortcutRegistering.swift
+++ b/macOS/DuckDuckGo/PromptBar/Shortcut/GlobalShortcutRegistering.swift
@@ -21,10 +21,9 @@ import AppKit
 /// Registers a system-wide keyboard shortcut that fires whether or not the app is active.
 protocol GlobalShortcutRegistering: AnyObject {
 
-    /// The shortcut currently held by the OS, or `nil` when none is registered.
     var registeredShortcut: PromptBarShortcut? { get }
 
-    /// Registers `shortcut`, replacing any shortcut this registrar already holds.
+    /// Replaces any shortcut this registrar already holds.
     /// - Returns: `false` when the OS refused the combination, typically because another app owns it.
     @discardableResult
     func register(_ shortcut: PromptBarShortcut, handler: @escaping () -> Void) -> Bool

--- a/macOS/DuckDuckGo/PromptBar/Shortcut/GlobalShortcutRegistering.swift
+++ b/macOS/DuckDuckGo/PromptBar/Shortcut/GlobalShortcutRegistering.swift
@@ -23,7 +23,6 @@ protocol GlobalShortcutRegistering: AnyObject {
 
     var registeredShortcut: PromptBarShortcut? { get }
 
-    /// Replaces any shortcut this registrar already holds.
     /// - Returns: `false` when the OS refused the combination, typically because another app owns it.
     @discardableResult
     func register(_ shortcut: PromptBarShortcut, handler: @escaping () -> Void) -> Bool

--- a/macOS/DuckDuckGo/PromptBar/Shortcut/GlobalShortcutRegistering.swift
+++ b/macOS/DuckDuckGo/PromptBar/Shortcut/GlobalShortcutRegistering.swift
@@ -1,0 +1,33 @@
+//
+//  GlobalShortcutRegistering.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+
+/// Registers a system-wide keyboard shortcut that fires whether or not the app is active.
+protocol GlobalShortcutRegistering: AnyObject {
+
+    /// The shortcut currently held by the OS, or `nil` when none is registered.
+    var registeredShortcut: PromptBarShortcut? { get }
+
+    /// Registers `shortcut`, replacing any shortcut this registrar already holds.
+    /// - Returns: `false` when the OS refused the combination, typically because another app owns it.
+    @discardableResult
+    func register(_ shortcut: PromptBarShortcut, handler: @escaping () -> Void) -> Bool
+
+    func unregister()
+}

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarContentHosting.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarContentHosting.swift
@@ -18,33 +18,25 @@
 
 import AppKit
 
-/// What `PromptBarPresenter` needs from the bar's content, so presentation and dismissal can be
-/// tested without building the Duck.ai prompt stack.
+/// What `PromptBarPresenter` needs from the bar's content.
 @MainActor
 protocol PromptBarContentHosting: AnyObject {
 
     var viewController: NSViewController { get }
 
-    /// True while a tool menu, file picker or modal is on screen. The presenter suppresses
-    /// dismiss-on-resign-key while it holds, otherwise opening the file picker would close the bar.
+    /// True while a menu, file picker or modal is up: those take key away, and must not dismiss the bar.
     var isPresentingAuxiliaryUI: Bool { get }
 
-    /// Window content size the current text and attachments need. Named to avoid colliding with
-    /// `NSViewController.preferredContentSize`, which conforming view controllers already inherit.
+    /// Not `preferredContentSize`, which would collide with the `NSViewController` property conformers inherit.
     var preferredWindowContentSize: NSSize { get }
 
-    /// Fires when `preferredWindowContentSize` changes, e.g. as the prompt wraps onto another line.
     var onPreferredWindowContentSizeChanged: ((NSSize) -> Void)? { get set }
-
-    /// Fires once the prompt has been handed off to Duck.ai; the presenter dismisses in response.
     var onSubmit: (() -> Void)? { get set }
 
-    /// Called before the window is shown, to refresh state that may have changed since last time.
     func prepareForPresentation()
 
-    /// Called once the window is key, when first responder assignment actually sticks.
+    /// Called once the window is key, when first responder assignment sticks.
     func focusPromptEditor()
 
-    /// Called after dismissal, to clear the draft so the next presentation starts clean.
     func resetAfterDismissal()
 }

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarContentHosting.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarContentHosting.swift
@@ -31,6 +31,9 @@ protocol PromptBarContentHosting: AnyObject {
     var preferredWindowContentSize: NSSize { get }
 
     var onPreferredWindowContentSizeChanged: ((NSSize) -> Void)? { get set }
+
+    /// Fired just before the prompt is handed off, so the bar is out of the way when a browser
+    /// window is raised.
     var onSubmit: (() -> Void)? { get set }
 
     func prepareForPresentation()

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarContentHosting.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarContentHosting.swift
@@ -32,8 +32,7 @@ protocol PromptBarContentHosting: AnyObject {
 
     var onPreferredWindowContentSizeChanged: ((NSSize) -> Void)? { get set }
 
-    /// Fired just before the prompt is handed off, so the bar is out of the way when a browser
-    /// window is raised.
+    /// Fired just *before* the prompt is handed off, so the bar is out of the way.
     var onSubmit: (() -> Void)? { get set }
 
     func prepareForPresentation()

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarContentHosting.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarContentHosting.swift
@@ -1,0 +1,50 @@
+//
+//  PromptBarContentHosting.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+
+/// What `PromptBarPresenter` needs from the bar's content, so presentation and dismissal can be
+/// tested without building the Duck.ai prompt stack.
+@MainActor
+protocol PromptBarContentHosting: AnyObject {
+
+    var viewController: NSViewController { get }
+
+    /// True while a tool menu, file picker or modal is on screen. The presenter suppresses
+    /// dismiss-on-resign-key while it holds, otherwise opening the file picker would close the bar.
+    var isPresentingAuxiliaryUI: Bool { get }
+
+    /// Window content size the current text and attachments need. Named to avoid colliding with
+    /// `NSViewController.preferredContentSize`, which conforming view controllers already inherit.
+    var preferredWindowContentSize: NSSize { get }
+
+    /// Fires when `preferredWindowContentSize` changes, e.g. as the prompt wraps onto another line.
+    var onPreferredWindowContentSizeChanged: ((NSSize) -> Void)? { get set }
+
+    /// Fires once the prompt has been handed off to Duck.ai; the presenter dismisses in response.
+    var onSubmit: (() -> Void)? { get set }
+
+    /// Called before the window is shown, to refresh state that may have changed since last time.
+    func prepareForPresentation()
+
+    /// Called once the window is key, when first responder assignment actually sticks.
+    func focusPromptEditor()
+
+    /// Called after dismissal, to clear the draft so the next presentation starts clean.
+    func resetAfterDismissal()
+}

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarMenuBarController.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarMenuBarController.swift
@@ -36,8 +36,7 @@ final class PromptBarMenuBarController: NSObject {
     private let makeStatusItem: @MainActor () -> PromptBarStatusItem
     private var statusItem: PromptBarStatusItem?
 
-    /// Called when the icon is clicked. Set by the owner so this controller stays unaware of what
-    /// the Prompt Bar is.
+    /// Set by the owner, so this controller stays unaware of what the Prompt Bar is.
     var onClick: (() -> Void)?
 
     /// - Parameter makeStatusItem: Injectable for testing; defaults to a real menu bar item.

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarMenuBarController.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarMenuBarController.swift
@@ -36,6 +36,10 @@ final class PromptBarMenuBarController: NSObject {
     private let makeStatusItem: @MainActor () -> PromptBarStatusItem
     private var statusItem: PromptBarStatusItem?
 
+    /// Called when the icon is clicked. Set by the owner so this controller stays unaware of what
+    /// the Prompt Bar is.
+    var onClick: (() -> Void)?
+
     /// - Parameter makeStatusItem: Injectable for testing; defaults to a real menu bar item.
     init(makeStatusItem: @escaping @MainActor () -> PromptBarStatusItem = { NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength) }) {
         self.makeStatusItem = makeStatusItem
@@ -54,8 +58,7 @@ final class PromptBarMenuBarController: NSObject {
 
     @objc
     private func statusBarButtonTapped() {
-        // No-op for now: this milestone only places the icon. Opening the floating
-        // Prompt Bar window is wired here in a later milestone.
+        onClick?()
     }
 
     /// The item is created on first show: `NSStatusBar` puts it on screen as soon

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarMenuBarController.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarMenuBarController.swift
@@ -36,7 +36,6 @@ final class PromptBarMenuBarController: NSObject {
     private let makeStatusItem: @MainActor () -> PromptBarStatusItem
     private var statusItem: PromptBarStatusItem?
 
-    /// Set by the owner, so this controller stays unaware of what the Prompt Bar is.
     var onClick: (() -> Void)?
 
     /// - Parameter makeStatusItem: Injectable for testing; defaults to a real menu bar item.

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarPlacement.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarPlacement.swift
@@ -19,10 +19,10 @@
 import AppKit
 
 /// Where the Prompt Bar sits on screen: horizontally centered, near the top, Spotlight-style.
-/// Pure geometry so the placement rules can be tested without a window or a real display.
+/// Pure geometry, so it tests without a window or a real display.
 enum PromptBarPlacement {
 
-    /// Preferred width. Narrower screens fall back to the widest width the margins allow.
+    /// Narrower screens fall back to the widest width the margins allow.
     static let preferredWidth: CGFloat = 680
 
     static let horizontalScreenMargin: CGFloat = 24
@@ -30,17 +30,14 @@ enum PromptBarPlacement {
     /// Gap between the screen's top edge and the bar's top edge, as a fraction of screen height.
     static let topOffsetRatio: CGFloat = 0.22
 
-    /// - Parameters:
-    ///   - contentHeight: Height the content currently needs; grows with text and attachments.
-    ///   - visibleFrame: `NSScreen.visibleFrame` of the target screen, so menu bar and Dock are excluded.
+    /// - Parameter visibleFrame: The target screen's `visibleFrame`, so menu bar and Dock are excluded.
     static func frame(forContentHeight contentHeight: CGFloat, in visibleFrame: NSRect) -> NSRect {
         let width = min(preferredWidth, max(0, visibleFrame.width - horizontalScreenMargin * 2))
-        // Never taller than the screen allows, so a long prompt can't push the bar off-screen.
         let height = min(contentHeight, visibleFrame.height)
 
         let originX = visibleFrame.minX + ((visibleFrame.width - width) / 2).rounded()
         let preferredTop = visibleFrame.maxY - (visibleFrame.height * topOffsetRatio).rounded()
-        // Clamp so growth downwards stays inside the visible frame.
+        // Clamp so downwards growth stays on screen.
         let top = min(visibleFrame.maxY, max(preferredTop, visibleFrame.minY + height))
 
         return NSRect(x: originX, y: top - height, width: width, height: height)
@@ -53,7 +50,7 @@ protocol PromptBarScreenProviding {
     var targetVisibleFrame: NSRect { get }
 }
 
-/// Opens on the screen holding the pointer, which is where the user's attention is.
+/// Opens on the screen holding the pointer.
 @MainActor
 struct MouseLocationScreenProvider: PromptBarScreenProviding {
 

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarPlacement.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarPlacement.swift
@@ -1,0 +1,65 @@
+//
+//  PromptBarPlacement.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+
+/// Where the Prompt Bar sits on screen: horizontally centered, near the top, Spotlight-style.
+/// Pure geometry so the placement rules can be tested without a window or a real display.
+enum PromptBarPlacement {
+
+    /// Preferred width. Narrower screens fall back to the widest width the margins allow.
+    static let preferredWidth: CGFloat = 680
+
+    static let horizontalScreenMargin: CGFloat = 24
+
+    /// Gap between the screen's top edge and the bar's top edge, as a fraction of screen height.
+    static let topOffsetRatio: CGFloat = 0.22
+
+    /// - Parameters:
+    ///   - contentHeight: Height the content currently needs; grows with text and attachments.
+    ///   - visibleFrame: `NSScreen.visibleFrame` of the target screen, so menu bar and Dock are excluded.
+    static func frame(forContentHeight contentHeight: CGFloat, in visibleFrame: NSRect) -> NSRect {
+        let width = min(preferredWidth, max(0, visibleFrame.width - horizontalScreenMargin * 2))
+        // Never taller than the screen allows, so a long prompt can't push the bar off-screen.
+        let height = min(contentHeight, visibleFrame.height)
+
+        let originX = visibleFrame.minX + ((visibleFrame.width - width) / 2).rounded()
+        let preferredTop = visibleFrame.maxY - (visibleFrame.height * topOffsetRatio).rounded()
+        // Clamp so growth downwards stays inside the visible frame.
+        let top = min(visibleFrame.maxY, max(preferredTop, visibleFrame.minY + height))
+
+        return NSRect(x: originX, y: top - height, width: width, height: height)
+    }
+}
+
+/// The screen the Prompt Bar should open on.
+@MainActor
+protocol PromptBarScreenProviding {
+    var targetVisibleFrame: NSRect { get }
+}
+
+/// Opens on the screen holding the pointer, which is where the user's attention is.
+@MainActor
+struct MouseLocationScreenProvider: PromptBarScreenProviding {
+
+    var targetVisibleFrame: NSRect {
+        let mouseLocation = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { $0.frame.contains(mouseLocation) } ?? NSScreen.main
+        return screen?.visibleFrame ?? .zero
+    }
+}

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarPlacement.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarPlacement.swift
@@ -18,39 +18,32 @@
 
 import AppKit
 
-/// Where the Prompt Bar sits on screen: horizontally centered, near the top, Spotlight-style.
-/// Pure geometry, so it tests without a window or a real display.
+/// Spotlight-style placement. Pure geometry, so it tests without a window or a real display.
 enum PromptBarPlacement {
 
-    /// Narrower screens fall back to the widest width the margins allow.
     static let preferredWidth: CGFloat = 680
 
     static let horizontalScreenMargin: CGFloat = 24
 
-    /// Gap between the screen's top edge and the bar's top edge, as a fraction of screen height.
     static let topOffsetRatio: CGFloat = 0.22
 
-    /// - Parameter visibleFrame: The target screen's `visibleFrame`, so menu bar and Dock are excluded.
     static func frame(forContentHeight contentHeight: CGFloat, in visibleFrame: NSRect) -> NSRect {
         let width = min(preferredWidth, max(0, visibleFrame.width - horizontalScreenMargin * 2))
         let height = min(contentHeight, visibleFrame.height)
 
         let originX = visibleFrame.minX + ((visibleFrame.width - width) / 2).rounded()
         let preferredTop = visibleFrame.maxY - (visibleFrame.height * topOffsetRatio).rounded()
-        // Clamp so downwards growth stays on screen.
         let top = min(visibleFrame.maxY, max(preferredTop, visibleFrame.minY + height))
 
         return NSRect(x: originX, y: top - height, width: width, height: height)
     }
 }
 
-/// The screen the Prompt Bar should open on.
 @MainActor
 protocol PromptBarScreenProviding {
     var targetVisibleFrame: NSRect { get }
 }
 
-/// Opens on the screen holding the pointer.
 @MainActor
 struct MouseLocationScreenProvider: PromptBarScreenProviding {
 

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarViewController.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarViewController.swift
@@ -109,8 +109,10 @@ final class PromptBarViewController: NSViewController {
         // Read the screen before dismissal tears the window down.
         let screen = view.window?.screen
         promptField.stringValue = ""
-        promptSubmitter.submit(prompt: prompt, preferringWindowOn: screen)
+        // Dismiss before submitting: the bar is a floating panel and holds key, so raising a browser
+        // window underneath it while it is still up leaves the window behind whatever was in front.
         onSubmit?()
+        promptSubmitter.submit(prompt: prompt, preferringWindowOn: screen)
     }
 }
 

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarViewController.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarViewController.swift
@@ -1,0 +1,163 @@
+//
+//  PromptBarViewController.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import DesignResourcesKit
+import DesignResourcesKitIcons
+
+/// Prompt Bar content: a single prompt field that hands what the user types to Duck.ai.
+///
+/// Intentionally minimal. The Duck.ai controls from the address bar panel (attach, tools, model and
+/// reasoning pickers, voice) replace this field's surroundings once they are extracted into a
+/// component both surfaces can share.
+@MainActor
+final class PromptBarViewController: NSViewController {
+
+    private enum Constants {
+        static let contentHeight: CGFloat = 56
+        static let cornerRadius: CGFloat = 12
+        static let horizontalInset: CGFloat = 16
+        static let iconSize: CGFloat = 16
+        static let iconTrailingSpacing: CGFloat = 12
+        static let promptFontSize: CGFloat = 16
+    }
+
+    private let aiChatTabOpener: AIChatTabOpening
+
+    private lazy var panelView = ColorView(frame: .zero,
+                                           backgroundColor: NSColor(designSystemColor: .surfacePrimary),
+                                           cornerRadius: Constants.cornerRadius,
+                                           borderColor: NSColor(designSystemColor: .lines),
+                                           borderWidth: 1)
+
+    private let iconView = NSImageView()
+    private let promptField = NSTextField()
+
+    var onPreferredWindowContentSizeChanged: ((NSSize) -> Void)?
+    var onSubmit: (() -> Void)?
+
+    init(aiChatTabOpener: AIChatTabOpening) {
+        self.aiChatTabOpener = aiChatTabOpener
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("PromptBarViewController: Bad initializer")
+    }
+
+    override func loadView() {
+        view = NSView(frame: NSRect(x: 0, y: 0, width: PromptBarPlacement.preferredWidth, height: Constants.contentHeight))
+        setUpUI()
+    }
+
+    private func setUpUI() {
+        panelView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(panelView)
+
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.image = DesignSystemImages.Glyphs.Size16.duckAi
+        iconView.image?.isTemplate = true
+        iconView.contentTintColor = NSColor(designSystemColor: .iconsPrimary)
+        panelView.addSubview(iconView)
+
+        promptField.translatesAutoresizingMaskIntoConstraints = false
+        promptField.isBordered = false
+        promptField.drawsBackground = false
+        promptField.focusRingType = .none
+        promptField.font = .systemFont(ofSize: Constants.promptFontSize)
+        promptField.textColor = NSColor(designSystemColor: .textPrimary)
+        promptField.placeholderString = UserText.aiChatOmnibarPlaceholder
+        promptField.cell?.usesSingleLineMode = true
+        promptField.lineBreakMode = .byTruncatingTail
+        promptField.delegate = self
+        promptField.setAccessibilityIdentifier("PromptBar.promptField")
+        panelView.addSubview(promptField)
+
+        NSLayoutConstraint.activate([
+            panelView.topAnchor.constraint(equalTo: view.topAnchor),
+            panelView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            panelView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            panelView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            iconView.leadingAnchor.constraint(equalTo: panelView.leadingAnchor, constant: Constants.horizontalInset),
+            iconView.centerYAnchor.constraint(equalTo: panelView.centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: Constants.iconSize),
+            iconView.heightAnchor.constraint(equalToConstant: Constants.iconSize),
+
+            promptField.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: Constants.iconTrailingSpacing),
+            promptField.trailingAnchor.constraint(equalTo: panelView.trailingAnchor, constant: -Constants.horizontalInset),
+            promptField.centerYAnchor.constraint(equalTo: panelView.centerYAnchor)
+        ])
+    }
+
+    /// Opens the prompt in a new selected Duck.ai tab, matching the address bar's hand-off. Blank
+    /// input is ignored so Enter on an empty bar does nothing rather than opening an empty chat.
+    private func submitPrompt() {
+        let prompt = promptField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else { return }
+
+        promptField.stringValue = ""
+        aiChatTabOpener.openAIChatTab(with: .query(prompt, shouldAutoSubmit: true), behavior: .newTab(selected: true))
+        onSubmit?()
+    }
+}
+
+// MARK: - PromptBarContentHosting
+
+extension PromptBarViewController: PromptBarContentHosting {
+
+    var viewController: NSViewController { self }
+
+    /// No menus or pickers in the MVP, so nothing ever suppresses dismissal.
+    var isPresentingAuxiliaryUI: Bool { false }
+
+    var preferredWindowContentSize: NSSize {
+        NSSize(width: PromptBarPlacement.preferredWidth, height: Constants.contentHeight)
+    }
+
+    func prepareForPresentation() {
+        promptField.stringValue = ""
+    }
+
+    func focusPromptEditor() {
+        view.window?.makeFirstResponder(promptField)
+    }
+
+    func resetAfterDismissal() {
+        promptField.stringValue = ""
+    }
+}
+
+// MARK: - NSTextFieldDelegate
+
+extension PromptBarViewController: NSTextFieldDelegate {
+
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        switch commandSelector {
+        case #selector(NSResponder.insertNewline(_:)):
+            submitPrompt()
+            return true
+        case #selector(NSResponder.cancelOperation(_:)):
+            // The field editor would otherwise swallow Escape to revert its own editing.
+            view.window?.cancelOperation(nil)
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarViewController.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarViewController.swift
@@ -20,7 +20,6 @@ import AppKit
 import DesignResourcesKit
 import DesignResourcesKitIcons
 
-/// Prompt Bar content: a single prompt field that hands what the user types to Duck.ai.
 /// Minimal until the address bar's Duck.ai controls are extracted into a shared component.
 @MainActor
 final class PromptBarViewController: NSViewController {
@@ -109,8 +108,7 @@ final class PromptBarViewController: NSViewController {
         // Read the screen before dismissal tears the window down.
         let screen = view.window?.screen
         promptField.stringValue = ""
-        // Dismiss before submitting: the bar is a floating panel and holds key, so raising a browser
-        // window underneath it while it is still up leaves the window behind whatever was in front.
+        // Dismiss first: raising a browser window under the still-key floating panel leaves it behind.
         onSubmit?()
         promptSubmitter.submit(prompt: prompt, preferringWindowOn: screen)
     }
@@ -122,7 +120,6 @@ extension PromptBarViewController: PromptBarContentHosting {
 
     var viewController: NSViewController { self }
 
-    /// No menus or pickers yet, so nothing suppresses dismissal.
     var isPresentingAuxiliaryUI: Bool { false }
 
     var preferredWindowContentSize: NSSize {

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarViewController.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarViewController.swift
@@ -37,7 +37,7 @@ final class PromptBarViewController: NSViewController {
         static let promptFontSize: CGFloat = 16
     }
 
-    private let aiChatTabOpener: AIChatTabOpening
+    private let promptSubmitter: PromptBarPromptSubmitting
 
     private lazy var panelView = ColorView(frame: .zero,
                                            backgroundColor: NSColor(designSystemColor: .surfacePrimary),
@@ -51,8 +51,8 @@ final class PromptBarViewController: NSViewController {
     var onPreferredWindowContentSizeChanged: ((NSSize) -> Void)?
     var onSubmit: (() -> Void)?
 
-    init(aiChatTabOpener: AIChatTabOpening) {
-        self.aiChatTabOpener = aiChatTabOpener
+    init(promptSubmitter: PromptBarPromptSubmitting) {
+        self.promptSubmitter = promptSubmitter
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -105,14 +105,16 @@ final class PromptBarViewController: NSViewController {
         ])
     }
 
-    /// Opens the prompt in a new selected Duck.ai tab, matching the address bar's hand-off. Blank
-    /// input is ignored so Enter on an empty bar does nothing rather than opening an empty chat.
+    /// Hands the prompt to Duck.ai. Blank input is ignored so Enter on an empty bar does nothing
+    /// rather than opening an empty chat. The window's screen decides where the chat lands.
     private func submitPrompt() {
         let prompt = promptField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !prompt.isEmpty else { return }
 
+        // Read the screen before dismissal tears the window down.
+        let screen = view.window?.screen
         promptField.stringValue = ""
-        aiChatTabOpener.openAIChatTab(with: .query(prompt, shouldAutoSubmit: true), behavior: .newTab(selected: true))
+        promptSubmitter.submit(prompt: prompt, preferringWindowOn: screen)
         onSubmit?()
     }
 }

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarViewController.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarViewController.swift
@@ -21,10 +21,7 @@ import DesignResourcesKit
 import DesignResourcesKitIcons
 
 /// Prompt Bar content: a single prompt field that hands what the user types to Duck.ai.
-///
-/// Intentionally minimal. The Duck.ai controls from the address bar panel (attach, tools, model and
-/// reasoning pickers, voice) replace this field's surroundings once they are extracted into a
-/// component both surfaces can share.
+/// Minimal until the address bar's Duck.ai controls are extracted into a shared component.
 @MainActor
 final class PromptBarViewController: NSViewController {
 
@@ -105,8 +102,6 @@ final class PromptBarViewController: NSViewController {
         ])
     }
 
-    /// Hands the prompt to Duck.ai. Blank input is ignored so Enter on an empty bar does nothing
-    /// rather than opening an empty chat. The window's screen decides where the chat lands.
     private func submitPrompt() {
         let prompt = promptField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !prompt.isEmpty else { return }
@@ -125,7 +120,7 @@ extension PromptBarViewController: PromptBarContentHosting {
 
     var viewController: NSViewController { self }
 
-    /// No menus or pickers in the MVP, so nothing ever suppresses dismissal.
+    /// No menus or pickers yet, so nothing suppresses dismissal.
     var isPresentingAuxiliaryUI: Bool { false }
 
     var preferredWindowContentSize: NSSize {
@@ -155,7 +150,7 @@ extension PromptBarViewController: NSTextFieldDelegate {
             submitPrompt()
             return true
         case #selector(NSResponder.cancelOperation(_:)):
-            // The field editor would otherwise swallow Escape to revert its own editing.
+            // The field editor would otherwise swallow Escape to revert its editing.
             view.window?.cancelOperation(nil)
             return true
         default:

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarWindow.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarWindow.swift
@@ -1,0 +1,65 @@
+//
+//  PromptBarWindow.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+
+/// The floating, borderless window hosting the Prompt Bar.
+///
+/// An `NSPanel` rather than an `NSWindow` so it never becomes the app's main window and stays out
+/// of the Window menu; the rounded chrome is drawn by the content view controller.
+final class PromptBarWindow: NSPanel {
+
+    /// Called on Escape. The presenter owns what dismissal means.
+    var onCancel: (() -> Void)?
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+
+    init(contentRect: NSRect) {
+        super.init(contentRect: contentRect,
+                   styleMask: [.borderless, .nonactivatingPanel],
+                   backing: .buffered,
+                   defer: true)
+        setUpWindow()
+    }
+
+    private func setUpWindow() {
+        isReleasedWhenClosed = false
+        isFloatingPanel = true
+        level = .floating
+        animationBehavior = .utilityWindow
+
+        // The content view controller draws the panel, so the window itself is fully transparent.
+        backgroundColor = .clear
+        isOpaque = false
+        hasShadow = true
+
+        isExcludedFromWindowsMenu = true
+        isMovableByWindowBackground = false
+
+        // Available over fullscreen apps and on whichever Space the user is on when the shortcut fires.
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+
+        // Dismissal is driven by the presenter so a tool menu or file picker can suppress it.
+        hidesOnDeactivate = false
+    }
+
+    override func cancelOperation(_ sender: Any?) {
+        onCancel?()
+    }
+}

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarWindow.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarWindow.swift
@@ -18,12 +18,9 @@
 
 import AppKit
 
-/// The floating, borderless window hosting the Prompt Bar.
-///
 /// An `NSPanel` so it never becomes the app's main window and stays out of the Window menu.
 final class PromptBarWindow: NSPanel {
 
-    /// Called on Escape; the presenter decides what dismissal means.
     var onCancel: (() -> Void)?
 
     override var canBecomeKey: Bool { true }
@@ -43,7 +40,6 @@ final class PromptBarWindow: NSPanel {
         level = .floating
         animationBehavior = .utilityWindow
 
-        // The content view controller draws the panel.
         backgroundColor = .clear
         isOpaque = false
         hasShadow = true
@@ -51,7 +47,6 @@ final class PromptBarWindow: NSPanel {
         isExcludedFromWindowsMenu = true
         isMovableByWindowBackground = false
 
-        // Reachable over fullscreen apps and on whichever Space the shortcut fires from.
         collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
 
         // The presenter owns dismissal, so that it can suppress it.

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarWindow.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarWindow.swift
@@ -20,11 +20,10 @@ import AppKit
 
 /// The floating, borderless window hosting the Prompt Bar.
 ///
-/// An `NSPanel` rather than an `NSWindow` so it never becomes the app's main window and stays out
-/// of the Window menu; the rounded chrome is drawn by the content view controller.
+/// An `NSPanel` so it never becomes the app's main window and stays out of the Window menu.
 final class PromptBarWindow: NSPanel {
 
-    /// Called on Escape. The presenter owns what dismissal means.
+    /// Called on Escape; the presenter decides what dismissal means.
     var onCancel: (() -> Void)?
 
     override var canBecomeKey: Bool { true }
@@ -44,7 +43,7 @@ final class PromptBarWindow: NSPanel {
         level = .floating
         animationBehavior = .utilityWindow
 
-        // The content view controller draws the panel, so the window itself is fully transparent.
+        // The content view controller draws the panel.
         backgroundColor = .clear
         isOpaque = false
         hasShadow = true
@@ -52,10 +51,10 @@ final class PromptBarWindow: NSPanel {
         isExcludedFromWindowsMenu = true
         isMovableByWindowBackground = false
 
-        // Available over fullscreen apps and on whichever Space the user is on when the shortcut fires.
+        // Reachable over fullscreen apps and on whichever Space the shortcut fires from.
         collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
 
-        // Dismissal is driven by the presenter so a tool menu or file picker can suppress it.
+        // The presenter owns dismissal, so that it can suppress it.
         hidesOnDeactivate = false
     }
 

--- a/macOS/DuckDuckGo/Windows/Model/WindowControllersManagerMock.swift
+++ b/macOS/DuckDuckGo/Windows/Model/WindowControllersManagerMock.swift
@@ -123,6 +123,28 @@ final class WindowControllersManagerMock: WindowControllersManagerProtocol, AICh
         openAIChatCalls.append(OpenAIChatCall(url: url, behavior: behavior, hasPrompt: hasPrompt))
     }
 
+    struct OpenAIChatInNewTabOfCall {
+        let url: URL
+        let windowController: MainWindowController
+        let hasPrompt: Bool
+    }
+    var openAIChatInNewTabOfCalls: [OpenAIChatInNewTabOfCall] = []
+
+    func openAIChat(_ url: URL, inNewTabOf windowController: MainWindowController, hasPrompt: Bool) {
+        openAIChatInNewTabOfCalls.append(OpenAIChatInNewTabOfCall(url: url, windowController: windowController, hasPrompt: hasPrompt))
+    }
+
+    struct OpenAIChatInNewWindowCall {
+        let url: URL
+        let droppingPoint: NSPoint
+        let hasPrompt: Bool
+    }
+    var openAIChatInNewWindowCalls: [OpenAIChatInNewWindowCall] = []
+
+    func openAIChat(_ url: URL, inNewWindowAt droppingPoint: NSPoint, hasPrompt: Bool) {
+        openAIChatInNewWindowCalls.append(OpenAIChatInNewWindowCall(url: url, droppingPoint: droppingPoint, hasPrompt: hasPrompt))
+    }
+
     struct InsertAIChatTabCall: Equatable {
         let url: URL
         let payload: AIChatPayload?

--- a/macOS/UnitTests/AIChat/AIChatCoordinatorTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatCoordinatorTests.swift
@@ -1107,6 +1107,25 @@ class MockAIChatTabOpener: AIChatTabOpening {
         openMethodCalledExpectation = expectation
     }
 
+    var lastTargetedQuery: String?
+    var lastTargetWindowController: MainWindowController?
+
+    @MainActor
+    func openAIChatTab(withQuery query: String, inNewTabOf windowController: MainWindowController) {
+        openAIChatTabCalled = true
+        lastTargetedQuery = query
+        lastTargetWindowController = windowController
+    }
+
+    var lastNewWindowDroppingPoint: NSPoint?
+
+    @MainActor
+    func openAIChatTab(withQuery query: String, inNewWindowAt droppingPoint: NSPoint) {
+        openAIChatTabCalled = true
+        lastTargetedQuery = query
+        lastNewWindowDroppingPoint = droppingPoint
+    }
+
     @MainActor
     func openAIChatTab(with trigger: AIChatOpenTrigger, behavior: LinkOpenBehavior) {
         openAIChatTabCalled = true

--- a/macOS/UnitTests/PromptBar/PromptBarCoordinatorTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarCoordinatorTests.swift
@@ -22,10 +22,22 @@ import PrivacyConfig
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 
+/// Both flags start off, mirroring the opt-in product default.
 private final class MockPromptBarPreferencesPersistor: PromptBarPreferencesPersistor {
-    var isKeyboardShortcutEnabled: Bool = true
+    var isKeyboardShortcutEnabled: Bool = false
     var keyboardShortcut: PromptBarShortcut = .defaultShortcut
-    var isMenuBarIconVisible: Bool = true
+    var isMenuBarIconVisible: Bool = false
+}
+
+private extension MockPromptBarPreferencesPersistor {
+    /// Opted in, so a test asserting nothing is registered isolates the gate it exercises
+    /// instead of passing on the off-by-default preference.
+    static var optedIn: MockPromptBarPreferencesPersistor {
+        let persistor = MockPromptBarPreferencesPersistor()
+        persistor.isKeyboardShortcutEnabled = true
+        persistor.isMenuBarIconVisible = true
+        return persistor
+    }
 }
 
 private final class MockGlobalShortcutRegistrar: GlobalShortcutRegistering {
@@ -90,7 +102,16 @@ final class PromptBarCoordinatorTests: XCTestCase {
     }
 
     func testWhenFeatureFlagIsOffThenNoShortcutIsRegistered() {
-        let (coordinator, _, registrar, _) = makeCoordinator(isFeatureOn: false)
+        let (coordinator, _, registrar, _) = makeCoordinator(isFeatureOn: false, persistor: .optedIn)
+
+        coordinator.start()
+
+        XCTAssertEqual(registrar.registerCallCount, 0)
+        XCTAssertNil(registrar.registeredShortcut)
+    }
+
+    func testWhenPreferencesAreAtTheirDefaultsThenNoShortcutIsRegistered() {
+        let (coordinator, _, registrar, _) = makeCoordinator()
 
         coordinator.start()
 
@@ -99,7 +120,7 @@ final class PromptBarCoordinatorTests: XCTestCase {
     }
 
     func testWhenStartedThenStoredShortcutIsRegistered() {
-        let persistor = MockPromptBarPreferencesPersistor()
+        let persistor = MockPromptBarPreferencesPersistor.optedIn
         persistor.keyboardShortcut = PromptBarShortcut(keyCode: UInt16(kVK_ANSI_D), modifierFlags: [.control, .option])
         let (coordinator, _, registrar, _) = makeCoordinator(persistor: persistor)
 
@@ -109,7 +130,7 @@ final class PromptBarCoordinatorTests: XCTestCase {
     }
 
     func testWhenShortcutSettingIsOffThenNothingIsRegistered() {
-        let persistor = MockPromptBarPreferencesPersistor()
+        let persistor = MockPromptBarPreferencesPersistor.optedIn
         persistor.isKeyboardShortcutEnabled = false
         let (coordinator, _, registrar, _) = makeCoordinator(persistor: persistor)
 
@@ -120,7 +141,7 @@ final class PromptBarCoordinatorTests: XCTestCase {
     }
 
     func testWhenDuckAIIsUnavailableThenNothingIsRegistered() {
-        let (coordinator, _, registrar, _) = makeCoordinator(isDuckAIAvailable: false)
+        let (coordinator, _, registrar, _) = makeCoordinator(persistor: .optedIn, isDuckAIAvailable: false)
 
         coordinator.start()
 
@@ -128,7 +149,7 @@ final class PromptBarCoordinatorTests: XCTestCase {
     }
 
     func testWhenShortcutChangesThenItIsReRegistered() {
-        let (coordinator, preferences, registrar, _) = makeCoordinator()
+        let (coordinator, preferences, registrar, _) = makeCoordinator(persistor: .optedIn)
         coordinator.start()
 
         let updated = PromptBarShortcut(keyCode: UInt16(kVK_ANSI_K), modifierFlags: [.command, .shift])
@@ -138,8 +159,18 @@ final class PromptBarCoordinatorTests: XCTestCase {
         XCTAssertEqual(registrar.registerCallCount, 2)
     }
 
-    func testWhenShortcutIsDisabledAfterStartThenItIsUnregistered() {
+    func testWhenShortcutIsEnabledAfterStartThenItIsRegistered() {
         let (coordinator, preferences, registrar, _) = makeCoordinator()
+        coordinator.start()
+
+        preferences.isKeyboardShortcutEnabled = true
+
+        XCTAssertEqual(registrar.registeredShortcut, preferences.keyboardShortcut)
+        XCTAssertEqual(registrar.registerCallCount, 1)
+    }
+
+    func testWhenShortcutIsDisabledAfterStartThenItIsUnregistered() {
+        let (coordinator, preferences, registrar, _) = makeCoordinator(persistor: .optedIn)
         coordinator.start()
 
         preferences.isKeyboardShortcutEnabled = false

--- a/macOS/UnitTests/PromptBar/PromptBarCoordinatorTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarCoordinatorTests.swift
@@ -1,0 +1,169 @@
+//
+//  PromptBarCoordinatorTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Carbon.HIToolbox
+import FeatureFlags
+import PrivacyConfig
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+private final class MockPromptBarPreferencesPersistor: PromptBarPreferencesPersistor {
+    var isKeyboardShortcutEnabled: Bool = true
+    var keyboardShortcut: PromptBarShortcut = .defaultShortcut
+    var isMenuBarIconVisible: Bool = true
+}
+
+private final class MockGlobalShortcutRegistrar: GlobalShortcutRegistering {
+    private(set) var registeredShortcut: PromptBarShortcut?
+    private(set) var registerCallCount = 0
+    private(set) var unregisterCallCount = 0
+    private var handler: (() -> Void)?
+
+    func register(_ shortcut: PromptBarShortcut, handler: @escaping () -> Void) -> Bool {
+        registerCallCount += 1
+        registeredShortcut = shortcut
+        self.handler = handler
+        return true
+    }
+
+    func unregister() {
+        unregisterCallCount += 1
+        registeredShortcut = nil
+        handler = nil
+    }
+
+    /// Stands in for the OS delivering the hot key.
+    func simulateShortcutPressed() {
+        handler?()
+    }
+}
+
+@MainActor
+private final class MockPromptBarPresenter: PromptBarPresenting {
+    var isVisible = false
+    private(set) var toggleCallCount = 0
+
+    func show() { isVisible = true }
+    func dismiss() { isVisible = false }
+    func toggle() {
+        toggleCallCount += 1
+        isVisible.toggle()
+    }
+}
+
+@MainActor
+final class PromptBarCoordinatorTests: XCTestCase {
+
+    /// The doubles are built here rather than passed as defaults: default parameter values are
+    /// evaluated in a nonisolated context, and `MockPromptBarPresenter` is main-actor isolated.
+    private func makeCoordinator(
+        isFeatureOn: Bool = true,
+        persistor: MockPromptBarPreferencesPersistor = MockPromptBarPreferencesPersistor(),
+        isDuckAIAvailable: Bool = true
+    ) -> (PromptBarCoordinator, PromptBarPreferences, MockGlobalShortcutRegistrar, MockPromptBarPresenter) {
+        let registrar = MockGlobalShortcutRegistrar()
+        let presenter = MockPromptBarPresenter()
+        let featureFlagger = MockFeatureFlagger(featuresStub: [FeatureFlag.macosPromptBar.rawValue: isFeatureOn])
+
+        let configuration = MockAIChatConfig()
+        configuration.shouldDisplayAnyAIChatFeature = isDuckAIAvailable
+
+        let preferences = PromptBarPreferences(persistor: persistor, aiChatMenuConfiguration: configuration)
+        let coordinator = PromptBarCoordinator(featureFlagger: featureFlagger,
+                                               preferences: preferences,
+                                               shortcutRegistrar: registrar,
+                                               presenter: presenter)
+        return (coordinator, preferences, registrar, presenter)
+    }
+
+    func testWhenFeatureFlagIsOffThenNoShortcutIsRegistered() {
+        let (coordinator, _, registrar, _) = makeCoordinator(isFeatureOn: false)
+
+        coordinator.start()
+
+        XCTAssertEqual(registrar.registerCallCount, 0)
+        XCTAssertNil(registrar.registeredShortcut)
+    }
+
+    func testWhenStartedThenStoredShortcutIsRegistered() {
+        let persistor = MockPromptBarPreferencesPersistor()
+        persistor.keyboardShortcut = PromptBarShortcut(keyCode: UInt16(kVK_ANSI_D), modifierFlags: [.control, .option])
+        let (coordinator, _, registrar, _) = makeCoordinator(persistor: persistor)
+
+        coordinator.start()
+
+        XCTAssertEqual(registrar.registeredShortcut, persistor.keyboardShortcut)
+    }
+
+    func testWhenShortcutSettingIsOffThenNothingIsRegistered() {
+        let persistor = MockPromptBarPreferencesPersistor()
+        persistor.isKeyboardShortcutEnabled = false
+        let (coordinator, _, registrar, _) = makeCoordinator(persistor: persistor)
+
+        coordinator.start()
+
+        XCTAssertNil(registrar.registeredShortcut)
+        XCTAssertEqual(registrar.unregisterCallCount, 1)
+    }
+
+    func testWhenDuckAIIsUnavailableThenNothingIsRegistered() {
+        let (coordinator, _, registrar, _) = makeCoordinator(isDuckAIAvailable: false)
+
+        coordinator.start()
+
+        XCTAssertNil(registrar.registeredShortcut)
+    }
+
+    func testWhenShortcutChangesThenItIsReRegistered() {
+        let (coordinator, preferences, registrar, _) = makeCoordinator()
+        coordinator.start()
+
+        let updated = PromptBarShortcut(keyCode: UInt16(kVK_ANSI_K), modifierFlags: [.command, .shift])
+        preferences.keyboardShortcut = updated
+
+        XCTAssertEqual(registrar.registeredShortcut, updated)
+        XCTAssertEqual(registrar.registerCallCount, 2)
+    }
+
+    func testWhenShortcutIsDisabledAfterStartThenItIsUnregistered() {
+        let (coordinator, preferences, registrar, _) = makeCoordinator()
+        coordinator.start()
+
+        preferences.isKeyboardShortcutEnabled = false
+
+        XCTAssertNil(registrar.registeredShortcut)
+        XCTAssertGreaterThanOrEqual(registrar.unregisterCallCount, 1)
+    }
+
+    func testWhenTogglingThenPresenterIsToggled() {
+        let (coordinator, _, _, presenter) = makeCoordinator()
+
+        coordinator.togglePromptBar()
+
+        XCTAssertEqual(presenter.toggleCallCount, 1)
+        XCTAssertTrue(presenter.isVisible)
+    }
+
+    func testWhenFeatureFlagIsOffThenTogglingDoesNothing() {
+        let (coordinator, _, _, presenter) = makeCoordinator(isFeatureOn: false)
+
+        coordinator.togglePromptBar()
+
+        XCTAssertEqual(presenter.toggleCallCount, 0)
+    }
+}

--- a/macOS/UnitTests/PromptBar/PromptBarCoordinatorTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarCoordinatorTests.swift
@@ -47,7 +47,6 @@ private final class MockGlobalShortcutRegistrar: GlobalShortcutRegistering {
         handler = nil
     }
 
-    /// Stands in for the OS delivering the hot key.
     func simulateShortcutPressed() {
         handler?()
     }
@@ -69,8 +68,7 @@ private final class MockPromptBarPresenter: PromptBarPresenting {
 @MainActor
 final class PromptBarCoordinatorTests: XCTestCase {
 
-    /// The doubles are built here rather than passed as defaults: default parameter values are
-    /// evaluated in a nonisolated context, and `MockPromptBarPresenter` is main-actor isolated.
+    // Doubles are built here, not passed as defaults: defaults are evaluated nonisolated.
     private func makeCoordinator(
         isFeatureOn: Bool = true,
         persistor: MockPromptBarPreferencesPersistor = MockPromptBarPreferencesPersistor(),

--- a/macOS/UnitTests/PromptBar/PromptBarPlacementTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarPlacementTests.swift
@@ -1,0 +1,72 @@
+//
+//  PromptBarPlacementTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+final class PromptBarPlacementTests: XCTestCase {
+
+    private let screen = NSRect(x: 0, y: 0, width: 1440, height: 900)
+
+    func testWhenScreenIsWideThenPreferredWidthIsUsedAndBarIsCentered() {
+        let frame = PromptBarPlacement.frame(forContentHeight: 56, in: screen)
+
+        XCTAssertEqual(frame.width, PromptBarPlacement.preferredWidth)
+        XCTAssertEqual(frame.midX, screen.midX)
+    }
+
+    func testWhenScreenIsNarrowerThanPreferredWidthThenMarginsAreHonored() {
+        let narrow = NSRect(x: 0, y: 0, width: 400, height: 800)
+
+        let frame = PromptBarPlacement.frame(forContentHeight: 56, in: narrow)
+
+        XCTAssertEqual(frame.width, narrow.width - PromptBarPlacement.horizontalScreenMargin * 2)
+        XCTAssertEqual(frame.midX, narrow.midX)
+    }
+
+    func testWhenPlacedThenTopEdgeSitsAtTheTopOffsetRatio() {
+        let frame = PromptBarPlacement.frame(forContentHeight: 56, in: screen)
+
+        let expectedTop = screen.maxY - (screen.height * PromptBarPlacement.topOffsetRatio).rounded()
+        XCTAssertEqual(frame.maxY, expectedTop)
+    }
+
+    func testWhenScreenIsOffsetThenFrameIsPlacedWithinThatScreen() {
+        let secondScreen = NSRect(x: 1440, y: 200, width: 1200, height: 800)
+
+        let frame = PromptBarPlacement.frame(forContentHeight: 56, in: secondScreen)
+
+        XCTAssertTrue(secondScreen.contains(frame), "Bar should stay inside the target screen")
+    }
+
+    func testWhenContentIsTallerThanScreenThenHeightIsClampedAndStaysOnScreen() {
+        let frame = PromptBarPlacement.frame(forContentHeight: 5000, in: screen)
+
+        XCTAssertEqual(frame.height, screen.height)
+        XCTAssertGreaterThanOrEqual(frame.minY, screen.minY)
+        XCTAssertLessThanOrEqual(frame.maxY, screen.maxY)
+    }
+
+    func testWhenContentIsTallEnoughToOverflowBelowThenFrameIsPushedUp() {
+        // Tall enough that the default top offset would put the bottom edge below the screen.
+        let frame = PromptBarPlacement.frame(forContentHeight: 800, in: screen)
+
+        XCTAssertGreaterThanOrEqual(frame.minY, screen.minY)
+    }
+}

--- a/macOS/UnitTests/PromptBar/PromptBarPreferencesPersistorTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarPreferencesPersistorTests.swift
@@ -39,21 +39,21 @@ final class PromptBarPreferencesPersistorTests: XCTestCase {
     }
 
     func testWhenNothingIsPersistedThenDefaultsAreReturned() {
-        XCTAssertTrue(persistor.isKeyboardShortcutEnabled)
-        XCTAssertTrue(persistor.isMenuBarIconVisible)
+        XCTAssertFalse(persistor.isKeyboardShortcutEnabled)
+        XCTAssertFalse(persistor.isMenuBarIconVisible)
         XCTAssertEqual(persistor.keyboardShortcut, .defaultShortcut)
     }
 
     func testWhenValuesAreSetThenTheyArePersistedToTheStore() {
         let customShortcut = PromptBarShortcut(keyCode: UInt16(kVK_ANSI_D), modifierFlags: [.control, .option])
 
-        persistor.isKeyboardShortcutEnabled = false
-        persistor.isMenuBarIconVisible = false
+        persistor.isKeyboardShortcutEnabled = true
+        persistor.isMenuBarIconVisible = true
         persistor.keyboardShortcut = customShortcut
 
         let rereadPersistor = PromptBarPreferencesUserDefaultsPersistor(keyValueStore: keyValueStore)
-        XCTAssertFalse(rereadPersistor.isKeyboardShortcutEnabled)
-        XCTAssertFalse(rereadPersistor.isMenuBarIconVisible)
+        XCTAssertTrue(rereadPersistor.isKeyboardShortcutEnabled)
+        XCTAssertTrue(rereadPersistor.isMenuBarIconVisible)
         XCTAssertEqual(rereadPersistor.keyboardShortcut, customShortcut)
     }
 
@@ -67,8 +67,8 @@ final class PromptBarPreferencesPersistorTests: XCTestCase {
     func testWhenStoreThrowsOnReadThenDefaultsAreReturned() {
         keyValueStore.shouldThrowOnGet = true
 
-        XCTAssertTrue(persistor.isKeyboardShortcutEnabled)
-        XCTAssertTrue(persistor.isMenuBarIconVisible)
+        XCTAssertFalse(persistor.isKeyboardShortcutEnabled)
+        XCTAssertFalse(persistor.isMenuBarIconVisible)
         XCTAssertEqual(persistor.keyboardShortcut, .defaultShortcut)
     }
 }

--- a/macOS/UnitTests/PromptBar/PromptBarPreferencesTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarPreferencesTests.swift
@@ -18,13 +18,15 @@
 
 import Carbon.HIToolbox
 import Combine
+import PersistenceTestingUtils
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 
+/// Both flags start off, mirroring the opt-in product default.
 private final class MockPromptBarPreferencesPersistor: PromptBarPreferencesPersistor {
-    var isKeyboardShortcutEnabled: Bool = true
+    var isKeyboardShortcutEnabled: Bool = false
     var keyboardShortcut: PromptBarShortcut = .defaultShortcut
-    var isMenuBarIconVisible: Bool = true
+    var isMenuBarIconVisible: Bool = false
 }
 
 private extension MockAIChatConfig {
@@ -42,16 +44,38 @@ final class PromptBarPreferencesTests: XCTestCase {
         PromptBarPreferences(persistor: persistor, aiChatMenuConfiguration: configuration)
     }
 
-    func testWhenInitializedThenValuesAreSeededFromPersistor() {
-        let persistor = MockPromptBarPreferencesPersistor()
-        persistor.isKeyboardShortcutEnabled = false
-        persistor.isMenuBarIconVisible = false
-        persistor.keyboardShortcut = PromptBarShortcut(keyCode: UInt16(kVK_ANSI_D), modifierFlags: [.control, .option])
+    func testWhenNothingIsPersistedThenBothEntryPointsAreOff() {
+        let persistor = PromptBarPreferencesUserDefaultsPersistor(keyValueStore: MockKeyValueFileStore())
 
         let preferences = makePreferences(persistor: persistor)
 
         XCTAssertFalse(preferences.isKeyboardShortcutEnabled)
         XCTAssertFalse(preferences.isMenuBarIconVisible)
+        XCTAssertFalse(preferences.isKeyboardShortcutEffectivelyEnabled)
+        XCTAssertFalse(preferences.isMenuBarIconEffectivelyVisible)
+    }
+
+    func testWhenNothingIsPersistedThenNoShortcutIsPublished() {
+        let persistor = PromptBarPreferencesUserDefaultsPersistor(keyValueStore: MockKeyValueFileStore())
+        let preferences = makePreferences(persistor: persistor)
+        var received: [PromptBarShortcut?] = []
+
+        let cancellable = preferences.effectiveKeyboardShortcutPublisher.sink { received.append($0) }
+
+        XCTAssertEqual(received, [nil])
+        cancellable.cancel()
+    }
+
+    func testWhenInitializedThenValuesAreSeededFromPersistor() {
+        let persistor = MockPromptBarPreferencesPersistor()
+        persistor.isKeyboardShortcutEnabled = true
+        persistor.isMenuBarIconVisible = true
+        persistor.keyboardShortcut = PromptBarShortcut(keyCode: UInt16(kVK_ANSI_D), modifierFlags: [.control, .option])
+
+        let preferences = makePreferences(persistor: persistor)
+
+        XCTAssertTrue(preferences.isKeyboardShortcutEnabled)
+        XCTAssertTrue(preferences.isMenuBarIconVisible)
         XCTAssertEqual(preferences.keyboardShortcut, persistor.keyboardShortcut)
     }
 
@@ -60,12 +84,12 @@ final class PromptBarPreferencesTests: XCTestCase {
         let preferences = makePreferences(persistor: persistor)
         let customShortcut = PromptBarShortcut(keyCode: UInt16(kVK_ANSI_D), modifierFlags: [.control, .option])
 
-        preferences.isKeyboardShortcutEnabled = false
-        preferences.isMenuBarIconVisible = false
+        preferences.isKeyboardShortcutEnabled = true
+        preferences.isMenuBarIconVisible = true
         preferences.keyboardShortcut = customShortcut
 
-        XCTAssertFalse(persistor.isKeyboardShortcutEnabled)
-        XCTAssertFalse(persistor.isMenuBarIconVisible)
+        XCTAssertTrue(persistor.isKeyboardShortcutEnabled)
+        XCTAssertTrue(persistor.isMenuBarIconVisible)
         XCTAssertEqual(persistor.keyboardShortcut, customShortcut)
     }
 
@@ -103,6 +127,7 @@ final class PromptBarPreferencesTests: XCTestCase {
     func testWhenKeyboardShortcutIsDisabledThenStoredMenuBarIconPreferenceIsUnchanged() {
         let persistor = MockPromptBarPreferencesPersistor()
         persistor.isMenuBarIconVisible = true
+        persistor.isKeyboardShortcutEnabled = true
         let preferences = makePreferences(persistor: persistor)
 
         preferences.isKeyboardShortcutEnabled = false
@@ -170,6 +195,7 @@ final class PromptBarPreferencesTests: XCTestCase {
     func testWhenAIFeaturesAreDisabledThenStoredMenuBarIconPreferenceIsUnchanged() {
         let persistor = MockPromptBarPreferencesPersistor()
         persistor.isMenuBarIconVisible = true
+        persistor.isKeyboardShortcutEnabled = true
         let configuration = MockAIChatConfig()
         configuration.shouldDisplayAnyAIChatFeature = false
 

--- a/macOS/UnitTests/PromptBar/PromptBarPromptSubmitterTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarPromptSubmitterTests.swift
@@ -70,7 +70,6 @@ final class PromptBarPromptSubmitterTests: XCTestCase {
         XCTAssertFalse(PromptBarPromptSubmitter.canHostPrompt(window, submittedFromScreenFrame: screenOne))
     }
 
-    /// With no source screen there is nothing to match against, so reusing a window beats opening one.
     func testWhenSourceScreenIsUnknownThenAnyVisibleWindowCanHostThePrompt() {
         let window = StubHostWindow(screenFrame: screenTwo)
 
@@ -90,8 +89,6 @@ final class PromptBarPromptSubmitterTests: XCTestCase {
         XCTAssertEqual(droppingPoint.y, screenTwo.maxY)
     }
 
-    /// The dropping point is the window's top-center, so a window placed with it stays on the
-    /// screen it was placed on rather than cascading onto another display.
     func testWhenPlacingANewWindowThenTheResultingFrameStaysOnTheTargetScreen() {
         let droppingPoint = PromptBarPromptSubmitter.newWindowDroppingPoint(in: screenTwo)
         let windowSize = NSSize(width: 1024, height: 768)

--- a/macOS/UnitTests/PromptBar/PromptBarPromptSubmitterTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarPromptSubmitterTests.swift
@@ -1,0 +1,103 @@
+//
+//  PromptBarPromptSubmitterTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+@MainActor
+private struct StubHostWindow: PromptBarHostWindow {
+    var isVisible = true
+    var isMiniaturized = false
+    var isOnActiveSpace = true
+    var screenFrame: NSRect?
+}
+
+@MainActor
+final class PromptBarPromptSubmitterTests: XCTestCase {
+
+    private let screenOne = NSRect(x: 0, y: 0, width: 1440, height: 900)
+    private let screenTwo = NSRect(x: 1440, y: 0, width: 1920, height: 1080)
+
+    func testWhenWindowIsOnTheSameScreenThenItCanHostThePrompt() {
+        let window = StubHostWindow(screenFrame: screenOne)
+
+        XCTAssertTrue(PromptBarPromptSubmitter.canHostPrompt(window, submittedFromScreenFrame: screenOne))
+    }
+
+    func testWhenWindowIsOnAnotherScreenThenItCannotHostThePrompt() {
+        let window = StubHostWindow(screenFrame: screenTwo)
+
+        XCTAssertFalse(PromptBarPromptSubmitter.canHostPrompt(window, submittedFromScreenFrame: screenOne))
+    }
+
+    func testWhenWindowIsOnAnotherSpaceThenItCannotHostThePrompt() {
+        let window = StubHostWindow(isOnActiveSpace: false, screenFrame: screenOne)
+
+        XCTAssertFalse(PromptBarPromptSubmitter.canHostPrompt(window, submittedFromScreenFrame: screenOne))
+    }
+
+    func testWhenWindowIsMiniaturizedThenItCannotHostThePrompt() {
+        let window = StubHostWindow(isMiniaturized: true, screenFrame: screenOne)
+
+        XCTAssertFalse(PromptBarPromptSubmitter.canHostPrompt(window, submittedFromScreenFrame: screenOne))
+    }
+
+    func testWhenWindowIsHiddenThenItCannotHostThePrompt() {
+        let window = StubHostWindow(isVisible: false, screenFrame: screenOne)
+
+        XCTAssertFalse(PromptBarPromptSubmitter.canHostPrompt(window, submittedFromScreenFrame: screenOne))
+    }
+
+    func testWhenWindowIsOffscreenThenItCannotHostAScreenScopedPrompt() {
+        let window = StubHostWindow(screenFrame: nil)
+
+        XCTAssertFalse(PromptBarPromptSubmitter.canHostPrompt(window, submittedFromScreenFrame: screenOne))
+    }
+
+    /// With no source screen there is nothing to match against, so reusing a window beats opening one.
+    func testWhenSourceScreenIsUnknownThenAnyVisibleWindowCanHostThePrompt() {
+        let window = StubHostWindow(screenFrame: screenTwo)
+
+        XCTAssertTrue(PromptBarPromptSubmitter.canHostPrompt(window, submittedFromScreenFrame: nil))
+    }
+
+    func testWhenSourceScreenIsUnknownThenAnOffSpaceWindowStillCannotHostThePrompt() {
+        let window = StubHostWindow(isOnActiveSpace: false, screenFrame: screenTwo)
+
+        XCTAssertFalse(PromptBarPromptSubmitter.canHostPrompt(window, submittedFromScreenFrame: nil))
+    }
+
+    func testWhenPlacingANewWindowThenItIsCenteredOnTheTargetScreen() {
+        let droppingPoint = PromptBarPromptSubmitter.newWindowDroppingPoint(in: screenTwo)
+
+        XCTAssertEqual(droppingPoint.x, screenTwo.midX)
+        XCTAssertEqual(droppingPoint.y, screenTwo.maxY)
+    }
+
+    /// The dropping point is the window's top-center, so a window placed with it stays on the
+    /// screen it was placed on rather than cascading onto another display.
+    func testWhenPlacingANewWindowThenTheResultingFrameStaysOnTheTargetScreen() {
+        let droppingPoint = PromptBarPromptSubmitter.newWindowDroppingPoint(in: screenTwo)
+        let windowSize = NSSize(width: 1024, height: 768)
+        let origin = NSRect(origin: .zero, size: windowSize).frameOrigin(fromDroppingPoint: droppingPoint)
+
+        let frame = NSRect(origin: origin, size: windowSize)
+        XCTAssertTrue(screenTwo.contains(frame))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1216915638786612?focus=true
Tech Design URL:
CC:

### Description
Adds the floating Prompt Bar itself: a borderless panel with a single prompt field that opens what the user types in a new Duck.ai tab. The user's configured shortcut is now registered system-wide, and the menu bar icon's placeholder click toggles the bar. The field is deliberately minimal for now — the address bar's Duck.ai controls (attach, tools, model and reasoning pickers, voice) land once they are extracted into a component both surfaces share.

### Testing Steps
1. On an internal build with `macosPromptBar` enabled, press ⌥Space from another app → the bar appears near the top of the screen holding the pointer, focused.
2. Type a prompt and press Enter → the bar closes and the prompt opens in a new selected Duck.ai tab. Reopen and press Escape, or click another window, → the bar dismisses without submitting.
3. In Settings → AI Features, change the shortcut and confirm the new combination opens the bar and the old one no longer does; switch the shortcut off and confirm neither works and the menu bar icon disappears.
4. Click the menu bar icon, check if the prompt bar correctly appears.

### Impact
Low

#### What could go wrong?
The Carbon hot key could collide with a combination another app already owns → registration fails and returns false rather than throwing, leaving the menu bar icon as a working entry point, and the settings recorder already rejects the reserved system combinations.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New global hotkey registration and window-less Duck.ai tab routing affect core navigation and multi-display behavior; failures are mostly localized (hotkey collision, wrong window reuse) rather than data or auth.
> 
> **Overview**
> Adds the **floating Prompt Bar** behind `macosPromptBar`: a borderless `NSPanel` with a minimal prompt field, opened by the user’s **Carbon global hotkey** or the **menu bar icon** (no longer a no-op).
> 
> **`PromptBarCoordinator`** wires shortcut registration to **`effectiveKeyboardShortcutPublisher`** (nil when Duck.ai is off or the shortcut is disabled) and toggles **`PromptBarPresenter`**, which places the bar via **`PromptBarPlacement`**, dismisses on resign-key unless auxiliary UI is up, and does not activate the full app on show.
> 
> Submitting a prompt runs **`PromptBarPromptSubmitter`**, which reuses a visible browser window on the same display/space when possible, otherwise opens Duck.ai via new **`AIChatTabOpening`** / **`AIChatTabManaging`** paths (new tab in a chosen window or a new window at a screen-centered drop point), then activates the app.
> 
> **Preference defaults** for shortcut and menu bar icon change from **on** to **off** when nothing is stored; **`effectiveKeyboardShortcutPublisher`** is added so the global shortcut stays unregistered when Duck.ai is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1704b9f26092fcde42746ab8ef695a0c526b1850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->