### PR TITLE
iOS: Expand (and smarter) suggested prompts for contextual sheet/sidepanel - translations

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionUserText.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionUserText.swift
@@ -18,127 +18,126 @@
 //
 
 import Foundation
-import FoundationExtensions
 
 extension UserText {
 
-    public static let aiChatSuggestionSummarizePageLabel = NotLocalizedString("duckai.suggestion.summarize-page.label", value: "Summarize this page", comment: "Suggested prompt chip: summarize the current page")
-    public static let aiChatSuggestionSummarizePagePrompt = NotLocalizedString("duckai.suggestion.summarize-page.prompt", value: "Summarize this page.", comment: "Suggested prompt submitted text: summarize the current page")
+    public static let aiChatSuggestionSummarizePageLabel = NSLocalizedString("duckai.suggestion.summarize-page.label", value: "Summarize this page", comment: "Suggested prompt chip: summarize the current page")
+    public static let aiChatSuggestionSummarizePagePrompt = NSLocalizedString("duckai.suggestion.summarize-page.prompt", value: "Summarize this page.", comment: "Suggested prompt submitted text: summarize the current page")
 
-    public static let aiChatSuggestionTranslatePageLabel = NotLocalizedString("duckai.suggestion.translate-page.label", value: "Translate this page", comment: "Suggested prompt chip: translate the current page")
-    public static let aiChatSuggestionTranslatePagePrompt = NotLocalizedString("duckai.suggestion.translate-page.prompt", value: "Translate this page into {language}.", comment: "Suggested prompt submitted text: translate the page. {language} is replaced with the user's language name, keep it verbatim.")
+    public static let aiChatSuggestionTranslatePageLabel = NSLocalizedString("duckai.suggestion.translate-page.label", value: "Translate this page", comment: "Suggested prompt chip: translate the current page")
+    public static let aiChatSuggestionTranslatePagePrompt = NSLocalizedString("duckai.suggestion.translate-page.prompt", value: "Translate this page into %@.", comment: "Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language.")
 
-    public static let aiChatSuggestionKeyTakeawaysLabel = NotLocalizedString("duckai.suggestion.key-takeaways.label", value: "What are the key takeaways?", comment: "Suggested prompt chip: key takeaways of an article")
-    public static let aiChatSuggestionKeyTakeawaysPrompt = NotLocalizedString("duckai.suggestion.key-takeaways.prompt", value: "What are the key takeaways from this article?", comment: "Suggested prompt submitted text: key takeaways of an article")
+    public static let aiChatSuggestionKeyTakeawaysLabel = NSLocalizedString("duckai.suggestion.key-takeaways.label", value: "What are the key takeaways?", comment: "Suggested prompt chip: key takeaways of an article")
+    public static let aiChatSuggestionKeyTakeawaysPrompt = NSLocalizedString("duckai.suggestion.key-takeaways.prompt", value: "What are the key takeaways from this article?", comment: "Suggested prompt submitted text: key takeaways of an article")
 
-    public static let aiChatSuggestionExplainSimplyLabel = NotLocalizedString("duckai.suggestion.explain-simply.label", value: "Explain this simply", comment: "Suggested prompt chip: explain the content simply")
-    public static let aiChatSuggestionExplainSimplyPrompt = NotLocalizedString("duckai.suggestion.explain-simply.prompt", value: "Explain this in simple, plain language.", comment: "Suggested prompt submitted text: explain the content simply")
+    public static let aiChatSuggestionExplainSimplyLabel = NSLocalizedString("duckai.suggestion.explain-simply.label", value: "Explain this simply", comment: "Suggested prompt chip: explain the content simply")
+    public static let aiChatSuggestionExplainSimplyPrompt = NSLocalizedString("duckai.suggestion.explain-simply.prompt", value: "Explain this in simple, plain language.", comment: "Suggested prompt submitted text: explain the content simply")
 
-    public static let aiChatSuggestionCounterargumentsLabel = NotLocalizedString("duckai.suggestion.counterarguments.label", value: "What are the counterarguments?", comment: "Suggested prompt chip: counterarguments")
-    public static let aiChatSuggestionCounterargumentsPrompt = NotLocalizedString("duckai.suggestion.counterarguments.prompt", value: "What are the main counterarguments or criticisms of this?", comment: "Suggested prompt submitted text: counterarguments")
+    public static let aiChatSuggestionCounterargumentsLabel = NSLocalizedString("duckai.suggestion.counterarguments.label", value: "What are the counterarguments?", comment: "Suggested prompt chip: counterarguments")
+    public static let aiChatSuggestionCounterargumentsPrompt = NSLocalizedString("duckai.suggestion.counterarguments.prompt", value: "What are the main counterarguments or criticisms of this?", comment: "Suggested prompt submitted text: counterarguments")
 
-    public static let aiChatSuggestionRelatedArticlesLabel = NotLocalizedString("duckai.suggestion.related-articles.label", value: "Suggest related articles to explore", comment: "Suggested prompt chip: related articles")
-    public static let aiChatSuggestionRelatedArticlesPrompt = NotLocalizedString("duckai.suggestion.related-articles.prompt", value: "Suggest related articles or topics worth exploring next.", comment: "Suggested prompt submitted text: related articles")
+    public static let aiChatSuggestionRelatedArticlesLabel = NSLocalizedString("duckai.suggestion.related-articles.label", value: "Suggest related articles to explore", comment: "Suggested prompt chip: related articles")
+    public static let aiChatSuggestionRelatedArticlesPrompt = NSLocalizedString("duckai.suggestion.related-articles.prompt", value: "Suggest related articles or topics worth exploring next.", comment: "Suggested prompt submitted text: related articles")
 
-    public static let aiChatSuggestionShoppingListLabel = NotLocalizedString("duckai.suggestion.shopping-list.label", value: "Generate a shopping list", comment: "Suggested prompt chip: shopping list from a recipe")
-    public static let aiChatSuggestionShoppingListPrompt = NotLocalizedString("duckai.suggestion.shopping-list.prompt", value: "Create a shopping list with quantities from this recipe.", comment: "Suggested prompt submitted text: shopping list from a recipe")
+    public static let aiChatSuggestionShoppingListLabel = NSLocalizedString("duckai.suggestion.shopping-list.label", value: "Generate a shopping list", comment: "Suggested prompt chip: shopping list from a recipe")
+    public static let aiChatSuggestionShoppingListPrompt = NSLocalizedString("duckai.suggestion.shopping-list.prompt", value: "Create a shopping list with quantities from this recipe.", comment: "Suggested prompt submitted text: shopping list from a recipe")
 
-    public static let aiChatSuggestionRecipeNutritionLabel = NotLocalizedString("duckai.suggestion.recipe-nutrition.label", value: "Estimate the nutrition", comment: "Suggested prompt chip: recipe nutrition")
-    public static let aiChatSuggestionRecipeNutritionPrompt = NotLocalizedString("duckai.suggestion.recipe-nutrition.prompt", value: "Estimate the nutritional information for this recipe.", comment: "Suggested prompt submitted text: recipe nutrition")
+    public static let aiChatSuggestionRecipeNutritionLabel = NSLocalizedString("duckai.suggestion.recipe-nutrition.label", value: "Estimate the nutrition", comment: "Suggested prompt chip: recipe nutrition")
+    public static let aiChatSuggestionRecipeNutritionPrompt = NSLocalizedString("duckai.suggestion.recipe-nutrition.prompt", value: "Estimate the nutritional information for this recipe.", comment: "Suggested prompt submitted text: recipe nutrition")
 
-    public static let aiChatSuggestionScaleRecipeLabel = NotLocalizedString("duckai.suggestion.scale-recipe.label", value: "Adjust the servings", comment: "Suggested prompt chip: scale a recipe")
-    public static let aiChatSuggestionScaleRecipePrompt = NotLocalizedString("duckai.suggestion.scale-recipe.prompt", value: "Rewrite this recipe scaled for a different number of servings.", comment: "Suggested prompt submitted text: scale a recipe")
+    public static let aiChatSuggestionScaleRecipeLabel = NSLocalizedString("duckai.suggestion.scale-recipe.label", value: "Adjust the servings", comment: "Suggested prompt chip: scale a recipe")
+    public static let aiChatSuggestionScaleRecipePrompt = NSLocalizedString("duckai.suggestion.scale-recipe.prompt", value: "Rewrite this recipe scaled for a different number of servings.", comment: "Suggested prompt submitted text: scale a recipe")
 
-    public static let aiChatSuggestionProductProsConsLabel = NotLocalizedString("duckai.suggestion.product-pros-cons.label", value: "What are the pros and cons?", comment: "Suggested prompt chip: product pros and cons")
-    public static let aiChatSuggestionProductProsConsPrompt = NotLocalizedString("duckai.suggestion.product-pros-cons.prompt", value: "What are the pros and cons of this product?", comment: "Suggested prompt submitted text: product pros and cons")
+    public static let aiChatSuggestionProductProsConsLabel = NSLocalizedString("duckai.suggestion.product-pros-cons.label", value: "What are the pros and cons?", comment: "Suggested prompt chip: product pros and cons")
+    public static let aiChatSuggestionProductProsConsPrompt = NSLocalizedString("duckai.suggestion.product-pros-cons.prompt", value: "What are the pros and cons of this product?", comment: "Suggested prompt submitted text: product pros and cons")
 
-    public static let aiChatSuggestionFindAlternativesLabel = NotLocalizedString("duckai.suggestion.find-alternatives.label", value: "Find me alternatives", comment: "Suggested prompt chip: product alternatives")
-    public static let aiChatSuggestionFindAlternativesPrompt = NotLocalizedString("duckai.suggestion.find-alternatives.prompt", value: "Suggest some alternatives to this product.", comment: "Suggested prompt submitted text: product alternatives")
+    public static let aiChatSuggestionFindAlternativesLabel = NSLocalizedString("duckai.suggestion.find-alternatives.label", value: "Find me alternatives", comment: "Suggested prompt chip: product alternatives")
+    public static let aiChatSuggestionFindAlternativesPrompt = NSLocalizedString("duckai.suggestion.find-alternatives.prompt", value: "Suggest some alternatives to this product.", comment: "Suggested prompt submitted text: product alternatives")
 
-    public static let aiChatSuggestionSummarizeVideoLabel = NotLocalizedString("duckai.suggestion.summarize-video.label", value: "Summarize this video", comment: "Suggested prompt chip: summarize a video")
-    public static let aiChatSuggestionSummarizeVideoPrompt = NotLocalizedString("duckai.suggestion.summarize-video.prompt", value: "Summarize this video.", comment: "Suggested prompt submitted text: summarize a video")
+    public static let aiChatSuggestionSummarizeVideoLabel = NSLocalizedString("duckai.suggestion.summarize-video.label", value: "Summarize this video", comment: "Suggested prompt chip: summarize a video")
+    public static let aiChatSuggestionSummarizeVideoPrompt = NSLocalizedString("duckai.suggestion.summarize-video.prompt", value: "Summarize this video.", comment: "Suggested prompt submitted text: summarize a video")
 
-    public static let aiChatSuggestionVideoKeyPointsLabel = NotLocalizedString("duckai.suggestion.video-key-points.label", value: "What are the key points?", comment: "Suggested prompt chip: video key points")
-    public static let aiChatSuggestionVideoKeyPointsPrompt = NotLocalizedString("duckai.suggestion.video-key-points.prompt", value: "What are the key points covered in this video?", comment: "Suggested prompt submitted text: video key points")
+    public static let aiChatSuggestionVideoKeyPointsLabel = NSLocalizedString("duckai.suggestion.video-key-points.label", value: "What are the key points?", comment: "Suggested prompt chip: video key points")
+    public static let aiChatSuggestionVideoKeyPointsPrompt = NSLocalizedString("duckai.suggestion.video-key-points.prompt", value: "What are the key points covered in this video?", comment: "Suggested prompt submitted text: video key points")
 
-    public static let aiChatSuggestionTailorResumeLabel = NotLocalizedString("duckai.suggestion.tailor-resume.label", value: "Tailor my resume", comment: "Suggested prompt chip: tailor a resume to a job")
-    public static let aiChatSuggestionTailorResumePrompt = NotLocalizedString("duckai.suggestion.tailor-resume.prompt", value: "Help me tailor my resume for this job.", comment: "Suggested prompt submitted text: tailor a resume to a job")
+    public static let aiChatSuggestionTailorResumeLabel = NSLocalizedString("duckai.suggestion.tailor-resume.label", value: "Tailor my resume", comment: "Suggested prompt chip: tailor a resume to a job")
+    public static let aiChatSuggestionTailorResumePrompt = NSLocalizedString("duckai.suggestion.tailor-resume.prompt", value: "Help me tailor my resume for this job.", comment: "Suggested prompt submitted text: tailor a resume to a job")
 
-    public static let aiChatSuggestionInterviewPrepLabel = NotLocalizedString("duckai.suggestion.interview-prep.label", value: "Help me prep for the interview", comment: "Suggested prompt chip: interview prep")
-    public static let aiChatSuggestionInterviewPrepPrompt = NotLocalizedString("duckai.suggestion.interview-prep.prompt", value: "What interview questions might come up for this role?", comment: "Suggested prompt submitted text: interview prep")
+    public static let aiChatSuggestionInterviewPrepLabel = NSLocalizedString("duckai.suggestion.interview-prep.label", value: "Help me prep for the interview", comment: "Suggested prompt chip: interview prep")
+    public static let aiChatSuggestionInterviewPrepPrompt = NSLocalizedString("duckai.suggestion.interview-prep.prompt", value: "What interview questions might come up for this role?", comment: "Suggested prompt submitted text: interview prep")
 
-    public static let aiChatSuggestionCoverLetterLabel = NotLocalizedString("duckai.suggestion.cover-letter.label", value: "Draft a cover letter", comment: "Suggested prompt chip: draft a cover letter")
-    public static let aiChatSuggestionCoverLetterPrompt = NotLocalizedString("duckai.suggestion.cover-letter.prompt", value: "Draft a cover letter for this job.", comment: "Suggested prompt submitted text: draft a cover letter")
+    public static let aiChatSuggestionCoverLetterLabel = NSLocalizedString("duckai.suggestion.cover-letter.label", value: "Draft a cover letter", comment: "Suggested prompt chip: draft a cover letter")
+    public static let aiChatSuggestionCoverLetterPrompt = NSLocalizedString("duckai.suggestion.cover-letter.prompt", value: "Draft a cover letter for this job.", comment: "Suggested prompt submitted text: draft a cover letter")
 
-    public static let aiChatSuggestionEventDetailsLabel = NotLocalizedString("duckai.suggestion.event-details.label", value: "What are the key details?", comment: "Suggested prompt chip: event details")
-    public static let aiChatSuggestionEventDetailsPrompt = NotLocalizedString("duckai.suggestion.event-details.prompt", value: "Summarize the key details of this event.", comment: "Suggested prompt submitted text: event details")
+    public static let aiChatSuggestionEventDetailsLabel = NSLocalizedString("duckai.suggestion.event-details.label", value: "What are the key details?", comment: "Suggested prompt chip: event details")
+    public static let aiChatSuggestionEventDetailsPrompt = NSLocalizedString("duckai.suggestion.event-details.prompt", value: "Summarize the key details of this event.", comment: "Suggested prompt submitted text: event details")
 
-    public static let aiChatSuggestionWorthWatchingLabel = NotLocalizedString("duckai.suggestion.worth-watching.label", value: "Is this worth watching?", comment: "Suggested prompt chip: is a movie/show worth watching")
-    public static let aiChatSuggestionWorthWatchingPrompt = NotLocalizedString("duckai.suggestion.worth-watching.prompt", value: "Is this worth watching? Give me a spoiler-free take.", comment: "Suggested prompt submitted text: is a movie/show worth watching")
+    public static let aiChatSuggestionWorthWatchingLabel = NSLocalizedString("duckai.suggestion.worth-watching.label", value: "Is this worth watching?", comment: "Suggested prompt chip: is a movie/show worth watching")
+    public static let aiChatSuggestionWorthWatchingPrompt = NSLocalizedString("duckai.suggestion.worth-watching.prompt", value: "Is this worth watching? Give me a spoiler-free take.", comment: "Suggested prompt submitted text: is a movie/show worth watching")
 
-    public static let aiChatSuggestionSimilarTitlesLabel = NotLocalizedString("duckai.suggestion.similar-titles.label", value: "Recommend similar titles", comment: "Suggested prompt chip: similar movies or shows")
-    public static let aiChatSuggestionSimilarTitlesPrompt = NotLocalizedString("duckai.suggestion.similar-titles.prompt", value: "Recommend similar movies or shows.", comment: "Suggested prompt submitted text: similar movies or shows")
+    public static let aiChatSuggestionSimilarTitlesLabel = NSLocalizedString("duckai.suggestion.similar-titles.label", value: "Recommend similar titles", comment: "Suggested prompt chip: similar movies or shows")
+    public static let aiChatSuggestionSimilarTitlesPrompt = NSLocalizedString("duckai.suggestion.similar-titles.prompt", value: "Recommend similar movies or shows.", comment: "Suggested prompt submitted text: similar movies or shows")
 
-    public static let aiChatSuggestionCastCrewLabel = NotLocalizedString("duckai.suggestion.cast-crew.label", value: "Cast & Crew", comment: "Suggested prompt chip: cast and crew")
-    public static let aiChatSuggestionCastCrewPrompt = NotLocalizedString("duckai.suggestion.cast-crew.prompt", value: "Who are the main cast and crew, and what else are they known for?", comment: "Suggested prompt submitted text: cast and crew")
+    public static let aiChatSuggestionCastCrewLabel = NSLocalizedString("duckai.suggestion.cast-crew.label", value: "Cast & Crew", comment: "Suggested prompt chip: cast and crew")
+    public static let aiChatSuggestionCastCrewPrompt = NSLocalizedString("duckai.suggestion.cast-crew.prompt", value: "Who are the main cast and crew, and what else are they known for?", comment: "Suggested prompt submitted text: cast and crew")
 
-    public static let aiChatSuggestionSummarizeBookLabel = NotLocalizedString("duckai.suggestion.summarize-book.label", value: "Summarize this book", comment: "Suggested prompt chip: summarize a book")
-    public static let aiChatSuggestionSummarizeBookPrompt = NotLocalizedString("duckai.suggestion.summarize-book.prompt", value: "Summarize this book.", comment: "Suggested prompt submitted text: summarize a book")
+    public static let aiChatSuggestionSummarizeBookLabel = NSLocalizedString("duckai.suggestion.summarize-book.label", value: "Summarize this book", comment: "Suggested prompt chip: summarize a book")
+    public static let aiChatSuggestionSummarizeBookPrompt = NSLocalizedString("duckai.suggestion.summarize-book.prompt", value: "Summarize this book.", comment: "Suggested prompt submitted text: summarize a book")
 
-    public static let aiChatSuggestionSimilarBooksLabel = NotLocalizedString("duckai.suggestion.similar-books.label", value: "Recommend similar books", comment: "Suggested prompt chip: similar books")
-    public static let aiChatSuggestionSimilarBooksPrompt = NotLocalizedString("duckai.suggestion.similar-books.prompt", value: "Recommend similar books.", comment: "Suggested prompt submitted text: similar books")
+    public static let aiChatSuggestionSimilarBooksLabel = NSLocalizedString("duckai.suggestion.similar-books.label", value: "Recommend similar books", comment: "Suggested prompt chip: similar books")
+    public static let aiChatSuggestionSimilarBooksPrompt = NSLocalizedString("duckai.suggestion.similar-books.prompt", value: "Recommend similar books.", comment: "Suggested prompt submitted text: similar books")
 
-    public static let aiChatSuggestionExplainPaperLabel = NotLocalizedString("duckai.suggestion.explain-paper.label", value: "Explain this paper", comment: "Suggested prompt chip: explain a research paper")
-    public static let aiChatSuggestionExplainPaperPrompt = NotLocalizedString("duckai.suggestion.explain-paper.prompt", value: "Explain this research paper in plain language.", comment: "Suggested prompt submitted text: explain a research paper")
+    public static let aiChatSuggestionExplainPaperLabel = NSLocalizedString("duckai.suggestion.explain-paper.label", value: "Explain this paper", comment: "Suggested prompt chip: explain a research paper")
+    public static let aiChatSuggestionExplainPaperPrompt = NSLocalizedString("duckai.suggestion.explain-paper.prompt", value: "Explain this research paper in plain language.", comment: "Suggested prompt submitted text: explain a research paper")
 
-    public static let aiChatSuggestionPaperContributionsLabel = NotLocalizedString("duckai.suggestion.paper-contributions.label", value: "What are the key contributions?", comment: "Suggested prompt chip: paper contributions")
-    public static let aiChatSuggestionPaperContributionsPrompt = NotLocalizedString("duckai.suggestion.paper-contributions.prompt", value: "What are the key contributions of this paper?", comment: "Suggested prompt submitted text: paper contributions")
+    public static let aiChatSuggestionPaperContributionsLabel = NSLocalizedString("duckai.suggestion.paper-contributions.label", value: "What are the key contributions?", comment: "Suggested prompt chip: paper contributions")
+    public static let aiChatSuggestionPaperContributionsPrompt = NSLocalizedString("duckai.suggestion.paper-contributions.prompt", value: "What are the key contributions of this paper?", comment: "Suggested prompt submitted text: paper contributions")
 
-    public static let aiChatSuggestionMenuHighlightsLabel = NotLocalizedString("duckai.suggestion.menu-highlights.label", value: "What should I order?", comment: "Suggested prompt chip: restaurant menu highlights")
-    public static let aiChatSuggestionMenuHighlightsPrompt = NotLocalizedString("duckai.suggestion.menu-highlights.prompt", value: "What are the must-try dishes here?", comment: "Suggested prompt submitted text: restaurant menu highlights")
+    public static let aiChatSuggestionMenuHighlightsLabel = NSLocalizedString("duckai.suggestion.menu-highlights.label", value: "What should I order?", comment: "Suggested prompt chip: restaurant menu highlights")
+    public static let aiChatSuggestionMenuHighlightsPrompt = NSLocalizedString("duckai.suggestion.menu-highlights.prompt", value: "What are the must-try dishes here?", comment: "Suggested prompt submitted text: restaurant menu highlights")
 
-    public static let aiChatSuggestionPlaceHoursLabel = NotLocalizedString("duckai.suggestion.place-hours.label", value: "What are the hours & location?", comment: "Suggested prompt chip: place hours and location")
-    public static let aiChatSuggestionPlaceHoursPrompt = NotLocalizedString("duckai.suggestion.place-hours.prompt", value: "What are the opening hours, location, and contact details for this place?", comment: "Suggested prompt submitted text: place hours and location")
+    public static let aiChatSuggestionPlaceHoursLabel = NSLocalizedString("duckai.suggestion.place-hours.label", value: "What are the hours & location?", comment: "Suggested prompt chip: place hours and location")
+    public static let aiChatSuggestionPlaceHoursPrompt = NSLocalizedString("duckai.suggestion.place-hours.prompt", value: "What are the opening hours, location, and contact details for this place?", comment: "Suggested prompt submitted text: place hours and location")
 
-    public static let aiChatSuggestionPlaceReviewsLabel = NotLocalizedString("duckai.suggestion.place-reviews.label", value: "Is this place any good?", comment: "Suggested prompt chip: place reputation")
-    public static let aiChatSuggestionPlaceReviewsPrompt = NotLocalizedString("duckai.suggestion.place-reviews.prompt", value: "Is this place any good? Summarize its reputation based on reviews and ratings.", comment: "Suggested prompt submitted text: place reputation")
+    public static let aiChatSuggestionPlaceReviewsLabel = NSLocalizedString("duckai.suggestion.place-reviews.label", value: "Is this place any good?", comment: "Suggested prompt chip: place reputation")
+    public static let aiChatSuggestionPlaceReviewsPrompt = NSLocalizedString("duckai.suggestion.place-reviews.prompt", value: "Is this place any good? Summarize its reputation based on reviews and ratings.", comment: "Suggested prompt submitted text: place reputation")
 
-    public static let aiChatSuggestionSummarizeThreadLabel = NotLocalizedString("duckai.suggestion.summarize-thread.label", value: "Summarize this discussion", comment: "Suggested prompt chip: summarize a discussion thread")
-    public static let aiChatSuggestionSummarizeThreadPrompt = NotLocalizedString("duckai.suggestion.summarize-thread.prompt", value: "Summarize this discussion thread.", comment: "Suggested prompt submitted text: summarize a discussion thread")
+    public static let aiChatSuggestionSummarizeThreadLabel = NSLocalizedString("duckai.suggestion.summarize-thread.label", value: "Summarize this discussion", comment: "Suggested prompt chip: summarize a discussion thread")
+    public static let aiChatSuggestionSummarizeThreadPrompt = NSLocalizedString("duckai.suggestion.summarize-thread.prompt", value: "Summarize this discussion thread.", comment: "Suggested prompt submitted text: summarize a discussion thread")
 
-    public static let aiChatSuggestionExplainRepoLabel = NotLocalizedString("duckai.suggestion.explain-repo.label", value: "Explain this repo", comment: "Suggested prompt chip: explain a code repository")
-    public static let aiChatSuggestionExplainRepoPrompt = NotLocalizedString("duckai.suggestion.explain-repo.prompt", value: "Explain what this repository does and how to use it.", comment: "Suggested prompt submitted text: explain a code repository")
+    public static let aiChatSuggestionExplainRepoLabel = NSLocalizedString("duckai.suggestion.explain-repo.label", value: "Explain this repo", comment: "Suggested prompt chip: explain a code repository")
+    public static let aiChatSuggestionExplainRepoPrompt = NSLocalizedString("duckai.suggestion.explain-repo.prompt", value: "Explain what this repository does and how to use it.", comment: "Suggested prompt submitted text: explain a code repository")
 
-    public static let aiChatSuggestionExplainAnswerLabel = NotLocalizedString("duckai.suggestion.explain-answer.label", value: "Explain the top answer", comment: "Suggested prompt chip: explain the top answer")
-    public static let aiChatSuggestionExplainAnswerPrompt = NotLocalizedString("duckai.suggestion.explain-answer.prompt", value: "Explain the accepted answer in simple terms.", comment: "Suggested prompt submitted text: explain the top answer")
+    public static let aiChatSuggestionExplainAnswerLabel = NSLocalizedString("duckai.suggestion.explain-answer.label", value: "Explain the top answer", comment: "Suggested prompt chip: explain the top answer")
+    public static let aiChatSuggestionExplainAnswerPrompt = NSLocalizedString("duckai.suggestion.explain-answer.prompt", value: "Explain the accepted answer in simple terms.", comment: "Suggested prompt submitted text: explain the top answer")
 
-    public static let aiChatSuggestionHowtoStepsLabel = NotLocalizedString("duckai.suggestion.howto-steps.label", value: "Walk me through the steps", comment: "Suggested prompt chip: how-to steps")
-    public static let aiChatSuggestionHowtoStepsPrompt = NotLocalizedString("duckai.suggestion.howto-steps.prompt", value: "Break this down into clear, numbered steps.", comment: "Suggested prompt submitted text: how-to steps")
+    public static let aiChatSuggestionHowtoStepsLabel = NSLocalizedString("duckai.suggestion.howto-steps.label", value: "Walk me through the steps", comment: "Suggested prompt chip: how-to steps")
+    public static let aiChatSuggestionHowtoStepsPrompt = NSLocalizedString("duckai.suggestion.howto-steps.prompt", value: "Break this down into clear, numbered steps.", comment: "Suggested prompt submitted text: how-to steps")
 
-    public static let aiChatSuggestionHowtoMaterialsLabel = NotLocalizedString("duckai.suggestion.howto-materials.label", value: "What will I need?", comment: "Suggested prompt chip: how-to materials")
-    public static let aiChatSuggestionHowtoMaterialsPrompt = NotLocalizedString("duckai.suggestion.howto-materials.prompt", value: "List the tools, materials, or prerequisites I need for this.", comment: "Suggested prompt submitted text: how-to materials")
+    public static let aiChatSuggestionHowtoMaterialsLabel = NSLocalizedString("duckai.suggestion.howto-materials.label", value: "What will I need?", comment: "Suggested prompt chip: how-to materials")
+    public static let aiChatSuggestionHowtoMaterialsPrompt = NSLocalizedString("duckai.suggestion.howto-materials.prompt", value: "List the tools, materials, or prerequisites I need for this.", comment: "Suggested prompt submitted text: how-to materials")
 
-    public static let aiChatSuggestionCourseLearnLabel = NotLocalizedString("duckai.suggestion.course-learn.label", value: "What will I learn?", comment: "Suggested prompt chip: course learning outcomes")
-    public static let aiChatSuggestionCourseLearnPrompt = NotLocalizedString("duckai.suggestion.course-learn.prompt", value: "What are the key things I will learn from this course?", comment: "Suggested prompt submitted text: course learning outcomes")
+    public static let aiChatSuggestionCourseLearnLabel = NSLocalizedString("duckai.suggestion.course-learn.label", value: "What will I learn?", comment: "Suggested prompt chip: course learning outcomes")
+    public static let aiChatSuggestionCourseLearnPrompt = NSLocalizedString("duckai.suggestion.course-learn.prompt", value: "What are the key things I will learn from this course?", comment: "Suggested prompt submitted text: course learning outcomes")
 
-    public static let aiChatSuggestionCourseWorthLabel = NotLocalizedString("duckai.suggestion.course-worth.label", value: "Is it worth taking?", comment: "Suggested prompt chip: is a course worth taking")
-    public static let aiChatSuggestionCourseWorthPrompt = NotLocalizedString("duckai.suggestion.course-worth.prompt", value: "Based on this page, is this course worth taking?", comment: "Suggested prompt submitted text: is a course worth taking")
+    public static let aiChatSuggestionCourseWorthLabel = NSLocalizedString("duckai.suggestion.course-worth.label", value: "Is it worth taking?", comment: "Suggested prompt chip: is a course worth taking")
+    public static let aiChatSuggestionCourseWorthPrompt = NSLocalizedString("duckai.suggestion.course-worth.prompt", value: "Based on this page, is this course worth taking?", comment: "Suggested prompt submitted text: is a course worth taking")
 
-    public static let aiChatSuggestionFaqAnswerLabel = NotLocalizedString("duckai.suggestion.faq-answer.label", value: "What does this answer?", comment: "Suggested prompt chip: what an FAQ page answers")
-    public static let aiChatSuggestionFaqAnswerPrompt = NotLocalizedString("duckai.suggestion.faq-answer.prompt", value: "What are the main questions this page answers?", comment: "Suggested prompt submitted text: what an FAQ page answers")
+    public static let aiChatSuggestionFaqAnswerLabel = NSLocalizedString("duckai.suggestion.faq-answer.label", value: "What does this answer?", comment: "Suggested prompt chip: what an FAQ page answers")
+    public static let aiChatSuggestionFaqAnswerPrompt = NSLocalizedString("duckai.suggestion.faq-answer.prompt", value: "What are the main questions this page answers?", comment: "Suggested prompt submitted text: what an FAQ page answers")
 
-    public static let aiChatSuggestionFaqSummaryLabel = NotLocalizedString("duckai.suggestion.faq-summary.label", value: "Summarize the Q&As", comment: "Suggested prompt chip: summarize FAQ Q&As")
-    public static let aiChatSuggestionFaqSummaryPrompt = NotLocalizedString("duckai.suggestion.faq-summary.prompt", value: "Summarize the questions and answers on this page.", comment: "Suggested prompt submitted text: summarize FAQ Q&As")
+    public static let aiChatSuggestionFaqSummaryLabel = NSLocalizedString("duckai.suggestion.faq-summary.label", value: "Summarize the Q&As", comment: "Suggested prompt chip: summarize FAQ Q&As")
+    public static let aiChatSuggestionFaqSummaryPrompt = NSLocalizedString("duckai.suggestion.faq-summary.prompt", value: "Summarize the questions and answers on this page.", comment: "Suggested prompt submitted text: summarize FAQ Q&As")
 
-    public static let aiChatSuggestionReviewVerdictLabel = NotLocalizedString("duckai.suggestion.review-verdict.label", value: "What's the verdict?", comment: "Suggested prompt chip: review verdict")
-    public static let aiChatSuggestionReviewVerdictPrompt = NotLocalizedString("duckai.suggestion.review-verdict.prompt", value: "What is the overall verdict and rating for this?", comment: "Suggested prompt submitted text: review verdict")
+    public static let aiChatSuggestionReviewVerdictLabel = NSLocalizedString("duckai.suggestion.review-verdict.label", value: "What's the verdict?", comment: "Suggested prompt chip: review verdict")
+    public static let aiChatSuggestionReviewVerdictPrompt = NSLocalizedString("duckai.suggestion.review-verdict.prompt", value: "What is the overall verdict and rating for this?", comment: "Suggested prompt submitted text: review verdict")
 
-    public static let aiChatSuggestionReviewSummaryLabel = NotLocalizedString("duckai.suggestion.review-summary.label", value: "Sum up the reviews", comment: "Suggested prompt chip: summarize reviews")
-    public static let aiChatSuggestionReviewSummaryPrompt = NotLocalizedString("duckai.suggestion.review-summary.prompt", value: "Summarize what the reviews say.", comment: "Suggested prompt submitted text: summarize reviews")
+    public static let aiChatSuggestionReviewSummaryLabel = NSLocalizedString("duckai.suggestion.review-summary.label", value: "Sum up the reviews", comment: "Suggested prompt chip: summarize reviews")
+    public static let aiChatSuggestionReviewSummaryPrompt = NSLocalizedString("duckai.suggestion.review-summary.prompt", value: "Summarize what the reviews say.", comment: "Suggested prompt submitted text: summarize reviews")
 
-    public static let aiChatSuggestionWhoIsThisLabel = NotLocalizedString("duckai.suggestion.who-is-this.label", value: "Who is this person?", comment: "Suggested prompt chip: person background")
-    public static let aiChatSuggestionWhoIsThisPrompt = NotLocalizedString("duckai.suggestion.who-is-this.prompt", value: "Give me a quick background on this person.", comment: "Suggested prompt submitted text: person background")
+    public static let aiChatSuggestionWhoIsThisLabel = NSLocalizedString("duckai.suggestion.who-is-this.label", value: "Who is this person?", comment: "Suggested prompt chip: person background")
+    public static let aiChatSuggestionWhoIsThisPrompt = NSLocalizedString("duckai.suggestion.who-is-this.prompt", value: "Give me a quick background on this person.", comment: "Suggested prompt submitted text: person background")
 
-    public static let aiChatSuggestionPersonBackgroundLabel = NotLocalizedString("duckai.suggestion.person-background.label", value: "Summarize their background", comment: "Suggested prompt chip: summarize a person's background")
-    public static let aiChatSuggestionPersonBackgroundPrompt = NotLocalizedString("duckai.suggestion.person-background.prompt", value: "Summarize the background and notable work of this person.", comment: "Suggested prompt submitted text: summarize a person's background")
+    public static let aiChatSuggestionPersonBackgroundLabel = NSLocalizedString("duckai.suggestion.person-background.label", value: "Summarize their background", comment: "Suggested prompt chip: summarize a person's background")
+    public static let aiChatSuggestionPersonBackgroundPrompt = NSLocalizedString("duckai.suggestion.person-background.prompt", value: "Summarize the background and notable work of this person.", comment: "Suggested prompt submitted text: summarize a person's background")
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionsMatcher.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionsMatcher.swift
@@ -152,9 +152,17 @@ struct ContextualSuggestionsMatcher {
         }
     }
 
