### PR TITLE
Fix dayAverage on origin-attributed rolling-average pixels (iOS/macOS)

### DIFF
--- a/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricManager.swift
+++ b/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricManager.swift
@@ -403,7 +403,7 @@ public final class AttributedMetricManager: @unchecked Sendable {
         guard dataStorage.searchLastThreshold != daysSinceInstalled else { return }
 
         let search8Days = dataStorage.search8Days
-        let result = search8Days.past7DaysAverage
+        let result = search8Days.past7DaysAverage(daysSinceInstalled: daysSinceInstalled)
 
         guard result.average > 0 else { return }
 
@@ -420,7 +420,7 @@ public final class AttributedMetricManager: @unchecked Sendable {
             pixelKit?.fire(AttributedMetricPixel.userAverageSearchesPastWeekFirstMonth(origin: originOrInstall.origin,
                                                                                        installDate: originOrInstall.installDate,
                                                                                        count: bucket.value,
-                                                                                       dayAverage: result.daysCounted,
+                                                                                       dayAverage: result.dayAverage,
                                                                                        bucketVersion: bucket.version),
                            frequency: .legacyDailyNoSuffix,
                            includeAppVersionParameter: false,
@@ -435,7 +435,7 @@ public final class AttributedMetricManager: @unchecked Sendable {
             pixelKit?.fire(AttributedMetricPixel.userAverageSearchesPastWeek(origin: originOrInstall.origin,
                                                                              installDate: originOrInstall.installDate,
                                                                              count: bucket.value,
-                                                                             dayAverage: result.daysCounted,
+                                                                             dayAverage: result.dayAverage,
                                                                              bucketVersion: bucket.version),
                            frequency: .legacyDailyNoSuffix,
                            includeAppVersionParameter: false,
@@ -462,7 +462,7 @@ public final class AttributedMetricManager: @unchecked Sendable {
 
         let adClick8Days = dataStorage.adClick8Days
         guard adClick8Days.countPast7Days > 0 else { return }
-        let result = adClick8Days.past7DaysAverage
+        let result = adClick8Days.past7DaysAverage(daysSinceInstalled: daysSinceInstalled)
         guard let bucket = try? bucketModifier.bucket(value: result.average, pixelName: .userAverageAdClicksPastWeek) else {
             Logger.attributedMetric.error("Failed to bucket average AD click value")
             return
@@ -472,7 +472,7 @@ public final class AttributedMetricManager: @unchecked Sendable {
         pixelKit?.fire(AttributedMetricPixel.userAverageAdClicksPastWeek(origin: originOrInstall.origin,
                                                                          installDate: originOrInstall.installDate,
                                                                          count: bucket.value,
-                                                                         dayAverage: result.daysCounted,
+                                                                         dayAverage: result.dayAverage,
                                                                          bucketVersion: bucket.version),
                        frequency: .legacyDailyNoSuffix,
                        includeAppVersionParameter: false,
@@ -498,7 +498,7 @@ public final class AttributedMetricManager: @unchecked Sendable {
 
         let duckAIChat8Days = dataStorage.duckAIChat8Days
         guard duckAIChat8Days.countPast7Days > 0 else { return }
-        let result = duckAIChat8Days.past7DaysAverage
+        let result = duckAIChat8Days.past7DaysAverage(daysSinceInstalled: daysSinceInstalled)
         guard let bucket = try? bucketModifier.bucket(value: result.average, pixelName: .userAverageDuckAiUsagePastWeek) else {
             Logger.attributedMetric.error("Failed to bucket average Duck.AI chat value")
             return
@@ -508,7 +508,7 @@ public final class AttributedMetricManager: @unchecked Sendable {
         pixelKit?.fire(AttributedMetricPixel.userAverageDuckAiUsagePastWeek(origin: originOrInstall.origin,
                                                                             installDate: originOrInstall.installDate,
                                                                             count: bucket.value,
-                                                                            dayAverage: result.daysCounted,
+                                                                            dayAverage: result.dayAverage,
                                                                             bucketVersion: bucket.version),
                        frequency: .legacyDailyNoSuffix,
                        includeAppVersionParameter: false,

--- a/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricPixel.swift
+++ b/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricPixel.swift
@@ -44,10 +44,10 @@ enum AttributedMetricPixel: PixelKitEvent {
     case userRetentionWeek(origin: String?, installDate: String?, defaultBrowser: Bool, count: Int, bucketVersion: Int)
     case userRetentionMonth(origin: String?, installDate: String?, defaultBrowser: Bool, count: Int, bucketVersion: Int)
     case userActivePastWeek(origin: String?, installDate: String?, days: Int, daysSinceInstalled: Int?, bucketVersion: Int)
-    case userAverageSearchesPastWeekFirstMonth(origin: String?, installDate: String?, count: Int, dayAverage: Int, bucketVersion: Int)
-    case userAverageSearchesPastWeek(origin: String?, installDate: String?, count: Int, dayAverage: Int, bucketVersion: Int)
-    case userAverageAdClicksPastWeek(origin: String?, installDate: String?, count: Int, dayAverage: Int, bucketVersion: Int)
-    case userAverageDuckAiUsagePastWeek(origin: String?, installDate: String?, count: Int, dayAverage: Int, bucketVersion: Int)
+    case userAverageSearchesPastWeekFirstMonth(origin: String?, installDate: String?, count: Int, dayAverage: Int?, bucketVersion: Int)
+    case userAverageSearchesPastWeek(origin: String?, installDate: String?, count: Int, dayAverage: Int?, bucketVersion: Int)
+    case userAverageAdClicksPastWeek(origin: String?, installDate: String?, count: Int, dayAverage: Int?, bucketVersion: Int)
+    case userAverageDuckAiUsagePastWeek(origin: String?, installDate: String?, count: Int, dayAverage: Int?, bucketVersion: Int)
     case userSubscribed(origin: String?, installDate: String?, month: Int, bucketVersion: Int)
     case userSyncedDevice(origin: String?, installDate: String?, devices: Int, bucketVersion: Int)
 
@@ -116,15 +116,19 @@ enum AttributedMetricPixel: PixelKitEvent {
         case .userAverageSearchesPastWeekFirstMonth(origin: let origin, installDate: let installDate, count: let count, dayAverage: let dayAverage, bucketVersion: let bucketVersion),
                 .userAverageSearchesPastWeek(origin: let origin, installDate: let installDate, count: let count, dayAverage: let dayAverage, bucketVersion: let bucketVersion):
             var result = [ConstantKeys.count: count.payloadString,
-                          ConstantKeys.bucketVersion: bucketVersion.payloadString,
-                          ConstantKeys.dayAverage: dayAverage.payloadString]
+                          ConstantKeys.bucketVersion: bucketVersion.payloadString]
+            if let dayAverage {
+                result[ConstantKeys.dayAverage] = dayAverage.payloadString
+            }
             addBaseParamFor(dictionary: &result, origin: origin, installDate: installDate)
             return result
         case .userAverageAdClicksPastWeek(origin: let origin, installDate: let installDate, count: let count, dayAverage: let dayAverage, bucketVersion: let bucketVersion),
                 .userAverageDuckAiUsagePastWeek(origin: let origin, installDate: let installDate, count: let count, dayAverage: let dayAverage, bucketVersion: let bucketVersion):
             var result = [ConstantKeys.count: count.payloadString,
-                          ConstantKeys.bucketVersion: bucketVersion.payloadString,
-                          ConstantKeys.dayAverage: dayAverage.payloadString]
+                          ConstantKeys.bucketVersion: bucketVersion.payloadString]
+            if let dayAverage {
+                result[ConstantKeys.dayAverage] = dayAverage.payloadString
+            }
             addBaseParamFor(dictionary: &result, origin: origin, installDate: installDate)
             return result
         case .userSubscribed(origin: let origin, installDate: let installDate, month: let month, bucketVersion: let bucketVersion):

--- a/SharedPackages/AttributedMetric/Sources/AttributedMetric/Models/RollingEightDays.swift
+++ b/SharedPackages/AttributedMetric/Sources/AttributedMetric/Models/RollingEightDays.swift
@@ -144,31 +144,32 @@ public class RollingEightDaysInt: RollingEightDays<Int>, CustomDebugStringConver
         }
     }
 
-    /// Calculates the average of the past 7 days, excluding today and unknown values.
-    public var past7DaysAverage: (average: Float, daysCounted: Int) {
-        var sum = 0
-        var notUnknownValues = 0
-        for value in values.dropLast() {
-            switch value {
-            case .unknown:
-                break
-            case .value(let intValue):
-                notUnknownValues += 1
-                sum += intValue
-            }
-        }
-
-        if notUnknownValues > 0 {
-            let average = (Float(sum) / Float(notUnknownValues))
-            return (average, notUnknownValues)
-        } else {
-            return (0, 0)
-        }
+    /// Average events per calendar day of history (`total / min(daysSinceInstalled, 7)`), not per active day.
+    /// `dayAverage` is that denominator during the days 1–6 ramp-up, and `nil` once the window is full (day 7+).
+    public func past7DaysAverage(daysSinceInstalled: Int) -> (average: Float, dayAverage: Int?) {
+        let windowDays = values.count - 1   // 8 slots, excluding today
+        let daysOfHistory = min(max(daysSinceInstalled, 0), windowDays)
+        guard daysOfHistory > 0 else { return (0, nil) }
+        let average = Float(past7DaysTotal) / Float(daysOfHistory)
+        let dayAverage = daysOfHistory < windowDays ? daysOfHistory : nil
+        return (average, dayAverage)
     }
 
     /// Counts non-unknown values in the past 7 days, excluding today.
     public var countPast7Days: Int {
         return values.dropLast().count(where: { $0 != .unknown })
+    }
+
+    /// Sum over the past 7 days, excluding today and unknown days. Numerator for the rolling average.
+    public var past7DaysTotal: Int {
+        values.dropLast().reduce(0) { partialResult, value in
+            switch value {
+            case .unknown:
+                return partialResult
+            case .value(let intValue):
+                return partialResult + intValue
+            }
+        }
     }
 
     public var debugDescription: String {
@@ -194,7 +195,7 @@ public class RollingEightDaysInt: RollingEightDays<Int>, CustomDebugStringConver
                 RollingEightDaysInt
                 lastDay: \(dateString)
                 values: [\(valuesDescription)]
-                past7DaysAverage: average: \(past7DaysAverage.average) - days counted: \(past7DaysAverage.daysCounted)
+                past7DaysTotal: \(past7DaysTotal)
                 countPast7Days: \(countPast7Days)
                 """
     }

--- a/SharedPackages/AttributedMetric/Tests/AttributedMetricTests/AttributedMetricManagerTests.swift
+++ b/SharedPackages/AttributedMetric/Tests/AttributedMetricTests/AttributedMetricManagerTests.swift
@@ -390,22 +390,7 @@ final class AttributedMetricManagerTests: XCTestCase {
 
     // MARK: - Average Search Count Tests
 
-    /// Tests average search count pixel within first month (includes dayAverage parameter)
-    ///
-    /// ## Input → Output Mapping
-    ///
-    /// | Days Since Install | Raw Average | Bucketed Count | Parameters |
-    /// |-------------------|-------------|----------------|------------|
-    /// | 18-20 (< 28 days) | varies      | varies         | count=bucketed, dayAverage=raw_count, origin/installDate |
-    ///
-    /// ## Bucket Configuration
-    /// - user_average_searches_past_week_first_month: [5, 9] → ≤5 maps to 0, ≤9 maps to 1, >9 maps to 2
-    ///
-    /// ## Test Validation
-    /// - Pixel fires within first 28 days with dayAverage parameter
-    /// - count parameter is bucketed
-    /// - dayAverage parameter contains raw search count
-    /// - Trigger: .userDidSearch calls processAverageSearchCount()
+    /// Within the first month but at a full window (day 20): fires the first-month pixel with no dayAverage.
     func testProcessAverageSearchCountFirstMonth() {
         let pixelExpectation = XCTestExpectation(description: "Average search count pixel fired")
         var capturedCount: Int?
@@ -418,10 +403,6 @@ final class AttributedMetricManagerTests: XCTestCase {
                 capturedDayAverage = self.extractIntParameter(parameters, key: "dayAverage")
                 if capturedCount == nil {
                     XCTFail("Missing or invalid count parameter")
-                    return
-                }
-                if capturedDayAverage == nil {
-                    XCTFail("Missing or invalid dayAverage parameter")
                     return
                 }
                 pixelExpectation.fulfill()
@@ -446,26 +427,11 @@ final class AttributedMetricManagerTests: XCTestCase {
 
         wait(for: [pixelExpectation], timeout: 5.0)
         XCTAssertNotNil(capturedCount, "Should capture bucketed count")
-        XCTAssertNotNil(capturedDayAverage, "Should capture day average")
+        // Days 20 and 31 are full 7-day windows, so dayAverage is dropped.
+        XCTAssertNil(capturedDayAverage, "dayAverage must be absent once the window is full (day 7+)")
     }
 
-    /// Tests average search count pixel after first month (includes dayAverage parameter)
-    ///
-    /// ## Input → Output Mapping
-    ///
-    /// | Days Since Install | Raw Average | Bucketed Count | Parameters |
-    /// |-------------------|-------------|----------------|------------|
-    /// | 29-31 (≥ 28 days) | varies      | varies         | count=bucketed, dayAverage=raw_count, origin/installDate |
-    ///
-    /// ## Bucket Configuration
-    /// - user_average_searches_past_week: [5, 9] → ≤5 maps to 0, ≤9 maps to 1, >9 maps to 2
-    ///
-    /// ## Test Validation
-    /// - Pixel fires after 28 days with dayAverage parameter
-    /// - count parameter is bucketed
-    /// - dayAverage parameter contains raw search count
-    /// - Different pixel name than first month version
-    /// - Trigger: .userDidSearch calls processAverageSearchCount()
+    /// After the first month (day 31): fires the non-first-month pixel; established user, so no dayAverage.
     func testProcessAverageSearchCountAfterFirstMonth() {
         let pixelExpectation = XCTestExpectation(description: "Average search count pixel fired")
         var capturedCount: Int?
@@ -478,10 +444,6 @@ final class AttributedMetricManagerTests: XCTestCase {
                 capturedDayAverage = self.extractIntParameter(parameters, key: "dayAverage")
                 if capturedCount == nil {
                     XCTFail("Missing or invalid count parameter")
-                    return
-                }
-                if capturedDayAverage == nil {
-                    XCTFail("Missing or invalid dayAverage parameter")
                     return
                 }
                 pixelExpectation.fulfill()
@@ -506,7 +468,152 @@ final class AttributedMetricManagerTests: XCTestCase {
 
         wait(for: [pixelExpectation], timeout: 5.0)
         XCTAssertNotNil(capturedCount, "Should capture bucketed count")
-        XCTAssertNotNil(capturedDayAverage, "Should capture day average")
+        // Days 20 and 31 are full 7-day windows, so dayAverage is dropped.
+        XCTAssertNil(capturedDayAverage, "dayAverage must be absent once the window is full (day 7+)")
+    }
+
+    // MARK: - Average search e2e (calendar-day denominator & dayAverage ramp-up)
+
+    /// Ramp-up: 6 searches on one active day, processed on day 2.
+    /// Denominator must be calendar days (2), not active days (1):
+    /// count = 6/2 = 3 → bucket 0 (buggy: 6/1 = 6 → bucket 1); dayAverage = 2 (buggy: 1).
+    func testAverageSearch_e2e_rampUp_dividesByCalendarDays() {
+        let pixelExpectation = XCTestExpectation(description: "search pixel fired at day 2")
+        var capturedCount: Int?
+        var capturedDayAverage: Int?
+
+        let fixture = createTestFixture { pixelName, _, parameters, _, _, _ in
+            guard pixelName == "attributed_metric_average_searches_past_week_first_month" else { return }
+            capturedCount = self.extractIntParameter(parameters, key: "count")
+            capturedDayAverage = self.extractIntParameter(parameters, key: "dayAverage")
+            pixelExpectation.fulfill()
+        }
+        defer { fixture.cleanup() }
+
+        fixture.installDateProvider.installDate = fixture.timeMachine.now()      // day 0
+        fixture.timeMachine.travel(by: .day, value: 1)                          // day 1: 6 searches, 1 active day
+        for _ in 0..<6 { fixture.attributionManager.process(trigger: .userDidSearch) }
+        fixture.timeMachine.travel(by: .day, value: 1)                          // day 2: triggering search, excluded from window
+        fixture.attributionManager.process(trigger: .userDidSearch)
+
+        wait(for: [pixelExpectation], timeout: 5.0)
+        XCTAssertEqual(capturedCount, 0, "6 searches ÷ 2 calendar days = 3 → bucket 0 (not 6 ÷ 1 active day = 6 → bucket 1)")
+        XCTAssertEqual(capturedDayAverage, 2, "dayAverage must be calendar days (2), not active days (1)")
+    }
+
+    /// Established user (day 8): divides by 7 and drops dayAverage.
+    func testAverageSearch_e2e_established_dividesBy7_dropsDayAverage() {
+        let pixelExpectation = XCTestExpectation(description: "search pixel fired at day 8")
+        var capturedParameters: [String: String]?
+
+        let fixture = createTestFixture { pixelName, _, parameters, _, _, _ in
+            guard pixelName == "attributed_metric_average_searches_past_week_first_month" else { return }
+            capturedParameters = parameters
+            pixelExpectation.fulfill()
+        }
+        defer { fixture.cleanup() }
+
+        fixture.installDateProvider.installDate = fixture.timeMachine.now()      // day 0
+        fixture.timeMachine.travel(by: .day, value: 1)                          // day 1: 6 searches
+        for _ in 0..<6 { fixture.attributionManager.process(trigger: .userDidSearch) }
+        fixture.timeMachine.travel(by: .day, value: 7)                          // day 8: full window; triggering search excluded
+        fixture.attributionManager.process(trigger: .userDidSearch)
+
+        wait(for: [pixelExpectation], timeout: 5.0)
+        XCTAssertEqual(extractIntParameter(capturedParameters ?? [:], key: "count"), 0,
+                       "6 searches ÷ 7 = 0.86 → bucket 0 (not 6 ÷ 1 active day = 6 → bucket 1)")
+        XCTAssertNil(capturedParameters?["dayAverage"], "dayAverage must be dropped from day 7 (full window)")
+    }
+
+    /// Install day: no history yet, so no average pixel is sent.
+    func testAverageSearch_e2e_installDay_doesNotFire() {
+        let pixelExpectation = XCTestExpectation(description: "no search pixel on install day")
+        pixelExpectation.isInverted = true
+
+        let fixture = createTestFixture { pixelName, _, _, _, _, _ in
+            if pixelName == "attributed_metric_average_searches_past_week_first_month" {
+                pixelExpectation.fulfill()
+            }
+        }
+        defer { fixture.cleanup() }
+
+        fixture.installDateProvider.installDate = fixture.timeMachine.now()      // day 0
+        fixture.attributionManager.process(trigger: .userDidSearch)             // same day
+
+        wait(for: [pixelExpectation], timeout: 1.0)
+    }
+
+    /// Higher bucket: 12 searches over 2 calendar days → 6 → bucket 1.
+    func testAverageSearch_e2e_rampUp_landsInHigherBucket() {
+        let pixelExpectation = XCTestExpectation(description: "search pixel fired at day 2")
+        var capturedCount: Int?
+        var capturedDayAverage: Int?
+
+        let fixture = createTestFixture { pixelName, _, parameters, _, _, _ in
+            guard pixelName == "attributed_metric_average_searches_past_week_first_month" else { return }
+            capturedCount = self.extractIntParameter(parameters, key: "count")
+            capturedDayAverage = self.extractIntParameter(parameters, key: "dayAverage")
+            pixelExpectation.fulfill()
+        }
+        defer { fixture.cleanup() }
+
+        fixture.installDateProvider.installDate = fixture.timeMachine.now()      // day 0
+        fixture.timeMachine.travel(by: .day, value: 1)                          // day 1: 12 searches, 1 active day
+        for _ in 0..<12 { fixture.attributionManager.process(trigger: .userDidSearch) }
+        fixture.timeMachine.travel(by: .day, value: 1)                          // day 2: triggering search, excluded from window
+        fixture.attributionManager.process(trigger: .userDidSearch)
+
+        wait(for: [pixelExpectation], timeout: 5.0)
+        XCTAssertEqual(capturedCount, 1, "12 ÷ 2 = 6 → bucket 1 [5,9] (buggy: 12 ÷ 1 = 12 → bucket 2)")
+        XCTAssertEqual(capturedDayAverage, 2, "dayAverage = calendar days (2)")
+    }
+
+    /// Ad clicks, established user (day 8): divides by 7 and drops dayAverage.
+    func testAverageAdClicks_e2e_established_dividesBy7_dropsDayAverage() {
+        let pixelExpectation = XCTestExpectation(description: "ad click pixel fired at day 8")
+        var capturedParameters: [String: String]?
+
+        let fixture = createTestFixture { pixelName, _, parameters, _, _, _ in
+            guard pixelName == "attributed_metric_average_ad_clicks_past_week" else { return }
+            capturedParameters = parameters
+            pixelExpectation.fulfill()
+        }
+        defer { fixture.cleanup() }
+
+        fixture.installDateProvider.installDate = fixture.timeMachine.now()      // day 0
+        fixture.timeMachine.travel(by: .day, value: 1)                          // day 1: 6 ad clicks
+        for _ in 0..<6 { fixture.attributionManager.process(trigger: .userDidSelectAD) }
+        fixture.timeMachine.travel(by: .day, value: 7)                          // day 8: full window
+        fixture.attributionManager.process(trigger: .userDidSelectAD)
+
+        wait(for: [pixelExpectation], timeout: 5.0)
+        XCTAssertEqual(extractIntParameter(capturedParameters ?? [:], key: "count"), 0,
+                       "6 ad clicks ÷ 7 → bucket 0 (not 6 ÷ 1 active day = 6 → bucket 2)")
+        XCTAssertNil(capturedParameters?["dayAverage"], "dayAverage must be dropped from day 7")
+    }
+
+    /// Duck.ai usage, established user (day 8): divides by 7 and drops dayAverage.
+    func testAverageDuckAiUsage_e2e_established_dividesBy7_dropsDayAverage() {
+        let pixelExpectation = XCTestExpectation(description: "duck.ai pixel fired at day 8")
+        var capturedParameters: [String: String]?
+
+        let fixture = createTestFixture { pixelName, _, parameters, _, _, _ in
+            guard pixelName == "attributed_metric_average_duck_ai_usage_past_week" else { return }
+            capturedParameters = parameters
+            pixelExpectation.fulfill()
+        }
+        defer { fixture.cleanup() }
+
+        fixture.installDateProvider.installDate = fixture.timeMachine.now()      // day 0
+        fixture.timeMachine.travel(by: .day, value: 1)                          // day 1: 6 chats
+        for _ in 0..<6 { fixture.attributionManager.process(trigger: .userDidDuckAIChat) }
+        fixture.timeMachine.travel(by: .day, value: 7)                          // day 8: full window
+        fixture.attributionManager.process(trigger: .userDidDuckAIChat)
+
+        wait(for: [pixelExpectation], timeout: 5.0)
+        XCTAssertEqual(extractIntParameter(capturedParameters ?? [:], key: "count"), 0,
+                       "6 chats ÷ 7 → bucket 0 (not 6 ÷ 1 active day = 6 → bucket 1)")
+        XCTAssertNil(capturedParameters?["dayAverage"], "dayAverage must be dropped from day 7")
     }
 
     // MARK: - Average AD Click Tests

--- a/SharedPackages/AttributedMetric/Tests/AttributedMetricTests/RollingEightDaysIntTests.swift
+++ b/SharedPackages/AttributedMetric/Tests/AttributedMetricTests/RollingEightDaysIntTests.swift
@@ -39,8 +39,7 @@ final class RollingEightDaysIntTests: XCTestCase {
     func testInitialization() {
         XCTAssertEqual(rollingInt.values.count, 8)
         XCTAssertEqual(rollingInt.count, 0)
-        XCTAssertEqual(rollingInt.past7DaysAverage.average, 0)
-        XCTAssertEqual(rollingInt.past7DaysAverage.daysCounted, 0)
+        XCTAssertEqual(rollingInt.past7DaysTotal, 0)
         XCTAssertNil(rollingInt.lastDay)
     }
 
@@ -100,46 +99,55 @@ final class RollingEightDaysIntTests: XCTestCase {
         XCTAssertEqual(rollingInt.lastDay, referenceDate)
     }
 
-    func testPast7DaysAverageEmptyArray() {
-        XCTAssertEqual(rollingInt.past7DaysAverage.average, 0)
-        XCTAssertEqual(rollingInt.past7DaysAverage.daysCounted, 0)
+    // MARK: - past7DaysAverage(daysSinceInstalled:)
+
+    func testAverage_installDay_returnsZeroAndNilDayAverage() {
+        rollingInt.append(5) // today's activity (excluded from the window)
+        let result = rollingInt.past7DaysAverage(daysSinceInstalled: 0)
+        XCTAssertEqual(result.average, 0)
+        XCTAssertNil(result.dayAverage)
     }
 
-    func testPast7DaysAverageSingleValue() {
-        // Add only one value (today)
-        rollingInt.append(10)
-
-        // With only one value, past7DaysAverage should return (0, 0) (no past days to average)
-        // This tests the guard clause that prevents division by zero
-        XCTAssertEqual(rollingInt.past7DaysAverage.average, 0)
-        XCTAssertEqual(rollingInt.past7DaysAverage.daysCounted, 0)
-        XCTAssertEqual(rollingInt.count, 1)
+    func testAverage_establishedUser_dividesByFullWindowAndDropsDayAverage() {
+        // 21 events across 3 active days of the window (today excluded).
+        rollingInt.append(99)   // today (excluded)
+        rollingInt[0] = 10
+        rollingInt[1] = 5
+        rollingInt[2] = 6
+        let result = rollingInt.past7DaysAverage(daysSinceInstalled: 30)
+        XCTAssertEqual(result.average, 3.0, accuracy: 0.0001)   // 21 / 7, not 21 / 3 active days
+        XCTAssertNil(result.dayAverage)                          // full window -> dropped
     }
 
-    func testPast7DaysAverageWithValues() {
-        // Add values to fill some slots (including today)
-        for i in 1...8 {
-            rollingInt.append(i)
-        }
-
-        // past7DaysAverage should exclude the last value (today)
-        // Values: [1, 2, 3, 4, 5, 6, 7], average = (1+2+3+4+5+6+7)/7 = 4
-        let expectedAverage = (Float(1+2+3+4+5+6+7) / Float(rollingInt.count-1))
-        XCTAssertEqual(rollingInt.past7DaysAverage.average, expectedAverage)
-        XCTAssertEqual(rollingInt.past7DaysAverage.daysCounted, 7)
+    func testAverage_day7_dividesBy7AndDropsDayAverage() {
+        rollingInt.append(99)   // today (excluded)
+        rollingInt[0] = 21
+        let result = rollingInt.past7DaysAverage(daysSinceInstalled: 7)
+        XCTAssertEqual(result.average, 3.0, accuracy: 0.0001)   // 21 / 7
+        XCTAssertNil(result.dayAverage)
     }
 
-    func testPast7DaysAverageWithUnknownValues() {
-        // Add some values and leave some unknown
-        rollingInt.append(3)
-        rollingInt.append(8)
-        rollingInt.append(11)
-        rollingInt.append(1)
-        // past7DaysAverage should only count known values (excluding today)
-        // Values excluding today: [3, 8, 11], average = (3+8+11)/3
-        let expectedAverage = Float(3 + 8 + 11) / 3.0
-        XCTAssertEqual(rollingInt.past7DaysAverage.average, expectedAverage, accuracy: 0.0001)
-        XCTAssertEqual(rollingInt.past7DaysAverage.daysCounted, 3)
+    func testAverage_rampUp_dividesByCalendarDaysNotActiveDays() {
+        // 12 events on a single active day, installed 3 days ago.
+        rollingInt.append(99)   // today (excluded)
+        rollingInt[0] = 12
+        let result = rollingInt.past7DaysAverage(daysSinceInstalled: 3)
+        XCTAssertEqual(result.average, 4.0, accuracy: 0.0001)   // 12 / 3 calendar days, not 12 / 1 active day
+        XCTAssertEqual(result.dayAverage, 3)                     // present during ramp-up
+    }
+
+    func testAverage_rampUp_lastPartialDay() {
+        rollingInt.append(99)   // today (excluded)
+        rollingInt[0] = 12
+        let result = rollingInt.past7DaysAverage(daysSinceInstalled: 6)
+        XCTAssertEqual(result.average, 2.0, accuracy: 0.0001)   // 12 / 6
+        XCTAssertEqual(result.dayAverage, 6)
+    }
+
+    func testAverage_noActivity_returnsZeroAndNilDayAverage() {
+        let result = rollingInt.past7DaysAverage(daysSinceInstalled: 10)
+        XCTAssertEqual(result.average, 0)
+        XCTAssertNil(result.dayAverage)
     }
 
     func testCountPast7DaysEmptyArray() {
@@ -166,92 +174,6 @@ final class RollingEightDaysIntTests: XCTestCase {
         // Should count only non-unknown values excluding today
         // Values excluding last: [unknown, unknown, unknown, unknown, unknown, 99, 1] = 2 non-unknown
         XCTAssertEqual(rollingInt.countPast7Days, 2)
-    }
-
-    func testPast7DaysAverageWithAllUnknownExceptToday() {
-        // Add only today's value, all others are unknown
-        rollingInt.append(10)
-
-        // Should return (0, 0) because there are no past days with values
-        XCTAssertEqual(rollingInt.past7DaysAverage.average, 0)
-        XCTAssertEqual(rollingInt.past7DaysAverage.daysCounted, 0)
-    }
-
-    func testPast7DaysAverageReturnsExactFloat() {
-        // Test that the average returns an exact Float without rounding
-        rollingInt.append(10)  // Today (excluded)
-        rollingInt[0] = 5
-        rollingInt[1] = 6
-        rollingInt[2] = 4
-
-        // Average = (5+6+4)/3 = 5.0
-        XCTAssertEqual(rollingInt.past7DaysAverage.average, 5.0)
-        XCTAssertEqual(rollingInt.past7DaysAverage.daysCounted, 3)
-
-        // Add one more value to produce a non-integer average
-        rollingInt[3] = 4
-        // Average = (5+6+4+5)/4 = 4.75
-        XCTAssertEqual(rollingInt.past7DaysAverage.average, 4.75)
-        XCTAssertEqual(rollingInt.past7DaysAverage.daysCounted, 4)
-    }
-
-    func testPast7DaysAverageWithSparseData() {
-        // Simulate sparse data: some days have values, most are unknown
-        rollingInt.append(20)    // Today (excluded)
-        rollingInt[1] = 5        // 6 days ago
-        rollingInt[4] = 10       // 3 days ago
-
-        // Only two past days have values: [5, 10]
-        // Average = (5+10)/2 = 7.5
-        XCTAssertEqual(rollingInt.past7DaysAverage.average, 7.5)
-        XCTAssertEqual(rollingInt.past7DaysAverage.daysCounted, 2)
-    }
-
-    func testPast7DaysAverageWithZeroValues() {
-        // Test that zero values are counted (not treated as unknown)
-        rollingInt.append(5)     // Today (excluded)
-        rollingInt[0] = 0        // Zero is a valid value
-        rollingInt[1] = 0
-        rollingInt[2] = 3
-
-        // Average = (0+0+3)/3 = 1.0
-        XCTAssertEqual(rollingInt.past7DaysAverage.average, 1)
-        XCTAssertEqual(rollingInt.past7DaysAverage.daysCounted, 3)
-    }
-
-    func testPast7DaysAverageWithLargeValues() {
-        // Test with large integer values
-        rollingInt.append(1000)  // Today (excluded)
-        rollingInt[0] = 100
-        rollingInt[1] = 200
-        rollingInt[2] = 150
-
-        // Average = (100+200+150)/3 = 150.0
-        XCTAssertEqual(rollingInt.past7DaysAverage.average, 150)
-        XCTAssertEqual(rollingInt.past7DaysAverage.daysCounted, 3)
-    }
-
-    func testPast7DaysAverageWithFullWeekOfData() {
-        // Fill 7 past days + 1 today = 8 values
-        for i in 1...8 {
-            rollingInt.append(i * 2)
-        }
-
-        // Past 7 days: [2, 4, 6, 8, 10, 12, 14]
-        // Average = (2+4+6+8+10+12+14)/7 = 56/7 = 8
-        XCTAssertEqual(rollingInt.past7DaysAverage.average, 8)
-        XCTAssertEqual(rollingInt.past7DaysAverage.daysCounted, 7)
-    }
-
-    func testPast7DaysAverageWithTwoValues() {
-        // Test with exactly two past values
-        rollingInt.append(7)     // Today (excluded)
-        rollingInt[0] = 10
-        rollingInt[1] = 12
-
-        // Average = (10+12)/2 = 11.0
-        XCTAssertEqual(rollingInt.past7DaysAverage.average, 11)
-        XCTAssertEqual(rollingInt.past7DaysAverage.daysCounted, 2)
     }
 
     func testMultipleDaysSequenceWithIncrements() {
@@ -379,6 +301,38 @@ final class RollingEightDaysIntTests: XCTestCase {
         XCTAssertEqual(rollingInt.last, 3)
         XCTAssertEqual(rollingInt.values.count, initialValuesCount) // No structural changes
         XCTAssertEqual(rollingInt.count, 1) // Still only one day with data
+    }
+
+    // MARK: - past7DaysTotal (numerator for the rolling average)
+
+    func testPast7DaysTotalEmptyArray() {
+        XCTAssertEqual(rollingInt.past7DaysTotal, 0)
+    }
+
+    func testPast7DaysTotalExcludesToday() {
+        // Fill 7 past days + 1 today = 8 values [1...8]; today (8) is excluded.
+        for i in 1...8 {
+            rollingInt.append(i)
+        }
+        XCTAssertEqual(rollingInt.past7DaysTotal, 1 + 2 + 3 + 4 + 5 + 6 + 7)
+    }
+
+    func testPast7DaysTotalIgnoresUnknownDays() {
+        // Sparse data: 6 searches 1 day, none since; then today.
+        rollingInt.append(6)     // active day
+        rollingInt.append(0)     // today (excluded)
+        // Window excluding today: [6] -> total 6 over 1 active day.
+        XCTAssertEqual(rollingInt.past7DaysTotal, 6)
+        XCTAssertEqual(rollingInt.countPast7Days, 1)
+    }
+
+    func testPast7DaysTotalSumsMultipleActiveDays() {
+        rollingInt.append(99)    // today (excluded)
+        rollingInt[0] = 10
+        rollingInt[1] = 11
+        // Window excluding today includes both active days: 10 + 11 = 21 over 2 active days.
+        XCTAssertEqual(rollingInt.past7DaysTotal, 21)
+        XCTAssertEqual(rollingInt.countPast7Days, 2)
     }
 
     // MARK: - Codable Persistence Tests


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216293055856693

### Description
The three "past week" rolling-average attributed metrics; average searches (and its first-month variant), average ad clicks, and average Duck.ai usage, computed their per-day average by dividing by the number of days the user was *active*, rather than by the number of *calendar* days of history available. They also always attached the `dayAverage` parameter, even once a full 7-day window existed.

This change divides by the calendar days of history available, capped at the 7-day window, and attaches `dayAverage` only during the days 1–6 ramp-up — omitting it entirely from day 7 onward (the parameter is dropped, not sent empty). This affects both iOS and macOS, which share the same metrics package.

### Testing Steps
Open the debug screen: **iOS** Settings → Debug → Attributed Metrics; **macOS** Debug menu → Attributed Metrics. Tap **Reset stored data** first, and note the **Install Date** shown. "Set Current Time" overrides the app's date (requires an app restart to apply).

*Scenario A — ramp-up sends `dayAverage` = calendar days:*
1. **Set Current Time** = Install Date + 1 day → restart the app.
2. Perform **6 searches** (no average pixel fires yet — the window excludes the current day).
3. **Set Current Time** = Install Date + 2 days → restart.
4. Perform **1 search** → `attributed_metric_average_searches_past_week_first_month` fires.
5. Confirm the logged params include **`dayAverage:2`** and a bucketed `count` (6 ÷ 2 = 3 → bucket 0).

*Scenario B — full window drops `dayAverage`:*
1. **Reset stored data**. **Set Current Time** = Install + 1 day → restart. Perform **6 searches**.
2. **Set Current Time** = Install + 8 days → restart. Perform **1 search** → pixel fires.
3. Confirm the logged params contain **no `dayAverage`** at all (key absent, not empty) and `count` reflects 6 ÷ 7 → bucket 0.

*Scenario C — a non-zero bucket (confirms `count` moves off 0):*
1. **Reset stored data**. **Set Current Time** = Install + 1 day → restart, close any SERP tab. Perform **12 searches**.
2. **Set Current Time** = Install + 2 days → restart, close any SERP tab. Perform **1 search** → pixel fires.
3. Confirm **`count:1`** (12 ÷ 2 = 6 → bucket 1, searches config `[5,9]`) and **`dayAverage:2`**.

*Repeat A and B for the other two types:*
- **Ad clicks** — trigger by clicking a sponsored result on the SERP → `attributed_metric_average_ad_clicks_past_week`.
- **Duck.ai** — trigger by sending a Duck.ai chat → `attributed_metric_average_duck_ai_usage_past_week`.

*After-month variant (search only):* set Install + 31 days and repeat Scenario B → the pixel name is `attributed_metric_average_searches_past_week` (no `first_month`) and, as an established user, it must also carry **no `dayAverage`**.

Note: these pixels fire at most once per day (per day-since-install threshold + daily de-dupe), so if one doesn't re-fire, advance the date or Reset stored data.

### Impact

Low — telemetry only. No user-facing behavior and no change to what data is collected (values remain bucketed). If wrong, the affected metrics stay biased.

#### What could go wrong?

- Off-by-one in the denominator (e.g. dividing by 6 vs 7 at the boundary) → mitigated by unit tests asserting exact values at install day, day 6, day 7, and established.
- `dayAverage` sent empty instead of omitted → mitigated by a test asserting the key is absent from the payload.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes to attributed metric pixel math and optional parameters; no user-facing or auth/data-path impact. Wrong logic would skew analytics buckets, mitigated by unit and e2e tests.
> 
> **Overview**
> Fixes **origin-attributed “past week” rolling averages** (searches, ad clicks, Duck.ai) so the per-day average uses **calendar days of history** (`total ÷ min(daysSinceInstalled, 7)`), not the count of **active** days in the window.
> 
> **`RollingEightDaysInt`** now exposes `past7DaysTotal` and `past7DaysAverage(daysSinceInstalled:)`, which returns `dayAverage` only during the **days 1–6 ramp-up** (the denominator) and **`nil` from day 7 onward** when the window is full.
> 
> **Pixel payloads** treat `dayAverage` as optional: it is **omitted** when `nil`, not sent as an empty value. Bucketed `count` values change for sparse early usage (e.g. 6 events on one day at day 2 → 3 instead of 6).
> 
> Shared **AttributedMetric** package affects iOS and macOS. Tests add e2e coverage for ramp-up, full window, and install-day behavior across all three metric types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8db57a5283d5e8e969536deef56d6bd0ff13a35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->