### PR TITLE
EventHub for Apple #2: macOS EventHub integration

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -89,6 +89,7 @@ public enum PrivacyFeature: String {
     case forceDarkModeOnWebsites
     case promoQueue
     case adBlockingExtension
+    case eventHub
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.

--- a/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
@@ -291,6 +291,11 @@ public final class EventHub: EventHubManaging {
             if let periodSeconds = telemetry.config.trigger.period?.periodSeconds {
                 params["attributionPeriod"] = String(EventHubAttribution.startOfIntervalSeconds(
                     periodStartMillis: telemetry.periodStartMillis, periodSeconds: periodSeconds))
+                let rawCounts = telemetry.rawCounterValues
+                    .sorted { $0.key < $1.key }
+                    .map { "\($0.key)=\($0.value)" }
+                    .joined(separator: ", ")
+                Logger.eventHub.info("firing period pixel \(name, privacy: .public), raw counts [\(rawCounts, privacy: .public)]")
                 pixelFiring.enqueueFirePixel(named: name, parameters: params)
             } else {
                 Logger.eventHub.error("pixel \(name, privacy: .public) not fired, its period trigger has no period to attribute to")

--- a/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
@@ -97,6 +97,14 @@ public final class EventHub: EventHubManaging {
     private var isForeground = false
     private var subscriptions = Set<AnyCancellable>()
 
+    /// `false` until `init` has consumed the settings publishers' initial replay. While `false` the
+    /// subscriptions only record state without applying it: applying during `init` would let a
+    /// transient `enabled == false` — e.g. remote config not loaded yet on a cold launch — reach
+    /// `disableLocked()` and wipe persisted period state that a later `enabled == true` cannot recover.
+    /// Startup instead applies config on the first `onAppForegrounded()`, which is also the earliest
+    /// point a period is allowed to start.
+    private var hasConsumedInitialSettings = false
+
     /// `internal`, not `public` — visible to `@testable import EventHub`, mirroring the Windows
     /// `internal IReadOnlyCollection<PixelState> ActivePixelStates` marker (exposed to tests only).
     var activePixelStates: [PixelState] {
@@ -125,16 +133,31 @@ public final class EventHub: EventHubManaging {
         self.queue = queue
         queue.setSpecific(key: Self.ownQueueIdentityKey, value: ObjectIdentifier(queue))
 
+        // Both subscriptions re-apply the config themselves, so any change in enablement *or* in the
+        // settings (including a consent grant/revoke, which `EventHubSettings` folds into the settings
+        // JSON) takes effect immediately. Integrators do not need to call `onConfigChanged()`.
         settings.enabledPublisher
-            .sink { [weak self] enabled in self?.queue.sync { self?.latestEnabled = enabled } }
+            .sink { [weak self] enabled in
+                self?.queue.sync {
+                    guard let self, self.latestEnabled != enabled else { return }
+                    self.latestEnabled = enabled
+                    Logger.eventHub.info("feature enabled = \(enabled, privacy: .public)")
+                    if self.hasConsumedInitialSettings { self.applyConfigLocked() }
+                }
+            }
             .store(in: &subscriptions)
         settings.settingsPublisher
             .sink { [weak self] settings in
                 self?.queue.sync {
-                    self?.latestConfigs = settings.map { self?.parser.parseTelemetry($0) ?? [] } ?? []
+                    guard let self else { return }
+                    self.latestConfigs = settings.map { self.parser.parseTelemetry($0) } ?? []
+                    Logger.eventHub.info("parsed \(self.latestConfigs.count, privacy: .public) telemetry config(s) from settings")
+                    if self.hasConsumedInitialSettings { self.applyConfigLocked() }
                 }
             }
             .store(in: &subscriptions)
+
+        queue.sync { hasConsumedInitialSettings = true }
     }
 
     public func handleWebEvent(_ webEventData: [String: Any], tabID: EventHubTabID) {

--- a/SharedPackages/EventHub/Sources/EventHub/Core/Telemetry.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/Telemetry.swift
@@ -83,6 +83,17 @@ final class Telemetry {
                     config: config, params: parameters.mapValues(\.state))
     }
 
+    /// Raw (pre-bucketing) counts per counter parameter, keyed by parameter name. For debug logging
+    /// only — the fired pixel carries the privacy-safe bucketed value (from `buildPixelParameters`),
+    /// never these exact numbers.
+    var rawCounterValues: [String: Int] {
+        var result: [String: Int] = [:]
+        for (paramName, paramConfig) in config.parameters where paramConfig.isCounter {
+            if let parameter = parameters[paramName] { result[paramName] = parameter.state.value }
+        }
+        return result
+    }
+
     /// The query parameters to emit for this pixel, or `nil` if nothing meaningful was measured
     /// (e.g. no counter matched a bucket and no data parameter has a value).
     func buildPixelParameters() -> [String: String]? {

--- a/SharedPackages/EventHub/Sources/EventHub/Logger+EventHub.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Logger+EventHub.swift
@@ -19,9 +19,12 @@
 import Foundation
 import os.log
 
-extension Logger {
+public extension Logger {
     /// Replaces the Windows implementation's `Diagnostic.cs` ETW source: every fail-safe boundary in
     /// EventHub logs here rather than swallowing silently. Local only — never PII, never a URL.
+    ///
+    /// `public` so each platform's wiring layer logs to the same subsystem, keeping all EventHub
+    /// activity filterable as one stream.
     ///
     /// Only config-governed identifiers (pixel names, parameter names, bucket names, data keys) and
     /// error descriptions are interpolated as `.public`; web-page-derived event payloads are never

--- a/SharedPackages/EventHub/Sources/EventHub/Persistence/EventHubStore.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Persistence/EventHubStore.swift
@@ -49,12 +49,13 @@ public final class EventHubKeyValueStore: EventHubStore {
     /// The single key under which the map of pixel-name to `EventHubStoredPixelState` is stored.
     public static let storageKey = "eventhub_pixel_states"
 
-    private let store: ThrowingKeyValueStoring
+    /// `nil` when the platform could not open its store: reads report absence, writes are dropped.
+    private let store: ThrowingKeyValueStoring?
     private let parser: EventHubConfigParsing
     private let eventMapping: EventMapping<EventHubDebugEvent>?
 
     public init(
-        store: ThrowingKeyValueStoring,
+        store: ThrowingKeyValueStoring?,
         parser: EventHubConfigParsing,
         eventMapping: EventMapping<EventHubDebugEvent>? = nil
     ) {
@@ -96,7 +97,7 @@ public final class EventHubKeyValueStore: EventHubStore {
 
     public func deleteAllPixelStates() {
         do {
-            try store.removeObject(forKey: Self.storageKey)
+            try store?.removeObject(forKey: Self.storageKey)
         } catch {
             Logger.eventHub.error("store: could not delete all pixel state: \(error.localizedDescription, privacy: .public)")
             eventMapping?.fire(.pixelStatePersistenceFailed(operation: .delete), error: error)
@@ -106,7 +107,7 @@ public final class EventHubKeyValueStore: EventHubStore {
     private func readMap() -> [String: EventHubStoredPixelState] {
         let stored: Any?
         do {
-            stored = try store.object(forKey: Self.storageKey)
+            stored = try store?.object(forKey: Self.storageKey)
         } catch {
             Logger.eventHub.error("store: could not read pixel state: \(error.localizedDescription, privacy: .public)")
             eventMapping?.fire(.pixelStatePersistenceFailed(operation: .read), error: error)
@@ -134,7 +135,7 @@ public final class EventHubKeyValueStore: EventHubStore {
             return
         }
         do {
-            try store.set(data, forKey: Self.storageKey)
+            try store?.set(data, forKey: Self.storageKey)
         } catch {
             Logger.eventHub.error("store: could not persist pixel state: \(error.localizedDescription, privacy: .public)")
             eventMapping?.fire(.pixelStatePersistenceFailed(operation: .write), error: error)

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubTests.swift
@@ -313,6 +313,50 @@ struct EventHubTests {
         #expect(f.count(of: Self.pixel1) == 1)
     }
 
+    // MARK: Settings changes apply without an explicit onConfigChanged
+
+    @Test("a settings change that adds a pixel starts counting it without an explicit onConfigChanged")
+    func settingsChangeAddingPixelAppliesWithoutOnConfigChanged() {
+        // Starts with the pixel absent, as a consent-gated entry stripped by EventHubSettings would be.
+        let f = EventHubFixture.active(#"{ "telemetry": { } }"#)
+        #expect(f.state(of: Self.pixel1) == nil)
+
+        // Consent granted: the entry reappears in the settings JSON. No onConfigChanged() call here —
+        // EventHub must pick it up itself, otherwise events are silently dropped until the next
+        // foreground or remote-config update.
+        f.setSettings(Self.dayConfig)
+
+        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: .new())
+        #expect(f.count(of: Self.pixel1) == 1)
+    }
+
+    @Test("a settings change that removes a pixel tears it down without an explicit onConfigChanged")
+    func settingsChangeRemovingPixelAppliesWithoutOnConfigChanged() {
+        let f = EventHubFixture.active(Self.dayConfig)
+        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: .new())
+        f.advance(by: EventHubFixture.writeBehindFlush)
+        #expect(f.repository.pixelState(named: Self.pixel1) != nil)
+
+        // Consent revoked: the entry is stripped. Again no explicit onConfigChanged().
+        f.setSettings(#"{ "telemetry": { } }"#)
+
+        #expect(f.state(of: Self.pixel1) == nil)
+        #expect(f.repository.pixelState(named: Self.pixel1) == nil)
+    }
+
+    @Test("disabling the feature clears state without an explicit onConfigChanged")
+    func disablingFeatureAppliesWithoutOnConfigChanged() {
+        let f = EventHubFixture.active(Self.dayConfig)
+        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: .new())
+        f.advance(by: EventHubFixture.writeBehindFlush)
+        #expect(f.repository.pixelState(named: Self.pixel1) != nil)
+
+        f.setEnabled(false)
+
+        #expect(f.state(of: Self.pixel1) == nil)
+        #expect(f.repository.pixelState(named: Self.pixel1) == nil)
+    }
+
     // MARK: onConfigChanged lifecycle
 
     @Test("onConfigChanged initialises new pixels")

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Persistence/EventHubStoreTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Persistence/EventHubStoreTests.swift
@@ -161,4 +161,20 @@ struct EventHubStoreTests {
         let restored = try #require(repository.pixelState(named: "testPixel"))
         #expect(restored.params.isEmpty)
     }
+
+    @Test("a nil backing store reports absence and drops writes without failing")
+    func nilBackingStoreReportsAbsenceAndDropsWrites() {
+        let repository: EventHubStore = EventHubKeyValueStore(store: nil, parser: EventHubConfigParser())
+        let state = PixelState(pixelName: "testPixel", periodStartMillis: 0, periodEndMillis: 86_400_000,
+                                config: Self.sampleConfig, params: ["count": ParamState(value: 3)])
+
+        repository.savePixelState(state)
+
+        #expect(repository.pixelState(named: "testPixel") == nil)
+        #expect(repository.allPixelStates().isEmpty)
+
+        // Must be no-ops rather than trapping.
+        repository.deletePixelState(named: "testPixel")
+        repository.deleteAllPixelStates()
+    }
 }

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -341,6 +341,10 @@
 		20AC3AA2FB956B8B11BCA072 /* DarkReaderFeatureSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC0C468BD3373676AC82B61 /* DarkReaderFeatureSettingsTests.swift */; };
 		28490640A8EB4AD68903FA02 /* RebrandedContextualOnboardingDialogs+Trackers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 486DE4DF1E7F43229D062937 /* RebrandedContextualOnboardingDialogs+Trackers.swift */; };
 		2934D5F7ED34D21C191CFA23 /* TabSuspensionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F16A73746AF35E5F7248523 /* TabSuspensionExtension.swift */; };
+		4E3C7A1113782980F29DFDD0 /* EventHubTabExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B283A52E00FF3D2C8240EA /* EventHubTabExtension.swift */; };
+		F34D15BE552CA8D563E0E8F6 /* MacOSEventHubIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4063303C52EE98D9AC6FAC /* MacOSEventHubIntegration.swift */; };
+		63F6360B709D803C891FB236 /* MacOSEventHubPixelFiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62DD4D2AC1D0C1F50B8025D3 /* MacOSEventHubPixelFiring.swift */; };
+		F89306773FE37E10EE24A19B /* YouTubeAdBlockingTelemetryConsentRequirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AA0ED38F7EA8BACD220B2F /* YouTubeAdBlockingTelemetryConsentRequirement.swift */; };
 		2B3C4D5E6F708192A3B4C5D6 /* BookmarksBarMenuPopoverPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B2C3D4E5F60718293A4B5 /* BookmarksBarMenuPopoverPresenting.swift */; };
 		2C358C150A134A3EB0D10E8D /* RebrandedContextualDaxDialogsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F1ACADA515C4BDD938B480B /* RebrandedContextualDaxDialogsFactory.swift */; };
 		30F066C9C4944314BCCB4775 /* RebrandedContextualOnboardingDialogs+Fire.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09265BA0D784C47B9644675 /* RebrandedContextualOnboardingDialogs+Fire.swift */; };
@@ -1747,6 +1751,10 @@
 		4B9EE32C2D76C87100DDC75C /* Onboarding in Frameworks */ = {isa = PBXBuildFile; productRef = 4B9EE32B2D76C87100DDC75C /* Onboarding */; };
 		4B9EE32E2D76C87C00DDC75C /* PageRefreshMonitor in Frameworks */ = {isa = PBXBuildFile; productRef = 4B9EE32D2D76C87C00DDC75C /* PageRefreshMonitor */; };
 		4B9EE3302D76C88300DDC75C /* Persistence in Frameworks */ = {isa = PBXBuildFile; productRef = 4B9EE32F2D76C88300DDC75C /* Persistence */; };
+		9FA9C53A7D5A0C25CA7ED287 /* EventHub in Frameworks */ = {isa = PBXBuildFile; productRef = 8714BC081D36DA291FF7A650 /* EventHub */; };
+		23F31642A4C5168A6538E6FD /* EventHub in Frameworks */ = {isa = PBXBuildFile; productRef = F07A89FE5A0959D49AF0E27F /* EventHub */; };
+		35F0EEDB46C5B99058C0A95A /* EventHub in Frameworks */ = {isa = PBXBuildFile; productRef = EC2E83ED38F4FAB06EE3D557 /* EventHub */; };
+		FD8C554D30455000D23DB903 /* EventHub in Frameworks */ = {isa = PBXBuildFile; productRef = CA7335A53836D5A56E2F5B4A /* EventHub */; };
 		4B9EE3322D76C89500DDC75C /* PixelKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4B9EE3312D76C89500DDC75C /* PixelKit */; };
 		4B9EE3342D76C89D00DDC75C /* RemoteMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 4B9EE3332D76C89D00DDC75C /* RemoteMessaging */; };
 		4B9EE3362D76C8A600DDC75C /* Subscription in Frameworks */ = {isa = PBXBuildFile; productRef = 4B9EE3352D76C8A600DDC75C /* Subscription */; };
@@ -2309,7 +2317,9 @@
 		7BBBD8902ED8A438003A7DA5 /* WebNotificationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBBD88F2ED8A438003A7DA5 /* WebNotificationsHandler.swift */; };
 		7BBBD8912ED8A438003A7DA5 /* WebNotificationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBBD88F2ED8A438003A7DA5 /* WebNotificationsHandler.swift */; };
 		7BBBD8942ED8A451003A7DA5 /* WebNotificationsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBBD8922ED8A451003A7DA5 /* WebNotificationsHandlerTests.swift */; };