+    /// Localized copy carries `%@` (the loc-pipeline placeholder format); the bundled catalog keeps
+    /// the FE's `{language}` token so it stays byte-comparable with the FE catalog. Both guards must
+    /// stay `contains`-based so copy without a placeholder never goes through `String(format:)`.
     private static func applyTemplate(_ prompt: String, input: ResolvePageSuggestionsInput) -> String {
-        guard prompt.contains("{language}") else { return prompt }
-        return prompt.replacingOccurrences(of: "{language}", with: languageDisplayName(input.uiLocale))
+        if prompt.contains("{language}") {
+            return prompt.replacingOccurrences(of: "{language}", with: languageDisplayName(input.uiLocale))
+        }
+        if prompt.contains("%@") {
+            return String(format: prompt, languageDisplayName(input.uiLocale))
+        }
+        return prompt
     }
 
     // MARK: Localization

--- a/iOS/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/bg.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Говорете с Duck.ai чрез Сири!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Актьорски състав и екип";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Кои са основните актьори и екипът и с какво друго са известни?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Какви са контрааргументите?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Кои са основните контрааргументи или критики към това?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Какво ще науча?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Кои са основните неща, които ще науча от този курс?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Струва ли си да бъде завършен?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Въз основа на тази страница, струва ли си този курс?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Напиши мотивационно писмо";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Напиши мотивационно писмо за тази работа.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Кои са основните подробности?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Обобщи основните подробности за това събитие.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Обясни най-горния отговор";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Обясни приетия отговор с прости думи.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Обясни тази статия";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Обясни тази научна статия на достъпен език.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Обясни това хранилище";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Обясни какво прави това хранилище и как да се използва.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Обясни това по-просто";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Обясни това на прост и ясен език.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Отговор на какъв въпрос е това?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "На какви основни въпроси отговаря тази страница?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Обобщи въпросите и отговорите";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Обобщи въпросите и отговорите на тази страница.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Намери ми алтернативи";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Предложи алтернативи на този продукт.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Какво ще ми трябва?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Изброй инструментите, материалите или предпоставките, които са ми необходими за това.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Преведи ме през стъпките";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Раздели това на отделни ясни и номерирани стъпки.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Помогни ми да се подготвя за интервюто";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Какви въпроси могат да бъдат зададени за тази роля?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Какви са основните изводи?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Какви са основните изводи от тази статия?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Какво да поръчам?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Кои са ястията, които задължително трябва да опитам тук?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Кои са основните приноси?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Какви са основните приноси на тази статия?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Обобщи биографията";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Обобщи биографията и значимите постижения на това лице.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Какво е работното време и местоположението?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Какво е работното време, местоположението и данните за контакт на това място?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Това място добро ли е?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Това място добро ли е? Обобщи репутацията му въз основа на отзиви и оценки.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Какви са плюсовете и минусите?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Какви са плюсовете и минусите на този продукт?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Изчисли хранителната стойност";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Изчисли хранителната стойност на тази рецепта.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Предложи сродни статии за преглед";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Предложи сродни статии или теми, които си струва да бъдат разгледани след това.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Обобщи рецензиите";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Обобщи мненията в отзивите.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Каква е крайната оценка?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Какво е общото мнение и оценка за това?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Промени порциите";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Пренапиши тази рецепта за различен брой порции.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Генерирай списък за пазаруване";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Създай списък за пазаруване с количествата от тази рецепта.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Препоръчай подобни книги";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Препоръчай подобни книги.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Препоръчай подобни заглавия";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Препоръчай подобни филми или предавания.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Обобщи тази книга";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Обобщи тази книга.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Обобщи тази страница";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Обобщи тази страница.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Обобщи тази дискусия";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Обобщи тази тема във форума.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Обобщи това видео";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Обобщи това видео.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Адаптирай автобиографията ми";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Помогни ми да адаптирам автобиографията си за тази работа.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Преведи тази страница";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Преведи тази страница на %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Кои са основните моменти?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Кои са основните моменти, разгледани в това видео?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Кой е този човек?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Дай ми кратка информация за този човек.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Струва ли си да се гледа?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Струва ли си да се гледа? Дай ми мнение без спойлери.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Всички чатове са %@ поверителни";
 

