### PR TITLE
[iOS] guard the open in youtube toast to iPad only

### DIFF
--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2346,7 +2346,8 @@ extension TabViewController: WKNavigationDelegate {
     }
 
     private func showDuckPlayerToastIfNeeded() {
-        guard let url = webView.url,
+        guard UIDevice.current.userInterfaceIdiom == .pad,
+              let url = webView.url,
               url.isYoutube,
               webView?.canGoBack == false else { return }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1216912355816386?focus=true
Tech Design URL:
CC:

### Description
Restricts the “Open in YouTube” message to iPad, where it is intended to appear.

### Testing Steps
On an iPad with YouTube installed, open a YouTube link in a new tab → the “Open in YouTube” message appears.
Repeat on an iPhone with YouTube installed → the message does not appear.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guard on device idiom in an optional toast; no navigation, auth, or data handling changes.
> 
> **Overview**
> Limits the **“Open in YouTube app”** toast so it only appears on **iPad**. The logic in `showDuckPlayerToastIfNeeded()` still runs after a YouTube page finishes loading in a new tab (no back history, YouTube app installed), but an extra guard on `UIDevice.current.userInterfaceIdiom == .pad` stops the message on iPhone.
> 
> No changes to when the toast fires on iPad or to the open-in-app action itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d86875cef24df400f61e03e5fd09ba9e85120182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->