### PR TITLE
iOS: Expand (and smarter) suggested prompts for contextual sheet/sidepanel - ship review fixes + pixels

### DIFF
--- a/iOS/Core/Pixel.swift
+++ b/iOS/Core/Pixel.swift
@@ -219,6 +219,11 @@ public struct PixelParameters {
 
     // Fire animation
     public static let fireAnimation = "fireAnimationType"
+
+    // Contextual suggested prompts
+    public static let suggestionId = "suggestionId"
+    public static let suggestionsPageType = "pageType"
+    public static let suggestionsAreSmart = "isSmart"
 }
 
 public struct PixelValues {

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1855,6 +1855,11 @@ extension Pixel {
 
         case aiChatContextualQuickActionAskAboutPageShown
         case aiChatContextualQuickActionAskAboutPageSelected
+        case aiChatContextualSuggestionSelected
+        case aiChatContextualSuggestionsViewed
+        case aiChatContextualHeaderTitleTapped
+        case aiChatContextualSuggestionsCatalogLoadFailed
+        case aiChatContextualSuggestionsContextCollectionTimedOut
         case aiChatContextualRecentChatsPopupDisplayed
         case aiChatContextualRecentChatSelected
         case aiChatContextualViewAllChatsTapped
@@ -3781,6 +3786,12 @@ extension Pixel.Event {
         case .aiChatPageContextExtractionPrevented: return "aichat_page_context_extraction_prevented"
         case .aiChatContextualQuickActionAskAboutPageShown: return "m_aichat_contextual_quick_action_ask_about_page_shown"
         case .aiChatContextualQuickActionAskAboutPageSelected: return "m_aichat_contextual_quick_action_ask_about_page_selected"
+        case .aiChatContextualSuggestionSelected: return "aichat_contextual_suggestion_selected"
+        case .aiChatContextualSuggestionsViewed: return "aichat_contextual_suggestions_viewed"
+        case .aiChatContextualHeaderTitleTapped: return "aichat_contextual_header_title_tapped"
+        case .aiChatContextualSuggestionsCatalogLoadFailed: return "debug_aichat_contextual_suggestions_catalog_load_failed"
+        case .aiChatContextualSuggestionsContextCollectionTimedOut:
+            return "debug_aichat_contextual_suggestions_context_collection_timed_out"
         case .aiChatContextualRecentChatsPopupDisplayed: return "m_aichat_contextual_recent_chats_popup_displayed"
         case .aiChatContextualRecentChatSelected: return "m_aichat_contextual_recent_chat_selected"
         case .aiChatContextualViewAllChatsTapped: return "m_aichat_contextual_view_all_chats_tapped"

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -216,6 +216,12 @@ final class AIChatContextualChatSessionState {
         featureFlagger.isFeatureOn(.contextualSuggestedPrompts)
     }
 
+    /// A pinned context remains tied to its original page while auto-attach is disabled, so page
+    /// suggestions must remain tied to that same context until the chip is removed.
+    var shouldSuspendSuggestionsRefresh: Bool {
+        !shouldAutoCollectContext && intendedAttachedContext != nil
+    }
+
     private var hasUserOptedOutOfContext: Bool {
         userDowngradedToPlaceholder
     }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -72,6 +72,9 @@ struct SheetViewState {
     let quickActions: [AIChatContextualQuickAction]
     let suggestions: [ContextualSuggestedPrompt]
     let suggestionsLoadState: SuggestionsLoadState
+    /// Analytics-only metadata for the resolved suggestions; meaningful when `suggestionsLoadState == .loaded`.
+    let suggestionsAreSmart: Bool
+    let suggestionsPageType: SuggestionsPageType
 
     enum ContentMode {
         case nativeInput
@@ -127,7 +130,9 @@ final class AIChatContextualChatSessionState {
         chipState: .placeholder,
         quickActions: [.summarize],
         suggestions: [],
-        suggestionsLoadState: .loaded
+        suggestionsLoadState: .loaded,
+        suggestionsAreSmart: false,
+        suggestionsPageType: .none
     )
 
     let effects = PassthroughSubject<SheetEffect, Never>()
@@ -150,6 +155,8 @@ final class AIChatContextualChatSessionState {
 
     private(set) var suggestionsLoadState: SuggestionsLoadState = .loaded
     private(set) var suggestions: [ContextualSuggestedPrompt] = []
+    private var suggestionsAreSmart = false
+    private var suggestionsPageType: SuggestionsPageType = .none
     private var suggestionsResolveTask: Task<Void, Never>?
     private var suggestionsTimeoutTask: Task<Void, Never>?
 
@@ -302,6 +309,8 @@ final class AIChatContextualChatSessionState {
         suggestionsResolveTask?.cancel()
         suggestionsTimeoutTask?.cancel()
         suggestions = []
+        suggestionsAreSmart = false
+        suggestionsPageType = .none
         suggestionsLoadState = .loaded
         pixelHandler.endManualAttach()
         rebuildViewState()
@@ -710,6 +719,10 @@ private extension AIChatContextualChatSessionState {
         suggestionsTimeoutTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
             guard let self, !Task.isCancelled else { return }
+            guard self.suggestionsLoadState == .loading,
+                  self.featureFlagger.isFeatureOn(.contextualSuggestedPrompts),
+                  !self.hasActiveChat else { return }
+            self.pixelHandler.fireSuggestionsContextCollectionTimedOut()
             self.resolveSuggestionsIfLoading(from: nil)
         }
     }
@@ -733,7 +746,9 @@ private extension AIChatContextualChatSessionState {
             // A prompt submission may start a chat while the resolve is in flight; submission
             // methods don't cancel this task, so drop late results to keep chat view state intact.
             guard let self, !Task.isCancelled, !self.hasActiveChat else { return }
-            self.suggestions = resolved
+            self.suggestions = resolved.suggestions
+            self.suggestionsAreSmart = resolved.isSmart
+            self.suggestionsPageType = resolved.pageType
             self.suggestionsLoadState = .loaded
             self.rebuildViewState()
         }
@@ -756,7 +771,9 @@ private extension AIChatContextualChatSessionState {
             chipState: chipState,
             quickActions: quickActions,
             suggestions: visibleSuggestions(reserving: quickActions.count),
-            suggestionsLoadState: suggestionsLoadState
+            suggestionsLoadState: suggestionsLoadState,
+            suggestionsAreSmart: suggestionsAreSmart,
+            suggestionsPageType: suggestionsPageType
         )
     }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualModePixelHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualModePixelHandler.swift
@@ -29,12 +29,19 @@ protocol AIChatContextualModePixelFiring {
 
     // MARK: - Sheet Actions
     func fireExpandButtonTapped()
+    func fireHeaderTitleTapped()
     func fireNewChatButtonTapped()
     func fireQuickActionSummarizeSelected()
     func fireQuickActionAskAboutPageShown()
     func fireQuickActionAskAboutPageSelected()
     func fireFireButtonTapped()
     func fireFireButtonConfirmed()
+
+    // MARK: - Suggested Prompts
+    func fireAskAboutPageSuggestionSelected(pageType: SuggestionsPageType)
+    func fireSuggestionSelected(suggestionId: String, pageType: SuggestionsPageType)
+    func fireSuggestionsViewed(isSmart: Bool, pageType: SuggestionsPageType)
+    func fireSuggestionsContextCollectionTimedOut()
 
     // MARK: - Recent Chats Popup
     func fireRecentChatsPopupDisplayed()
@@ -74,6 +81,8 @@ protocol AIChatContextualModePixelFiring {
 /// **Thread Safety**: This class is thread-safe. All mutable state access is synchronized using a serial queue.
 final class AIChatContextualModePixelHandler: AIChatContextualModePixelFiring {
 
+    private static let askAboutPageSuggestionId = "ask-about-page"
+
     // MARK: - State
 
     /// Serial queue for synchronizing access to mutable state
@@ -85,6 +94,7 @@ final class AIChatContextualModePixelHandler: AIChatContextualModePixelFiring {
     // MARK: - Dependencies
 
     private let firePixel: (Pixel.Event) -> Void
+    private let firePixelWithParameters: (Pixel.Event, [String: String]) -> Void
 
     // MARK: - Public Properties
 
@@ -94,8 +104,12 @@ final class AIChatContextualModePixelHandler: AIChatContextualModePixelFiring {
 
     // MARK: - Initialization
 
-    init(firePixel: @escaping (Pixel.Event) -> Void = { DailyPixel.fireDailyAndCount(pixel: $0) }) {
+    init(firePixel: @escaping (Pixel.Event) -> Void = { DailyPixel.fireDailyAndCount(pixel: $0) },
+         firePixelWithParameters: @escaping (Pixel.Event, [String: String]) -> Void = {
+             DailyPixel.fireDailyAndCount(pixel: $0, withAdditionalParameters: $1)
+         }) {
         self.firePixel = firePixel
+        self.firePixelWithParameters = firePixelWithParameters
     }
 
     // MARK: - Sheet Lifecycle
@@ -116,6 +130,10 @@ final class AIChatContextualModePixelHandler: AIChatContextualModePixelFiring {
 
     func fireExpandButtonTapped() {
         firePixel(.aiChatContextualExpandButtonTapped)
+    }
+
+    func fireHeaderTitleTapped() {
+        firePixel(.aiChatContextualHeaderTitleTapped)
     }
 
     func fireNewChatButtonTapped() {
@@ -188,6 +206,30 @@ final class AIChatContextualModePixelHandler: AIChatContextualModePixelFiring {
 
     func firePromptSubmittedWithoutContext() {
         firePixel(.aiChatContextualPromptSubmittedWithoutContextNative)
+    }
+
+    // MARK: - Suggested Prompts
+
+    func fireAskAboutPageSuggestionSelected(pageType: SuggestionsPageType) {
+        fireSuggestionSelected(suggestionId: Self.askAboutPageSuggestionId, pageType: pageType)
+    }
+
+    func fireSuggestionSelected(suggestionId: String, pageType: SuggestionsPageType) {
+        firePixelWithParameters(.aiChatContextualSuggestionSelected, [
+            PixelParameters.suggestionId: suggestionId,
+            PixelParameters.suggestionsPageType: pageType.rawValue
+        ])
+    }
+
+    func fireSuggestionsViewed(isSmart: Bool, pageType: SuggestionsPageType) {
+        firePixelWithParameters(.aiChatContextualSuggestionsViewed, [
+            PixelParameters.suggestionsAreSmart: String(isSmart),
+            PixelParameters.suggestionsPageType: pageType.rawValue
+        ])
+    }
+
+    func fireSuggestionsContextCollectionTimedOut() {
+        firePixel(.aiChatContextualSuggestionsContextCollectionTimedOut)
     }
 
     // MARK: - Recent Chats Popup

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -283,10 +283,7 @@ final class AIChatContextualSheetCoordinator {
             sessionState.clearProcessingNavigationFlag()
             pageContextHandler.reportAttachabilityMeasurement(trigger: .navigation)
         } else if shouldCollectSignalsOnly {
-            sessionState.markPendingSignalsOnlyCollection()
-            if !pageContextHandler.triggerContextCollection(trigger: .tabContent) {
-                sessionState.clearProcessingNavigationFlag()
-            }
+            startSignalsOnlyCollection()
         } else {
             sessionState.clearProcessingNavigationFlag()
             pageContextHandler.reportAttachabilityMeasurement(trigger: .navigation)
@@ -302,6 +299,28 @@ final class AIChatContextualSheetCoordinator {
         featureFlagger.isFeatureOn(.contextualSuggestedPrompts)
             && !sessionState.hasActiveChat
             && !sessionState.shouldAutoCollectContext
+            && !sessionState.shouldSuspendSuggestionsRefresh
+    }
+
+    private func startSignalsOnlyCollection() {
+        guard shouldCollectSignalsOnly else { return }
+        sessionState.markPendingSignalsOnlyCollection()
+        if !pageContextHandler.triggerContextCollection(trigger: .tabContent) {
+            sessionState.clearProcessingNavigationFlag()
+        }
+    }
+
+    private func removeAttachedContext() {
+        sessionState.downgradeToPlaceholder()
+        guard currentPageURL != nil, shouldCollectSignalsOnly else {
+            pageContextHandler.clear()
+            return
+        }
+
+        stopObservingContextUpdates()
+        pageContextHandler.clear()
+        startObservingContextUpdates()
+        startSignalsOnlyCollection()
     }
 
     /// Attachment (and its delivery state) a freshly created persistent UTI host should start with.
@@ -402,8 +421,7 @@ private extension AIChatContextualSheetCoordinator {
         }
         host.onRemoveRequested = { [weak self] in
             guard let self else { return }
-            self.sessionState.downgradeToPlaceholder()
-            self.pageContextHandler.clear()
+            self.removeAttachedContext()
         }
         host.onPromptSubmitted = { [weak self] in
             guard let self else { return }
@@ -685,8 +703,7 @@ extension AIChatContextualSheetCoordinator: AIChatContextualSheetViewControllerD
     }
 
     func aiChatContextualSheetViewControllerDidRequestRemoveChip(_ viewController: AIChatContextualSheetViewController) {
-        sessionState.downgradeToPlaceholder()
-        pageContextHandler.clear()
+        removeAttachedContext()
     }
 
     func aiChatContextualSheetViewController(_ viewController: AIChatContextualSheetViewController, didUpdateContextualChatURL url: URL?) {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -869,7 +869,7 @@ extension AIChatContextualSheetViewController: AIChatContextualInputViewControll
     func contextualInputViewController(_ viewController: AIChatContextualInputViewController, didSelectSuggestion suggestion: ContextualSuggestedPrompt) {
         guard featureFlagger.isFeatureOn(.contextualSuggestedPrompts) else { return }
         cancelSuggestionSubmission()
-        pixelHandler.fireSuggestionSelected(suggestionId: suggestion.id,pageType: sessionState.viewState.suggestionsPageType)
+        pixelHandler.fireSuggestionSelected(suggestionId: suggestion.id, pageType: sessionState.viewState.suggestionsPageType)
         contextualInputViewController.setStartActionsDimmed(true)
         let submissionID = UUID()
         suggestionSubmissionID = submissionID

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -175,6 +175,7 @@ final class AIChatContextualSheetViewController: UIViewController {
     /// Tracks whether the "Ask about page" quick action chip is currently on screen, so the impression
     /// pixel fires once per appearance rather than on every view-state update.
     private var isAskAboutPageQuickActionVisible = false
+    private var areSuggestionsVisible = false
 
     /// Stops async suggestion work as soon as the sheet starts dismissing.
     private var canProcessSuggestionSubmission = false
@@ -413,8 +414,14 @@ final class AIChatContextualSheetViewController: UIViewController {
         hideDimmingView(animated: animated)
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        fireSuggestionsViewedPixelIfNeeded(for: sessionState.viewState)
+    }
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+        areSuggestionsVisible = false
         if isBeingDismissed {
             prepareForDismissal()
             delegate?.aiChatContextualSheetViewControllerDidDismiss(self)
@@ -454,6 +461,7 @@ final class AIChatContextualSheetViewController: UIViewController {
     }
 
     @objc private func titleTapped() {
+        pixelHandler.fireHeaderTitleTapped()
         requestExpand()
     }
 
@@ -833,6 +841,9 @@ extension AIChatContextualSheetViewController: AIChatContextualInputViewControll
         switch action {
         case .askAboutPage:
             pixelHandler.fireQuickActionAskAboutPageSelected()
+            if featureFlagger.isFeatureOn(.contextualSuggestedPrompts) {
+                pixelHandler.fireAskAboutPageSuggestionSelected(pageType: sessionState.viewState.suggestionsPageType)
+            }
             delegate?.aiChatContextualSheetViewControllerDidRequestAttachPage(self)
             if let persistentUTIHost {
                 persistentUTIHost.activateInput()
@@ -858,6 +869,7 @@ extension AIChatContextualSheetViewController: AIChatContextualInputViewControll
     func contextualInputViewController(_ viewController: AIChatContextualInputViewController, didSelectSuggestion suggestion: ContextualSuggestedPrompt) {
         guard featureFlagger.isFeatureOn(.contextualSuggestedPrompts) else { return }
         cancelSuggestionSubmission()
+        pixelHandler.fireSuggestionSelected(suggestionId: suggestion.id,pageType: sessionState.viewState.suggestionsPageType)
         contextualInputViewController.setStartActionsDimmed(true)
         let submissionID = UUID()
         suggestionSubmissionID = submissionID
@@ -1022,6 +1034,7 @@ private extension AIChatContextualSheetViewController {
         contextualInputViewController.updateStartActions(suggestions: viewState.suggestions, quickActions: viewState.quickActions)
         contextualInputViewController.updateSuggestionsLoading(viewState.suggestionsLoadState == .loading)
         fireAskAboutPageShownPixelIfNeeded(for: viewState)
+        fireSuggestionsViewedPixelIfNeeded(for: viewState)
 
         switch viewState.content {
         case .nativeInput:
@@ -1077,6 +1090,25 @@ private extension AIChatContextualSheetViewController {
         defer { isAskAboutPageQuickActionVisible = isVisible }
         guard isVisible, !isAskAboutPageQuickActionVisible else { return }
         pixelHandler.fireQuickActionAskAboutPageShown()
+    }
+
+    private func fireSuggestionsViewedPixelIfNeeded(for viewState: SheetViewState) {
+        let isVisible: Bool
+        switch viewState.content {
+        case .nativeInput:
+            isVisible = viewIfLoaded?.window != nil
+                && viewState.suggestionsLoadState == .loaded
+                && !viewState.suggestions.isEmpty
+        case .webView:
+            isVisible = false
+        }
+
+        defer { areSuggestionsVisible = isVisible }
+        guard isVisible, !areSuggestionsVisible else { return }
+        pixelHandler.fireSuggestionsViewed(
+            isSmart: viewState.suggestionsAreSmart,
+            pageType: viewState.suggestionsPageType
+        )
     }
 }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestedPromptsProviding.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestedPromptsProviding.swift
@@ -26,11 +26,40 @@ struct ResolvePageSuggestionsInput {
     let uiLocale: String
 }
 
+/// Coarse, pixel-safe classification of the current page, mirroring the frontend's `PageType`.
+/// Analytics-only — never drives which suggestions are offered. Raw values are the pixel
+/// parameter values.
+enum SuggestionsPageType: String, Equatable {
+    case recipe
+    case product
+    case article
+    case video
+    case job
+    case book
+    case event
+    case place
+    case forum
+    case code
+    case course
+    case review
+    case person
+    case howto
+    case faq
+    case none
+}
+
+struct ResolvedPageSuggestions: Equatable {
+    let suggestions: [ContextualSuggestedPrompt]
+    /// Whether the suggestions came from a page-tailored (contextual) match rather than the generic defaults.
+    let isSmart: Bool
+    let pageType: SuggestionsPageType
+}
+
 protocol ContextualSuggestedPromptsProviding {
     /// Catalog-owned chip budget shared by suggestions and quick actions.
     var maxSuggestedPrompts: Int { get }
     /// Suggestions that must displace a regular suggestion rather than be trimmed from the end.
     var prioritySuggestionIDs: Set<String> { get }
 
-    func resolveSuggestions(_ input: ResolvePageSuggestionsInput) async -> [ContextualSuggestedPrompt]
+    func resolveSuggestions(_ input: ResolvePageSuggestionsInput) async -> ResolvedPageSuggestions
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionsMatcher.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionsMatcher.swift
@@ -18,6 +18,7 @@
 //
 
 import AIChat
+import Core
 import Foundation
 import os.log
 
@@ -64,13 +65,13 @@ struct ContextualSuggestionsMatcher {
 
     private init() {}
 
-    static func resolve(_ input: ResolvePageSuggestionsInput, catalog: SuggestionCatalog) -> [ContextualSuggestedPrompt] {
+    static func resolve(_ input: ResolvePageSuggestionsInput, catalog: SuggestionCatalog) -> ResolvedPageSuggestions {
         let cap = max(1, catalog.maxSuggestedPrompts)
-        let candidateIds = collectCandidateIds(input, catalog: catalog, cap: cap)
+        let candidates = collectCandidateIds(input, catalog: catalog, cap: cap)
         var seen = Set<String>()
         var resolved: [ContextualSuggestedPrompt] = []
 
-        for id in candidateIds {
+        for id in candidates.ids {
             if resolved.count >= cap { break }
             if seen.contains(id) { continue }
             seen.insert(id)
@@ -86,12 +87,79 @@ struct ContextualSuggestionsMatcher {
             ))
         }
 
-        return resolved
+        return ResolvedPageSuggestions(
+            suggestions: resolved,
+            isSmart: candidates.isSmart,
+            pageType: classifyPageType(input.pageTypeSignals)
+        )
     }
+
+    // MARK: Page-type classification
+
+    /// 1:1 port of the frontend's `classifyPageType`: JSON-LD types are scanned in *signal* order
+    /// (not catalog order), then the OG type, else `.none`. A domain-only match deliberately yields
+    /// `.none`.
+    static func classifyPageType(_ signals: AIChatPageTypeSignals?) -> SuggestionsPageType {
+        guard let signals else { return .none }
+        for type in signals.jsonLdType {
+            if let bucket = jsonLdTypeToPageType[type.trimmingCharacters(in: .whitespaces).lowercased()] {
+                return bucket
+            }
+        }
+        if let ogType = signals.ogType?.trimmingCharacters(in: .whitespaces).lowercased(),
+           let bucket = ogTypeToPageType[ogType] {
+            return bucket
+        }
+        return .none
+    }
+
+    private static let jsonLdTypeToPageType: [String: SuggestionsPageType] = [
+        "recipe": .recipe,
+        "product": .product,
+        "article": .article,
+        "newsarticle": .article,
+        "reportagenewsarticle": .article,
+        "liveblogposting": .article,
+        "blogposting": .article,
+        "scholarlyarticle": .article,
+        "videoobject": .video,
+        "movie": .video,
+        "tvseries": .video,
+        "jobposting": .job,
+        "book": .book,
+        "course": .course,
+        "event": .event,
+        "restaurant": .place,
+        "foodestablishment": .place,
+        "localbusiness": .place,
+        "discussionforumposting": .forum,
+        "qapage": .forum,
+        "faqpage": .faq,
+        "softwaresourcecode": .code,
+        "review": .review,
+        "aggregaterating": .review,
+        "person": .person,
+        "howto": .howto
+    ]
+
+    private static let ogTypeToPageType: [String: SuggestionsPageType] = [
+        "article": .article,
+        "product": .product,
+        "product.item": .product,
+        "video": .video,
+        "video.other": .video,
+        "video.movie": .video,
+        "video.episode": .video,
+        "video.tv_show": .video,
+        "book": .book,
+        "profile": .person
+    ]
 
     // MARK: Candidate collection
 
-    private static func collectCandidateIds(_ input: ResolvePageSuggestionsInput, catalog: SuggestionCatalog, cap: Int) -> [String] {
+    private static func collectCandidateIds(_ input: ResolvePageSuggestionsInput,
+                                            catalog: SuggestionCatalog,
+                                            cap: Int) -> (ids: [String], isSmart: Bool) {
         var contextual: [String]?
 
         if let signals = input.pageTypeSignals {
@@ -118,7 +186,7 @@ struct ContextualSuggestionsMatcher {
 
         let body = contextual ?? floorDefaults
         let bodyBudget = max(0, cap - priorityDefaults.count)
-        return Array(body.prefix(bodyBudget)) + priorityDefaults
+        return (ids: Array(body.prefix(bodyBudget)) + priorityDefaults, isSmart: contextual != nil)
     }
 
     private static func matchByJsonLdType(_ types: [String], _ mappings: [SuggestionCatalog.JSONLDMapping]) -> [String]? {
@@ -249,9 +317,10 @@ struct ContextualSuggestionsMatcher {
 
 struct DefaultContextualSuggestedPromptsProvider: ContextualSuggestedPromptsProviding {
     private let catalog: SuggestionCatalog?
+    private let fireCatalogLoadFailedPixel: () -> Void
 
     var maxSuggestedPrompts: Int {
-        catalog?.maxSuggestedPrompts ?? Self.decodeFailureFallback.count
+        catalog?.maxSuggestedPrompts ?? 1
     }
 
     var prioritySuggestionIDs: Set<String> {
@@ -259,23 +328,35 @@ struct DefaultContextualSuggestedPromptsProvider: ContextualSuggestedPromptsProv
         return Set(catalog.defaults.filter { catalog.catalog[$0]?.condition != nil })
     }
 
-    init(catalog: SuggestionCatalog? = SuggestionCatalog.bundled) {
+    init(catalog: SuggestionCatalog? = SuggestionCatalog.bundled,
+         fireCatalogLoadFailedPixel: @escaping () -> Void = {
+             DailyPixel.fireDailyAndCount(pixel: .aiChatContextualSuggestionsCatalogLoadFailed)
+         }) {
         self.catalog = catalog
+        self.fireCatalogLoadFailedPixel = fireCatalogLoadFailedPixel
     }
 
-    func resolveSuggestions(_ input: ResolvePageSuggestionsInput) async -> [ContextualSuggestedPrompt] {
-        guard let catalog else { return Self.decodeFailureFallback }
+    func resolveSuggestions(_ input: ResolvePageSuggestionsInput) async -> ResolvedPageSuggestions {
+        guard let catalog else {
+            fireCatalogLoadFailedPixel()
+            return Self.decodeFailureFallback(for: input)
+        }
         return ContextualSuggestionsMatcher.resolve(input, catalog: catalog)
     }
 
     /// Last-resort floor if the bundled catalog cannot be decoded: a single unconditional
-    /// "Summarize this page" so the start surface is never empty.
-    private static var decodeFailureFallback: [ContextualSuggestedPrompt] {
-        [ContextualSuggestedPrompt(
-            id: "summarize-page",
-            label: UserText.aiChatSuggestionSummarizePageLabel,
-            prompt: UserText.aiChatSuggestionSummarizePagePrompt,
-            icon: "summary"
-        )]
+    /// "Summarize this page" so the start surface is never empty. The page type is still
+    /// classified — it does not depend on the catalog.
+    private static func decodeFailureFallback(for input: ResolvePageSuggestionsInput) -> ResolvedPageSuggestions {
+        ResolvedPageSuggestions(
+            suggestions: [ContextualSuggestedPrompt(
+                id: "summarize-page",
+                label: UserText.aiChatSuggestionSummarizePageLabel,
+                prompt: UserText.aiChatSuggestionSummarizePagePrompt,
+                icon: "summary"
+            )],
+            isSmart: false,
+            pageType: ContextualSuggestionsMatcher.classifyPageType(input.pageTypeSignals)
+        )
     }
 }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -468,6 +468,36 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertTrue(mockPixelHandler.manualAttachEnded)
     }
 
+    func testSuggestionsRefreshSuspensionTracksPinnedContextWhenAutoAttachIsOff() {
+        // Given
+        mockSettings.isAutomaticContextAttachmentEnabled = false
+        XCTAssertFalse(sessionState.shouldSuspendSuggestionsRefresh)
+
+        // When
+        sessionState.beginManualAttach()
+        sessionState.updateContext(makeTestContext(title: "Page A"))
+
+        // Then
+        XCTAssertTrue(sessionState.shouldSuspendSuggestionsRefresh)
+
+        // When
+        sessionState.downgradeToPlaceholder()
+
+        // Then
+        XCTAssertFalse(sessionState.shouldSuspendSuggestionsRefresh)
+    }
+
+    func testSuggestionsRefreshIsNotSuspendedForAttachedContextWhenAutoAttachIsOn() {
+        // Given
+        mockSettings.isAutomaticContextAttachmentEnabled = true
+
+        // When
+        sessionState.updateContext(makeTestContext(title: "Page A"))
+
+        // Then
+        XCTAssertFalse(sessionState.shouldSuspendSuggestionsRefresh)
+    }
+
     func testManualAttachWithAutoAttachOffStaysStickyAcrossNavigationWhileSheetIsOpen() {
         mockSettings.isAutomaticContextAttachmentEnabled = false
         sessionState.beginManualAttach()

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -2188,10 +2188,15 @@ private final class MockContextualModePixelHandler: AIChatContextualModePixelFir
     func fireSheetDismissed() { sheetDismissedFired = true }
     func fireSessionRestored() { sessionRestoredFired = true }
     func fireExpandButtonTapped() { expandButtonTappedFired = true }
+    func fireHeaderTitleTapped() {}
     func fireNewChatButtonTapped() { newChatButtonTappedFired = true }
     func fireQuickActionSummarizeSelected() { quickActionSummarizeSelectedFired = true }
     func fireQuickActionAskAboutPageShown() { quickActionAskAboutPageShownCount += 1 }
     func fireQuickActionAskAboutPageSelected() {}
+    func fireAskAboutPageSuggestionSelected(pageType: SuggestionsPageType) {}
+    func fireSuggestionSelected(suggestionId: String, pageType: SuggestionsPageType) {}
+    func fireSuggestionsViewed(isSmart: Bool, pageType: SuggestionsPageType) {}
+    func fireSuggestionsContextCollectionTimedOut() {}
     func fireRecentChatsPopupDisplayed() {}
     func fireRecentChatSelected() {}
     func fireViewAllChatsTapped() {}
@@ -2250,9 +2255,9 @@ private final class MockContextualSuggestedPromptsProvider: ContextualSuggestedP
         self.prioritySuggestionIDs = prioritySuggestionIDs
     }
 
-    func resolveSuggestions(_ input: ResolvePageSuggestionsInput) async -> [ContextualSuggestedPrompt] {
+    func resolveSuggestions(_ input: ResolvePageSuggestionsInput) async -> ResolvedPageSuggestions {
         lastInput = input
-        return suggestions
+        return ResolvedPageSuggestions(suggestions: suggestions, isSmart: false, pageType: .none)
     }
 }
 
@@ -2264,15 +2269,15 @@ private final class GatedContextualSuggestedPromptsProvider: ContextualSuggested
     let maxSuggestedPrompts = 4
     let prioritySuggestionIDs: Set<String> = []
     private(set) var startedCount = 0
-    private var continuations: [CheckedContinuation<[ContextualSuggestedPrompt], Never>] = []
+    private var continuations: [CheckedContinuation<ResolvedPageSuggestions, Never>] = []
 
-    func resolveSuggestions(_ input: ResolvePageSuggestionsInput) async -> [ContextualSuggestedPrompt] {
+    func resolveSuggestions(_ input: ResolvePageSuggestionsInput) async -> ResolvedPageSuggestions {
         startedCount += 1
         return await withCheckedContinuation { continuations.append($0) }
     }
 
     /// Resumes the resolve started as the `index`-th call (0-based), in any order the test needs.
     func resume(at index: Int, returning suggestions: [ContextualSuggestedPrompt]) {
-        continuations[index].resume(returning: suggestions)
+        continuations[index].resume(returning: ResolvedPageSuggestions(suggestions: suggestions, isSmart: false, pageType: .none))
     }
 }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualModePixelHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualModePixelHandlerTests.swift
@@ -116,6 +116,62 @@ final class AIChatContextualModePixelHandlerTests {
         #expect(PixelFiringMock.lastPixelName == Pixel.Event.aiChatContextualQuickActionSummarizeSelected.name)
     }
 
+    // MARK: - Suggested Prompt Pixels
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Suggestion selected includes suggestion id and page type", .timeLimit(.minutes(1)))
+    func suggestion_selected_includes_suggestion_id_and_page_type() {
+        var firedEventName: String?
+        var firedParameters: [String: String]?
+        let sut = AIChatContextualModePixelHandler(
+            firePixel: { _ in },
+            firePixelWithParameters: { event, parameters in
+                firedEventName = event.name
+                firedParameters = parameters
+            })
+
+        sut.fireSuggestionSelected(suggestionId: "shopping-list", pageType: .recipe)
+
+        #expect(firedEventName == Pixel.Event.aiChatContextualSuggestionSelected.name)
+        #expect(firedParameters == ["suggestionId": "shopping-list", "pageType": "recipe"])
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Ask about page uses the cross-platform suggestion id", .timeLimit(.minutes(1)))
+    func ask_about_page_uses_cross_platform_suggestion_id() {
+        var firedEventName: String?
+        var firedParameters: [String: String]?
+        let sut = AIChatContextualModePixelHandler(
+            firePixel: { _ in },
+            firePixelWithParameters: { event, parameters in
+                firedEventName = event.name
+                firedParameters = parameters
+            })
+
+        sut.fireAskAboutPageSuggestionSelected(pageType: .article)
+
+        #expect(firedEventName == Pixel.Event.aiChatContextualSuggestionSelected.name)
+        #expect(firedParameters == ["suggestionId": "ask-about-page", "pageType": "article"])
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Suggestions viewed includes smartness and page type", .timeLimit(.minutes(1)))
+    func suggestions_viewed_includes_smartness_and_page_type() {
+        var firedEventName: String?
+        var firedParameters: [String: String]?
+        let sut = AIChatContextualModePixelHandler(
+            firePixel: { _ in },
+            firePixelWithParameters: { event, parameters in
+                firedEventName = event.name
+                firedParameters = parameters
+            })
+
+        sut.fireSuggestionsViewed(isSmart: true, pageType: .video)
+
+        #expect(firedEventName == Pixel.Event.aiChatContextualSuggestionsViewed.name)
+        #expect(firedParameters == ["isSmart": "true", "pageType": "video"])
+    }
+
     // MARK: - Page Context Attachment Pixels
 
     @Test("Page context auto attached pixel fires correctly")

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -400,6 +400,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     func testNotifyPageChangedTriggersCollectionWhenAutoAttachEnabled() async {
         mockSettings.isAutomaticContextAttachmentEnabled = true
         await sut.presentSheet(from: mockPresentingVC)
+        sut.sessionState.updateContext(makeTestContext(title: "Page A"))
         mockPageContextHandler.triggerContextCollectionCallCount = 0
 
         await sut.notifyPageChanged()
@@ -459,6 +460,78 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         await sut.notifyPageChanged()
 
         XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
+    }
+
+    @MainActor
+    func testNotifyPageChangedDoesNotRefreshSuggestionsWhenAutoAttachIsOffAndContextIsPinned() async {
+        // Given
+        let pageAURL = URL(string: "https://example.com/page-a")!
+        let pageBURL = URL(string: "https://example.com/page-b")!
+        mockFeatureFlagger.enabledFeatureFlags = [.contextualSuggestedPrompts]
+        mockSettings.isAutomaticContextAttachmentEnabled = false
+        await sut.presentSheet(from: mockPresentingVC)
+        originatingTabURLSubject.send(pageAURL)
+        sut.sessionState.beginManualAttach()
+        mockPageContextHandler.sendContext(makeTestContext(title: "Page A", url: pageAURL.absoluteString))
+        await waitForAttachedChip()
+        originatingTabURLSubject.send(pageBURL)
+        mockPageContextHandler.triggerContextCollectionCallCount = 0
+
+        // When
+        await sut.notifyPageChanged()
+
+        // Then
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 0)
+        XCTAssertEqual(sut.sessionState.suggestionsLoadState, .loaded)
+    }
+
+    @MainActor
+    func testRemovePinnedContextImmediatelyRefreshesSuggestionsForCurrentPage() async {
+        // Given
+        let pageAURL = URL(string: "https://example.com/page-a")!
+        let pageBURL = URL(string: "https://example.com/page-b")!
+        mockFeatureFlagger.enabledFeatureFlags = [.contextualSuggestedPrompts]
+        mockSettings.isAutomaticContextAttachmentEnabled = false
+        await sut.presentSheet(from: mockPresentingVC)
+        originatingTabURLSubject.send(pageAURL)
+        sut.sessionState.beginManualAttach()
+        mockPageContextHandler.sendContext(makeTestContext(title: "Page A", url: pageAURL.absoluteString))
+        await waitForAttachedChip()
+        originatingTabURLSubject.send(pageBURL)
+        await sut.notifyPageChanged()
+        mockPageContextHandler.triggerContextCollectionCallCount = 0
+        let refreshStarted = expectation(description: "suggestions refresh started")
+        mockPageContextHandler.onTriggerContextCollection = {
+            refreshStarted.fulfill()
+        }
+
+        // When
+        sut.aiChatContextualSheetViewControllerDidRequestRemoveChip(sut.sheetViewController!)
+        await fulfillment(of: [refreshStarted], timeout: 1.0)
+
+        // Then
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
+        XCTAssertEqual(mockPageContextHandler.lastTriggerContextCollectionTrigger, .tabContent)
+        XCTAssertEqual(sut.sessionState.suggestionsLoadState, .loading)
+    }
+
+    @MainActor
+    func testNotifyPageChangedRefreshesSuggestionsWhenAutoAttachIsOffAndContextIsNotPinned() async {
+        // Given
+        let pageURL = URL(string: "https://example.com/page")!
+        mockFeatureFlagger.enabledFeatureFlags = [.contextualSuggestedPrompts]
+        mockSettings.isAutomaticContextAttachmentEnabled = false
+        await sut.presentSheet(from: mockPresentingVC)
+        originatingTabURLSubject.send(pageURL)
+        mockPageContextHandler.triggerContextCollectionCallCount = 0
+
+        // When
+        await sut.notifyPageChanged()
+
+        // Then
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 1)
+        XCTAssertEqual(mockPageContextHandler.lastTriggerContextCollectionTrigger, .tabContent)
+        XCTAssertEqual(sut.sessionState.suggestionsLoadState, .loading)
     }
 
     @MainActor

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualWebViewControllerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualWebViewControllerTests.swift
@@ -246,10 +246,15 @@ private final class StubContextualModePixelHandler: AIChatContextualModePixelFir
     func fireSheetDismissed() {}
     func fireSessionRestored() {}
     func fireExpandButtonTapped() {}
+    func fireHeaderTitleTapped() {}
     func fireNewChatButtonTapped() {}
     func fireQuickActionSummarizeSelected() {}
     func fireQuickActionAskAboutPageShown() {}
     func fireQuickActionAskAboutPageSelected() {}
+    func fireAskAboutPageSuggestionSelected(pageType: SuggestionsPageType) {}
+    func fireSuggestionSelected(suggestionId: String, pageType: SuggestionsPageType) {}
+    func fireSuggestionsViewed(isSmart: Bool, pageType: SuggestionsPageType) {}
+    func fireSuggestionsContextCollectionTimedOut() {}
     func fireRecentChatsPopupDisplayed() {}
     func fireRecentChatSelected() {}
     func fireViewAllChatsTapped() {}

--- a/iOS/DuckDuckGoTests/AIChat/AIChatPageContextHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatPageContextHandlerTests.swift
@@ -662,10 +662,15 @@ private final class MockContextualModePixelHandler: AIChatContextualModePixelFir
     func fireSheetDismissed() {}
     func fireSessionRestored() {}
     func fireExpandButtonTapped() {}
+    func fireHeaderTitleTapped() {}
     func fireNewChatButtonTapped() {}
     func fireQuickActionSummarizeSelected() {}
     func fireQuickActionAskAboutPageShown() {}
     func fireQuickActionAskAboutPageSelected() {}
+    func fireAskAboutPageSuggestionSelected(pageType: SuggestionsPageType) {}
+    func fireSuggestionSelected(suggestionId: String, pageType: SuggestionsPageType) {}
+    func fireSuggestionsViewed(isSmart: Bool, pageType: SuggestionsPageType) {}
+    func fireSuggestionsContextCollectionTimedOut() {}
     func fireRecentChatsPopupDisplayed() {}
     func fireRecentChatSelected() {}
     func fireViewAllChatsTapped() {}

--- a/iOS/DuckDuckGoTests/AIChat/ContextualSuggestionsMatcherTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/ContextualSuggestionsMatcherTests.swift
@@ -90,7 +90,7 @@ final class ContextualSuggestionsMatcherTests: XCTestCase {
     }
 
     private func resolvedIDs(_ input: ResolvePageSuggestionsInput, _ catalog: SuggestionCatalog) -> [String] {
-        ContextualSuggestionsMatcher.resolve(input, catalog: catalog).map(\.id)
+        ContextualSuggestionsMatcher.resolve(input, catalog: catalog).suggestions.map(\.id)
     }
 
     // MARK: - Defaults / floor
@@ -99,7 +99,7 @@ final class ContextualSuggestionsMatcherTests: XCTestCase {
         let result = ContextualSuggestionsMatcher.resolve(input(nil, uiLocale: "en_US"), catalog: try standardCatalog())
         // translate-page carries `differentLanguage`; with no page language it is filtered, leaving the
         // unconditional summarize-page floor.
-        XCTAssertEqual(result.map(\.id), ["summarize-page"])
+        XCTAssertEqual(result.suggestions.map(\.id), ["summarize-page"])
     }
 
     func testUnknownTypeFallsBackToDefaults() throws {
@@ -159,6 +159,43 @@ final class ContextualSuggestionsMatcherTests: XCTestCase {
         let ids = resolvedIDs(input(signals(jsonLd: ["Recipe"], lang: "en"), url: "https://github.com/foo"), try standardCatalog())
         XCTAssertFalse(ids.contains("repo-a"))
         XCTAssertEqual(ids, ["recipe-a", "recipe-b", "recipe-c"])
+    }
+
+    // MARK: - Analytics metadata
+
+    func testWhenJsonLdMatchesThenResultIsSmartAndUsesMappedPageType() throws {
+        let result = ContextualSuggestionsMatcher.resolve(
+            input(signals(jsonLd: ["Recipe"], lang: "en")),
+            catalog: try standardCatalog())
+
+        XCTAssertTrue(result.isSmart)
+        XCTAssertEqual(result.pageType, .recipe)
+    }
+
+    func testWhenNoContextualMatchThenResultIsNotSmartAndPageTypeIsNone() throws {
+        let result = ContextualSuggestionsMatcher.resolve(
+            input(signals(jsonLd: ["Nonexistent"], lang: "en")),
+            catalog: try standardCatalog())
+
+        XCTAssertFalse(result.isSmart)
+        XCTAssertEqual(result.pageType, .none)
+    }
+
+    func testWhenDomainMatchesThenResultIsSmartAndPageTypeIsNone() throws {
+        let result = ContextualSuggestionsMatcher.resolve(
+            input(signals(lang: "en"), url: "https://github.com/duckduckgo/apple-browsers"),
+            catalog: try standardCatalog())
+
+        XCTAssertTrue(result.isSmart)
+        XCTAssertEqual(result.pageType, .none)
+    }
+
+    func testWhenJsonLdAndOgTypeMatchThenJsonLdDeterminesPageType() throws {
+        let result = ContextualSuggestionsMatcher.resolve(
+            input(signals(jsonLd: ["Recipe"], ogType: "article", lang: "en")),
+            catalog: try standardCatalog())
+
+        XCTAssertEqual(result.pageType, .recipe)
     }
 
     // MARK: - Dedup & cap
@@ -258,19 +295,19 @@ final class ContextualSuggestionsMatcherTests: XCTestCase {
         }
         """
         let result = ContextualSuggestionsMatcher.resolve(input(nil, uiLocale: "en_US"), catalog: try catalog(json))
-        XCTAssertEqual(result.map(\.prompt), ["Translate into English."])
+        XCTAssertEqual(result.suggestions.map(\.prompt), ["Translate into English."])
     }
 
     func testTemplateLeavesPromptsWithoutPlaceholderUnchanged() throws {
         let result = ContextualSuggestionsMatcher.resolve(input(signals(jsonLd: ["Recipe"], lang: "en")), catalog: try standardCatalog())
-        XCTAssertEqual(result.first { $0.id == "recipe-a" }?.prompt, "Make a list.")
+        XCTAssertEqual(result.suggestions.first { $0.id == "recipe-a" }?.prompt, "Make a list.")
     }
 
     // MARK: - Copy & icon passthrough
 
     func testUnmappedIDsUseCatalogCopyAndIcon() throws {
         let result = ContextualSuggestionsMatcher.resolve(input(signals(jsonLd: ["Recipe"], lang: "en")), catalog: try standardCatalog())
-        let recipeA = try XCTUnwrap(result.first { $0.id == "recipe-a" })
+        let recipeA = try XCTUnwrap(result.suggestions.first { $0.id == "recipe-a" })
         XCTAssertEqual(recipeA.label, "Shopping list")
         XCTAssertEqual(recipeA.prompt, "Make a list.")
         XCTAssertNil(recipeA.icon)
@@ -278,22 +315,29 @@ final class ContextualSuggestionsMatcherTests: XCTestCase {
 
     func testIconIsPassedThroughFromCatalog() throws {
         let result = ContextualSuggestionsMatcher.resolve(input(nil, uiLocale: "en_US"), catalog: try standardCatalog())
-        XCTAssertEqual(result.first { $0.id == "summarize-page" }?.icon, "summary")
+        XCTAssertEqual(result.suggestions.first { $0.id == "summarize-page" }?.icon, "summary")
     }
 
     // MARK: - Provider
 
-    func testProviderWithNilCatalogReturnsSummarizeFallback() async {
-        let provider = DefaultContextualSuggestedPromptsProvider(catalog: nil)
+    func testWhenCatalogIsMissingThenProviderFiresDebugPixelAndReturnsNonSmartFallback() async {
+        var pixelFireCount = 0
+        let provider = DefaultContextualSuggestedPromptsProvider(
+            catalog: nil,
+            fireCatalogLoadFailedPixel: { pixelFireCount += 1 })
         let result = await provider.resolveSuggestions(input(signals(jsonLd: ["Recipe"], lang: "es")))
-        XCTAssertEqual(result.map(\.id), ["summarize-page"])
-        XCTAssertEqual(result.first?.icon, "summary")
+
+        XCTAssertEqual(result.suggestions.map(\.id), ["summarize-page"])
+        XCTAssertEqual(result.suggestions.first?.icon, "summary")
+        XCTAssertFalse(result.isSmart)
+        XCTAssertEqual(result.pageType, .recipe)
+        XCTAssertEqual(pixelFireCount, 1)
     }
 
     func testProviderWithCatalogDelegatesToMatcher() async throws {
         let catalog = try standardCatalog()
         let provider = DefaultContextualSuggestedPromptsProvider(catalog: catalog)
         let result = await provider.resolveSuggestions(input(signals(jsonLd: ["Recipe"], lang: "en")))
-        XCTAssertEqual(result.map(\.id), ["recipe-a", "recipe-b", "recipe-c"])
+        XCTAssertEqual(result.suggestions.map(\.id), ["recipe-a", "recipe-b", "recipe-c"])
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_contextual_mode.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_contextual_mode.json5
@@ -180,5 +180,100 @@
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
+    },
+    "aichat_contextual_suggestion_selected": {
+        "description": "Fired when the user taps a suggested-prompt chip on the contextual sheet start surface. Under contextualSuggestedPrompts this also represents the Ask about page quick action, which additionally fires the legacy m_aichat_contextual_quick_action_ask_about_page_selected pixel.",
+        "owners": ["pikorddg"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "suggestionId",
+                "description": "Catalog key of the selected suggestion (e.g. summarize-page, translate-page, ask-about-page).",
+                "type": "string"
+            },
+            {
+                "key": "pageType",
+                "description": "Coarse page-type bucket computed natively from page-type signals. Never a URL, domain or page content.",
+                "type": "string",
+                "enum": [
+                    "recipe",
+                    "product",
+                    "article",
+                    "video",
+                    "job",
+                    "book",
+                    "event",
+                    "place",
+                    "forum",
+                    "code",
+                    "course",
+                    "review",
+                    "person",
+                    "howto",
+                    "faq",
+                    "none"
+                ]
+            }
+        ]
+    },
+    "aichat_contextual_suggestions_viewed": {
+        "description": "Fired when the contextual sheet start surface renders suggested-prompt chips to the user; every render (sheet presentation or navigation re-resolve) counts as an impression",
+        "owners": ["pikorddg"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "isSmart",
+                "description": "Whether the shown suggestions were smart (page-tailored) rather than generic defaults.",
+                "type": "boolean"
+            },
+            {
+                "key": "pageType",
+                "description": "Coarse page-type bucket computed natively from page-type signals. Never a URL, domain or page content.",
+                "type": "string",
+                "enum": [
+                    "recipe",
+                    "product",
+                    "article",
+                    "video",
+                    "job",
+                    "book",
+                    "event",
+                    "place",
+                    "forum",
+                    "code",
+                    "course",
+                    "review",
+                    "person",
+                    "howto",
+                    "faq",
+                    "none"
+                ]
+            }
+        ]
+    },
+    "aichat_contextual_header_title_tapped": {
+        "description": "Fired when the user taps the Duck.ai title in the contextual sheet header to expand into full AI Chat",
+        "owners": ["pikorddg"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "debug_aichat_contextual_suggestions_catalog_load_failed": {
+        "description": "Fired when the bundled PageSuggestionsCatalog.json is missing or fails to decode and the suggested-prompts matcher falls back to the single Summarize this page floor",
+        "owners": ["pikorddg"],
+        "triggers": ["exception"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "debug_aichat_contextual_suggestions_context_collection_timed_out": {
+        "description": "Fired when page-type signal collection times out and contextual suggested prompts fall back to generic defaults",
+        "owners": ["pikorddg"],
+        "triggers": ["exception"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1215959396625891?focus=true + https://app.asana.com/1/137249556945/project/1210947754188321/task/1215929491350223?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->
- Keep suggested prompts aligned with a manually pinned page when automatic context attachment is disabled, then refresh them for the current page after the context is removed.
- Adds pixels for suggested-prompt impressions and selections, Ask about page selection, and header expansion, using coarse smart/default and page-type metadata.
- Add diagnostics and safe fallback coverage for suggestion catalog failures and page-signal collection timeouts, with pixel registry entries and focused unit tests.

### Testing Steps - LP1 fix

Enable `contextualSuggestedPrompts`. Use:

- Page A: **[https://www.bbc.co.uk/food/recipes/no-bake_strawberry_30276](https://www.bbc.co.uk/food/recipes/no-bake_strawberry_30276)**
- Page B: BBC homepage, opened by tapping the BBC header.

1. Disable auto-attach, open the sheet on Page A, tap **Ask about page**, and wait for the context to attach.
2. Without closing the sheet, navigate to Page B. Verify the attached context and suggestions remain associated with Page A; no suggestions loading state appears.
3. Remove the attached Page A context. Verify suggestions refresh for Page B without another navigation
4. Enable auto-attach and navigate from Page A to Page B. Verify the attached context and suggestions update to Page B as before.

### Testing Steps - pixels

Enable `contextualSuggestedPrompts`. Filter the Xcode console with `pixel fired`. Use:

- a recipe page with JSON-LD `Recipe`: [https://www.bbc.co.uk/food/recipes/no-bake_strawberry_30276](https://www.bbc.co.uk/food/recipes/no-bake_strawberry_30276);
- the generic BBC homepage with no matching JSON-LD (`none`), reached by tapping the BBC header on the recipe page.

1. **P1 — Smart suggestions viewed:** Open the sheet on the recipe page. Verify `aichat.contextual.suggestions.viewed.count` fires with `isSmart=true` and `pageType=recipe`.
2. **P2 — Generic suggestions viewed:** Tap the BBC header to open the generic BBC homepage, then open the sheet. Verify the viewed pixel fires with `isSmart=false` and `pageType=none`.
3. **P3 — Suggestion selected:** Open the recipe page and the sheet, then tap a contextual suggestion. Verify `aichat.contextual.suggestion.selected.count` fires with its catalog `suggestionId` and `pageType=recipe`.
4. **P4 — Ask about page dual-fire:** Open a new tab, visit a website, and open a new sheet. With auto-attach disabled, tap **Ask about page**. Verify both `m.aichat.contextual.quick.action.ask.about.page.selected.count` and `aichat.contextual.suggestion.selected.count` with `suggestionId=ask-about-page`.
5. **P5 — Header title:** Tap the Duck.ai title in the sheet header. Verify `aichat.contextual.header.title.tapped.count` fires and Duck.ai expands.
6. **C1 — Domain-only match:** Open [https://github.com/duckduckgo/apple-browsers](https://github.com/duckduckgo/apple-browsers), which is matched only by domain. Verify the viewed pixel reports `isSmart=true` and `pageType=none`.
7. **L1 — Navigation refresh:** Open the sheet on the recipe page, then tap the BBC header without closing it. Verify suggestions refresh and viewed fires first with `pageType=recipe`, then with `isSmart=false` and `pageType=none`.
8. **L2 — Reopen:** Close and reopen the sheet on the same page. Verify the cached suggestions are shown and viewed fires again.
9. **R1 — Flag disabled:** Disable `contextualSuggestedPrompts` and tap **Ask about page**. Verify only the legacy quick-action pixel fires; no new suggestion viewed/selected pixel is emitted.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Medium

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->
- Navigation or context-removal transitions could leave stale suggestions or start unnecessary signal collection; pinned, unpinned, and removal flows are covered by focused state/coordinator tests.

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->
- Pixels sends only catalog suggestion IDs, booleans, and coarse page-type buckets; it does not include URLs, domains, page content, or other user-identifiable data.
- Classification is local and bounded, and no additional page-content extraction is introduced beyond the existing signals-only collection flow.
---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches navigation, context attachment, and suggestion refresh together; behavior is covered by coordinator/session tests, but wrong gating could still show stale prompts or extra collection work.
> 
> **Overview**
> Fixes **suggested prompts staying aligned with a manually pinned page** when auto-attach is off: navigation no longer triggers signals-only refresh while a pinned chip remains, and **removing the chip** restarts collection so suggestions update for the current tab without another navigation.
> 
> **Suggestion resolution** now returns **`ResolvedPageSuggestions`** with **`isSmart`** and coarse **`SuggestionsPageType`** (ported from frontend classification for analytics). Session/view state carries that metadata for pixels.
> 
> Adds **analytics** for the contextual start surface: suggestion **viewed** and **selected** (with `suggestionId`, `pageType`, `isSmart`), **Ask about page** mapped to `ask-about-page`, **header title** expand tap, plus **debug** pixels for **catalog decode failure** and **page-signal collection timeout** on suggestion loading.
> 
> Coordinator consolidates **signals-only collection** and **remove-context** paths so chip removal can refresh suggestions for the visible page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7b56f4d35841bdbec7c06ca443985719b67560e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->