--- a/iOS/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/cs.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Povídej si s Duck.ai přes Siri.";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Obsazení a štáb";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Kdo tvoří hlavní obsazení a štáb a čím dalším jsou známí?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Jaké jsou protiargumenty?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Jaké jsou proti tomu hlavní protiargumenty nebo kritika?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Co se dozvím?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Co jsou ty hlavní věci, které se v tomto kurzu dozvím?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Stojí to za to?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Stojí tento kurz podle této stránky za to?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Napiš motivační dopis";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Napiš motivační dopis pro tuto pracovní pozici.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Jaké jsou klíčové podrobnosti?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Shrň mi hlavní fakta o téhle události.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Vysvětlit nejlepší odpověď";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Vysvětli přijatou odpověď jednoduchými slovy.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Vysvětli tento článek";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Vysvětli tento vědecký článek jednoduše.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Vysvětli tento repozitář";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Vysvětli, co tento repozitář dělá a jak ho používat.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Vysvětli to jednoduše";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Vysvětli to jednoduše a srozumitelně.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Na co to odpovídá?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Na jaké hlavní otázky tato stránka odpovídá?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Shrň mi otázky a odpovědi";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Shrň mi otázky a odpovědi na této stránce.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Najdi mi alternativy";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Navrhni nějaké alternativy k tomuto produktu.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Co budu potřebovat?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Vypiš nástroje, materiály nebo předpoklady, které k tomu potřebuješ.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Proveď mě jednotlivými kroky";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Rozděl to na jasné, očíslované kroky.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Pomoz mi s přípravou na pohovor";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Jaké otázky mohou být pro tuto roli položeny u pohovoru?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Jaké jsou hlavní poznatky?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Jaké jsou hlavní body tohoto článku?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Co si mám objednat?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Jaká jídla tady musím ochutnat?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Jaké jsou hlavní přínosy?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Jaké jsou hlavní přínosy tohoto článku?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Shrň mi základní informace";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Shrň mi základní informace a významná díla této osoby.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Jaká je otevírací doba a poloha?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Jaká je otevírací doba, poloha a kontaktní údaje tohoto místa?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Stojí to tady za něco?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Stojí to tady za něco? Shrň pověst podniku na základě recenzí a hodnocení.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Jaké jsou výhody a nevýhody?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Jaké jsou výhody a nevýhody tohoto produktu?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Odhadni nutriční hodnoty";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Odhadni nutriční informace pro tento recept.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Navrhni související články k prozkoumání";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Navrhni související články nebo témata, která stojí za to prozkoumat.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Shrň mi recenze";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Shrň mi, co říkají recenze.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Jaký je verdikt?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Jaké je pro to celkové hodnocení a známka?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Uprav porce";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Přepiš tento recept pro jiný počet porcí.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Vytvoř nákupní seznam";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Vytvoř nákupní seznam s množstvími z tohoto receptu.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Doporuč mi podobné knihy";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Doporuč mi podobné knihy.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Doporuč mi podobné tituly";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Doporuč mi podobné filmy nebo pořady.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Shrň mi tuhle knihu";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Shrň mi tuhle knihu.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Shrň mi tuhle stránku";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Shrň mi tuhle stránku.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Shrň mi tuhle diskuzi";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Shrň mi tohle diskuzní vlákno.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Shrň mi tohle video";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Shrň mi tohle video.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Uprav můj životopis";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Pomoz mi upravit můj životopis pro tuto pracovní pozici.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Přelož tuto stránku";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Přelož tuto stránku do jazyka %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Jaké jsou hlavní body?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Jaké jsou hlavní body tohoto videa?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Kdo je tato osoba?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Řekni mi stručně něco o této osobě.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Stojí to za zhlédnutí?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Stojí to za zhlédnutí? Řekni mi tvůj názor bez spoilerů.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Všechny chaty jsou %@ soukromé";
 

--- a/iOS/DuckDuckGo/da.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/da.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Tal med Duck.ai ved hjælp af Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Rollebesætning og filmhold";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Hvem er de vigtigste skuespillere og filmfolk, og hvad er de ellers kendt for?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Hvad er modargumenterne?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Hvad er de vigtigste modargumenter eller kritikpunkter af dette?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Hvad vil jeg lære?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Hvad er de vigtigste ting, jeg vil lære på dette kursus?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Er det værd at tage?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Er dette kursus værd at tage på baggrund af denne side?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Skriv en ansøgning";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Lav et udkast til en ansøgning til dette job.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Hvad er de vigtigste detaljer?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Sammenfat de vigtigste detaljer om denne begivenhed.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Forklar det øverste svar";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Forklar det accepterede svar i simple termer.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Forklar denne artikel";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Forklar denne forskningsartikel i et letforståeligt sprog.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Forklar dette repo";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Forklar, hvad dette kodelager gør, og hvordan du bruger det.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Forklar dette enkelt";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Forklar dette i et enkelt og letforståeligt sprog.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Hvad svarer dette på?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Hvad er de vigtigste spørgsmål, denne side besvarer?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Sammenfat spørgsmål og svar";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Sammenfat spørgsmålene og svarene på denne side.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Find alternativer til mig";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Foreslå nogle alternativer til dette produkt.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Hvad skal jeg bruge?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Angiv de værktøjer, materialer eller forudsætninger, jeg har brug for til dette.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Gennemgå trinnene med mig";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Opdel dette i klare, nummererede trin.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Hjælp mig med at forberede mig til jobsamtalen";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Hvilke spørgsmål kan blive stillet under jobsamtalen til denne stilling?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Hvad er de vigtigste pointer?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Hvad er de vigtigste pointer fra denne artikel?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Hvad skal jeg bestille?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Hvilke retter bør man prøve her?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Hvad er de vigtigste bidrag?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Hvad er de vigtigste bidrag fra denne artikel?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Sammenfat personens baggrund";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Sammenfat denne persons baggrund og bemærkelsesværdige arbejde.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Hvad er åbningstiderne og placeringen?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Hvad er åbningstiderne, placeringen og kontaktoplysningerne for dette sted?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Er det her sted godt?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Er det her sted godt? Sammenfat dets omdømme baseret på anmeldelser og vurderinger.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Hvad er fordelene og ulemperne?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Hvad er fordelene og ulemperne ved dette produkt?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Vurder ernæringen";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Vurder næringsindholdet for denne opskrift.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Foreslå relaterede artikler at udforske";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Foreslå relaterede artikler eller emner, der er værd at udforske som det næste.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Sammenfat anmeldelserne";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Sammenfat hvad anmeldelserne siger.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Hvad er dommen?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Hvad er den samlede vurdering og bedømmelse af dette?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Tilpas portionerne";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Omskriv denne opskrift, så den passer til et andet antal portioner.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Generér en indkøbsliste";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Opret en indkøbsliste med mængder fra denne opskrift.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Anbefal lignende bøger";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Anbefal lignende bøger.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Anbefal lignende titler";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Anbefal lignende film eller serier.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Sammenfat denne bog";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Sammenfat denne bog.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Sammenfat denne side";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Sammenfat denne side.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Sammenfat denne diskussion";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Sammenfat denne diskussionstråd.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Sammenfat denne video";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Sammenfat denne video.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Tilpas mit CV";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Hjælp mig med at tilpasse mit CV til dette job.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Oversæt denne side";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Oversæt denne side til %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Hvad er de vigtigste pointer?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Hvad er hovedpunkterne i denne video?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Hvem er denne person?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Giv mig en hurtig oversigt om denne persons baggrund.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Er dette værd at se?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Er dette værd at se? Giv mig en vurdering uden spoilere.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Alle chats er %@ private";
 

--- a/iOS/DuckDuckGo/de.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/de.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Sprich mit Duck.ai mithilfe von Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Besetzung & Crew";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Wer gehört zur Hauptbesetzung und zum Stab, und wofür sind sie sonst noch bekannt?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Was sind die Gegenargumente?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Was sind die wichtigsten Gegenargumente oder Kritikpunkte dazu?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Was werde ich lernen?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Was sind die wichtigsten Dinge, die ich in diesem Kurs lernen werde?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Lohnt es sich, daran teilzunehmen?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Lohnt es sich, basierend auf dieser Seite, diesen Kurs zu belegen?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Schreibe ein Anschreiben";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Schreibe ein Anschreiben für diesen Job.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Was sind die wichtigsten Details?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Fasse die wichtigsten Details dieses Ereignisses zusammen.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Erkläre die oberste Antwort";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Erkläre die akzeptierte Antwort in einfachen Worten.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Erkläre diese Arbeit";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Erkläre dieses Forschungspapier in einfachen Worten.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Erkläre dieses Repo";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Erkläre, was dieses Repository tut und wie man es verwendet.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Erkläre das einfach";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Erkläre das in einfachen, klaren Worten.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Was beantwortet das?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Welche Hauptfragen beantwortet diese Seite?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Q&As zusammenfassen";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Die Fragen und Antworten auf dieser Seite zusammenfassen.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Finde mir Alternativen";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Schlage einige Alternativen zu diesem Produkt vor.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Was brauche ich?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Ich benötige eine Liste der Werkzeuge, Materialien oder Voraussetzungen, die ich dafür brauche.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Führe mich durch die Schritte";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Unterteile dies in klare, nummerierte Schritte.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Hilf mir, mich auf das Vorstellungsgespräch vorzubereiten";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Welche Fragen könnten bei diesem Vorstellungsgespräch für diese Rolle aufkommen?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Was sind die wichtigsten Erkenntnisse?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Was sind die wichtigsten Erkenntnisse aus diesem Artikel?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Was soll ich bestellen?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Was muss man hier unbedingt probieren?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Was sind die wichtigsten Beiträge?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Was sind die wichtigsten Beiträge dieses Artikels?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Hintergrund zusammenfassen";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Fasse den Hintergrund und die bemerkenswerte Arbeit dieser Person zusammen.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Wie sind die Öffnungszeiten & der Standort?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Wie sind die Öffnungszeiten, der Standort und die Kontaktdaten dieses Ortes?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Ist dieser Ort gut?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Ist dieser Ort gut? Fasse den Ruf basierend auf Bewertungen und Rezensionen zusammen.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Was sind die Vor- und Nachteile?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Was sind die Vor- und Nachteile dieses Produkts?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Ernährung schätzen";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Schätze die Nährwertinformationen für dieses Rezept.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Schlage verwandte Artikel zum Erkunden vor";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Schlage verwandte Artikel oder Themen vor, die als Nächstes interessant sein könnten.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Fasse die Rezensionen zusammen";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Fasse zusammen, was in den Bewertungen steht.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Wie lautet das Fazit?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Wie lauten das Gesamturteil und die Bewertung hierfür?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Portionen anpassen";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Schreibe dieses Rezept für eine andere Anzahl an Portionen um.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Erstelle eine Einkaufsliste";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Erstelle eine Einkaufsliste mit Mengen aus diesem Rezept.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Ähnliche Bücher empfehlen";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Empfiehl ähnliche Bücher.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Ähnliche Titel empfehlen";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Ähnliche Filme oder Serien empfehlen.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Dieses Buch zusammenfassen";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Fasse dieses Buch zusammen.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Diese Seite zusammenfassen";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Diese Seite zusammenfassen.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Diese Diskussion zusammenfassen";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Fasse diesen Diskussionsfaden zusammen.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Dieses Video zusammenfassen";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Dieses Video zusammenfassen.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Passe meinen Lebenslauf an";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Hilf mir, meinen Lebenslauf für diesen Job anzupassen.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Diese Seite übersetzen";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Diese Seite in %@ übersetzen.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Was sind die wichtigsten Punkte?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Was sind die wichtigsten Punkte, die in diesem Video behandelt werden?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Wer ist diese Person?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Gib mir einen kurzen Hintergrund zu dieser Person.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Lohnt es sich, das anzuschauen?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Lohnt es sich, das anzuschauen? Gib mir eine spoilerfreie Einschätzung.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Alle Chats sind %@ privat";
 

