### PR TITLE
[macOS] Validate release builds before publishing them to Sparkle

### DIFF
--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -237,6 +237,10 @@ jobs:
         pixel-params: |
           runner: ${{ env.RUNS_ON }}
 
+    - name: Validate official release app
+      if: env.is-official-release == 'true'
+      run: ./scripts/validate_release_artifact.sh app "release/${{ env.app-name }}.app" "${{ env.app-version }}"
+
     - name: Set app name and version
       id: set-outputs
       run: |
@@ -368,6 +372,7 @@ jobs:
           macOS/Gemfile.lock
           macOS/fastlane
           macOS/scripts/assets
+          macOS/scripts/validate_release_artifact.sh
 
     - name: Start measuring duration
       id: start-duration
@@ -434,6 +439,10 @@ jobs:
             --app-drop-link 430 160 "${dmg}" \
             "dmg"
         echo "dmg=${dmg}" >> $GITHUB_OUTPUT
+
+    - name: Validate official release DMG
+      if: env.release-type == 'release' && env.upload-to == 's3'
+      run: ./scripts/validate_release_artifact.sh dmg "${{ steps.create-dmg.outputs.dmg }}" "${{ env.app-version }}"
 
     - name: Report job duration
       continue-on-error: true

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -440,7 +440,7 @@ jobs:
             "dmg"
         echo "dmg=${dmg}" >> $GITHUB_OUTPUT
 
-    - name: Validate official release DMG
+    - name: Validate release DMG
       if: env.release-type == 'release' && env.upload-to == 's3'
       run: ./scripts/validate_release_artifact.sh dmg "${{ steps.create-dmg.outputs.dmg }}" "${{ env.app-version }}"
 

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -237,7 +237,7 @@ jobs:
         pixel-params: |
           runner: ${{ env.RUNS_ON }}
 
-    - name: Validate official release app
+    - name: Validate release build
       if: env.is-official-release == 'true'
       run: ./scripts/validate_release_artifact.sh app "release/${{ env.app-name }}.app" "${{ env.app-version }}"
 

--- a/.github/workflows/macos_publish_dmg_release.yml
+++ b/.github/workflows/macos_publish_dmg_release.yml
@@ -209,13 +209,13 @@ jobs:
         env:
           DMG_NAME: duckduckgo-${{ steps.verify-tag.outputs.release-version }}.dmg
         run: |
-          # Public release doesn't need fetching a DMG (it's already uploaded to S3)
-          if [[ "${RELEASE_TYPE}" != 'public' ]]; then
-            DMG_URL="${{ vars.DMG_URL_ROOT }}${DMG_NAME}"
-            curl -fLSs -o "$DMG_NAME" "$DMG_URL"
-          fi
+          DMG_URL="${{ vars.DMG_URL_ROOT }}${DMG_NAME}"
+          curl -fLSs -o "$DMG_NAME" "$DMG_URL"
           echo "dmg-name=$DMG_NAME" >> $GITHUB_OUTPUT
           echo "dmg-path=$DMG_NAME" >> $GITHUB_OUTPUT
+
+      - name: Validate release DMG before publishing to Sparkle
+        run: ./scripts/validate_release_artifact.sh dmg "${{ steps.fetch-dmg.outputs.dmg-path }}" "${{ steps.verify-tag.outputs.release-version }}"
 
       - name: Generate appcast
         id: appcast

