### PR TITLE
Add V2 sync-setup prompt pixels

### DIFF
--- a/iOS/Core/Pixel.swift
+++ b/iOS/Core/Pixel.swift
@@ -190,6 +190,7 @@ public struct PixelParameters {
     // Sync
     public static let connectedDevices = "connected_devices"
     public static let syncPromptOption = "option"
+    public static let uiVersion = "ui_version"
 
     // Persistent pixel
     public static let originalPixelTimestamp = "originalPixelTimestamp"

--- a/iOS/Core/Pixel.swift
+++ b/iOS/Core/Pixel.swift
@@ -189,6 +189,7 @@ public struct PixelParameters {
 
     // Sync
     public static let connectedDevices = "connected_devices"
+    public static let syncPromptOption = "option"
 
     // Persistent pixel
     public static let originalPixelTimestamp = "originalPixelTimestamp"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1445,6 +1445,8 @@ extension Pixel {
         case settingsSyncRecoverSyncedDataTapped
         case settingsSyncSignupConfirmedTapped
         case settingsSyncRecoveryConfirmedTapped
+        case settingsSyncAnotherDevicePromptShown
+        case settingsSyncAnotherDevicePromptOptionTapped
         case settingsAppearanceOpen
         case settingsThemeSelectorPressed
         case settingsAddressBarTopSelected
@@ -2209,6 +2211,8 @@ extension Pixel.Event {
         case .settingsSyncRecoverSyncedDataTapped: return "m_settings_sync_recover_synced_data_tapped"
         case .settingsSyncSignupConfirmedTapped: return "m_settings_sync_signup_confirmed_tapped"
         case .settingsSyncRecoveryConfirmedTapped: return "m_settings_sync_recovery_confirmed_tapped"
+        case .settingsSyncAnotherDevicePromptShown: return "m_settings_sync_another_device_prompt_shown"
+        case .settingsSyncAnotherDevicePromptOptionTapped: return "m_settings_sync_another_device_prompt_option_tapped"
         case .settingsAppearanceOpen: return "m_settings_appearance_open"
         case .settingsThemeSelectorPressed: return "m_settings_theme_selector_pressed"
         case .settingsAddressBarTopSelected: return "m_settings_address_bar_top_selected"

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -177,10 +177,13 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                     return
                 }
                 try await self.syncService.createAccount(deviceName: self.deviceName, deviceType: self.deviceType)
-                let additionalParameters = self.source.map { ["source": $0] } ?? [:]
+                var additionalParameters = self.uiVersionParameters
+                additionalParameters[PixelParameters.source] = self.source
                 try await Pixel.fire(pixel: .syncSignupDirect, withAdditionalParameters: additionalParameters, includedParameters: [.appVersion])
+                var setupEndedParameters = self.uiVersionParameters
+                setupEndedParameters[PixelParameters.source] = "signup"
                 Pixel.fire(pixel: .syncSetupEndedSuccessful,
-                           withAdditionalParameters: [PixelParameters.source: "signup"],
+                           withAdditionalParameters: setupEndedParameters,
                            includedParameters: [.appVersion],
                            onComplete: { _ in })
                 optionsViewModel.syncEnabled(recoveryCode: self.recoveryCode)
@@ -441,22 +444,36 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
     func fireSyncSetupPixel(event: SyncSettingsViewModel.SyncSetupPixelEvent) {
         switch event {
         case .backUpThisDeviceTapped:
-            Pixel.fire(pixel: .settingsSyncBackUpThisDeviceTapped, includedParameters: [.appVersion])
+            Pixel.fire(pixel: .settingsSyncBackUpThisDeviceTapped,
+                       withAdditionalParameters: uiVersionParameters,
+                       includedParameters: [.appVersion])
         case .signupConfirmedTapped:
-            Pixel.fire(pixel: .settingsSyncSignupConfirmedTapped, includedParameters: [.appVersion])
+            Pixel.fire(pixel: .settingsSyncSignupConfirmedTapped,
+                       withAdditionalParameters: uiVersionParameters,
+                       includedParameters: [.appVersion])
         case .signupAbandoned:
+            var parameters = uiVersionParameters
+            parameters[PixelParameters.source] = "signup"
             Pixel.fire(pixel: .syncSetupEndedAbandoned,
-                       withAdditionalParameters: [PixelParameters.source: "signup"],
+                       withAdditionalParameters: parameters,
                        includedParameters: [.appVersion])
         case .recoverSyncedDataTapped:
-            Pixel.fire(pixel: .settingsSyncRecoverSyncedDataTapped, includedParameters: [.appVersion])
+            Pixel.fire(pixel: .settingsSyncRecoverSyncedDataTapped,
+                       withAdditionalParameters: uiVersionParameters,
+                       includedParameters: [.appVersion])
         case .recoveryConfirmedTapped:
-            Pixel.fire(pixel: .settingsSyncRecoveryConfirmedTapped, includedParameters: [.appVersion])
+            Pixel.fire(pixel: .settingsSyncRecoveryConfirmedTapped,
+                       withAdditionalParameters: uiVersionParameters,
+                       includedParameters: [.appVersion])
         case .anotherDevicePromptShown:
-            Pixel.fire(pixel: .settingsSyncAnotherDevicePromptShown, includedParameters: [.appVersion])
+            Pixel.fire(pixel: .settingsSyncAnotherDevicePromptShown,
+                       withAdditionalParameters: uiVersionParameters,
+                       includedParameters: [.appVersion])
         case .anotherDevicePromptOptionTapped(let option):
+            var parameters = uiVersionParameters
+            parameters[PixelParameters.syncPromptOption] = option.rawValue
             Pixel.fire(pixel: .settingsSyncAnotherDevicePromptOptionTapped,
-                       withAdditionalParameters: [PixelParameters.syncPromptOption: option.rawValue],
+                       withAdditionalParameters: parameters,
                        includedParameters: [.appVersion])
         }
     }
@@ -667,7 +684,8 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                 let pixelSource = self.source ?? onPresentPixelInfo.source.rawValue
                 var parameters = [
                     PixelParameters.source: pixelSource,
-                    SyncSetupPixelInfo.Parameter.myKind: SyncSetupPixelInfo.Value.ddg
+                    SyncSetupPixelInfo.Parameter.myKind: SyncSetupPixelInfo.Value.ddg,
+                    PixelParameters.uiVersion: self.syncUIVersion
                 ]
                 parameters[SyncSetupPixelInfo.Parameter.flowVersion] = onPresentPixelInfo.flowVersion
                 Pixel.fire(pixel: onPresentPixelInfo.pixel, withAdditionalParameters: parameters, includedParameters: [.appVersion])
@@ -785,7 +803,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                 Task { @MainActor in
                     do {
                         try await self.syncService.disconnect()
-                        Pixel.fire(pixel: .syncDisabled)
+                        Pixel.fire(pixel: .syncDisabled, withAdditionalParameters: self.uiVersionParameters)
                         self.syncPausedStateManager.syncDidTurnOff()
                         continuation.resume(returning: true)
                     } catch {
@@ -802,6 +820,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
 
     func confirmAndDeleteAllData() async -> Bool {
         let deviceCount = viewModel.devices.count
+        let pixelParameters = uiVersionParameters
         return await withCheckedContinuation { continuation in
             let alert = UIAlertController(title: useSimplifiedLayoutV2 ? UserText.simplifiedSyncDeleteAllConfirmTitle : UserText.syncDeleteAllConfirmTitle,
                                           message: useSimplifiedLayoutV2 ? UserText.simplifiedSyncDeleteAllConfirmMessage : UserText.syncDeleteAllConfirmMessage,
@@ -813,7 +832,9 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                 Task { @MainActor in
                     do {
                         try await self?.syncService.deleteAccount()
-                        Pixel.fire(pixel: .syncDisabledAndDeleted, withAdditionalParameters: [PixelParameters.connectedDevices: "\(deviceCount)"])
+                        var parameters = pixelParameters
+                        parameters[PixelParameters.connectedDevices] = "\(deviceCount)"
+                        Pixel.fire(pixel: .syncDisabledAndDeleted, withAdditionalParameters: parameters)
                         self?.viewModel.isSyncEnabled = false
                         self?.syncPausedStateManager.syncDidTurnOff()
                         if self?.useSimplifiedLayoutV2 == true {
@@ -863,7 +884,8 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
         Pixel.fire(pixel: .syncSetupManualCodeEntryScreenShown,
                    withAdditionalParameters: [
                     SyncSetupPixelInfo.Parameter.myKind: SyncSetupPixelInfo.Value.ddg,
-                    SyncSetupPixelInfo.Parameter.flowVersion: syncSetupPixelFlowVersion
+                    SyncSetupPixelInfo.Parameter.flowVersion: syncSetupPixelFlowVersion,
+                    PixelParameters.uiVersion: syncUIVersion
                    ],
                    includedParameters: [.appVersion])
     }

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -452,6 +452,12 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
             Pixel.fire(pixel: .settingsSyncRecoverSyncedDataTapped, includedParameters: [.appVersion])
         case .recoveryConfirmedTapped:
             Pixel.fire(pixel: .settingsSyncRecoveryConfirmedTapped, includedParameters: [.appVersion])
+        case .anotherDevicePromptShown:
+            Pixel.fire(pixel: .settingsSyncAnotherDevicePromptShown, includedParameters: [.appVersion])
+        case .anotherDevicePromptOptionTapped(let option):
+            Pixel.fire(pixel: .settingsSyncAnotherDevicePromptOptionTapped,
+                       withAdditionalParameters: [PixelParameters.syncPromptOption: option.rawValue],
+                       includedParameters: [.appVersion])
         }
     }
 

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -105,8 +105,18 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
 
     let useSimplifiedLayoutV2: Bool
 
+    var syncUIVersion: String {
+        useSimplifiedLayoutV2 ? "v2" : "v1"
+    }
+
+    var uiVersionParameters: [String: String] {
+        [PixelParameters.uiVersion: syncUIVersion]
+    }
+
     private var sourcePixelParameters: [String: String] {
-        source.map { [PixelParameters.source: $0] } ?? [:]
+        var parameters = uiVersionParameters
+        parameters[PixelParameters.source] = source
+        return parameters
     }
 
     // For some reason, on iOS 14, the viewDidLoad wasn't getting called so do some setup here
@@ -325,7 +335,8 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
         super.viewDidAppear(animated)
 
         Pixel.fire(pixel: .settingsSyncOpen, withAdditionalParameters: [
-            "is_enabled": isSyncEnabled ? "1" : "0"
+            "is_enabled": isSyncEnabled ? "1" : "0",
+            PixelParameters.uiVersion: syncUIVersion
         ])
 
         startPairingIfNecessary()
@@ -450,7 +461,10 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
                 return
             }
 
-            Pixel.fire(pixel: .syncSetupDeepLinkFlowStarted, includedParameters: [.appVersion])
+            Pixel.fire(pixel: .syncSetupDeepLinkFlowStarted,
+                       withAdditionalParameters: uiVersionParameters,
+                       includedParameters: [.appVersion],
+                       onComplete: { _ in })
 
             await connectionController.syncCodeEntered(
                 code: pairingInfo.base64Code,
@@ -476,12 +490,16 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
 
     private func handlePairingConfirmation() {
         askForAuthThenStartPairing()
-        Pixel.fire(pixel: .syncSetupDeepLinkFlowStarted, includedParameters: [.appVersion])
+        Pixel.fire(pixel: .syncSetupDeepLinkFlowStarted,
+                   withAdditionalParameters: uiVersionParameters,
+                   includedParameters: [.appVersion])
     }
 
     private func handlePairingCancellation() {
         pairingInfo = nil
-        Pixel.fire(pixel: .syncSetupDeepLinkFlowAbandoned, includedParameters: [.appVersion])
+        Pixel.fire(pixel: .syncSetupDeepLinkFlowAbandoned,
+                   withAdditionalParameters: uiVersionParameters,
+                   includedParameters: [.appVersion])
     }
 }
 
@@ -845,7 +863,9 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
             Pixel.fire(pixel: .syncSetupEndedSuccessful, withAdditionalParameters: parameters, includedParameters: [.appVersion])
             pairingV2PeerKind = nil
         case .deepLink:
-            Pixel.fire(pixel: .syncSetupDeepLinkFlowSuccess, includedParameters: [.appVersion])
+            Pixel.fire(pixel: .syncSetupDeepLinkFlowSuccess,
+                       withAdditionalParameters: uiVersionParameters,
+                       includedParameters: [.appVersion])
         }
     }
 
@@ -879,7 +899,9 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         guard case .receiver(_, .deepLink) = setupRole else {
             return
         }
-        Pixel.fire(pixel: .syncSetupDeepLinkFlowAbandoned, includedParameters: [.appVersion])
+        Pixel.fire(pixel: .syncSetupDeepLinkFlowAbandoned,
+                   withAdditionalParameters: uiVersionParameters,
+                   includedParameters: [.appVersion])
     }
 
     private func syncSetupPixelParameters(setupRole: SyncSetupRole, reason: String?, timeoutStage: String? = nil) -> [String: String] {
@@ -911,6 +933,7 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
                                           peerKind: String? = nil,
                                           myRole: String? = nil) -> [String: String] {
         var parameters = source.map { [PixelParameters.source: $0] } ?? [PixelParameters.source: setupSource.rawValue]
+        parameters[PixelParameters.uiVersion] = syncUIVersion
         parameters[SyncSetupPixelParameter.myKind] = SyncSetupPixelValue.ddg
         parameters[SyncSetupPixelParameter.codeType] = codeType
         parameters[SyncSetupPixelParameter.codeVersion] = codeVersion
@@ -953,7 +976,9 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
         guard case .deepLink = codeSource else {
             return
         }
-        Pixel.fire(pixel: .syncSetupDeepLinkFlowTimeout, includedParameters: [.appVersion])
+        Pixel.fire(pixel: .syncSetupDeepLinkFlowTimeout,
+                   withAdditionalParameters: uiVersionParameters,
+                   includedParameters: [.appVersion])
     }
 }
 

--- a/iOS/DuckDuckGoTests/SyncSettingsViewControllerErrorTests.swift
+++ b/iOS/DuckDuckGoTests/SyncSettingsViewControllerErrorTests.swift
@@ -96,6 +96,29 @@ final class SyncSettingsViewControllerErrorTests: XCTestCase {
     }
 
     @MainActor
+    func testWhenSimplifiedSyncSetupV2IsDisabledThenSyncUIVersionIsV1() {
+        XCTAssertEqual(vc.syncUIVersion, "v1")
+        XCTAssertEqual(vc.uiVersionParameters, [PixelParameters.uiVersion: "v1"])
+    }
+
+    @MainActor
+    func testWhenSimplifiedSyncSetupV2IsEnabledThenSyncUIVersionIsV2() {
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.simplifiedSyncSetupV2])
+        let vc = SyncSettingsViewController(
+            syncService: ddgSyncing,
+            syncBookmarksAdapter: syncBookmarksAdapter,
+            syncCredentialsAdapter: syncCredentialsAdapter,
+            syncCreditCardsAdapter: syncCreditCardsAdapter,
+            syncPausedStateManager: errorHandler,
+            featureFlagger: featureFlagger,
+            syncAutoRestoreHandler: syncAutoRestoreHandler
+        )
+
+        XCTAssertEqual(vc.syncUIVersion, "v2")
+        XCTAssertEqual(vc.uiVersionParameters, [PixelParameters.uiVersion: "v2"])
+    }
+
+    @MainActor
     func test_WhenSyncPausedIsTrue_andChangePublished_isSyncPausedIsUpdated() async {
         let expectation2 = XCTestExpectation(description: "isSyncPaused received the update")
         let expectation1 = XCTestExpectation(description: "isSyncPaused published")

--- a/iOS/DuckDuckGoTests/SyncUI/SyncSettingsViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/SyncUI/SyncSettingsViewModelTests.swift
@@ -677,6 +677,33 @@ final class SyncSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(sut.connectingSheetPhase, .success(isRecovery: false))
     }
 
+    func testWhenAnotherDevicePromptAppearedThenFiresPromptShownPixel() {
+        let delegate = MockSyncSettingsViewModelDelegate()
+        let sut = makeSut(autoRestoreProvider: MockSyncAutoRestoreHandler(), delegate: delegate)
+
+        sut.anotherDevicePromptAppeared()
+
+        XCTAssertEqual(delegate.firedSyncSetupPixelEvents, [.anotherDevicePromptShown])
+    }
+
+    func testWhenSyncAnotherDeviceFromConnectingSheetThenFiresOptionTappedPixelForSyncAnotherDevice() {
+        let delegate = MockSyncSettingsViewModelDelegate()
+        let sut = makeSut(autoRestoreProvider: MockSyncAutoRestoreHandler(), delegate: delegate)
+
+        sut.syncAnotherDeviceFromConnectingSheet()
+
+        XCTAssertEqual(delegate.firedSyncSetupPixelEvents, [.anotherDevicePromptOptionTapped(.syncAnotherDevice)])
+    }
+
+    func testWhenSyncThisDeviceOnlyFromConnectingSheetThenFiresOptionTappedPixelForThisDeviceOnly() {
+        let delegate = MockSyncSettingsViewModelDelegate()
+        let sut = makeSut(autoRestoreProvider: MockSyncAutoRestoreHandler(), delegate: delegate)
+
+        sut.syncThisDeviceOnlyFromConnectingSheet()
+
+        XCTAssertEqual(delegate.firedSyncSetupPixelEvents, [.anotherDevicePromptOptionTapped(.thisDeviceOnly)])
+    }
+
     private func makeSut(autoRestoreProvider: MockSyncAutoRestoreHandler,
                          delegate: MockSyncSettingsViewModelDelegate? = nil) -> SyncSettingsViewModel {
         let model = SyncSettingsViewModel(
@@ -707,6 +734,7 @@ private final class MockSyncSettingsViewModelDelegate: SyncManagementViewModelDe
     var onShowRecoveryCodeEntry: (() -> Void)?
     var onAuthenticateUserFinished: (() -> Void)?
     var hasShownSimplifiedSyncAnotherDevicePrompt: Bool = false
+    var firedSyncSetupPixelEvents: [SyncSettingsViewModel.SyncSetupPixelEvent] = []
 
     var syncBookmarksPausedTitle: String?
     var syncCredentialsPausedTitle: String?
@@ -770,6 +798,9 @@ private final class MockSyncSettingsViewModelDelegate: SyncManagementViewModelDe
     func showOtherPlatformLinks() {}
     func fireOtherPlatformLinksPixel(event: SyncSettingsViewModel.PlatformLinksPixelEvent, with source: SyncSettingsViewModel.PlatformLinksPixelSource) {}
     func shareLink(for url: URL, with message: String, from rect: CGRect) {}
+    func fireSyncSetupPixel(event: SyncSettingsViewModel.SyncSetupPixelEvent) {
+        firedSyncSetupPixelEvents.append(event)
+    }
 }
 
 private enum SyncSettingsViewModelTestsError: Error {

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/SyncSettingsViewModel.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/SyncSettingsViewModel.swift
@@ -128,12 +128,19 @@ public class SyncSettingsViewModel: ObservableObject {
         case readySkipRestoreTapped
     }
 
-    public enum SyncSetupPixelEvent {
+    public enum SyncSetupPixelEvent: Equatable {
         case backUpThisDeviceTapped
         case signupConfirmedTapped
         case signupAbandoned
         case recoverSyncedDataTapped
         case recoveryConfirmedTapped
+        case anotherDevicePromptShown
+        case anotherDevicePromptOptionTapped(SyncAnotherDeviceOption)
+    }
+
+    public enum SyncAnotherDeviceOption: String {
+        case thisDeviceOnly = "this_device_only"
+        case syncAnotherDevice = "sync_another_device"
     }
 
     public enum SyncSetupEntryPoint: Equatable {
@@ -440,7 +447,12 @@ public class SyncSettingsViewModel: ObservableObject {
         return true
     }
 
+    public func anotherDevicePromptAppeared() {
+        delegate?.fireSyncSetupPixel(event: .anotherDevicePromptShown)
+    }
+
     public func syncAnotherDeviceFromConnectingSheet() {
+        delegate?.fireSyncSetupPixel(event: .anotherDevicePromptOptionTapped(.syncAnotherDevice))
         postConnectingSheetDismissAction = { [weak self] in
             guard let self else { return }
             guard isConnectingDevicesAvailable else { return }
@@ -452,6 +464,7 @@ public class SyncSettingsViewModel: ObservableObject {
 
     @MainActor
     public func syncThisDeviceOnlyFromConnectingSheet() {
+        delegate?.fireSyncSetupPixel(event: .anotherDevicePromptOptionTapped(.thisDeviceOnly))
         guard !isBusy else { return }
         connectingSheetPhase = .syncAnotherDevice(isConnecting: true)
         beginSimplifiedSyncSetup()

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncAnotherDevicePromptViewV2.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncAnotherDevicePromptViewV2.swift
@@ -78,6 +78,9 @@ struct SyncAnotherDevicePromptViewV2: View {
             }
             .padding(.horizontal, 24)
             .navigationBarTitleDisplayMode(.inline)
+            .onAppear {
+                model.anotherDevicePromptAppeared()
+            }
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {

--- a/iOS/PixelDefinitions/pixels/definitions/settings_sync.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/settings_sync.json5
@@ -26,5 +26,27 @@
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
+    },
+    "m_settings_sync_another_device_prompt_shown": {
+        "description": "Fired when the 'Sync another device / set up this device only' prompt (simplifiedSyncSetupV2) is shown after the user turns on the sync toggle.",
+        "owners": ["frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_settings_sync_another_device_prompt_option_tapped": {
+        "description": "Fired when the user chooses an option on the Sync Another Device prompt (simplifiedSyncSetupV2).",
+        "owners": ["frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "option",
+                "type": "string",
+                "description": "Which option the user tapped on the prompt.",
+                "enum": ["this_device_only", "sync_another_device"]
+            }
+        ]
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/settings_sync.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/settings_sync.json5
@@ -29,14 +29,14 @@
     },
     "m_settings_sync_another_device_prompt_shown": {
         "description": "Fired when the 'Sync another device / set up this device only' prompt (simplifiedSyncSetupV2) is shown after the user turns on the sync toggle.",
-        "owners": ["frosty"],
+        "owners": ["pballart"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_settings_sync_another_device_prompt_option_tapped": {
         "description": "Fired when the user chooses an option on the Sync Another Device prompt (simplifiedSyncSetupV2).",
-        "owners": ["frosty"],
+        "owners": ["pballart"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": [

--- a/iOS/PixelDefinitions/pixels/definitions/settings_sync.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/settings_sync.json5
@@ -1,7 +1,7 @@
 {
     "m_settings_sync_open": {
         "description": "Fired when the Sync & Backup settings screen is shown.",
-        "owners": ["frosty"],
+        "owners": ["pballart"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": [
@@ -17,28 +17,28 @@
     },
     "m_settings_sync_back_up_this_device_tapped": {
         "description": "Fired when the user taps the 'Sync And Back Up This Device' action from the sync settings screen.",
-        "owners": ["frosty"],
+        "owners": ["pballart"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion", "ui_version"]
     },
     "m_settings_sync_recover_synced_data_tapped": {
         "description": "Fired when the user taps the entry point to the Recover Synced Data flow from the sync settings screen.",
-        "owners": ["frosty"],
+        "owners": ["pballart"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion", "ui_version"]
     },
     "m_settings_sync_signup_confirmed_tapped": {
         "description": "Fired when the user taps the primary 'Turn On Sync and Backup' button on the Sync With Server confirmation sheet (SyncWithServerView), confirming intent to set up sync on this device.",
-        "owners": ["frosty"],
+        "owners": ["pballart"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion", "ui_version"]
     },
     "m_settings_sync_recovery_confirmed_tapped": {
         "description": "Fired when the user taps the primary 'Recover Synced Data' button on the Recover Synced Data sheet (RecoverSyncedDataView), confirming intent to begin recovery.",
-        "owners": ["frosty"],
+        "owners": ["pballart"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion", "ui_version"]

--- a/iOS/PixelDefinitions/pixels/definitions/settings_sync.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/settings_sync.json5
@@ -1,38 +1,54 @@
 {
+    "m_settings_sync_open": {
+        "description": "Fired when the Sync & Backup settings screen is shown.",
+        "owners": ["frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "ui_version",
+            {
+                "key": "is_enabled",
+                "type": "string",
+                "description": "Whether Sync is enabled when the screen is shown.",
+                "enum": ["0", "1"]
+            }
+        ]
+    },
     "m_settings_sync_back_up_this_device_tapped": {
         "description": "Fired when the user taps the 'Sync And Back Up This Device' action from the sync settings screen.",
         "owners": ["frosty"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "ui_version"]
     },
     "m_settings_sync_recover_synced_data_tapped": {
         "description": "Fired when the user taps the entry point to the Recover Synced Data flow from the sync settings screen.",
         "owners": ["frosty"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "ui_version"]
     },
     "m_settings_sync_signup_confirmed_tapped": {
         "description": "Fired when the user taps the primary 'Turn On Sync and Backup' button on the Sync With Server confirmation sheet (SyncWithServerView), confirming intent to set up sync on this device.",
         "owners": ["frosty"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "ui_version"]
     },
     "m_settings_sync_recovery_confirmed_tapped": {
         "description": "Fired when the user taps the primary 'Recover Synced Data' button on the Recover Synced Data sheet (RecoverSyncedDataView), confirming intent to begin recovery.",
         "owners": ["frosty"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "ui_version"]
     },
     "m_settings_sync_another_device_prompt_shown": {
         "description": "Fired when the 'Sync another device / set up this device only' prompt (simplifiedSyncSetupV2) is shown after the user turns on the sync toggle.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "ui_version"]
     },
     "m_settings_sync_another_device_prompt_option_tapped": {
         "description": "Fired when the user chooses an option on the Sync Another Device prompt (simplifiedSyncSetupV2).",
@@ -41,6 +57,7 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "ui_version",
             {
                 "key": "option",
                 "type": "string",

--- a/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -6,6 +6,7 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "ui_version",
             {
                 "key": "source",
                 "type": "string",
@@ -29,6 +30,7 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "ui_version",
             {
                 "key": "source",
                 "type": "string",
@@ -55,6 +57,7 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "ui_version",
             {
                 "key": "source",
                 "type": "string",
@@ -93,6 +96,7 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "ui_version",
             {
                 "key": "source",
                 "type": "string",
@@ -125,6 +129,7 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "ui_version",
             {
                 "key": "source",
                 "type": "string",
@@ -157,6 +162,7 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "ui_version",
             {
                 "key": "flow_version",
                 "type": "string",
@@ -178,6 +184,7 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "ui_version",
             {
                 "key": "source",
                 "type": "string",
@@ -216,6 +223,7 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "ui_version",
             {
                 "key": "source",
                 "type": "string",
@@ -248,6 +256,7 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "ui_version",
             {
                 "key": "source",
                 "type": "string",
@@ -280,6 +289,7 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "ui_version",
             {
                 "key": "source",
                 "type": "string",
@@ -364,6 +374,7 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "ui_version",
             {
                 "key": "source",
                 "type": "string",
@@ -400,5 +411,85 @@
                 "enum": ["host", "joiner"]
             }
         ]
+    },
+    "m_sync_signup_direct": {
+        "description": "Fired when the app creates a Sync account directly for this device.",
+        "owners": ["amddg44", "frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "ui_version",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The Sync entry point or promotion source that led to account creation, when known."
+            }
+        ]
+    },
+    "m_sync_signup_connect": {
+        "description": "Fired when the app creates a Sync account while connecting another device.",
+        "owners": ["amddg44", "frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "ui_version",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The Sync entry point or promotion source that led to account creation, when known."
+            }
+        ]
+    },
+    "sync_disabled": {
+        "description": "Fired when the user turns off Sync without deleting server data.",
+        "owners": ["amddg44", "frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "ui_version"]
+    },
+    "sync_disabledanddeleted": {
+        "description": "Fired when the user turns off Sync and deletes the account's server data.",
+        "owners": ["amddg44", "frosty"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "ui_version",
+            {
+                "key": "connected_devices",
+                "type": "integer",
+                "description": "The number of connected devices when the account was deleted."
+            }
+        ]
+    },
+    "sync_setup_deep_link_flow_started": {
+        "description": "Fired when a Sync setup flow starts from a deep link.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "ui_version"]
+    },
+    "sync_setup_deep_link_flow_success": {
+        "description": "Fired when a Sync setup flow started from a deep link completes successfully.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "ui_version"]
+    },
+    "sync_setup_deep_link_flow_abandoned": {
+        "description": "Fired when the user abandons a Sync setup flow started from a deep link.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "ui_version"]
+    },
+    "sync_setup_deep_link_timeout": {
+        "description": "Fired when a Sync setup flow started from a deep link times out.",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "ui_version"]
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -1,7 +1,7 @@
 {
     "m_sync_login": {
         "description": "Fired when the app successfully logs in to an existing Sync account.",
-        "owners": ["amddg44", "frosty"],
+        "owners": ["amddg44", "pballart"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": [
@@ -414,7 +414,7 @@
     },
     "m_sync_signup_direct": {
         "description": "Fired when the app creates a Sync account directly for this device.",
-        "owners": ["amddg44", "frosty"],
+        "owners": ["amddg44", "pballart"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": [
@@ -429,7 +429,7 @@
     },
     "m_sync_signup_connect": {
         "description": "Fired when the app creates a Sync account while connecting another device.",
-        "owners": ["amddg44", "frosty"],
+        "owners": ["amddg44", "pballart"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": [
@@ -444,14 +444,14 @@
     },
     "sync_disabled": {
         "description": "Fired when the user turns off Sync without deleting server data.",
-        "owners": ["amddg44", "frosty"],
+        "owners": ["amddg44", "pballart"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion", "ui_version"]
     },
     "sync_disabledanddeleted": {
         "description": "Fired when the user turns off Sync and deletes the account's server data.",
-        "owners": ["amddg44", "frosty"],
+        "owners": ["amddg44", "pballart"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": [

--- a/iOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/iOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -9,6 +9,12 @@
         "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
         "examples": ["7.175.1"]
     },
+    "ui_version": {
+        "key": "ui_version",
+        "type": "string",
+        "description": "The version of the Sync settings and setup user interface.",
+        "enum": ["v1", "v2"]
+    },
     "unified_input_surface": {
         "key": "surface",
         "type": "string",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1216033863922288?focus=true

### Description

Improves iOS Sync analytics so V1 vs V2 (`simplifiedSyncSetupV2`) UI can be told apart, and adds coverage for the new V2 "sync another device" prompt.

**1. New `ui_version` parameter across the sync pixel family**

Adds a `ui_version` (`v1` | `v2`) parameter to the sync settings and setup pixels so the two UI flavours can be distinguished on the dashboards.

**2. Two new pixels for the V2 "sync another device" prompt**

Adds pixel coverage for `SyncAnotherDevicePromptViewV2`, a V2-only screen that previously had none:

- `m_settings_sync_another_device_prompt_shown` — impression when the prompt appears.
- `m_settings_sync_another_device_prompt_option_tapped` — which option the user taps (`option` = `this_device_only` | `sync_another_device`).

### Testing Steps

- Enable `simplifiedSyncSetupV2`. Settings → Sync & Backup → toggle Sync on → the prompt appears (`..._prompt_shown` with `ui_version=v2`). Tap "This device only" or "Sync with another device" → `..._option_tapped` with the matching `option`.
- With the flag off, confirm the sync-setup pixels fire with `ui_version=v1`.

### Impact and Risks

None: analytics only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes to pixel parameters and new event definitions; no sync behavior or user-facing flow changes.
> 
> **Overview**
> Adds **`ui_version`** (`v1` / `v2`) to iOS Sync settings and setup pixels so analytics can separate legacy UI from **`simplifiedSyncSetupV2`**. The value comes from **`syncUIVersion`** on **`SyncSettingsViewController`** and is wired through **`uiVersionParameters`** on existing fires (settings open, backup/recovery taps, signup success/abandon, disable/delete, deep-link setup, barcode/manual entry, etc.) and in **`sync_setup.json5`** / **`params_dictionary.json5**.
> 
> Introduces two new settings pixels for the V2 **“sync another device / this device only”** prompt: **`m_settings_sync_another_device_prompt_shown`** on **`SyncAnotherDevicePromptViewV2`** appear, and **`m_settings_sync_another_device_prompt_option_tapped`** with **`option`** (`this_device_only` | `sync_another_device`) when the user picks an action. **`SyncSettingsViewModel`** delegates these via new **`SyncSetupPixelEvent`** cases; unit tests cover **`syncUIVersion`** and delegate pixel firing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e439d3c7285fcbe2c69c548aad2cfb4c90c5f2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->