--- a/iOS/DuckDuckGo/el.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/el.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Συνομιλήστε με το Duck.ai χρησιμοποιώντας το Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Ηθοποιοί και συντελεστές";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Ποιοι είναι οι βασικοί ηθοποιοί και οι συντελεστές, και για τι άλλο είναι γνωστοί;";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Ποια είναι τα αντεπιχειρήματα;";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Ποια είναι τα κύρια αντεπιχειρήματα ή οι επικρίσεις γι' αυτό;";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Τι θα μάθω;";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Ποια είναι τα βασικά πράγματα που θα μάθω από αυτή τη σειρά μαθημάτων;";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Αξίζει να την παρακολουθήσω;";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Με βάση αυτήν τη σελίδα, αξίζει να παρακολουθήσω αυτήν τη σειρά μαθημάτων;";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Σύνταξε μια συνοδευτική επιστολή";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Σύνταξε μια συνοδευτική επιστολή γι' αυτήν την εργασία.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Ποιες είναι οι βασικές λεπτομέρειες;";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Συνόψισε τις βασικές λεπτομέρειες αυτού του γεγονότος.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Εξήγησε την κορυφαία απάντηση";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Εξήγησε την αποδεκτή απάντηση με απλά λόγια.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Εξήγησε αυτή την εργασία";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Εξήγησε αυτή την ερευνητική εργασία με απλά λόγια.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Εξήγησε αυτό το αποθετήριο";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Εξήγησε τι κάνει αυτό το αποθετήριο και πώς χρησιμοποιείται.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Εξήγησέ το αυτό απλά";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Εξήγησέ το αυτό με απλά, κατανοητά λόγια.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Σε τι απαντά αυτό;";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Ποιες είναι οι κύριες ερωτήσεις που απαντά αυτή η σελίδα;";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Συνόψισε τις ερωταπαντήσεις";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Συνόψισε τις ερωτήσεις και τις απαντήσεις σε αυτήν τη σελίδα.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Βρες μου εναλλακτικές λύσεις";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Πρότεινε μερικές εναλλακτικές γι' αυτό το προϊόν.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Τι θα χρειαστώ;";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Απαρίθμησε εργαλεία, υλικά ή προϋποθέσεις που χρειάζομαι γι' αυτό.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Καθοδήγησέ με στα βήματα";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Χώρισέ το σε σαφή, αριθμημένα βήματα.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Βοήθησέ με να προετοιμαστώ για τη συνέντευξη";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Ποιες ερωτήσεις συνέντευξης μπορεί να προκύψουν για αυτόν τον ρόλο;";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Ποια είναι τα βασικά σημεία;";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Ποια είναι τα βασικά σημεία αυτού του άρθρου;";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Τι να παραγγείλω;";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Ποια πιάτα πρέπει οπωσδήποτε να δοκιμάσω εδώ;";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Ποιες είναι οι βασικές συνεισφορές;";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Ποιες είναι οι βασικές συνεισφορές αυτής της εργασίας;";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Συνόψισε το ιστορικό τους";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Συνόψισε το ιστορικό αυτού του ατόμου και το σημαντικό του έργο.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Ποιες είναι οι ώρες και η τοποθεσία;";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Ποιες είναι οι ώρες λειτουργίας, η τοποθεσία και τα στοιχεία επικοινωνίας γι' αυτό το μέρος;";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Είναι καλό αυτό το μέρος;";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Είναι καλό αυτό το μέρος; Συνόψισε τη φήμη του με βάση κριτικές και αξιολογήσεις.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Ποια είναι τα πλεονεκτήματα και τα μειονεκτήματα;";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Ποια είναι τα πλεονεκτήματα και τα μειονεκτήματα αυτού του προϊόντος;";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Υπολόγισε τη διατροφή";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Υπολόγισε τις διατροφικές πληροφορίες γι' αυτήν τη συνταγή.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Πρότεινε σχετικά άρθρα για εξερεύνηση";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Πρότεινε σχετικά άρθρα ή θέματα που αξίζουν εξερεύνηση στη συνέχεια.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Συνόψισε τις κριτικές";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Συνόψισε τι λένε οι κριτικές.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Ποιο είναι η ετυμηγορία;";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Ποια είναι η συνολική ετυμηγορία και η βαθμολογία γι' αυτό;";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Προσάρμοσε τις μερίδες";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Ξαναγράψε αυτή τη συνταγή προσαρμοσμένη για διαφορετικό αριθμό μερίδων.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Δημιούργησε μια λίστα αγορών";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Δημιούργησε μια λίστα αγορών με τις ποσότητες από αυτήν τη συνταγή.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Πρότεινε παρόμοια βιβλία";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Πρότεινε παρόμοια βιβλία.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Πρότεινε παρόμοιους τίτλους";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Πρότεινε παρόμοιες ταινίες ή εκπομπές.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Συνόψισε αυτό το βιβλίο";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Συνόψισε αυτό το βιβλίο.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Συνόψισε αυτήν τη σελίδα";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Συνόψισε αυτήν τη σελίδα.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Συνόψισε αυτήν τη συζήτηση";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Συνόψισε αυτό το νήμα συζήτησης.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Συνόψισε αυτό το βίντεο";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Συνόψισε αυτό το βίντεο.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Προσάρμοσε το βιογραφικό μου";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Βοήθησέ με να προσαρμόσω το βιογραφικό μου γι' αυτήν τη θέση εργασίας.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Μετάφρασε αυτή τη σελίδα";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Μετάφρασε αυτή τη σελίδα στα %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Ποια είναι τα βασικά σημεία;";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Ποια είναι τα βασικά σημεία που καλύπτονται σε αυτό το βίντεο;";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Ποιο είναι αυτό το άτομο;";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Δώσε μου ένα σύντομο ιστορικό γι' αυτό το άτομο.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Αξίζει να το παρακολουθήσω;";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Αξίζει να το παρακολουθήσω; Δώσε μου μια ιδέα χωρίς spoiler.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Όλες οι συνομιλίες είναι %@ ιδιωτικές";
 

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -1873,6 +1873,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Talk with Duck.ai using Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Cast & Crew";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Who are the main cast and crew, and what else are they known for?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "What are the counterarguments?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "What are the main counterarguments or criticisms of this?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "What will I learn?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "What are the key things I will learn from this course?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Is it worth taking?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Based on this page, is this course worth taking?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Draft a cover letter";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Draft a cover letter for this job.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "What are the key details?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Summarize the key details of this event.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Explain the top answer";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Explain the accepted answer in simple terms.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Explain this paper";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Explain this research paper in plain language.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Explain this repo";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Explain what this repository does and how to use it.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Explain this simply";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Explain this in simple, plain language.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "What does this answer?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "What are the main questions this page answers?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Summarize the Q&As";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Summarize the questions and answers on this page.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Find me alternatives";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Suggest some alternatives to this product.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "What will I need?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "List the tools, materials, or prerequisites I need for this.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Walk me through the steps";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Break this down into clear, numbered steps.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Help me prep for the interview";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "What interview questions might come up for this role?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "What are the key takeaways?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "What are the key takeaways from this article?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "What should I order?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "What are the must-try dishes here?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "What are the key contributions?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "What are the key contributions of this paper?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Summarize their background";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Summarize the background and notable work of this person.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "What are the hours & location?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "What are the opening hours, location, and contact details for this place?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Is this place any good?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Is this place any good? Summarize its reputation based on reviews and ratings.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "What are the pros and cons?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "What are the pros and cons of this product?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Estimate the nutrition";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Estimate the nutritional information for this recipe.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Suggest related articles to explore";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Suggest related articles or topics worth exploring next.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Sum up the reviews";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Summarize what the reviews say.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "What's the verdict?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "What is the overall verdict and rating for this?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Adjust the servings";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Rewrite this recipe scaled for a different number of servings.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Generate a shopping list";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Create a shopping list with quantities from this recipe.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Recommend similar books";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Recommend similar books.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Recommend similar titles";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Recommend similar movies or shows.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Summarize this book";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Summarize this book.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Summarize this page";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Summarize this page.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Summarize this discussion";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Summarize this discussion thread.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Summarize this video";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Summarize this video.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Tailor my resume";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Help me tailor my resume for this job.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Translate this page";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Translate this page into %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "What are the key points?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "What are the key points covered in this video?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Who is this person?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Give me a quick background on this person.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Is this worth watching?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Is this worth watching? Give me a spoiler-free take.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "All chats are %@ private";
 

--- a/iOS/DuckDuckGo/es.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/es.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "¡Habla con Duck.ai usando Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Reparto y equipo";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "¿Quiénes son los principales miembros del reparto y del equipo, y por qué más se los conoce?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "¿Cuáles son los argumentos en contra?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "¿Cuáles son los principales argumentos en contra o críticas a esto?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "¿Qué aprenderé?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "¿Cuáles son las enseñanzas clave que aprenderé en este curso?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "¿Merece la pena hacerlo?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Según esta página, ¿merece la pena hacer este curso?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Redacta una carta de presentación";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Redacta una carta de presentación para este trabajo.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "¿Cuáles son los detalles clave?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Resume los detalles clave de este evento.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Explica la respuesta principal";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Explica la respuesta aceptada en términos sencillos.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Explica este artículo";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Explica este artículo de investigación en lenguaje sencillo.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Explica este repositorio";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Explica qué hace este repositorio y cómo utilizarlo.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Explica esto de forma sencilla";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Explica esto con un lenguaje sencillo y claro.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "¿A qué responde esto?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "¿Cuáles son las preguntas principales que responde esta página?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Resume las preguntas y respuestas";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Resume las preguntas y respuestas de esta página.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Búscame alternativas";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Sugiere algunas alternativas a este producto.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "¿Qué necesitaré?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Enumera las herramientas, los materiales o los requisitos previos que necesito para esto.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Explícame paso a paso cómo hacerlo";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Divide esto en pasos claros y numerados.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Ayúdame a prepararme para la entrevista";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "¿Qué preguntas de entrevista podrían surgir para esta posición?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "¿Cuáles son los puntos clave?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "¿Cuáles son los puntos clave de este artículo?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "¿Qué debo pedir?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "¿Cuáles son los platos imprescindibles aquí?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "¿Cuáles son las contribuciones clave?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "¿Cuáles son las contribuciones clave de este artículo?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Resume sus antecedentes";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Resume la trayectoria y el trabajo notable de esta persona.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "¿Cuáles son el horario y la ubicación?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "¿Cuáles son el horario de apertura, la ubicación y los datos de contacto de este lugar?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "¿Es bueno este sitio?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "¿Es bueno este sitio? Resume su reputación basándote en las reseñas y valoraciones.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "¿Cuáles son los pros y los contras?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "¿Cuáles son los pros y los contras de este producto?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Estima la nutrición";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Estima la información nutricional de esta receta.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Sugiere artículos relacionados para explorar";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Sugiere artículos o temas relacionados que valga la pena explorar a continuación.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Resume las reseñas";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Resume lo que dicen las opiniones.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "¿Cuál es el veredicto?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "¿Cuál es el veredicto y la calificación general de esto?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Ajusta las porciones";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Reescribe esta receta ajustándola para un número diferente de raciones.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Genera una lista de la compra";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Crea una lista de la compra con las cantidades de esta receta.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Recomienda libros similares";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Recomienda libros similares.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Recomienda títulos similares";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Recomienda películas o programas similares.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Resume este libro";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Resume este libro.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Resume esta página";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Resumir esta página.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Resume este debate";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Resume este hilo de discusión.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Resume este vídeo";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Resume este vídeo.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Adapta mi currículum";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Ayúdame a adaptar mi currículum para este trabajo.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Traducir esta página";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Traduce esta página al %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "¿Cuáles son los puntos clave?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "¿Cuáles son los puntos clave que se tratan en este vídeo?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "¿Quién es esta persona?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Dame un resumen rápido sobre esta persona.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "¿Merece la pena verlo?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "¿Merece la pena verlo? Dame una opinión sin spoilers.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Todos los chats son %@ privados";
 

--- a/iOS/DuckDuckGo/et.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/et.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Vestle Duck.ai-ga Siri abil!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Osatäitjad ja võttemeeskond";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Kes on peamised näitlejad ja võttegrupi liikmed ning mille poolest neid veel teatakse?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Millised on vastuväited?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Millised on selle peamised vastuväited või kriitika?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Mida ma õpin?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Millised on peamised asjad, mida ma sellest kursusest õpin?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Kas sellest tasub osa võtta?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Kas see kursus on selle lehe põhjal läbimist väärt?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Koosta kaaskiri";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Koosta selle töö jaoks kaaskiri.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Millised on peamised üksikasjad?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Tee selle sündmuse põhiandmetest kokkuvõte.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Selgita esimest vastust";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Selgita aktsepteeritud vastust lihtsate sõnadega.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Selgita seda artiklit";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Selgita seda uurimistööd lihtsas keeles.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Selgita seda repo't";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Selgita, mida see repositoorium teeb ja kuidas seda kasutada.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Selgita seda lihtsalt";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Selgita seda lihtsalt ja arusaadavalt.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Millele see vastab?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Millistele peamistele küsimustele see leht vastab?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Tee küsimustest ja vastustest kokkuvõte";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Tee selle lehe küsimustest ja vastustest kokkuvõte.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Leia mulle alternatiive";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Soovita sellele tootele alternatiive.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Mida mul vaja läheb?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Loetle tööriistad, materjalid või eeltingimused, mida ma selleks vajan.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Juhenda mind samm-sammult";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Jaota see selgeteks nummerdatud sammudeks.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Aita mul intervjuuks valmistuda";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Millised töövestluse küsimused võivad selle rolli puhul ette tulla?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Millised on peamised järeldused?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Millised on selle artikli peamised järeldused?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Mida peaksin tellima?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Milliseid roogi peab siin kindlasti proovima?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Millised on peamised panused?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Millised on selle artikli peamised panused?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Tee nende taustast kokkuvõte";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Tee kokkuvõte selle isiku taustast ja tähelepanuväärsest tööst.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Millised on lahtiolekuajad ja asukoht?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Millised on selle koha lahtiolekuajad, asukoht ja kontaktandmed?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Kas see koht on üldse hea?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Kas see koht on üldse hea? Tee kokkuvõte selle mainest arvustuste ja hinnangute põhjal.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Millised on plussid ja miinused?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Millised on selle toote plussid ja miinused?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Hinda toiteväärtust";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Hinda selle retsepti toiteväärtust.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Soovita seotud artikleid, mida uurida";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Soovita seotud artikleid või teemasid, mida tasub järgmisena uurida.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Võta arvustused kokku";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Võta kokku, mida arvustused ütlevad.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Mis on otsus?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Milline on selle üldine hinnang ja reiting?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Kohanda portsjonid";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Kirjuta see retsept ümber, kohandades seda teistsugusele portsjonite arvule.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Loo ostunimekiri";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Loo selle retsepti põhjal kogustega ostunimekiri.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Soovita sarnaseid raamatuid";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Soovita sarnaseid raamatuid.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Soovita sarnaseid teoseid";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Soovita sarnaseid filme või sarju.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Tee sellest raamatu kokkuvõte";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Tee sellest raamatust kokkuvõte.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Tee selle lehekülje kokkuvõte";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Tee selle lehekülje kokkuvõte.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Tee arutelust kokkuvõte";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Tee sellest aruteluteemast kokkuvõte.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Tee sellest videost kokkuvõte";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Tee sellest videost kokkuvõte.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Kohanda minu CV-d";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Aita mul kohandada oma CV selle töökoha jaoks.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Tõlgi see leht";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Tõlgi see leht %@ keelde.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Millised on põhipunktid?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Millised on selle video peamised punktid?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Kes see inimene on?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Anna mulle selle isiku kohta lühike ülevaade.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Kas seda tasub vaadata?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Kas seda tasub vaadata? Anna mulle ülevaade ilma sisu avaldamata.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Kõik vestlused on %@ privaatsed";
 

--- a/iOS/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fi.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Keskustele Duck.ai:n kanssa Sirin avulla!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Näyttelijät ja työryhmä";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Keitä ovat pääosan esittäjät ja tekijät, ja mistä muusta heidät tunnetaan?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Mitkä ovat vasta-argumentit?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Mitkä ovat tämän tärkeimmät vastaväitteet tai kritiikin aiheet?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Mitä opin?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Mitkä ovat tärkeimmät asiat, jotka opin tällä kurssilla?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Kannattaako se suorittaa?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Kannattaako tämä kurssi suorittaa tämän sivun perusteella?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Kirjoita saatekirje";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Kirjoita työhakemus tähän työpaikkaan.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Mitkä ovat tärkeimmät yksityiskohdat?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Tee yhteenveto tämän tapahtuman keskeisistä yksityiskohdista.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Selitä parhaiten arvioitu vastaus";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Selitä hyväksytty vastaus yksinkertaisin termein.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Selitä tämä artikkeli";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Selitä tämä tutkimusartikkeli selkokielellä.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Selitä tämä säilö";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Selitä, mitä tämä arkisto tekee ja miten sitä käytetään.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Selitä tämä yksinkertaisesti";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Selitä tämä yksinkertaisella ja selkeällä kielellä.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Mihin tämä vastaa?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Mihin pääkysymyksiin tämä sivu vastaa?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Tee yhteenveto kysymyksistä ja vastauksista";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Tee yhteenveto tämän sivun kysymyksistä ja vastauksista.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Etsi minulle vaihtoehtoja";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Ehdota vaihtoehtoja tälle tuotteelle.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Mitä tarvitsen?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Listaa työkalut, materiaalit tai esivaatimukset, joita tarvitsen tätä varten.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Opasta minua vaihe vaiheelta";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Jaa tämä selkeisiin, numeroituihin vaiheisiin.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Auta minua valmistautumaan haastatteluun";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Mitä haastattelukysymyksiä tässä roolissa voi tulla vastaan?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Mitkä ovat keskeiset opit?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Mitkä ovat tämän artikkelin keskeiset opit?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Mitä minun pitäisi tilata?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Mitä täällä kannattaa maistaa?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Mitkä ovat tärkeimmät tulokset?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Mitkä ovat tämän artikkelin tärkeimmät tulokset?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Tee yhteenveto heidän taustastaan";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Tee yhteenveto tämän henkilön taustasta ja merkittävistä töistä.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Mitkä ovat aukioloajat ja sijainti?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Mitkä ovat tämän paikan aukioloajat, sijainti ja yhteystiedot?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Onko tämä paikka hyvä?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Onko tämä paikka hyvä? Tee yhteenveto sen maineesta arvostelujen ja luokitusten perusteella.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Mitkä ovat hyvät ja huonot puolet?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Mitkä ovat tämän tuotteen hyvät ja huonot puolet?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Arvioi ravitsemus";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Arvioi tämän reseptin ravintosisältö.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Ehdota aiheeseen liittyviä artikkeleita tutkittavaksi";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Ehdota seuraavaksi tutustumisen arvoisia aiheeseen liittyviä artikkeleita tai aiheita.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Tee yhteenveto arvosteluista";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Tee yhteenveto siitä, mitä arvosteluissa sanotaan.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Mikä on lopputulos?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Mikä on tämän yleisarvio ja arvosana?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Säädä annosten määrää";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Muokkaa tätä reseptiä eri annosmäärälle.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Luo ostoslista";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Luo ostoslista ja määrät tästä reseptistä.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Suosittele samankaltaisia kirjoja";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Suosittele samankaltaisia kirjoja.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Suosittele samankaltaisia otsikoita";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Suosittele samankaltaisia elokuvia tai sarjoja.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Tee yhteenveto tästä kirjasta";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Tee yhteenveto tästä kirjasta.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Tee yhteenveto tästä sivusta";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Tee yhteenveto tästä sivusta.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Tee yhteenveto tästä keskustelusta";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Tee yhteenveto tästä keskusteluketjusta.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Tee yhteenveto tästä videosta";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Tee yhteenveto tästä videosta.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Räätälöi ansioluetteloni";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Auta minua muokkaamaan ansioluetteloni tähän työpaikkaan sopivaksi.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Käännä tämä sivu";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Käännä tämä sivu kielelle %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Mitkä ovat tärkeimmät kohdat?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Mitkä ovat tämän videon keskeiset kohdat?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Kuka tämä henkilö on?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Kerro minulle lyhyesti tämän henkilön taustat.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Kannattaako tämä katsoa?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Kannattaako tämä katsoa? Anna minulle spoilerivapaa arvio.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Kaikki keskustelut ovat %@ yksityisiä";
 

--- a/iOS/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fr.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Parlez avec Duck.ai en utilisant Siri !";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Casting et équipe";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Qui sont les acteurs principaux et l'équipe, et pour quoi d'autre sont-ils connus ?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Quels sont les contre-arguments ?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Quels sont les principaux contre-arguments ou critiques à ce sujet ?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Que vais-je apprendre ?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Quelles sont les principales choses que ce cours va m'apprendre ?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Est-ce que ça vaut le coup de le suivre ?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "D'après cette page, est-ce que ce cours vaut la peine d'être suivi ?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Rédiger une lettre de motivation";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Rédige une lettre de motivation pour ce poste.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Quels sont les détails clés ?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Résume les détails clés de cet événement.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Expliquer la réponse principale";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Explique la réponse acceptée en termes simples.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Expliquer cet article";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Explique cet article de recherche en termes simples.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Explique ce référentiel";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Explique ce que fait ce référentiel et comment l'utiliser.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Expliquer cela simplement";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Explique ça en termes simples et clairs.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "À quoi cela répond-il ?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Quelles sont les principales questions auxquelles cette page répond ?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Résumer les questions et réponses";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Résume les questions et réponses sur cette page.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Trouve-moi des alternatives";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Suggère quelques alternatives à ce produit.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "De quoi aurai-je besoin ?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Liste les outils, le matériel ou les prérequis dont j'ai besoin pour cela.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "M'expliquer les étapes";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Décompose cela en étapes claires et numérotées.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Aide-moi à me préparer pour l'entretien";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Quelles questions pourraient être posées lors de l'entretien pour ce poste ?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Quels sont les points clés ?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Quels sont les points clés de cet article ?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Que dois-je commander ?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Quels sont les plats incontournables ici ?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Quelles sont les contributions clés ?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Quelles sont les contributions clés de cet article ?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Résumer son parcours";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Résume le parcours et les travaux notables de cette personne.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Quels sont les horaires et la situation géographique ?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Quels sont les horaires d'ouverture, la situation géographique et les coordonnées de cet endroit ?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Cet endroit est-il bien ?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Cet endroit est-il bien ? Résume sa réputation en te basant sur les avis et les notes.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Quels sont les avantages et les inconvénients ?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Quels sont les avantages et les inconvénients de ce produit ?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Estimer la nutrition";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Estime les informations nutritionnelles de cette recette.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Suggérer des articles connexes à explorer";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Suggère des articles ou des sujets connexes qui valent la peine d'être explorés ensuite.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Résumer les avis";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Résume ce que disent les avis.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Quel est le verdict ?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Quel est le verdict global et la note pour ceci ?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Ajuster les portions";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Réécris cette recette pour l'adapter à un nombre de portions différent.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Générer une liste de courses";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Crée une liste de courses avec les quantités de cette recette.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Recommander des livres similaires";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Recommande des livres similaires.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Recommander des titres similaires";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Recommande des films ou des séries similaires.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Résumer ce livre";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Résume ce livre.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Résumer cette page";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Résume cette page.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Résumer cette discussion";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Résume ce fil de discussion.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Résumer cette vidéo";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Résume cette vidéo.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Personnaliser mon CV";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Aide-moi à adapter mon CV pour ce poste.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Traduire cette page";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Traduis cette page en %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Quels sont les points clés ?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Quels sont les points clés abordés dans cette vidéo ?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Qui est cette personne ?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Donne-moi un bref aperçu de cette personne.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Ça vaut le coup de regarder ?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Ça vaut le coup de regarder ? Donne-moi un avis sans spoiler.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Toutes les discussions sont %@ privées";
 