+		C9BE9F534296EB9B99954781 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D6E49F5A586E6C68C37BA8 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift */; };
 		7BBBD8952ED8A451003A7DA5 /* WebNotificationsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBBD8922ED8A451003A7DA5 /* WebNotificationsHandlerTests.swift */; };
+		A4D2EDD63CCEEDAAC428F0D3 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D6E49F5A586E6C68C37BA8 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift */; };
 		7BBBD8982ED8DA51003A7DA5 /* NotificationIconFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBBD8962ED8DA51003A7DA5 /* NotificationIconFetcher.swift */; };
 		7BBBD8992ED8DA51003A7DA5 /* NotificationIconFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBBD8962ED8DA51003A7DA5 /* NotificationIconFetcher.swift */; };
 		7BBD45B12A691AB500C83CA9 /* NetworkProtectionDebugUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD45B02A691AB500C83CA9 /* NetworkProtectionDebugUtilities.swift */; };
@@ -2958,6 +2968,10 @@
 		A1B2C3D52F16000000000001 /* AIChatSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D32F16000000000001 /* AIChatSession.swift */; };
 		A2386B5C129943ED88670FBE /* AIChatFloatingWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A12E99106CCA4281998533BC /* AIChatFloatingWindow.swift */; };
 		A370E7706B30748FF9DEAD3F /* TabSuspensionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F16A73746AF35E5F7248523 /* TabSuspensionExtension.swift */; };
+		2BF629A1D6EF34452B6729C1 /* EventHubTabExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B283A52E00FF3D2C8240EA /* EventHubTabExtension.swift */; };
+		4DF11EDDA9F96915ABE128D2 /* MacOSEventHubIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4063303C52EE98D9AC6FAC /* MacOSEventHubIntegration.swift */; };
+		965772510DB9E9272C960181 /* MacOSEventHubPixelFiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62DD4D2AC1D0C1F50B8025D3 /* MacOSEventHubPixelFiring.swift */; };
+		C21FEF2AD7C1EC5678C3E1A4 /* YouTubeAdBlockingTelemetryConsentRequirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AA0ED38F7EA8BACD220B2F /* YouTubeAdBlockingTelemetryConsentRequirement.swift */; };
 		A73FF53A415CF3340D986951 /* SafariVersionReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACF6FD526BC366D00CF09F9 /* SafariVersionReader.swift */; };
 		A79433C7FCB2CA08F8782A94 /* UnloadedTabViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BC7E0753A96C3B81E3BCB2 /* UnloadedTabViewModelTests.swift */; };
 		A7C3D1E92F4B5A100654B4E /* SERPInstallOrigin in Frameworks */ = {isa = PBXBuildFile; productRef = A7C3D1EA2F4B5A200654B4E /* SERPInstallOrigin */; };
@@ -5830,6 +5844,7 @@
 		7BB9F8E72DFC1AB700741690 /* VPN */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = VPN; path = ../SharedPackages/VPN; sourceTree = SOURCE_ROOT; };
 		7BBBD88F2ED8A438003A7DA5 /* WebNotificationsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebNotificationsHandler.swift; sourceTree = "<group>"; };
 		7BBBD8922ED8A451003A7DA5 /* WebNotificationsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebNotificationsHandlerTests.swift; sourceTree = "<group>"; };
+		C4D6E49F5A586E6C68C37BA8 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeAdBlockingTelemetryConsentRequirementTests.swift; sourceTree = "<group>"; };
 		7BBBD8962ED8DA51003A7DA5 /* NotificationIconFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationIconFetcher.swift; sourceTree = "<group>"; };
 		7BBD45B02A691AB500C83CA9 /* NetworkProtectionDebugUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionDebugUtilities.swift; sourceTree = "<group>"; };
 		7BC16BA82E724CF80016EE8E /* ContentScopePreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentScopePreferences.swift; sourceTree = "<group>"; };
@@ -6027,6 +6042,10 @@
 		85F91D9327F47BC40096B1C8 /* History 5.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "History 5.xcdatamodel"; sourceTree = "<group>"; };
 		8B2C3D4E5F60718293A4B5C6 /* BookmarksBarMenuCustomPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksBarMenuCustomPopover.swift; sourceTree = "<group>"; };
 		8F16A73746AF35E5F7248523 /* TabSuspensionExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSuspensionExtension.swift; sourceTree = "<group>"; };
+		B4B283A52E00FF3D2C8240EA /* EventHubTabExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHubTabExtension.swift; sourceTree = "<group>"; };
+		DD4063303C52EE98D9AC6FAC /* MacOSEventHubIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSEventHubIntegration.swift; sourceTree = "<group>"; };
+		62DD4D2AC1D0C1F50B8025D3 /* MacOSEventHubPixelFiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSEventHubPixelFiring.swift; sourceTree = "<group>"; };
+		26AA0ED38F7EA8BACD220B2F /* YouTubeAdBlockingTelemetryConsentRequirement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeAdBlockingTelemetryConsentRequirement.swift; sourceTree = "<group>"; };
 		91BBCD4E443448C19C16F91E /* ContextMenuSubfeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextMenuSubfeatureTests.swift; sourceTree = "<group>"; };
 		9812D894276CEDA5004B6181 /* ContentBlockerRulesLists.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlockerRulesLists.swift; sourceTree = "<group>"; };
 		9826B09F2747DF3D0092F683 /* ContentBlocking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBlocking.swift; sourceTree = "<group>"; };
@@ -7101,6 +7120,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				23F31642A4C5168A6538E6FD /* EventHub in Frameworks */,
 				84DD63DB2E9662700043A25E /* FoundationExtensions in Frameworks */,
 				F1DF95E42BD1807C0045E591 /* Crashes in Frameworks */,
 				4B9EE3502D76C9DA00DDC75C /* MaliciousSiteProtection in Frameworks */,
