### PR TITLE
Updates Lottie to 4.6.1

### DIFF
--- a/.github/workflows/macos_sync_end_to_end.yml
+++ b/.github/workflows/macos_sync_end_to_end.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         runner: [macos-14-xlarge, macos-15-xlarge, macos-26-xlarge]
         include:
-          - xcode-version: "15.4"
+          - xcode-version: "16.2"
             runner: macos-14-xlarge
             os-version: 14
           - xcode-version: "26.2"

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -142,7 +142,7 @@ jobs:
             all_os_versions='true'
             runner='["macos-14-xlarge", "macos-15-xlarge", "macos-26-xlarge"]'
             include=$(jq -c <<< '[
-              {"runner": "macos-14-xlarge", "os-version": "14", "xcode-version": "15.4"},
+              {"runner": "macos-14-xlarge", "os-version": "14", "xcode-version": "16.2"},
               {"runner": "macos-15-xlarge", "os-version": "15", "xcode-version": "26.2"},
               {"runner": "macos-26-xlarge", "os-version": "26", "xcode-version": "26.4"}
             ]')

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -18512,7 +18512,7 @@
 			repositoryURL = "https://github.com/airbnb/lottie-spm.git";
 			requirement = {
 				kind = exactVersion;
-				version = 4.5.2;
+				version = 4.6.1;
 			};
 		};
 		9FADFC482F5FC56400CA16F7 /* XCRemoteSwiftPackageReference "native-apps-ducksans" */ = {

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-spm.git",
       "state" : {
-        "revision" : "04f2fd18cc9404a0a0917265a449002674f24ec9",
-        "version" : "4.5.2"
+        "revision" : "0aff16288f8dc1e3dab35cbf5cf45979673fd3df",
+        "version" : "4.6.1"
       }
     },
     {

--- a/iOS/LocalPackages/SyncUI-iOS/Package.resolved
+++ b/iOS/LocalPackages/SyncUI-iOS/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-spm.git",
       "state" : {
-        "revision" : "04f2fd18cc9404a0a0917265a449002674f24ec9",
-        "version" : "4.5.2"
+        "revision" : "0aff16288f8dc1e3dab35cbf5cf45979673fd3df",
+        "version" : "4.6.1"
       }
     },
     {

--- a/iOS/LocalPackages/SyncUI-iOS/Package.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .package(path: "../../../SharedPackages/Infrastructure/MetricBuilder"),
         .package(path: "../../../SharedPackages/UIComponents"),
         .package(url: "https://github.com/duckduckgo/apple-toolbox.git", exact: "3.2.1"),
-        .package(url: "https://github.com/airbnb/lottie-spm.git", exact: "4.5.2"),
+        .package(url: "https://github.com/airbnb/lottie-spm.git", exact: "4.6.1"),
     ],
     targets: [
         .target(

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -20619,7 +20619,7 @@
 			repositoryURL = "https://github.com/airbnb/lottie-spm.git";
 			requirement = {
 				kind = exactVersion;
-				version = 4.5.2;
+				version = 4.6.1;
 			};
 		};
 		B65CD8C92B316DF100A595BB /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-spm.git",
       "state" : {
-        "revision" : "04f2fd18cc9404a0a0917265a449002674f24ec9",
-        "version" : "4.5.2"
+        "revision" : "0aff16288f8dc1e3dab35cbf5cf45979673fd3df",
+        "version" : "4.6.1"
       }
     },
     {

--- a/macOS/LocalPackages/NetworkProtectionMac/Package.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         .library(name: "VPNNotifications", targets: ["VPNNotifications"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.5.2"),
+        .package(url: "https://github.com/airbnb/lottie-spm", exact: "4.6.1"),
         .package(path: "../../../SharedPackages/BrowserServicesKit"),
         .package(path: "../../../SharedPackages/Infrastructure/DesignResourcesKit"),
         .package(path: "../../../SharedPackages/Infrastructure/DesignResourcesKitIcons"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206329551987282/task/1212706550114243?focus=true
Tech Design URL:
CC:

### Description
This PR updates Lottie to Mark 4.6.1.

Plus: since the Lottie requires `swift-tools-version: 6.0`,  we're also bumping Xcode `15.4` > `16.2` in these workflows:
- `macos_sync_end_to_end`
- `macos_ui_tests`

### Testing Steps
- [ ] Verify iOS Animations work as expected (Fire, VPN)
- [ ] Verify macOS Animations also work great (Fire, VPN, Privacy Shield)
- [ ] Verify [the UI Tests are green](https://github.com/duckduckgo/apple-browsers/actions/runs/30317411443)
- [ ] Verify [the Sync E2E Tests are green](https://github.com/duckduckgo/apple-browsers/actions/runs/30317415683)

### Impact
Medium: Could disrupt specific features or user flows

#### What could go wrong?
Lottie could introduce a regression (OR) we could introduce CI issues.

### Quality Considerations
None

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency upgrade can affect Lottie-driven UI (e.g. Sync and VPN animations), and raising the macOS 14 CI Xcode version can surface build or test issues on that matrix leg.
> 
> **Overview**
> Bumps **lottie-spm** from **4.5.2** to **4.6.1** across iOS and macOS (Xcode SPM pins, `Package.resolved`, **SyncUI-iOS**, and **NetworkProtectionMac**).
> 
> Because the new Lottie release needs a newer Swift toolchain, **macOS 14** CI legs in **`macos_sync_end_to_end`** and **`macos_ui_tests`** now use **Xcode 16.2** instead of **15.4** (macOS 15/26 Xcode versions unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9576821cff3899e46f3fd14bdaf30ed37f39a6e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->