### PR TITLE
macOS: Send tab attachment limit to the Duck.ai sidebar

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
@@ -79,6 +79,25 @@ public struct AIChatNativeHandoffData: Codable {
     }
 }
 
+/// Native-owned attachment caps for the duck.ai web app, keyed by type; an absent entry means no limit.
+public struct AIChatNativeAttachmentLimits: Codable, Equatable {
+    public struct TabLimits: Codable, Equatable {
+        /// Max open tabs attachable to one prompt; omit the entry for "no limit" (0/negative aren't sentinels).
+        public let maxAttached: Int
+
+        public init(maxAttached: Int) {
+            self.maxAttached = maxAttached
+        }
+    }
+
+    /// Cap on tabs attached via the sidebar picker; nil = no tab limit (kill switch off).
+    public let tabs: TabLimits?
+
+    public init(tabs: TabLimits?) {
+        self.tabs = tabs
+    }
+}
+
 public struct AIChatNativeConfigValues: Codable {
     public let isAIChatHandoffEnabled: Bool
     public let platform: String
@@ -119,6 +138,8 @@ public struct AIChatNativeConfigValues: Codable {
     /// Bucketed age of the install (days since the ATB install date):
     /// 0 = same day, 1 = 1–7, 2 = 8–14, 3 = 15–21, 4 = 22–28, 5 = after day 28.
     public let installAge: Int
+    /// Native-owned attachment caps read by the sidebar; nil (omitted) means no caps.
+    public let attachmentLimits: AIChatNativeAttachmentLimits?
 
     public static var defaultValues: AIChatNativeConfigValues {
 #if os(iOS)
@@ -188,7 +209,8 @@ public struct AIChatNativeConfigValues: Codable {
                 supportsNativeVoicePermissionHandler: Bool = false,
                 supportsNativeDictationPermissionHandler: Bool = false,
                 installType: AIChatInstallType = .new,
-                installAge: Int = 0) {
+                installAge: Int = 0,
+                attachmentLimits: AIChatNativeAttachmentLimits? = nil) {
         self.isAIChatHandoffEnabled = isAIChatHandoffEnabled
         self.platform = Platform.name
         self.supportsClosingAIChat = supportsClosingAIChat
@@ -213,6 +235,7 @@ public struct AIChatNativeConfigValues: Codable {
         self.supportsNativeDictationPermissionHandler = supportsNativeDictationPermissionHandler
         self.installType = installType
         self.installAge = installAge
+        self.attachmentLimits = attachmentLimits
     }
 
     /// Buckets the days between the install date and `now` into the values expected by the

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatNativeConfigValuesTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatNativeConfigValuesTests.swift
@@ -88,12 +88,25 @@ final class AIChatNativeConfigValuesTests: XCTestCase {
         XCTAssertEqual(json["supportsSuggestions"] as? Bool, false)
     }
 
+    func testAttachmentLimitsOmittedWhenNil() throws {
+        let json = try jsonObject(makeConfig(supportsSuggestions: false))
+        XCTAssertNil(json["attachmentLimits"])
+    }
+
+    func testAttachmentLimitsEncodeTabsMaxAttached() throws {
+        let config = makeConfig(supportsSuggestions: false, attachmentLimits: .init(tabs: .init(maxAttached: 3)))
+        let json = try jsonObject(config)
+        let limits = try XCTUnwrap(json["attachmentLimits"] as? [String: Any])
+        let tabs = try XCTUnwrap(limits["tabs"] as? [String: Any])
+        XCTAssertEqual(tabs["maxAttached"] as? Int, 3)
+    }
+
     private func jsonObject(_ config: AIChatNativeConfigValues) throws -> [String: Any] {
         let data = try JSONEncoder().encode(config)
         return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 
-    private func makeConfig(supportsSuggestions: Bool) -> AIChatNativeConfigValues {
+    private func makeConfig(supportsSuggestions: Bool, attachmentLimits: AIChatNativeAttachmentLimits? = nil) -> AIChatNativeConfigValues {
         AIChatNativeConfigValues(
             isAIChatHandoffEnabled: false,
             supportsClosingAIChat: true,
@@ -108,7 +121,8 @@ final class AIChatNativeConfigValuesTests: XCTestCase {
             supportsAIChatContextualMode: false,
             appVersion: "1.0.0",
             supportsAIChatSync: false,
-            supportsSuggestions: supportsSuggestions
+            supportsSuggestions: supportsSuggestions,
+            attachmentLimits: attachmentLimits
         )
     }
 

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
@@ -147,7 +147,10 @@ extension AIChatMessageHandler {
             supportsNativeVoicePermissionHandler: featureFlagger.isFeatureOn(.aiChatNativeVoicePermissionFlow),
             supportsNativeDictationPermissionHandler: true,
             installType: installTypeProvider(),
-            installAge: AIChatNativeConfigValues.installAgeBucket(installDate: installDateProvider())
+            installAge: AIChatNativeConfigValues.installAgeBucket(installDate: installDateProvider()),
+            attachmentLimits: featureFlagger.isFeatureOn(.aiChatTabAttachmentLimit)
+                ? AIChatNativeAttachmentLimits(tabs: .init(maxAttached: AIChatOmnibarController.maxTabAttachments))
+                : nil
         )
     }
 

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -824,11 +824,13 @@ struct AIChatUserScriptHandlerTests {
 
     private func makeFeatureFlagger(aiChatSyncEnabled: Bool = false,
                                     aiChatNativeStorageEnabled: Bool = false,
-                                    aiChatNativeVoicePermissionFlowEnabled: Bool = false) -> MockFeatureFlagger {
+                                    aiChatNativeVoicePermissionFlowEnabled: Bool = false,
+                                    aiChatTabAttachmentLimitEnabled: Bool = false) -> MockFeatureFlagger {
         let featureFlagger = MockFeatureFlagger()
         featureFlagger.featuresStub["aiChatSync"] = aiChatSyncEnabled
         featureFlagger.featuresStub["aiChatNativeStorage"] = aiChatNativeStorageEnabled
         featureFlagger.featuresStub["aiChatNativeVoicePermissionFlow"] = aiChatNativeVoicePermissionFlowEnabled
+        featureFlagger.featuresStub["aiChatTabAttachmentLimit"] = aiChatTabAttachmentLimitEnabled
         return featureFlagger
     }
 
@@ -1045,6 +1047,32 @@ struct AIChatUserScriptHandlerTests {
                                            installTypeProvider: { .new })
 
         #expect(handler.getNativeConfigValues(isFireWindow: false).supportsNativeVoicePermissionHandler == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("When aiChatTabAttachmentLimit is enabled, attachmentLimits.tabs carries the native cap", .timeLimit(.minutes(1)))
+    func testWhenTabAttachmentLimitEnabledThenAttachmentLimitsCarriesTabCap() {
+        let featureFlagger = makeFeatureFlagger(aiChatTabAttachmentLimitEnabled: true)
+        let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
+                                           promptHandler: AIChatPromptHandler.shared,
+                                           installDateProvider: { nil },
+                                           installTypeProvider: { .new })
+
+        let config = handler.getNativeConfigValues(isFireWindow: false)
+
+        #expect(config.attachmentLimits?.tabs?.maxAttached == AIChatOmnibarController.maxTabAttachments)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("When aiChatTabAttachmentLimit is disabled, attachmentLimits is omitted", .timeLimit(.minutes(1)))
+    func testWhenTabAttachmentLimitDisabledThenAttachmentLimitsIsNil() {
+        let featureFlagger = makeFeatureFlagger(aiChatTabAttachmentLimitEnabled: false)
+        let handler = AIChatMessageHandler(featureFlagger: featureFlagger,
+                                           promptHandler: AIChatPromptHandler.shared,
+                                           installDateProvider: { nil },
+                                           installTypeProvider: { .new })
+
+        #expect(handler.getNativeConfigValues(isFireWindow: false).attachmentLimits == nil)
     }
 
     // MARK: - voiceChatStartFailed flag gating


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1216955258764244

### Description

Extends the native-owned tab-attachment cap to the Duck.ai sidebar. `AIChatMessageHandler.getNativeConfigValues` now sends `attachmentLimits.tabs.maxAttached` (the same hardcoded cap the omnibar uses) in the sidebar's config response, gated on `aiChatTabAttachmentLimit`. When the flag is off the field is omitted entirely, which the web app reads as no limit — the same contract older builds that predate the field rely on.

### Testing Steps
1. Go to Debug -> Feature Flags and turn on `aiChatTabAttachmentLimit` and `aiChatSidebarAttachMoreTabs`
2. Go to Debug -> AI Chat -> Web Communication -> Set URL, and set the URL to `https://euw-serp-dev-testing22.duck.ai`
3. Open four tabs with different content
4. Open the sidebar, tap the attachment icon, and try to attach more than four tabs. An error message should appear and the submit button should be disabled. If you remove one tab (stay in the 3 limit), the submit button should be enabled again, and the error message should disappear.
5. Turn `aiChatTabAttachmentLimit` off, reload chat → no tab cap applied.

<img width="400" height="834" alt="Screenshot 2026-07-28 at 12 23 07 PM" src="https://github.com/user-attachments/assets/cf7de8cc-ecf6-4ae3-896c-1bdab0f1c04b" />


### Impact
Low. Default-on remote kill switch; omitting the field is the safe no-limit default.

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Config-only change behind an existing feature flag; omitting the field preserves the no-limit default for older web builds.
> 
> **Overview**
> The Duck.ai **sidebar** can now read native-owned tab attachment caps from the same config payload the web app already uses for other native flags.
> 
> **`AIChatNativeConfigValues`** gains optional **`attachmentLimits`** (with **`tabs.maxAttached`**). When **`attachmentLimits`** is **nil**, JSON omits the field so the web treats it as **no limit**—matching older clients.
> 
> On macOS, **`AIChatMessageHandler.getNativeConfigValues`** sets **`attachmentLimits.tabs.maxAttached`** to **`AIChatOmnibarController.maxTabAttachments`** (the omnibar’s hardcoded **3**) when **`aiChatTabAttachmentLimit`** is on; when the flag is off, **`attachmentLimits`** stays **nil**.
> 
> Unit tests cover JSON encoding (omitted vs present) and handler flag gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9a40fc2d95d74b56d769e091bad41e8f61e3c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>