### PR TITLE
[macOS] Fix popover message alignment

### DIFF
--- a/macOS/DuckDuckGo/MessageViews/PopoverMessageViewController.swift
+++ b/macOS/DuckDuckGo/MessageViews/PopoverMessageViewController.swift
@@ -138,7 +138,8 @@ final class PopoverMessageViewController: NSHostingController<PopoverMessageView
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if #available(macOS 26.0, *) {
+        if #available(macOS 26.0, *),
+           viewModel.configuration.usesCompactLayout {
             view.prefersCompactControlSizeMetrics = true
         }
     }

--- a/macOS/DuckDuckGo/MessageViews/PopoverMessageViewController.swift
+++ b/macOS/DuckDuckGo/MessageViews/PopoverMessageViewController.swift
@@ -135,6 +135,14 @@ final class PopoverMessageViewController: NSHostingController<PopoverMessageView
 
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        if #available(macOS 26.0, *) {
+            view.prefersCompactControlSizeMetrics = true
+        }
+    }
+
     override func viewDidAppear() {
         super.viewDidAppear()
         createTrackingArea()
@@ -174,7 +182,7 @@ final class PopoverMessageViewController: NSHostingController<PopoverMessageView
         self.preferredContentSize.width = self.view.fittingSize.width
 
         parent.present(self,
-                       asPopoverRelativeTo: self.view.bounds,
+                       asPopoverRelativeTo: view.bounds,
                        of: view,
                        preferredEdge: preferredEdge,
                        behavior: behavior)

--- a/macOS/DuckDuckGo/MessageViews/PopoverMessageViewController.swift
+++ b/macOS/DuckDuckGo/MessageViews/PopoverMessageViewController.swift
@@ -135,15 +135,6 @@ final class PopoverMessageViewController: NSHostingController<PopoverMessageView
 
     }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        if #available(macOS 26.0, *),