--- a/iOS/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hr.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Razgovaraj s Duck.ai koristeći Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Glumačka postava i ekipa";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Tko su glavni glumci i članovi ekipe i po čemu su još poznati?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Koji su protuargumenti?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Koji su glavni protuargumenti ili kritike navedenog?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Što ću naučiti?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Koje su ključne stvari koje ću naučiti iz ovog tečaja?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Isplati li se pohađati?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Na temelju ove stranice, isplati li se pohađati ovaj tečaj?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Izradi popratno pismo";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Izradi popratno pismo za ovaj posao.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Koji su ključni detalji?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Sažmi ključne pojedinosti ovog događaja.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Objasni glavni odgovor";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Objasni prihvaćeni odgovor jednostavnim riječima.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Objasni ovaj rad";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Objasni ovaj istraživački rad jednostavnim jezikom.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Objasni ovaj repozitorij";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Objasni što ovaj repozitorij radi i kako ga koristiti.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Objasni ovo na jednostavan način";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Objasni ovo jednostavnim, jasnim jezikom.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Na što ovo odgovara?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Na koja glavna pitanja ova stranica odgovara?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Sažmi pitanja i odgovore";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Sažmi pitanja i odgovore na ovoj stranici.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Pronađi mi druge mogućnosti";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Predloži neke druge mogućnosti za ovaj proizvod.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Što će mi trebati?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Navedi alate, materijale ili preduvjete koji su mi potrebni za ovo.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Provedi me kroz korake";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Raščlani to u jasne, numerirane korake.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Pomozi mi pripremiti se za intervju";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Koja bi se pitanja za intervju mogla pojaviti za ovu poziciju?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Koji su ključni zaključci?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Koje su ključne pouke iz ovog članka?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Što da naručim?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Koja jela ovdje svakako moram probati?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Koji su ključni doprinosi?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Koji su glavni doprinosi ovog rada?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Sažmi njihovu pozadinu";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Sažmi pozadinu i značajan rad ove osobe.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Koje je radno vrijeme i lokacija?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Koje je radno vrijeme, lokacija i kontakt podaci za ovo mjesto?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Je li ovo mjesto dobro?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Je li ovo mjesto dobro? Sažmi njegovu reputaciju na temelju recenzija i ocjena.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Koje su prednosti i mane?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Koje su prednosti i mane ovog proizvoda?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Procijeni prehranu";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Procijeni nutritivne vrijednosti ovog recepta.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Predloži povezane članke za istraživanje";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Predloži povezane članke ili teme koje vrijedi istražiti sljedeće.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Sažmi recenzije";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Sažmi što kažu recenzije.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Kakav je zaključak?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Kakav je ukupni dojam i ocjena za ovo?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Prilagodi porcije";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Prepiši ovaj recept prilagođen za drugačiji broj porcija.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Generiraj popis za kupnju";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Izradi popis za kupnju s količinama iz ovog recepta.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Preporuči slične knjige";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Preporuči slične knjige.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Preporuči slične naslove";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Preporuči slične filmove ili TV emisije.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Sažmi ovu knjigu";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Sažmi ovu knjigu.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Sažmi ovu stranicu";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Sažmi ovu stranicu.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Sažmi ovu raspravu";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Sažmi ovu raspravu.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Sažmi ovaj video";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Sažmi ovaj video.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Prilagodi moj životopis";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Pomozi mi prilagoditi životopis za ovaj posao.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Prevedi ovu stranicu";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Prevedi ovu stranicu na %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Koje su ključne točke?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Koje su ključne točke obrađene u ovom videozapisu?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Tko je ova osoba?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Daj mi kratke informacije o ovoj osobi.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Isplati li se ovo gledati?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Isplati li se ovo gledati? Daj mi mišljenje bez spoilera.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Sva čavrljanja su %@ privatna";
 

--- a/iOS/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hu.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Beszélgess a Duck.ai-jal a Siri segítségével!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Szereplők és alkotók";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Kik a legfontosabb szereplők és alkotók, és miről ismertek még?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Mik az ellenérvek?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Mik a fő ellenérvek vagy kritikák ezzel kapcsolatban?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Mit fogok megtanulni?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Mik azok a legfontosabb dolgok, amiket megtanulok ezen a kurzuson?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Érdemes elvégezni?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Az oldalon szereplő információk alapján érdemes elvégezni ezt a tanfolyamot?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Motivációs levél írása";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Írj egy motivációs levelet ehhez az álláshoz.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Mik a legfontosabb részletek?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Foglald össze az esemény legfontosabb részleteit.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Legjobb válasz magyarázata";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Magyarázd el egyszerűen az elfogadott választ.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Tanulmány magyarázata";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Magyarázd el ezt a kutatási tanulmányt közérthetően.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Kódtár magyarázata";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Magyarázd el, mire szolgál ez a kódtár, és hogyan használható.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Magyarázd el egyszerűen";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Magyarázd el ezt egyszerű, közérthető nyelven.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Mire ad ez választ?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Melyek a fő kérdések, amelyekre választ ad ez az oldal?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Kérdések és válaszok összefoglalása";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Foglald össze az oldalon szereplő kérdéseket és válaszokat.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Mutass alternatívákat";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Ajánlj néhány alternatívát ehhez a termékhez.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Mire lesz szükségem?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Sorold fel, milyen eszközökre, anyagokra vagy előfeltételekre van szükségem ehhez.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Vezess végig a lépéseken";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Bontsd le ezt világos, számozott lépésekre.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Segíts felkészülni az interjúra";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Milyen interjúkérdések merülhetnek fel ennél a munkakörnél?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Melyek a legfontosabb tanulságok?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Mik a cikk legfontosabb tanulságai?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Mit rendeljek?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Melyek a kihagyhatatlan ételek itt?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Mik a főbb eredmények?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Mik a tanulmány főbb eredményei?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Háttér összefoglalása";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Foglald össze ennek a személynek a hátterét és jelentősebb munkáit.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Mi a nyitvatartás és a cím?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Milyen a hely nyitvatartása, hol található, és mik az elérhetőségei?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Jó ez a hely?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Jó ez a hely? Foglald össze a megítélését az értékelések és a vélemények alapján.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Mik az előnyök és a hátrányok?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Milyen előnyei és hátrányai vannak ennek a terméknek?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Tápérték becslése";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Becsüld meg ennek a receptnek a tápértékadatait.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Kapcsolódó cikkek javaslata";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Javasolj kapcsolódó cikkeket vagy témákat, amelyeket érdemes lenne ezután megnézni.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Értékelések összefoglalása";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Foglald össze, mit mondanak az értékelések.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Mi a végső vélemény?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Mi az általános vélemény és értékelés erről?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Adagok módosítása";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Írd át ezt a receptet más adagszámra méretezve.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Bevásárlólista generálása";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Készíts a receptből egy bevásárlólistát, amelyen a mennyiségek is szerepelnek.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Hasonló könyvek ajánlása";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Ajánlj hasonló könyveket.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Hasonló tartalmak ajánlása";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Ajánlj hasonló filmeket vagy sorozatokat.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Könyv összefoglalása";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Foglald össze ezt a könyvet.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Oldal összefoglalása";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Foglald össze ezt az oldalt.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Beszélgetés összefoglalása";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Foglald össze ezt a beszélgetési szálat.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Videó összefoglalása";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Foglald össze ezt a videót.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Önéletrajz igazítása";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Segíts hozzáigazítani az önéletrajzomat ehhez az álláshoz.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Oldal lefordítása";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Fordítsd le ezt az oldalt %@ nyelvre.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Mik a legfontosabb pontok?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Melyek a videóban érintett legfontosabb pontok?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Ki ez a személy?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Adj egy rövid áttekintést erről a személyről.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Érdemes megnézni?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Érdemes megnézni? Mondj egy spoilermentes véleményt.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Minden csevegés %@ privát";
 

--- a/iOS/DuckDuckGo/it.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/it.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Interagisci con Duck.ai usando Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Cast e troupe";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Chi sono i principali membri del cast e della troupe e per cos'altro sono conosciuti?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Quali sono le contro-argomentazioni?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Quali sono le principali obiezioni o critiche a questo?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Cosa imparerò?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Cosa imparerò in particolare in questo corso?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Vale la pena acquistarlo?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "In base a questa pagina, vale la pena seguire questo corso?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Scrivi una lettera di presentazione";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Scrivi una lettera di presentazione per questo lavoro.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Quali sono i dettagli principali?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Riassumi i dettagli principali di questo evento.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Spiega la risposta principale";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Spiega la risposta accettata in termini semplici.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Spiega questo documento";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Spiega questo articolo di ricerca in un linguaggio semplice.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Spiega questo repository";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Spiega a cosa serve questo repository e come utilizzarlo.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Spiegalo in modo semplice";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Spiega questo concetto in modo semplice e chiaro.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "A cosa risponde questo?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Quali sono le domande principali a cui risponde questa pagina?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Riassumi le domande e risposte";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Riassumi le domande e le risposte presenti in questa pagina.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Trova alternative";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Suggerisci alcune alternative a questo prodotto.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Cosa mi serve?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Elenca gli strumenti, i materiali o i prerequisiti che mi servono per questo.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Guidami nei passaggi";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Suddividilo in passaggi chiari e numerati.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Aiutami a prepararmi per il colloquio";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Quali domande di colloquio potrebbero emergere per questo ruolo?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Quali sono i punti chiave?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Quali sono i punti chiave di questo articolo?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Cosa dovrei ordinare?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Quali sono i piatti da provare in questo caso?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Quali sono i contributi chiave?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Quali sono i contributi chiave di questo documento?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Riassumi il suo profilo";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Riassumi il background e il lavoro più rilevante di questa persona.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Quali sono gli orari e la posizione?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Quali sono gli orari di apertura, la posizione e i recapiti di questo luogo?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Com'è questo posto?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Com'è questo posto? Riassumi la sua reputazione in base a recensioni e valutazioni.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Quali sono i pro e i contro?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Quali sono i pro e i contro di questo prodotto?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Stima i valori nutrizionali";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Stima le informazioni nutrizionali per questa ricetta.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Suggerisci articoli correlati da esplorare";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Suggerisci articoli o argomenti correlati da esplorare in seguito.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Riassumi le recensioni";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Riassumi le opinioni nelle recensioni.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Qual è il verdetto?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Qual è il verdetto generale e la valutazione per questo?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Regola le porzioni";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Riscrivi questa ricetta adattandola a un numero diverso di porzioni.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Genera una lista della spesa";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Crea una lista della spesa con le quantità di questa ricetta.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Consiglia libri simili";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Consiglia libri simili.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Consiglia titoli simili";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Consiglia film o programmi simili.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Riassumi questo libro";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Riassumi questo libro.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Riassumi questa pagina";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Riassumi questa pagina.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Riassumi questa discussione";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Riassumi questa discussione.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Riassumi questo video";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Riassumi questo video.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Personalizza il mio curriculum";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Aiutami ad adattare il mio curriculum per questo lavoro.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Traduci questa pagina";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Traduci questa pagina in %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Quali sono i punti chiave?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Quali sono i punti chiave trattati in questo video?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Chi è questa persona?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Dammi alcune informazioni su questa persona.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Vale la pena guardarlo?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Vale la pena guardarlo? Dammi un parere senza spoiler.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Tutte le chat sono %@ private";
 

--- a/iOS/DuckDuckGo/ja.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ja.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Siriを使ってDuck.aiと話そう！";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "キャスト & スタッフ";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "主なキャストとスタッフは誰で、ほかにどのような作品で知られていますか？";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "反論にはどのようなものがありますか？";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "この主張に対して主にどのような反論や批判がありますか？";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "何を学びますか？";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "この講座で学ぶ主なトピックは何ですか？";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "取得する価値はありますか？";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "このページの内容から判断して、この講座を受講する価値はありますか？";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "カバーレターの下書きを作成";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "この求人のカバーレターの下書きを作成してください。";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "主な内容は何ですか？";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "このイベントの主な情報を要約してください。";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "最上位の回答を説明";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "採用された回答を単純な用語で説明してください。";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "この論文について説明";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "この研究論文を平易な言葉で説明してください。";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "このリポジトリについて説明";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "このリポジトリの機能と使用方法を説明してください。";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "この内容を分かりやすく説明";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "わかりやすく、平易な言葉で説明してください。";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "これは何に対する回答ですか？";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "このページでは主にどのような質問の回答が得られますか？";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Q&Aを要約";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "このページの質問と回答を要約してください。";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "他のオプションを探す";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "この製品の他のオプションを提案してください。";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "何が必要ですか？";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "必要な道具、材料、または準備を列挙してください。";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "手順を順番に説明";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "明確な番号付きのステップに分けてください。";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "面接準備を手伝う";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "この職務の面接ではどのような質問が想定されますか？";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "要点は何ですか？";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "この記事の要点は何ですか？";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "何を注文すればよいですか？";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "ここで絶対試すべき料理は何ですか？";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "主な貢献は何ですか？";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "この論文の主な貢献は何ですか？";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "経歴を要約";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "この人物の経歴と主な業績を要約してください。";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "営業時間と場所は？";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "この場所の営業時間、場所、連絡先を教えてください。";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "この場所はおすすめですか？";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "この場所はおすすめですか？レビューと評価に基づいて評判を要約してください。";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "どのような長所と短所がありますか？";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "この製品の長所と短所は何ですか？";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "栄養価を推定";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "このレシピの栄養情報を推定してください。";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "関連記事を提案";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "次に読んだ方がよい関連記事やトピックを提案してください。";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "レビューを要約";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "レビューの内容を要約してください。";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "最終評価は？";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "総合的な評価とスコアは？";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "サービング数を調整";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "このレシピを別の人数分で書き直してください。";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "買い物リストを作成";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "このレシピの買い物リストを分量入りで作成してください。";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "類似の書籍を推薦";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "類似の書籍を推薦してください。";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "類似の作品を推薦";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "類似の映画や番組を推薦してください。";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "この本を要約";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "この本を要約してください。";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "このページを要約";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "このページを要約してください。";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "このディスカッションを要約";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "このディスカッションスレッドを要約してください。";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "この動画を要約";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "この動画を要約してください。";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "履歴書をアレンジ";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "この求人向けに履歴書をアレンジするのを手伝ってください。";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "このページを翻訳";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "このページを%@に翻訳してください。";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "要点は何ですか？";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "この動画の要点は何ですか？";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "この人は誰ですか？";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "この人物の簡単な経歴を教えてください。";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "この作品は見る価値がありますか？";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "この作品は見る価値がありますか？ネタバレなしで感想を教えてください。";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "すべてのチャットは%@非公開です";
 

--- a/iOS/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lt.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Kalbėkite su „Duck.ai“ naudodami „Siri“!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Aktoriai ir kūrybinė grupė";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Kas sudaro pagrindinę aktorių ir kūrybinę grupę ir kuo jie dar žinomi?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Kokie kontrargumentai?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Kokie pagrindiniai to kontrargumentai ar kritika?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Ko išmoksiu?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Kokie pagrindiniai dalykai, kurių išmoksiu šiame kurse?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Ar verta rinktis?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Sprendžiant iš šio puslapio, ar verta rinktis šį kursą?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Parenk motyvacinį laišką";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Parenk motyvacinį laišką šioms pareigoms.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Kokia yra svarbiausia informacija?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Apibendrink svarbiausią informaciją apie šį įvykį.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Paaiškink viršutinį atsakymą";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Paprastais žodžiais paaiškink priimtą atsakymą.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Paaiškink šį mokslinį darbą";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Paaiškink šį mokslinį darbą paprasta kalba.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Paaiškink šią saugyklą";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Paaiškink, kam skirta ši saugykla ir kaip ja naudotis.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Paaiškink tai paprastai";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Paaiškink tai paprasta, suprantama kalba.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Į ką tai atsako?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Į kokius pagrindinius klausimus atsako šis puslapis?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Apibendrink klausimus ir atsakymus";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Apibendrink šiame puslapyje esančius klausimus ir atsakymus.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Rask alternatyvų";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Pasiūlyk kelias šio produkto alternatyvas.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Ko prireiks?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Išvardyk įrankius, medžiagas ar išankstines sąlygas, kurių tam prireiks.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Paaiškink man žingsnius";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Išskaidyk tai į aiškius, sunumeruotus žingsnius.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Padėk pasiruošti darbo pokalbiui";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Kokių darbo pokalbio klausimų galima sulaukti pretenduojant į šias pareigas?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Kokie pagrindiniai akcentai?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Kokie pagrindiniai šio straipsnio akcentai?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Ką užsisakyti?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Kokių patiekalų čia būtina paragauti?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Koks pagrindinis indėlis?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Koks pagrindinis šio mokslinio darbo indėlis?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Apibendrink šio asmens biografiją";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Apibendrink šio asmens biografiją ir svarbiausius darbus.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Koks darbo laikas ir vieta?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Koks šios vietos darbo laikas, adresas ir kontaktiniai duomenys?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Ar ši vieta verta dėmesio?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Ar ši vieta verta dėmesio? Apibendrink reputaciją pagal atsiliepimus ir įvertinimus.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Kokie privalumai ir trūkumai?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Kokie šio produkto privalumai ir trūkumai?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Įvertink maistinę vertę";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Įvertink šio recepto maistinės vertės informaciją.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Pasiūlyk susijusių straipsnių, kuriais verta pasidomėti";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Pasiūlyk susijusių straipsnių ar temų, kuriomis verta pasidomėti toliau.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Apibendrink atsiliepimus";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Apibendrink, kas rašoma atsiliepimuose.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Kokia išvada?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Kokia bendra išvada ir įvertinimas?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Pakeisk porcijų kiekį";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Pritaikyk šį receptą kitam porcijų kiekiui.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Sudaryk pirkinių sąrašą";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Pagal šį receptą sudaryk pirkinių sąrašą su kiekiais.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Rekomenduok panašių knygų";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Rekomenduok panašių knygų.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Rekomenduok panašių kūrinių";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Rekomenduok panašių filmų ar laidų.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Pateik šios knygos santrauką";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Pateik šios knygos santrauką.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Pateik šio puslapio santrauką";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Pateik šio puslapio santrauką.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Pateik šios diskusijos santrauką";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Pateik šios diskusijos gijos santrauką.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Pateik šio vaizdo įrašo santrauką";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Pateik šio vaizdo įrašo santrauką.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Pritaikyk mano gyvenimo aprašymą";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Padėk pritaikyti mano gyvenimo aprašymą šioms pareigoms.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Išversk šį puslapį";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Išversk šį puslapį į %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Kokios svarbiausios mintys?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Kokios svarbiausios mintys pateikiamos šiame vaizdo įraše?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Kas yra šis asmuo?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Pateik trumpą informaciją apie šį asmenį.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Ar verta žiūrėti?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Ar verta žiūrėti? Aprašyk neatskleisdamas siužeto.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Visi pokalbiai – %@ privatūs";
 