@@ -7185,6 +7205,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FD8C554D30455000D23DB903 /* EventHub in Frameworks */,
 				3706FE88293F661700E42796 /* OHHTTPStubs in Frameworks */,
 				B65CD8CF2B316E0200A595BB /* SnapshotTesting in Frameworks */,
 				845F57072E97BFF100C7F78A /* SharedTestUtilities in Frameworks */,
@@ -7478,6 +7499,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9FA9C53A7D5A0C25CA7ED287 /* EventHub in Frameworks */,
 				8456E3612F56D7950045E2B1 /* BWIntegration in Frameworks */,
 				84DD63DA2E9662700043A25E /* FoundationExtensions in Frameworks */,
 				C18BF9CC2C73678500ED6B8A /* Freemium in Frameworks */,
@@ -7565,6 +7587,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				35F0EEDB46C5B99058C0A95A /* EventHub in Frameworks */,
 				B6DA44172616C13800DD1EC2 /* OHHTTPStubs in Frameworks */,
 				B65CD8CB2B316DF100A595BB /* SnapshotTesting in Frameworks */,
 				845F56FF2E97BFD100C7F78A /* SharedTestUtilities in Frameworks */,
@@ -9687,6 +9710,16 @@
 			path = AdBlocking;
 			sourceTree = "<group>";
 		};
+		A589AEF6A192823DA71425A3 /* EventHub */ = {
+			isa = PBXGroup;
+			children = (
+				DD4063303C52EE98D9AC6FAC /* MacOSEventHubIntegration.swift */,
+				62DD4D2AC1D0C1F50B8025D3 /* MacOSEventHubPixelFiring.swift */,
+				26AA0ED38F7EA8BACD220B2F /* YouTubeAdBlockingTelemetryConsentRequirement.swift */,
+			);
+			path = EventHub;
+			sourceTree = "<group>";
+		};
 		7B0A6DF92D47CCDF00FDFDC2 /* ExcludedApps */ = {
 			isa = PBXGroup;
 			children = (
@@ -9874,6 +9907,14 @@
 				7BAC0C302DF84292008D26EC /* SupportedOSCheckerTests.swift */,
 			);
 			path = OSVersion;
+			sourceTree = "<group>";
+		};
+		221F63F17389076B339393AE /* EventHub */ = {
+			isa = PBXGroup;
+			children = (
+				C4D6E49F5A586E6C68C37BA8 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift */,
+			);
+			path = EventHub;
 			sourceTree = "<group>";
 		};
 		7BBBD8932ED8A451003A7DA5 /* UserScripts */ = {
@@ -10892,6 +10933,7 @@
 				85A0115D25AF1C4700FA6A0C /* FindInPage */,
 				AA6820E825503A21005ED0D5 /* Fire */,
 				68E7E683755D62949300B1D8 /* AdBlocking */,
+				A589AEF6A192823DA71425A3 /* EventHub */,
 				4B02197B25E05FAC00ED7DEA /* Fireproofing */,
 				C1858CCF2C7C95DB00C9BEAB /* Freemium */,
 				B65536902684409300085A79 /* Geolocation */,
@@ -10977,6 +11019,7 @@
 				4BBC16A327C488B900E00A38 /* DeviceAuthentication */,
 				56A054392C20876F007D8FAB /* DuckSchemeHandler */,
 				CD33012E2C89B5B3009AA127 /* ErrorPage */,
+				221F63F17389076B339393AE /* EventHub */,
 				1D77921628FDC51B00BE0210 /* Favicons */,
 				BB0036602E426E9D0016DDEF /* Feedback */,
 				8553FF50257523630029327F /* FileDownload */,
@@ -12077,6 +12120,7 @@
 				B6C416A6294A4AE500C4F2E7 /* DuckPlayerTabExtension.swift */,
 				373C82502D8326E4004FBBBE /* FaviconsTabExtension.swift */,
 				8F16A73746AF35E5F7248523 /* TabSuspensionExtension.swift */,
+				B4B283A52E00FF3D2C8240EA /* EventHubTabExtension.swift */,
 				B6D574B329472253008ED1B6 /* FBProtectionTabExtension.swift */,
 				B6C00ECC292F89D9009C73A6 /* FindInPageTabExtension.swift */,
 				B66260DF29AC6EBD00E9E3EE /* HistoryTabExtension.swift */,
@@ -13352,6 +13396,7 @@
 				4B9EE3552D76CA1500DDC75C /* Onboarding */,
 				4B9EE3572D76CA3500DDC75C /* PageRefreshMonitor */,
 				4B9EE3592D76CA4100DDC75C /* Persistence */,
+				F07A89FE5A0959D49AF0E27F /* EventHub */,
 				4B9EE35B2D76CA6600DDC75C /* PixelKit */,
 				4B9EE35D2D76CA6F00DDC75C /* RemoteMessaging */,
 				4B9EE35F2D76CA7900DDC75C /* SpecialErrorPages */,
@@ -13410,6 +13455,7 @@
 			packageProductDependencies = (
 				3706FDD6293F661700E42796 /* OHHTTPStubs */,
 				3706FDD8293F661700E42796 /* OHHTTPStubsSwift */,
+				CA7335A53836D5A56E2F5B4A /* EventHub */,
 				B65CD8CE2B316E0200A595BB /* SnapshotTesting */,
 				9DC5FACC2C6B8E620011F068 /* AppKitExtensions */,
 				374EFDF02D01C70A00B30939 /* Utilities */,
@@ -13947,6 +13993,7 @@
 				4B9EE32B2D76C87100DDC75C /* Onboarding */,
 				4B9EE32D2D76C87C00DDC75C /* PageRefreshMonitor */,
 				4B9EE32F2D76C88300DDC75C /* Persistence */,
+				8714BC081D36DA291FF7A650 /* EventHub */,
 				4B9EE3312D76C89500DDC75C /* PixelKit */,
 				4B9EE3332D76C89D00DDC75C /* RemoteMessaging */,
 				4B9EE3352D76C8A600DDC75C /* Subscription */,
@@ -14014,6 +14061,7 @@
 				374EFDEE2D01C70300B30939 /* Utilities */,
 				F124E0DC2D6E12190035C7BA /* NetworkingTestingUtils */,
 				F124E0DE2D6E12190035C7BA /* PersistenceTestingUtils */,
+				EC2E83ED38F4FAB06EE3D557 /* EventHub */,
 				4B9EE3672D76CB1600DDC75C /* SubscriptionTestingUtilities */,
 				4B9EE3692D76CB2300DDC75C /* PixelKitTestingUtilities */,
 				84EFBCCF2D817CC400706739 /* InlineSnapshotTesting */,
@@ -15676,6 +15724,10 @@
 				BD7090D72C540D5D009EED82 /* EmptyMetadataCollector.swift in Sources */,
 				373C82512D8326E8004FBBBE /* FaviconsTabExtension.swift in Sources */,
 				A370E7706B30748FF9DEAD3F /* TabSuspensionExtension.swift in Sources */,
+				2BF629A1D6EF34452B6729C1 /* EventHubTabExtension.swift in Sources */,
+				4DF11EDDA9F96915ABE128D2 /* MacOSEventHubIntegration.swift in Sources */,
+				965772510DB9E9272C960181 /* MacOSEventHubPixelFiring.swift in Sources */,
+				C21FEF2AD7C1EC5678C3E1A4 /* YouTubeAdBlockingTelemetryConsentRequirement.swift in Sources */,
 				1E75FA3F2FED2BE30036D3C8 /* CookiePopupProtectionOptInView.swift in Sources */,
 				C0DE0071E018E1FA30000000 /* CookiePopupProtectionOptInPixel.swift in Sources */,
 				0DE0003CB1E0041EDE1E6A00 /* CookiePopupProtectionOptInPromoDelegate.swift in Sources */,
@@ -16384,6 +16436,7 @@
 				BBC063E92C5A9E4B007BDC18 /* BookmarkManagementDetailViewModelTests.swift in Sources */,
 				C3A357144DFF4A47914A933D /* ContextMenuSubfeatureTests.swift in Sources */,
 				7BBBD8942ED8A451003A7DA5 /* WebNotificationsHandlerTests.swift in Sources */,
+				C9BE9F534296EB9B99954781 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift in Sources */,
 				3706FDE8293F661700E42796 /* TemporaryFileHandlerTests.swift in Sources */,
 				37D315C32D4A42280019C1F8 /* RecentActivityFavoritesHandlerTests.swift in Sources */,
 				3706FDE9293F661700E42796 /* StateRestorationManagerTests.swift in Sources */,
@@ -18359,6 +18412,10 @@
 				B6E3E5582BBFD51400A41922 /* PreviewViewController.swift in Sources */,
 				373C82522D8326E8004FBBBE /* FaviconsTabExtension.swift in Sources */,
 				2934D5F7ED34D21C191CFA23 /* TabSuspensionExtension.swift in Sources */,
+				4E3C7A1113782980F29DFDD0 /* EventHubTabExtension.swift in Sources */,
+				F34D15BE552CA8D563E0E8F6 /* MacOSEventHubIntegration.swift in Sources */,
+				63F6360B709D803C891FB236 /* MacOSEventHubPixelFiring.swift in Sources */,
+				F89306773FE37E10EE24A19B /* YouTubeAdBlockingTelemetryConsentRequirement.swift in Sources */,
 				3646AC412F88EC880093AEA7 /* PromoServiceFactory+SubscriptionPromo.swift in Sources */,
 				109992D9325DA6243CD6ADE5 /* TabSuspensionService.swift in Sources */,
 				4B379C1527BD91E3008A968E /* QuartzIdleStateProvider.swift in Sources */,
@@ -19121,6 +19178,7 @@
 				37CD54B527F1AC1300F1F7B9 /* PreferencesSidebarModelTests.swift in Sources */,
 				C5965506B4FA4A4E92FD11C9 /* ContextMenuSubfeatureTests.swift in Sources */,
 				7BBBD8952ED8A451003A7DA5 /* WebNotificationsHandlerTests.swift in Sources */,
+				A4D2EDD63CCEEDAAC428F0D3 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift in Sources */,
 				BBA9A8572E40E23D00FB29A1 /* VPNPopoverPresenterTests.swift in Sources */,
 				31031EB72CC94C6E00684340 /* AIChatRemoteSettingsTests.swift in Sources */,
 				7B7B0B082F7C31D1007F0F3A /* TabRestorationDataCodingTests.swift in Sources */,
@@ -20904,6 +20962,22 @@
 		4B9EE32F2D76C88300DDC75C /* Persistence */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Persistence;
+		};
+		8714BC081D36DA291FF7A650 /* EventHub */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EventHub;
+		};
+		F07A89FE5A0959D49AF0E27F /* EventHub */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EventHub;
+		};
+		EC2E83ED38F4FAB06EE3D557 /* EventHub */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EventHub;
+		};
+		CA7335A53836D5A56E2F5B4A /* EventHub */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EventHub;
 		};
 		4B9EE3312D76C89500DDC75C /* PixelKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -14239,6 +14239,7 @@
 				CCF78AD42F34996900263097 /* XCRemoteSwiftPackageReference "combine-schedulers" */,
 				A1A1A1A12F50000600A0A0A0 /* XCLocalSwiftPackageReference "LocalPackages/CrashReporting" */,
 				315E395D2F86A36200D2289D /* XCLocalSwiftPackageReference "../SharedPackages/DebugServer" */,
