### PR TITLE
Remove PIR profile reconciliation from the launch path

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -1048,6 +1048,7 @@ public class MockDataBrokerProtectionPixelsHandler: EventMapping<DataBrokerProte
 public final class MockDatabase: DataBrokerProtectionRepository {
     public enum MockError: Error {
         case saveFailed
+        case fetchFailed
     }
 
     public var wasSaveProfileCalled = false
@@ -1108,6 +1109,7 @@ public final class MockDatabase: DataBrokerProtectionRepository {
     public var lastAddedHistoryEvent: HistoryEvent?
 
     public var saveResult: Result<Void, Error> = .success(())
+    public var fetchProfileError: Error?
     public var addHistoryEventError: Error?
     public var updateLastRunDateError: Error?
     public var updatePreferredRunDateError: Error?
@@ -1157,8 +1159,11 @@ public final class MockDatabase: DataBrokerProtectionRepository {
         }
     }
 
-    public func fetchProfile() -> DataBrokerProtectionProfile? {
+    public func fetchProfile() throws -> DataBrokerProtectionProfile? {
         wasFetchProfileCalled = true
+        if let fetchProfileError {
+            throw fetchProfileError
+        }
         return profile
     }
 

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DBPProfileStateManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DBPProfileStateManager.swift
@@ -31,7 +31,6 @@ public protocol DBPProfileStateManaging {
 
     func recordProfileSaved()
     func recordProfileDeleted()
-    func recordProfileStateUnknown()
     func reconcileProfileState(hasSavedProfile: Bool)
 }
 
@@ -62,10 +61,6 @@ public final class DefaultDBPProfileStateManager: DBPProfileStateManaging {
 
     public func recordProfileDeleted() {
         setProfileState(.noProfile)
-    }
-
-    public func recordProfileStateUnknown() {
-        setProfileState(.unknown)
     }
 
     public func reconcileProfileState(hasSavedProfile: Bool) {

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManager.swift
@@ -447,6 +447,27 @@ public final class DataBrokerProtectionIOSManager {
         }
     }
 
+    private func reconcileProfileState() {
+        guard let resources = try? vaultResources() else {
+            Logger.dataBrokerProtection.log("Skipping profile state reconciliation: vault not initialized")
+            return
+        }
+
+        let hasSavedProfile: Bool
+        do {
+            hasSavedProfile = try resources.database.fetchProfile() != nil
+        } catch {
+            Logger.dataBrokerProtection.error("Profile state read failed, keeping cached state: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+
+        let currentState: DBPProfileState = hasSavedProfile ? .hasProfile : .noProfile
+
+        guard profileStateManager.profileState != currentState else { return }
+
+        profileStateManager.reconcileProfileState(hasSavedProfile: hasSavedProfile)
+    }
+
     /// Central gate for Secure Vault-backed resources. Every caller either starts initialization
     /// or joins one already in progress; the gate ensures a single initialization even when
     /// multiple entry points (launch, app-active, background task) arrive concurrently.
@@ -534,6 +555,7 @@ public final class DataBrokerProtectionIOSManager {
 extension DataBrokerProtectionIOSManager: DBPIOSInterface.AppLifecycleEventsDelegate {
 
     public func appDidEnterBackground() {
+        reconcileProfileState()
         scheduleBGProcessingTask()
     }
 
@@ -725,6 +747,8 @@ extension DataBrokerProtectionIOSManager: DBPIOSInterface.DatabaseDelegate {
 
 extension DataBrokerProtectionIOSManager: JobQueueManagerDelegate {
     public func queueManagerWillEnqueueOperations(_ queueManager: JobQueueManaging) {
+        reconcileProfileState()
+
         Task {
             do {
                 try await vaultResources().brokerUpdater?.checkForUpdates()

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManagerProvider.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManagerProvider.swift
@@ -178,11 +178,13 @@ public class DataBrokerProtectionIOSManagerProvider {
                                                         optOutRetryErrorFeatureFlagger: featureFlagger)
 
         let database = DataBrokerProtectionDatabase(fakeBrokerFlag: fakeBroker, pixelHandler: sharedPixelsHandler, vault: vault, localBrokerService: localBrokerService)
-        do {
-            profileStateManager.reconcileProfileState(hasSavedProfile: try database.fetchProfile() != nil)
-        } catch {
-            profileStateManager.recordProfileStateUnknown()
-            Logger.dataBrokerProtection.error("Error reconciling profile state, error: \(error.localizedDescription, privacy: .public)")
+
+        if profileStateManager.profileState == .unknown {
+            do {
+                profileStateManager.reconcileProfileState(hasSavedProfile: try database.fetchProfile() != nil)
+            } catch {
+                Logger.dataBrokerProtection.error("Error reconciling profile state, error: \(error.localizedDescription, privacy: .public)")
+            }
         }
 
         let operationQueue = OperationQueue()

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManagerProvider.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/ManagingAndCoordinating/DataBrokerProtectionIOSManagerProvider.swift
@@ -95,8 +95,7 @@ public class DataBrokerProtectionIOSManagerProvider {
                 applicationNameForUserAgentProvider: applicationNameForUserAgentProvider,
                 contentBlocking: contentBlocking,
                 dbpSettings: dbpSettings,
-                contentScopeProperties: contentScopeProperties,
-                profileStateManager: profileStateManager
+                contentScopeProperties: contentScopeProperties
             )
         }
 
@@ -161,8 +160,7 @@ public class DataBrokerProtectionIOSManagerProvider {
                                            applicationNameForUserAgentProvider: @escaping () -> String?,
                                            contentBlocking: DBPWebViewContentBlocking,
                                            dbpSettings: DataBrokerProtectionSettings,
-                                           contentScopeProperties: ContentScopeProperties,
-                                           profileStateManager: DBPProfileStateManaging) throws -> DBPVaultResources {
+                                           contentScopeProperties: ContentScopeProperties) throws -> DBPVaultResources {
         let fakeBroker = DataBrokerDebugFlagFakeBroker()
         let databaseURL = DefaultDataBrokerProtectionDatabaseProvider.databaseFilePath(directoryName: DatabaseConstants.directoryName, fileName: DatabaseConstants.fileName)
         let vaultFactory = createDataBrokerProtectionSecureVaultFactory(appGroupName: nil, databaseFileURL: databaseURL)
@@ -178,14 +176,6 @@ public class DataBrokerProtectionIOSManagerProvider {
                                                         optOutRetryErrorFeatureFlagger: featureFlagger)
 
         let database = DataBrokerProtectionDatabase(fakeBrokerFlag: fakeBroker, pixelHandler: sharedPixelsHandler, vault: vault, localBrokerService: localBrokerService)
-
-        if profileStateManager.profileState == .unknown {
-            do {
-                profileStateManager.reconcileProfileState(hasSavedProfile: try database.fetchProfile() != nil)
-            } catch {
-                Logger.dataBrokerProtection.error("Error reconciling profile state, error: \(error.localizedDescription, privacy: .public)")
-            }
-        }
 
         let operationQueue = OperationQueue()
         let jobProvider = BrokerProfileJobProvider()

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerProfileStateTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerProfileStateTests.swift
@@ -52,12 +52,13 @@ final class DataBrokerProtectionIOSManagerProfileStateTests: XCTestCase {
         XCTAssertEqual(dependencies.profileStateManager.profileState, .noProfile)
     }
 
-    func test_recordProfileStateUnknown_clearsStaleProfileState() {
-        let (_, dependencies) = DBPIOSManagerTestUtils.makeTestIOSManager()
+    func test_appDidEnterBackground_keepsCachedState_whenProfileReadFails() {
+        let (manager, dependencies) = DBPIOSManagerTestUtils.makeTestIOSManager()
         dependencies.profileStateManager.recordProfileSaved()
+        dependencies.database.fetchProfileError = MockDatabase.MockError.fetchFailed
 
-        dependencies.profileStateManager.recordProfileStateUnknown()
+        manager.appDidEnterBackground()
 
-        XCTAssertEqual(dependencies.profileStateManager.profileState, .unknown)
+        XCTAssertEqual(dependencies.profileStateManager.profileState, .hasProfile)
     }
 }

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerVaultInitReasonTests.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/DataBrokerProtectionIOSManagerVaultInitReasonTests.swift
@@ -54,8 +54,7 @@ final class DataBrokerProtectionIOSManagerVaultInitReasonTests: XCTestCase {
 
     func test_launch_unknownProfile_initializes() async throws {
         let initAttemptCount = LockedCount()
-        let (sut, dependencies) = makeDeferredManager(countingInto: initAttemptCount)
-        dependencies.profileStateManager.recordProfileStateUnknown()
+        let (sut, _) = makeDeferredManager(countingInto: initAttemptCount)
 
         try await sut.prepareSecureVaultResourcesAtLaunch()
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216961530048684?focus=true
Tech Design URL:
CC: @jozsef-vesza 

### Description

iOS 7.231.0 uses deferred secure vault init which should address the 7.229.0 regression. In case we have to use the kill-switch to turn off deferred secure path, we should stop reconciling profile state to avoid the regression too.  

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. CI passes 
2. Smoke test PIR

### Impact

Low, profile reconciliation is only used in `isCurrentPIRUser` RMF matcher which is not active in 7.230.0+

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes when cached PIR profile state is refreshed, with guards for uninitialized vault and failed reads; primary consumer noted as inactive in recent releases.
> 
> **Overview**
> Moves iOS PIR **profile state reconciliation** out of secure vault construction so launch/deferred init no longer reads the database to sync `DBPProfileState`.
> 
> **`makeVaultResources`** no longer fetches the profile or reconciles state (and no longer sets **unknown** on read errors). **`recordProfileStateUnknown()`** is removed from the profile state manager API.
> 
> Reconciliation now happens in **`DataBrokerProtectionIOSManager.reconcileProfileState()`**, invoked from **`appDidEnterBackground`** and **`queueManagerWillEnqueueOperations`**. It only runs when the vault is already initialized, updates cached state only when the DB read disagrees, and **preserves cached state** if `fetchProfile()` fails.
> 
> Test mocks gain a throwing **`fetchProfile()`** path; tests cover keeping cached state on background when the profile read fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19800a9f71e9e65b0438ac374ca09b77a42c00d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->