--- a/iOS/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lv.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Sazinies ar Duck.ai, izmantojot Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Lomu atveidotāji un veidotāji";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Kas ir galvenie aktieri un filmēšanas grupa, un ar ko vēl viņi ir pazīstami?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Kādi ir pretargumenti?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Kādi ir galvenie pretargumenti vai kritika?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Ko es uzzināšu?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Kādas ir galvenās lietas, ko es apgūšu šajā kursā?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Vai ir vērts to apgūt?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Vai, spriežot pēc šīs lapas, šo kursu ir vērts apgūt?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Sagatavo pieteikuma vēstuli";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Sagatavo pieteikuma vēstuli šai vakancei.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Kāda ir svarīgākā informācija?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Apkopo svarīgāko informāciju par šo notikumu.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Izskaidro labāko atbildi";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Izskaidro pieņemtāko atbildi vienkāršā valodā.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Izskaidro šo rakstu";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Izskaidro šo pētniecisko darbu vienkāršā valodā.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Izskaidro šo repozitoriju";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Paskaidro, ko šis repozitorijs dara un kā to izmantot.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Izskaidro to vienkārši";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Paskaidro to vienkāršā, saprotamā valodā.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Kādu atbildi tas sniedz?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Uz kādiem galvenajiem jautājumiem šī lapa sniedz atbildes?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Apkopo jautājumus un atbildes";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Apkopo jautājumus un atbildes šajā lapā.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Atrodi man alternatīvas";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Iesaki dažas alternatīvas šai precei.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Kas man būs nepieciešams?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Uzskaiti rīkus, materiālus vai priekšnosacījumus, kas man tam ir nepieciešami.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Paskaidro man soli pa solim";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Sadali to skaidros, numurētos soļos.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Palīdzi man sagatavoties intervijai";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Kādi intervijas jautājumi varētu tikt uzdoti par šo vakanci?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Kādi ir galvenie secinājumi?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Kādi ir galvenie šī raksta secinājumi?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Ko man pasūtīt?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Kādus ēdienus šeit noteikti ir vērts nogaršot?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Kas ir galvenie autori?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Kādi ir šī raksta galvenie autori?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Apkopo informāciju par tiem";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Apkopo šī cilvēka biogrāfiju un ievērojamākos darbus.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Kāds ir darba laiks un atrašanās vieta?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Kāds ir šīs vietas darba laiks, atrašanās vieta un kontaktinformācija?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Vai šī vieta ir laba?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Vai šī vieta ir laba? Apkopo tās reputāciju, pamatojoties uz atsauksmēm un vērtējumiem.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Kādi ir plusi un mīnusi?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Kādi ir šī produkta plusi un mīnusi?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Aprēķini uzturvērtību";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Aprēķini šīs receptes uzturvērtību.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Iesaki saistītus rakstus, ko apskatīt";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Iesaki saistītus rakstus vai tēmas, ko vērts izpētīt tālāk.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Apkopo atsauksmes";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Apkopo atsauksmēs teikto.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Kāds ir vērtējums?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Kāds ir kopējais viedoklis un vērtējums par šo?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Pielāgo porciju skaitu";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Pārraksti šo recepti, pielāgojot to citam porciju skaitam.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Ģenerē iepirkumu sarakstu";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Izveido iepirkumu sarakstu ar šai receptei atbilstošiem daudzumiem.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Iesaki līdzīgas grāmatas";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Iesaki līdzīgas grāmatas.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Iesaki līdzīgus darbus";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Iesaki līdzīgas filmas vai seriālus.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Apkopo šo grāmatu";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Apkopo šo grāmatu.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Apkopot šo lapu";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Apkopo šo lapu.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Apkopot šo diskusiju";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Apkopo šo diskusiju pavedienu.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Apkopo šo video";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Apkopo šo video.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Pielāgo manu CV";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Palīdzi man pielāgot savu CV šai vakancei.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Tulkot šo lapu";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Tulko šo lapu – %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Kādi ir galvenie punkti?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Kādi ir galvenie punkti, kas apskatīti šajā video?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Kas ir šis cilvēks?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Sniedz man īsu informāciju par šo cilvēku.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Vai to ir vērts skatīties?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Vai to ir vērts skatīties? Sniedz man pārskatu, neatklājot sižeta pavērsienus.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Visas tērzēšanas sarunas ir %@ privātas";
 

--- a/iOS/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nb.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Snakk med Duck.ai ved hjelp av Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Rollebesetning og stab";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Hvem utgjør hovedrollelisten og produksjonsteamet, og hva mer er de kjent for?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Hva er motargumentene?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Hva er hovedargumentene eller -kritikken mot dette?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Hva kommer jeg til å lære?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Hva er det viktigste jeg kommer til å lære i dette kurset?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Er dette verdt å ta?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Er dette kurset verdt å ta, basert på denne siden?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Skriv et følgebrev";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Skriv et følgebrev for denne stillingen.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Hva er de viktigste detaljene?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Oppsummer de viktigste detaljene i denne begivenheten.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Forklar det øverste svaret";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Forklar det godtatte svaret i enkle ord.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Forklar denne artikkelen";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Forklar denne forskningsartikkelen på en forståelig måte.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Forklar dette repositoriet";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Forklar hva dette repositoriet gjør og hvordan man bruker det.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Forklar dette enkelt";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Forklar dette på en enkel og forståelig måte.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Hva gir dette et svar på?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Hvilke hovedspørsmål svarer denne siden på?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Oppsummer spørsmålene og svarene";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Oppsummer spørsmålene og svarene på denne siden.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Finn alternativer";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Foreslå noen alternativer til dette produktet.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Hva trenger jeg?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Si hvilke verktøy, materialer eller forutsetninger jeg trenger til dette.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Forklar meg fremgangsmåten";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Del dette opp i tydelige, nummererte trinn.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Hjelp meg å forberede meg til intervjuet";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Hvilke intervjuspørsmål kan jeg bli stilt for denne stillingen?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Hva er hovedpunktene?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Hva er hovedpunktene i denne artikkelen?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Hva bør jeg bestille?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Hvilke retter bør jeg prøve her?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Hva er de viktigste bidragene?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Hva er de viktigste bidragene i denne artikkelen?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Oppsummer denne personens bakgrunn";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Oppsummer denne personens bakgrunn og viktigste arbeid.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Når er åpningstidene, og hvor er det?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Når er åpningstidene for dette stedet, hvor ligger det, og hva er kontaktinformasjonen?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Er dette stedet bra?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Er dette stedet bra? Oppsummer stedets omdømme basert på anmeldelser og vurderinger.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Hva er fordelene og ulempene?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Hva er fordelene og ulempene med dette produktet?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Beregn næringsinnholdet";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Beregn næringsinnholdet i denne oppskriften.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Foreslå relaterte artikler jeg kan utforske";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Foreslå relaterte artikler eller emner det er verdt å utforske videre.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Oppsummer anmeldelsene";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Oppsummer det som står i anmeldelsene.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Hva er konklusjonen?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Hva er konklusjonen og den samlede vurderingen av dette?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Juster porsjonene";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Tilpass denne oppskriften til et annet antall porsjoner.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Lag en handleliste";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Skriv en handleliste med mengder basert på denne oppskriften.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Anbefal lignende bøker";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Anbefal lignende bøker.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Anbefal lignende titler";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Anbefal lignende filmer eller serier.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Oppsummer denne boken";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Oppsummer denne boken.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Oppsummer denne siden";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Oppsummer denne siden.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Oppsummer denne diskusjonen";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Oppsummer denne diskusjonstråden.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Oppsummer denne videoen";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Oppsummer denne videoen.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Skreddersy CV-en min";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Hjelp meg å tilpasse CV-en min til denne stillingen.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Oversett denne siden";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Oversett denne siden til %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Hva er de viktigste detaljene?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Hvilke hovedpunkter dekker denne videoen?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Hvem er denne personen?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Gi meg litt bakgrunnsinformasjon om denne personen.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Er dette verdt å se på?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Er dette verdt å se på? Gi meg en vurdering uten spoilere.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Alle chatter er %@ private";
 

--- a/iOS/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nl.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Praat met Duck.ai met behulp van Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Cast en crew";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Wie zijn de belangrijkste leden in de cast en crew, en waar staan ze nog meer om bekend?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Wat zijn de tegenargumenten?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Wat zijn de belangrijkste tegenargumenten of kritiekpunten hierop?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Wat ga ik leren?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Wat zijn de belangrijkste dingen die ik in deze cursus kan leren?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Is het de moeite waard?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Is deze cursus aan de hand van deze pagina de moeite waard?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Een sollicitatiebrief opstellen";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Stel een sollicitatiebrief op voor deze baan.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Wat zijn de belangrijkste details?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Vat de belangrijkste details van dit evenement samen.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Geef uitleg voor het beste antwoord";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Leg het geaccepteerde antwoord in eenvoudige bewoordingen uit.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Dit artikel nader uitleggen";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Leg dit onderzoeksartikel uit in eenvoudige taal.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Leg deze repo uit";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Leg uit wat deze repository doet en hoe je deze gebruikt.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Leg dit eenvoudig uit";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Leg dit uit in eenvoudige, gewone taal.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Welke vragen worden hier beantwoord?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Wat zijn de belangrijkste vragen die deze pagina beantwoordt?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "De Q&A's samenvatten";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Vat de vragen en antwoorden op deze pagina samen.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Alternatieven zoeken";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Stel een aantal alternatieven voor dit product voor.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Wat heb ik nodig?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Maak een lijst van het gereedschap, de materialen en andere dingen die ik hiervoor nodig heb.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Help me door de stappen";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Deel dit op in duidelijke, genummerde stappen.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Help me met de voorbereiding op het sollicitatiegesprek";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Welke sollicitatievragen kan ik voor deze vacature verwachten?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Wat zijn de belangrijkste punten?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Wat zijn de belangrijkste punten uit dit artikel?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Wat moet ik bestellen?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Wat zijn de gerechten die hier aangeraden worden?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Wat zijn de belangrijkste bijdragen?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Wat zijn de belangrijkste bijdragen van dit artikel?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Hun achtergrond samenvatten";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Geef een samenvatting van de achtergrond en het belangrijkste werk van deze persoon.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Wat zijn de openingstijden en locatie?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Wat zijn de openingstijden, locatie en contactgegevens van deze plek?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Is dit een goede plek?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Is dit een goede plek? Vat de reputatie samen op basis van beoordelingen en ratings.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Wat zijn de voor- en nadelen?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Wat zijn de voor- en nadelen van dit product?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "De voedingswaarde inschatten";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Schat de voedingsinformatie voor dit recept in.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Gerelateerde artikelen voorstellen om verder te lezen";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Stel gerelateerde artikelen of onderwerpen voor die de moeite waard zijn om verder te lezen.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "De beoordelingen samenvatten";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Vat samen wat er in de beoordelingen staat.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Wat is het oordeel?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Wat is hiervan de beoordeling en de conclusie?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Aanpassen voor een ander aantal porties";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Pas dit recept aan voor een ander aantal porties.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Een boodschappenlijst genereren";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Maak een boodschappenlijst met de juiste hoeveelheden om dit recept te maken.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Vergelijkbare boeken aanbevelen";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Beveel vergelijkbare boeken aan.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Beveel vergelijkbare titels aan";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Beveel soortgelijke films of series aan.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Dit boek samenvatten";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Vat dit boek samen.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Deze pagina samenvatten";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Deze pagina samenvatten.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Deze discussie samenvatten";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Vat deze discussiethread samen.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Deze video samenvatten";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Vat deze video samen.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Mijn cv aanpassen";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Help me mijn cv af te stemmen op deze vacature.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Vertaal deze pagina";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Vertaal deze pagina naar %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Wat zijn de belangrijkste punten?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Wat zijn de belangrijkste punten die in deze video aan bod komen?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Wie is deze persoon?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Geef me korte achtergrondinformatie over deze persoon.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Is dit de moeite waard om te bekijken?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Is dit de moeite waard? Geef me een mening zonder spoilers.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Alle chats zijn %@ privé";
 

--- a/iOS/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pl.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Porozmawiaj z Duck.ai używając Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Obsada & ekipa";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Kto należy do głównej obsady i ekipy oraz z czego jeszcze są znani?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Jakie są argumenty przeciw?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Jakie są główne kontrargumenty i zarzuty wobec tego stwierdzenia?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Czego się dowiem?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Jakie są najważniejsze rzeczy, których dowiem się z tego kursu?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Warto w nim wziąć udział?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Czy na podstawie tej strony warto wziąć udział w tym kursie?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Napisz list motywacyjny";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Napisz list motywacyjny na to stanowisko.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Jakie są najważniejsze szczegóły?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Podsumuj najważniejsze szczegóły tego wydarzenia.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Wyjaśnij najlepszą odpowiedź";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Wyjaśnij zaakceptowaną odpowiedź w prostych słowach.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Wyjaśnij ten artykuł";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Wyjaśnij ten artykuł naukowy prostym językiem.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Wyjaśnij to repozytorium";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Wyjaśnij, co robi to repozytorium i jak z niego korzystać.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Wyjaśnij to prosto";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Wyjaśnij to prostym, zrozumiałym językiem.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Na jakie pytania odpowiada ta strona?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Na jakie główne pytania odpowiada ta strona?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Podsumuj pytania i odpowiedzi";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Podsumuj pytania i odpowiedzi na tej stronie.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Znajdź alternatywy";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Zaproponuj alternatywy dla tego produktu.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Czego będę potrzebować?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Wymień narzędzia, materiały lub warunki wstępne, których do tego potrzebuję.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Przeprowadź mnie przez kolejne kroki";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Podziel to na jasne, ponumerowane kroki.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Pomóż mi przygotować się do rozmowy kwalifikacyjnej";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Jakie pytania mogą pojawić się podczas rozmowy kwalifikacyjnej na to stanowisko?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Jakie są najważniejsze wnioski?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Jakie są najważniejsze wnioski z tego artykułu?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Co powinienem zamówić?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Jakie dania warto tu zjeść?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Jakie są najważniejsze wnioski?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Jakie są najważniejsze wnioski zawarte w tym artykule?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Podsumuj doświadczenie tej osoby";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Podsumuj doświadczenie tej osoby i jej najważniejsze osiągnięcia zawodowe.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Jakie są godziny otwarcia i lokalizacja?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Jakie są godziny otwarcia, lokalizacja i dane kontaktowe tego miejsca?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Czy warto odwiedzić to miejsce?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Czy warto odwiedzić to miejsce? Podsumuj reputację tego miejsca na podstawie recenzji i ocen.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Jakie są zalety i wady?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Jakie są zalety i wady tego produktu?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Oszacuj wartość odżywczą";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Oszacuj wartość odżywczą tego przepisu.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Zaproponuj powiązane artykuły do przejrzenia";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Zaproponuj powiązane artykuły lub tematy, które warto sprawdzić w następnej kolejności.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Podsumuj recenzje";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Podsumuj, co mówią recenzje.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Jaki jest werdykt?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Jaki jest ogólny werdykt i ocena?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Dostosuj porcje";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Przepisz ten przepis z inną liczbą porcji.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Wygeneruj listę zakupów";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Przygotuj listę zakupów z ilościami potrzebnymi do tego przepisu.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Poleć podobne książki";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Poleć podobne książki.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Poleć podobne tytuły";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Poleć podobne filmy lub programy.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Podsumuj tę książkę";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Podsumuj tę książkę.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Podsumuj tę stronę";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Podsumuj tę stronę.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Podsumuj tę dyskusję";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Podsumuj ten wątek dyskusji.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Podsumuj ten film";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Podsumuj ten film.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Dopasuj moje CV";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Pomóż mi dopasować moje CV do tej oferty pracy.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Przetłumacz tę stronę";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Przetłumacz tę stronę na język %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Jakie są najważniejsze punkty?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Jakie są najważniejsze punkty omówione w tym filmie?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Kim jest ta osoba?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Podaj mi krótkie informacje o tej osobie.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Warto to obejrzeć?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Warto to obejrzeć? Opowiedz o tym bez zdradzania fabuły.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Wszystkie czaty są %@ prywatne";
 