+				55EE0BC98B362A2A48B16BD0 /* XCLocalSwiftPackageReference "../SharedPackages/EventHub" */,
 			);
 			productRefGroup = AA585D7F248FD31100E9A3E2 /* Products */;
 			projectDirPath = "";
@@ -20475,6 +20476,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../SharedPackages/AutomationServer;
 		};
+		55EE0BC98B362A2A48B16BD0 /* XCLocalSwiftPackageReference "../SharedPackages/EventHub" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../SharedPackages/EventHub;
+		};
 		7BBE51062DC27EAB004F08B3 /* XCLocalSwiftPackageReference "LocalPackages/BuildToolPlugins" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = LocalPackages/BuildToolPlugins;
@@ -20971,18 +20976,22 @@
 		};
 		8714BC081D36DA291FF7A650 /* EventHub */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 55EE0BC98B362A2A48B16BD0 /* XCLocalSwiftPackageReference "../SharedPackages/EventHub" */;
 			productName = EventHub;
 		};
 		F07A89FE5A0959D49AF0E27F /* EventHub */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 55EE0BC98B362A2A48B16BD0 /* XCLocalSwiftPackageReference "../SharedPackages/EventHub" */;
 			productName = EventHub;
 		};
 		EC2E83ED38F4FAB06EE3D557 /* EventHub */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 55EE0BC98B362A2A48B16BD0 /* XCLocalSwiftPackageReference "../SharedPackages/EventHub" */;
 			productName = EventHub;
 		};
 		CA7335A53836D5A56E2F5B4A /* EventHub */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 55EE0BC98B362A2A48B16BD0 /* XCLocalSwiftPackageReference "../SharedPackages/EventHub" */;
 			productName = EventHub;
 		};
 		4B9EE3312D76C89500DDC75C /* PixelKit */ = {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -2318,8 +2318,10 @@
 		7BBBD8912ED8A438003A7DA5 /* WebNotificationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBBD88F2ED8A438003A7DA5 /* WebNotificationsHandler.swift */; };
 		7BBBD8942ED8A451003A7DA5 /* WebNotificationsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBBD8922ED8A451003A7DA5 /* WebNotificationsHandlerTests.swift */; };
 		C9BE9F534296EB9B99954781 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D6E49F5A586E6C68C37BA8 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift */; };
+		92BB8FF182EF6C4500826314 /* MacOSEventHubPixelFiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD582F0992E9E5E353BCFACF /* MacOSEventHubPixelFiringTests.swift */; };
 		7BBBD8952ED8A451003A7DA5 /* WebNotificationsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBBD8922ED8A451003A7DA5 /* WebNotificationsHandlerTests.swift */; };
 		A4D2EDD63CCEEDAAC428F0D3 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D6E49F5A586E6C68C37BA8 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift */; };
+		EE51291A027CBB88A19BB465 /* MacOSEventHubPixelFiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD582F0992E9E5E353BCFACF /* MacOSEventHubPixelFiringTests.swift */; };
 		7BBBD8982ED8DA51003A7DA5 /* NotificationIconFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBBD8962ED8DA51003A7DA5 /* NotificationIconFetcher.swift */; };
 		7BBBD8992ED8DA51003A7DA5 /* NotificationIconFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBBD8962ED8DA51003A7DA5 /* NotificationIconFetcher.swift */; };
 		7BBD45B12A691AB500C83CA9 /* NetworkProtectionDebugUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD45B02A691AB500C83CA9 /* NetworkProtectionDebugUtilities.swift */; };
@@ -5845,6 +5847,7 @@
 		7BBBD88F2ED8A438003A7DA5 /* WebNotificationsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebNotificationsHandler.swift; sourceTree = "<group>"; };
 		7BBBD8922ED8A451003A7DA5 /* WebNotificationsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebNotificationsHandlerTests.swift; sourceTree = "<group>"; };
 		C4D6E49F5A586E6C68C37BA8 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeAdBlockingTelemetryConsentRequirementTests.swift; sourceTree = "<group>"; };
+		DD582F0992E9E5E353BCFACF /* MacOSEventHubPixelFiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOSEventHubPixelFiringTests.swift; sourceTree = "<group>"; };
 		7BBBD8962ED8DA51003A7DA5 /* NotificationIconFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationIconFetcher.swift; sourceTree = "<group>"; };
 		7BBD45B02A691AB500C83CA9 /* NetworkProtectionDebugUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionDebugUtilities.swift; sourceTree = "<group>"; };
 		7BC16BA82E724CF80016EE8E /* ContentScopePreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentScopePreferences.swift; sourceTree = "<group>"; };
@@ -9913,6 +9916,7 @@
 			isa = PBXGroup;
 			children = (
 				C4D6E49F5A586E6C68C37BA8 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift */,
+				DD582F0992E9E5E353BCFACF /* MacOSEventHubPixelFiringTests.swift */,
 			);
 			path = EventHub;
 			sourceTree = "<group>";
@@ -16437,6 +16441,7 @@
 				C3A357144DFF4A47914A933D /* ContextMenuSubfeatureTests.swift in Sources */,
 				7BBBD8942ED8A451003A7DA5 /* WebNotificationsHandlerTests.swift in Sources */,
 				C9BE9F534296EB9B99954781 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift in Sources */,
+				92BB8FF182EF6C4500826314 /* MacOSEventHubPixelFiringTests.swift in Sources */,
 				3706FDE8293F661700E42796 /* TemporaryFileHandlerTests.swift in Sources */,
 				37D315C32D4A42280019C1F8 /* RecentActivityFavoritesHandlerTests.swift in Sources */,
 				3706FDE9293F661700E42796 /* StateRestorationManagerTests.swift in Sources */,
@@ -19179,6 +19184,7 @@
 				C5965506B4FA4A4E92FD11C9 /* ContextMenuSubfeatureTests.swift in Sources */,
 				7BBBD8952ED8A451003A7DA5 /* WebNotificationsHandlerTests.swift in Sources */,
 				A4D2EDD63CCEEDAAC428F0D3 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift in Sources */,
+				EE51291A027CBB88A19BB465 /* MacOSEventHubPixelFiringTests.swift in Sources */,
 				BBA9A8572E40E23D00FB29A1 /* VPNPopoverPresenterTests.swift in Sources */,
 				31031EB72CC94C6E00684340 /* AIChatRemoteSettingsTests.swift in Sources */,
 				7B7B0B082F7C31D1007F0F3A /* TabRestorationDataCodingTests.swift in Sources */,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1525,6 +1525,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         startAutomationServerIfNeeded()
 
+        // This is also called in applicationDidBecomeActive, but we're also calling it here, since
+        // applicationDidBecomeActive returns early on `didFinishLaunching` when it's delivered during
+        // startup (e.g. if a modal alert is shown first). EventHub cannot start any measurement period
+        // until it has been foregrounded at least once, so missing that first activation would leave it
+        // silently inert. Calling it twice is harmless — it re-checks already-settled state.
+        eventHubIntegration.applicationDidBecomeActive()
+
         PixelKit.fire(GeneralPixel.launch, doNotEnforcePrefix: true)
         profilerToken.stop()
     }

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1847,10 +1847,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 stateRestorationManager?.applicationWillTerminate()
             },
 
