### PR TITLE
[macOS] Revert "Build UI Tests for arm64 only" (#5858) to restore Intel builds

### DIFF
--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -87,7 +87,6 @@ jobs:
     with:
       release-type: alpha
       create-dmg: true
-      include-x86-architecture: true
       build-number-override: ${{ needs.calculate-alpha-build-number.outputs.build-number }}
       skip-notify: true
     secrets: inherit

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -24,10 +24,6 @@ on:
         description: "Asana release task URL"
         required: false
         type: string
-      include-x86-architecture:
-        description: "Include x86_64 architecture in the build"
-        default: false
-        type: boolean
   workflow_call:
     inputs:
       release-type:
@@ -56,10 +52,6 @@ on:
         type: string
       skip-notify:
         description: "Skip Mattermost notification"
-        default: false
-        type: boolean
-      include-x86-architecture:
-        description: "Include x86_64 architecture in the build"
         default: false
         type: boolean
     secrets:
@@ -108,7 +100,6 @@ jobs:
       release-type: ${{ github.event.inputs.release-type || inputs.release-type }}
       asana-task-url: ${{ github.event.inputs.asana-task-url || inputs.asana-task-url }}
       branch: ${{ inputs.branch || github.ref_name }}
-      EXCLUDED_ARCHS: ${{ inputs.include-x86-architecture && '' || 'x86_64' }}
 
     steps:
     - name: Register SSH keys for private repos

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -75,7 +75,6 @@ jobs:
     with:
       release-type: release
       create-dmg: true
-      include-x86-architecture: true
       asana-task-url: ${{ inputs.asana-task-url }}
       branch: ${{ inputs.branch }}
       commit-sha: ${{ inputs.commit-sha }}

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -95,7 +95,6 @@ jobs:
       create-dmg: false
       branch: ${{ inputs.branch || github.sha }}
       skip-notify: true
-      include-x86-architecture: false
     secrets: inherit
 
   # This job sets up the matrix strategy arguments for the ui-tests jobs

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests App Store CI.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests App Store CI.xcscheme
@@ -4,8 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "NO"
-      buildArchitectures = "Automatic">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests App Store.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests App Store.xcscheme
@@ -4,8 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      buildArchitectures = "Automatic">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests CI.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests CI.xcscheme
@@ -4,8 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "NO"
-      buildArchitectures = "Automatic">
+      buildImplicitDependencies = "NO">
    </BuildAction>
    <TestAction
       buildConfiguration = "Review"

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests.xcscheme
@@ -4,8 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      buildArchitectures = "Automatic">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/macOS/scripts/archive.sh
+++ b/macOS/scripts/archive.sh
@@ -262,7 +262,6 @@ archive_and_export() {
 		CURRENT_PROJECT_VERSION="${build_number}" \
 		RELEASE_PRODUCT_NAME_OVERRIDE=DuckDuckGo \
 		${extra_xcargs:+"${extra_xcargs}"} \
-		${EXCLUDED_ARCHS:+"EXCLUDED_ARCHS=${EXCLUDED_ARCHS}"} \
 		2>&1 \
 		| ${log_formatter}
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1216927711019208?focus=true
Tech Design URL:
CC:

### Description

Reverts #5858. That PR added an `EXCLUDED_ARCHS` expression to `macos_build_notarized.yml` using the GHA `A && '' || 'x86_64'` idiom, whose true-branch value `''` is falsy — so the expression resolves to `x86_64` regardless of the `include-x86-architecture` input. Every notarized archive (including release) has shipped arm64-only since 2026-07-16, so 1.200 fails to launch on Intel Macs ("not supported on this Mac", X'd icon). Reverting restores universal (arm64 + x86_64) archives.

### Impact

High. Unblocks all Intel-Mac users, who cannot launch 1.200 at all.

#### What could go wrong?
Reverts the UI-test arm64-only speedup → CI UI-test prebuilds go universal again (slower), no correctness impact. A hotfix build off this revert must be published via Sparkle; the already-distributed arm64-only 1.200 DMG stays broken until users get a universal build.

### Quality Considerations
Verify the produced app is universal before release: `lipo -archs <DuckDuckGo.app>/Contents/MacOS/DuckDuckGo` should list both `x86_64` and `arm64`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Fixes a production outage for Intel Mac users on distributed DMGs; release pipeline changes require verifying universal binaries before shipping the hotfix.
> 
> **Overview**
> Reverts the broken **arm64-only** notarized archive path introduced in #5858 so **release, alpha, and review** DMG builds again produce **universal** binaries (`arm64` + `x86_64`).
> 
> The revert removes the `include-x86-architecture` workflow input and the `EXCLUDED_ARCHS` env/`archive.sh` wiring that always excluded `x86_64` (the GHA `A && '' || 'x86_64'` expression treated `''` as falsy, so every build dropped Intel). Callers in `macos_release.yml`, `macos_alpha_release.yml`, and `macos_ui_tests.yml` no longer pass that flag.
> 
> Four **UI test** Xcode schemes drop explicit `buildArchitectures = "Automatic"` on `BuildAction`, returning to default scheme behavior alongside the archive fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a7d480471c3ad5d196b75c80f8b455101b5493. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->