### PR TITLE
iOS: Sync setup V2 Maestro E2E tests

### DIFF
--- a/.github/workflows/ios_sync_end_to_end.yml
+++ b/.github/workflows/ios_sync_end_to_end.yml
@@ -208,10 +208,84 @@ jobs:
       with:
         pixel-name: m_ci_apple_status_ios_e2e_sync_${{ steps.upload.outcome }}
 
+  sync-v2-end-to-end-tests:
+    name: Sync V2 End To End Tests
+    needs: build-for-sync-end-to-end-tests
+    runs-on: macos-26
+
+    env:
+      RUNS_ON: macos-26 # keep this in sync with runs-on above
+
+    timeout-minutes: 240
+
+    steps:
+    - name: Check out the code
+      uses: actions/checkout@v6 # Don't need submodules here as this is only for the tests folder
+
+    - name: Start measuring duration
+      id: start-duration
+      uses: ./.github/actions/measure-duration
+      with:
+        mode: start
+
+    - name: Create test account for Sync and return the recovery code
+      uses: duckduckgo/sync_crypto/action@chore/github-action-node24-runtime
+      id: sync-recovery-code
+      with:
+        debug: true
+
+    - name: Retrieve Binary
+      uses: actions/download-artifact@v7
+      with:
+        name: duckduckgo-ios-app
+        path: iOS/DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app
+
+    - name: Overwrite default config with sync V2 one
+      run: |
+        cp ../.maestro/config-sync-v2 ../.maestro/config.yaml
+
+    - name: Sync V2 e2e tests
+      id: upload
+      uses: mobile-dev-inc/action-maestro-cloud@v3.0.1
+      with:
+        api-key: ${{ secrets.ROBIN_API_KEY }}
+        project-id: ${{ vars.ROBIN_PROJECT_KEY }}
+        name: sync_v2_${{ github.sha }}
+        timeout: 240
+        app-file: iOS/DerivedData/Build/Products/Debug-iphonesimulator/DuckDuckGo.app
+        workspace: .maestro
+        include-tags: sync_v2
+        env: |
+          ONBOARDING_COMPLETED=true
+          CODE=${{ steps.sync-recovery-code.outputs.recovery-code }}
+        device-os: iOS-18-2
+        device-model: iPhone-16
+
+    - name: Reset config
+      run: |
+        git checkout ../.maestro/config.yaml
+
+    - name: Report job duration
+      if: success() || (always() && steps.upload.outcome == 'failure')
+      continue-on-error: true
+      uses: ./.github/actions/measure-duration
+      with:
+        mode: stop
+        start-timestamp: ${{ steps.start-duration.outputs.start-timestamp }}
+        pixel-name: m_ci_apple_duration_ios_18_sync_v2_tests
+        pixel-params: |
+          runner: ${{ env.RUNS_ON }}
+
+    - name: Send Status Pixel
+      if: always() && github.ref_name == 'main'
+      uses: ./.github/actions/send-pixel
+      with:
+        pixel-name: m_ci_apple_status_ios_e2e_sync_v2_${{ steps.upload.outcome }}
+
   notify-failure:
     name: Notify on failure
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && github.ref_name == 'main' }}
-    needs: [build-for-sync-end-to-end-tests, sync-end-to-end-tests]
+    needs: [build-for-sync-end-to-end-tests, sync-end-to-end-tests, sync-v2-end-to-end-tests]
     runs-on: ubuntu-latest
 
     steps:

--- a/.maestro/config-sync-v2
+++ b/.maestro/config-sync-v2
@@ -1,0 +1,10 @@
+flows:
+  - "**"
+executionOrder:
+  flowsOrder:
+    - 01_create_account_v2
+    - 02_login_account_v2
+    - 03_recover_account_v2
+    - 04_sync_data_setup_v2
+    - 05_sync_data_check_v2
+    - 06_delete_account_v2

--- a/.maestro/shared/sync_create_v2.yaml
+++ b/.maestro/shared/sync_create_v2.yaml
@@ -1,0 +1,35 @@
+appId: com.duckduckgo.mobile.ios
+# Creates a Sync account on this device using the V2 simplified Sync setup UI.
+# Enables the "Sync This Device" toggle, chooses "Sync This Device Only" on the
+# sync-another-device prompt, then copies the recovery code from the success screen
+# so downstream flows can paste it. Starts on the Settings screen.
+---
+
+- tapOn: Sync & Backup
+- assertVisible: Sync & Backup
+- tapOn:
+    id: "SyncToggle"
+- tapOn: Passcode field
+- inputText: "0000"
+- pressKey: Enter
+# Sync-another-device prompt shown after enabling the toggle.
+- extendedWaitUntil:
+    visible: Sync This Device Only
+    timeout: 30000
+- tapOn: Sync This Device Only
+# Success screen showing the recovery code for this new account.
+- extendedWaitUntil:
+    visible: has been added to Sync & Backup
+    timeout: 30000
+# Copy the recovery code so recover/login flows can paste it later.
+- tapOn: Copy Recovery Code
+# Re-authenticate only if the auth session has expired since enabling sync.
+- runFlow:
+    when:
+      visible: Unlock device to set up Sync & Backup
+    commands:
+      - tapOn: Passcode field
+      - inputText: "0000"
+      - pressKey: Enter
+- tapOn: Done
+- assertVisible: Sync & Backup

