### PR TITLE
PIR: Only reconcile unknown profile state at launch

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -1048,6 +1048,7 @@ public class MockDataBrokerProtectionPixelsHandler: EventMapping<DataBrokerProte
 public final class MockDatabase: DataBrokerProtectionRepository {
     public enum MockError: Error {
         case saveFailed
+        case fetchFailed
     }
 
     public var wasSaveProfileCalled = false
@@ -1108,6 +1109,7 @@ public final class MockDatabase: DataBrokerProtectionRepository {
     public var lastAddedHistoryEvent: HistoryEvent?
 
     public var saveResult: Result<Void, Error> = .success(())
+    public var fetchProfileError: Error?
     public var addHistoryEventError: Error?
     public var updateLastRunDateError: Error?
     public var updatePreferredRunDateError: Error?
@@ -1157,8 +1159,11 @@ public final class MockDatabase: DataBrokerProtectionRepository {
         }
     }
 
-    public func fetchProfile() -> DataBrokerProtectionProfile? {
+    public func fetchProfile() throws -> DataBrokerProtectionProfile? {
         wasFetchProfileCalled = true
+        if let fetchProfileError {
+            throw fetchProfileError
+        }
         return profile
     }
 

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DBPProfileStateManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DBPProfileStateManager.swift
@@ -31,7 +31,6 @@ public protocol DBPProfileStateManaging {
 
     func recordProfileSaved()
     func recordProfileDeleted()
-    func recordProfileStateUnknown()
     func reconcileProfileState(hasSavedProfile: Bool)
 }
 
@@ -62,10 +61,6 @@ public final class DefaultDBPProfileStateManager: DBPProfileStateManaging {
 
     public func recordProfileDeleted() {
         setProfileState(.noProfile)
-    }
-
-    public func recordProfileStateUnknown() {
-        setProfileState(.unknown)
     }
 
     public func reconcileProfileState(hasSavedProfile: Bool) {

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
@@ -447,6 +447,27 @@ public final class DataBrokerProtectionIOSManager {
         }
     }
 
+    private func reconcileProfileState() {
+        guard let resources = try? vaultResources() else {
+            Logger.dataBrokerProtection.log("Skipping profile state reconciliation: vault not initialized")
+            return
+        }
+
+        let hasSavedProfile: Bool
+        do {
+            hasSavedProfile = try resources.database.fetchProfile() != nil
+        } catch {
+            Logger.dataBrokerProtection.error("Profile state read failed, keeping cached state: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        let currentState: DBPProfileState = hasSavedProfile ? .hasProfile : .noProfile
+
+        guard profileStateManager.profileState != currentState else { return }
+
+        profileStateManager.reconcileProfileState(hasSavedProfile: hasSavedProfile)
+    }
+
     /// Central gate for Secure Vault-backed resources. Every caller either starts initialization
     /// or joins one already in progress; the gate ensures a single initialization even when
     /// multiple entry points (launch, app-active, background task) arrive concurrently.
@@ -534,6 +555,7 @@ public final class DataBrokerProtectionIOSManager {
 extension DataBrokerProtectionIOSManager: DBPIOSInterface.AppLifecycleEventsDelegate {
 
     public func appDidEnterBackground() {
+        reconcileProfileState()
         scheduleBGProcessingTask()
     }
 
@@ -725,6 +747,8 @@ extension DataBrokerProtectionIOSManager: DBPIOSInterface.DatabaseDelegate {
 
 extension DataBrokerProtectionIOSManager: JobQueueManagerDelegate {
     public func queueManagerWillEnqueueOperations(_ queueManager: JobQueueManaging) {
+        reconcileProfileState()
+
         Task {
             do {
                 try await vaultResources().brokerUpdater?.checkForUpdates()

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManagerProvider.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManagerProvider.swift
@@ -178,11 +178,13 @@ public class DataBrokerProtectionIOSManagerProvider {
                                                         optOutRetryErrorFeatureFlagger: featureFlagger)
 
         let database = DataBrokerProtectionDatabase(fakeBrokerFlag: fakeBroker, pixelHandler: sharedPixelsHandler, vault: vault, localBrokerService: localBrokerService)
-        do {
-            profileStateManager.reconcileProfileState(hasSavedProfile: try database.fetchProfile() != nil)
-        } catch {
-            profileStateManager.recordProfileStateUnknown()
-            Logger.dataBrokerProtection.error("Error reconciling profile state, error: \(error.localizedDescription, privacy: .public)")
+
+        if profileStateManager.profileState == .unknown {
+            do {
+                profileStateManager.reconcileProfileState(hasSavedProfile: try database.fetchProfile() != nil)
+            } catch {
+                Logger.dataBrokerProtection.error("Error reconciling profile state, error: \(error.localizedDescription, privacy: .public)")
+            }
         }
 
         let operationQueue = OperationQueue()

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerProfileStateTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerProfileStateTests.swift
@@ -52,12 +52,13 @@ final class DataBrokerProtectionIOSManagerProfileStateTests: XCTestCase {
         XCTAssertEqual(dependencies.profileStateManager.profileState, .noProfile)
     }
 
-    func test_recordProfileStateUnknown_clearsStaleProfileState() {
-        let (_, dependencies) = DBPIOSManagerTestUtils.makeTestIOSManager()
+    func test_appDidEnterBackground_keepsCachedState_whenProfileReadFails() {
+        let (manager, dependencies) = DBPIOSManagerTestUtils.makeTestIOSManager()
         dependencies.profileStateManager.recordProfileSaved()
+        dependencies.database.fetchProfileError = MockDatabase.MockError.fetchFailed
 
-        dependencies.profileStateManager.recordProfileStateUnknown()
+        manager.appDidEnterBackground()
 
-        XCTAssertEqual(dependencies.profileStateManager.profileState, .unknown)
+        XCTAssertEqual(dependencies.profileStateManager.profileState, .hasProfile)
     }
 }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerVaultInitReasonTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerVaultInitReasonTests.swift
@@ -54,8 +54,7 @@ final class DataBrokerProtectionIOSManagerVaultInitReasonTests: XCTestCase {
 
     func test_launch_unknownProfile_initializes() async throws {
         let initAttemptCount = LockedCount()
-        let (sut, dependencies) = makeDeferredManager(countingInto: initAttemptCount)
-        dependencies.profileStateManager.recordProfileStateUnknown()
+        let (sut, _) = makeDeferredManager(countingInto: initAttemptCount)
 
         try await sut.prepareSecureVaultResourcesAtLaunch()
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216918310397095?focus=true
Tech Design URL:
CC:

### Description

As part of iOS 7.229.0 we moved to using profile state cache for RMF matcher & Settings menu badge, but having the reconciliation method run at launch every time introduces a launch time degradation.

This PR ensures we only run that at startup if the profile state is unknown. 

### Testing Steps

1. CI passes
2.


### Impact

Low 

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to iOS PIR profile-state caching and launch timing; explicit save/delete paths still update the cache, and failed reads preserve the previous cache.
> 
> **Overview**
> Reduces launch cost by **not** reading the secure vault on every startup to reconcile the cached PIR profile state (used for RMF matcher and Settings badge). **Vault setup** now reconciles only when cached state is `.unknown`; if that read fails, it logs and leaves `.unknown` instead of forcing unknown via a removed API.
> 
> Adds **`reconcileProfileState()`** on the iOS manager: when the vault is available, compares the cache to `fetchProfile()` and updates only on mismatch. Fetch errors keep the cached value. This runs on **background** and when the **job queue** is about to enqueue work, so the cache can still catch profile changes without a launch-time DB read.
> 
> Test mocks gain **`fetchProfile` throw** support; profile-state tests cover failed reads during background reconciliation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9231df9889df737c3803341ab25dc403ec832f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->