--- a/iOS/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pt.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Usa a Siri para falar com o Duck.ai!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Elenco e equipa técnica";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Quem são os principais membros do elenco e da equipa técnica, e por que outros projetos são conhecidos?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Quais são os contra-argumentos?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Quais são os principais contra-argumentos ou críticas a isto?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "O que vou aprender?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Quais são as principais coisas que vou aprender neste curso?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Vale a pena fazer?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Com base nesta página, vale a pena fazer este curso?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Escreve uma carta de apresentação";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Escreve uma carta de apresentação para este trabalho.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Quais são os detalhes principais?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Resume os detalhes principais deste evento.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Explica a resposta principal";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Explica a resposta aceite de forma simples.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Explica este artigo";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Explica este artigo de investigação numa linguagem simples.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Explica este repositório";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Explica o que este repositório faz e como utilizá-lo.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Explica isto de forma simples";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Explica esta informação numa linguagem simples e clara.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "O que é que isto responde?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Quais são as principais perguntas que esta página responde?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Resume as perguntas e respostas";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Resume as perguntas e respostas nesta página.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Encontra alternativas";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Sugere algumas alternativas a este produto.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Do que vou precisar?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Lista as ferramentas, materiais ou pré-requisitos de que preciso para isto.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Guia-me pelos passos";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Divide isto em passos claros e numerados.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Ajuda-me a preparar-me para a entrevista";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "O que me podem perguntar na entrevista para esta função?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Quais são as principais conclusões?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Quais são as principais conclusões deste artigo?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "O que devo pedir?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Quais são os pratos que tens de experimentar aqui?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Quais são as principais contribuições?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Quais são os principais contributos deste artigo?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Resume o historial deles";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Resume o historial e o trabalho notável desta pessoa.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Quais são os horários e a localização?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Quais são os horários de funcionamento, localização e contactos deste local?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Este local é bom?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Este local é bom? Resume a reputação do local com base em comentários e classificações.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Quais são os prós e contras?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Quais são os prós e contras deste produto?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Faz uma estimativa da nutrição";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Faz uma estimativa das informações nutricionais desta receita.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Sugere artigos relacionados para explorar";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Sugere artigos ou tópicos relacionados que valha a pena explorar a seguir.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Resume os comentários";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Resume o que dizem os comentários.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Qual é o veredito?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Qual é o veredito e a classificação geral disto?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Ajusta as doses";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Reescreve esta receita ajustada para um número diferente de doses.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Gera uma lista de compras";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Cria uma lista de compras com as quantidades desta receita.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Recomenda livros semelhantes";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Recomenda livros semelhantes.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Recomenda títulos semelhantes";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Recomenda filmes ou séries semelhantes.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Resume este livro";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Resume este livro.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Resume esta página";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Resumir esta página.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Resume esta discussão";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Resume este tópico de discussão.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Resume este vídeo";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Resume este vídeo.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Personaliza o meu CV";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Ajuda-me a adaptar o meu currículo a este emprego.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Traduz esta página";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Traduz esta página para %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Quais são os pontos principais?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Quais são os pontos principais abordados neste vídeo?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Quem é esta pessoa?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Dá-me um historial rápido sobre esta pessoa.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Vale a pena ver?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Vale a pena ver? Dá-me uma opinião sem spoilers.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Todos os chats são %@ privados";
 

--- a/iOS/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ro.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Vorbește cu Duck.ai folosind Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Distribuție și echipă";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Cine sunt principalii actori și membri ai echipei de producție și pentru ce altceva mai sunt cunoscuți?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Care sunt contraargumentele?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Care sunt principalele contraargumente sau critici la adresa acestui lucru?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Ce voi învăța?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Care sunt principalele lucruri pe care le voi învăța din acest curs?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Merită să-l urmez?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Pe baza acestei pagini, merită să urmez acest curs?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Redactează o scrisoare de intenție";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Redactează o scrisoare de intenție pentru acest post.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Care sunt detaliile principale?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Rezumă principalele detalii ale acestui eveniment.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Explică răspunsul de sus";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Explică răspunsul acceptat în termeni simpli.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Explică această lucrare";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Explică această lucrare de cercetare pe înțelesul tuturor.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Explică acest depozit";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Explică ce face acest depozit și cum să-l folosești.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Explică simplu";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Explică asta pe înțelesul tuturor.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "La ce răspunde aceasta?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Care sunt principalele întrebări la care răspunde această pagină?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Rezumă întrebările și răspunsurile";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Rezumă întrebările și răspunsurile de pe această pagină.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Găsește-mi alternative";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Sugerează câteva alternative pentru acest produs.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "De ce am nevoie?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Enumeră instrumentele, materialele sau condițiile prealabile de care am nevoie pentru asta.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Ghidează-mă prin pași";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Împarte acest lucru în pași clari, numerotați.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Ajută-mă să mă pregătesc pentru interviu";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Ce întrebări din interviu ar putea apărea pentru acest post?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Care sunt ideile principale?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Care sunt principalele idei ale acestui articol?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Ce ar trebui să comand?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Care sunt preparatele pe care trebuie neapărat să le încerc aici?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Care sunt principalele contribuții?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Care sunt contribuțiile principale ale acestei lucrări?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Rezumă parcursul său";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Rezumă parcursul și activitatea notabilă a acestei persoane.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Care sunt programul și locația?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Care sunt programul de funcționare, locația și detaliile de contact pentru acest loc?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "E bun acest loc?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "E bun acest loc? Rezumă-i reputația pe baza recenziilor și a evaluărilor.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Care sunt argumentele pro și contra?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Care sunt argumentele pro și contra pentru acest produs?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Estimează nutriția";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Estimează informațiile nutriționale pentru această rețetă.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Sugerează articole conexe de explorat";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Sugerează articole sau subiecte similare care merită explorate în continuare.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Rezumă recenziile";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Rezumă ce spun recenziile.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Care e verdictul?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Care este verdictul și evaluarea generală pentru acest lucru?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Ajustează porțiile";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Rescrie această rețetă adaptată pentru un număr diferit de porții.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Generează o listă de cumpărături";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Creează o listă de cumpărături cu cantități din această rețetă.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Recomandă cărți similare";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Recomandă cărți similare.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Recomandă titluri similare";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Recomandă filme sau emisiuni similare.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Rezumă această carte";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Rezumă această carte.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Rezumă această pagină";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Rezumă această pagină.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Rezumă această discuție";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Rezumă acest fir de discuție.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Rezumă acest videoclip";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Rezumă acest videoclip.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Adaptează-mi CV-ul";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Ajută-mă să-mi adaptez CV-ul pentru acest post.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Tradu această pagină";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Tradu această pagină în %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Care sunt punctele principale?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Care sunt punctele principale acoperite în acest videoclip?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Cine este această persoană?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Dă-mi rapid câteva informații despre parcursul acestei persoane.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Merită vizionat?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Merită vizionat? Oferă-mi o părere fără spoilere.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Toate chaturile sunt %@ private";
 

--- a/iOS/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ru.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Запуск Duck.ai с помощью Siri";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Актеры и съемочная группа";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Кто входит в основной актерский состав и съемочную группу и чем еще они известны?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Какие есть контраргументы?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Каковы основные контраргументы или критические замечания по этому поводу?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Чему я научусь?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Чему я научусь на этом курсе?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Стоит попробовать?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Стоит ли проходить этот курс, судя по этой странице?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Подготовь сопроводительное письмо";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Подготовь сопроводительное письмо для этой вакансии.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Каковы основные детали?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Кратко изложи основные детали этого события.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Объясни ответ вверху";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Объясни принятый ответ простыми словами.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Объясни эту статью";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Объясни эту научную статью простым языком.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Расскажи про этот репозиторий";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Объясни, что делает этот репозиторий и как им пользоваться.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Объясни это просто";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Объясни это простым и понятным языком.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Ответы на какие вопросы здесь можно найти?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "На какие основные вопросы отвечает эта страница?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Кратко изложи вопросы и ответы";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Кратко изложи вопросы и ответы на этой странице.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Найди альтернативы";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Предложи альтернативы этому продукту.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Что мне понадобится?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Перечисли инструменты, материалы или условия, которые мне для этого понадобятся.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Поэтапно проведи меня по инструкции";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Разбей это на понятные пронумерованные шаги.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Помоги подготовиться к собеседованию";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Какие вопросы могут возникнуть на собеседовании на эту должность?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Какие основные выводы?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Какие основные выводы из этой статьи?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Что мне заказать?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Что здесь стоит попробовать?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Каковы основные положения?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Каковы основные положения этой статьи?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Кратко изложи биографию этого человека";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Расскажи вкратце об этом человеке и его известных работах.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Где находится это место и каков его график работы?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Какие здесь часы работы, адрес и контактные данные?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Это хорошее место?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Это хорошее место? Кратко изложи, какая у него репутация на основе отзывов и оценок.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "В чем плюсы и минусы?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "В чем плюсы и минусы этого продукта?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Оцени пищевую ценность";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Оцени пищевую ценность блюда по рецепту.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Предложи похожие статьи";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Предложи похожие статьи или темы, которые стоит рассмотреть далее.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Подытожь отзывы";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Обобщи, что пишут в отзывах.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Каков вердикт?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Каков общий вердикт и оценка?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Измени количество порций";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Пересчитай этот рецепт на другое количество порций.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Составь список покупок";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Создай список покупок с указанием количества ингредиентов из этого рецепта.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Посоветуй похожие книги";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Посоветуй похожие книги.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Посоветуй похожее";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Посоветуй похожие фильмы или сериалы.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Кратко изложи содержимое книги";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Кратко изложи содержимое книги.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Кратко изложи содержимое страницы";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Кратко изложи содержимое страницы.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Кратко изложи суть обсуждения";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Кратко изложи суть этой ветки обсуждения.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Кратко изложи содержимое видео";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Кратко изложи содержимое видео.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Адаптируй мое резюме";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Помоги мне адаптировать мое резюме для этой вакансии.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Переведи эту страницу";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Переведи эту страницу на %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Какие основные моменты?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Какие основные моменты освещаются в этом видео?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Кто этот человек?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Расскажи вкратце об этом человеке.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Стоит ли это смотреть?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Стоит ли это смотреть? Дай отзыв без спойлеров.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Все чаты %@ конфиденциальны";
 

--- a/iOS/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sk.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Hovor s Duck.ai pomocou Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Obsadenie a štáb";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Kto je v hlavnom hereckom obsadení a štábe, a čím ďalším sú dané osoby známe?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Aké sú protiargumenty?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Aké sú hlavné argumenty proti, alebo kritika?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Čo sa dozviem?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Aké sú hlavné veci, ktoré sa v tomto kurze naučím?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Oplatí sa to?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Oplatí sa podľa tejto stránky absolvovať tento kurz?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Napíš motivačný list";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Napíš motivačný list na túto pracovnú pozíciu.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Aké sú kľúčové informácie?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Zhrň kľúčové podrobnosti tejto udalosti.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Vysvetli najlepšiu odpoveď";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Vysvetli prijatú odpoveď jednoduchými slovami.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Vysvetli tento dokument";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Vysvetli tento výskumný článok jednoduchým jazykom.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Vysvetli tento repozitár";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Vysvetli, čo tento repozitár robí a ako ho používať.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Vysvetli to jednoducho";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Vysvetli to jednoduchou a zrozumiteľnou rečou.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Na čo táto odpoveď odpovedá?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Aké sú hlavné otázky, na ktoré táto stránka odpovedá?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Zhrň otázky a odpovede";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Zhrň otázky a odpovede na tejto stránke.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Nájdi mi alternatívy";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Navrhni nejaké alternatívy k tomuto produktu.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Čo budem potrebovať?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Vymenuj nástroje, materiály alebo predpoklady, ktoré na to potrebujem.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Preveď ma krokmi";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Rozdeľ to na jasné očíslované kroky.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Pomôž mi pripraviť sa na pohovor";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Aké otázky by mohli padnúť na pohovore na túto pozíciu?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Aké sú hlavné body?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Aké sú hlavné myšlienky tohto článku?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Čo si mám objednať?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Ktoré jedlá tu mám ochutnať?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Aké sú hlavné prínosy?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Aké sú hlavné prínosy tohto článku?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Zhrň ich pozadie";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Zhrň pozadie a významnú prácu tejto osoby.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Aké sú otváracie hodiny a poloha?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Aké sú otváracie hodiny, poloha a kontaktné údaje tohto miesta?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Je toto miesto dobré?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Je toto miesto dobré? Zhrň jeho reputáciu na základe recenzií a hodnotení.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Aké sú výhody a nevýhody?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Aké sú výhody a nevýhody tohto produktu?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Odhadni nutričné údaje";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Odhadni nutričné údaje pre tento recept.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Navrhni súvisiace články na preskúmanie";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Navrhni súvisiace články alebo témy, ktoré stoja za preskúmanie.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Zhrň recenzie";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Zhrň, čo sa spomína v recenziách.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Aký je verdikt?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Aký je pre toto celkový verdikt a hodnotenie?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Upraviť porcie";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Prepíš tento recept na iný počet porcií.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Vytvor nákupný zoznam";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Vytvor nákupný zoznam s množstvami z tohto receptu.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Odporuč podobné knihy";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Odporuč podobné knihy.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Odporuč podobné tituly";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Odporuč podobné filmy alebo relácie.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Zhrň túto knihu";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Zhrň túto knihu.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Zhrň túto stránku";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Zhrň túto stránku.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Zhrň túto diskusiu";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Zhrň toto diskusné vlákno.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Zhrň toto video";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Zhrň toto video.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Prispôsob môj životopis";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Pomôž mi prispôsobiť môj životopis pre túto pracovnú pozíciu.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Prelož túto stránku";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Prelož túto stránku do jazyka %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Aké sú hlavné body?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Aké sú hlavné body tohto videa?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Kto je táto osoba?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Poskytni mi stručné informácie o tejto osobe.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Oplatí sa to pozrieť?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Oplatí sa to pozrieť? Povedz mi o tom bez prezradenia výsledkov deja.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Všetky chaty sú %@ súkromné";
 

--- a/iOS/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sl.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Pogovarjajte se z Duck.ai s pomočjo Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Igralska zasedba in ekipa";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Kdo so glavni igralci in člani ekipe ter po čem so še znani?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Kateri so protiargumenti?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Kateri so glavni protiargumenti ali kritike tega?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Kaj se bom naučil/-a?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Katere so ključne stvari, ki se jih bom naučil/-a v tem tečaju?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Se splača udeležiti?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Glede na to stran se ta tečaj splača opraviti?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Pripravi spremno pismo";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Pripravi spremno pismo za to delovno mesto.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Katere so ključne podrobnosti?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Povzemi ključne podrobnosti tega dogodka.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Razloži najboljši odgovor";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Razloži sprejeti odgovor s preprostimi besedami.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Razloži mi ta članek";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Razloži ta raziskovalni članek v preprostem jeziku.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Razloži mi ta repozitorij";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Pojasni, kaj počne ta repozitorij in kako ga uporabljati.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Razloži preprosto";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Razloži to s preprostim, razumljivim jezikom.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Na kaj to odgovarja?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Na katera glavna vprašanja odgovarja ta stran?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Povzemi vprašanja in odgovore";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Povzemi vprašanja in odgovore na tej strani.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Poišči druge možnosti";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Predlagaj nekaj alternativ za ta izdelek.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Kaj potrebujem?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Naštej orodja, materiale ali pogoje, ki jih potrebujem za to.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Vodi me skozi korake";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Razdeli to na jasne, oštevilčene korake.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Pomagaj mi pri pripravi na razgovor";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Katera vprašanja za razgovor se lahko pojavijo za to vlogo?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Kateri so ključne ugotovitve?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Katere so ključne ugotovitve tega članka?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Kaj naj naročim?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Katere jedi moraš tukaj poskusiti?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Kateri so ključni prispevki?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Kateri so ključni prispevki tega članka?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Povzemi ozadje";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Povzemi ozadje in pomembnejše delo te osebe.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Kakšen je delovni čas in lokacija?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Kakšen je delovni čas, lokacija in kontaktni podatki za ta kraj?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Je ta kraj v redu?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Je ta kraj vreden obiska? Povzemi njegov ugled na podlagi ocen in mnenj.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Katere so prednosti in slabosti?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Katere so prednosti in slabosti tega izdelka?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Oceni hranilne vrednosti";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Oceni hranilne vrednosti za ta recept.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Predlagaj sorodne članke za raziskovanje";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Predlagaj sorodne članke ali teme, ki jih je vredno raziskati.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Povzemi mnenja";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Povzemi, kaj pravijo ocene.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Kakšna je razsodba?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Kakšna je skupna razsodba in ocena za to?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Prilagodi porcije";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Prepiši ta recept, prilagojen za drugo število porcij.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Ustvari nakupovalni seznam";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Ustvari nakupovalni seznam s količinami iz tega recepta.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Priporoči podobne knjige";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Priporoči podobne knjige.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Priporoči podobne naslove";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Priporoči podobne filme ali TV-oddaje.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Povzemi to knjigo";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Povzemi to knjigo.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Povzemi to stran";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Povzemi to stran.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Povzemi to razpravo";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Povzemi to nit razprave.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Povzemi ta videoposnetek";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Povzemi ta videoposnetek.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Prilagodi moj življenjepis";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Pomagaj mi prilagoditi življenjepis za to delovno mesto.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Prevedi to stran";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Prevedi to stran v jezik %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Katere so ključne točke?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Katere so ključne točke, zajete v tem videoposnetku?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Kdo je ta oseba?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Na kratko mi opiši to osebo.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Se splača gledati?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Se splača gledati? Podaj mi mnenje brez razkritja vsebine.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Vsi klepeti so %@ zasebni";
 

--- a/iOS/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sv.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Prata med Duck.ai med hjälp av Siri!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Medverkande";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Vilka ingår i rollistan och filmteamet, och vad är de annars kända för?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Vilka är motargumenten?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Vilka är de främsta motargumenten eller invändningarna mot detta?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Vad kommer jag att lära mig?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Vilka är de viktigaste sakerna jag kommer att lära mig av den här kursen?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Är den värd att ta?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Är det värt att ta kursen baserat på den här sidan?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Skriv ett personligt brev";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Skapa ett personligt brev för det här jobbet.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Vilka är de viktigaste detaljerna?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Sammanfatta de viktigaste detaljerna om den här händelsen.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "Förklara det bästa svaret";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Förklara det accepterade svaret med enkla ord.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Förklara den här artikeln";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Förklara den här forskningsartikeln på ett enkelt och tydligt språk.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Förklara det här arkivet";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Förklara vad det här arkivet gör och hur man använder det.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Förklara detta på ett enkelt sätt";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Förklara detta på ett enkelt och tydligt språk.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Vad svarar det här på?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Vilka är de viktigaste frågorna som den här sidan besvarar?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Sammanfatta frågorna och svaren";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Sammanfatta frågorna och svaren på den här sidan.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Hitta alternativ åt mig";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Föreslå ett par alternativ till den här produkten.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Vad behöver jag?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Lista verktygen, materialen eller förutsättningarna jag behöver för detta.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Förklara stegen";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Dela upp detta i tydliga, numrerade steg.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Hjälp mig att förbereda mig inför intervjun";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Vilka frågor kan dyka upp under intervjun för den här rollen?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Vilka är de viktigaste lärdomarna?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Vilka är de viktigaste lärdomarna från den här artikeln?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Vad ska jag beställa?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Vilka är de mest rekommenderade rätterna här?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Vilka är de viktigaste bidragen?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Vilka är de viktigaste bidragen i den här artikeln?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Sammanfatta deras bakgrund";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Sammanfatta den här personens bakgrund och anmärkningsvärda arbete.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Vilka är öppettiderna och platsen?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Vilka är öppettiderna, platsen och kontaktuppgifterna för det här stället?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Är det här stället bra?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Är det här stället bra? Sammanfatta platsens rykte baserat på recensioner och betyg.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Vilka är för- och nackdelarna?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Vilka är för- och nackdelarna med den här produkten?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Uppskatta näringsinnehållet";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Uppskatta näringsinnehållet för det här receptet.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Föreslå relaterade artiklar att utforska";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Föreslå relaterade artiklar eller ämnen som är värda att utforska härnäst.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "Summera recensionerna";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "Sammanfatta vad recensionerna säger.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Vad blir omdömet?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Vad är det övergripande omdömet och betyget för detta?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Justera portionerna";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Skriv om det här receptet och anpassa det för ett annat antal portioner.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Skapa en inköpslista";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Skapa en inköpslista med mängder från det här receptet.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Rekommendera liknande böcker";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Rekommendera liknande böcker.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Rekommendera liknande titlar";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Rekommendera liknande filmer eller program.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Sammanfatta denna bok";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Sammanfatta denna bok.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Sammanfatta denna sida";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Sammanfatta denna sida.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Sammanfatta denna diskussion";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Sammanfatta denna diskussionstråd.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Sammanfatta denna video";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Sammanfatta denna video.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Anpassa mitt CV";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Hjälp mig att anpassa mitt CV för det här jobbet.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Översätt den här sidan";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Översätt den här sidan till %@.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Vilka är de viktigaste punkterna?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Vilka är de viktigaste punkterna som tas upp i den här videon?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Vem är den här personen?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Ge mig en presentation av den här personen.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Är det värt att titta på?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Är det värt att titta på? Ge mig en spoilerfri bedömning.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Alla chattar är %@ privata";
 