--- a/.maestro/shared/sync_create_v2.yaml
+++ b/.maestro/shared/sync_create_v2.yaml
@@ -17,10 +17,12 @@ appId: com.duckduckgo.mobile.ios
     visible: Sync This Device Only
     timeout: 30000
 - tapOn: Sync This Device Only
-# Success screen showing the recovery code for this new account.
+# Success screen for the new account. Its title is "<device name> has been added to Sync
+# & Backup" — since Maestro matches the full element text, anchor on the stable, exact
+# "Copy Recovery Code" button label instead of the device-name-prefixed title.
 - extendedWaitUntil:
-    visible: has been added to Sync & Backup
-    timeout: 30000
+    visible: Copy Recovery Code
+    timeout: 60000
 # Copy the recovery code so recover/login flows can paste it later.
 - tapOn: Copy Recovery Code
 # Re-authenticate only if the auth session has expired since enabling sync.

--- a/.maestro/shared/sync_create_v2.yaml
+++ b/.maestro/shared/sync_create_v2.yaml
@@ -17,14 +17,14 @@ appId: com.duckduckgo.mobile.ios
     visible: Sync This Device Only
     timeout: 30000
 - tapOn: Sync This Device Only
-# Success screen for the new account. Its title is "<device name> has been added to Sync
-# & Backup" — since Maestro matches the full element text, anchor on the stable, exact
-# "Copy Recovery Code" button label instead of the device-name-prefixed title.
+# Success screen for the new account (title carries the device name, so match by id).
 - extendedWaitUntil:
-    visible: Copy Recovery Code
+    visible:
+      id: "SyncSuccessTitle"
     timeout: 60000
 # Copy the recovery code so recover/login flows can paste it later.
-- tapOn: Copy Recovery Code
+- tapOn:
+    id: "SyncSuccessCopyRecoveryCodeButton"
 # Re-authenticate only if the auth session has expired since enabling sync.
 - runFlow:
     when:
@@ -33,5 +33,6 @@ appId: com.duckduckgo.mobile.ios
       - tapOn: Passcode field
       - inputText: "0000"
       - pressKey: Enter
-- tapOn: Done
+- tapOn:
+    id: "SyncSuccessDoneButton"
 - assertVisible: Sync & Backup

--- a/.maestro/shared/sync_create_v2.yaml
+++ b/.maestro/shared/sync_create_v2.yaml
@@ -9,7 +9,11 @@ appId: com.duckduckgo.mobile.ios
 - assertVisible: Sync & Backup
 - tapOn:
     id: "SyncToggle"
-- tapOn: Passcode field
+# The passcode screen auto-focuses its field, so wait for the screen and type directly.
+# Its field's label differs across iOS versions, so don't match "Passcode field" by name.
+- extendedWaitUntil:
+    visible: Unlock device to set up Sync & Backup
+    timeout: 30000
 - inputText: "0000"
 - pressKey: Enter
 # Sync-another-device prompt shown after enabling the toggle.
@@ -30,7 +34,6 @@ appId: com.duckduckgo.mobile.ios
     when:
       visible: Unlock device to set up Sync & Backup
     commands:
-      - tapOn: Passcode field
       - inputText: "0000"
       - pressKey: Enter
 - tapOn:

--- a/.maestro/shared/sync_delete_v2.yaml
+++ b/.maestro/shared/sync_delete_v2.yaml
@@ -1,0 +1,20 @@
+appId: com.duckduckgo.mobile.ios
+# Turns off Sync and deletes server data in the V2 UI via the
+# "Turn Off Sync and Delete Server Data" action. In V2 this action authenticates first,
+# then shows the delete confirmation alert. Ends on the logged-out Sync settings screen.
+---
+
+- assertVisible: Sync & Backup
+- scrollUntilVisible:
+    element:
+      text: Turn Off Sync and Delete Server Data
+    direction: DOWN
+- tapOn: Turn Off Sync and Delete Server Data
+- tapOn: Passcode field
+- inputText: "0000"
+- pressKey: Enter
+- assertVisible: Turn Off Sync & Backup and Delete Server Data?
+- tapOn: Delete Server Data
+- extendedWaitUntil:
+    visible: I Have a Recovery Code
+    timeout: 30000

--- a/.maestro/shared/sync_delete_v2.yaml
+++ b/.maestro/shared/sync_delete_v2.yaml
@@ -10,9 +10,14 @@ appId: com.duckduckgo.mobile.ios
       text: Turn Off Sync and Delete Server Data
     direction: DOWN
 - tapOn: Turn Off Sync and Delete Server Data
-- tapOn: Passcode field
-- inputText: "0000"
-- pressKey: Enter
+# Authenticate only if prompted — the auth session may still be valid from a recent step.
+- runFlow:
+    when:
+      visible: Unlock device to set up Sync & Backup
+    commands:
+      - tapOn: Passcode field
+      - inputText: "0000"
+      - pressKey: Enter
 - assertVisible: Turn Off Sync & Backup and Delete Server Data?
 - tapOn: Delete Server Data
 - extendedWaitUntil:

