### PR TITLE
Fix PIR wide event submission

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/EmailConfirmationJob.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/EmailConfirmationJob.swift
@@ -170,7 +170,6 @@ public class EmailConfirmationJob: Operation, @unchecked Sendable {
             stageDurationCalculator.fireOptOutSubmitSuccess(tries: attemptNumber)
             markSubmissionWideEventCompleted(
                 broker: broker,
-                profileIdentifier: extractedProfile.identifier,
                 brokerId: jobData.brokerId,
                 profileQueryId: jobData.profileQueryId,
                 extractedProfileId: jobData.extractedProfileId
@@ -413,7 +412,6 @@ public class EmailConfirmationJob: Operation, @unchecked Sendable {
     }
 
     private func markSubmissionWideEventCompleted(broker: DataBroker,
-                                                  profileIdentifier: String?,
                                                   brokerId: Int64,
                                                   profileQueryId: Int64,
                                                   extractedProfileId: Int64) {
@@ -423,10 +421,9 @@ public class EmailConfirmationJob: Operation, @unchecked Sendable {
                                                               brokerId: brokerId,
                                                               profileQueryId: profileQueryId,
                                                               extractedProfileId: extractedProfileId)
-        let wideEventId = OptOutWideEventIdentifier(profileIdentifier: profileIdentifier,
-                                                            brokerId: brokerId,
-                                                            profileQueryId: profileQueryId,
-                                                            extractedProfileId: extractedProfileId)
+        let wideEventId = OptOutWideEventIdentifier(brokerId: brokerId,
+                                                    profileQueryId: profileQueryId,
+                                                    extractedProfileId: extractedProfileId)
         OptOutSubmissionWideEventRecorder.startIfPossible(
             wideEvent: wideEvent,
             identifier: wideEventId,

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/BrokerProfileOptOutSubJob.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/BrokerProfileOptOutSubJob.swift
@@ -95,7 +95,6 @@ struct BrokerProfileOptOutSubJob {
 
             startWideEventRecorders(brokerProfileQueryData: brokerProfileQueryData,
                                     repository: dependencies.database,
-                                    extractedProfile: extractedProfile,
                                     identifiers: identifiers)
 
             try await executeOptOut(on: runner,
@@ -133,12 +132,10 @@ struct BrokerProfileOptOutSubJob {
 
     private func startWideEventRecorders(brokerProfileQueryData: BrokerProfileQueryData,
                                          repository: DataBrokerProtectionRepository,
-                                         extractedProfile: ExtractedProfile,
                                          identifiers: OptOutIdentifiers) {
         guard let wideEvent = dependencies.wideEvent else { return }
 
-        let wideEventId = OptOutWideEventIdentifier(profileIdentifier: extractedProfile.identifier,
-                                                    brokerId: identifiers.brokerId,
+        let wideEventId = OptOutWideEventIdentifier(brokerId: identifiers.brokerId,
                                                     profileQueryId: identifiers.profileQueryId,
                                                     extractedProfileId: identifiers.extractedProfileId)
         let recordFoundDate = RecordFoundDateResolver.resolve(repository: repository,
@@ -295,12 +292,8 @@ struct BrokerProfileOptOutSubJob {
         stageDurationCalculator.fireOptOutValidate()
         stageDurationCalculator.fireOptOutSubmitSuccess(tries: tries)
 
-        let profileIdentifier = brokerProfileQueryData.optOutJobData
-            .first(where: { $0.extractedProfile.id == identifiers.extractedProfileId })?
-            .extractedProfile.identifier
         markSubmissionWideEventCompleted(brokerProfileQueryData: brokerProfileQueryData,
                                          database: database,
-                                         profileIdentifier: profileIdentifier,
                                          brokerId: identifiers.brokerId,
                                          profileQueryId: identifiers.profileQueryId,
                                          extractedProfileId: identifiers.extractedProfileId)
@@ -329,7 +322,6 @@ struct BrokerProfileOptOutSubJob {
 
     private func markSubmissionWideEventCompleted(brokerProfileQueryData: BrokerProfileQueryData,
                                                   database: DataBrokerProtectionRepository,
-                                                  profileIdentifier: String?,
                                                   brokerId: Int64,
                                                   profileQueryId: Int64,
                                                   extractedProfileId: Int64) {
@@ -337,8 +329,7 @@ struct BrokerProfileOptOutSubJob {
                                                               brokerId: brokerId,
                                                               profileQueryId: profileQueryId,
                                                               extractedProfileId: extractedProfileId)
-        let wideEventId = OptOutWideEventIdentifier(profileIdentifier: profileIdentifier,
-                                                    brokerId: brokerId,
+        let wideEventId = OptOutWideEventIdentifier(brokerId: brokerId,
                                                     profileQueryId: profileQueryId,
                                                     extractedProfileId: extractedProfileId)
         OptOutSubmissionWideEventRecorder.startIfPossible(

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/BrokerProfileScanSubJob.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/BrokerProfileScanSubJob.swift
@@ -477,6 +477,10 @@ struct BrokerProfileScanSubJob {
         var shouldSendProfileRemovedEvent = false
         for removedProfile in removedProfiles {
             if let extractedProfileId = removedProfile.id {
+                let recordFoundDate = RecordFoundDateResolver.resolve(repository: database,
+                                                                      brokerId: brokerId,
+                                                                      profileQueryId: profileQueryId,
+                                                                      extractedProfileId: extractedProfileId)
                 let event = HistoryEvent(
                     extractedProfileId: extractedProfileId,
                     brokerId: brokerId,
@@ -489,11 +493,10 @@ struct BrokerProfileScanSubJob {
 
                 markConfirmationWideEventCompleted(
                     brokerProfileQueryData: brokerProfileQueryData,
-                    database: database,
-                    profileIdentifier: removedProfile.identifier,
                     brokerId: brokerId,
                     profileQueryId: profileQueryId,
-                    extractedProfileId: extractedProfileId
+                    extractedProfileId: extractedProfileId,
+                    recordFoundDate: recordFoundDate
                 )
 
                 try updateOperationDataDates(
@@ -535,17 +538,11 @@ struct BrokerProfileScanSubJob {
     }
 
     private func markConfirmationWideEventCompleted(brokerProfileQueryData: BrokerProfileQueryData,
-                                                    database: DataBrokerProtectionRepository,
-                                                    profileIdentifier: String?,
                                                     brokerId: Int64,
                                                     profileQueryId: Int64,
-                                                    extractedProfileId: Int64) {
-        let recordFoundDate = RecordFoundDateResolver.resolve(repository: database,
-                                                              brokerId: brokerId,
-                                                              profileQueryId: profileQueryId,
-                                                              extractedProfileId: extractedProfileId)
-        let wideEventId = OptOutWideEventIdentifier(profileIdentifier: profileIdentifier,
-                                                    brokerId: brokerId,
+                                                    extractedProfileId: Int64,
+                                                    recordFoundDate: Date?) {
+        let wideEventId = OptOutWideEventIdentifier(brokerId: brokerId,
                                                     profileQueryId: profileQueryId,
                                                     extractedProfileId: extractedProfileId)
         OptOutConfirmationWideEventRecorder.startIfPossible(

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/WideEvent/OptOutWideEventIdentifier.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/WideEvent/OptOutWideEventIdentifier.swift
@@ -18,21 +18,24 @@
 
 import Foundation
 import BrowserServicesKit
-import PixelKit
 
 /// We want a stable ID for different opt-out attempts associated with an extracted profile,
 /// so we can measure the time spent to successfully submit/confirm an opt-out request
 struct OptOutWideEventIdentifier {
-    let profileIdentifier: String?
     let brokerId: Int64
     let profileQueryId: Int64
     let extractedProfileId: Int64
 
-    /// Ideally we use the profile identifier on the broker (which falls back to the profile URL),
-    /// but we need another fallback in case it's nil, so that we won't under count wide events
-    ///
+    /// Returns UUID-shaped string
     /// These only need to be locally unique as they aren't sent with the wide events.
     var toGlobalId: String {
-        profileIdentifier?.sha256 ?? "\(brokerId)-\(profileQueryId)-\(extractedProfileId)"
+        let hash = "\(brokerId)-\(profileQueryId)-\(extractedProfileId)".sha256
+        return [
+            String(hash.prefix(8)),
+            String(hash.dropFirst(8).prefix(4)),
+            String(hash.dropFirst(12).prefix(4)),
+            String(hash.dropFirst(16).prefix(4)),
+            String(hash.dropFirst(20).prefix(12))
+        ].joined(separator: "-")
     }
 }

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileScanSubJobTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileScanSubJobTests.swift
@@ -20,6 +20,7 @@ import XCTest
 import BrowserServicesKit
 import Common
 import PixelKit
+import PixelKitTestingUtilities
 @testable import DataBrokerProtectionCore
 import DataBrokerProtectionCoreTestsUtils
 
@@ -605,6 +606,47 @@ final class BrokerProfileScanSubJobTests: XCTestCase {
         let firedNames = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.map(\.name)
         XCTAssertFalse(firedNames.contains("dbp_optout_process_success"))
         XCTAssertFalse(firedNames.contains("dbp_optout_stage_finish"))
+    }
+
+    func testMarkSavedProfilesAsRemovedAndNotifyUser_resolvesFoundDateBeforeStoringConfirmation() throws {
+        let identifiers = makeFixtureIdentifiers()
+        let foundDate = Date().addingTimeInterval(-60)
+        mockDatabase.scanEvents = [
+            HistoryEvent(brokerId: identifiers.brokerId,
+                         profileQueryId: identifiers.profileQueryId,
+                         type: .matchesFound(count: 1),
+                         date: foundDate)
+        ]
+        mockDatabase.optOutEvents = [
+            HistoryEvent(extractedProfileId: 1,
+                         brokerId: identifiers.brokerId,
+                         profileQueryId: identifiers.profileQueryId,
+                         type: .optOutRequested,
+                         date: foundDate.addingTimeInterval(10))
+        ]
+        let wideEvent = WideEventMock()
+        mockDependencies.wideEvent = wideEvent
+        let completionExpectation = expectation(description: "confirmation wide event completed")
+        wideEvent.onComplete = { data, status in
+            let confirmationData = data as? OptOutConfirmationWideEventData
+            XCTAssertEqual(status, .success)
+            XCTAssertEqual(confirmationData?.confirmationInterval?.start, foundDate)
+            XCTAssertNotNil(confirmationData?.confirmationInterval?.end)
+            XCTAssertGreaterThan(confirmationData?.confirmationInterval?.durationMilliseconds ?? 0, 0)
+            completionExpectation.fulfill()
+        }
+
+        try sut.markSavedProfilesAsRemovedAndNotifyUser(
+            removedProfiles: [.mockWithoutRemovedDate],
+            brokerId: identifiers.brokerId,
+            profileQueryId: identifiers.profileQueryId,
+            brokerProfileQueryData: makeFixtureBrokerProfileQueryData(),
+            database: mockDatabase,
+            pixelHandler: mockPixelHandler,
+            eventsHandler: mockEventsHandler
+        )
+
+        wait(for: [completionExpectation], timeout: 1.0)
     }
 
     // MARK: - handleRemovedProfiles

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/OptOutSubmissionWideEventRecorderTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/OptOutSubmissionWideEventRecorderTests.swift
@@ -25,7 +25,6 @@ import BrowserServicesKit
 final class OptOutSubmissionWideEventRecorderTests: XCTestCase {
 
     private var wideEventMock: WideEventMock!
-    private let profileIdentifier = "profile-id"
     private let brokerId: Int64 = 42
     private let profileQueryId: Int64 = 13
     private let extractedProfileId: Int64 = 99
@@ -45,7 +44,6 @@ final class OptOutSubmissionWideEventRecorderTests: XCTestCase {
 
     func testMakeIfPossibleStartsFlow() {
         let recorderIdentifier = OptOutWideEventIdentifier(
-            profileIdentifier: profileIdentifier,
             brokerId: brokerId,
             profileQueryId: profileQueryId,
             extractedProfileId: extractedProfileId
@@ -62,14 +60,14 @@ final class OptOutSubmissionWideEventRecorderTests: XCTestCase {
         XCTAssertEqual(wideEventMock.started.count, 1)
 
         let data = wideEventMock.started.first as? OptOutSubmissionWideEventData
-        XCTAssertEqual(data?.globalData.id, "profile-id".sha256)
+        XCTAssertEqual(data?.globalData.id, "de5543ce-6121-4f6e-12ef-d6db414e4a64")
+        XCTAssertNotNil(UUID(uuidString: recorderIdentifier.toGlobalId))
         XCTAssertEqual(data?.submissionInterval?.start, recordFoundDate)
         XCTAssertNil(data?.submissionInterval?.end)
     }
 
     func testResumeIfPossibleReturnsExistingFlow() {
         let identifier = OptOutWideEventIdentifier(
-            profileIdentifier: profileIdentifier,
             brokerId: brokerId,
             profileQueryId: profileQueryId,
             extractedProfileId: extractedProfileId
@@ -86,10 +84,9 @@ final class OptOutSubmissionWideEventRecorderTests: XCTestCase {
         XCTAssertEqual(wideEventMock.started.count, 1)
 
         let otherIdentifier = OptOutWideEventIdentifier(
-            profileIdentifier: "other-profile",
             brokerId: brokerId,
             profileQueryId: profileQueryId,
-            extractedProfileId: extractedProfileId
+            extractedProfileId: extractedProfileId + 1
         )
         XCTAssertNil(
             OptOutSubmissionWideEventRecorder.resumeIfPossible(
@@ -129,32 +126,39 @@ final class OptOutSubmissionWideEventRecorderTests: XCTestCase {
         XCTAssertEqual(wideEventMock.started.count, 1)
     }
 
-    func testMakeIfPossibleUsesFallbackIdentifierWhenProfileIdentifierMissing() {
-        let identifierWithoutProfile = OptOutWideEventIdentifier(
-            profileIdentifier: nil,
+    func testStoredFlowCanBeEnumeratedFromUserDefaultsStorage() {
+        let suiteName = "\(type(of: self))-\(UUID().uuidString)"
+        let testDefaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defer {
+            testDefaults.removePersistentDomain(forName: suiteName)
+        }
+        let wideEvent = WideEvent(
+            storage: WideEventUserDefaultsStorage(userDefaults: testDefaults),
+            failureEventMapping: nil,
+            featureFlagProvider: TestWideEventFeatureFlagProvider()
+        )
+        let identifier = OptOutWideEventIdentifier(
             brokerId: brokerId,
             profileQueryId: profileQueryId,
             extractedProfileId: extractedProfileId
         )
 
         let recorder = OptOutSubmissionWideEventRecorder.makeIfPossible(
-            wideEvent: wideEventMock,
-            identifier: identifierWithoutProfile,
+            wideEvent: wideEvent,
+            identifier: identifier,
             dataBrokerURL: "broker.com",
             dataBrokerVersion: "1.0",
             recordFoundDate: recordFoundDate
         )
 
         XCTAssertNotNil(recorder)
-        XCTAssertEqual(wideEventMock.started.count, 1)
-
-        let data = wideEventMock.started.first as? OptOutSubmissionWideEventData
-        XCTAssertEqual(data?.globalData.id, "42-13-99")
+        let storedFlows = wideEvent.getAllFlowData(OptOutSubmissionWideEventData.self)
+        XCTAssertEqual(storedFlows.count, 1)
+        XCTAssertEqual(storedFlows.first?.globalData.id, "de5543ce-6121-4f6e-12ef-d6db414e4a64")
     }
 
     func testStartIfPossibleCreatesRecorderWhenNoneExists() {
         let identifier = OptOutWideEventIdentifier(
-            profileIdentifier: profileIdentifier,
             brokerId: brokerId,
             profileQueryId: profileQueryId,
             extractedProfileId: extractedProfileId
@@ -171,5 +175,12 @@ final class OptOutSubmissionWideEventRecorderTests: XCTestCase {
         XCTAssertNotNil(recorder)
         let data = wideEventMock.started.first as? OptOutSubmissionWideEventData
         XCTAssertEqual(data?.submissionInterval?.start, recordFoundDate)
+    }
+
+}
+
+private struct TestWideEventFeatureFlagProvider: WideEventFeatureFlagProviding {
+    func isEnabled(_ flag: WideEventFeatureFlag) -> Bool {
+        true
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1215419848050295/task/1216921094533878?focus=true
Tech Design URL:
CC:

### Description

Fixes 2 bugs in PIR wide event submissions that prevent many of them from being sent:
1. Global ID not using UUID format
2. Record found date miscalculation 

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. —>
1. CI passes
3.


### Impact

Low, PIR wide events not used in any current dashboard.

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." —>

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only wide-event identifier and interval metadata changes; PIR wide events are not used in current dashboards per the PR description.
> 
> **Overview**
> Fixes PIR opt-out **wide event** plumbing so more submission and confirmation events can be recorded and sent.
> 
> **Stable global IDs:** `OptOutWideEventIdentifier` no longer uses broker `profileIdentifier` (or a raw `brokerId-profileQueryId-extractedProfileId` fallback). IDs are always a **UUID-shaped string** from an SHA-256 of those three numeric keys, so flows can resume consistently and stored `globalData.id` matches what the wide-event pipeline expects.
> 
> **Call-site cleanup:** Email confirmation, opt-out, and scan paths build identifiers from broker/profile/extracted-profile IDs only—no passing `extractedProfile.identifier` into wide-event helpers.
> 
> **Confirmation timing:** When a scan marks profiles as removed, **record found date** is resolved via `RecordFoundDateResolver` **before** writing `optOutConfirmed` and updating removal dates, then passed into confirmation wide-event completion so the confirmation interval **starts at the true match-found time**, not a value skewed by ordering or stale history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0497f6f2dbecb3d4464dc54fb1b1b9447032163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->