-            // 6. Auto-clear (burn on quit)
+            // 6. EventHub pending telemetry flush
+            .perform { [eventHubIntegration] in
+                eventHubIntegration.applicationWillTerminate()
+            },
+
+            // 7. Auto-clear (burn on quit)
             autoClearHandler,
 
-            // 7. Privacy stats cleanup
+            // 8. Privacy stats cleanup
             .terminationDecider { [privacyStats] _ in
                 .async(Task {
                     await privacyStats.handleAppTermination()
@@ -1858,7 +1863,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 })
             },
 
-            // 8. Close windows before quitting while waiting for ⌘Q release
+            // 9. Close windows before quitting while waiting for ⌘Q release
             .perform {
                 NSApp.visibleWindows.forEach { $0.close() }
             }

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1049,8 +1049,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                                                 uiHosting: { windowControllersManager.activeViewController },
                                                                                 isOnboardingCompletedProvider: { onboardingManager.state == .onboardingCompleted },
                                                                                 dockCustomization: dockCustomization)
-        eventHubIntegration = MacOSEventHubIntegration(privacyConfigurationManager: privacyConfigurationManager,
-                                                        keyValueStore: keyValueStore)
+        // Dedicated store: EventHub flushes often and `KeyValueFileStore.set` rewrites the whole file.
+        // `try?` — telemetry runs in memory rather than failing launch.
+        eventHubIntegration = MacOSEventHubIntegration(
+            privacyConfigurationManager: privacyConfigurationManager,
+            keyValueStore: try? KeyValueFileStore(location: URL.sandboxApplicationSupportURL, name: "EventHubKeyValueStore"))
 
         if AppVersion.runType.requiresEnvironment {
             remoteMessagingClient = RemoteMessagingClient(

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -39,6 +39,7 @@ import DataBrokerProtection_macOS
 import DataBrokerProtectionCore
 import DDGSync
 import DuckAiDataStore
+import EventHub
 import FeatureFlags
 import FoundationExtensions
 import Freemium
@@ -288,6 +289,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let remoteMessagingClient: RemoteMessagingClient!
     let onboardingContextualDialogsManager: ContextualOnboardingDialogTypeProviding & ContextualOnboardingStateUpdater
     let defaultBrowserAndDockPromptService: DefaultBrowserAndDockPromptService
+    let eventHubIntegration: MacOSEventHubIntegration
     private lazy var webNotificationClickHandler = WebNotificationClickHandler(tabFinder: windowControllersManager)
     let userChurnScheduler: UserChurnBackgroundActivityScheduler
     lazy var vpnUpsellPopoverPresenter = DefaultVPNUpsellPopoverPresenter(
@@ -1047,6 +1049,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                                                 uiHosting: { windowControllersManager.activeViewController },
                                                                                 isOnboardingCompletedProvider: { onboardingManager.state == .onboardingCompleted },
                                                                                 dockCustomization: dockCustomization)
+        eventHubIntegration = MacOSEventHubIntegration(privacyConfigurationManager: privacyConfigurationManager,
+                                                        keyValueStore: keyValueStore)
 
         if AppVersion.runType.requiresEnvironment {
             remoteMessagingClient = RemoteMessagingClient(
@@ -1527,6 +1531,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidResignActive(_ notification: Notification) {
         cleanScreenTimeDataOnMacOS26()
+        eventHubIntegration.applicationDidResignActive()
     }
 
     private func cleanScreenTimeDataOnMacOS26() {
@@ -1591,6 +1596,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         defaultBrowserAndDockPromptService.applicationDidBecomeActive()
+        eventHubIntegration.applicationDidBecomeActive()
 
         Task { @MainActor in
             await autoconsentStatsPopoverCoordinator.checkAndShowDialogIfNeeded()

--- a/macOS/DuckDuckGo/EventHub/MacOSEventHubIntegration.swift
+++ b/macOS/DuckDuckGo/EventHub/MacOSEventHubIntegration.swift
@@ -42,7 +42,12 @@ final class MacOSEventHubIntegration {
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(privacyConfigurationManager: PrivacyConfigurationManaging, keyValueStore: ThrowingKeyValueStoring) {
+    /// - Parameter keyValueStore: `nil` if the dedicated store could not be opened; telemetry then runs
+    ///   in memory only.
+    init(privacyConfigurationManager: PrivacyConfigurationManaging, keyValueStore: ThrowingKeyValueStoring?) {
+        if keyValueStore == nil {
+            Logger.eventHub.error("Dedicated key value store unavailable — telemetry will not survive a restart")
+        }
         let parser = EventHubConfigParser()
         let store = EventHubKeyValueStore(store: keyValueStore, parser: parser)
 

--- a/macOS/DuckDuckGo/EventHub/MacOSEventHubIntegration.swift
+++ b/macOS/DuckDuckGo/EventHub/MacOSEventHubIntegration.swift
@@ -1,0 +1,94 @@
+//
+//  MacOSEventHubIntegration.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import EventHub
+import Foundation
+import os.log
+import Persistence
+import PrivacyConfig
+
+/// Owns and wires up the macOS `EventHub` instance: remote-config bridging, persistence, scheduling,
+/// pixel firing, and consent gating. Constructed once by `AppDelegate`.
+final class MacOSEventHubIntegration {
+
+    /// The `telemetry` config names (keys in the remote eventHub settings) gated behind the YouTube
+    /// analytics opt-in. These must byte-match the server-side config keys: a mismatch fails open — the
+    /// entry is never stripped, so its telemetry would be collected without consent.
+    private static let youTubeAdBlockingTelemetryConfigNames: Set<String> = [
+        "webTelemetry_youtube_adBlocker_day",
+        "webTelemetry_youtube_playabilityError_day",
+        "webTelemetry_youtube_videoAd_day",
+        "webTelemetry_youtube_staticAd_day",
+        "webTelemetry_youtube_buffering_day"
+    ]
+
+    let eventHub: EventHubManaging
+
+    private var cancellables = Set<AnyCancellable>()
+
+    init(privacyConfigurationManager: PrivacyConfigurationManaging, keyValueStore: ThrowingKeyValueStoring) {
+        let parser = EventHubConfigParser()
+        let store = EventHubKeyValueStore(store: keyValueStore, parser: parser)
+
+        let enabledSubject = CurrentValueSubject<Bool, Never>(
+            privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .eventHub))
+        let settingsSubject = CurrentValueSubject<[String: Any]?, Never>(
+            privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
+
+        let settings = EventHubSettings(
+            featureEnabledPublisher: enabledSubject.eraseToAnyPublisher(),
+            featureSettingsPublisher: settingsSubject.eraseToAnyPublisher(),
+            consentRequirements: [
+                YouTubeAdBlockingTelemetryConsentRequirement(configNames: Self.youTubeAdBlockingTelemetryConfigNames)
+            ]
+        )
+
+        let eventHub = EventHub(
+            store: store,
+            parser: parser,
+            settings: settings,
+            scheduler: DispatchQueueEventHubScheduler(queue: DispatchQueue(label: "com.duckduckgo.eventhub.scheduler")),
+            pixelFiring: MacOSEventHubPixelFiring()
+        )
+        self.eventHub = eventHub
+
+        // `EventHub`'s own subscriptions (set up in its init, fed by `settings` above) update its
+        // internal state synchronously on `.send()`. Pushing the new values here before calling
+        // `onConfigChanged()` — in the same closure, no dispatch hop in between — is what guarantees
+        // `onConfigChanged()` observes fresh state; `EventHub` never calls it on its own.
+        privacyConfigurationManager.updatesPublisher
+            .sink { [weak privacyConfigurationManager, weak eventHub] in
+                guard let privacyConfigurationManager else { return }
+                let enabled = privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .eventHub)
+                Logger.eventHub.debug("Remote config updated — pushing to EventHub (enabled=\(enabled, privacy: .public))")
+                enabledSubject.send(enabled)
+                settingsSubject.send(privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
+                eventHub?.onConfigChanged()
+            }
+            .store(in: &cancellables)
+    }
+
+    func applicationDidBecomeActive() {
+        eventHub.onAppForegrounded()
+    }
+
+    func applicationDidResignActive() {
+        eventHub.onAppBackgrounded()
+    }
+}

--- a/macOS/DuckDuckGo/EventHub/MacOSEventHubIntegration.swift
+++ b/macOS/DuckDuckGo/EventHub/MacOSEventHubIntegration.swift
@@ -68,18 +68,17 @@ final class MacOSEventHubIntegration {
         )
         self.eventHub = eventHub
 
-        // `EventHub`'s own subscriptions (set up in its init, fed by `settings` above) update its
-        // internal state synchronously on `.send()`. Pushing the new values here before calling
-        // `onConfigChanged()` — in the same closure, no dispatch hop in between — is what guarantees
-        // `onConfigChanged()` observes fresh state; `EventHub` never calls it on its own.
+        // Pushing the new values is all that is needed: `EventHub` subscribes to both publishers and
+        // re-applies its config whenever either emits, so there is no explicit `onConfigChanged()` call
+        // to keep in sync here. The same holds for consent changes, which reach `EventHub` through
+        // `EventHubSettings`' settings publisher rather than through this subscription.
         privacyConfigurationManager.updatesPublisher
-            .sink { [weak privacyConfigurationManager, weak eventHub] in
+            .sink { [weak privacyConfigurationManager] in
                 guard let privacyConfigurationManager else { return }
                 let enabled = privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .eventHub)
                 Logger.eventHub.debug("Remote config updated — pushing to EventHub (enabled=\(enabled, privacy: .public))")
                 enabledSubject.send(enabled)
                 settingsSubject.send(privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
-                eventHub?.onConfigChanged()
             }
             .store(in: &cancellables)
     }

--- a/macOS/DuckDuckGo/EventHub/MacOSEventHubIntegration.swift
+++ b/macOS/DuckDuckGo/EventHub/MacOSEventHubIntegration.swift
@@ -90,4 +90,10 @@ final class MacOSEventHubIntegration {
     func applicationDidResignActive() {
         eventHub.onAppBackgrounded()
     }
+
+    /// Backgrounding is EventHub's flush boundary, so it doubles as the final persist on quit
+    /// (`applicationDidResignActive` is not reliably delivered before termination).
+    func applicationWillTerminate() {
+        eventHub.onAppBackgrounded()
+    }
 }

--- a/macOS/DuckDuckGo/EventHub/MacOSEventHubPixelFiring.swift
+++ b/macOS/DuckDuckGo/EventHub/MacOSEventHubPixelFiring.swift
@@ -34,6 +34,9 @@ struct MacOSEventHubPixelFiring: EventHubPixelFiring {
     func enqueueFirePixel(named name: String, parameters: [String: String]) {
         let pixelName = "\(name)_macos"
         Logger.eventHub.info("PixelKit fire: \(pixelName, privacy: .public) \(parameters, privacy: .public)")
-        PixelKit.fire(Event(name: pixelName, parameters: parameters))
+        // `doNotEnforcePrefix` is required: these names already carry the `_macos` platform suffix, and
+        // without it PixelKit prepends `m_mac_` to any macOS name that lacks that prefix — which would
+        // both double the platform marker and diverge from the names declared in event_hub.json5.
+        PixelKit.fire(Event(name: pixelName, parameters: parameters), doNotEnforcePrefix: true)
     }
 }

--- a/macOS/DuckDuckGo/EventHub/MacOSEventHubPixelFiring.swift
+++ b/macOS/DuckDuckGo/EventHub/MacOSEventHubPixelFiring.swift
@@ -1,0 +1,39 @@
+//
+//  MacOSEventHubPixelFiring.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import EventHub
+import Foundation
+import os.log
+import PixelKit
+
+/// Fires EventHub-originated pixels through PixelKit, appending the macOS platform suffix per the
+/// Tech Design's platform-suffix split (`EventHub` itself fires the bare governed config name).
+struct MacOSEventHubPixelFiring: EventHubPixelFiring {
+
+    private struct Event: PixelKitEvent {
+        let name: String
+        let parameters: [String: String]?
+        let standardParameters: [PixelKitStandardParameter]? = nil
+    }
+
+    func enqueueFirePixel(named name: String, parameters: [String: String]) {
+        let pixelName = "\(name)_macos"
+        Logger.eventHub.info("PixelKit fire: \(pixelName, privacy: .public) \(parameters, privacy: .public)")
+        PixelKit.fire(Event(name: pixelName, parameters: parameters))
+    }
+}

--- a/macOS/DuckDuckGo/EventHub/YouTubeAdBlockingTelemetryConsentRequirement.swift
+++ b/macOS/DuckDuckGo/EventHub/YouTubeAdBlockingTelemetryConsentRequirement.swift
@@ -22,7 +22,14 @@ import Foundation
 import Persistence
 
 /// Gates the migrated YouTube ad-blocking-detection telemetry configs behind the user's YouTube
-/// analytics opt-in (`YouTubeAdBlockingSettings.youTubeAnalyticsEnabled`).
+/// Ad Blocking *and* analytics opt-ins, matching the composite check the retired `WebEventsSubfeature`
+/// applied per event.
+///
+/// Both flags are required deliberately, rather than relying on analytics alone. Turning YouTube Ad
+/// Blocking off does clear the analytics opt-in, but that coupling is a `didSet` side effect in
+/// `YouTubeAdBlockingPreferences` — it only runs while an instance of that model exists and the value
+/// actually changes. The two flags are independently writable defaults with no storage-level invariant
+/// tying them together, so a consent gate must not depend on that side effect having run.
 final class YouTubeAdBlockingTelemetryConsentRequirement: EventHubConsentRequirement {
 
     let consentID = "youTubeAdBlockingAnalytics"
@@ -32,8 +39,10 @@ final class YouTubeAdBlockingTelemetryConsentRequirement: EventHubConsentRequire
     init(configNames: Set<String>, store: any ObservableKeyValueStoring = UserDefaults.standard) {
         self.configNames = configNames
         let settings: any ObservableKeyedStoring<YouTubeAdBlockingSettings> = store.observableKeyedStoring()
-        isGrantedPublisher = settings.publisher(for: \.youTubeAnalyticsEnabled)
-            .map { $0 ?? false }
+        isGrantedPublisher = settings.publisher(for: \.youTubeAdBlockingEnabled)
+            .combineLatest(settings.publisher(for: \.youTubeAnalyticsEnabled))
+            .map { ($0 ?? false) && ($1 ?? false) }
+            .removeDuplicates()
             .eraseToAnyPublisher()
     }
 }

--- a/macOS/DuckDuckGo/EventHub/YouTubeAdBlockingTelemetryConsentRequirement.swift
+++ b/macOS/DuckDuckGo/EventHub/YouTubeAdBlockingTelemetryConsentRequirement.swift
@@ -1,0 +1,39 @@
+//
+//  YouTubeAdBlockingTelemetryConsentRequirement.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import EventHub
+import Foundation
+import Persistence
+
+/// Gates the migrated YouTube ad-blocking-detection telemetry configs behind the user's YouTube
+/// analytics opt-in (`YouTubeAdBlockingSettings.youTubeAnalyticsEnabled`).
+final class YouTubeAdBlockingTelemetryConsentRequirement: EventHubConsentRequirement {
+
+    let consentID = "youTubeAdBlockingAnalytics"
+    let configNames: Set<String>
+    let isGrantedPublisher: AnyPublisher<Bool, Never>
+
+    init(configNames: Set<String>, store: any ObservableKeyValueStoring = UserDefaults.standard) {
+        self.configNames = configNames
+        let settings: any ObservableKeyedStoring<YouTubeAdBlockingSettings> = store.observableKeyedStoring()
+        isGrantedPublisher = settings.publisher(for: \.youTubeAnalyticsEnabled)
+            .map { $0 ?? false }
+            .eraseToAnyPublisher()
+    }
+}

--- a/macOS/DuckDuckGo/Tab/Model/Tab+Navigation.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab+Navigation.swift
@@ -103,6 +103,9 @@ extension Tab: NavigationResponder {
             // Tab Suspension
             .weak(nullable: self.tabSuspension),
 
+            // EventHub — observe navigation starts to reset per-tab web-event dedup on URL change
+            .weak(nullable: self.eventHub),
+
             // should be the last, for Unit Tests navigation events tracking
             .struct(nullable: testsClosureNavigationResponder)
             // !! don't add Tab Extensions after this line !!

--- a/macOS/DuckDuckGo/Tab/Model/Tab.swift
+++ b/macOS/DuckDuckGo/Tab/Model/Tab.swift
@@ -22,6 +22,7 @@ import Combine
 import CombineExtensions
 import Common
 import ConcurrencyExtensions
+import EventHub
 import FeatureFlags
 import Foundation
 import FoundationExtensions
@@ -72,6 +73,7 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
         var autoplayPreferences: AutoplayPreferences
         var permissionManager: PermissionManagerProtocol
         var webTrackingProtectionPreferences: WebTrackingProtectionPreferences
+        let eventHub: EventHubManaging
     }
 
     fileprivate weak var delegate: TabDelegate?
@@ -160,7 +162,8 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
                      aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable? = nil,
                      aiChatSessionStore: AIChatSessionStoring? = nil,
                      tabCrashAggregator: TabCrashAggregator? = nil,
-                     themeManager: ThemeManaging? = nil
+                     themeManager: ThemeManaging? = nil,
+                     eventHub: EventHubManaging? = nil
     ) {
 
         let duckPlayer = duckPlayer
@@ -227,7 +230,8 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
                   aiChatMenuConfiguration: aiChatMenuConfiguration ?? NSApp.delegateTyped.aiChatMenuConfiguration,
                   aiChatSessionStore: aiChatSessionStore ?? NSApp.delegateTyped.aiChatSessionStore,
                   tabCrashAggregator: tabCrashAggregator ?? NSApp.delegateTyped.tabCrashAggregator,
-                  themeManager: themeManager ?? NSApp.delegateTyped.themeManager
+                  themeManager: themeManager ?? NSApp.delegateTyped.themeManager,
+                  eventHub: eventHub ?? NSApp.delegateTyped.eventHubIntegration.eventHub
         )
     }
 
@@ -278,7 +282,8 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
          aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable,
          aiChatSessionStore: AIChatSessionStoring,
          tabCrashAggregator: TabCrashAggregator,
-         themeManager: ThemeManaging
+         themeManager: ThemeManaging,
+         eventHub: EventHubManaging
     ) {
         self._id = id
         self.uuid = uuid ?? UUID().uuidString
@@ -362,7 +367,8 @@ protocol TabDelegate: ContentOverlayUserScriptDelegate {
                                                           tabsPreferences: tabsPreferences,
                                                           autoplayPreferences: autoplayPreferences,
                                                           permissionManager: permissionManager,
-                                                          webTrackingProtectionPreferences: webTrackingProtectionPreferences)
+                                                          webTrackingProtectionPreferences: webTrackingProtectionPreferences,
+                                                          eventHub: eventHub)
         let tabExtensionsBuilderArguments: TabExtensionsBuilderArguments = (tabIdentifier: instrumentation.currentTabIdentifier,
                                                                             tabID: self.uuid,
                                                                             isTabPinned: { tabGetter().map { tab in pinnedTabsManagerProvider.pinnedTabsManager(for: tab)?.isTabPinned(tab) ?? false } ?? false },

--- a/macOS/DuckDuckGo/Tab/TabExtensions/EventHubTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/EventHubTabExtension.swift
@@ -1,0 +1,80 @@
+//
+//  EventHubTabExtension.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import BrowserServicesKit
+import Combine
+import EventHub
+import Foundation
+import Navigation
+import os.log
+
+/// Bridges this tab's lifecycle into `EventHub`: owns the tab's `WebEventsHandler` (constructed with
+/// this tab's ID baked directly into its `tabIDProvider`, mirroring `WebNotificationsTabExtension`'s
+/// handling of `WebNotificationsHandler`) and registers it with the content scope user script when
+/// available, reports navigation starts, and reports tab closure via `deinit` (Tab Extensions live
+/// exactly as long as their owning `Tab`).
+final class EventHubTabExtension {
+
+    private let tabID: EventHubTabID
+    private let eventHub: EventHubManaging
+    private let handler: WebEventsHandler
+    private var cancellables = Set<AnyCancellable>()
+
+    init(tabID: String,
+         eventHub: EventHubManaging,
+         contentScopeUserScriptPublisher: some Publisher<ContentScopeUserScript, Never>) {
+        let eventHubTabID = EventHubTabID(rawValue: UUID(uuidString: tabID) ?? UUID())
+        self.tabID = eventHubTabID
+        self.eventHub = eventHub
+        self.handler = WebEventsHandler(manager: eventHub, tabIDProvider: { _ in eventHubTabID })
+
+        contentScopeUserScriptPublisher.sink { [weak self] contentScopeUserScript in
+            guard let handler = self?.handler else { return }
+            contentScopeUserScript.registerSubfeature(delegate: handler)
+        }.store(in: &cancellables)
+    }
+
+    deinit {
+        Logger.eventHub.debug("Tab closed — reporting to EventHub")
+        eventHub.onTabClosed(tabID: tabID)
+    }
+}
+
+/// Public surface of `EventHubTabExtension`. Empty beyond `NavigationResponder` — the extension
+/// exposes no API of its own — but it must be a distinct protocol (not the concrete type): the
+/// `TabExtensionsBuilder.resolve` overload for `where PublicProtocol == T` deliberately traps.
+protocol EventHubTabExtensionProtocol: AnyObject, NavigationResponder {}
+
+extension EventHubTabExtension: TabExtension, EventHubTabExtensionProtocol {
+    func getPublicProtocol() -> EventHubTabExtensionProtocol { self }
+}
+
+extension EventHubTabExtension: NavigationResponder {
+    func didStart(_ navigation: Navigation) {
+        Logger.eventHub.debug("Tab navigation started — reporting to EventHub")
+        eventHub.onNavigationStarted(tabID: tabID, url: navigation.url.absoluteString)
+    }
+}
+
+extension TabExtensions {
+    /// Resolves the per-tab EventHub extension. Also how `Tab` reaches it (via its `dynamicMember`
+    /// subscript) to register it as a navigation responder in `setupNavigationDelegate`.
+    var eventHub: EventHubTabExtensionProtocol? {
+        resolve(EventHubTabExtension.self)
+    }
+}

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -23,6 +23,7 @@ import Combine
 import Common
 import FoundationExtensions
 import ContentBlocking
+import EventHub
 import Foundation
 import History
 import MaliciousSiteProtection
@@ -92,6 +93,7 @@ protocol TabExtensionDependencies {
     var autoplayPreferences: AutoplayPreferences { get }
     var permissionManager: PermissionManagerProtocol { get }
     var webTrackingProtectionPreferences: WebTrackingProtectionPreferences { get }
+    var eventHub: EventHubManaging { get }
 }
 
 // swiftlint:disable:next large_tuple
@@ -373,6 +375,14 @@ extension TabExtensionsBuilder {
                 privacyConfigurationManager: dependencies.privacyFeatures.contentBlocking.privacyConfigurationManager,
                 tld: dependencies.privacyFeatures.contentBlocking.tld,
                 isTabPinned: args.isTabPinned
+            )
+        }
+
+        add {
+            EventHubTabExtension(
+                tabID: args.tabID,
+                eventHub: dependencies.eventHub,
+                contentScopeUserScriptPublisher: userScripts.compactMap(\.?.contentScopeUserScriptIsolated)
             )
         }
     }

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -63,7 +63,6 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
     let faviconScript = FaviconUserScript()
     let webTelemetryScript = WebTelemetryUserScript()
     let tabSuspensionScript = TabSuspensionUserScript()
-    let webEventsSubfeature: WebEventsSubfeature
 
     private let contentScopePreferences: ContentScopePreferences
 
@@ -156,18 +155,6 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
             fatalError("Failed to initialize ContentScopeUserScript: \(error.localizedDescription)")
         }
 
-        let youTubeAdBlockingStorage: any KeyedStoring<YouTubeAdBlockingSettings> = UserDefaults.standard.keyedStoring()
-        webEventsSubfeature = WebEventsSubfeature(
-            isUserOptedIn: {
-                (youTubeAdBlockingStorage.youTubeAdBlockingEnabled ?? false)
-                    && (youTubeAdBlockingStorage.youTubeAnalyticsEnabled ?? false)
-            },
-            onEvent: { type, loginState in
-                guard let pixel = WebExtensionPixel.adBlockingDetectedEvent(type: type, loginState: loginState.rawValue) else { return }
-                PixelKit.fire(pixel, frequency: .daily)
-            }
-        )
-
         autofillScript = WebsiteAutofillUserScript(scriptSourceProvider: sourceProvider.autofillSourceProvider!)
 
         autoconsentUserScript = AutoconsentUserScript(
@@ -222,7 +209,6 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
         }
 
         contentScopeUserScriptIsolated.registerSubfeature(delegate: webTelemetryScript)
-        contentScopeUserScriptIsolated.registerSubfeature(delegate: webEventsSubfeature)
         contentScopeUserScriptIsolated.registerSubfeature(delegate: faviconScript)
         contentScopeUserScriptIsolated.registerSubfeature(delegate: tabSuspensionScript)
         contentScopeUserScriptIsolated.registerSubfeature(delegate: contextMenuSubfeature)

--- a/macOS/PixelDefinitions/pixels/definitions/event_hub.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/event_hub.json5
@@ -1,0 +1,122 @@
+{
+    "webTelemetry_youtube_adBlocker_day_macos": {
+        "description": "Daily bucketed count of YouTube ad-blocker-challenge detections, with the user's login state at detection time. Fired by the eventHub feature at the end of each 1-day period. Successor to the retired m_mac_web_extension_adblocking_detected_ad_blocker pixel.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed detection count for the period (e.g. \"0\", \"1+\")",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "loginState",
+                "type": "string",
+                "description": "User's YouTube login state at detection time, as percent-encoded JSON (e.g. %22logged-in%22)"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_youtube_playabilityError_day_macos": {
+        "description": "Daily bucketed count of YouTube playability-error detections, with the user's login state at detection time. Fired by the eventHub feature at the end of each 1-day period. Successor to the retired m_mac_web_extension_adblocking_detected_playability_error pixel.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed detection count for the period (e.g. \"0\", \"1+\")",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "loginState",
+                "type": "string",
+                "description": "User's YouTube login state at detection time, as percent-encoded JSON (e.g. %22logged-in%22)"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_youtube_videoAd_day_macos": {
+        "description": "Daily bucketed count of YouTube video-ad detections, with the user's login state at detection time. Fired by the eventHub feature at the end of each 1-day period. Successor to the retired m_mac_web_extension_adblocking_detected_video_ad pixel.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed detection count for the period (e.g. \"0\", \"1+\")",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "loginState",
+                "type": "string",
+                "description": "User's YouTube login state at detection time, as percent-encoded JSON (e.g. %22logged-in%22)"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_youtube_staticAd_day_macos": {
+        "description": "Daily bucketed count of YouTube static-ad detections, with the user's login state at detection time. Fired by the eventHub feature at the end of each 1-day period. Successor to the retired m_mac_web_extension_adblocking_detected_static_ad pixel.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed detection count for the period (e.g. \"0\", \"1+\")",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "loginState",
+                "type": "string",
+                "description": "User's YouTube login state at detection time, as percent-encoded JSON (e.g. %22logged-in%22)"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_youtube_buffering_day_macos": {
+        "description": "Daily bucketed count of YouTube playback-buffering detections, with the user's login state at detection time. Fired by the eventHub feature at the end of each 1-day period. Successor to the retired m_mac_web_extension_adblocking_detected_buffering pixel.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed detection count for the period (e.g. \"0\", \"1+\")",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "loginState",
+                "type": "string",
+                "description": "User's YouTube login state at detection time, as percent-encoded JSON (e.g. %22logged-in%22)"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    }
+}

--- a/macOS/UnitTests/EventHub/MacOSEventHubPixelFiringTests.swift
+++ b/macOS/UnitTests/EventHub/MacOSEventHubPixelFiringTests.swift
@@ -1,0 +1,67 @@
+//
+//  MacOSEventHubPixelFiringTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import PixelKit
+import XCTest
+
+@testable import DuckDuckGo_Privacy_Browser
+
+/// Pins the exact pixel name EventHub telemetry goes out under. PixelKit rewrites macOS pixel names
+/// after the fact (prepending `m_mac_` unless told not to), so asserting on the name PixelKit actually
+/// requests — not the name we pass in — is what keeps these in sync with `event_hub.json5`.
+final class MacOSEventHubPixelFiringTests: XCTestCase {
+
+    private var firedNames: [String] = []
+    private var firedParameters: [[String: String]] = []
+
+    override func setUp() {
+        super.setUp()
+        firedNames = []
+        firedParameters = []
+        // `dryRun: false` — PixelKit deliberately skips `fireRequest` entirely when dry-running.
+        PixelKit.setUp(dryRun: false,
+                       appVersion: "1.0.0",
+                       session: "test",
+                       defaultHeaders: [:],
+                       defaults: UserDefaults(suiteName: "\(type(of: self))")!) { name, _, parameters, _, _, _ in
+            self.firedNames.append(name)
+            self.firedParameters.append(parameters)
+        }
+    }
+
+    override func tearDown() {
+        PixelKit.tearDown()
+        firedNames = []
+        firedParameters = []
+        super.tearDown()
+    }
+
+    func testFiredNameCarriesMacOSSuffixAndNoMacPrefix() {
+        MacOSEventHubPixelFiring().enqueueFirePixel(named: "webTelemetry_youtube_staticAd_day", parameters: [:])
+
+        XCTAssertEqual(firedNames, ["webTelemetry_youtube_staticAd_day_macos"])
+    }
+
+    func testParametersArePassedThrough() {
+        MacOSEventHubPixelFiring().enqueueFirePixel(named: "some_telemetry",
+                                                    parameters: ["count": "1+", "attributionPeriod": "1769126400"])
+
+        XCTAssertEqual(firedParameters.first?["count"], "1+")
+        XCTAssertEqual(firedParameters.first?["attributionPeriod"], "1769126400")
+    }
+}

--- a/macOS/UnitTests/EventHub/YouTubeAdBlockingTelemetryConsentRequirementTests.swift
+++ b/macOS/UnitTests/EventHub/YouTubeAdBlockingTelemetryConsentRequirementTests.swift
@@ -1,0 +1,68 @@
+//
+//  YouTubeAdBlockingTelemetryConsentRequirementTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import XCTest
+
+@testable import DuckDuckGo_Privacy_Browser
+
+final class YouTubeAdBlockingTelemetryConsentRequirementTests: XCTestCase {
+
+    private static let analyticsEnabledKey = "preferences_youtube-analytics_enabled"
+
+    private var defaults: UserDefaults!
+    private var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: "\(type(of: self))")!
+        defaults.removePersistentDomain(forName: "\(type(of: self))")
+        cancellables = []
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: "\(type(of: self))")
+        defaults = nil
+        cancellables = nil
+        super.tearDown()
+    }
+
+    func testConfigNamesAreStoredVerbatim() {
+        let sut = YouTubeAdBlockingTelemetryConsentRequirement(configNames: ["a", "b"], store: defaults)
+        XCTAssertEqual(sut.configNames, ["a", "b"])
+    }
+
+    func testIsGrantedPublisherEmitsFalseByDefault() {
+        let sut = YouTubeAdBlockingTelemetryConsentRequirement(configNames: [], store: defaults)
+
+        var received: [Bool] = []
+        sut.isGrantedPublisher.sink { received.append($0) }.store(in: &cancellables)
+
+        XCTAssertEqual(received, [false])
+    }
+
+    func testIsGrantedPublisherEmitsCurrentValueOnSubscribe() {
+        defaults.set(true, forKey: Self.analyticsEnabledKey)
+        let sut = YouTubeAdBlockingTelemetryConsentRequirement(configNames: [], store: defaults)
+
+        var received: [Bool] = []
+        sut.isGrantedPublisher.sink { received.append($0) }.store(in: &cancellables)
+
+        XCTAssertEqual(received, [true])
+    }
+}

--- a/macOS/UnitTests/EventHub/YouTubeAdBlockingTelemetryConsentRequirementTests.swift
+++ b/macOS/UnitTests/EventHub/YouTubeAdBlockingTelemetryConsentRequirementTests.swift
@@ -23,6 +23,7 @@ import XCTest
 
 final class YouTubeAdBlockingTelemetryConsentRequirementTests: XCTestCase {
 
+    private static let adBlockingEnabledKey = "preferences_youtube-ad-blocking_enabled"
     private static let analyticsEnabledKey = "preferences_youtube-analytics_enabled"
 
     private var defaults: UserDefaults!
@@ -57,6 +58,7 @@ final class YouTubeAdBlockingTelemetryConsentRequirementTests: XCTestCase {
     }
 
     func testIsGrantedPublisherEmitsCurrentValueOnSubscribe() {
+        defaults.set(true, forKey: Self.adBlockingEnabledKey)
         defaults.set(true, forKey: Self.analyticsEnabledKey)
         let sut = YouTubeAdBlockingTelemetryConsentRequirement(configNames: [], store: defaults)
 
@@ -64,5 +66,42 @@ final class YouTubeAdBlockingTelemetryConsentRequirementTests: XCTestCase {
         sut.isGrantedPublisher.sink { received.append($0) }.store(in: &cancellables)
 
         XCTAssertEqual(received, [true])
+    }
+
+    /// Both opt-ins are required, matching the composite check the retired `WebEventsSubfeature` applied.
+    /// The two flags are independently writable defaults — nothing at the storage level guarantees that
+    /// disabling ad blocking clears the analytics flag — so consent must not be granted on analytics alone.
+    func testIsNotGrantedWhenAdBlockingIsOffButAnalyticsIsOn() {
+        defaults.set(false, forKey: Self.adBlockingEnabledKey)
+        defaults.set(true, forKey: Self.analyticsEnabledKey)
+        let sut = YouTubeAdBlockingTelemetryConsentRequirement(configNames: [], store: defaults)
+
+        var received: [Bool] = []
+        sut.isGrantedPublisher.sink { received.append($0) }.store(in: &cancellables)
+
+        XCTAssertEqual(received, [false])
+    }
+
+    /// The ad-blocking flag being unset (never explicitly chosen) must also withhold consent — the
+    /// retired gate read it as `?? false`.
+    func testIsNotGrantedWhenAdBlockingIsUnsetButAnalyticsIsOn() {
+        defaults.set(true, forKey: Self.analyticsEnabledKey)
+        let sut = YouTubeAdBlockingTelemetryConsentRequirement(configNames: [], store: defaults)
+
+        var received: [Bool] = []
+        sut.isGrantedPublisher.sink { received.append($0) }.store(in: &cancellables)
+
+        XCTAssertEqual(received, [false])
+    }
+
+    func testIsNotGrantedWhenAdBlockingIsOnButAnalyticsIsOff() {
+        defaults.set(true, forKey: Self.adBlockingEnabledKey)
+        defaults.set(false, forKey: Self.analyticsEnabledKey)
+        let sut = YouTubeAdBlockingTelemetryConsentRequirement(configNames: [], store: defaults)
+
+        var received: [Bool] = []
+        sut.isGrantedPublisher.sink { received.append($0) }.store(in: &cancellables)
+
+        XCTAssertEqual(received, [false])
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216947041711145
Tech Design URL: https://app.asana.com/1/137249556945/project/1203936086921904/task/1216592765148783?focus=true
CC:

### Description
Second in the stack, targeting `michal/event-hub-1`. Wires the EventHub package from #5959 into macOS and moves the five YouTube ad-blocking detection events onto it, retiring the hardcoded path (opt-in check plus event-type-to-pixel mapping compiled into the app). Which events are measured, and how, now comes from remote config instead of an app release.

Two behavioural changes: detections are aggregated into a bucketed daily count fired once per period rather than a pixel per detection, and the analytics opt-in now strips gated entries from the config before EventHub sees them — so a withheld opt-in means the measurement doesn't exist rather than being filtered later.

macOS only — iOS still uses the old path.

### Testing Steps
Use the setup described in https://app.asana.com/1/137249556945/project/414235014887631/task/1216994836433629?focus=true and the sample test page to trigger the web detector event. Filter the logs by "EventHub" subsystem. Please verify the following:

- [ ] On app launch the feature is reported as enabled telemetry definitions are being loaded
- [ ] Triggering an event starts the period
- [ ] When app is in foreground the pixel is fired at the period end
- [ ] Triggering an event on a single tab on a single page and reloading it will register it only once (de-dup)
- [ ] Triggering an event on the same page but opened in separate tabs is registered individually
- [ ] Triggering an event on a page, then in the same tab navigating elsewhere, then navigating again to the first page will record the event twice (navigation clears de-dup state)
- [ ] Recorded counts are not cleared by the Fire button
- [ ] Recorded counts are persisted between app relaunch

### Impact
High — touches per-tab lifecycle code that runs regardless of the feature flag, and the consent gate deciding whether telemetry is collected.

#### What could go wrong?
- Gated config names not byte-matching the server-side telemetry keys → the consent strip silently no-ops and telemetry is collected without opt-in. Names come from the shipped Windows config; nothing on-device validates them, so worth a second pair of eyes.
- The per-tab component is created for every tab, so a fault there affects all browsing → mitigated by following the existing tab-extension registration pattern.
- Pixel names drifting from the definitions, since PixelKit rewrites macOS names → mitigated by a test asserting the name PixelKit actually requests.
- Counts recorded shortly before quit being lost → mitigated by a flush in the termination sequence.

### Quality Considerations
- Resolves the open question from #5959: the platform-suffix split holds — the package fires the bare config name, macOS appends `_macos`. Matching the declared names required opting out of PixelKit's automatic `m_mac_` prefix.
- Privacy: consent stripping fails closed, and navigation URLs are never logged. Fired parameters (including YouTube login state) are logged at info level — flagging in case that's too permissive for a persisted system log.
- Not addressed here: the now-unused ad-blocking pixel mapping and its five stale definitions (kept for the iOS transition), measurement being suspended while the app is inactive, and fire-window tabs counted like any other.
- As in #5959, the package suite isn't in a scheme test plan, so CI won't run its 128 tests — local `swift test` only.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Per-tab EventHub wiring runs for all tabs regardless of the feature flag, and consent/config key mismatches could collect telemetry without opt-in; changes also affect launch, termination, and pixel naming paths.
> 
> **Overview**
> **macOS** integrates the shared **EventHub** package and moves five YouTube ad-blocking detection signals off the retired **`WebEventsSubfeature`** path (per-detection daily pixels with hardcoded opt-in and name mapping). Telemetry is now driven by remote **`eventHub`** privacy config, aggregated into **bucketed daily counts** fired once per period, with pixels sent through PixelKit as `*_macos` using `doNotEnforcePrefix`.
> 
> `MacOSEventHubIntegration` owns the hub: dedicated **`EventHubKeyValueStore`**, privacy-config publishers, **`YouTubeAdBlockingTelemetryConsentRequirement`** (both YouTube ad-blocking and analytics must be on—consent strips gated config keys before EventHub sees them), and app lifecycle hooks (foreground/background/terminate flush). **`EventHubTabExtension`** registers **`WebEventsHandler`** per tab and reports navigation/tab close for dedup. **`UserScripts`** no longer registers **`webEventsSubfeature`**.
> 
> The **EventHub** package gains cold-start safety (`hasConsumedInitialSettings` defers config apply until after initial publisher replay), automatic re-apply on settings/enablement changes without `onConfigChanged()`, optional nil backing store, public **`Logger.eventHub`**, and debug logging for period fires. **`PrivacyFeature.eventHub`** is added. New **`event_hub.json5`** pixel definitions document the successor metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68800aeb363b06a78bd33e173303b820a148d5d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->