--- a/.maestro/shared/sync_delete_v2.yaml
+++ b/.maestro/shared/sync_delete_v2.yaml
@@ -15,7 +15,6 @@ appId: com.duckduckgo.mobile.ios
     when:
       visible: Unlock device to set up Sync & Backup
     commands:
-      - tapOn: Passcode field
       - inputText: "0000"
       - pressKey: Enter
 - assertVisible: Turn Off Sync & Backup and Delete Server Data?

--- a/.maestro/shared/sync_login_v2.yaml
+++ b/.maestro/shared/sync_login_v2.yaml
@@ -1,0 +1,35 @@
+appId: com.duckduckgo.mobile.ios
+# Logs into an existing Sync account in the V2 UI by tapping "Sync With Another Device",
+# switching to the "Enter Code" tab on the V2 scan screen and pasting the code from the
+# clipboard. Starts on the logged-out Sync settings screen. On success the device-added
+# success screen is shown, which this flow dismisses with Done.
+---
+
+- assertVisible: Sync With Another Device
+- tapOn: Sync With Another Device
+- tapOn: Passcode field
+- inputText: "0000"
+- pressKey: Enter
+- runFlow:
+    when:
+      visible: Allows you to upload photographs and videos
+    commands:
+        - tapOn: "Allow"
+# V2 scan screen: switch to the Enter Code tab and paste the code.
+- extendedWaitUntil:
+    visible: Enter Code
+    timeout: 30000
+- tapOn: Enter Code
+# The scan tab requests camera permission when its intro animation ends; dismiss the
+# prompt if it raced in before we switched tabs.
+- runFlow:
+    when:
+      visible: Allows you to upload photographs and videos
+    commands:
+        - tapOn: "Allow"
+- tapOn: Paste Sync Code
+# Device-added success screen confirms the connection.
+- extendedWaitUntil:
+    visible: has been added to Sync & Backup
+    timeout: 30000
+- tapOn: Done

--- a/.maestro/shared/sync_login_v2.yaml
+++ b/.maestro/shared/sync_login_v2.yaml
@@ -28,9 +28,11 @@ appId: com.duckduckgo.mobile.ios
     commands:
         - tapOn: "Allow"
 - tapOn: Paste Sync Code
-# Device-added success screen confirms the connection. Its title is device-name-prefixed,
-# so anchor on the stable, exact "Copy Recovery Code" button label (Maestro full-matches text).
+# Device-added success screen confirms the connection (title carries the device name, so
+# match by id).
 - extendedWaitUntil:
-    visible: Copy Recovery Code
+    visible:
+      id: "SyncSuccessTitle"
     timeout: 60000
-- tapOn: Done
+- tapOn:
+    id: "SyncSuccessDoneButton"

--- a/.maestro/shared/sync_login_v2.yaml
+++ b/.maestro/shared/sync_login_v2.yaml
@@ -7,7 +7,11 @@ appId: com.duckduckgo.mobile.ios
 
 - assertVisible: Sync With Another Device
 - tapOn: Sync With Another Device
-- tapOn: Passcode field
+# The passcode screen auto-focuses its field, so wait for the screen and type directly
+# (the field's label differs across iOS versions, so don't match it by name).
+- extendedWaitUntil:
+    visible: Unlock device to set up Sync & Backup
+    timeout: 30000
 - inputText: "0000"
 - pressKey: Enter
 - runFlow:

--- a/.maestro/shared/sync_login_v2.yaml
+++ b/.maestro/shared/sync_login_v2.yaml
@@ -28,8 +28,9 @@ appId: com.duckduckgo.mobile.ios
     commands:
         - tapOn: "Allow"
 - tapOn: Paste Sync Code
-# Device-added success screen confirms the connection.
+# Device-added success screen confirms the connection. Its title is device-name-prefixed,
+# so anchor on the stable, exact "Copy Recovery Code" button label (Maestro full-matches text).
 - extendedWaitUntil:
-    visible: has been added to Sync & Backup
-    timeout: 30000
+    visible: Copy Recovery Code
+    timeout: 60000
 - tapOn: Done

--- a/.maestro/shared/sync_logout_v2.yaml
+++ b/.maestro/shared/sync_logout_v2.yaml
@@ -13,7 +13,6 @@ appId: com.duckduckgo.mobile.ios
     when:
       visible: Unlock device to set up Sync & Backup
     commands:
-      - tapOn: Passcode field
       - inputText: "0000"
       - pressKey: Enter
 - extendedWaitUntil:

--- a/.maestro/shared/sync_logout_v2.yaml
+++ b/.maestro/shared/sync_logout_v2.yaml
@@ -1,0 +1,25 @@
+appId: com.duckduckgo.mobile.ios
+# Turns off Sync (without deleting server data) in the V2 UI. When Sync is enabled there
+# is no top-level toggle: turn-off lives on the per-device screen. This opens "This Device"
+# from the My Devices list, toggles "Sync This Device" off and confirms the alert. Ends on
+# the logged-out Sync settings screen.
+---
+
+- assertVisible: Sync & Backup
+# Open this device's management screen (tapping the row triggers authentication).
+- tapOn: This Device
+- tapOn: Passcode field
+- inputText: "0000"
+- pressKey: Enter
+- extendedWaitUntil:
+    visible:
+      id: "SyncThisDeviceToggle"
+    timeout: 30000
+- tapOn:
+    id: "SyncThisDeviceToggle"
+- assertVisible: Turn Off Sync & Backup?
+- tapOn: Turn Off
+# Back on the logged-out Sync settings screen.
+- extendedWaitUntil:
+    visible: I Have a Recovery Code
+    timeout: 30000

--- a/.maestro/shared/sync_logout_v2.yaml
+++ b/.maestro/shared/sync_logout_v2.yaml
@@ -8,9 +8,14 @@ appId: com.duckduckgo.mobile.ios
 - assertVisible: Sync & Backup
 # Open this device's management screen (tapping the row triggers authentication).
 - tapOn: This Device
-- tapOn: Passcode field
-- inputText: "0000"
-- pressKey: Enter
+# Authenticate only if prompted — the auth session may still be valid from a recent step.
+- runFlow:
+    when:
+      visible: Unlock device to set up Sync & Backup
+    commands:
+      - tapOn: Passcode field
+      - inputText: "0000"
+      - pressKey: Enter
 - extendedWaitUntil:
     visible:
       id: "SyncThisDeviceToggle"

--- a/.maestro/shared/sync_recover_data_v2.yaml
+++ b/.maestro/shared/sync_recover_data_v2.yaml
@@ -12,7 +12,6 @@ appId: com.duckduckgo.mobile.ios
     when:
       visible: Unlock device to set up Sync & Backup
     commands:
-      - tapOn: Passcode field
       - inputText: "0000"
       - pressKey: Enter
 - assertVisible: Recover your synced data

--- a/.maestro/shared/sync_recover_data_v2.yaml
+++ b/.maestro/shared/sync_recover_data_v2.yaml
@@ -7,9 +7,14 @@ appId: com.duckduckgo.mobile.ios
 
 - assertVisible: I Have a Recovery Code
 - tapOn: I Have a Recovery Code
-- tapOn: Passcode field
-- inputText: "0000"
-- pressKey: Enter
+# Authenticate only if prompted — the auth session may still be valid from a recent step.
+- runFlow:
+    when:
+      visible: Unlock device to set up Sync & Backup
+    commands:
+      - tapOn: Passcode field
+      - inputText: "0000"
+      - pressKey: Enter
 - assertVisible: Recover your synced data
 - tapOn: Recover Synced Data
 - runFlow:

--- a/.maestro/shared/sync_recover_data_v2.yaml
+++ b/.maestro/shared/sync_recover_data_v2.yaml
@@ -29,8 +29,9 @@ appId: com.duckduckgo.mobile.ios
     commands:
         - tapOn: "Allow"
 - tapOn: Paste Sync Code
-# Recovery-complete success screen.
+# Recovery-complete success screen. Its title "Sync & Backup enabled" has no device-name
+# prefix, so it full-matches directly.
 - extendedWaitUntil:
     visible: Sync & Backup enabled
-    timeout: 30000
+    timeout: 60000
 - tapOn: Done

--- a/.maestro/shared/sync_recover_data_v2.yaml
+++ b/.maestro/shared/sync_recover_data_v2.yaml
@@ -29,9 +29,10 @@ appId: com.duckduckgo.mobile.ios
     commands:
         - tapOn: "Allow"
 - tapOn: Paste Sync Code
-# Recovery-complete success screen. Its title "Sync & Backup enabled" has no device-name
-# prefix, so it full-matches directly.
+# Recovery-complete success screen (match the title by id for consistency with the other flows).
 - extendedWaitUntil:
-    visible: Sync & Backup enabled
+    visible:
+      id: "SyncSuccessTitle"
     timeout: 60000
-- tapOn: Done
+- tapOn:
+    id: "SyncSuccessDoneButton"

--- a/.maestro/shared/sync_recover_data_v2.yaml
+++ b/.maestro/shared/sync_recover_data_v2.yaml
@@ -1,0 +1,36 @@
+appId: com.duckduckgo.mobile.ios
+# Recovers a Sync account from a recovery code in the V2 UI:
+# "I Have a Recovery Code" -> authenticate -> "Recover your synced data" sheet ->
+# "Enter Code" tab -> paste the code. Starts on the logged-out Sync settings screen.
+# On success the recovery-complete screen is shown, which this flow dismisses with Done.
+---
+
+- assertVisible: I Have a Recovery Code
+- tapOn: I Have a Recovery Code
+- tapOn: Passcode field
+- inputText: "0000"
+- pressKey: Enter
+- assertVisible: Recover your synced data
+- tapOn: Recover Synced Data
+- runFlow:
+    when:
+      visible: Allows you to upload photographs and videos
+    commands:
+        - tapOn: "Allow"
+- extendedWaitUntil:
+    visible: Enter Code
+    timeout: 30000
+- tapOn: Enter Code
+# The scan tab requests camera permission when its intro animation ends; dismiss the
+# prompt if it raced in before we switched tabs.
+- runFlow:
+    when:
+      visible: Allows you to upload photographs and videos
+    commands:
+        - tapOn: "Allow"
+- tapOn: Paste Sync Code
+# Recovery-complete success screen.
+- extendedWaitUntil:
+    visible: Sync & Backup enabled
+    timeout: 30000
+- tapOn: Done

