### PR TITLE
Add SnapshotTestingSupport package

### DIFF
--- a/DuckDuckGo.xcworkspace/contents.xcworkspacedata
+++ b/DuckDuckGo.xcworkspace/contents.xcworkspacedata
@@ -42,6 +42,9 @@
          location = "group:SERPSettings">
       </FileRef>
       <FileRef
+         location = "group:SnapshotTestingSupport">
+      </FileRef>
+      <FileRef
          location = "group:UIComponents">
       </FileRef>
       <FileRef

--- a/SharedPackages/SnapshotTestingSupport/Package.resolved
+++ b/SharedPackages/SnapshotTestingSupport/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "f602833a86b45025c9867cf4358fbeeef8cf3b75029d57f08e4568ccbd3f51bb",
+  "pins" : [
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "b9b59eb58c946236d6f16305c576ad194c36444e",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "cb281f343fd953280336dcbd3822cdf47c182f5b",
+        "version" : "1.10.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/SharedPackages/SnapshotTestingSupport/Package.swift
+++ b/SharedPackages/SnapshotTestingSupport/Package.swift
@@ -1,0 +1,58 @@
+// swift-tools-version: 5.10
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+//
+//  Package.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import PackageDescription
+
+let package = Package(
+    name: "SnapshotTestingSupport",
+    platforms: [
+        .iOS("15.0"),
+        .macOS("12.3")
+    ],
+    products: [
+        .library(
+            name: "PreviewSnapshots",
+            targets: ["PreviewSnapshots"]
+        ),
+        .library(
+            name: "SnapshotTestingSupport",
+            targets: ["SnapshotTestingSupport"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", exact: "1.19.2"),
+    ],
+    targets: [
+        .target(name: "PreviewSnapshots"),
+        .target(
+            name: "SnapshotTestingSupport",
+            dependencies: [
+                "PreviewSnapshots",
+                .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
+                .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
+            ]
+        ),
+        .testTarget(
+            name: "SnapshotTestingSupportTests",
+            dependencies: ["SnapshotTestingSupport"]
+        ),
+    ],
+    swiftLanguageVersions: [.v5]
+)

--- a/SharedPackages/SnapshotTestingSupport/README.md
+++ b/SharedPackages/SnapshotTestingSupport/README.md
@@ -1,0 +1,177 @@
+# SnapshotTestingSupport
+
+DuckDuckGo wrapper around [Point-Free's `swift-snapshot-testing`](https://github.com/pointfreeco/swift-snapshot-testing) with conventions for iOS / macOS image snapshots and SwiftUI preview reuse.
+
+This package gives shared UI snapshot tests one consistent home for rendering SwiftUI views, validating the simulator or host environment, naming generated images, and keeping preview states reusable between Xcode previews and automated tests. It keeps the app-facing preview helpers separate from the test-only assertion helpers, so production targets can share preview configuration without taking a dependency on snapshot testing libraries.
+
+## Why snapshot testing?
+
+Snapshot testing records the rendered output of a view, data structure, or other value as a reference artifact, then compares future test runs against that reference. For UI work, this is useful because many regressions are visual rather than purely behavioral: spacing changes, missing states, clipped text, incorrect colors, light / dark appearance differences, or unexpected layout shifts can all be caught by comparing the final rendered image.
+
+Use snapshot tests as a focused regression safety net for stable UI states. They are especially valuable when a view has several meaningful configurations that can be represented by previews, because the same list of states can document the component, power Xcode previews, and verify the rendered output in tests. Snapshot tests complement unit and interaction tests; they prove that a known state still looks the way reviewers approved, while other tests should continue to cover logic, accessibility behavior, navigation, and user flows.
+
+## Products
+
+| Product | Link from | Purpose |
+|---|---|---|
+| `PreviewSnapshots` | App target (only when the view file exposes states) | Defines `PreviewSnapshots<State>` so a `PreviewProvider` and a test can share the same configuration list. |
+| `SnapshotTestingSupport` | Test target | Re-exports `SnapshotTesting` + `InlineSnapshotTesting`, adds DDG image snapshot helpers, environment validation, and naming. |
+
+Keep `SnapshotTestingSupport` linked only to test targets.
+
+## Quick start
+
+### Direct view snapshots
+
+```swift
+import SnapshotTestingSupport
+import Testing
+
+@MainActor
+@Suite("My View Tests")
+final class MyViewTests {
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func testMyViewSnapshot() {
+        assertImageSnapshot(
+            matching: MyView().snapshotBackground(),
+            size: .intrinsicContentSize
+        )
+    }
+}
+```
+
+### Preview-backed snapshots
+
+In the view file:
+
+```swift
+struct MyView_Previews: PreviewProvider {
+    typealias State = MyViewModel
+
+    static var previews: some View {
+        snapshots.previews
+    }
+
+    static let snapshots = PreviewSnapshots<State>(
+        configurations: [
+            .init(name: "Empty", state: .empty),
+            .init(name: "Loaded", state: .loaded)
+        ],
+        configure: { MyView(viewModel: $0) }
+    )
+}
+```
+
+In the test:
+
+```swift
+@Test(.timeLimit(.minutes(1)))
+func testMyViewSnapshots() {
+    assertImageSnapshots(MyView_Previews.snapshots, size: .screen)
+}
+```
+
+If preview states need mocks, put them in a sibling `MyView_PreviewMocks.swift` under `#if DEBUG` so the view file stays focused.
+
+### Existing Point-Free APIs
+
+Re-exported transitively, so JSON / inline / AppKit `NSImage` snapshots keep working:
+
+```swift
+assertSnapshot(of: value, as: .json)
+```
+
+## Size modes
+
+`SnapshotImageSize` controls layout. Each mode resolves to one or more configurations (light + dark, sometimes phone + pad).
+
+| Mode | Use when | Devices |
+|---|---|---|
+| `.intrinsicContentSize` | Compact view sized by its content | none |
+| `.constrainedWidth` | Content-driven height, default iPhone width (390) | none |
+| `.screen` | Full-screen layout | iPhone + iPad on iOS |
+| `.sheet` | Sheet presentation; iPhone bottom-aligned, iPad centered with padding | iPhone + iPad on iOS |
+| `.fixed(CGSize)` | Explicit size (typical for macOS windows/panels) | none |
+
+Only `.sheet` adds a backdrop automatically (it simulates the sheet chrome). For every other mode the snapshot reflects the view as-is — call `.snapshotBackground()` on your view if you want `systemBackground` / `windowBackgroundColor` behind it.
+
+On macOS, device variants don't apply — `.screen`/`.sheet`/`.fixed` all resolve to the configuration's size (default `800x600` if unspecified).
+
+Default appearance strategy is `.allAppearances` (light + dark). Use `.single(.light)` or `.single(.dark)` to scope, or `.custom([...])` for full control.
+
+## Environment requirements
+
+Snapshots are pixel-strict, so the test environment is validated before each assertion:
+
+- **iOS**: must run on **iOS 26.4** at **@3x**.
+- **macOS**: must run on **macOS 26.x**.
+
+Wrong OS or scale → the helper calls `XCTFail` with an explanatory message and skips the comparison. Make sure your simulator / runner matches before recording.
+
+When the OS rolls forward, bump `SnapshotEnvironment.expectedMajorVersion` and `expectedMinorVersion` and re-record affected references.
+
+## Recording
+
+- Missing references are recorded automatically (`.missing` mode).
+- `record: true` on a specific call records that assertion.
+- `GENERATE_SNAPSHOTS=1` in the test scheme's env records everything.
+
+After re-recording, inspect every diff and commit only the intentional ones.
+
+## Conventions
+
+- Snapshot tests use Swift Testing with `@MainActor`, `@Suite`, and `@Test(.timeLimit(.minutes(1)))`.
+- Function names that start with `test` keep `#function`-derived snapshot paths consistent with the legacy XCTest convention.
+- One `@Suite` per view test file; one `@Test` per view configuration.
+- `*_PreviewMocks.swift` under `#if DEBUG` for preview-only mocks.
+
+## Examples in the repo
+
+Real test sites you can crib from:
+
+### iOS — preview-backed compact view (`.constrainedWidth`)
+- View: `iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/AIChatSyncPromoView.swift`
+- Test: `iOS/DuckDuckGoTests/AIChat/InputBox/SwitchBar/Suggestions/AIChatSyncPromoViewTests.swift`
+- Snapshots: same folder under `__Snapshots__/AIChatSyncPromoViewTests`
+- Shows a small SwiftUI view whose `PreviewProvider` lives in the same file as the view and is reused directly by the test.
+
+### iOS — direct SwiftUI sheet (`.sheet`)
+- Test: `iOS/DuckDuckGoTests/AIChat/InputBox/SwitchBar/Suggestions/AIChatSyncIntroSheetViewTests.swift`
+- Shows `assertImageSnapshot(matching:size:)` against a constructed view (no `PreviewProvider`), exercising iPhone + iPad sheet sizing automatically.
+
+### iOS — preview-backed screen with mocks (`.screen`)
+- View: `iOS/DuckDuckGo/VoiceSearchFeedbackView.swift`
+- Preview mocks: `iOS/DuckDuckGo/VoiceSearchFeedbackView_PreviewMocks.swift`
+- Test: `iOS/DuckDuckGoTests/VoiceSearchFeedbackViewTests.swift`
+- Shows the preferred structure when preview states need mocks: keep `PreviewProvider`, `typealias State`, and `static let snapshots` in the view file; move mocks to the sibling `_PreviewMocks.swift` under `#if DEBUG`.
+
+### macOS — preview-backed fixed-size view (`.fixed`)
+- View: `macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptInactiveUserView.swift`
+- Preview mocks: `macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptInactiveUserView_PreviewMocks.swift`
+- Test: `macOS/UnitTests/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptInactiveUserViewTests.swift`
+- Same `_PreviewMocks` pattern on macOS, with explicit `CGSize` for views that have a fixed canvas.
+
+### macOS — direct SwiftUI intrinsic size (`.intrinsicContentSize`)
+- Test: `macOS/UnitTests/InfoViews/InfoViewTests.swift`
+- Smallest possible direct snapshot — combine with `.snapshotBackground()` to make the surface explicit.
+
+### macOS — existing Point-Free AppKit image snapshots
+- Test: `macOS/UnitTests/URLDragPreviewProvider/URLDragPreviewProviderTests.swift`
+- Older style that still works through the re-exports — manual `NSAppearance.Name.aqua` / `.darkAqua` loop with a custom snapshot window. Useful when you need full control of the host window.
+
+### macOS — JSON / data snapshots
+- Test: `macOS/UnitTests/DataImport/BookmarksHTMLReaderTests.swift`
+- Demonstrates that non-UI Point-Free strategies (`as: .json`) still work via the re-exports.
+
+## Package layout
+
+```
+SharedPackages/SnapshotTestingSupport/
+├── Package.swift                       # PreviewSnapshots library + test-only helpers
+├── Sources/
+│   ├── PreviewSnapshots/               # SwiftUI-only product safe to link from app targets
+│   └── SnapshotTestingSupport/         # Test-only helpers + Point-Free re-exports
+└── Tests/SnapshotTestingSupportTests/  # Pure-logic Swift Testing suites
+```

--- a/SharedPackages/SnapshotTestingSupport/README.md
+++ b/SharedPackages/SnapshotTestingSupport/README.md
@@ -105,12 +105,18 @@ Default appearance strategy is `.allAppearances` (light + dark). Use `.single(.l
 
 Snapshots are pixel-strict, so the test environment is validated before each assertion:
 
-- **iOS**: must run on **iOS 26.4** at **@3x**.
-- **macOS**: must run on **macOS 26.x**.
+- **iOS**: must run on **iOS 26.4** at **@3x** (simulator runtime).
+- **macOS**: must run on the exact host version, **macOS 26.5.2** (major.minor.patch).
 
-Wrong OS or scale → the helper calls `XCTFail` with an explanatory message and skips the comparison. Make sure your simulator / runner matches before recording.
+macOS pins the exact version because macOS snapshots render on the uncontrolled host, whereas iOS renders in a pinnable simulator runtime. A mismatch → the helper records a failure (`XCTFail` / `Issue.record`) with an explanatory message and skips the comparison — the same in CI and locally; a developer on a different OS opts out by not running the snapshot suite.
 
-When the OS rolls forward, bump `SnapshotEnvironment.expectedMajorVersion` and `expectedMinorVersion` and re-record affected references.
+When the OS rolls forward, bump `SnapshotEnvironment.expectedIOSVersion` / `expectedMacOSVersion` and re-record affected references.
+
+## Reference storage
+
+Reference images live in the `SnapshotReferences` git submodule at the repo root, mirroring each test's repo-relative path (`<platform>/…/__Snapshots__/<TestClass>/`). The wrapper redirects the library's `snapshotDirectory` there automatically, so references stay out of the app trees.
+
+Each image name carries the recording environment as a suffix so references are unambiguous across OSes: iOS uses `…_iOS-26-4` (major.minor), macOS uses `…_macOS-26-5-2` (exact version).
 
 ## Recording
 
@@ -134,12 +140,8 @@ Real test sites you can crib from:
 ### iOS — preview-backed compact view (`.constrainedWidth`)
 - View: `iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/Suggestions/AIChatSyncPromoView.swift`
 - Test: `iOS/DuckDuckGoTests/AIChat/InputBox/SwitchBar/Suggestions/AIChatSyncPromoViewTests.swift`
-- Snapshots: same folder under `__Snapshots__/AIChatSyncPromoViewTests`
+- References: `SnapshotReferences` submodule, mirroring the test path (`iOS/DuckDuckGoTests/AIChat/InputBox/SwitchBar/Suggestions/__Snapshots__/AIChatSyncPromoViewTests/`)
 - Shows a small SwiftUI view whose `PreviewProvider` lives in the same file as the view and is reused directly by the test.
-
-### iOS — direct SwiftUI sheet (`.sheet`)
-- Test: `iOS/DuckDuckGoTests/AIChat/InputBox/SwitchBar/Suggestions/AIChatSyncIntroSheetViewTests.swift`
-- Shows `assertImageSnapshot(matching:size:)` against a constructed view (no `PreviewProvider`), exercising iPhone + iPad sheet sizing automatically.
 
 ### iOS — preview-backed screen with mocks (`.screen`)
 - View: `iOS/DuckDuckGo/VoiceSearchFeedbackView.swift`

--- a/SharedPackages/SnapshotTestingSupport/Sources/PreviewSnapshots/PreviewSnapshots.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/PreviewSnapshots/PreviewSnapshots.swift
@@ -1,0 +1,108 @@
+//
+//  PreviewSnapshots.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+
+public struct PreviewSnapshotScope: OptionSet, Equatable {
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    public static let previews = PreviewSnapshotScope(rawValue: 1 << 0)
+    public static let snapshots = PreviewSnapshotScope(rawValue: 1 << 1)
+    public static let all: PreviewSnapshotScope = [.previews, .snapshots]
+}
+
+public struct PreviewSnapshots<State> {
+    public let configurations: [Configuration]
+    public let configure: (State) -> AnyView
+
+    public init<Content: View>(
+        configurations: [Configuration],
+        configure: @escaping (State) -> Content
+    ) {
+        self.configurations = configurations
+        self.configure = { AnyView(configure($0)) }
+    }
+
+    public init<Content: View>(
+        states: [State],
+        configure: @escaping (State) -> Content
+    ) where State: NamedPreviewState {
+        self.init(states: states, name: \.name, configure: configure)
+    }
+
+    public init<Content: View>(
+        states: [State],
+        name namePath: KeyPath<State, String>,
+        configure: @escaping (State) -> Content
+    ) {
+        self.init(
+            configurations: states.map { Configuration(name: $0[keyPath: namePath], state: $0) },
+            configure: configure
+        )
+    }
+
+    public var previewConfigurations: [Configuration] {
+        configurations.filter { $0.scope.contains(.previews) }
+    }
+
+    public var snapshotConfigurations: [Configuration] {
+        configurations.filter { $0.scope.contains(.snapshots) }
+    }
+
+    public var previews: some View {
+        ForEach(Array(previewConfigurations.enumerated()), id: \.offset) { _, configuration in
+            preview(for: configuration)
+        }
+    }
+
+    @ViewBuilder
+    private func preview(for configuration: Configuration) -> some View {
+        if configuration.name.isEmpty {
+            configure(configuration.state)
+        } else {
+            configure(configuration.state)
+                .previewDisplayName(configuration.name)
+        }
+    }
+}
+
+public extension PreviewSnapshots {
+    struct Configuration {
+        public let name: String
+        public let state: State
+        public let scope: PreviewSnapshotScope
+
+        public init(
+            name: String,
+            state: State,
+            scope: PreviewSnapshotScope = .all
+        ) {
+            self.name = name
+            self.state = state
+            self.scope = scope
+        }
+    }
+}
+
+public protocol NamedPreviewState {
+    var name: String { get }
+}

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/AppKitImageSnapshots.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/AppKitImageSnapshots.swift
@@ -1,0 +1,248 @@
+//
+//  AppKitImageSnapshots.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#if os(macOS)
+import AppKit
+import SnapshotTesting
+import SwiftUI
+import XCTest
+
+public func assertImageSnapshot(
+    matching view: NSView,
+    strategy: SnapshotImageStrategy = .allAppearances,
+    size: SnapshotImageSize,
+    record: Bool = false,
+    perceptualPrecision: Float = 0.98,
+    fileID: StaticString = #fileID,
+    file: StaticString = #filePath,
+    testName: String = #function,
+    line: UInt = #line,
+    column: UInt = #column
+) {
+    guard assertSnapshotEnvironment(fileID: fileID, file: file, line: line, column: column) else { return }
+
+    for configuration in strategy.configurations(for: .macOS, size: size) {
+        view.appearance = configuration.appearance.nsAppearance
+        let snapshotSize = resolvedSize(for: view, configuration: configuration, size: size)
+
+        assertSnapshot(
+            of: view,
+            as: .image(
+                perceptualPrecision: perceptualPrecision,
+                size: snapshotSize
+            ),
+            named: configuration.name,
+            record: SnapshotRecordMode.snapshotTestingRecord(record: record),
+            snapshotDirectory: snapshotReferenceDirectory(file: file),
+            fileID: fileID,
+            file: file,
+            testName: testName,
+            line: line,
+            column: column
+        )
+    }
+}
+
+public func assertImageSnapshot(
+    matching viewController: NSViewController,
+    strategy: SnapshotImageStrategy = .allAppearances,
+    size: SnapshotImageSize,
+    record: Bool = false,
+    perceptualPrecision: Float = 0.98,
+    fileID: StaticString = #fileID,
+    file: StaticString = #filePath,
+    testName: String = #function,
+    line: UInt = #line,
+    column: UInt = #column
+) {
+    assertImageSnapshot(
+        matching: viewController.view,
+        strategy: strategy,
+        size: size,
+        record: record,
+        perceptualPrecision: perceptualPrecision,
+        fileID: fileID,
+        file: file,
+        testName: testName,
+        line: line,
+        column: column
+    )
+}
+
+public func assertImageSnapshot<Value: SwiftUI.View>(
+    matching view: Value,
+    strategy: SnapshotImageStrategy = .allAppearances,
+    size: SnapshotImageSize,
+    record: Bool = false,
+    perceptualPrecision: Float = 0.98,
+    fileID: StaticString = #fileID,
+    file: StaticString = #filePath,
+    testName: String = #function,
+    line: UInt = #line,
+    column: UInt = #column
+) {
+    guard assertSnapshotEnvironment(fileID: fileID, file: file, line: line, column: column) else { return }
+
+    for configuration in strategy.configurations(for: .macOS, size: size) {
+        let rootView = view.environment(\.colorScheme, configuration.appearance.colorScheme)
+        let viewController = NSHostingController(rootView: rootView)
+        viewController.view.appearance = configuration.appearance.nsAppearance
+
+        assertSwiftUIImageSnapshot(
+            of: viewController,
+            configuration: configuration,
+            size: size,
+            record: record,
+            perceptualPrecision: perceptualPrecision,
+            fileID: fileID,
+            file: file,
+            testName: testName,
+            line: line,
+            column: column
+        )
+    }
+}
+
+private func resolvedSize(
+    for view: NSView,
+    configuration: SnapshotImageConfiguration,
+    size: SnapshotImageSize
+) -> CGSize {
+    if let width = size.fixedConstrainedWidth {
+        return constrainedSize(for: view, width: width)
+    }
+
+    return size.resolvedSize(
+        for: configuration,
+        defaultSize: SnapshotDevice.macOSDefaultSize
+    ) ?? resolvedSize(for: view)
+}
+
+private func resolvedSize(for view: NSView) -> CGSize {
+    if view.frame.width > 0, view.frame.height > 0 {
+        return view.frame.size
+    }
+
+    let fittingSize = view.fittingSize
+    if fittingSize.width > 0, fittingSize.height > 0 {
+        return fittingSize
+    }
+
+    return SnapshotDevice.macOSDefaultSize
+}
+
+private func constrainedSize(for view: NSView, width: CGFloat) -> CGSize {
+    let originalSize = view.frame.size
+    view.setFrameSize(CGSize(width: width, height: 0))
+    let fittingHeight = view.fittingSize.height
+    view.setFrameSize(originalSize)
+
+    if fittingHeight > 0 {
+        return CGSize(width: width, height: fittingHeight)
+    }
+
+    return CGSize(width: width, height: SnapshotDevice.macOSDefaultSize.height)
+}
+
+private func assertSwiftUIImageSnapshot<Value: SwiftUI.View>(
+    of viewController: NSHostingController<Value>,
+    configuration: SnapshotImageConfiguration,
+    size: SnapshotImageSize,
+    record: Bool,
+    perceptualPrecision: Float,
+    fileID: StaticString,
+    file: StaticString,
+    testName: String,
+    line: UInt,
+    column: UInt
+) {
+    let snapshotSize = swiftUISnapshotSize(
+        for: viewController,
+        configuration: configuration,
+        size: size
+    )
+    viewController.view.setFrameSize(snapshotSize)
+
+    assertSnapshot(
+        of: viewController.view,
+        as: .image(
+            perceptualPrecision: perceptualPrecision,
+            size: snapshotSize
+        ),
+        named: configuration.name,
+        record: SnapshotRecordMode.snapshotTestingRecord(record: record),
+        snapshotDirectory: snapshotReferenceDirectory(file: file),
+        fileID: fileID,
+        file: file,
+        testName: testName,
+        line: line,
+        column: column
+    )
+}
+
+private func swiftUISnapshotSize<Value: SwiftUI.View>(
+    for viewController: NSHostingController<Value>,
+    configuration: SnapshotImageConfiguration,
+    size: SnapshotImageSize
+) -> CGSize {
+    if let width = size.fixedConstrainedWidth {
+        let measuredSize = viewController.sizeThatFits(
+            in: CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+        )
+
+        if measuredSize.height > 0 {
+            return CGSize(width: width, height: measuredSize.height)
+        }
+
+        return CGSize(width: width, height: SnapshotDevice.macOSDefaultSize.height)
+    }
+
+    if let snapshotSize = size.resolvedSize(
+        for: configuration,
+        defaultSize: SnapshotDevice.macOSDefaultSize
+    ) {
+        return snapshotSize
+    }
+
+    let measuredSize = viewController.sizeThatFits(
+        in: CGSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+    )
+    if measuredSize.width > 0, measuredSize.height > 0 {
+        return measuredSize
+    }
+
+    return resolvedSize(for: viewController.view)
+}
+
+private extension SnapshotAppearance {
+    var nsAppearance: NSAppearance? {
+        let name: NSAppearance.Name
+        switch self {
+        case .light:
+            name = .aqua
+        case .dark:
+            name = .darkAqua
+        }
+
+        return NSAppearance(named: name)
+    }
+}
+#endif

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/AppKitImageSnapshots.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/AppKitImageSnapshots.swift
@@ -34,9 +34,11 @@ public func assertImageSnapshot(
     line: UInt = #line,
     column: UInt = #column
 ) {
+    let configurations = strategy.configurations(for: .macOS, size: size)
+    guard assertSnapshotConfigurations(configurations, fileID: fileID, file: file, line: line, column: column) else { return }
     guard assertSnapshotEnvironment(fileID: fileID, file: file, line: line, column: column) else { return }
 
-    for configuration in strategy.configurations(for: .macOS, size: size) {
+    for configuration in configurations {
         view.appearance = configuration.appearance.nsAppearance
         let snapshotSize = resolvedSize(for: view, configuration: configuration, size: size)
 
@@ -96,9 +98,11 @@ public func assertImageSnapshot<Value: SwiftUI.View>(
     line: UInt = #line,
     column: UInt = #column
 ) {
+    let configurations = strategy.configurations(for: .macOS, size: size)
+    guard assertSnapshotConfigurations(configurations, fileID: fileID, file: file, line: line, column: column) else { return }
     guard assertSnapshotEnvironment(fileID: fileID, file: file, line: line, column: column) else { return }
 
-    for configuration in strategy.configurations(for: .macOS, size: size) {
+    for configuration in configurations {
         let rootView = view.environment(\.colorScheme, configuration.appearance.colorScheme)
         let viewController = NSHostingController(rootView: rootView)
         viewController.view.appearance = configuration.appearance.nsAppearance

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/AssertPreviewSnapshots.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/AssertPreviewSnapshots.swift
@@ -1,0 +1,122 @@
+//
+//  AssertPreviewSnapshots.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import PreviewSnapshots
+import SwiftUI
+
+public func assertImageSnapshots<State>(
+    _ previews: PreviewSnapshots<State>,
+    strategy: SnapshotImageStrategy = .allAppearances,
+    size: SnapshotImageSize,
+    record: Bool = false,
+    perceptualPrecision: Float = 0.98,
+    fileID: StaticString = #fileID,
+    file: StaticString = #filePath,
+    testName: String = #function,
+    line: UInt = #line,
+    column: UInt = #column
+) {
+    assertImageSnapshots(
+        previews,
+        strategy: { _ in strategy },
+        size: size,
+        record: record,
+        perceptualPrecision: perceptualPrecision,
+        fileID: fileID,
+        file: file,
+        testName: testName,
+        line: line,
+        column: column
+    )
+}
+
+public func assertImageSnapshots<State>(
+    _ previews: PreviewSnapshots<State>,
+    strategy: (State) -> SnapshotImageStrategy,
+    size: SnapshotImageSize,
+    record: Bool = false,
+    perceptualPrecision: Float = 0.98,
+    fileID: StaticString = #fileID,
+    file: StaticString = #filePath,
+    testName: String = #function,
+    line: UInt = #line,
+    column: UInt = #column
+) {
+    let snapshotConfigurations = previews.snapshotConfigurations
+    guard !snapshotConfigurations.isEmpty else {
+        recordSnapshotIssue(
+            "No snapshot configurations found. At least one preview configuration must include the .snapshots scope.",
+            fileID: fileID,
+            file: file,
+            line: line,
+            column: column
+        )
+        return
+    }
+
+    for configuration in snapshotConfigurations {
+        assertImageSnapshot(
+            matching: previews.configure(configuration.state),
+            strategy: namedStrategy(
+                strategy(configuration.state),
+                previewName: configuration.name,
+                size: size
+            ),
+            size: size,
+            record: record,
+            perceptualPrecision: perceptualPrecision,
+            fileID: fileID,
+            file: file,
+            testName: testName,
+            line: line,
+            column: column
+        )
+    }
+}
+
+private func namedStrategy(
+    _ strategy: SnapshotImageStrategy,
+    previewName: String,
+    size: SnapshotImageSize
+) -> SnapshotImageStrategy {
+    .custom(
+        strategy.configurationsForCurrentPlatform(size: size).map {
+            SnapshotImageConfiguration(
+                appearance: $0.appearance,
+                device: $0.device,
+                name: SnapshotNameGenerator.name(
+                    forPreview: previewName,
+                    snapshotName: $0.name
+                ),
+                size: $0.size
+            )
+        }
+    )
+}
+
+private extension SnapshotImageStrategy {
+    func configurationsForCurrentPlatform(size: SnapshotImageSize) -> [SnapshotImageConfiguration] {
+        #if os(iOS)
+        return configurations(for: .iOS, size: size)
+        #elseif os(macOS)
+        return configurations(for: .macOS, size: size)
+        #else
+        return []
+        #endif
+    }
+}

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/AssertSnapshot+Directory.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/AssertSnapshot+Directory.swift
@@ -1,0 +1,62 @@
+//
+//  AssertSnapshot+Directory.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SnapshotTesting
+
+// Point-Free's `assertSnapshot` does not expose `snapshotDirectory` (only `verifySnapshot` does).
+// This overload adds a required `snapshotDirectory:` so reference images can be redirected into the
+// SnapshotReferences submodule, and mirrors the library's own reporting (verifySnapshot + recordIssue).
+// `snapshotDirectory` is non-optional-defaulted so calls that pass it resolve here unambiguously,
+// while calls without it keep using the library's `assertSnapshot`.
+func assertSnapshot<Value, Format>(
+    of value: @autoclosure () throws -> Value,
+    as snapshotting: Snapshotting<Value, Format>,
+    named name: String? = nil,
+    record: SnapshotTestingConfiguration.Record? = nil,
+    snapshotDirectory: String?,
+    timeout: TimeInterval = 5,
+    fileID: StaticString = #fileID,
+    file filePath: StaticString = #filePath,
+    testName: String = #function,
+    line: UInt = #line,
+    column: UInt = #column
+) {
+    let resolvedName: String?
+    if let name, let suffix = SnapshotEnvironment.currentReferenceEnvironmentSuffix() {
+        resolvedName = "\(name)_\(suffix)"
+    } else {
+        resolvedName = name
+    }
+
+    let failure = verifySnapshot(
+        of: try value(),
+        as: snapshotting,
+        named: resolvedName,
+        record: record,
+        snapshotDirectory: snapshotDirectory,
+        timeout: timeout,
+        fileID: fileID,
+        file: filePath,
+        testName: testName,
+        line: line,
+        column: column
+    )
+    guard let message = failure else { return }
+    recordSnapshotIssue(message, fileID: fileID, file: filePath, line: line, column: column)
+}

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/AssertSnapshotEnvironment.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/AssertSnapshotEnvironment.swift
@@ -36,6 +36,25 @@ func assertSnapshotEnvironment(
     return false
 }
 
+func assertSnapshotConfigurations(
+    _ configurations: [SnapshotImageConfiguration],
+    fileID: StaticString,
+    file: StaticString,
+    line: UInt,
+    column: UInt
+) -> Bool {
+    guard configurations.isEmpty else { return true }
+
+    recordSnapshotIssue(
+        "Snapshot strategy produced no configurations, so nothing was verified.",
+        fileID: fileID,
+        file: file,
+        line: line,
+        column: column
+    )
+    return false
+}
+
 func recordSnapshotIssue(
     _ message: String,
     fileID: StaticString,

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/AssertSnapshotEnvironment.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/AssertSnapshotEnvironment.swift
@@ -1,0 +1,62 @@
+//
+//  AssertSnapshotEnvironment.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+#if canImport(Testing)
+import Testing
+#endif
+
+func assertSnapshotEnvironment(
+    fileID: StaticString,
+    file: StaticString,
+    line: UInt,
+    column: UInt
+) -> Bool {
+    guard let message = SnapshotEnvironment.currentValidationMessage() else {
+        return true
+    }
+
+    recordSnapshotIssue(message, fileID: fileID, file: file, line: line, column: column)
+    return false
+}
+
+func recordSnapshotIssue(
+    _ message: String,
+    fileID: StaticString,
+    file: StaticString,
+    line: UInt,
+    column: UInt
+) {
+    #if canImport(Testing)
+    if Test.current != nil {
+        Issue.record(
+            Comment(rawValue: message),
+            sourceLocation: SourceLocation(
+                fileID: "\(fileID)",
+                filePath: "\(file)",
+                line: Int(line),
+                column: Int(column)
+            )
+        )
+        return
+    }
+    #endif
+
+    XCTFail(message, file: file, line: line)
+}

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/PointFreeSnapshotTesting.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/PointFreeSnapshotTesting.swift
@@ -1,0 +1,21 @@
+//
+//  PointFreeSnapshotTesting.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@_exported import PreviewSnapshots
+@_exported import InlineSnapshotTesting
+@_exported import SnapshotTesting

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotAppearance.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotAppearance.swift
@@ -1,0 +1,34 @@
+//
+//  SnapshotAppearance.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SwiftUI
+
+public enum SnapshotAppearance: String, CaseIterable, Equatable {
+    case light
+    case dark
+}
+
+extension SnapshotAppearance {
+    var colorScheme: ColorScheme {
+        switch self {
+        case .light: return .light
+        case .dark: return .dark
+        }
+    }
+}

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotDevice.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotDevice.swift
@@ -1,0 +1,93 @@
+//
+//  SnapshotDevice.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import CoreGraphics
+
+#if os(iOS)
+import UIKit
+#endif
+
+public struct SnapshotDevice: Equatable {
+    public let name: String
+    public let size: CGSize
+
+    #if os(iOS)
+    let userInterfaceIdiom: UIUserInterfaceIdiom
+    let horizontalSizeClass: UIUserInterfaceSizeClass
+    let verticalSizeClass: UIUserInterfaceSizeClass
+    #endif
+
+    #if os(iOS)
+    public init(
+        name: String,
+        size: CGSize,
+        userInterfaceIdiom: UIUserInterfaceIdiom = .unspecified,
+        horizontalSizeClass: UIUserInterfaceSizeClass = .unspecified,
+        verticalSizeClass: UIUserInterfaceSizeClass = .unspecified
+    ) {
+        self.name = name
+        self.size = size
+        self.userInterfaceIdiom = userInterfaceIdiom
+        self.horizontalSizeClass = horizontalSizeClass
+        self.verticalSizeClass = verticalSizeClass
+    }
+    #else
+    public init(
+        name: String,
+        size: CGSize
+    ) {
+        self.name = name
+        self.size = size
+    }
+    #endif
+
+    #if os(iOS)
+    public static let iPhoneDefault = SnapshotDevice(
+        name: "iPhoneDefault",
+        size: CGSize(width: 390, height: 844),
+        userInterfaceIdiom: .phone,
+        horizontalSizeClass: .compact,
+        verticalSizeClass: .regular
+    )
+
+    public static let iPadDefault = SnapshotDevice(
+        name: "iPadDefault",
+        size: CGSize(width: 820, height: 1180),
+        userInterfaceIdiom: .pad,
+        horizontalSizeClass: .regular,
+        verticalSizeClass: .regular
+    )
+    #else
+    public static let iPhoneDefault = SnapshotDevice(
+        name: "iPhoneDefault",
+        size: CGSize(width: 390, height: 844)
+    )
+
+    public static let iPadDefault = SnapshotDevice(
+        name: "iPadDefault",
+        size: CGSize(width: 820, height: 1180)
+    )
+    #endif
+
+    public static let defaultIOSDevices: [SnapshotDevice] = [
+        .iPhoneDefault,
+        .iPadDefault
+    ]
+
+    public static let macOSDefaultSize = CGSize(width: 800, height: 600)
+}

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotEnvironment.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotEnvironment.swift
@@ -1,0 +1,141 @@
+//
+//  SnapshotEnvironment.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+#if os(iOS)
+import UIKit
+#endif
+
+public enum SnapshotPlatform: Equatable {
+    case iOS
+    case macOS
+
+    var displayName: String {
+        switch self {
+        case .iOS:
+            return "iOS"
+        case .macOS:
+            return "macOS"
+        }
+    }
+}
+
+public enum SnapshotEnvironment {
+    public static let expectedIOSVersion = OperatingSystemVersion(majorVersion: 26, minorVersion: 4, patchVersion: 0)
+    public static let expectedMacOSVersion = OperatingSystemVersion(majorVersion: 26, minorVersion: 5, patchVersion: 2)
+    public static let expectedIOSDisplayScale = 3.0
+
+    public static func currentValidationMessage() -> String? {
+        #if os(iOS)
+        return validationMessage(
+            platform: .iOS,
+            operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersion,
+            displayScale: currentIOSDisplayScale()
+        )
+        #elseif os(macOS)
+        return validationMessage(
+            platform: .macOS,
+            operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersion
+        )
+        #else
+        return "UI snapshots are supported only on iOS and macOS."
+        #endif
+    }
+
+    public static func validationMessage(
+        platform: SnapshotPlatform,
+        operatingSystemVersion: OperatingSystemVersion,
+        displayScale: Double? = nil
+    ) -> String? {
+        switch platform {
+        case .iOS:
+            guard operatingSystemVersion.majorVersion == expectedIOSVersion.majorVersion,
+                  operatingSystemVersion.minorVersion == expectedIOSVersion.minorVersion else {
+                return "UI snapshots must run on iOS \(expectedVersionString(for: .iOS)). Current OS is \(versionString(operatingSystemVersion))."
+            }
+
+            guard let displayScale else {
+                return "iOS UI snapshots must run at @\(Int(expectedIOSDisplayScale))x scale. Current scale is unknown."
+            }
+            guard displayScale == expectedIOSDisplayScale else {
+                return "iOS UI snapshots must run at @\(Int(expectedIOSDisplayScale))x scale. Current scale is \(displayScale)."
+            }
+            return nil
+
+        case .macOS:
+            guard operatingSystemVersion.majorVersion == expectedMacOSVersion.majorVersion,
+                  operatingSystemVersion.minorVersion == expectedMacOSVersion.minorVersion,
+                  operatingSystemVersion.patchVersion == expectedMacOSVersion.patchVersion else {
+                return "UI snapshots must run on macOS \(expectedVersionString(for: .macOS)). Current OS is \(versionString(operatingSystemVersion))."
+            }
+            return nil
+        }
+    }
+
+    public static func referenceEnvironmentSuffix(
+        platform: SnapshotPlatform,
+        operatingSystemVersion version: OperatingSystemVersion
+    ) -> String {
+        switch platform {
+        case .iOS:
+            return "\(platform.displayName)-\(version.majorVersion)-\(version.minorVersion)"
+        case .macOS:
+            return "\(platform.displayName)-\(version.majorVersion)-\(version.minorVersion)-\(version.patchVersion)"
+        }
+    }
+
+    static func currentReferenceEnvironmentSuffix() -> String? {
+        #if os(iOS)
+        return referenceEnvironmentSuffix(
+            platform: .iOS,
+            operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersion
+        )
+        #elseif os(macOS)
+        return referenceEnvironmentSuffix(
+            platform: .macOS,
+            operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersion
+        )
+        #else
+        return nil
+        #endif
+    }
+
+    private static func versionString(_ version: OperatingSystemVersion) -> String {
+        "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    }
+
+    private static func expectedVersionString(for platform: SnapshotPlatform) -> String {
+        switch platform {
+        case .iOS:
+            return "\(expectedIOSVersion.majorVersion).\(expectedIOSVersion.minorVersion)"
+        case .macOS:
+            return "\(expectedMacOSVersion.majorVersion).\(expectedMacOSVersion.minorVersion).\(expectedMacOSVersion.patchVersion)"
+        }
+    }
+
+    #if os(iOS)
+    private static func currentIOSDisplayScale() -> Double? {
+        let scale = UITraitCollection.current.displayScale
+        guard scale > 0 else {
+            return nil
+        }
+        return Double(scale)
+    }
+    #endif
+}

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotImageConfiguration.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotImageConfiguration.swift
@@ -1,0 +1,42 @@
+//
+//  SnapshotImageConfiguration.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import CoreGraphics
+
+public struct SnapshotImageConfiguration: Equatable {
+    public let appearance: SnapshotAppearance
+    public let device: SnapshotDevice?
+    public let name: String
+    public let size: CGSize?
+
+    public init(
+        appearance: SnapshotAppearance,
+        device: SnapshotDevice? = nil,
+        name: String? = nil,
+        size: CGSize? = nil
+    ) {
+        self.appearance = appearance
+        self.device = device
+        self.name = name ?? SnapshotNameGenerator.name(for: appearance, device: device)
+        self.size = size
+    }
+
+    func resolvedSize(defaultSize: CGSize) -> CGSize {
+        size ?? device?.size ?? defaultSize
+    }
+}

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotImageSize.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotImageSize.swift
@@ -1,0 +1,59 @@
+//
+//  SnapshotImageSize.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import CoreGraphics
+
+public enum SnapshotImageSize: Equatable {
+    case intrinsicContentSize
+    case constrainedWidth
+    case screen
+    case sheet
+    case fixed(CGSize)
+
+    var usesDefaultIOSDevices: Bool {
+        switch self {
+        case .screen, .sheet:
+            return true
+        case .intrinsicContentSize, .constrainedWidth, .fixed:
+            return false
+        }
+    }
+
+    var fixedConstrainedWidth: CGFloat? {
+        switch self {
+        case .constrainedWidth:
+            return SnapshotDevice.iPhoneDefault.size.width
+        case .intrinsicContentSize, .screen, .sheet, .fixed:
+            return nil
+        }
+    }
+
+    func resolvedSize(
+        for configuration: SnapshotImageConfiguration,
+        defaultSize: CGSize
+    ) -> CGSize? {
+        switch self {
+        case .intrinsicContentSize, .constrainedWidth:
+            return configuration.size
+        case .screen, .sheet:
+            return configuration.resolvedSize(defaultSize: defaultSize)
+        case .fixed(let size):
+            return size
+        }
+    }
+}

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotImageStrategy.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotImageStrategy.swift
@@ -1,0 +1,56 @@
+//
+//  SnapshotImageStrategy.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+public enum SnapshotImageStrategy: Equatable {
+    case single(SnapshotAppearance)
+    case allAppearances
+    case custom([SnapshotImageConfiguration])
+
+    public func configurations(
+        for platform: SnapshotPlatform,
+        size: SnapshotImageSize
+    ) -> [SnapshotImageConfiguration] {
+        switch self {
+        case .single(let appearance):
+            return configurations(for: platform, size: size, appearances: [appearance])
+        case .allAppearances:
+            return configurations(for: platform, size: size, appearances: SnapshotAppearance.allCases)
+        case .custom(let configurations):
+            return configurations
+        }
+    }
+
+    private func configurations(
+        for platform: SnapshotPlatform,
+        size: SnapshotImageSize,
+        appearances: [SnapshotAppearance]
+    ) -> [SnapshotImageConfiguration] {
+        switch platform {
+        case .iOS where size.usesDefaultIOSDevices:
+            return SnapshotDevice.defaultIOSDevices.flatMap { device in
+                appearances.map {
+                    SnapshotImageConfiguration(appearance: $0, device: device)
+                }
+            }
+        case .iOS, .macOS:
+            return appearances.map {
+                SnapshotImageConfiguration(appearance: $0)
+            }
+        }
+    }
+}

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotNameGenerator.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotNameGenerator.swift
@@ -1,0 +1,43 @@
+//
+//  SnapshotNameGenerator.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+public enum SnapshotNameGenerator {
+    public static func name(
+        for appearance: SnapshotAppearance,
+        device: SnapshotDevice? = nil
+    ) -> String {
+        guard let device else {
+            return appearance.rawValue
+        }
+
+        return "\(device.name)_\(appearance.rawValue)"
+    }
+
+    public static func name(forPreview previewName: String, snapshotName: String) -> String {
+        let previewName = previewName
+            .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+            .map(String.init)
+            .joined(separator: "_")
+
+        guard !previewName.isEmpty else {
+            return snapshotName
+        }
+
+        return "\(previewName)_\(snapshotName)"
+    }
+}

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotRecordMode.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotRecordMode.swift
@@ -1,0 +1,47 @@
+//
+//  SnapshotRecordMode.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SnapshotTesting
+
+public enum SnapshotRecordMode {
+    public static let environmentVariableName = "GENERATE_SNAPSHOTS"
+
+    public static func shouldRecord(
+        record: Bool,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        record || isEnabled(environment[environmentVariableName])
+    }
+
+    static func snapshotTestingRecord(
+        record: Bool,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> SnapshotTestingConfiguration.Record {
+        shouldRecord(record: record, environment: environment) ? .all : .missing
+    }
+
+    private static func isEnabled(_ value: String?) -> Bool {
+        switch value?.lowercased() {
+        case "1", "true", "yes":
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotReferenceDirectory.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotReferenceDirectory.swift
@@ -1,0 +1,68 @@
+//
+//  SnapshotReferenceDirectory.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+func snapshotReferenceDirectory(file: StaticString) -> String? {
+    let fileURL = URL(fileURLWithPath: "\(file)")
+    let testDirectory = fileURL.deletingLastPathComponent()
+    let fileBaseName = fileURL.deletingPathExtension().lastPathComponent
+    let fileManager = FileManager.default
+
+    guard let repoRoot = repositoryRoot(startingFrom: testDirectory, fileManager: fileManager) else {
+        return nil
+    }
+
+    let referenceRoot: URL
+    if let override = ProcessInfo.processInfo.environment["SNAPSHOT_REFERENCE_DIR"], !override.isEmpty {
+        referenceRoot = URL(fileURLWithPath: override, isDirectory: true)
+    } else {
+        referenceRoot = repoRoot.appendingPathComponent("SnapshotReferences", isDirectory: true)
+    }
+
+    let destination = relativePathComponents(of: testDirectory, from: repoRoot)
+        .reduce(referenceRoot) { $0.appendingPathComponent($1, isDirectory: true) }
+        .appendingPathComponent("__Snapshots__", isDirectory: true)
+        .appendingPathComponent(fileBaseName, isDirectory: true)
+
+    return destination.path
+}
+
+private func repositoryRoot(startingFrom directory: URL, fileManager: FileManager) -> URL? {
+    var current = directory.standardizedFileURL
+    while true {
+        if fileManager.fileExists(atPath: current.appendingPathComponent(".git").path) {
+            return current
+        }
+        let parent = current.deletingLastPathComponent()
+        if parent.path == current.path {
+            return nil
+        }
+        current = parent
+    }
+}
+
+private func relativePathComponents(of url: URL, from base: URL) -> [String] {
+    let urlComponents = url.standardizedFileURL.pathComponents
+    let baseComponents = base.standardizedFileURL.pathComponents
+    guard urlComponents.count >= baseComponents.count,
+          Array(urlComponents.prefix(baseComponents.count)) == baseComponents else {
+        return []
+    }
+    return Array(urlComponents.dropFirst(baseComponents.count))
+}

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/UIKitImageSnapshots.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/UIKitImageSnapshots.swift
@@ -34,9 +34,11 @@ public func assertImageSnapshot(
     line: UInt = #line,
     column: UInt = #column
 ) {
+    let configurations = strategy.configurations(for: .iOS, size: size)
+    guard assertSnapshotConfigurations(configurations, fileID: fileID, file: file, line: line, column: column) else { return }
     guard assertSnapshotEnvironment(fileID: fileID, file: file, line: line, column: column) else { return }
 
-    for configuration in strategy.configurations(for: .iOS, size: size) {
+    for configuration in configurations {
         view.overrideUserInterfaceStyle = configuration.appearance.userInterfaceStyle
         let snapshotSize = resolvedSize(for: view, configuration: configuration, size: size)
 
@@ -72,9 +74,11 @@ public func assertImageSnapshot(
     line: UInt = #line,
     column: UInt = #column
 ) {
+    let configurations = strategy.configurations(for: .iOS, size: size)
+    guard assertSnapshotConfigurations(configurations, fileID: fileID, file: file, line: line, column: column) else { return }
     guard assertSnapshotEnvironment(fileID: fileID, file: file, line: line, column: column) else { return }
 
-    for configuration in strategy.configurations(for: .iOS, size: size) {
+    for configuration in configurations {
         viewController.overrideUserInterfaceStyle = configuration.appearance.userInterfaceStyle
         let snapshotSize = resolvedSize(for: viewController, configuration: configuration, size: size)
 
@@ -110,9 +114,11 @@ public func assertImageSnapshot<Value: SwiftUI.View>(
     line: UInt = #line,
     column: UInt = #column
 ) {
+    let configurations = strategy.configurations(for: .iOS, size: size)
+    guard assertSnapshotConfigurations(configurations, fileID: fileID, file: file, line: line, column: column) else { return }
     guard assertSnapshotEnvironment(fileID: fileID, file: file, line: line, column: column) else { return }
 
-    for configuration in strategy.configurations(for: .iOS, size: size) {
+    for configuration in configurations {
         let rootView = view.environment(\.colorScheme, configuration.appearance.colorScheme)
         assertSwiftUIImageSnapshot(
             of: rootView,

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/UIKitImageSnapshots.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/UIKitImageSnapshots.swift
@@ -1,0 +1,388 @@
+//
+//  UIKitImageSnapshots.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#if os(iOS)
+import SnapshotTesting
+import SwiftUI
+import UIKit
+import XCTest
+
+public func assertImageSnapshot(
+    matching view: UIView,
+    strategy: SnapshotImageStrategy = .allAppearances,
+    size: SnapshotImageSize,
+    record: Bool = false,
+    perceptualPrecision: Float = 0.98,
+    fileID: StaticString = #fileID,
+    file: StaticString = #filePath,
+    testName: String = #function,
+    line: UInt = #line,
+    column: UInt = #column
+) {
+    guard assertSnapshotEnvironment(fileID: fileID, file: file, line: line, column: column) else { return }
+
+    for configuration in strategy.configurations(for: .iOS, size: size) {
+        view.overrideUserInterfaceStyle = configuration.appearance.userInterfaceStyle
+        let snapshotSize = resolvedSize(for: view, configuration: configuration, size: size)
+
+        assertSnapshot(
+            of: view,
+            as: .image(
+                drawHierarchyInKeyWindow: false,
+                perceptualPrecision: perceptualPrecision,
+                size: snapshotSize,
+                traits: configuration.traits
+            ),
+            named: configuration.name,
+            record: SnapshotRecordMode.snapshotTestingRecord(record: record),
+            snapshotDirectory: snapshotReferenceDirectory(file: file),
+            fileID: fileID,
+            file: file,
+            testName: testName,
+            line: line,
+            column: column
+        )
+    }
+}
+
+public func assertImageSnapshot(
+    matching viewController: UIViewController,
+    strategy: SnapshotImageStrategy = .allAppearances,
+    size: SnapshotImageSize,
+    record: Bool = false,
+    perceptualPrecision: Float = 0.98,
+    fileID: StaticString = #fileID,
+    file: StaticString = #filePath,
+    testName: String = #function,
+    line: UInt = #line,
+    column: UInt = #column
+) {
+    guard assertSnapshotEnvironment(fileID: fileID, file: file, line: line, column: column) else { return }
+
+    for configuration in strategy.configurations(for: .iOS, size: size) {
+        viewController.overrideUserInterfaceStyle = configuration.appearance.userInterfaceStyle
+        let snapshotSize = resolvedSize(for: viewController, configuration: configuration, size: size)
+
+        assertSnapshot(
+            of: viewController,
+            as: .image(
+                drawHierarchyInKeyWindow: false,
+                perceptualPrecision: perceptualPrecision,
+                size: snapshotSize,
+                traits: configuration.traits
+            ),
+            named: configuration.name,
+            record: SnapshotRecordMode.snapshotTestingRecord(record: record),
+            snapshotDirectory: snapshotReferenceDirectory(file: file),
+            fileID: fileID,
+            file: file,
+            testName: testName,
+            line: line,
+            column: column
+        )
+    }
+}
+
+public func assertImageSnapshot<Value: SwiftUI.View>(
+    matching view: Value,
+    strategy: SnapshotImageStrategy = .allAppearances,
+    size: SnapshotImageSize,
+    record: Bool = false,
+    perceptualPrecision: Float = 0.98,
+    fileID: StaticString = #fileID,
+    file: StaticString = #filePath,
+    testName: String = #function,
+    line: UInt = #line,
+    column: UInt = #column
+) {
+    guard assertSnapshotEnvironment(fileID: fileID, file: file, line: line, column: column) else { return }
+
+    for configuration in strategy.configurations(for: .iOS, size: size) {
+        let rootView = view.environment(\.colorScheme, configuration.appearance.colorScheme)
+        assertSwiftUIImageSnapshot(
+            of: rootView,
+            configuration: configuration,
+            size: size,
+            record: record,
+            perceptualPrecision: perceptualPrecision,
+            fileID: fileID,
+            file: file,
+            testName: testName,
+            line: line,
+            column: column
+        )
+    }
+}
+
+private func resolvedSize(
+    for view: UIView,
+    configuration: SnapshotImageConfiguration,
+    size: SnapshotImageSize
+) -> CGSize? {
+    if let width = size.fixedConstrainedWidth {
+        return constrainedSize(for: view, width: width)
+    }
+
+    return size.resolvedSize(
+        for: configuration,
+        defaultSize: SnapshotDevice.iPhoneDefault.size
+    ) ?? intrinsicSize(for: view)
+}
+
+private func resolvedSize(
+    for viewController: UIViewController,
+    configuration: SnapshotImageConfiguration,
+    size: SnapshotImageSize
+) -> CGSize? {
+    viewController.loadViewIfNeeded()
+
+    if let width = size.fixedConstrainedWidth {
+        return constrainedSize(for: viewController.view, width: width)
+    }
+
+    return size.resolvedSize(
+        for: configuration,
+        defaultSize: SnapshotDevice.iPhoneDefault.size
+    ) ?? intrinsicSize(for: viewController.view)
+}
+
+private func intrinsicSize(for view: UIView) -> CGSize? {
+    view.setNeedsLayout()
+    view.layoutIfNeeded()
+
+    if view.intrinsicContentSize.isRenderableSnapshotSize {
+        return view.intrinsicContentSize
+    }
+
+    let fittingSize = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+    if fittingSize.isRenderableSnapshotSize {
+        return fittingSize
+    }
+
+    if view.frame.size.isRenderableSnapshotSize {
+        return view.frame.size
+    }
+
+    return nil
+}
+
+private func constrainedSize(for view: UIView, width: CGFloat) -> CGSize? {
+    view.setNeedsLayout()
+    view.layoutIfNeeded()
+
+    let fittingSize = view.systemLayoutSizeFitting(
+        CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+        withHorizontalFittingPriority: .required,
+        verticalFittingPriority: .fittingSizeLevel
+    )
+
+    if fittingSize.height.isRenderableSnapshotDimension {
+        return CGSize(width: width, height: fittingSize.height)
+    }
+
+    if view.frame.height.isRenderableSnapshotDimension {
+        return CGSize(width: width, height: view.frame.height)
+    }
+
+    return nil
+}
+
+private func assertSwiftUIImageSnapshot<Value: SwiftUI.View>(
+    of view: Value,
+    configuration: SnapshotImageConfiguration,
+    size: SnapshotImageSize,
+    record: Bool,
+    perceptualPrecision: Float,
+    fileID: StaticString,
+    file: StaticString,
+    testName: String,
+    line: UInt,
+    column: UInt
+) {
+    switch size {
+    case .intrinsicContentSize:
+        assertSnapshot(
+            of: view.fixedSize(),
+            as: .image(
+                drawHierarchyInKeyWindow: false,
+                perceptualPrecision: perceptualPrecision,
+                layout: .sizeThatFits,
+                traits: configuration.traits
+            ),
+            named: configuration.name,
+            record: SnapshotRecordMode.snapshotTestingRecord(record: record),
+            snapshotDirectory: snapshotReferenceDirectory(file: file),
+            fileID: fileID,
+            file: file,
+            testName: testName,
+            line: line,
+            column: column
+        )
+
+    case .constrainedWidth:
+        assertSnapshot(
+            of: view.frame(width: SnapshotDevice.iPhoneDefault.size.width).fixedSize(),
+            as: .image(
+                drawHierarchyInKeyWindow: false,
+                perceptualPrecision: perceptualPrecision,
+                layout: .sizeThatFits,
+                traits: configuration.traits
+            ),
+            named: configuration.name,
+            record: SnapshotRecordMode.snapshotTestingRecord(record: record),
+            snapshotDirectory: snapshotReferenceDirectory(file: file),
+            fileID: fileID,
+            file: file,
+            testName: testName,
+            line: line,
+            column: column
+        )
+
+    case .sheet:
+        let snapshotSize = size.resolvedSize(
+            for: configuration,
+            defaultSize: SnapshotDevice.iPhoneDefault.size
+        ) ?? SnapshotDevice.iPhoneDefault.size
+
+        assertSnapshot(
+            of: SheetSnapshotContainer(
+                content: view,
+                snapshotSize: snapshotSize,
+                isPad: configuration.device == .iPadDefault
+            ),
+            as: .image(
+                drawHierarchyInKeyWindow: false,
+                perceptualPrecision: perceptualPrecision,
+                layout: .fixed(width: snapshotSize.width, height: snapshotSize.height),
+                traits: configuration.traits
+            ),
+            named: configuration.name,
+            record: SnapshotRecordMode.snapshotTestingRecord(record: record),
+            snapshotDirectory: snapshotReferenceDirectory(file: file),
+            fileID: fileID,
+            file: file,
+            testName: testName,
+            line: line,
+            column: column
+        )
+
+    case .screen, .fixed:
+        let snapshotSize = size.resolvedSize(
+            for: configuration,
+            defaultSize: SnapshotDevice.iPhoneDefault.size
+        ) ?? SnapshotDevice.iPhoneDefault.size
+
+        assertSnapshot(
+            of: view,
+            as: .image(
+                drawHierarchyInKeyWindow: false,
+                perceptualPrecision: perceptualPrecision,
+                layout: .fixed(width: snapshotSize.width, height: snapshotSize.height),
+                traits: configuration.traits
+            ),
+            named: configuration.name,
+            record: SnapshotRecordMode.snapshotTestingRecord(record: record),
+            snapshotDirectory: snapshotReferenceDirectory(file: file),
+            fileID: fileID,
+            file: file,
+            testName: testName,
+            line: line,
+            column: column
+        )
+    }
+}
+
+private struct SheetSnapshotContainer<Content: SwiftUI.View>: SwiftUI.View {
+    let content: Content
+    let snapshotSize: CGSize
+    let isPad: Bool
+
+    var body: some SwiftUI.View {
+        ZStack(alignment: alignment) {
+            Color(uiColor: .systemBackground)
+                .ignoresSafeArea()
+
+            content
+                .frame(width: contentWidth)
+                .fixedSize(horizontal: false, vertical: true)
+                .clipped()
+        }
+        .frame(width: snapshotSize.width, height: snapshotSize.height)
+    }
+
+    private var alignment: Alignment {
+        isPad ? .center : .bottom
+    }
+
+    private var contentWidth: CGFloat {
+        max(snapshotSize.width - horizontalPadding * 2, 1)
+    }
+
+    private var horizontalPadding: CGFloat {
+        isPad ? 140 : 0
+    }
+}
+
+private extension SnapshotImageConfiguration {
+    var traits: UITraitCollection {
+        var traits = [
+            UITraitCollection(displayScale: CGFloat(SnapshotEnvironment.expectedIOSDisplayScale)),
+            UITraitCollection(userInterfaceStyle: appearance.userInterfaceStyle)
+        ]
+
+        if let device {
+            traits.append(device.traits)
+        }
+
+        return UITraitCollection(traitsFrom: traits)
+    }
+}
+
+private extension SnapshotDevice {
+    var traits: UITraitCollection {
+        UITraitCollection(traitsFrom: [
+            UITraitCollection(userInterfaceIdiom: userInterfaceIdiom),
+            UITraitCollection(horizontalSizeClass: horizontalSizeClass),
+            UITraitCollection(verticalSizeClass: verticalSizeClass)
+        ])
+    }
+}
+
+private extension SnapshotAppearance {
+    var userInterfaceStyle: UIUserInterfaceStyle {
+        switch self {
+        case .light:
+            return .light
+        case .dark:
+            return .dark
+        }
+    }
+}
+
+private extension CGSize {
+    var isRenderableSnapshotSize: Bool {
+        width.isRenderableSnapshotDimension && height.isRenderableSnapshotDimension
+    }
+}
+
+private extension CGFloat {
+    var isRenderableSnapshotDimension: Bool {
+        isFinite && self > 0
+    }
+}
+#endif

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/View+SnapshotBackground.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/View+SnapshotBackground.swift
@@ -1,0 +1,46 @@
+//
+//  View+SnapshotBackground.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
+import SwiftUI
+
+public extension View {
+    func snapshotBackground() -> some View {
+        background(SnapshotBackground())
+    }
+}
+
+private struct SnapshotBackground: View {
+    var body: some View {
+        backgroundColor
+    }
+
+    private var backgroundColor: Color {
+        #if os(iOS)
+        return Color(uiColor: .systemBackground)
+        #elseif os(macOS)
+        return Color(nsColor: .windowBackgroundColor)
+        #else
+        return Color.clear
+        #endif
+    }
+}

--- a/SharedPackages/SnapshotTestingSupport/Tests/SnapshotTestingSupportTests/EmptyStrategyTests.swift
+++ b/SharedPackages/SnapshotTestingSupport/Tests/SnapshotTestingSupportTests/EmptyStrategyTests.swift
@@ -1,0 +1,55 @@
+//
+//  EmptyStrategyTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SnapshotTestingSupport
+import SwiftUI
+import Testing
+
+@MainActor
+@Suite("Empty Strategy Tests")
+struct EmptyStrategyTests {
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func directAssertionWithEmptyCustomStrategyRecordsIssue() {
+        withKnownIssue("An empty strategy must record an issue instead of silently passing.") {
+            assertImageSnapshot(
+                matching: Text("snapshot"),
+                strategy: .custom([]),
+                size: .intrinsicContentSize
+            )
+        }
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func previewBackedAssertionWithEmptyCustomStrategyRecordsIssue() {
+        let previews = PreviewSnapshots<Int>(
+            configurations: [.init(name: "Default", state: 0)],
+            configure: { _ in Text("snapshot") }
+        )
+
+        withKnownIssue("An empty strategy must record an issue instead of silently passing.") {
+            assertImageSnapshots(
+                previews,
+                strategy: .custom([]),
+                size: .intrinsicContentSize
+            )
+        }
+    }
+}

--- a/SharedPackages/SnapshotTestingSupport/Tests/SnapshotTestingSupportTests/PreviewSnapshotsTests.swift
+++ b/SharedPackages/SnapshotTestingSupport/Tests/SnapshotTestingSupportTests/PreviewSnapshotsTests.swift
@@ -1,0 +1,81 @@
+//
+//  PreviewSnapshotsTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SnapshotTestingSupport
+import SwiftUI
+import Testing
+
+@Suite("Preview Snapshots Tests")
+struct PreviewSnapshotsTests {
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func previewCollectionKeepsConfigurationsAndBuildsViews() {
+        let previews = PreviewSnapshots(
+            configurations: [
+                .init(name: "Enabled", state: "enabled"),
+                .init(name: "Disabled", state: "disabled", scope: .previews),
+                .init(name: "Snapshots Only", state: "snapshots", scope: .snapshots)
+            ],
+            configure: { Text($0) }
+        )
+
+        #expect(previews.configurations.map(\.name) == ["Enabled", "Disabled", "Snapshots Only"])
+        #expect(previews.previewConfigurations.map(\.name) == ["Enabled", "Disabled"])
+        #expect(previews.snapshotConfigurations.map(\.name) == ["Enabled", "Snapshots Only"])
+        _ = previews.configure("enabled")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func statesInitializerUsesNamedStateNames() {
+        let previews = PreviewSnapshots(
+            states: [
+                NamedState(name: "First", value: 1),
+                NamedState(name: "Second", value: 2)
+            ],
+            configure: { Text(String($0.value)) }
+        )
+
+        #expect(previews.configurations.map(\.name) == ["First", "Second"])
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func statesInitializerUsesNameKeyPath() {
+        let previews = PreviewSnapshots(
+            states: [
+                KeyPathNamedState(title: "Alpha"),
+                KeyPathNamedState(title: "Beta")
+            ],
+            name: \.title,
+            configure: { Text($0.title) }
+        )
+
+        #expect(previews.configurations.map(\.name) == ["Alpha", "Beta"])
+    }
+}
+
+private struct NamedState: NamedPreviewState {
+    let name: String
+    let value: Int
+}
+
+private struct KeyPathNamedState {
+    let title: String
+}

--- a/SharedPackages/SnapshotTestingSupport/Tests/SnapshotTestingSupportTests/SnapshotEnvironmentTests.swift
+++ b/SharedPackages/SnapshotTestingSupport/Tests/SnapshotTestingSupportTests/SnapshotEnvironmentTests.swift
@@ -1,0 +1,123 @@
+//
+//  SnapshotEnvironmentTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SnapshotTestingSupport
+import Testing
+
+@Suite("Snapshot Environment Tests")
+struct SnapshotEnvironmentTests {
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func macOS2652IsAccepted() {
+        let message = SnapshotEnvironment.validationMessage(
+            platform: .macOS,
+            operatingSystemVersion: OperatingSystemVersion(majorVersion: 26, minorVersion: 5, patchVersion: 2)
+        )
+
+        #expect(message == nil)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func macOSWrongMajorVersionIsRejected() {
+        let message = SnapshotEnvironment.validationMessage(
+            platform: .macOS,
+            operatingSystemVersion: OperatingSystemVersion(majorVersion: 25, minorVersion: 6, patchVersion: 0)
+        )
+
+        #expect(message == "UI snapshots must run on macOS 26.5.2. Current OS is 25.6.0.")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func macOSDifferentMinorVersionIsRejected() {
+        let message = SnapshotEnvironment.validationMessage(
+            platform: .macOS,
+            operatingSystemVersion: OperatingSystemVersion(majorVersion: 26, minorVersion: 1, patchVersion: 0)
+        )
+
+        #expect(message == "UI snapshots must run on macOS 26.5.2. Current OS is 26.1.0.")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func macOSDifferentPatchVersionIsRejected() {
+        let message = SnapshotEnvironment.validationMessage(
+            platform: .macOS,
+            operatingSystemVersion: OperatingSystemVersion(majorVersion: 26, minorVersion: 5, patchVersion: 1)
+        )
+
+        #expect(message == "UI snapshots must run on macOS 26.5.2. Current OS is 26.5.1.")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func iOS264At3xIsAccepted() {
+        let message = SnapshotEnvironment.validationMessage(
+            platform: .iOS,
+            operatingSystemVersion: OperatingSystemVersion(majorVersion: 26, minorVersion: 4, patchVersion: 0),
+            displayScale: 3
+        )
+
+        #expect(message == nil)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func iOSWrongMinorVersionIsRejected() {
+        let message = SnapshotEnvironment.validationMessage(
+            platform: .iOS,
+            operatingSystemVersion: OperatingSystemVersion(majorVersion: 26, minorVersion: 1, patchVersion: 0),
+            displayScale: 3
+        )
+
+        #expect(message == "UI snapshots must run on iOS 26.4. Current OS is 26.1.0.")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func iOS26At2xIsRejected() {
+        let message = SnapshotEnvironment.validationMessage(
+            platform: .iOS,
+            operatingSystemVersion: OperatingSystemVersion(majorVersion: 26, minorVersion: 4, patchVersion: 0),
+            displayScale: 2
+        )
+
+        #expect(message == "iOS UI snapshots must run at @3x scale. Current scale is 2.0.")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func referenceEnvironmentSuffixMatchesGuardGranularity() {
+        #expect(
+            SnapshotEnvironment.referenceEnvironmentSuffix(
+                platform: .iOS,
+                operatingSystemVersion: OperatingSystemVersion(majorVersion: 26, minorVersion: 4, patchVersion: 1)
+            ) == "iOS-26-4"
+        )
+
+        #expect(
+            SnapshotEnvironment.referenceEnvironmentSuffix(
+                platform: .macOS,
+                operatingSystemVersion: OperatingSystemVersion(majorVersion: 26, minorVersion: 5, patchVersion: 2)
+            ) == "macOS-26-5-2"
+        )
+    }
+}

--- a/SharedPackages/SnapshotTestingSupport/Tests/SnapshotTestingSupportTests/SnapshotImageSizeTests.swift
+++ b/SharedPackages/SnapshotTestingSupport/Tests/SnapshotTestingSupportTests/SnapshotImageSizeTests.swift
@@ -1,0 +1,111 @@
+//
+//  SnapshotImageSizeTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import CoreGraphics
+@testable import SnapshotTestingSupport
+import Testing
+
+@Suite("Snapshot Image Size Tests")
+struct SnapshotImageSizeTests {
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func intrinsicContentSizeUsesConfigurationSizeWhenProvided() {
+        let configuration = SnapshotImageConfiguration(
+            appearance: .light,
+            size: CGSize(width: 320, height: 240)
+        )
+
+        #expect(
+            SnapshotImageSize.intrinsicContentSize.resolvedSize(
+                for: configuration,
+                defaultSize: SnapshotDevice.iPhoneDefault.size
+            ) == CGSize(width: 320, height: 240)
+        )
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func intrinsicContentSizeDefersToViewWhenConfigurationHasNoSize() {
+        #expect(
+            SnapshotImageSize.intrinsicContentSize.resolvedSize(
+                for: SnapshotImageConfiguration(appearance: .light),
+                defaultSize: SnapshotDevice.iPhoneDefault.size
+            ) == nil
+        )
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func constrainedWidthDefersHeightToView() {
+        #expect(
+            SnapshotImageSize.constrainedWidth.resolvedSize(
+                for: SnapshotImageConfiguration(appearance: .light),
+                defaultSize: SnapshotDevice.iPhoneDefault.size
+            ) == nil
+        )
+        #expect(SnapshotImageSize.constrainedWidth.fixedConstrainedWidth == SnapshotDevice.iPhoneDefault.size.width)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func screenUsesConfigurationDeviceSize() {
+        let configuration = SnapshotImageConfiguration(
+            appearance: .dark,
+            device: .iPadDefault
+        )
+
+        #expect(
+            SnapshotImageSize.screen.resolvedSize(
+                for: configuration,
+                defaultSize: SnapshotDevice.iPhoneDefault.size
+            ) == SnapshotDevice.iPadDefault.size
+        )
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func sheetUsesConfigurationDeviceSize() {
+        let configuration = SnapshotImageConfiguration(
+            appearance: .dark,
+            device: .iPadDefault
+        )
+
+        #expect(
+            SnapshotImageSize.sheet.resolvedSize(
+                for: configuration,
+                defaultSize: SnapshotDevice.iPhoneDefault.size
+            ) == SnapshotDevice.iPadDefault.size
+        )
+        #expect(SnapshotImageSize.sheet.fixedConstrainedWidth == nil)
+        #expect(SnapshotImageSize.sheet.usesDefaultIOSDevices)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func fixedUsesExplicitSize() {
+        let size = CGSize(width: 500, height: 700)
+
+        #expect(
+            SnapshotImageSize.fixed(size).resolvedSize(
+                for: SnapshotImageConfiguration(appearance: .light),
+                defaultSize: SnapshotDevice.iPhoneDefault.size
+            ) == size
+        )
+    }
+}

--- a/SharedPackages/SnapshotTestingSupport/Tests/SnapshotTestingSupportTests/SnapshotImageStrategyTests.swift
+++ b/SharedPackages/SnapshotTestingSupport/Tests/SnapshotTestingSupportTests/SnapshotImageStrategyTests.swift
@@ -1,0 +1,131 @@
+//
+//  SnapshotImageStrategyTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import CoreGraphics
+import SnapshotTestingSupport
+import Testing
+
+@Suite("Snapshot Image Strategy Tests")
+struct SnapshotImageStrategyTests {
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func macOSAllAppearancesExpandsToLightAndDark() {
+        let configurations = SnapshotImageStrategy.allAppearances.configurations(
+            for: .macOS,
+            size: .intrinsicContentSize
+        )
+
+        #expect(configurations.map(\.appearance) == [.light, .dark])
+        #expect(configurations.map(\.name) == ["light", "dark"])
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func iOSAllAppearancesDefaultsToIntrinsicLightAndDark() {
+        let configurations = SnapshotImageStrategy.allAppearances.configurations(
+            for: .iOS,
+            size: .intrinsicContentSize
+        )
+
+        #expect(configurations.map(\.appearance) == [.light, .dark])
+        #expect(configurations.map(\.name) == ["light", "dark"])
+        #expect(configurations.map(\.device) == [nil, nil])
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func iOSAllAppearancesExpandsToPhoneAndPadForScreenSnapshots() {
+        let configurations = SnapshotImageStrategy.allAppearances.configurations(for: .iOS, size: .screen)
+
+        #expect(
+            configurations.map(\.name) == [
+                "iPhoneDefault_light",
+                "iPhoneDefault_dark",
+                "iPadDefault_light",
+                "iPadDefault_dark"
+            ]
+        )
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func iOSAllAppearancesExpandsToPhoneAndPadForSheetSnapshots() {
+        let configurations = SnapshotImageStrategy.allAppearances.configurations(for: .iOS, size: .sheet)
+
+        #expect(
+            configurations.map(\.name) == [
+                "iPhoneDefault_light",
+                "iPhoneDefault_dark",
+                "iPadDefault_light",
+                "iPadDefault_dark"
+            ]
+        )
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func macOSSingleAppearanceExpandsToOneConfiguration() {
+        let configurations = SnapshotImageStrategy.single(.dark).configurations(
+            for: .macOS,
+            size: .intrinsicContentSize
+        )
+
+        #expect(configurations == [SnapshotImageConfiguration(appearance: .dark)])
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func iOSSingleAppearanceDefaultsToIntrinsic() {
+        let configurations = SnapshotImageStrategy.single(.dark).configurations(
+            for: .iOS,
+            size: .intrinsicContentSize
+        )
+
+        #expect(configurations == [SnapshotImageConfiguration(appearance: .dark)])
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func iOSSingleAppearanceExpandsToPhoneAndPadForScreenSnapshots() {
+        let configurations = SnapshotImageStrategy.single(.dark).configurations(for: .iOS, size: .screen)
+
+        #expect(
+            configurations.map(\.name) == [
+                "iPhoneDefault_dark",
+                "iPadDefault_dark"
+            ]
+        )
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func customConfigurationsArePreserved() {
+        let custom = [
+            SnapshotImageConfiguration(
+                appearance: .light,
+                name: "compact-light",
+                size: CGSize(width: 320, height: 480)
+            )
+        ]
+
+        #expect(
+            SnapshotImageStrategy.custom(custom).configurations(for: .iOS, size: .intrinsicContentSize) == custom
+        )
+    }
+}

--- a/SharedPackages/SnapshotTestingSupport/Tests/SnapshotTestingSupportTests/SnapshotNameGeneratorTests.swift
+++ b/SharedPackages/SnapshotTestingSupport/Tests/SnapshotTestingSupportTests/SnapshotNameGeneratorTests.swift
@@ -1,0 +1,66 @@
+//
+//  SnapshotNameGeneratorTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SnapshotTestingSupport
+import Testing
+
+@Suite("Snapshot Name Generator Tests")
+struct SnapshotNameGeneratorTests {
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func appearanceNamesAreStable() {
+        #expect(SnapshotNameGenerator.name(for: .light) == "light")
+        #expect(SnapshotNameGenerator.name(for: .dark) == "dark")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func deviceNamesAreIncludedWhenProvided() {
+        #expect(
+            SnapshotNameGenerator.name(for: .light, device: .iPadDefault) == "iPadDefault_light"
+        )
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func configurationUsesGeneratedNameWhenNoNameIsProvided() {
+        let configuration = SnapshotImageConfiguration(
+            appearance: .light,
+            device: .iPhoneDefault
+        )
+
+        #expect(configuration.name == "iPhoneDefault_light")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func configurationUsesCustomNameWhenProvided() {
+        let configuration = SnapshotImageConfiguration(appearance: .dark, name: "custom-dark")
+
+        #expect(configuration.name == "custom-dark")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func previewNamesAreSanitizedAndPrepended() {
+        #expect(
+            SnapshotNameGenerator.name(forPreview: "Empty State", snapshotName: "iPadDefault_dark") == "Empty_State_iPadDefault_dark"
+        )
+    }
+}

--- a/SharedPackages/SnapshotTestingSupport/Tests/SnapshotTestingSupportTests/SnapshotRecordModeTests.swift
+++ b/SharedPackages/SnapshotTestingSupport/Tests/SnapshotTestingSupportTests/SnapshotRecordModeTests.swift
@@ -1,0 +1,57 @@
+//
+//  SnapshotRecordModeTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@testable import SnapshotTestingSupport
+import Testing
+
+@Suite("Snapshot Record Mode Tests")
+struct SnapshotRecordModeTests {
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func recordArgumentEnablesRecording() {
+        #expect(SnapshotRecordMode.shouldRecord(record: true, environment: [:]))
+        #expect(
+            SnapshotRecordMode.snapshotTestingRecord(record: true, environment: [:]) == .all
+        )
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func environmentFlagEnablesRecording() {
+        #expect(SnapshotRecordMode.shouldRecord(record: false, environment: ["GENERATE_SNAPSHOTS": "1"]))
+        #expect(SnapshotRecordMode.shouldRecord(record: false, environment: ["GENERATE_SNAPSHOTS": "true"]))
+        #expect(SnapshotRecordMode.shouldRecord(record: false, environment: ["GENERATE_SNAPSHOTS": "YES"]))
+        #expect(
+            SnapshotRecordMode.snapshotTestingRecord(record: false, environment: ["GENERATE_SNAPSHOTS": "1"]) == .all
+        )
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func onlyMissingSnapshotsAreRecordedByDefault() {
+        #expect(!SnapshotRecordMode.shouldRecord(record: false, environment: [:]))
+        #expect(!SnapshotRecordMode.shouldRecord(record: false, environment: ["GENERATE_SNAPSHOTS": "0"]))
+        #expect(
+            SnapshotRecordMode.snapshotTestingRecord(record: false, environment: [:]) == .missing
+        )
+        #expect(
+            SnapshotRecordMode.snapshotTestingRecord(record: false, environment: ["GENERATE_SNAPSHOTS": "0"]) == .missing
+        )
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1216948720664505?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/task/1216266676088027

First of a stacked series landing snapshot testing incrementally: **package (this PR) → iOS adoption → macOS adoption.**

### Description

`SnapshotTestingSupport` is a thin DuckDuckGo wrapper around [Point-Free's swift-snapshot-testing](https://github.com/pointfreeco/swift-snapshot-testing) that gives shared UI snapshot tests one consistent home: rendering SwiftUI views for iOS and macOS, validating the recording environment (OS version / scale), naming reference images, and reusing SwiftUI preview states between Xcode previews and automated tests. App-facing preview helpers stay separate from the test-only assertion helpers, so production targets can share preview configuration without depending on snapshot-testing libraries.

Nothing consumes the package yet — no app, project, or submodule changes, and no reference images — so there's no behavioural impact on the apps. Adoption lands in the follow-up PRs.

See [`SharedPackages/SnapshotTestingSupport/README.md`](https://github.com/duckduckgo/apple-browsers/blob/pau/snapshot-support-package/SharedPackages/SnapshotTestingSupport/README.md) for full details — size modes, environment requirements, recording, conventions, reference storage, and worked examples.

### Testing Steps
1. In `SharedPackages/SnapshotTestingSupport`, run `swift test` → 35 tests across 7 suites pass.

### Impact
None — internal test tooling; no target consumes it yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New internal test infrastructure with no app or production target adoption in this PR; changes affect only future snapshot test workflows.
> 
> **Overview**
> Introduces **`SharedPackages/SnapshotTestingSupport`**, a DuckDuckGo wrapper around Point-Free **`swift-snapshot-testing`**, and registers it in the Xcode workspace. Nothing in iOS/macOS app targets links it yet, so there is no runtime impact.
> 
> The package ships two libraries: **`PreviewSnapshots`** (SwiftUI-only, safe for app targets) to share preview state lists between Xcode previews and tests, and **`SnapshotTestingSupport`** (test-only) with **`assertImageSnapshot`** / **`assertImageSnapshots`**, size modes, light/dark and iPhone/iPad strategies, and **`snapshotBackground()`**.
> 
> Test helpers enforce a pinned recording environment (iOS 26.4 @3x, macOS 26.5.2), append OS suffixes to reference names, route images into **`SnapshotReferences`** via **`snapshotDirectory`**, and support recording via **`GENERATE_SNAPSHOTS`**. Package tests cover environment rules, naming, strategies, and empty-strategy failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6588e8c80708e853a195278ffbf699e8a9690bea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->