--- a/iOS/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/tr.lproj/Localizable.strings
@@ -1935,6 +1935,246 @@
 /* Title for the Duck.ai Siri education screen */
 "duckai.siri.education.screen.title" = "Siri'yi kullanarak Duck.ai ile konuş!";
 
+/* Suggested prompt chip: cast and crew */
+"duckai.suggestion.cast-crew.label" = "Oyuncular ve Ekip";
+
+/* Suggested prompt submitted text: cast and crew */
+"duckai.suggestion.cast-crew.prompt" = "Ana oyuncu kadrosu ve ekip kimlerden oluşuyor ve başka hangi işlerle tanınıyorlar?";
+
+/* Suggested prompt chip: counterarguments */
+"duckai.suggestion.counterarguments.label" = "Karşı argümanlar nelerdir?";
+
+/* Suggested prompt submitted text: counterarguments */
+"duckai.suggestion.counterarguments.prompt" = "Bunun temel karşı argümanları veya eleştirileri nelerdir?";
+
+/* Suggested prompt chip: course learning outcomes */
+"duckai.suggestion.course-learn.label" = "Neler öğreneceğim?";
+
+/* Suggested prompt submitted text: course learning outcomes */
+"duckai.suggestion.course-learn.prompt" = "Bu kurstan öğreneceğim temel şeyler nelerdir?";
+
+/* Suggested prompt chip: is a course worth taking */
+"duckai.suggestion.course-worth.label" = "Katılmaya değer mi?";
+
+/* Suggested prompt submitted text: is a course worth taking */
+"duckai.suggestion.course-worth.prompt" = "Bu sayfaya dayalı olarak bu kursa katılmaya değer mi?";
+
+/* Suggested prompt chip: draft a cover letter */
+"duckai.suggestion.cover-letter.label" = "Bir ön yazı taslağı hazırla";
+
+/* Suggested prompt submitted text: draft a cover letter */
+"duckai.suggestion.cover-letter.prompt" = "Bu pozisyon için bir ön yazı taslağı hazırla.";
+
+/* Suggested prompt chip: event details */
+"duckai.suggestion.event-details.label" = "Temel ayrıntılar nelerdir?";
+
+/* Suggested prompt submitted text: event details */
+"duckai.suggestion.event-details.prompt" = "Bu etkinliğin önemli ayrıntılarını özetle.";
+
+/* Suggested prompt chip: explain the top answer */
+"duckai.suggestion.explain-answer.label" = "En üstteki yanıtı açıkla";
+
+/* Suggested prompt submitted text: explain the top answer */
+"duckai.suggestion.explain-answer.prompt" = "Kabul edilen yanıtı basit terimlerle açıkla.";
+
+/* Suggested prompt chip: explain a research paper */
+"duckai.suggestion.explain-paper.label" = "Bu makaleyi açıkla";
+
+/* Suggested prompt submitted text: explain a research paper */
+"duckai.suggestion.explain-paper.prompt" = "Bu araştırma makalesini sade bir dille açıkla.";
+
+/* Suggested prompt chip: explain a code repository */
+"duckai.suggestion.explain-repo.label" = "Bu depoyu açıkla";
+
+/* Suggested prompt submitted text: explain a code repository */
+"duckai.suggestion.explain-repo.prompt" = "Bu deponun ne işe yaradığını ve nasıl kullanılacağını açıkla.";
+
+/* Suggested prompt chip: explain the content simply */
+"duckai.suggestion.explain-simply.label" = "Bunu basitçe açıkla";
+
+/* Suggested prompt submitted text: explain the content simply */
+"duckai.suggestion.explain-simply.prompt" = "Bunu basit ve anlaşılır bir dille açıkla.";
+
+/* Suggested prompt chip: what an FAQ page answers */
+"duckai.suggestion.faq-answer.label" = "Bu neyi yanıtlıyor?";
+
+/* Suggested prompt submitted text: what an FAQ page answers */
+"duckai.suggestion.faq-answer.prompt" = "Bu sayfanın yanıtladığı temel sorular nelerdir?";
+
+/* Suggested prompt chip: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.label" = "Soru-Cevapları özetle";
+
+/* Suggested prompt submitted text: summarize FAQ Q&As */
+"duckai.suggestion.faq-summary.prompt" = "Bu sayfadaki soru ve cevapları özetle.";
+
+/* Suggested prompt chip: product alternatives */
+"duckai.suggestion.find-alternatives.label" = "Bana alternatifler bul";
+
+/* Suggested prompt submitted text: product alternatives */
+"duckai.suggestion.find-alternatives.prompt" = "Bu ürün için bazı alternatifler öner.";
+
+/* Suggested prompt chip: how-to materials */
+"duckai.suggestion.howto-materials.label" = "Nelere ihtiyacım olacak?";
+
+/* Suggested prompt submitted text: how-to materials */
+"duckai.suggestion.howto-materials.prompt" = "Bunun için ihtiyacım olan araçları, malzemeleri veya ön koşulları listele.";
+
+/* Suggested prompt chip: how-to steps */
+"duckai.suggestion.howto-steps.label" = "Adımları bana anlat";
+
+/* Suggested prompt submitted text: how-to steps */
+"duckai.suggestion.howto-steps.prompt" = "Bunu net, numaralandırılmış adımlara böl.";
+
+/* Suggested prompt chip: interview prep */
+"duckai.suggestion.interview-prep.label" = "Mülakata hazırlanmama yardım et";
+
+/* Suggested prompt submitted text: interview prep */
+"duckai.suggestion.interview-prep.prompt" = "Bu pozisyon için mülakatta hangi sorular gelebilir?";
+
+/* Suggested prompt chip: key takeaways of an article */
+"duckai.suggestion.key-takeaways.label" = "Temel çıkarımlar nelerdir?";
+
+/* Suggested prompt submitted text: key takeaways of an article */
+"duckai.suggestion.key-takeaways.prompt" = "Bu makaledeki önemli noktalar nelerdir?";
+
+/* Suggested prompt chip: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.label" = "Ne sipariş etmeliyim?";
+
+/* Suggested prompt submitted text: restaurant menu highlights */
+"duckai.suggestion.menu-highlights.prompt" = "Burada mutlaka denemek gereken yemekler neler?";
+
+/* Suggested prompt chip: paper contributions */
+"duckai.suggestion.paper-contributions.label" = "Temel katkılar nelerdir?";
+
+/* Suggested prompt submitted text: paper contributions */
+"duckai.suggestion.paper-contributions.prompt" = "Bu makalenin temel katkıları nelerdir?";
+
+/* Suggested prompt chip: summarize a person's background */
+"duckai.suggestion.person-background.label" = "Geçmişini özetle";
+
+/* Suggested prompt submitted text: summarize a person's background */
+"duckai.suggestion.person-background.prompt" = "Bu kişinin geçmişini ve önemli çalışmalarını özetle.";
+
+/* Suggested prompt chip: place hours and location */
+"duckai.suggestion.place-hours.label" = "Çalışma saatleri ve konum nedir?";
+
+/* Suggested prompt submitted text: place hours and location */
+"duckai.suggestion.place-hours.prompt" = "Bu yerin çalışma saatleri, konumu ve iletişim bilgileri nelerdir?";
+
+/* Suggested prompt chip: place reputation */
+"duckai.suggestion.place-reviews.label" = "Bu yer iyi mi?";
+
+/* Suggested prompt submitted text: place reputation */
+"duckai.suggestion.place-reviews.prompt" = "Bu yer iyi mi? İncelemelere ve puanlara dayanarak itibarını özetle.";
+
+/* Suggested prompt chip: product pros and cons */
+"duckai.suggestion.product-pros-cons.label" = "Artıları ve eksileri nelerdir?";
+
+/* Suggested prompt submitted text: product pros and cons */
+"duckai.suggestion.product-pros-cons.prompt" = "Bu ürünün artıları ve eksileri nelerdir?";
+
+/* Suggested prompt chip: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.label" = "Besin değerlerini tahmin et";
+
+/* Suggested prompt submitted text: recipe nutrition */
+"duckai.suggestion.recipe-nutrition.prompt" = "Bu tarifin besin değerlerini tahmin et.";
+
+/* Suggested prompt chip: related articles */
+"duckai.suggestion.related-articles.label" = "Keşfetmek için ilgili makaleler öner";
+
+/* Suggested prompt submitted text: related articles */
+"duckai.suggestion.related-articles.prompt" = "Sonraki adımda göz atmaya değer ilgili makaleler veya konular öner.";
+
+/* Suggested prompt chip: summarize reviews */
+"duckai.suggestion.review-summary.label" = "İncelemeleri özetle";
+
+/* Suggested prompt submitted text: summarize reviews */
+"duckai.suggestion.review-summary.prompt" = "İncelemelerde anlatılanları özetle.";
+
+/* Suggested prompt chip: review verdict */
+"duckai.suggestion.review-verdict.label" = "Sonuç ne?";
+
+/* Suggested prompt submitted text: review verdict */
+"duckai.suggestion.review-verdict.prompt" = "Bunun için genel değerlendirme ve puan nedir?";
+
+/* Suggested prompt chip: scale a recipe */
+"duckai.suggestion.scale-recipe.label" = "Porsiyonları ayarla";
+
+/* Suggested prompt submitted text: scale a recipe */
+"duckai.suggestion.scale-recipe.prompt" = "Bu tarifi farklı bir porsiyon sayısına göre yeniden yaz.";
+
+/* Suggested prompt chip: shopping list from a recipe */
+"duckai.suggestion.shopping-list.label" = "Alışveriş listesi oluştur";
+
+/* Suggested prompt submitted text: shopping list from a recipe */
+"duckai.suggestion.shopping-list.prompt" = "Bu tariften miktarlarıyla birlikte bir alışveriş listesi oluştur.";
+
+/* Suggested prompt chip: similar books */
+"duckai.suggestion.similar-books.label" = "Benzer kitaplar öner";
+
+/* Suggested prompt submitted text: similar books */
+"duckai.suggestion.similar-books.prompt" = "Benzer kitaplar öner.";
+
+/* Suggested prompt chip: similar movies or shows */
+"duckai.suggestion.similar-titles.label" = "Benzer başlıklar öner";
+
+/* Suggested prompt submitted text: similar movies or shows */
+"duckai.suggestion.similar-titles.prompt" = "Benzer filmler veya diziler öner.";
+
+/* Suggested prompt chip: summarize a book */
+"duckai.suggestion.summarize-book.label" = "Bu kitabı özetle";
+
+/* Suggested prompt submitted text: summarize a book */
+"duckai.suggestion.summarize-book.prompt" = "Bu kitabı özetle.";
+
+/* Suggested prompt chip: summarize the current page */
+"duckai.suggestion.summarize-page.label" = "Bu Sayfayı Özetle";
+
+/* Suggested prompt submitted text: summarize the current page */
+"duckai.suggestion.summarize-page.prompt" = "Bu sayfayı özetle.";
+
+/* Suggested prompt chip: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.label" = "Bu tartışmayı özetle";
+
+/* Suggested prompt submitted text: summarize a discussion thread */
+"duckai.suggestion.summarize-thread.prompt" = "Bu tartışma konusunu özetle.";
+
+/* Suggested prompt chip: summarize a video */
+"duckai.suggestion.summarize-video.label" = "Bu videoyu özetle";
+
+/* Suggested prompt submitted text: summarize a video */
+"duckai.suggestion.summarize-video.prompt" = "Bu videoyu özetle.";
+
+/* Suggested prompt chip: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.label" = "Özgeçmişimi düzenle";
+
+/* Suggested prompt submitted text: tailor a resume to a job */
+"duckai.suggestion.tailor-resume.prompt" = "Özgeçmişimi bu pozisyon için uyarlamama yardım et.";
+
+/* Suggested prompt chip: translate the current page */
+"duckai.suggestion.translate-page.label" = "Bu sayfayı çevir";
+
+/* Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language. */
+"duckai.suggestion.translate-page.prompt" = "Bu sayfayı %@ diline çevir.";
+
+/* Suggested prompt chip: video key points */
+"duckai.suggestion.video-key-points.label" = "Önemli noktalar nelerdir?";
+
+/* Suggested prompt submitted text: video key points */
+"duckai.suggestion.video-key-points.prompt" = "Bu videoda ele alınan ana noktalar nelerdir?";
+
+/* Suggested prompt chip: person background */
+"duckai.suggestion.who-is-this.label" = "Bu kişi kim?";
+
+/* Suggested prompt submitted text: person background */
+"duckai.suggestion.who-is-this.prompt" = "Bu kişinin geçmişi hakkında kısaca bilgi ver.";
+
+/* Suggested prompt chip: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.label" = "Bunu izlemeye değer mi?";
+
+/* Suggested prompt submitted text: is a movie/show worth watching */
+"duckai.suggestion.worth-watching.prompt" = "Bunu izlemeye değer mi? Bana spoiler vermeden özetle.";
+
 /* Welcome message in Duck.ai contextual sheet. %@ is replaced by a shield icon. */
 "duckai.welcome.message" = "Tüm sohbetler %@ gizlidir";
 

--- a/iOS/DuckDuckGoTests/AIChat/ContextualSuggestionsMatcherTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/ContextualSuggestionsMatcherTests.swift
@@ -266,6 +266,31 @@ final class ContextualSuggestionsMatcherTests: XCTestCase {
         XCTAssertEqual(result.first { $0.id == "recipe-a" }?.prompt, "Make a list.")
     }
 
+    func testLocalizedTranslatePromptInterpolatesLanguageViaFormatPlaceholder() throws {
+        // translate-page resolves through the native localized copy, which carries `%@`
+        // (the loc-pipeline placeholder) instead of the catalog's `{language}` token.
+        let result = ContextualSuggestionsMatcher.resolve(input(signals(lang: "es"), uiLocale: "en_US"), catalog: try standardCatalog())
+        let translate = try XCTUnwrap(result.first { $0.id == "translate-page" })
+        XCTAssertFalse(translate.prompt.contains("%@"))
+        XCTAssertFalse(translate.prompt.contains("{language}"))
+        XCTAssertTrue(translate.prompt.contains("English"))
+    }
+
+    func testTemplateDoesNotFormatPromptWithLiteralPercentButNoPlaceholder() throws {
+        let json = """
+        {
+          "maxSuggestedPrompts": 4,
+          "defaults": ["percent-x"],
+          "catalog": { "percent-x": { "label": "P", "prompt": "Summarize with 100% accuracy." } },
+          "byJsonLdType": [],
+          "byOgType": {},
+          "byDomain": {}
+        }
+        """
+        let result = ContextualSuggestionsMatcher.resolve(input(nil, uiLocale: "en_US"), catalog: try catalog(json))
+        XCTAssertEqual(result.map(\.prompt), ["Summarize with 100% accuracy."])
+    }
+
     // MARK: - Copy & icon passthrough
 
     func testUnmappedIDsUseCatalogCopyAndIcon() throws {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1216903900693181?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->
This PR add translations supports for https://github.com/duckduckgo/apple-browsers/pull/6022

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->

**Setup**
1. Enable the `aiChatContextualUnifiedToggleInput` and `contextualSuggesatedPrompts` features flags.
2. Open Debug Settings > Configuration Refresh Info > Tap `Reset Last Refresh Date` and then `Trigger Refresh`. 
3. Restart app.
4. Open System Settings > Apps > DuckDuckGo app (red one) > Set language to Polish (or your preferred one, but different than English)
5. Open app.
6. Open https://www.bbc.co.uk/food/recipes/no-bake_strawberry_30276 and then open contextual sheet
7. **Pass:** confirm suggested prompts are in Polish (or your preferred language)
8. **Pass:** tap one of the suggested prompts. Confirm translated version of prompt is sent.


<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
8. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low, adds translations

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->
A translated prompt could expose an unresolved language placeholder → mitigated by handling both `%@` and `{language}` formats and matcher test coverage.

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String catalog and template substitution only; no auth, networking, or data-model changes. Residual risk is wrong or missing locale strings or a bad `%@` format string for translate prompts.
> 
> **Overview**
> Adds **localization** for Duck.ai contextual suggestion chips and submitted prompts (companion to the expanded suggestions feature).
> 
> **`ContextualSuggestionUserText`** now uses **`NSLocalizedString`** instead of **`NotLocalizedString`** for every `duckai.suggestion.*` key, and drops the **`FoundationExtensions`** import. The translate prompt’s bundled English default uses **`%@`** for the user’s language name (aligned with the loc pipeline), while the FE catalog can still use **`{language}`**.
> 
> **`ContextualSuggestionsMatcher.applyTemplate`** fills in the language name for both placeholder styles: **`{language}`** via string replacement and **`%@`** via **`String(format:)`**, only when the prompt actually contains a placeholder.
> 
> **`Localizable.strings`** gains the full set of **`duckai.suggestion.*`** label and prompt entries across the shipped locales (e.g. en, de, fr, ja, and others in the diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3da52a43a95783ae74cc3a19d7dfd73e9931472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->