--- a/.maestro/shared/sync_setup.yaml
+++ b/.maestro/shared/sync_setup.yaml
@@ -1,5 +1,8 @@
 # sync_setup.yaml
 # Shared setup for the sync_tests suite.
+# Forces the simplifiedSyncSetupV2 feature flag off via the ff.<flag> UI-test
+# launch-argument override, so these flows keep exercising the V1 Sync setup UI
+# regardless of the flag's default value (sync_setup_v2.yaml forces it on).
 appId: com.duckduckgo.mobile.ios
 
 ---
@@ -13,3 +16,4 @@ appId: com.duckduckgo.mobile.ios
         currentAppVariant: ${APP_VARIANT}
         isRunningUITests: true
         isInternalUser: ${INTERNAL_USER_MODE}
+        ff.simplifiedSyncSetupV2: "false"

--- a/.maestro/shared/sync_setup_v2.yaml
+++ b/.maestro/shared/sync_setup_v2.yaml
@@ -1,0 +1,19 @@
+# sync_setup_v2.yaml
+# Shared setup for the sync_v2_tests suite.
+# Identical to sync_setup.yaml but forces the simplifiedSyncSetupV2 feature flag on
+# via the ff.<flag> UI-test launch-argument override, so these flows exercise the
+# V2 simplified Sync setup UI while sync_setup.yaml keeps testing the flag-off flow.
+appId: com.duckduckgo.mobile.ios
+
+---
+
+- launchApp:
+    appId: "com.duckduckgo.mobile.ios"
+    clearState: true
+    clearKeychain: true
+    arguments:
+        isOnboardingCompleted: ${ONBOARDING_COMPLETED}
+        currentAppVariant: ${APP_VARIANT}
+        isRunningUITests: true
+        isInternalUser: ${INTERNAL_USER_MODE}
+        ff.simplifiedSyncSetupV2: "true"

--- a/.maestro/sync_v2_tests/01_create_account.yaml
+++ b/.maestro/sync_v2_tests/01_create_account.yaml
@@ -1,0 +1,31 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - sync_v2
+name: 01_create_account_v2
+
+---
+
+# Set up
+- runFlow:
+    file: ../shared/sync_setup_v2.yaml
+
+# Set Internal User
+- tapOn: Browsing menu
+- tapOn: Settings
+- runFlow:
+    file: ../shared/set_internal_user_from_settings.yaml
+
+# Set Dev environment
+- runFlow:
+    file: ../shared/set_sync_dev_environment.yaml
+
+# Create account
+- runFlow:
+    file: ../shared/sync_create_v2.yaml
+
+
+# Clean up
+- assertVisible: Sync & Backup
+- runFlow:
+    file: ../shared/sync_delete_v2.yaml

--- a/.maestro/sync_v2_tests/02_login_account.yaml
+++ b/.maestro/sync_v2_tests/02_login_account.yaml
@@ -1,0 +1,38 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - sync_v2
+name: 02_login_account_v2
+
+---
+
+# Set up
+- runFlow:
+    file: ../shared/sync_setup_v2.yaml
+
+#  Copy Recovery Code
+- tapOn: Browsing menu
+- tapOn: Settings
+- runFlow:
+    file: ../shared/copy_recovery_code_from_settings.yaml
+    env:
+        CODE: ${CODE}
+
+# Set Internal User
+- runFlow:
+    file: ../shared/set_internal_user_from_settings.yaml
+
+    # Set Dev environment
+- runFlow:
+    file: ../shared/set_sync_dev_environment.yaml
+
+# Login
+- assertVisible: Sync & Backup
+- tapOn: Sync & Backup
+- runFlow:
+    file: ../shared/sync_login_v2.yaml
+- assertVisible: Sync & Backup
+
+# Clean up
+- runFlow:
+    file: ../shared/sync_logout_v2.yaml

--- a/.maestro/sync_v2_tests/03_recover_account.yaml
+++ b/.maestro/sync_v2_tests/03_recover_account.yaml
@@ -1,0 +1,37 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - sync_v2
+name: 03_recover_account_v2
+
+---
+
+# Set up
+- runFlow:
+    file: ../shared/sync_setup_v2.yaml
+
+# Set Internal User
+- tapOn: "Browsing menu"
+- tapOn: "Settings"
+- runFlow:
+    file: ../shared/set_internal_user_from_settings.yaml
+
+    # Set Dev environment
+- runFlow:
+    file: ../shared/set_sync_dev_environment.yaml
+
+# Create account
+- runFlow:
+    file: ../shared/sync_create_v2.yaml
+
+# Log Out
+- runFlow:
+    file: ../shared/sync_logout_v2.yaml
+
+# Recover Data
+- runFlow:
+    file: ../shared/sync_recover_data_v2.yaml
+
+# Clean up
+- runFlow:
+    file: ../shared/sync_delete_v2.yaml