--- a/macOS/scripts/validate_release_artifact.sh
+++ b/macOS/scripts/validate_release_artifact.sh
@@ -106,7 +106,7 @@ validate_mach_o_architectures() {
 validate_code_signing() {
 	local app_path=$1
 
-	codesign --verify --deep --strict --verbose=2 "${app_path}" \
+	codesign --verify --strict --verbose=2 "${app_path}" \
 		|| die "Code signature validation failed for ${app_path}"
 
 	spctl --assess --type execute --verbose=4 "${app_path}" \

--- a/macOS/scripts/validate_release_artifact.sh
+++ b/macOS/scripts/validate_release_artifact.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly EXPECTED_MAIN_BUNDLE_IDENTIFIER="com.duckduckgo.macos.browser"
+readonly -a REQUIRED_ARCHITECTURES=("arm64" "x86_64")
+
+usage() {
+	cat <<- EOF
+	Usage:
+	  $(basename "$0") app <path-to-app> <marketing-version.build-number>
+	  $(basename "$0") dmg <path-to-dmg> <marketing-version.build-number>
+
+	Validates a production DuckDuckGo release app or DMG. Release artifacts must:
+	  - use the production bundle identifier and expected version
+	  - contain arm64 and x86_64 in the main browser executable
+	  - have a valid signature and notarization ticket
+	  - pass Gatekeeper assessment
+
+	DMG validation also verifies and mounts the image, checks its installation layout,
+	and applies the complete app validation to the app inside it.
+	EOF
+}
+
+die() {
+	echo "❌ $*" >&2
+	exit 1
+}
+
+read_plist_value() {
+	local plist_path=$1
+	local key=$2
+
+	/usr/libexec/PlistBuddy -c "Print :${key}" "${plist_path}" 2>/dev/null
+}
+
+absolute_path() {
+	local path=$1
+	local directory
+	local filename
+
+	directory=$(dirname "${path}")
+	filename=$(basename "${path}")
+	[[ -e "${path}" ]] || die "Artifact does not exist: ${path}"
+
+	echo "$(cd "${directory}" && pwd -P)/${filename}"
+}
+
+validate_app_metadata() {
+	local app_path=$1
+	local expected_marketing_version=$2
+	local expected_build_number=$3
+	local plist_path="${app_path}/Contents/Info.plist"
+	local actual_bundle_identifier
+	local actual_marketing_version
+	local actual_build_number
+	local executable_name
+	local executable_path
+
+	[[ -f "${plist_path}" ]] || die "Required bundle metadata is missing: ${plist_path}"
+	plutil -lint "${plist_path}" > /dev/null || die "Invalid property list: ${plist_path}"
+
+	actual_bundle_identifier=$(read_plist_value "${plist_path}" "CFBundleIdentifier") \
+		|| die "CFBundleIdentifier is missing from ${plist_path}"
+	[[ "${actual_bundle_identifier}" == "${EXPECTED_MAIN_BUNDLE_IDENTIFIER}" ]] \
+		|| die "Unexpected bundle identifier: expected ${EXPECTED_MAIN_BUNDLE_IDENTIFIER}, found ${actual_bundle_identifier}"
+
+	actual_marketing_version=$(read_plist_value "${plist_path}" "CFBundleShortVersionString") \
+		|| die "CFBundleShortVersionString is missing from ${plist_path}"
+	[[ "${actual_marketing_version}" == "${expected_marketing_version}" ]] \
+		|| die "Unexpected marketing version in ${plist_path}: expected ${expected_marketing_version}, found ${actual_marketing_version}"
+
+	actual_build_number=$(read_plist_value "${plist_path}" "CFBundleVersion") \
+		|| die "CFBundleVersion is missing from ${plist_path}"
+	[[ "${actual_build_number}" == "${expected_build_number}" ]] \
+		|| die "Unexpected build number in ${plist_path}: expected ${expected_build_number}, found ${actual_build_number}"
+
+	executable_name=$(read_plist_value "${plist_path}" "CFBundleExecutable") \
+		|| die "CFBundleExecutable is missing from ${plist_path}"
+	executable_path="$(dirname "${plist_path}")/MacOS/${executable_name}"
+	[[ -f "${executable_path}" ]] \
+		|| die "Bundle executable does not exist: ${executable_path}"
+	echo "✅ Production bundle identifier and version are valid"
+}
+
+validate_mach_o_architectures() {
+	local app_path=$1
+	local plist_path="${app_path}/Contents/Info.plist"
+	local executable_name
+	local executable_path
+	local architectures
+
+	executable_name=$(read_plist_value "${plist_path}" "CFBundleExecutable") \
+		|| die "CFBundleExecutable is missing from ${plist_path}"
+	executable_path="${app_path}/Contents/MacOS/${executable_name}"
+	architectures=$(lipo -archs "${executable_path}") \
+		|| die "Could not inspect architectures in ${executable_path}"
+
+	if ! lipo "${executable_path}" -verify_arch "${REQUIRED_ARCHITECTURES[@]}"; then
+		die "Main browser executable is missing a required architecture: found ${architectures}, expected ${REQUIRED_ARCHITECTURES[*]}"
+	fi
+
+	echo "✅ Main browser executable contains ${architectures}"
+}
+
+validate_code_signing() {
+	local app_path=$1
+
+	codesign --verify --deep --strict --verbose=2 "${app_path}" \
+		|| die "Code signature validation failed for ${app_path}"
+
+	spctl --assess --type execute --verbose=4 "${app_path}" \
+		|| die "Gatekeeper assessment failed for ${app_path}"
+	xcrun stapler validate "${app_path}" \
+		|| die "Notarization ticket validation failed for ${app_path}"
+
+	echo "✅ Signature, Gatekeeper assessment, and notarization ticket are valid"
+}
+
+validate_app() {
+	local app_path=$1
+	local expected_version=$2
+	local expected_marketing_version
+	local expected_build_number
+
+	[[ -d "${app_path}" ]] || die "App bundle does not exist: ${app_path}"
+	[[ "${expected_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+		|| die "Expected version must use marketing-version.build-number format: ${expected_version}"
+
+	expected_marketing_version=${expected_version%.*}
+	expected_build_number=${expected_version##*.}
+
+	echo "Validating production release app: ${app_path}"
+	echo "Expected version: ${expected_marketing_version} (${expected_build_number})"
+
+	validate_app_metadata "${app_path}" "${expected_marketing_version}" "${expected_build_number}"
+	validate_mach_o_architectures "${app_path}"
+	validate_code_signing "${app_path}"
+
+	echo "✅ Production release app validation passed"
+}
+
+cleanup_dmg_mount() {
+	local mount_point=$1
+	local is_mounted=$2
+
+	if [[ "${is_mounted}" == "true" ]]; then
+		hdiutil detach "${mount_point}" -quiet \
+			|| hdiutil detach "${mount_point}" -force -quiet \
+			|| true
+	fi
+	rm -rf "${mount_point}"
+}
+
+validate_dmg() {
+	local dmg_path=$1
+	local expected_version=$2
+	local mount_point
+	local is_mounted=false
+	local app_path
+
+	[[ -f "${dmg_path}" ]] || die "DMG does not exist: ${dmg_path}"
+
+	echo "Validating production release DMG: ${dmg_path}"
+	hdiutil verify "${dmg_path}" > /dev/null || die "DMG verification failed for ${dmg_path}"
+	echo "✅ DMG image verification passed"
+
+	mount_point=$(mktemp -d "/tmp/duckduckgo-release-dmg.XXXXXX")
+	trap 'cleanup_dmg_mount "${mount_point}" "${is_mounted}"' EXIT
+
+	hdiutil attach \
+		-readonly \
+		-nobrowse \
+		-noautoopen \
+		-mountpoint "${mount_point}" \
+		"${dmg_path}" > /dev/null \
+		|| die "Could not mount ${dmg_path}"
+	is_mounted=true
+
+	app_path="${mount_point}/DuckDuckGo.app"
+	[[ -d "${app_path}" ]] || die "DMG does not contain DuckDuckGo.app at its top level"
+	[[ -L "${mount_point}/Applications" ]] || die "DMG does not contain an Applications drop link"
+	[[ "$(readlink "${mount_point}/Applications")" == "/Applications" ]] \
+		|| die "DMG Applications drop link does not point to /Applications"
+	echo "✅ DMG installation layout is valid"
+
+	validate_app "${app_path}" "${expected_version}"
+
+	cleanup_dmg_mount "${mount_point}" "${is_mounted}"
+	trap - EXIT
+	echo "✅ Production release DMG validation passed"
+}
+
+main() {
+	local mode=${1:-}
+	local artifact_path=${2:-}
+	local expected_version=${3:-}
+
+	if [[ $# -ne 3 ]]; then
+		usage
+		exit 1
+	fi
+
+	artifact_path=$(absolute_path "${artifact_path}")
+
+	case "${mode}" in
+		app)
+			validate_app "${artifact_path}" "${expected_version}"
+			;;
+		dmg)
+			validate_dmg "${artifact_path}" "${expected_version}"
+			;;
+		*)
+			usage
+			die "Unknown validation mode: ${mode}"
+			;;
+	esac
+}
+
+main "$@"


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1216929622551635?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

This PR adds a build validation script and wires it up to the release workflows.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Download a good version of the app from duckduckgo.com/mac and run the validation script against the DMG, you just need to pass it the DMG and the app version - you can ask Claude to do it for you, it will look up the version :)
2. Download a bad version of the app from [here](https://app.asana.com/1/137249556945/project/1199230911884351/task/1216694471714345?focus=true), and run the validation script against the DMG

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
3. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New mandatory gates on official release and Sparkle publish paths could block releases if validation is overly strict or flaky on runners, but changes only add pre-publish checks and do not alter app runtime code.
> 
> **Overview**
> Adds **`macOS/scripts/validate_release_artifact.sh`**, which checks production release **`.app`** and **DMG** artifacts: production bundle ID (`com.duckduckgo.macos.browser`), expected marketing/build version, **arm64** and **x86_64** on the main executable, **codesign**, **Gatekeeper**, and **notarization** stapling. DMG mode also verifies the image, expected layout (`DuckDuckGo.app` + Applications link), and runs the full app checks on the mounted bundle.
> 
> **Notarized build workflow** runs app validation for official release builds (`is-official-release`) and DMG validation when `release-type == release` and uploading to S3; the create-DMG job sparse-checkout now includes the script.
> 
> **Publish DMG / Sparkle workflow** always downloads the release DMG from CDN (removes the skip for public releases) and validates it **before** generating the appcast, so bad artifacts fail CI instead of reaching Sparkle users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13ce8a5a10ba79aed039fdb54c4aa895f9cd0180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->