-           viewModel.configuration.usesCompactLayout {
-            view.prefersCompactControlSizeMetrics = true
-        }
-    }
-
     override func viewDidAppear() {
         super.viewDidAppear()
         createTrackingArea()

--- a/macOS/DuckDuckGo/Updates/Sparkle/UpdatesDebugMenu.swift
+++ b/macOS/DuckDuckGo/Updates/Sparkle/UpdatesDebugMenu.swift
@@ -54,6 +54,8 @@ final class UpdatesDebugMenu: NSMenu {
             NSMenuItem.separator()
             NSMenuItem(title: "Show Browser Updated Popover", action: #selector(showBrowserUpdatedPopover))
                 .targetting(self)
+            NSMenuItem(title: "Show Critical Update Popover", action: #selector(showCriticalUpdatePopover))
+                .targetting(self)
             NSMenuItem.separator()
             NSMenuItem(title: "Test Update Pixels") {
                 NSMenuItem(title: "Success (Expected)", action: #selector(testUpdateSuccessOnNextLaunch))
@@ -104,6 +106,10 @@ final class UpdatesDebugMenu: NSMenu {
 
     @objc func showBrowserUpdatedPopover() {
         Application.appDelegate.updateController?.notificationPresenter.showUpdateNotification(for: .updated)
+    }
+
+    @objc func showCriticalUpdatePopover() {
+        Application.appDelegate.updateController?.notificationPresenter.showUpdateNotification(for: .critical, areAutomaticUpdatesEnabled: true)
     }
 
     // MARK: - Custom Feed URL

--- a/macOS/DuckDuckGo/Updates/UpdateNotificationPresenter.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateNotificationPresenter.swift
@@ -119,6 +119,9 @@ final class UpdateNotificationPresenter: UpdateNotificationPresenting {
                 self?.currentPopover = nil
             })
 
+            if #available(macOS 26.0, *) {
+                viewController.view.prefersCompactControlSizeMetrics = true
+            }
             viewController.identifier = .updateNotificationPopover
 
             if self.showNotificationPopover(viewController) {

--- a/macOS/DuckDuckGo/Updates/UpdateNotificationPresenter.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateNotificationPresenter.swift
@@ -104,7 +104,7 @@ final class UpdateNotificationPresenter: UpdateNotificationPresenting {
 
             let viewController = PopoverMessageViewController(message: text,
                                                               image: icon,
-                                                              configuration: .updateNotification,
+                                                              configuration: presentMultiline ? .default : .updateNotification,
                                                               autoDismissDuration: Self.presentationTimeInterval,
                                                               shouldShowCloseButton: true,
                                                               presentMultiline: presentMultiline,

--- a/macOS/DuckDuckGo/Updates/UpdateNotificationPresenter.swift
+++ b/macOS/DuckDuckGo/Updates/UpdateNotificationPresenter.swift
@@ -104,6 +104,7 @@ final class UpdateNotificationPresenter: UpdateNotificationPresenting {
 
             let viewController = PopoverMessageViewController(message: text,
                                                               image: icon,
+                                                              configuration: .updateNotification,
                                                               autoDismissDuration: Self.presentationTimeInterval,
                                                               shouldShowCloseButton: true,
                                                               presentMultiline: presentMultiline,

--- a/macOS/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/PopoverMessageView.swift
+++ b/macOS/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/PopoverMessageView.swift
@@ -209,10 +209,10 @@ public struct PopoverMessageView: View {
 
     @ViewBuilder
     private var messageBody: some View {
-        HStack(alignment: .top) {
+        HStack(alignment: viewModel.shouldPresentMultiline ? .top : .center) {
             if let image = viewModel.image {
                 Image(nsImage: image)
-                    .padding(.top, 3)
+                    .padding(.top, viewModel.shouldPresentMultiline ? 3 : 0)
             }
 
             Text(viewModel.message)
@@ -231,7 +231,7 @@ public struct PopoverMessageView: View {
                     action()
                     viewModel.dismissAction?()
                 })
-                .padding(.top, 2)
+                .padding(.top, viewModel.shouldPresentMultiline ? 2 : 0)
                 .padding(.leading, 4)
             }
 
@@ -244,7 +244,7 @@ public struct PopoverMessageView: View {
                         .frame(width: 16, height: 16)
                 }
                 .buttonStyle(PlainButtonStyle())
-                .padding(.top, viewModel.buttonText != nil ? 4 : 0)
+                .padding(.top, viewModel.shouldPresentMultiline && viewModel.buttonText != nil ? 4 : 0)
             }
         }
         .padding()

--- a/macOS/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/PopoverMessageView.swift
+++ b/macOS/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/PopoverMessageView.swift
@@ -42,19 +42,22 @@ public struct PopoverConfiguration {
     public var imageSize: CGSize?
     public var buttonStyle: PopoverButtonStyle
     public var accentColor: Color?
+    public var usesCompactLayout: Bool
 
     public init(
         style: PopoverStyle = .basic,
         buttonLayout: PopoverButtonLayout = .horizontal,
         imageSize: CGSize? = nil,
         buttonStyle: PopoverButtonStyle = .standard,
-        accentColor: Color? = nil
+        accentColor: Color? = nil,
+        usesCompactLayout: Bool = false
     ) {
         self.style = style
         self.buttonLayout = buttonLayout
         self.imageSize = imageSize
         self.buttonStyle = buttonStyle
         self.accentColor = accentColor
+        self.usesCompactLayout = usesCompactLayout
     }
 
     /// Default configuration matching current behavior
@@ -64,6 +67,11 @@ public struct PopoverConfiguration {
         imageSize: nil,
         buttonStyle: .standard,
         accentColor: nil
+    )
+
+    /// Update notification style with compact control metrics
+    public static let updateNotification = PopoverConfiguration(
+        usesCompactLayout: true
     )
 
     /// Feature discovery style with 24x24 image
@@ -209,10 +217,10 @@ public struct PopoverMessageView: View {
 
     @ViewBuilder
     private var messageBody: some View {
-        HStack(alignment: viewModel.shouldPresentMultiline ? .top : .center) {
+        HStack(alignment: shouldCenterContentVertically ? .center : .top) {
             if let image = viewModel.image {
                 Image(nsImage: image)
-                    .padding(.top, viewModel.shouldPresentMultiline ? 3 : 0)
+                    .padding(.top, shouldCenterContentVertically ? 0 : 3)
             }
 
             Text(viewModel.message)
@@ -231,7 +239,7 @@ public struct PopoverMessageView: View {
                     action()
                     viewModel.dismissAction?()
                 })
-                .padding(.top, viewModel.shouldPresentMultiline ? 2 : 0)
+                .padding(.top, shouldCenterContentVertically ? 0 : 2)
                 .padding(.leading, 4)
             }
 
@@ -244,10 +252,14 @@ public struct PopoverMessageView: View {
                         .frame(width: 16, height: 16)
                 }
                 .buttonStyle(PlainButtonStyle())
-                .padding(.top, viewModel.shouldPresentMultiline && viewModel.buttonText != nil ? 4 : 0)
+                .padding(.top, shouldCenterContentVertically || viewModel.buttonText == nil ? 0 : 4)
             }
         }
         .padding()
+    }
+
+    private var shouldCenterContentVertically: Bool {
+        viewModel.configuration.usesCompactLayout && !viewModel.shouldPresentMultiline
     }
 
     @ViewBuilder

--- a/macOS/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/PopoverMessageView.swift
+++ b/macOS/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/PopoverMessageView.swift
@@ -217,10 +217,10 @@ public struct PopoverMessageView: View {
 
     @ViewBuilder
     private var messageBody: some View {
-        HStack(alignment: shouldCenterContentVertically ? .center : .top) {
+        HStack(alignment: viewModel.configuration.usesCompactLayout ? .center : .top) {
             if let image = viewModel.image {
                 Image(nsImage: image)
-                    .padding(.top, shouldCenterContentVertically ? 0 : 3)
+                    .padding(.top, viewModel.configuration.usesCompactLayout ? 0 : 3)
             }
 
             Text(viewModel.message)
@@ -239,7 +239,7 @@ public struct PopoverMessageView: View {
                     action()
                     viewModel.dismissAction?()
                 })
-                .padding(.top, shouldCenterContentVertically ? 0 : 2)
+                .padding(.top, viewModel.configuration.usesCompactLayout ? 0 : 2)
                 .padding(.leading, 4)
             }
 
@@ -252,14 +252,10 @@ public struct PopoverMessageView: View {
                         .frame(width: 16, height: 16)
                 }
                 .buttonStyle(PlainButtonStyle())
-                .padding(.top, shouldCenterContentVertically || viewModel.buttonText == nil ? 0 : 4)
+                .padding(.top, viewModel.configuration.usesCompactLayout || viewModel.buttonText == nil ? 0 : 4)
             }
         }
         .padding()
-    }
-
-    private var shouldCenterContentVertically: Bool {
-        viewModel.configuration.usesCompactLayout && !viewModel.shouldPresentMultiline
     }
 
     @ViewBuilder

--- a/macOS/UnitTests/Updates/UpdateNotificationPresenterTests.swift
+++ b/macOS/UnitTests/Updates/UpdateNotificationPresenterTests.swift
@@ -26,9 +26,10 @@ final class UpdateNotificationPresenterTests: XCTestCase {
 
     // MARK: - Post-Update Notification (showUpdateNotification(for: AppUpdateStatus))
 
-    func testShowUpdateNotification_updated_callsShowNotificationPopover() {
+    func testShowUpdateNotification_updated_usesCompactLayout() {
         let expectation = expectation(description: "showNotificationPopover called")
-        let presenter = makePresenter(showNotificationPopover: { _ in
+        let presenter = makePresenter(showNotificationPopover: { viewController in
+            XCTAssertTrue(viewController.viewModel.configuration.usesCompactLayout)
             expectation.fulfill()
             return true
         })


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216909495810344

### Description

Update notification popovers can look misaligned, especially with single-line content and macOS 26 control sizing. This update centers compact update notifications while preserving existing layouts for other popovers and positions popovers relative to their originating control.

### Testing Steps

1. Select Debug > Updates > Show Browser Updated Popover → verify the single-line content is vertically centered and the popover is positioned correctly.
2. Select Debug > Updates > Show Critical Update Popover → verify the multiline content is top-aligned and the popover is positioned correctly.
3. Add `UIDesignRequiresCompatibility` with value `true` to `macOS/DuckDuckGo/Info.plist`, rebuild, and repeat steps 1 and 2 → verify both popovers remain correctly aligned and positioned.
4. Remove `UIDesignRequiresCompatibility` from `macOS/DuckDuckGo/Info.plist`.

<!--
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. Check the document to see if the class is listed.
2. If it exists, increase its encounter count by 1.
3. Otherwise, add a new entry.
-->

### Impact

Low

#### What could go wrong?

Update notification popovers could render with incorrect spacing or positioning → compact layout is limited to update notifications and multiline content retains its existing spacing.

### Quality Considerations

No privacy, security, or performance impact is expected. Earlier macOS versions retain their existing control-size behavior.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only popover layout and positioning for update notifications; multiline paths retain existing layout via `.default`.
> 
> **Overview**
> Fixes **misaligned update notification popovers** (especially single-line content and macOS 26 control sizing) by introducing a compact popover layout and correcting anchor geometry.
> 
> **Compact layout for post-update notifications:** `PopoverConfiguration` gains `usesCompactLayout` and a `.updateNotification` preset. Single-line “browser updated” style notifications use it so the icon, text, action button, and close control are **vertically centered** with padding adjustments; **multiline** critical/regular available-update messages keep the **default** (top-aligned) layout.
> 
> **Presentation:** `UpdateNotificationPresenter` picks configuration from `presentMultiline`, and on **macOS 26+** sets `prefersCompactControlSizeMetrics` on the hosting view. `PopoverMessageViewController` now anchors the popover with the passed-in **`view.bounds`** instead of `self.view.bounds` for correct positioning.
> 
> Debug menu adds **Show Critical Update Popover**; unit test asserts compact layout for the updated status path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c267e82a36299da5aa525d317c0bd07b7f7ef698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->