--- a/.maestro/sync_v2_tests/04_sync_data_setup.yaml
+++ b/.maestro/sync_v2_tests/04_sync_data_setup.yaml
@@ -1,0 +1,80 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - sync_v2
+name: 04_sync_data_setup_v2
+
+---
+
+# Set up
+- runFlow:
+    file: ../shared/sync_setup_v2.yaml
+
+# Add local favorite and bookmark
+- runFlow:
+    file: ../shared/add_bookmarks_and_favorites.yaml
+- runFlow:
+    file: ../shared/use_firebutton.yaml
+
+# Add local login
+- runFlow:
+    when:
+      visible:
+        text: "Cancel"
+    commands:
+      - tapOn: Cancel
+- tapOn: Browsing menu
+- tapOn: Settings
+- runFlow:
+    file: ../shared/add_login_from_settings.yaml
+
+# Add local credit card
+- tapOn: Browsing menu
+- tapOn: Settings
+- runFlow:
+    file: ../shared/add_credit_card_from_settings.yaml
+
+#  Copy Recovery Code
+- tapOn: Browsing menu
+- tapOn: Settings
+- runFlow:
+    file: ../shared/copy_recovery_code_from_settings.yaml
+    env:
+        CODE: ${CODE}
+
+# Set Internal User
+- runFlow:
+    file: ../shared/set_internal_user_from_settings.yaml
+
+    # Set Dev environment
+- runFlow:
+    file: ../shared/set_sync_dev_environment.yaml
+
+# Login
+- assertVisible: Sync & Backup
+- tapOn: Sync & Backup
+- runFlow:
+    file: ../shared/sync_login_v2.yaml
+- assertVisible: Sync & Backup
+
+# Log Out
+- runFlow:
+    file: ../shared/sync_logout_v2.yaml
+- tapOn: Settings
+- tapOn: Done
+
+# Remove bookmarks that were added locally
+- runFlow:
+    file: ../shared/remove_local_bookmarks.yaml
+
+# Remove Login that was added locally
+- runFlow:
+    file: ../shared/remove_local_logins.yaml
+
+# Remove Credit Card that was added locally
+- runFlow:
+    file: ../shared/remove_local_credit_cards.yaml
+
+# Maestro seems to get stuck without an additional step here
+- assertVisible:
+    id: searchEntry

--- a/.maestro/sync_v2_tests/05_sync_data_check.yaml
+++ b/.maestro/sync_v2_tests/05_sync_data_check.yaml
@@ -1,0 +1,68 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - sync_v2
+name: 05_sync_data_check_v2
+
+---
+# IMPORTANT: This test is strictly related to 04_sync_data_setup_v2
+#            and it will fail if 04 is not executed before.
+#            The test is split in two different flow to accomodate
+#            for Maestro CI max execution time.
+
+- runFlow:
+    file: ../shared/sync_setup_v2.yaml
+
+#  Copy Recovery Code
+- tapOn: Browsing menu
+- tapOn: Settings
+- runFlow:
+    file: ../shared/copy_recovery_code_from_settings.yaml
+    env:
+        CODE: ${CODE}
+
+# Set Internal User
+- runFlow:
+    file: ../shared/set_internal_user_from_settings.yaml
+
+    # Set Dev environment
+- runFlow:
+    file: ../shared/set_sync_dev_environment.yaml
+
+# Login
+- assertVisible: Sync & Backup
+- tapOn: Sync & Backup
+- runFlow:
+    file: ../shared/sync_login_v2.yaml
+- assertVisible: Sync & Backup
+
+# Verify bookmarks have been merged
+- tapOn: Settings
+- runFlow:
+    file: ../shared/sync_verify_bookmarks.yaml
+
+# Verify favorites are unified
+- tapOn: Done
+- tapOn: Browsing menu
+- tapOn: Settings
+- runFlow:
+    file: ../shared/sync_verify_unified_favorites.yaml
+
+# Ensure the keyboard is dismissed before continuing.
+# This flow sets internal user above, which enables the unified toggle input, so the
+# address-bar dismiss is the "Back" chevron rather than the classic "Cancel"/Dismiss button.
+- runFlow:
+    file: ../shared/dismiss_address_bar_editing.yaml
+
+# Verify logins
+- tapOn: Browsing menu
+- tapOn: Settings
+- runFlow:
+    file: ../shared/sync_verify_logins.yaml
+
+# Verify credit cards
+- tapOn: Done
+- tapOn: Browsing menu
+- tapOn: Settings
+- runFlow:
+    file: ../shared/sync_verify_credit_cards.yaml

