### PR TITLE
[macOS] Fix CTL tests

### DIFF
--- a/macOS/UnitTests/ContentBlocker/ClickToLoadTDSTests.swift
+++ b/macOS/UnitTests/ContentBlocker/ClickToLoadTDSTests.swift
@@ -29,6 +29,12 @@ private extension KnownTracker {
 
 }
 
+private extension TrackerData {
+
+    var containsCTLActions: Bool { trackers.values.contains { $0.countCTLActions > 0 } }
+
+}
+
 class ClickToLoadTDSTests: XCTestCase {
 
     func testEnsureClickToLoadTDSCompiles() throws {
@@ -40,22 +46,23 @@ class ClickToLoadTDSTests: XCTestCase {
                                          data: trackerData,
                                          embeddedDataProvider: provider)
 
+        try skipUnlessTDSContainsCTLRules(trackerManager)
+
         let cbrLists = ContentBlockerRulesLists(trackerDataManager: trackerManager, adClickAttribution: MockAttributing())
         let ruleSets = cbrLists.contentBlockerRulesLists
         let tdsName = DefaultContentBlockerRulesListsSource.Constants.clickToLoadRulesListName
 
-        let ctlRules = ruleSets.first(where: { $0.name == tdsName })
-        let ctlTrackerData = ctlRules?.trackerData
-        let ctlTds = ctlTrackerData?.tds
+        let ctlRules = try XCTUnwrap(ruleSets.first(where: { $0.name == tdsName }), "The TDS carries CTL rules, so a '\(tdsName)' rule list should have been split out")
+        let ctlTds = try XCTUnwrap(ctlRules.trackerData?.tds, "'\(tdsName)' rule list is missing its tracker data")
 
-        let builder = ContentBlockerRulesBuilder(trackerData: ctlTds!)
+        let builder = ContentBlockerRulesBuilder(trackerData: ctlTds)
 
         let rules = builder.buildRules(withExceptions: [],
                                        andTemporaryUnprotectedDomains: [],
                                        andTrackerAllowlist: [])
 
         let data = try JSONEncoder().encode(rules)
-        let ruleList = String(data: data, encoding: .utf8)!
+        let ruleList = try XCTUnwrap(String(data: data, encoding: .utf8))
 
         let identifier = UUID().uuidString
 
@@ -89,6 +96,8 @@ class ClickToLoadTDSTests: XCTestCase {
                                     embeddedDataProvider: provider
         )
 
+        try skipUnlessTDSContainsCTLRules(trackerManager)
+
         let cbrLists = ContentBlockerRulesLists(trackerDataManager: trackerManager, adClickAttribution: MockAttributing())
         let ruleSets = cbrLists.contentBlockerRulesLists
 
@@ -98,8 +107,8 @@ class ClickToLoadTDSTests: XCTestCase {
         let (fbMainRules, mainCTLRuleCount) = getFBTrackerRules(for: mainTdsName, ruleSets: ruleSets)
         let (fbCTLRules, ctlCTLRuleCount) = getFBTrackerRules(for: ctlTdsName, ruleSets: ruleSets)
 
-        let fbMainRuleCount = fbMainRules!.count
-        let fbCTLRuleCount = fbCTLRules!.count
+        let fbMainRuleCount = try XCTUnwrap(fbMainRules, "'\(mainTdsName)' rule list is missing facebook.net rules").count
+        let fbCTLRuleCount = try XCTUnwrap(fbCTLRules, "'\(ctlTdsName)' rule list is missing facebook.net rules").count
 
         // ensure both rulesets contains facebook.net rules
         XCTAssert(fbMainRuleCount > 0)
@@ -112,6 +121,11 @@ class ClickToLoadTDSTests: XCTestCase {
         // ensure FB CTL rules are the sum of the main rules + CTL custom action rules
         XCTAssert(fbMainRuleCount + ctlCTLRuleCount == fbCTLRuleCount)
 
+    }
+
+    private func skipUnlessTDSContainsCTLRules(_ trackerDataManager: TrackerDataManager) throws {
+        try XCTSkipUnless(trackerDataManager.trackerData.containsCTLActions,
+                          "Embedded TDS carries no block-ctl-fb rules - Click to Load is disabled upstream")
     }
 }
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1216925317069073?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

This PR fixes an issue where a TDS file without CTL rules causes the test suite to crash, as a result of https://app.asana.com/1/137249556945/project/1201720254973470/task/1216208388522812?focus=true.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Check that CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to macOS unit tests; no production code or user-facing behavior is modified.
> 
> **Overview**
> **Click to Load TDS unit tests** no longer crash when the embedded tracker data set omits `block-ctl-fb` rules (Click to Load disabled upstream).
> 
> Both tests call a shared **`skipUnlessTDSContainsCTLRules`** helper that uses **`XCTSkipUnless`** after checking **`TrackerData.containsCTLActions** (any tracker with CTL actions). When CTL is absent, tests skip with a clear message instead of failing on missing rule lists or force unwraps.
> 
> **Assertion style** is tightened: optional rule sets and encoded rule strings use **`try XCTUnwrap`** with descriptive failure messages instead of force unwraps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9501ebf470f50c0b8a19013b19df996d166d8fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->