### PR TITLE
Add Review-only replay automation controls

### DIFF
--- a/SharedPackages/AutomationServer/Sources/AutomationServer/AutomationServerCore.swift
+++ b/SharedPackages/AutomationServer/Sources/AutomationServer/AutomationServerCore.swift
@@ -180,10 +180,14 @@ public final class AutomationServerCore {
     private let authToken: String?
     private let maxRequestSize = 1_048_576 // 1MB
 
-    public init(provider: BrowserAutomationProvider, port: Int?) throws {
+    public init(
+        provider: BrowserAutomationProvider,
+        port: Int?,
+        authToken: String? = ProcessInfo.processInfo.environment["AUTOMATION_TOKEN"]
+    ) throws {
         let port = port ?? 8788
         self.provider = provider
-        self.authToken = ProcessInfo.processInfo.environment["AUTOMATION_TOKEN"]
+        self.authToken = authToken.flatMap { $0.isEmpty ? nil : $0 }
 
         // Validate port is in valid range before UInt16 conversion
         guard port.isValidPort else {
@@ -301,18 +305,6 @@ public final class AutomationServerCore {
             Logger.automationServer.debug("First line: \(firstLine)")
         }
 
-        // Validate authentication token if configured
-        if let expectedToken = authToken {
-            let headers = extractHeaders(from: stringContent)
-            let authHeader = headers["authorization"] ?? ""
-            let expectedValue = "Bearer \(expectedToken)"
-
-            guard authHeader == expectedValue else {
-                Logger.automationServer.error("Unauthorized request - invalid or missing auth token")
-                return ("unauthorized", .failure(.unauthorized))
-            }
-        }
-
         guard let (method, pathString) = extractMethodAndPath(from: stringContent) else {
             return ("unknown", .failure(.unknownMethod))
         }
@@ -322,6 +314,21 @@ public final class AutomationServerCore {
             Logger.automationServer.error("Invalid URL: \(pathString)")
             return ("unknown", .failure(.invalidURL))
         }
+
+        if let expectedToken = authToken {
+            let headers = extractHeaders(from: stringContent)
+            let authHeader = headers["authorization"] ?? ""
+            let expectedValue = "Bearer \(expectedToken)"
+
+            guard authHeader == expectedValue else {
+                Logger.automationServer.error("Unauthorized request - invalid or missing auth token")
+                return ("unauthorized", .failure(.unauthorized))
+            }
+        } else if url.path == "/clearWebsiteData" {
+            Logger.automationServer.error("Unauthorized website data clearing request - automation token is not configured")
+            return ("unauthorized", .failure(.unauthorized))
+        }
+
         return (url.path, await handlePath(url, method: method))
     }
 
@@ -426,6 +433,9 @@ public final class AutomationServerCore {
         case "/contentBlockerReady":
             guard method == "GET" else { return .failure(.methodNotAllowed) }
             return contentBlockerReady()
+        case "/clearWebsiteData":
+            guard method == "POST" else { return .failure(.methodNotAllowed) }
+            return await clearWebsiteData()
         default:
             return .failure(.unknownMethod)
         }
@@ -572,6 +582,13 @@ public final class AutomationServerCore {
         let isReady = provider.isContentBlockerReady
         Logger.automationServer.debug("Content blocker ready: \(isReady)")
         return .success(isReady ? "true" : "false")
+    }
+
+    public func clearWebsiteData() async -> ConnectionResult {
+        guard await provider.clearWebsiteData() else {
+            return .failure(.websiteDataClearingFailed)
+        }
+        return .success("done")
     }
 
     public func executeScript(_ script: String, args: [String: Any]) async -> ConnectionResult {

--- a/SharedPackages/AutomationServer/Sources/AutomationServer/AutomationServerError.swift
+++ b/SharedPackages/AutomationServer/Sources/AutomationServer/AutomationServerError.swift
@@ -32,4 +32,5 @@ public enum AutomationServerError: Error {
     case unauthorized
     case requestTooLarge
     case invalidPort
+    case websiteDataClearingFailed
 }

--- a/SharedPackages/AutomationServer/Sources/AutomationServer/BrowserAutomationProvider.swift
+++ b/SharedPackages/AutomationServer/Sources/AutomationServer/BrowserAutomationProvider.swift
@@ -68,3 +68,9 @@ public protocol BrowserAutomationProvider: AnyObject {
     /// - Returns: PNG image data, or nil if screenshot failed
     func takeScreenshot(rect: CGRect?) async -> Data?
 }
+
+public extension BrowserAutomationProvider {
+    func clearWebsiteData() async -> Bool {
+        false
+    }
+}

--- a/SharedPackages/AutomationServer/Sources/AutomationServer/BrowserAutomationProvider.swift
+++ b/SharedPackages/AutomationServer/Sources/AutomationServer/BrowserAutomationProvider.swift
@@ -60,6 +60,9 @@ public protocol BrowserAutomationProvider: AnyObject {
     /// Execute a script in the current tab's webview
     func executeScript(_ script: String, args: [String: Any]) async -> Result<Any?, Error>
 
+    /// Clear all website data from the store used by the current web view.
+    func clearWebsiteData() async -> Bool
+
     /// Take a screenshot of the current webview
     /// - Parameter rect: Optional rect to crop the screenshot (for element screenshots)
     /// - Returns: PNG image data, or nil if screenshot failed

--- a/SharedPackages/AutomationServer/Tests/AutomationServerTests/MockBrowserAutomationProvider.swift
+++ b/SharedPackages/AutomationServer/Tests/AutomationServerTests/MockBrowserAutomationProvider.swift
@@ -41,6 +41,7 @@ final class MockBrowserAutomationProvider: BrowserAutomationProvider {
     var switchToTabCalled: String?
     var newTabCalled = false
     var executeScriptCalled: (script: String, args: [String: Any])?
+    var clearWebsiteDataCalled = false
 
     // MARK: - Configurable Responses
 
@@ -48,6 +49,7 @@ final class MockBrowserAutomationProvider: BrowserAutomationProvider {
     var switchToTabResult: Bool = true
     var newTabResult: String? = "mock-new-tab"
     var executeScriptResult: Result<Any?, Error> = .success(nil)
+    var clearWebsiteDataResult = true
     var screenshotResult: Data?
 
     // MARK: - BrowserAutomationProvider
@@ -80,6 +82,11 @@ final class MockBrowserAutomationProvider: BrowserAutomationProvider {
         return executeScriptResult
     }
 
+    func clearWebsiteData() async -> Bool {
+        clearWebsiteDataCalled = true
+        return clearWebsiteDataResult
+    }
+
     func takeScreenshot(rect: CGRect?) async -> Data? {
         return screenshotResult
     }
@@ -92,5 +99,6 @@ final class MockBrowserAutomationProvider: BrowserAutomationProvider {
         switchToTabCalled = nil
         newTabCalled = false
         executeScriptCalled = nil
+        clearWebsiteDataCalled = false
     }
 }

--- a/SharedPackages/AutomationServer/Tests/AutomationServerTests/RouteHandlerTests.swift
+++ b/SharedPackages/AutomationServer/Tests/AutomationServerTests/RouteHandlerTests.swift
@@ -27,7 +27,7 @@ final class RouteHandlerTests: XCTestCase {
 
     override func setUp() async throws {
         mockProvider = MockBrowserAutomationProvider()
-        server = try AutomationServerCore(provider: mockProvider, port: 59998)
+        server = try AutomationServerCore(provider: mockProvider, port: 59998, authToken: nil)
     }
 
     override func tearDown() async throws {
@@ -320,5 +320,168 @@ final class RouteHandlerTests: XCTestCase {
         } else {
             XCTFail("Expected success")
         }
+    }
+
+    // MARK: - /clearWebsiteData Tests
+
+    func testClearWebsiteData_CallsProvider() async {
+        let url = URLComponents(string: "/clearWebsiteData")!
+
+        let result = await server.handlePath(url, method: "POST")
+
+        XCTAssertTrue(mockProvider.clearWebsiteDataCalled)
+        if case .success(let message) = result {
+            XCTAssertEqual(message, "done")
+        } else {
+            XCTFail("Expected success")
+        }
+    }
+
+    func testClearWebsiteData_ReturnsErrorWhenProviderFails() async {
+        mockProvider.clearWebsiteDataResult = false
+        let url = URLComponents(string: "/clearWebsiteData")!
+
+        let result = await server.handlePath(url, method: "POST")
+
+        if case .failure(let error) = result {
+            XCTAssertEqual(error, .websiteDataClearingFailed)
+        } else {
+            XCTFail("Expected failure")
+        }
+    }
+
+    func testClearWebsiteData_RejectsGet() async {
+        let url = URLComponents(string: "/clearWebsiteData")!
+
+        let result = await server.handlePath(url, method: "GET")
+
+        XCTAssertFalse(mockProvider.clearWebsiteDataCalled)
+        if case .failure(let error) = result {
+            XCTAssertEqual(error, .methodNotAllowed)
+        } else {
+            XCTFail("Expected failure")
+        }
+    }
+
+    func testClearWebsiteData_RejectsRequestWhenTokenIsAbsent() async {
+        let result = await server.handleConnection(request(path: "/clearWebsiteData", method: "POST"))
+
+        XCTAssertEqual(result.0, "unauthorized")
+        assertUnauthorized(result.1)
+        XCTAssertFalse(mockProvider.clearWebsiteDataCalled)
+    }
+
+    func testClearWebsiteData_RejectsRequestWhenTokenIsEmpty() async throws {
+        let serverWithEmptyToken = try AutomationServerCore(provider: mockProvider, port: 59997, authToken: "")
+        defer { serverWithEmptyToken.listener.cancel() }
+
+        let result = await serverWithEmptyToken.handleConnection(request(path: "/clearWebsiteData", method: "POST"))
+
+        XCTAssertEqual(result.0, "unauthorized")
+        assertUnauthorized(result.1)
+        XCTAssertFalse(mockProvider.clearWebsiteDataCalled)
+    }
+
+    func testClearWebsiteData_RejectsRequestWithIncorrectToken() async throws {
+        let authenticatedServer = try AutomationServerCore(provider: mockProvider, port: 59997, authToken: "expected-token")
+        defer { authenticatedServer.listener.cancel() }
+
+        let result = await authenticatedServer.handleConnection(
+            request(path: "/clearWebsiteData", method: "POST", token: "incorrect-token")
+        )
+
+        XCTAssertEqual(result.0, "unauthorized")
+        assertUnauthorized(result.1)
+        XCTAssertFalse(mockProvider.clearWebsiteDataCalled)
+    }
+
+    func testClearWebsiteData_AllowsRequestWithCorrectToken() async throws {
+        let authenticatedServer = try AutomationServerCore(provider: mockProvider, port: 59997, authToken: "expected-token")
+        defer { authenticatedServer.listener.cancel() }
+
+        let result = await authenticatedServer.handleConnection(
+            request(path: "/clearWebsiteData", method: "POST", token: "expected-token")
+        )
+
+        XCTAssertEqual(result.0, "/clearWebsiteData")
+        assertSuccess(result.1, expectedMessage: "done")
+        XCTAssertTrue(mockProvider.clearWebsiteDataCalled)
+    }
+
+    func testLegacyRoute_AllowsRequestWhenTokenIsAbsent() async {
+        mockProvider.currentURL = URL(string: "https://duckduckgo.com")
+
+        let result = await server.handleConnection(request(path: "/getUrl"))
+
+        XCTAssertEqual(result.0, "/getUrl")
+        assertSuccess(result.1, expectedMessage: "https://duckduckgo.com")
+    }
+
+    func testLegacyRoute_AllowsRequestWhenTokenIsEmpty() async throws {
+        let serverWithEmptyToken = try AutomationServerCore(provider: mockProvider, port: 59997, authToken: "")
+        defer { serverWithEmptyToken.listener.cancel() }
+        mockProvider.currentURL = URL(string: "https://duckduckgo.com")
+
+        let result = await serverWithEmptyToken.handleConnection(request(path: "/getUrl"))
+
+        XCTAssertEqual(result.0, "/getUrl")
+        assertSuccess(result.1, expectedMessage: "https://duckduckgo.com")
+    }
+
+    func testLegacyRoute_RejectsIncorrectTokenWhenTokenIsConfigured() async throws {
+        let authenticatedServer = try AutomationServerCore(provider: mockProvider, port: 59997, authToken: "expected-token")
+        defer { authenticatedServer.listener.cancel() }
+
+        let result = await authenticatedServer.handleConnection(
+            request(path: "/getUrl", token: "incorrect-token")
+        )
+
+        XCTAssertEqual(result.0, "unauthorized")
+        assertUnauthorized(result.1)
+    }
+
+    func testLegacyRoute_AllowsCorrectTokenWhenTokenIsConfigured() async throws {
+        let authenticatedServer = try AutomationServerCore(provider: mockProvider, port: 59997, authToken: "expected-token")
+        defer { authenticatedServer.listener.cancel() }
+        mockProvider.currentURL = URL(string: "https://duckduckgo.com")
+
+        let result = await authenticatedServer.handleConnection(
+            request(path: "/getUrl", token: "expected-token")
+        )
+
+        XCTAssertEqual(result.0, "/getUrl")
+        assertSuccess(result.1, expectedMessage: "https://duckduckgo.com")
+    }
+
+    private func request(path: String, method: String = "GET", token: String? = nil) -> Data {
+        var lines = [
+            "\(method) \(path) HTTP/1.1",
+            "Host: 127.0.0.1",
+        ]
+        if let token {
+            lines.append("Authorization: Bearer \(token)")
+        }
+        return (lines.joined(separator: "\r\n") + "\r\n\r\n").data(using: .utf8)!
+    }
+
+    private func assertUnauthorized(_ result: ConnectionResult, file: StaticString = #filePath, line: UInt = #line) {
+        guard case .failure(let error) = result else {
+            XCTFail("Expected unauthorized failure", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(error, .unauthorized, file: file, line: line)
+    }
+
+    private func assertSuccess(
+        _ result: ConnectionResult,
+        expectedMessage: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard case .success(let message) = result else {
+            XCTFail("Expected success", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(message, expectedMessage, file: file, line: line)
     }
 }

--- a/iOS/DuckDuckGo/Automation/AutomationServer.swift
+++ b/iOS/DuckDuckGo/Automation/AutomationServer.swift
@@ -97,6 +97,17 @@ final class IOSAutomationProvider: BrowserAutomationProvider {
         return result.mapError { $0 as Error }
     }
 
+    func clearWebsiteData() async -> Bool {
+        guard let dataStore = currentWebView?.configuration.websiteDataStore else {
+            return false
+        }
+        await dataStore.removeData(
+            ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
+            modifiedSince: .distantPast
+        )
+        return true
+    }
+
     func takeScreenshot(rect: CGRect?) async -> Data? {
         guard let webView = currentWebView else { return nil }
 

--- a/iOS/DuckDuckGo/Automation/AutomationServer.swift
+++ b/iOS/DuckDuckGo/Automation/AutomationServer.swift
@@ -97,17 +97,6 @@ final class IOSAutomationProvider: BrowserAutomationProvider {
         return result.mapError { $0 as Error }
     }
 
-    func clearWebsiteData() async -> Bool {
-        guard let dataStore = currentWebView?.configuration.websiteDataStore else {
-            return false
-        }
-        await dataStore.removeData(
-            ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
-            modifiedSince: .distantPast
-        )
-        return true
-    }
-
     func takeScreenshot(rect: CGRect?) async -> Data? {
         guard let webView = currentWebView else { return nil }
 

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -2934,6 +2934,8 @@
 		9FFBEE702DDEDB3C0058B11A /* MockDefaultBrowserAndDockPromptCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFBEE6E2DDEDB2D0058B11A /* MockDefaultBrowserAndDockPromptCoordinator.swift */; };
 		9FFBEE732DDEDC650058B11A /* ApplicationBuildTypeMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFBEE722DDEDC600058B11A /* ApplicationBuildTypeMock.swift */; };
 		9FFBEE742DDEDC650058B11A /* ApplicationBuildTypeMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFBEE722DDEDC600058B11A /* ApplicationBuildTypeMock.swift */; };
+		DDAC10022F90000100000002 /* LaunchOptionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAC10012F90000100000001 /* LaunchOptionsHandlerTests.swift */; };
+		DDAC10032F90000100000003 /* LaunchOptionsHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAC10012F90000100000001 /* LaunchOptionsHandlerTests.swift */; };
 		9FFBEE762DDEDE870058B11A /* DefaultBrowserAndDockPromptStoreMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFBEE752DDEDE770058B11A /* DefaultBrowserAndDockPromptStoreMigrator.swift */; };
 		9FFBEE772DDEDE870058B11A /* DefaultBrowserAndDockPromptStoreMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFBEE752DDEDE770058B11A /* DefaultBrowserAndDockPromptStoreMigrator.swift */; };
 		9FFBEE7A2DDEE1E80058B11A /* DefaultBrowserAndDockStoreMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFBEE792DDEE1E40058B11A /* DefaultBrowserAndDockStoreMigratorTests.swift */; };
@@ -6174,6 +6176,7 @@
 		9FFBEE6B2DDEAF7E0058B11A /* MockDefaultBrowserAndDockPromptTypeDecider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDefaultBrowserAndDockPromptTypeDecider.swift; sourceTree = "<group>"; };
 		9FFBEE6E2DDEDB2D0058B11A /* MockDefaultBrowserAndDockPromptCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDefaultBrowserAndDockPromptCoordinator.swift; sourceTree = "<group>"; };
 		9FFBEE722DDEDC600058B11A /* ApplicationBuildTypeMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBuildTypeMock.swift; sourceTree = "<group>"; };
+		DDAC10012F90000100000001 /* LaunchOptionsHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchOptionsHandlerTests.swift; sourceTree = "<group>"; };
 		9FFBEE752DDEDE770058B11A /* DefaultBrowserAndDockPromptStoreMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserAndDockPromptStoreMigrator.swift; sourceTree = "<group>"; };
 		9FFBEE792DDEE1E40058B11A /* DefaultBrowserAndDockStoreMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserAndDockStoreMigratorTests.swift; sourceTree = "<group>"; };
 		9FFBEE7C2DDF02CE0058B11A /* DefaultBrowserAndDockPromptStatusUpdateNotifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserAndDockPromptStatusUpdateNotifier.swift; sourceTree = "<group>"; };
@@ -10686,6 +10689,7 @@
 			children = (
 				BBB819192EC493DD0064977E /* MockBlackFridayCampaignProvider.swift */,
 				9FFBEE722DDEDC600058B11A /* ApplicationBuildTypeMock.swift */,
+				DDAC10012F90000100000001 /* LaunchOptionsHandlerTests.swift */,
 				CC34456E2E674E7700019518 /* UserScriptErrorTests.swift */,
 				BBE9A9AA2E9D1DED00E573AA /* MockWinBackOfferVisibilityManager.swift */,
 			);
@@ -16754,6 +16758,7 @@
 				1DA6D1032A1FFA3B00540406 /* HTTPCookieTests.swift in Sources */,
 				31A2FD182BAB43BA00D0E741 /* DataBrokerProtectionFeatureGatekeeperTests.swift in Sources */,
 				9FFBEE732DDEDC650058B11A /* ApplicationBuildTypeMock.swift in Sources */,
+				DDAC10022F90000100000002 /* LaunchOptionsHandlerTests.swift in Sources */,
 				B6619F072B17138D00CD9186 /* DataImportSourceViewModelTests.swift in Sources */,
 				3706FE46293F661700E42796 /* EncryptedValueTransformerTests.swift in Sources */,
 				9F3910632B68C35600CB5112 /* DownloadsTabExtensionTests.swift in Sources */,
@@ -19208,6 +19213,7 @@
 				9FFBEE6D2DDEAF820058B11A /* MockDefaultBrowserAndDockPromptTypeDecider.swift in Sources */,
 				4BB99D1026FE1A84001E4761 /* FirefoxBookmarksReaderTests.swift in Sources */,
 				9FFBEE742DDEDC650058B11A /* ApplicationBuildTypeMock.swift in Sources */,
+				DDAC10032F90000100000003 /* LaunchOptionsHandlerTests.swift in Sources */,
 				9FBD84702BB3DD8400220859 /* MockAttributionsPixelHandler.swift in Sources */,
 				37657FC52DB8D564003D749E /* TabCrashRecoveryExtensionTests.swift in Sources */,
 				DBDE0003000000000000BDE0 /* NavigationPixelNavigationResponderTests.swift in Sources */,

--- a/macOS/DuckDuckGo/Automation/AutomationServer.swift
+++ b/macOS/DuckDuckGo/Automation/AutomationServer.swift
@@ -164,6 +164,17 @@ final class MacOSAutomationProvider: BrowserAutomationProvider {
         }
     }
 
+    func clearWebsiteData() async -> Bool {
+        guard let dataStore = currentWebView?.configuration.websiteDataStore else {
+            return false
+        }
+        await dataStore.removeData(
+            ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(),
+            modifiedSince: .distantPast
+        )
+        return true
+    }
+
     func takeScreenshot(rect: CGRect?) async -> Data? {
         guard let webView = currentWebView else { return nil }
 

--- a/macOS/DuckDuckGo/Automation/LaunchOptionsHandler.swift
+++ b/macOS/DuckDuckGo/Automation/LaunchOptionsHandler.swift
@@ -106,7 +106,7 @@ public final class LaunchOptionsHandler {
         }
 
         // If developer override via Scheme Environment variable temporarily it means we want to show the onboarding.
-        if let developerOnboardingOverride = ProcessInfo.processInfo.environment["ONBOARDING"] {
+        if let developerOnboardingOverride = environment["ONBOARDING"] {
             return .overridden(.developer(completed: developerOnboardingOverride == "false"))
         }
 

--- a/macOS/DuckDuckGo/Automation/LaunchOptionsHandler.swift
+++ b/macOS/DuckDuckGo/Automation/LaunchOptionsHandler.swift
@@ -25,12 +25,28 @@ public final class LaunchOptionsHandler {
     public static let isOnboardingCompleted = "isOnboardingCompleted"
     private static let automationPortKey = "automationPort"
     private static let isInternalUserKey = "isInternalUser"
+    private static let webViewProxyKey = "webViewProxy"
+    private static let acceptInsecureCertsKey = "acceptInsecureCerts"
     private let userDefaults: UserDefaults
+    private let applicationBuildType: ApplicationBuildType
+    private let environment: [String: String]
 
     public init(
         userDefaults: UserDefaults = .standard
     ) {
         self.userDefaults = userDefaults
+        self.applicationBuildType = StandardApplicationBuildType()
+        self.environment = ProcessInfo.processInfo.environment
+    }
+
+    init(
+        userDefaults: UserDefaults,
+        applicationBuildType: ApplicationBuildType,
+        environment: [String: String]
+    ) {
+        self.userDefaults = userDefaults
+        self.applicationBuildType = applicationBuildType
+        self.environment = environment
     }
 
     public var isInternalUserRequested: Bool {
@@ -53,21 +69,34 @@ public final class LaunchOptionsHandler {
 
     /// Returns true only when WebDriver automation is active.
     public var isWebDriverAutomationSession: Bool {
-        let buildType = StandardApplicationBuildType()
-        guard buildType.isDebugBuild || buildType.isReviewBuild else { return false }
+        guard isDebugOrReviewBuild else { return false }
         return AutomationSession.isWebDriverActive(automationPort: automationPort)
+    }
+
+    var webViewProxy: WebViewProxy? {
+        guard isAuthenticatedWebDriverAutomationSession,
+              let value = argumentDomain[Self.webViewProxyKey] as? String else {
+            return nil
+        }
+        return WebViewProxy(value)
+    }
+
+    var acceptsInsecureCertificates: Bool {
+        guard isAuthenticatedWebDriverAutomationSession,
+              webViewProxy != nil else {
+            return false
+        }
+        return argumentBoolean(forKey: Self.acceptInsecureCertsKey)
     }
 
     /// Returns true if the app is running in any automation mode (WebDriver or UI Tests)
     public var isAutomationSession: Bool {
-        let buildType = StandardApplicationBuildType()
-        guard buildType.isDebugBuild || buildType.isReviewBuild else { return isUITesting }
+        guard isDebugOrReviewBuild else { return isUITesting }
         return isWebDriverAutomationSession || isUITesting
     }
 
     public var onboardingStatus: OnboardingStatus {
-        let buildType = StandardApplicationBuildType()
-        guard buildType.isDebugBuild || buildType.isReviewBuild else { return .notOverridden }
+        guard isDebugOrReviewBuild else { return .notOverridden }
 
         // Override onboarding settings permanently to keep state consistency across app launches.
         // This applies to both UI Tests and WebDriver automation sessions.
@@ -82,6 +111,61 @@ public final class LaunchOptionsHandler {
         }
 
         return .notOverridden
+    }
+
+    private var isDebugOrReviewBuild: Bool {
+        applicationBuildType.isDebugBuild || applicationBuildType.isReviewBuild
+    }
+
+    private var isAuthenticatedWebDriverAutomationSession: Bool {
+        guard isWebDriverAutomationSession else { return false }
+        return environment["AUTOMATION_TOKEN"]?.isEmpty == false
+    }
+
+    private var argumentDomain: [String: Any] {
+        userDefaults.volatileDomain(forName: UserDefaults.argumentDomain)
+    }
+
+    private func argumentBoolean(forKey key: String) -> Bool {
+        switch argumentDomain[key] {
+        case let value as Bool:
+            return value
+        case let value as String:
+            return ["1", "true", "yes"].contains(value.lowercased())
+        default:
+            return false
+        }
+    }
+}
+
+struct WebViewProxy: Equatable {
+    let host: String
+    let port: UInt16
+
+    init?(_ value: String) {
+        guard let components = URLComponents(string: value),
+              components.scheme == "socks5",
+              components.user == nil,
+              components.password == nil,
+              components.path.isEmpty,
+              components.query == nil,
+              components.fragment == nil,
+              let host = components.host.map(Self.normalizedHost),
+              ["127.0.0.1", "::1"].contains(host),
+              let portValue = components.port,
+              let port = UInt16(exactly: portValue),
+              port > 0 else {
+            return nil
+        }
+        self.host = host
+        self.port = port
+    }
+
+    private static func normalizedHost(_ host: String) -> String {
+        guard host.hasPrefix("["), host.hasSuffix("]") else {
+            return host
+        }
+        return String(host.dropFirst().dropLast())
     }
 }
 

--- a/macOS/DuckDuckGo/Common/Extensions/WKWebViewConfigurationExtensions.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/WKWebViewConfigurationExtensions.swift
@@ -20,6 +20,7 @@ import BrowserServicesKit
 import Combine
 import Common
 import FoundationExtensions
+import Network
 import WebKit
 import UserScript
 
@@ -41,6 +42,8 @@ extension WKWebViewConfiguration {
             // set shared object if not set yet
             Self.sharedVisitedLinkStore = self.visitedLinkStore
         }
+
+        applyWebViewProxyIfNeeded()
 
         allowsAirPlayForMediaPlayback = true
         preferences.isElementFullscreenEnabled = true
@@ -74,6 +77,21 @@ extension WKWebViewConfiguration {
         self.processPool.geolocationProvider = GeolocationProvider(processPool: self.processPool)
     }
 
+    @MainActor
+    private func applyWebViewProxyIfNeeded() {
+        guard #available(macOS 14.0, *),
+              let proxy = LaunchOptionsHandler().webViewProxy,
+              let port = NWEndpoint.Port(rawValue: proxy.port) else {
+            return
+        }
+        let endpoint = NWEndpoint.hostPort(
+            host: NWEndpoint.Host(proxy.host),
+            port: port
+        )
+        websiteDataStore.proxyConfigurations = [
+            ProxyConfiguration(socksv5Proxy: endpoint)
+        ]
+    }
 }
 
 extension WKPreferences {

--- a/macOS/DuckDuckGo/Tab/TabExtensions/SpecialErrorPageTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/SpecialErrorPageTabExtension.swift
@@ -42,6 +42,7 @@ final class SpecialErrorPageTabExtension {
     private let featureFlagger: FeatureFlagger
     private let detector: MaliciousSiteDetecting
     private let tld = TLD()
+    private let acceptsInsecureCertificates: Bool
 
     @MainActor private weak var webView: ErrorPageTabExtensionNavigationDelegate?
     @MainActor private weak var specialErrorPageUserScript: SpecialErrorPageUserScript?
@@ -59,12 +60,14 @@ final class SpecialErrorPageTabExtension {
          closeTab: @escaping () -> Void,
          urlCredentialCreator: URLCredentialCreating = URLCredentialCreator(),
          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
-         maliciousSiteDetector: some MaliciousSiteDetecting) {
+         maliciousSiteDetector: some MaliciousSiteDetecting,
+         acceptsInsecureCertificates: Bool = false) {
 
         self.featureFlagger = featureFlagger
         self.urlCredentialCreator = urlCredentialCreator
         self.detector = maliciousSiteDetector
         self.closeTab = closeTab
+        self.acceptsInsecureCertificates = acceptsInsecureCertificates
 
         webViewPublisher.sink { [weak self] webView in
             MainActor.assumeMainThread {
@@ -197,6 +200,10 @@ extension SpecialErrorPageTabExtension: NavigationResponder {
     @MainActor
     func didReceive(_ challenge: URLAuthenticationChallenge, for navigation: Navigation?) async -> AuthChallengeDisposition? {
         guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust else { return nil }
+        if acceptsInsecureCertificates {
+            guard let credential = urlCredentialCreator.urlCredentialFrom(trust: challenge.protectionSpace.serverTrust) else { return nil }
+            return .credential(credential)
+        }
         guard shouldBypassSSLError else { return nil }
         guard navigation?.url == webView?.url else { return nil }
         guard let credential = urlCredentialCreator.urlCredentialFrom(trust: challenge.protectionSpace.serverTrust) else { return nil }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabExtensions.swift
@@ -159,7 +159,8 @@ extension TabExtensionsBuilder {
             SpecialErrorPageTabExtension(webViewPublisher: args.webViewFuture,
                                          scriptsPublisher: userScripts.compactMap { $0 },
                                          closeTab: args.closeTab,
-                                         maliciousSiteDetector: dependencies.maliciousSiteDetector)
+                                         maliciousSiteDetector: dependencies.maliciousSiteDetector,
+                                         acceptsInsecureCertificates: LaunchOptionsHandler().acceptsInsecureCertificates)
         }
 
         add {

--- a/macOS/UnitTests/Common/Utilities/LaunchOptionsHandlerTests.swift
+++ b/macOS/UnitTests/Common/Utilities/LaunchOptionsHandlerTests.swift
@@ -7,7 +7,7 @@
 //  you may not use this file except in compliance with the License.
 //  You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
 //  Unless required by applicable law or agreed to in writing, software
 //  distributed under the License is distributed on an "AS IS" BASIS,

--- a/macOS/UnitTests/Common/Utilities/LaunchOptionsHandlerTests.swift
+++ b/macOS/UnitTests/Common/Utilities/LaunchOptionsHandlerTests.swift
@@ -1,0 +1,162 @@
+//
+//  LaunchOptionsHandlerTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+@testable import DuckDuckGo_Privacy_Browser
+
+final class LaunchOptionsHandlerTests: XCTestCase {
+
+    private var userDefaults: UserDefaults!
+    private var buildType: ApplicationBuildTypeMock!
+    private var userDefaultsSuiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        userDefaultsSuiteName = "LaunchOptionsHandlerTests-\(UUID().uuidString)"
+        userDefaults = UserDefaults(suiteName: userDefaultsSuiteName)
+        buildType = ApplicationBuildTypeMock()
+    }
+
+    override func tearDown() {
+        userDefaults.setVolatileDomain([:], forName: UserDefaults.argumentDomain)
+        userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
+        userDefaultsSuiteName = nil
+        buildType = nil
+        userDefaults = nil
+        super.tearDown()
+    }
+
+    func testWebDriverAutomationSessionIsEnabledForDebugBuildWithValidPort() {
+        buildType.isDebugBuild = true
+
+        let handler = makeHandler(arguments: ["automationPort": 8788])
+
+        XCTAssertTrue(handler.isWebDriverAutomationSession)
+    }
+
+    func testWebDriverAutomationSessionIsEnabledForReviewBuildWithValidPort() {
+        buildType.isReviewBuild = true
+
+        let handler = makeHandler(arguments: ["automationPort": 8788])
+
+        XCTAssertTrue(handler.isWebDriverAutomationSession)
+    }
+
+    func testWebDriverAutomationSessionIsDisabledForProductionBuild() {
+        let handler = makeHandler(arguments: ["automationPort": 8788])
+
+        XCTAssertFalse(handler.isWebDriverAutomationSession)
+    }
+
+    func testWebDriverAutomationSessionIsDisabledWithoutValidPort() {
+        buildType.isReviewBuild = true
+
+        XCTAssertFalse(makeHandler(arguments: [:]).isWebDriverAutomationSession)
+        XCTAssertFalse(makeHandler(arguments: ["automationPort": 0]).isWebDriverAutomationSession)
+        XCTAssertFalse(makeHandler(arguments: ["automationPort": 65_536]).isWebDriverAutomationSession)
+    }
+
+    func testWebViewProxyAcceptsOnlyLoopbackSOCKS5EndpointsWithValidPorts() {
+        let ipv4Proxy = WebViewProxy("socks5://127.0.0.1:1")
+        XCTAssertEqual(ipv4Proxy?.host, "127.0.0.1")
+        XCTAssertEqual(ipv4Proxy?.port, 1)
+
+        let ipv6Proxy = WebViewProxy("socks5://[::1]:65535")
+        XCTAssertEqual(ipv6Proxy?.host, "::1")
+        XCTAssertEqual(ipv6Proxy?.port, 65_535)
+
+        XCTAssertNil(WebViewProxy("http://127.0.0.1:9997"))
+        XCTAssertNil(WebViewProxy("socks5://localhost:9997"))
+        XCTAssertNil(WebViewProxy("socks5://192.168.1.10:9997"))
+        XCTAssertNil(WebViewProxy("socks5://127.0.0.1"))
+        XCTAssertNil(WebViewProxy("socks5://127.0.0.1:0"))
+        XCTAssertNil(WebViewProxy("socks5://127.0.0.1:65536"))
+        XCTAssertNil(WebViewProxy("socks5://user@127.0.0.1:9997"))
+        XCTAssertNil(WebViewProxy("socks5://127.0.0.1:9997/path"))
+    }
+
+    func testWebViewProxyRequiresAuthenticatedDebugOrReviewAutomationSession() {
+        let arguments: [String: Any] = [
+            "automationPort": 8788,
+            "webViewProxy": "socks5://127.0.0.1:9997",
+        ]
+
+        XCTAssertNil(makeHandler(arguments: arguments, environment: [:]).webViewProxy)
+        XCTAssertNil(makeHandler(arguments: arguments, environment: ["AUTOMATION_TOKEN": ""]).webViewProxy)
+        XCTAssertNil(makeHandler(arguments: arguments, environment: ["AUTOMATION_TOKEN": "token"]).webViewProxy)
+
+        buildType.isDebugBuild = true
+        let proxy = makeHandler(arguments: arguments, environment: ["AUTOMATION_TOKEN": "token"]).webViewProxy
+        XCTAssertEqual(proxy?.host, "127.0.0.1")
+        XCTAssertEqual(proxy?.port, 9_997)
+    }
+
+    func testAcceptInsecureCertificatesRequiresAuthenticatedSessionAndProxy() {
+        buildType.isReviewBuild = true
+        let completeArguments: [String: Any] = [
+            "automationPort": 8788,
+            "webViewProxy": "socks5://127.0.0.1:9997",
+            "acceptInsecureCerts": true,
+        ]
+
+        XCTAssertTrue(makeHandler(arguments: completeArguments, environment: ["AUTOMATION_TOKEN": "token"]).acceptsInsecureCertificates)
+        XCTAssertFalse(makeHandler(arguments: completeArguments, environment: [:]).acceptsInsecureCertificates)
+        XCTAssertFalse(
+            makeHandler(
+                arguments: ["automationPort": 8788, "acceptInsecureCerts": true],
+                environment: ["AUTOMATION_TOKEN": "token"]
+            ).acceptsInsecureCertificates
+        )
+        XCTAssertFalse(
+            makeHandler(
+                arguments: [
+                    "webViewProxy": "socks5://127.0.0.1:9997",
+                    "acceptInsecureCerts": true,
+                ],
+                environment: ["AUTOMATION_TOKEN": "token"]
+            ).acceptsInsecureCertificates
+        )
+    }
+
+    func testAcceptInsecureCertificatesReadsStringLaunchArgument() {
+        buildType.isReviewBuild = true
+        let handler = makeHandler(
+            arguments: [
+                "automationPort": 8788,
+                "webViewProxy": "socks5://127.0.0.1:9997",
+                "acceptInsecureCerts": "true",
+            ],
+            environment: ["AUTOMATION_TOKEN": "token"]
+        )
+
+        XCTAssertTrue(handler.acceptsInsecureCertificates)
+    }
+
+    private func makeHandler(
+        arguments: [String: Any],
+        environment: [String: String] = [:]
+    ) -> LaunchOptionsHandler {
+        userDefaults.setVolatileDomain(arguments, forName: UserDefaults.argumentDomain)
+        return LaunchOptionsHandler(
+            userDefaults: userDefaults,
+            applicationBuildType: buildType,
+            environment: environment
+        )
+    }
+}

--- a/macOS/UnitTests/TabExtensionsTests/ErrorPageTabExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/ErrorPageTabExtensionTests.swift
@@ -55,7 +55,7 @@ final class ErrorPageTabExtensionTests: XCTestCase {
         let featureFlagger = MockFeatureFlagger()
         credentialCreator = MockCredentialCreator()
         detector = MockMaliciousSiteDetector { _ in .phishing }
-        errorPageExtention = SpecialErrorPageTabExtension(webViewPublisher: mockWebViewPublisher, scriptsPublisher: scriptPublisher, closeTab: self.closeTab, urlCredentialCreator: credentialCreator, featureFlagger: featureFlagger, maliciousSiteDetector: detector)
+        errorPageExtention = makeErrorPageExtension(featureFlagger: featureFlagger)
     }
 
     override func tearDownWithError() throws {
@@ -68,6 +68,21 @@ final class ErrorPageTabExtensionTests: XCTestCase {
 
     private func closeTab() {
         onCloseTab()
+    }
+
+    private func makeErrorPageExtension(
+        featureFlagger: FeatureFlagger = MockFeatureFlagger(),
+        acceptsInsecureCertificates: Bool = false
+    ) -> SpecialErrorPageTabExtension {
+        SpecialErrorPageTabExtension(
+            webViewPublisher: mockWebViewPublisher,
+            scriptsPublisher: scriptPublisher,
+            closeTab: closeTab,
+            urlCredentialCreator: credentialCreator,
+            featureFlagger: featureFlagger,
+            maliciousSiteDetector: detector,
+            acceptsInsecureCertificates: acceptsInsecureCertificates
+        )
     }
 
     @MainActor func testWhenCertificateExpired_ThenTabExtenstionErrorIsExpectedError() {
@@ -357,6 +372,46 @@ final class ErrorPageTabExtensionTests: XCTestCase {
 
         // THEN
         XCTAssertNil(disposition)
+    }
+
+    @MainActor
+    func testWhenInsecureCertificatesAreAccepted_ServerTrustChallengeReturnsCredential() async {
+        errorPageExtention = makeErrorPageExtension(acceptsInsecureCertificates: true)
+        let challenge = serverTrustChallenge()
+
+        let disposition = await errorPageExtention.didReceive(challenge, for: nil)
+
+        guard case .credential(let credential) = disposition else {
+            return XCTFail("Expected a credential")
+        }
+        XCTAssertNotNil(credential)
+    }
+
+    @MainActor
+    func testWhenInsecureCertificatesAreNotAccepted_ServerTrustChallengeReturnsNil() async {
+        let challenge = serverTrustChallenge()
+
+        let disposition = await errorPageExtention.didReceive(challenge, for: nil)
+
+        XCTAssertNil(disposition)
+    }
+
+    private func serverTrustChallenge() -> URLAuthenticationChallenge {
+        let protectionSpace = URLProtectionSpace(
+            host: "",
+            port: 4,
+            protocol: nil,
+            realm: nil,
+            authenticationMethod: NSURLAuthenticationMethodServerTrust
+        )
+        return URLAuthenticationChallenge(
+            protectionSpace: protectionSpace,
+            proposedCredential: nil,
+            previousFailureCount: 0,
+            failureResponse: nil,
+            error: nil,
+            sender: ChallangeSender()
+        )
     }
 
     @MainActor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206580121312550/task/1216945014763359?focus=true

### Description

Adds guarded automation capabilities required to run DuckDuckGo Review builds for LCP measurements.

Replay proxying and certificate handling are restricted to authenticated Debug or Review automation sessions, while website data can be explicitly cleared between measurements.

### Testing Steps

1. Select the `macOS Browser Review` scheme.
2. Add launch arguments `-automationPort 8788 -webViewProxy socks5://127.0.0.1:9997 -acceptInsecureCerts true` and environment variable `AUTOMATION_TOKEN=test`.
3. Add breakpoints in `LaunchOptionsHandler.webViewProxy` and `LaunchOptionsHandler.acceptsInsecureCertificates`, then run the app. Confirm the proxy resolves to `127.0.0.1:9997` and certificate acceptance is `true`.
4. Add a breakpoint in `MacOSAutomationProvider.clearWebsiteData()`, then run `curl -X POST -H 'Authorization: Bearer test' http://localhost:8788/clearWebsiteData`. Confirm the breakpoint is reached.

### Impact

Low. The behavior is available only to local Debug or Review automation sessions.

#### What could go wrong?

Replay settings could affect normal browsing. They only work in authenticated Debug or Review automation sessions using a local proxy.

Someone could try to clear browsing data without permission. The operation only works when the correct authentication token is provided.

### Quality Considerations

The proxy must run on the same machine. Ignoring certificate errors requires an authenticated replay session, and these settings do not work in production builds. Existing automation continues to work as before.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TLS validation and network proxy behavior for automation sessions, and adds a token-gated API that wipes website data; scope is limited to Debug/Review builds with authentication, but mistakes in gating could affect local browsing during automation.
> 
> **Overview**
> Adds **Debug/Review WebDriver automation** hooks for LCP-style replay runs: loopback SOCKS5 proxying, optional TLS bypass, and authenticated clearing of website data between measurements.
> 
> **Launch options** (`LaunchOptionsHandler`): `webViewProxy` and `acceptInsecureCerts` only apply when the build is Debug or Review, WebDriver is active (`automationPort`), and `AUTOMATION_TOKEN` is set. `WebViewProxy` accepts only `socks5://127.0.0.1` or `socks5://[::1]` with a valid port.
> 
> **Web configuration**: standard `WKWebViewConfiguration` can apply a SOCKS5 `ProxyConfiguration` to the website data store when a proxy is configured. **Certificate handling**: `SpecialErrorPageTabExtension` accepts server-trust challenges when `acceptsInsecureCertificates` is enabled (wired from launch options in tab extensions).
> 
> **Automation server**: new `POST /clearWebsiteData` clears the current web view’s website data via the provider; it **requires** a configured auth token (unlike legacy routes when no token is set). `AutomationServerCore` accepts an injectable `authToken` and treats empty tokens as absent.
> 
> Tests cover route auth, provider behavior, launch-option gating, and insecure-cert challenge handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a651c5c8b2a8eaa684883294a7b95c5c19e0dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->