--- a/.maestro/sync_v2_tests/06_delete_account.yaml
+++ b/.maestro/sync_v2_tests/06_delete_account.yaml
@@ -1,0 +1,55 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - sync_v2
+name: 06_delete_account_v2
+---
+
+# Set up
+- runFlow:
+    file: ../shared/sync_setup_v2.yaml
+
+# Set Internal User
+- tapOn: Browsing menu
+- tapOn: Settings
+- runFlow:
+    file: ../shared/set_internal_user_from_settings.yaml
+
+    # Set Dev environment
+- runFlow:
+    file: ../shared/set_sync_dev_environment.yaml
+
+# Create account
+- runFlow:
+    file: ../shared/sync_create_v2.yaml
+
+# Remove account
+- runFlow:
+    file: ../shared/sync_delete_v2.yaml
+
+# Try to login with the now-deleted account's recovery code and check for error
+- assertVisible: Sync With Another Device
+- tapOn: Sync With Another Device
+- tapOn: Passcode field
+- inputText: "0000"
+- pressKey: Enter
+- runFlow:
+    when:
+      visible: Allows you to upload photographs and videos
+    commands:
+        - tapOn: "Allow"
+- extendedWaitUntil:
+    visible: Enter Code
+    timeout: 30000
+- tapOn: Enter Code
+# The scan tab requests camera permission when its intro animation ends; dismiss the
+# prompt if it raced in before we switched tabs.
+- runFlow:
+    when:
+      visible: Allows you to upload photographs and videos
+    commands:
+        - tapOn: "Allow"
+- tapOn: Paste Sync Code
+- assertVisible: Sync failed.
+- assertVisible: Please try again.
+- tapOn: Got It

--- a/.maestro/sync_v2_tests/06_delete_account.yaml
+++ b/.maestro/sync_v2_tests/06_delete_account.yaml
@@ -30,9 +30,14 @@ name: 06_delete_account_v2
 # Try to login with the now-deleted account's recovery code and check for error
 - assertVisible: Sync With Another Device
 - tapOn: Sync With Another Device
-- tapOn: Passcode field
-- inputText: "0000"
-- pressKey: Enter
+# Authenticate only if prompted — the auth session may still be valid from a recent step.
+- runFlow:
+    when:
+      visible: Unlock device to set up Sync & Backup
+    commands:
+      - tapOn: Passcode field
+      - inputText: "0000"
+      - pressKey: Enter
 - runFlow:
     when:
       visible: Allows you to upload photographs and videos

--- a/.maestro/sync_v2_tests/06_delete_account.yaml
+++ b/.maestro/sync_v2_tests/06_delete_account.yaml
@@ -35,7 +35,6 @@ name: 06_delete_account_v2
     when:
       visible: Unlock device to set up Sync & Backup
     commands:
-      - tapOn: Passcode field
       - inputText: "0000"
       - pressKey: Enter
 - runFlow:

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/ManageDeviceViewV2.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/ManageDeviceViewV2.swift
@@ -123,14 +123,17 @@ struct ManageDeviceViewV2: View {
 
     private var syncToggleSection: some View {
         Section {
-            Toggle(isOn: syncToggleBinding) {
+            HStack {
                 Text(UserText.simplifiedSyncToggleTitleThisDevice)
                     .daxBodyRegular()
                     .foregroundColor(Color(designSystemColor: .textPrimary))
+                Spacer()
+                Toggle("", isOn: syncToggleBinding)
+                    .labelsHidden()
+                    .tint(Color(designSystemColor: .accentPrimary))
+                    .disabled(model.isBusy)
+                    .accessibility(identifier: "SyncThisDeviceToggle")
             }
-            .tint(Color(designSystemColor: .accentPrimary))
-            .disabled(model.isBusy)
-            .accessibility(identifier: "SyncThisDeviceToggle")
         } footer: {
             Text(UserText.simplifiedManageDeviceTurnOffFooter)
         }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/ManageDeviceViewV2.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/ManageDeviceViewV2.swift
@@ -132,6 +132,7 @@ struct ManageDeviceViewV2: View {
                     .labelsHidden()
                     .tint(Color(designSystemColor: .accentPrimary))
                     .disabled(model.isBusy)
+                    .accessibilityLabel(UserText.simplifiedSyncToggleTitleThisDevice)
                     .accessibility(identifier: "SyncThisDeviceToggle")
             }
         } footer: {

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SimplifiedSyncSettingsViewV2.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SimplifiedSyncSettingsViewV2.swift
@@ -497,7 +497,7 @@ extension SimplifiedSyncSettingsViewV2 {
     @ViewBuilder
     var bookmarksSection: some View {
         Section {
-            Toggle(isOn: $model.isUnifiedFavoritesEnabled) {
+            HStack {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(UserText.unifiedFavoritesTitle)
                         .daxBodyRegular()
@@ -506,11 +506,15 @@ extension SimplifiedSyncSettingsViewV2 {
                         .foregroundColor(Color(designSystemColor: .textSecondary))
                 }
                 .fixedSize(horizontal: false, vertical: true)
+                Spacer()
+                Toggle("", isOn: $model.isUnifiedFavoritesEnabled)
+                    .labelsHidden()
+                    .tint(Color(designSystemColor: .accentPrimary))
+                    .accessibilityLabel(UserText.unifiedFavoritesTitle)
+                    .accessibility(identifier: "UnifiedFavoritesToggle")
             }
-            .tint(Color(designSystemColor: .accentPrimary))
-            .accessibility(identifier: "UnifiedFavoritesToggle")
 
-            Toggle(isOn: $model.isFaviconsFetchingEnabled) {
+            HStack {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(UserText.fetchFaviconsOptionTitle)
                         .daxBodyRegular()
@@ -519,9 +523,13 @@ extension SimplifiedSyncSettingsViewV2 {
                         .foregroundColor(Color(designSystemColor: .textSecondary))
                 }
                 .fixedSize(horizontal: false, vertical: true)
+                Spacer()
+                Toggle("", isOn: $model.isFaviconsFetchingEnabled)
+                    .labelsHidden()
+                    .tint(Color(designSystemColor: .accentPrimary))
+                    .accessibilityLabel(UserText.fetchFaviconsOptionTitle)
+                    .accessibility(identifier: "FaviconFetchingToggle")
             }
-            .tint(Color(designSystemColor: .accentPrimary))
-            .accessibility(identifier: "FaviconFetchingToggle")
         } header: {
             Text(UserText.simplifiedBookmarksSectionHeader)
         }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SimplifiedSyncSettingsViewV2.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SimplifiedSyncSettingsViewV2.swift
@@ -220,6 +220,7 @@ extension SimplifiedSyncSettingsViewV2 {
                 .labelsHidden()
                 .tint(Color(designSystemColor: .accentPrimary))
                 .accessibilityLabel(UserText.simplifiedSyncToggleTitleThisDevice)
+                .accessibility(identifier: "SyncToggle")
             }
             .animation(.easeInOut(duration: 0.3), value: model.isBusy)
             .disabled(model.isBusy || (!model.isSyncEnabled && !model.isAccountCreationAvailable))

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncSuccessViewV2.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncSuccessViewV2.swift
@@ -54,6 +54,7 @@ struct SyncSuccessViewV2: View {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     doneButton
                         .accessibilityLabel(UserText.doneButton)
+                        .accessibility(identifier: "SyncSuccessDoneButton")
                 }
             }
         }
@@ -102,6 +103,7 @@ struct SyncSuccessViewV2: View {
                     .daxTitle1()
                     .multilineTextAlignment(.center)
                     .foregroundColor(Color(designSystemColor: .textPrimary))
+                    .accessibility(identifier: "SyncSuccessTitle")
 
                 Text(description)
                     .daxBodyRegular()
@@ -138,6 +140,7 @@ struct SyncSuccessViewV2: View {
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel(UserText.simplifiedCopyRecoveryCodeButton)
+                .accessibility(identifier: "SyncSuccessCopyRecoveryCodeButton")
             }
 
             Button {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1216032812325058

### Description
Duplicates the Sync end-to-end Maestro suite for the new simplified Sync setup V2 flow, so both variants run **in parallel** until V1 is removed. The new V2 tests force `simplifiedSyncSetupV2` on via the `ff.` UI-test launch-arg override; the existing V1 tests are untouched and keep exercising the flag-off flow.

Adds a parallel `Sync V2 End To End Tests` job to the Sync end-to-end workflow that reuses the same build (tag `sync_v2`, config `config-sync-v2`), alongside the existing V1 `Sync End To End Tests` job.

A few small product changes were needed so Maestro can drive the V2 UI (all behind the `simplifiedSyncSetupV2` flag or accessibility-only):
- Restore the `SyncToggle` accessibility id and add ids to the success screen (title / Done / copy-code button), so elements are matched independently of the device-name-prefixed title.
- Switch the "Sync This Device" and unified-favorites/favicons toggles to the `labelsHidden` pattern already used elsewhere, so a tap lands on the switch (renders identically; keeps the VoiceOver label).

### Testing Steps
The Sync end-to-end workflow runs on a schedule / `workflow_dispatch` (not automatically on PRs), and now runs **both** the V1 and V2 suites in parallel off one build.

1. Check the **[iOS - Sync-End-to-End tests](https://github.com/duckduckgo/apple-browsers/actions/runs/30443069587)** workflow and confirm both test jobs run and pass: **Sync End To End Tests** (V1, flag off) and **Sync V2 End To End Tests** (V2, flag on) → both green.

### Impact
Low — new tests plus small, flag-gated V2 UI adjustments (accessibility ids and a visually-identical toggle refactor). No behavior change for users off the V2 flag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly new Maestro flows and CI; product edits are accessibility ids and toggle layout on flag-gated V2 Sync UI with no intended user behavior change.
> 
> **Overview**
> Adds a **parallel Maestro end-to-end suite** for simplified Sync setup V2 so it runs alongside the existing V1 sync tests on the same build, until V1 is removed.
> 
> The new **`sync-v2-end-to-end-tests`** workflow job mirrors the V1 job: Maestro Cloud with tag `sync_v2`, `config-sync-v2` execution order, and recovery-code env from `sync_crypto`. V1 setup now explicitly sets `ff.simplifiedSyncSetupV2: "false"`; V2 flows use shared `sync_*_v2` steps with the flag forced **on**. Coverage matches V1 (create, login, recover, data setup/check, delete).
> 
> Small **V2 Sync UI** tweaks support automation: accessibility ids on the main sync toggle, success screen title/Done/copy recovery code, and `labelsHidden` toggle layout on device management and bookmarks settings (same visuals; taps hit the switch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3f71b1d7f97db2298dad18860e02fda54767bf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->