### PR TITLE
PIR: Add deferred secure vault init success pixel (#5951)

### DIFF
--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
@@ -477,6 +477,7 @@ public final class DataBrokerProtectionIOSManager {
                 do {
                     let resources = try await loadVaultResources()
                     publishVaultResources(resources)
+                    iOSPixelsHandler.fire(.deferredSecureVaultInitSucceeded(trigger: reason.rawValue))
                     return resources
                 } catch {
                     clearVaultResourcesInitAttempt()

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/Pixels/IOSPixels.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/Pixels/IOSPixels.swift
@@ -30,6 +30,13 @@ public enum IOSPixels {
     case backgroundTaskExpired(duration: Double)
     case backgroundTaskEndedHavingCompletedAllJobs(duration: Double)
     case backgroundTaskSchedulingFailed(error: Error?)
+
+    // Deferred Secure Vault initialization
+    case deferredSecureVaultInitSucceeded(trigger: String)
+
+    enum Consts {
+        static let trigger = "trigger"
+    }
 }
 
 extension IOSPixels: PixelKitEvent {
@@ -39,6 +46,7 @@ extension IOSPixels: PixelKitEvent {
         case .backgroundTaskExpired: return "m_ios_dbp_background-task_expired"
         case .backgroundTaskEndedHavingCompletedAllJobs: return "m_ios_dbp_background-task_ended-having-completed-all-jobs"
         case .backgroundTaskSchedulingFailed: return "m_ios_dbp_background-task_scheduling-failed"
+        case .deferredSecureVaultInitSucceeded: return "m_ios_dbp_secure-vault_deferred-init-succeeded"
         }
     }
 
@@ -54,6 +62,8 @@ extension IOSPixels: PixelKitEvent {
         case .backgroundTaskExpired(let duration),
                 .backgroundTaskEndedHavingCompletedAllJobs(let duration):
             return [DataBrokerProtectionSharedPixels.Consts.durationInMs: String(duration)]
+        case .deferredSecureVaultInitSucceeded(let trigger):
+            return [Consts.trigger: trigger]
         }
     }
 
@@ -62,7 +72,8 @@ extension IOSPixels: PixelKitEvent {
         case .backgroundTaskStarted,
                 .backgroundTaskExpired,
                 .backgroundTaskEndedHavingCompletedAllJobs,
-                .backgroundTaskSchedulingFailed:
+                .backgroundTaskSchedulingFailed,
+                .deferredSecureVaultInitSucceeded:
             return [.pixelSource]
         }
     }
@@ -81,6 +92,8 @@ public class IOSPixelsHandler: EventMapping<IOSPixels> {
                     .backgroundTaskExpired,
                     .backgroundTaskEndedHavingCompletedAllJobs:
                 pixelKit.fire(event)
+            case .deferredSecureVaultInitSucceeded:
+                pixelKit.fire(event, frequency: .dailyAndCount)
             case .backgroundTaskSchedulingFailed(let error):
                 pixelKit.fire(DebugEvent(event, error: error))
             }

--- a/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -1,4 +1,20 @@
 {
+    "m_ios_dbp_secure-vault_deferred-init-succeeded": {
+        "description": "Fired daily and count when deferred secure vault initialization completes successfully.",
+        "owners": ["quanganhdo"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "trigger",
+                "description": "The app lifecycle entry point that triggered deferred secure vault initialization",
+                "type": "string",
+                "enum": ["launch", "appActive", "dashboard", "backgroundTask"]
+            }
+        ]
+    },
     "m_ios_dbp_optout_stage_start": {
         "description": "Fired at the start stage of an opt-out attempt.",
         "owners": ["quanganhdo", "THISISDINOSAUR"],


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR. -->

Task/Issue URL:
https://app.asana.com/1/137249556945/project/72649045549333/task/1216389800185774?focus=true
Tech Design URL:
CC:

### Description

Adds success pixels for deferred secure vault init. Errors are already covered by existing secure vault pixels.

This is already part of `main`, just cherry-picked here for inclusion with the reset of the deferred secure vault init code shipped in 7.231.0.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Smoke test PIR, make sure to override deferred vault init to true
2. Expect to see PixelKit logs

```
👾[Daily and Count-Fired] m_ios_dbp_secure-vault_deferred-init-succeeded_daily ["appVersion": "7.230.0", "pixelSource": "phone", "trigger": "appActive"]
👾[Daily and Count-Fired] m_ios_dbp_secure-vault_deferred-init-succeeded_count ["appVersion": "7.230.0", "pixelSource": "phone", "trigger": "appActive”]
```

### Impact

Low

#### What could go wrong?

### Quality Considerations

—
###### Internal references:
[Definition of
Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering
Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design
Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change on the deferred vault init success path; no changes to vault initialization logic or user-facing behavior.
> 
> **Overview**
> Adds **daily/count telemetry** when deferred PIR secure vault initialization finishes successfully, complementing existing secure-vault error pixels.
> 
> After `loadVaultResources()` and `publishVaultResources()`, `DataBrokerProtectionIOSManager` fires `deferredSecureVaultInitSucceeded` with the **`trigger`** entry point (`launch`, `appActive`, `dashboard`, or `backgroundTask` from `VaultInitReason`). The new `m_ios_dbp_secure-vault_deferred-init-succeeded` pixel is wired through `IOSPixels` / `IOSPixelsHandler` with **`dailyAndCount`** frequency and registered in `data_broker_protection.json5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bca4c4228584bbcc15dc230ed0e24fe4d9e8d437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL:
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1.
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
