### PR TITLE
iOS: Add promo queue core admission

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -370,6 +370,7 @@ public enum FeatureFlag: String {
     case showNTPAfterIdleReturn
 
     /// Coordinates launch modal prompts and Remote Messaging Framework cards.
+    /// https://app.asana.com/1/137249556945/project/1208671677432066/task/1214300205792360?focus=true
     case promoQueue
 
     /// Test-only feature flag for verifying UI test override mechanism.

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -369,6 +369,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1213076120133808?focus=true
     case showNTPAfterIdleReturn
 
+    /// Coordinates launch modal prompts and Remote Messaging Framework cards.
+    case promoQueue
+
     /// Test-only feature flag for verifying UI test override mechanism.
     /// Used in Debug > UI Test Overrides screen.
     case uiTestFeatureFlag
@@ -794,6 +797,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(TabSwitcherTrackerCountSubfeature.featureEnabled))
         case .showNTPAfterIdleReturn:
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.showNTPAfterIdleReturn))
+        case .promoQueue:
+            Config(defaultValue: .disabled, source: .remoteReleasable(PromoQueueSubfeature.featureEnabled))
         case .uiTestFeatureFlag:
             Config(source: .disabled)
         case .uiTestExperiment:

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1457,6 +1457,7 @@
 		9F0B19AB2EA5DF78001FA867 /* ModalPromptProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B19A92EA5DF78001FA867 /* ModalPromptProvider.swift */; };
 		9F0B19B42EA5E4FA001FA867 /* DefaultBrowserModalPromptProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B19AF2EA5E4FA001FA867 /* DefaultBrowserModalPromptProvider.swift */; };
 		9F0B19B72EA5E74F001FA867 /* ModalPromptCoordinationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0B19B62EA5E740001FA867 /* ModalPromptCoordinationManager.swift */; };
+		B6A7C20231A1000100F00D01 /* PromoQueueLeaseArbiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C20131A1000100F00D01 /* PromoQueueLeaseArbiter.swift */; };
 		9F104B942F4EA27200FD6139 /* ScrollableOnboardingBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F104B932F4EA26600FD6139 /* ScrollableOnboardingBackground.swift */; };
 		9F12A0C12FB187FD00F80554 /* OnboardingRichTextMessageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F12A0C02FB187F400F80554 /* OnboardingRichTextMessageRenderer.swift */; };
 		9F16230B2CA0F0190093C4FC /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */; };
@@ -1508,6 +1509,7 @@
 		9F387DE22EA891E8006861F8 /* NewAddressBarPickerModalPromptProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DE12EA891DE006861F8 /* NewAddressBarPickerModalPromptProvider.swift */; };
 		9F387DE42EA8922B006861F8 /* WinBackOfferModalPromptProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DE32EA89228006861F8 /* WinBackOfferModalPromptProvider.swift */; };
 		9F387DE62EA89551006861F8 /* ModalPromptCoordinationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DE52EA89551006861F8 /* ModalPromptCoordinationManagerTests.swift */; };
+		B6A7C20531A1000100F00D01 /* PromoQueueLeaseArbiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C20431A1000100F00D01 /* PromoQueueLeaseArbiterTests.swift */; };
 		9F387DE82EA895B7006861F8 /* MockModalPromptProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DE72EA895B6006861F8 /* MockModalPromptProvider.swift */; };
 		9F387DE92EA895B7006861F8 /* MockModalPromptProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DE72EA895B6006861F8 /* MockModalPromptProvider.swift */; };
 		9F387DEA2EA895B7006861F8 /* MockModalPromptProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DE72EA895B6006861F8 /* MockModalPromptProvider.swift */; };
@@ -4275,6 +4277,7 @@
 		9F0B19A92EA5DF78001FA867 /* ModalPromptProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptProvider.swift; sourceTree = "<group>"; };
 		9F0B19AF2EA5E4FA001FA867 /* DefaultBrowserModalPromptProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultBrowserModalPromptProvider.swift; sourceTree = "<group>"; };
 		9F0B19B62EA5E740001FA867 /* ModalPromptCoordinationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationManager.swift; sourceTree = "<group>"; };
+		B6A7C20131A1000100F00D01 /* PromoQueueLeaseArbiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueLeaseArbiter.swift; sourceTree = "<group>"; };
 		9F104B932F4EA26600FD6139 /* ScrollableOnboardingBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollableOnboardingBackground.swift; sourceTree = "<group>"; };
 		9F12A0C02FB187F400F80554 /* OnboardingRichTextMessageRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRichTextMessageRenderer.swift; sourceTree = "<group>"; };
 		9F16230A2CA0F0190093C4FC /* DebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncerTests.swift; sourceTree = "<group>"; };
@@ -4314,6 +4317,7 @@
 		9F387DE12EA891DE006861F8 /* NewAddressBarPickerModalPromptProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewAddressBarPickerModalPromptProvider.swift; sourceTree = "<group>"; };
 		9F387DE32EA89228006861F8 /* WinBackOfferModalPromptProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinBackOfferModalPromptProvider.swift; sourceTree = "<group>"; };
 		9F387DE52EA89551006861F8 /* ModalPromptCoordinationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationManagerTests.swift; sourceTree = "<group>"; };
+		B6A7C20431A1000100F00D01 /* PromoQueueLeaseArbiterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueLeaseArbiterTests.swift; sourceTree = "<group>"; };
 		9F387DE72EA895B6006861F8 /* MockModalPromptProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockModalPromptProvider.swift; sourceTree = "<group>"; };
 		9F387DEC2EA895DC006861F8 /* MockModalPromptPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockModalPromptPresenter.swift; sourceTree = "<group>"; };
 		9F387DF22EA8AB43006861F8 /* ModalPromptCoordinationManagerIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationManagerIntegrationTests.swift; sourceTree = "<group>"; };
@@ -8562,6 +8566,7 @@
 		9F0B19AA2EA5DF78001FA867 /* ModalPromptCoordination */ = {
 			isa = PBXGroup;
 			children = (
+				B6A7C20331A1000100F00D01 /* Arbitration */,
 				9F8828462EBAAF46006C878B /* DebugMenu */,
 				9F387E002EA9812F006861F8 /* Factory */,
 				9F80A9862EA9DE3D0079C5AD /* Migrator */,
@@ -8572,6 +8577,14 @@
 				9F0B19B62EA5E740001FA867 /* ModalPromptCoordinationManager.swift */,
 			);
 			path = ModalPromptCoordination;
+			sourceTree = "<group>";
+		};
+		B6A7C20331A1000100F00D01 /* Arbitration */ = {
+			isa = PBXGroup;
+			children = (
+				B6A7C20131A1000100F00D01 /* PromoQueueLeaseArbiter.swift */,
+			);
+			path = Arbitration;
 			sourceTree = "<group>";
 		};
 		9F0B19B22EA5E4FA001FA867 /* Providers */ = {
@@ -8891,6 +8904,7 @@
 				9F7634BC2EA8633300804550 /* Cooldown */,
 				9F387E052EA9A1D8006861F8 /* Providers */,
 				9F387DE52EA89551006861F8 /* ModalPromptCoordinationManagerTests.swift */,
+				B6A7C20431A1000100F00D01 /* PromoQueueLeaseArbiterTests.swift */,
 			);
 			path = ModalPromptCoordination;
 			sourceTree = "<group>";
@@ -13769,6 +13783,7 @@
 				5AB12C3D4E5F60718293A4E1 /* ChatExportWriter.swift in Sources */,
 				5AB12C3D4E5F60718293A4E3 /* ChatHistoryDownloader.swift in Sources */,
 				9F0B19B72EA5E74F001FA867 /* ModalPromptCoordinationManager.swift in Sources */,
+				B6A7C20231A1000100F00D01 /* PromoQueueLeaseArbiter.swift in Sources */,
 				CBD4F13C279EBF4A00B20FD7 /* HomeMessage.swift in Sources */,
 				6FB2A67E2C2DAFB4004D20C8 /* NewTabPageGridView.swift in Sources */,
 				80A09D4E2F6B80B900AACDEE /* WebsiteDataFireWorker.swift in Sources */,
@@ -14345,6 +14360,7 @@
 				98E563122DE8AF3100E6E75F /* CombineTestUtilities.swift in Sources */,
 				98E563162DE8AF3100E6E75F /* TestDataLoader.swift in Sources */,
 				9F387DE62EA89551006861F8 /* ModalPromptCoordinationManagerTests.swift in Sources */,
+				B6A7C20531A1000100F00D01 /* PromoQueueLeaseArbiterTests.swift in Sources */,
 				98E5631D2DE8AF3100E6E75F /* CoreDataTestUtilities.swift in Sources */,
 				9F3361BC2F2B394700E0C21A /* ContextualOnboardingDelegateMock.swift in Sources */,
 				98E563242DE8AF3100E6E75F /* SwiftUITestUtilities.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1529,6 +1529,10 @@
 		9F387DFD2EA8BFA4006861F8 /* MockModalPromptCoordinationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DFB2EA8BFA0006861F8 /* MockModalPromptCoordinationManager.swift */; };
 		9F387DFE2EA8BFA4006861F8 /* MockModalPromptCoordinationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DFB2EA8BFA0006861F8 /* MockModalPromptCoordinationManager.swift */; };
 		9F387DFF2EA8BFA4006861F8 /* MockModalPromptCoordinationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DFB2EA8BFA0006861F8 /* MockModalPromptCoordinationManager.swift */; };
+		B6A7C20C31A1000100F00D01 /* MockNewTabPagePromoCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C20B31A1000100F00D01 /* MockNewTabPagePromoCoordinator.swift */; };
+		B6A7C20D31A1000100F00D01 /* MockNewTabPagePromoCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C20B31A1000100F00D01 /* MockNewTabPagePromoCoordinator.swift */; };
+		B6A7C20E31A1000100F00D01 /* MockNewTabPagePromoCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C20B31A1000100F00D01 /* MockNewTabPagePromoCoordinator.swift */; };
+		B6A7C20F31A1000100F00D01 /* MockNewTabPagePromoCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C20B31A1000100F00D01 /* MockNewTabPagePromoCoordinator.swift */; };
 		9F387E032EA98146006861F8 /* ModalPromptCoordinationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387E022EA98140006861F8 /* ModalPromptCoordinationFactory.swift */; };
 		9F387E062EA9A1D8006861F8 /* NewAddressBarPickerModalPromptProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387E042EA9A1D8006861F8 /* NewAddressBarPickerModalPromptProviderTests.swift */; };
 		9F387E082EA9A29A006861F8 /* MockNewAddressBarPickerDisplayValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387E072EA9A297006861F8 /* MockNewAddressBarPickerDisplayValidator.swift */; };
@@ -4326,6 +4330,7 @@
 		9F387DF42EA8BED0006861F8 /* ModalPromptCoordinationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationServiceTests.swift; sourceTree = "<group>"; };
 		9F387DF62EA8BF46006861F8 /* MockLaunchSourceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLaunchSourceManager.swift; sourceTree = "<group>"; };
 		9F387DFB2EA8BFA0006861F8 /* MockModalPromptCoordinationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockModalPromptCoordinationManager.swift; sourceTree = "<group>"; };
+		B6A7C20B31A1000100F00D01 /* MockNewTabPagePromoCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNewTabPagePromoCoordinator.swift; sourceTree = "<group>"; };
 		9F387E022EA98140006861F8 /* ModalPromptCoordinationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationFactory.swift; sourceTree = "<group>"; };
 		9F387E042EA9A1D8006861F8 /* NewAddressBarPickerModalPromptProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewAddressBarPickerModalPromptProviderTests.swift; sourceTree = "<group>"; };
 		9F387E072EA9A297006861F8 /* MockNewAddressBarPickerDisplayValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNewAddressBarPickerDisplayValidator.swift; sourceTree = "<group>"; };
@@ -8748,6 +8753,7 @@
 			isa = PBXGroup;
 			children = (
 				9F387DFB2EA8BFA0006861F8 /* MockModalPromptCoordinationManager.swift */,
+				B6A7C20B31A1000100F00D01 /* MockNewTabPagePromoCoordinator.swift */,
 				9F387DDC2EA881C7006861F8 /* PromptCooldownMocks.swift */,
 				9F387DE72EA895B6006861F8 /* MockModalPromptProvider.swift */,
 				9F387DEC2EA895DC006861F8 /* MockModalPromptPresenter.swift */,
@@ -14557,6 +14563,7 @@
 				98E563FD2DE8B32D00E6E75F /* OnboardingManagerMock.swift in Sources */,
 				9FE7CD5E2E14C81A006691AB /* MockDefaultBrowserPromptUserActivityStorage.swift in Sources */,
 				9F387DFD2EA8BFA4006861F8 /* MockModalPromptCoordinationManager.swift in Sources */,
+				B6A7C20E31A1000100F00D01 /* MockNewTabPagePromoCoordinator.swift in Sources */,
 				C19888EC2EF18B69004612AD /* DaxEasterEggLogoStoreTests.swift in Sources */,
 				98E563FF2DE8B32D00E6E75F /* DuckPlayerMocks.swift in Sources */,
 				CB6D17A22FA397FC00ECD5AE /* UnifiedToggleInputPageContextChipViewModelTests.swift in Sources */,
@@ -14927,6 +14934,7 @@
 				98E5642F2DE8B32D00E6E75F /* MockTutorialSettings.swift in Sources */,
 				989F0DAA2ECB517100781641 /* MockDefaultScriptSourceProviderDependencies.swift in Sources */,
 				9F387DFE2EA8BFA4006861F8 /* MockModalPromptCoordinationManager.swift in Sources */,
+				B6A7C20C31A1000100F00D01 /* MockNewTabPagePromoCoordinator.swift in Sources */,
 				36F2CA622E6098F800C7039D /* InactivityNotificationSchedulerServiceIntegrationTests.swift in Sources */,
 				98E564302DE8B32D00E6E75F /* OnboardingPixelReporterMock.swift in Sources */,
 				80483EEF2F4D5C0100563037 /* MockAutoconsentManagement.swift in Sources */,
@@ -15007,6 +15015,7 @@
 				9F60CBBB2E989EDC004D2367 /* MockLastSearchStateRefresher.swift in Sources */,
 				98E564A02DE8EDCE00E6E75F /* CapturingSyncPausedStateManager.swift in Sources */,
 				9F387DFC2EA8BFA4006861F8 /* MockModalPromptCoordinationManager.swift in Sources */,
+				B6A7C20F31A1000100F00D01 /* MockNewTabPagePromoCoordinator.swift in Sources */,
 				989F0DA22ECB278600781641 /* ContentBlockerRulesManagerMock.swift in Sources */,
 				98E563472DE8B04D00E6E75F /* TestDataLoader.swift in Sources */,
 				9FA0AF242EB8358100713387 /* MockWhatsNewDisplayModelMapper.swift in Sources */,
@@ -15132,6 +15141,7 @@
 				9F60CBBA2E989EDC004D2367 /* MockLastSearchStateRefresher.swift in Sources */,
 				98E564AA2DE8EDF000E6E75F /* CapturingAdapterErrorHandler.swift in Sources */,
 				9F387DFF2EA8BFA4006861F8 /* MockModalPromptCoordinationManager.swift in Sources */,
+				B6A7C20D31A1000100F00D01 /* MockNewTabPagePromoCoordinator.swift in Sources */,
 				989F0DA02ECB278600781641 /* ContentBlockerRulesManagerMock.swift in Sources */,
 				9876DF2C2DEEE21700E30713 /* MockThemeManager.swift in Sources */,
 				9FA0AF222EB8358100713387 /* MockWhatsNewDisplayModelMapper.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1510,6 +1510,7 @@
 		9F387DE42EA8922B006861F8 /* WinBackOfferModalPromptProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DE32EA89228006861F8 /* WinBackOfferModalPromptProvider.swift */; };
 		9F387DE62EA89551006861F8 /* ModalPromptCoordinationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DE52EA89551006861F8 /* ModalPromptCoordinationManagerTests.swift */; };
 		B6A7C20531A1000100F00D01 /* PromoQueueLeaseArbiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C20431A1000100F00D01 /* PromoQueueLeaseArbiterTests.swift */; };
+		B6A7C20A31A1000100F00D01 /* PromoQueueFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C20931A1000100F00D01 /* PromoQueueFeatureFlagTests.swift */; };
 		9F387DE82EA895B7006861F8 /* MockModalPromptProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DE72EA895B6006861F8 /* MockModalPromptProvider.swift */; };
 		9F387DE92EA895B7006861F8 /* MockModalPromptProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DE72EA895B6006861F8 /* MockModalPromptProvider.swift */; };
 		9F387DEA2EA895B7006861F8 /* MockModalPromptProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DE72EA895B6006861F8 /* MockModalPromptProvider.swift */; };
@@ -4318,6 +4319,7 @@
 		9F387DE32EA89228006861F8 /* WinBackOfferModalPromptProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinBackOfferModalPromptProvider.swift; sourceTree = "<group>"; };
 		9F387DE52EA89551006861F8 /* ModalPromptCoordinationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationManagerTests.swift; sourceTree = "<group>"; };
 		B6A7C20431A1000100F00D01 /* PromoQueueLeaseArbiterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueLeaseArbiterTests.swift; sourceTree = "<group>"; };
+		B6A7C20931A1000100F00D01 /* PromoQueueFeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueFeatureFlagTests.swift; sourceTree = "<group>"; };
 		9F387DE72EA895B6006861F8 /* MockModalPromptProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockModalPromptProvider.swift; sourceTree = "<group>"; };
 		9F387DEC2EA895DC006861F8 /* MockModalPromptPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockModalPromptPresenter.swift; sourceTree = "<group>"; };
 		9F387DF22EA8AB43006861F8 /* ModalPromptCoordinationManagerIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationManagerIntegrationTests.swift; sourceTree = "<group>"; };
@@ -6985,6 +6987,7 @@
 			children = (
 				563A3D002D37BF83001966FD /* ConfigurationManagerTests.swift */,
 				563A3D022D37C363001966FD /* AppConfigurationURLProviderTests.swift */,
+				B6A7C20931A1000100F00D01 /* PromoQueueFeatureFlagTests.swift */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
@@ -14361,6 +14364,7 @@
 				98E563162DE8AF3100E6E75F /* TestDataLoader.swift in Sources */,
 				9F387DE62EA89551006861F8 /* ModalPromptCoordinationManagerTests.swift in Sources */,
 				B6A7C20531A1000100F00D01 /* PromoQueueLeaseArbiterTests.swift in Sources */,
+				B6A7C20A31A1000100F00D01 /* PromoQueueFeatureFlagTests.swift in Sources */,
 				98E5631D2DE8AF3100E6E75F /* CoreDataTestUtilities.swift in Sources */,
 				9F3361BC2F2B394700E0C21A /* ContextualOnboardingDelegateMock.swift in Sources */,
 				98E563242DE8AF3100E6E75F /* SwiftUITestUtilities.swift in Sources */,

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -272,6 +272,7 @@ struct Launching: LaunchingHandling {
 
         // Initialise modal prompts coordination
         let omniBarFocuser = OmniBarFocuserProvider()
+        let promoQueueLeaseArbiter = PromoQueueLeaseArbiter()
         let modalPromptCoordinationService = ModalPromptCoordinationFactory.makeService(
             dependency: .init(
                 launchSourceManager: launchSourceManager,
@@ -279,6 +280,7 @@ struct Launching: LaunchingHandling {
                 keyValueFileStoreService: appKeyValueFileStoreService.keyValueFilesStore,
                 privacyConfigurationManager: contentBlockingService.common.privacyConfigurationManager,
                 featureFlagger: featureFlagger,
+                promoQueueLeaseArbiter: promoQueueLeaseArbiter,
                 whatsNewRepository: whatsNewRepository,
                 remoteMessagingActionHandler: remoteMessagingService.remoteMessagingActionHandler,
                 remoteMessagingPixelReporter: remoteMessagingService.pixelReporter,

--- a/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
@@ -348,6 +348,11 @@ final class ModalPromptCoordinationService {
             .sink { [weak self] targetState in
                 self?.transitionPromoQueueFeature(to: targetState)
             }
+
+        // Re-read after the subscriber is attached so a flag update emitted while the subscription was being
+        // established cannot leave the initial seed stale.
+        let subscribedTargetState = PromoQueueFeatureTargetState(isEnabled: featureFlagger.isFeatureOn(.promoQueue))
+        transitionPromoQueueFeature(to: subscribedTargetState)
     }
 
     private func transitionPromoQueueFeature(to targetState: PromoQueueFeatureTargetState) {

--- a/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
@@ -80,10 +80,6 @@ enum VisiblePromoAdmissionResult {
     case acquired(PromoQueueVisiblePromoLease)
     /// A coordinated modal attempt owns the slot.
     case blockedByModal
-    /// Reserved: carries the blocking identities, but is not currently produced — visible-promo acquisition
-    /// only rejects on the modal lease and on an occupied surface slot, so only `acquireModalLease()` can be
-    /// blocked by visible promos.
-    case blockedByVisiblePromos(Set<VisiblePromoIdentity>)
     /// The requesting surface's `(surfaceID, promoType)` slot already holds a lease; carries the occupying identity.
     case occupiedSurfaceSlot(VisiblePromoIdentity)
     /// The promo queue flag is off, so admission is not arbitrated.
@@ -281,8 +277,6 @@ final class ModalPromptCoordinationService {
             Logger.modalPrompt.debug("[Modal Prompt Coordination] - Skipping modal prompt - A coordinated modal attempt already owns the slot.")
         case .blockedByVisiblePromos:
             Logger.modalPrompt.debug("[Modal Prompt Coordination] - Skipping modal prompt - One or more visible promos own the slot.")
-        case .occupiedSurfaceSlot:
-            assertionFailure("Modal lease acquisition cannot be blocked by an occupied surface slot.")
         }
     }
 
@@ -303,8 +297,6 @@ final class ModalPromptCoordinationService {
             result = .acquired(lease)
         case .blockedByModal:
             result = .blockedByModal
-        case .blockedByVisiblePromos(let identities):
-            result = .blockedByVisiblePromos(identities)
         case .occupiedSurfaceSlot(let identity):
             result = .occupiedSurfaceSlot(identity)
         }

--- a/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
@@ -17,9 +17,11 @@
 //  limitations under the License.
 //
 
-import UIKit
+import Combine
+import Core
 import Persistence
-import protocol PrivacyConfig.PrivacyConfigurationManaging
+import PrivacyConfig
+import UIKit
 
 // MARK: - Modal Prompt Presenter
 
@@ -31,6 +33,44 @@ protocol ModalPromptPresenter: AnyObject {
 }
 
 extension MainViewController: ModalPromptPresenter {}
+
+// MARK: - Promo Queue Feature State
+
+enum PromoQueueFeatureTargetState: Equatable {
+    case disabled
+    case enabled
+
+    init(isEnabled: Bool) {
+        self = isEnabled ? .enabled : .disabled
+    }
+}
+
+enum PromoQueueFeatureState: Equatable {
+    case disabled
+    case transitioning(to: PromoQueueFeatureTargetState)
+    case enabled
+
+    init(targetState: PromoQueueFeatureTargetState) {
+        switch targetState {
+        case .disabled:
+            self = .disabled
+        case .enabled:
+            self = .enabled
+        }
+    }
+
+    var isTransitioning: Bool {
+        if case .transitioning = self {
+            return true
+        }
+        return false
+    }
+}
+
+@MainActor
+protocol NewTabPagePromoCoordinating: AnyObject {
+    var promoQueueFeatureState: PromoQueueFeatureState { get }
+}
 
 // MARK: - Service
 
@@ -48,13 +88,21 @@ struct ModalPromptProviders {
 final class ModalPromptCoordinationService {
     private let modalPromptCoordinationManager: ModalPromptCoordinationManaging
     private let launchSourceManager: LaunchSourceManaging
+    private let promoQueueLeaseArbiter: PromoQueueLeaseArbitrating
+    private let featureFlagger: FeatureFlagger
+    private var promoQueueFeatureStateCancellable: AnyCancellable?
+    private var pendingPromoQueueFeatureTargetState: PromoQueueFeatureTargetState?
+
+    private(set) var promoQueueFeatureState: PromoQueueFeatureState
 
     convenience init(
         launchSourceManager: LaunchSourceManaging,
         keyValueStore: ThrowingKeyValueStoring,
         contextualOnboardingStatusProvider: ContextualDaxDialogStatusProvider,
         privacyConfigManager: PrivacyConfigurationManaging,
-        providers: ModalPromptProviders
+        providers: ModalPromptProviders,
+        featureFlagger: FeatureFlagger,
+        promoQueueLeaseArbiter: PromoQueueLeaseArbitrating
     ) {
 
         // Providers are sort from highest to lowest priority, with item at index 0 being the highest priority.
@@ -85,21 +133,40 @@ final class ModalPromptCoordinationService {
         let modalPromptCoordinationManager = ModalPromptCoordinationManager(
             providers: providers,
             cooldownManager: cooldownManager,
-            onboardingStatusProvider: contextualOnboardingStatusProvider
+            onboardingStatusProvider: contextualOnboardingStatusProvider,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
         )
 
-        self.init(launchSourceManager: launchSourceManager, modalPromptCoordinationManager: modalPromptCoordinationManager)
+        self.init(
+            launchSourceManager: launchSourceManager,
+            modalPromptCoordinationManager: modalPromptCoordinationManager,
+            featureFlagger: featureFlagger,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
     }
 
     init(
         launchSourceManager: LaunchSourceManaging,
-        modalPromptCoordinationManager: ModalPromptCoordinationManaging
+        modalPromptCoordinationManager: ModalPromptCoordinationManaging,
+        featureFlagger: FeatureFlagger,
+        promoQueueLeaseArbiter: PromoQueueLeaseArbitrating
     ) {
         self.launchSourceManager = launchSourceManager
         self.modalPromptCoordinationManager = modalPromptCoordinationManager
+        self.featureFlagger = featureFlagger
+        self.promoQueueLeaseArbiter = promoQueueLeaseArbiter
+
+        let initialTargetState = PromoQueueFeatureTargetState(isEnabled: featureFlagger.isFeatureOn(.promoQueue))
+        promoQueueFeatureState = PromoQueueFeatureState(targetState: initialTargetState)
+        subscribeToPromoQueueFeatureState(initialTargetState: initialTargetState)
     }
 
     func presentModalPromptIfNeeded(from viewController: ModalPromptPresenter) {
+        guard !promoQueueFeatureState.isTransitioning else {
+            Logger.modalPrompt.debug("[Modal Prompt Coordination] - Skipping modal prompt during promo queue feature transition.")
+            return
+        }
+
         guard launchSourceManager.source == .standard else {
             Logger.modalPrompt.info("[Modal Prompt Coordination] - Skipping modal prompt - Launched from non-standard source.")
             return
@@ -125,7 +192,52 @@ final class ModalPromptCoordinationService {
         modalPromptCoordinationManager.presentModalPromptIfNeeded(from: viewController)
     }
 
+    private func subscribeToPromoQueueFeatureState(initialTargetState: PromoQueueFeatureTargetState) {
+        promoQueueFeatureStateCancellable = featureFlagger.updatesPublisher
+            .receive(on: DispatchQueue.main)
+            .map { [featureFlagger] in
+                PromoQueueFeatureTargetState(isEnabled: featureFlagger.isFeatureOn(.promoQueue))
+            }
+            .prepend(initialTargetState)
+            .removeDuplicates()
+            .dropFirst()
+            .sink { [weak self] targetState in
+                self?.transitionPromoQueueFeature(to: targetState)
+            }
+    }
+
+    private func transitionPromoQueueFeature(to targetState: PromoQueueFeatureTargetState) {
+        guard !promoQueueFeatureState.isTransitioning else {
+            pendingPromoQueueFeatureTargetState = targetState
+            return
+        }
+
+        guard promoQueueFeatureState != PromoQueueFeatureState(targetState: targetState) else {
+            return
+        }
+
+        promoQueueFeatureState = .transitioning(to: targetState)
+        defer {
+            promoQueueFeatureState = PromoQueueFeatureState(targetState: targetState)
+
+            if let pendingTargetState = pendingPromoQueueFeatureTargetState {
+                pendingPromoQueueFeatureTargetState = nil
+                transitionPromoQueueFeature(to: pendingTargetState)
+            }
+        }
+
+        modalPromptCoordinationManager.promoQueueWillTransition(to: targetState)
+
+        // The manager and NTP transition callbacks will add their target-specific work in Steps 4–6.
+        // Invalidating here establishes the shared serialized reset point for both transition directions.
+        promoQueueLeaseArbiter.invalidateAllLeases()
+
+        modalPromptCoordinationManager.promoQueueDidTransition(to: targetState)
+    }
+
 }
+
+extension ModalPromptCoordinationService: NewTabPagePromoCoordinating {}
 
 extension ModalPromptCoordinationService: RecentModalPromptStatusProviding {
     var wasModalPromptRecentlyPresented: Bool { modalPromptCoordinationManager.didPresentModalPromptThisSession }

--- a/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
@@ -39,6 +39,7 @@ extension MainViewController: ModalPromptPresenter {
 
 // MARK: - Promo Queue Feature State
 
+/// The resolved promo queue flag reading: `PromoQueueFeatureState`'s settled subset, so `.transitioning(to:)` cannot nest — the seed at init and a transition's destination.
 enum PromoQueueFeatureTargetState: Equatable {
     case disabled
     case enabled
@@ -49,8 +50,12 @@ enum PromoQueueFeatureTargetState: Equatable {
 }
 
 enum PromoQueueFeatureState: Equatable {
+    /// Coordination is bypassed: the legacy modal and RMF paths are in force.
     case disabled
+    /// The serialized main-actor flag-change barrier is up while moving to the carried target state: modal
+    /// evaluation is deferred and public NTP admission cannot acquire a lease.
     case transitioning(to: PromoQueueFeatureTargetState)
+    /// Coordinated admission is active.
     case enabled
 
     init(targetState: PromoQueueFeatureTargetState) {
@@ -71,11 +76,19 @@ enum PromoQueueFeatureState: Equatable {
 }
 
 enum VisiblePromoAdmissionResult {
+    /// Admitted: the caller owns the lease and must release it.
     case acquired(PromoQueueVisiblePromoLease)
+    /// A coordinated modal attempt owns the slot.
     case blockedByModal
+    /// Reserved: carries the blocking identities, but is not currently produced — visible-promo acquisition
+    /// only rejects on the modal lease and on an occupied surface slot, so only `acquireModalLease()` can be
+    /// blocked by visible promos.
     case blockedByVisiblePromos(Set<VisiblePromoIdentity>)
+    /// The requesting surface's `(surfaceID, promoType)` slot already holds a lease; carries the occupying identity.
     case occupiedSurfaceSlot(VisiblePromoIdentity)
+    /// The promo queue flag is off, so admission is not arbitrated.
     case featureDisabled
+    /// A flag transition barrier is up; the caller should retry after the transition.
     case unavailableDuringTransition
 }
 
@@ -111,23 +124,6 @@ protocol NewTabPagePromoCoordinating: AnyObject {
         for surfaceID: UUID,
         target: NewTabPagePromoRetrying
     ) -> NewTabPagePromoRetryRegistration
-}
-
-extension NewTabPagePromoCoordinating {
-    func admitVisiblePromo(_ identity: VisiblePromoIdentity) -> VisiblePromoAdmissionResult {
-        .featureDisabled
-    }
-
-    func releaseVisiblePromoLease(_ lease: PromoQueueVisiblePromoLease) {
-        lease.release()
-    }
-
-    func registerVisiblePromoRetry(
-        for surfaceID: UUID,
-        target: NewTabPagePromoRetrying
-    ) -> NewTabPagePromoRetryRegistration {
-        NewTabPagePromoRetryRegistration()
-    }
 }
 
 // MARK: - Service
@@ -371,8 +367,6 @@ final class ModalPromptCoordinationService {
 
         promoQueueFeatureState = .transitioning(to: targetState)
         defer {
-            promoQueueFeatureState = PromoQueueFeatureState(targetState: targetState)
-
             if let pendingTargetState = pendingPromoQueueFeatureTargetState {
                 pendingPromoQueueFeatureTargetState = nil
                 transitionPromoQueueFeature(to: pendingTargetState)
@@ -385,6 +379,9 @@ final class ModalPromptCoordinationService {
 
         modalPromptCoordinationManager.promoQueueDidTransition(to: targetState)
 
+        // The barrier must be lifted here, before the retry pass: retry targets come back through
+        // `admitVisiblePromo`, which answers `.unavailableDuringTransition` while it is still up. Do not
+        // move this into the `defer` above — that would run after the retries and re-write a stale value.
         promoQueueFeatureState = PromoQueueFeatureState(targetState: targetState)
         if targetState == .enabled {
             retryActiveVisiblePromoRegistrations()

--- a/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
@@ -28,14 +28,11 @@ import UIKit
 @MainActor
 protocol ModalPromptPresenter: AnyObject {
     var presentedViewController: UIViewController? { get }
-    var modalPromptPresentationViewController: UIViewController? { get }
 
     func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?)
 }
 
-extension MainViewController: ModalPromptPresenter {
-    var modalPromptPresentationViewController: UIViewController? { self }
-}
+extension MainViewController: ModalPromptPresenter {}
 
 // MARK: - Promo Queue Feature State
 
@@ -266,12 +263,16 @@ final class ModalPromptCoordinationService {
 
         switch promoQueueLeaseArbiter.acquireModalLease() {
         case .acquired(let lease):
-            let disposition = modalPromptCoordinationManager.presentModalPromptIfNeeded(
-                from: viewController,
-                with: lease
-            )
-            if disposition == .released {
-                retryActiveVisiblePromoRegistrations()
+            switch modalPromptCoordinationManager.presentModalPromptIfNeeded(from: viewController, with: lease) {
+            case .retained:
+                Logger.modalPrompt.debug("[Modal Prompt Coordination] - The coordinated modal attempt holds the slot.")
+            case .released:
+                // Deliberately no retry pass here. The manager only answers `.released` synchronously — cooldown or no
+                // eligible provider — microseconds after the pre-gate pass above ran against identical arbiter state,
+                // so every active registration has already been asked once on this foreground. Step 5 adds the
+                // asynchronous release sites (a committed attempt failing preflight, or refused by UIKit); those
+                // release after arbiter state has moved on, so they must trigger the registry-wide retry themselves.
+                Logger.modalPrompt.debug("[Modal Prompt Coordination] - The coordinated modal attempt released the slot without presenting.")
             }
         case .blockedByModal:
             Logger.modalPrompt.debug("[Modal Prompt Coordination] - Skipping modal prompt - A coordinated modal attempt already owns the slot.")
@@ -297,11 +298,13 @@ final class ModalPromptCoordinationService {
             result = .acquired(lease)
         case .blockedByModal:
             result = .blockedByModal
-        case .occupiedSurfaceSlot(let identity):
-            result = .occupiedSurfaceSlot(identity)
+        case .occupiedSurfaceSlot(let occupyingIdentity):
+            result = .occupiedSurfaceSlot(occupyingIdentity)
         }
 
         if didReleaseModalLease {
+            // Excludes the *requesting* surface, whose admission this call has just completed, rather than any identity
+            // carried back by the arbiter's answer.
             retryActiveVisiblePromoRegistrations(excluding: identity.surfaceID)
         }
         return result

--- a/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
@@ -36,7 +36,8 @@ extension MainViewController: ModalPromptPresenter {}
 
 // MARK: - Promo Queue Feature State
 
-/// The resolved promo queue flag reading: `PromoQueueFeatureState`'s settled subset, so `.transitioning(to:)` cannot nest — the seed at init and a transition's destination.
+/// The resolved promo queue flag reading: `PromoQueueFeatureState`'s settled subset, so `.transitioning(to:)` cannot
+/// nest — the seed at init and a transition's destination.
 enum PromoQueueFeatureTargetState: Equatable {
     case disabled
     case enabled

--- a/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/ModalPromptCoordinationService.swift
@@ -28,11 +28,14 @@ import UIKit
 @MainActor
 protocol ModalPromptPresenter: AnyObject {
     var presentedViewController: UIViewController? { get }
+    var modalPromptPresentationViewController: UIViewController? { get }
 
     func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?)
 }
 
-extension MainViewController: ModalPromptPresenter {}
+extension MainViewController: ModalPromptPresenter {
+    var modalPromptPresentationViewController: UIViewController? { self }
+}
 
 // MARK: - Promo Queue Feature State
 
@@ -67,9 +70,64 @@ enum PromoQueueFeatureState: Equatable {
     }
 }
 
+enum VisiblePromoAdmissionResult {
+    case acquired(PromoQueueVisiblePromoLease)
+    case blockedByModal
+    case blockedByVisiblePromos(Set<VisiblePromoIdentity>)
+    case occupiedSurfaceSlot(VisiblePromoIdentity)
+    case featureDisabled
+    case unavailableDuringTransition
+}
+
+@MainActor
+protocol NewTabPagePromoRetrying: AnyObject {
+    var isActiveForPromoRetry: Bool { get }
+
+    func retryVisiblePromoAdmission()
+}
+
+@MainActor
+final class NewTabPagePromoRetryRegistration {
+    private var deregistrationHandler: (@MainActor () -> Void)?
+
+    init(deregistrationHandler: (@MainActor () -> Void)? = nil) {
+        self.deregistrationHandler = deregistrationHandler
+    }
+
+    func deregister() {
+        let deregistrationHandler = deregistrationHandler
+        self.deregistrationHandler = nil
+        deregistrationHandler?()
+    }
+}
+
 @MainActor
 protocol NewTabPagePromoCoordinating: AnyObject {
     var promoQueueFeatureState: PromoQueueFeatureState { get }
+
+    func admitVisiblePromo(_ identity: VisiblePromoIdentity) -> VisiblePromoAdmissionResult
+    func releaseVisiblePromoLease(_ lease: PromoQueueVisiblePromoLease)
+    func registerVisiblePromoRetry(
+        for surfaceID: UUID,
+        target: NewTabPagePromoRetrying
+    ) -> NewTabPagePromoRetryRegistration
+}
+
+extension NewTabPagePromoCoordinating {
+    func admitVisiblePromo(_ identity: VisiblePromoIdentity) -> VisiblePromoAdmissionResult {
+        .featureDisabled
+    }
+
+    func releaseVisiblePromoLease(_ lease: PromoQueueVisiblePromoLease) {
+        lease.release()
+    }
+
+    func registerVisiblePromoRetry(
+        for surfaceID: UUID,
+        target: NewTabPagePromoRetrying
+    ) -> NewTabPagePromoRetryRegistration {
+        NewTabPagePromoRetryRegistration()
+    }
 }
 
 // MARK: - Service
@@ -86,12 +144,26 @@ struct ModalPromptProviders {
 
 @MainActor
 final class ModalPromptCoordinationService {
+    private final class WeakPromoRetryRegistration {
+        let id: UUID
+        let surfaceID: UUID
+        weak var target: NewTabPagePromoRetrying?
+
+        init(id: UUID, surfaceID: UUID, target: NewTabPagePromoRetrying) {
+            self.id = id
+            self.surfaceID = surfaceID
+            self.target = target
+        }
+    }
+
     private let modalPromptCoordinationManager: ModalPromptCoordinationManaging
     private let launchSourceManager: LaunchSourceManaging
     private let promoQueueLeaseArbiter: PromoQueueLeaseArbitrating
     private let featureFlagger: FeatureFlagger
     private var promoQueueFeatureStateCancellable: AnyCancellable?
     private var pendingPromoQueueFeatureTargetState: PromoQueueFeatureTargetState?
+    private var promoRetryRegistrations = [WeakPromoRetryRegistration]()
+    private var isRetryingVisiblePromoRegistrations = false
 
     private(set) var promoQueueFeatureState: PromoQueueFeatureState
 
@@ -167,6 +239,11 @@ final class ModalPromptCoordinationService {
             return
         }
 
+        if promoQueueFeatureState == .enabled {
+            _ = modalPromptCoordinationManager.reconcilePresentedModal()
+            retryActiveVisiblePromoRegistrations()
+        }
+
         guard launchSourceManager.source == .standard else {
             Logger.modalPrompt.info("[Modal Prompt Coordination] - Skipping modal prompt - Launched from non-standard source.")
             return
@@ -189,7 +266,83 @@ final class ModalPromptCoordinationService {
             presentationStatusMessage = "No Modal is currently presented."
         }
         Logger.modalPrompt.info("[Modal Prompt Coordination] - ✓ \(presentationStatusMessage, privacy: .public)")
-        modalPromptCoordinationManager.presentModalPromptIfNeeded(from: viewController)
+
+        guard promoQueueFeatureState == .enabled else {
+            modalPromptCoordinationManager.presentModalPromptIfNeeded(from: viewController)
+            return
+        }
+
+        switch promoQueueLeaseArbiter.acquireModalLease() {
+        case .acquired(let lease):
+            let disposition = modalPromptCoordinationManager.presentModalPromptIfNeeded(
+                from: viewController,
+                with: lease
+            )
+            if disposition == .released {
+                retryActiveVisiblePromoRegistrations()
+            }
+        case .blockedByModal:
+            Logger.modalPrompt.debug("[Modal Prompt Coordination] - Skipping modal prompt - A coordinated modal attempt already owns the slot.")
+        case .blockedByVisiblePromos:
+            Logger.modalPrompt.debug("[Modal Prompt Coordination] - Skipping modal prompt - One or more visible promos own the slot.")
+        case .occupiedSurfaceSlot:
+            assertionFailure("Modal lease acquisition cannot be blocked by an occupied surface slot.")
+        }
+    }
+
+    func admitVisiblePromo(_ identity: VisiblePromoIdentity) -> VisiblePromoAdmissionResult {
+        switch promoQueueFeatureState {
+        case .disabled:
+            return .featureDisabled
+        case .transitioning:
+            return .unavailableDuringTransition
+        case .enabled:
+            break
+        }
+
+        let didReleaseModalLease = modalPromptCoordinationManager.reconcilePresentedModal()
+        let result: VisiblePromoAdmissionResult
+        switch promoQueueLeaseArbiter.acquireVisiblePromoLease(for: identity) {
+        case .acquired(let lease):
+            result = .acquired(lease)
+        case .blockedByModal:
+            result = .blockedByModal
+        case .blockedByVisiblePromos(let identities):
+            result = .blockedByVisiblePromos(identities)
+        case .occupiedSurfaceSlot(let identity):
+            result = .occupiedSurfaceSlot(identity)
+        }
+
+        if didReleaseModalLease {
+            retryActiveVisiblePromoRegistrations(excluding: identity.surfaceID)
+        }
+        return result
+    }
+
+    func releaseVisiblePromoLease(_ lease: PromoQueueVisiblePromoLease) {
+        lease.release()
+    }
+
+    func registerVisiblePromoRetry(
+        for surfaceID: UUID,
+        target: NewTabPagePromoRetrying
+    ) -> NewTabPagePromoRetryRegistration {
+        let registrationID = UUID()
+        let registration = WeakPromoRetryRegistration(
+            id: registrationID,
+            surfaceID: surfaceID,
+            target: target
+        )
+
+        promoRetryRegistrations.removeAll { $0.surfaceID == surfaceID }
+        promoRetryRegistrations.append(registration)
+
+        return NewTabPagePromoRetryRegistration { [weak self] in
+            self?.deregisterVisiblePromoRetry(
+                for: surfaceID,
+                registrationID: registrationID
+            )
+        }
     }
 
     private func subscribeToPromoQueueFeatureState(initialTargetState: PromoQueueFeatureTargetState) {
@@ -228,11 +381,43 @@ final class ModalPromptCoordinationService {
 
         modalPromptCoordinationManager.promoQueueWillTransition(to: targetState)
 
-        // The manager and NTP transition callbacks will add their target-specific work in Steps 4–6.
-        // Invalidating here establishes the shared serialized reset point for both transition directions.
         promoQueueLeaseArbiter.invalidateAllLeases()
 
         modalPromptCoordinationManager.promoQueueDidTransition(to: targetState)
+
+        promoQueueFeatureState = PromoQueueFeatureState(targetState: targetState)
+        if targetState == .enabled {
+            retryActiveVisiblePromoRegistrations()
+        }
+    }
+
+    private func deregisterVisiblePromoRetry(for surfaceID: UUID, registrationID: UUID) {
+        promoRetryRegistrations.removeAll {
+            $0.surfaceID == surfaceID && $0.id == registrationID
+        }
+    }
+
+    private func retryActiveVisiblePromoRegistrations(excluding excludedSurfaceID: UUID? = nil) {
+        guard !isRetryingVisiblePromoRegistrations else {
+            return
+        }
+
+        isRetryingVisiblePromoRegistrations = true
+        defer {
+            isRetryingVisiblePromoRegistrations = false
+            promoRetryRegistrations.removeAll { $0.target == nil }
+        }
+
+        let registrationsSnapshot = promoRetryRegistrations
+        for registration in registrationsSnapshot {
+            guard registration.surfaceID != excludedSurfaceID,
+                  promoRetryRegistrations.contains(where: { $0.id == registration.id }),
+                  let target = registration.target,
+                  target.isActiveForPromoRetry else {
+                continue
+            }
+            target.retryVisiblePromoAdmission()
+        }
     }
 
 }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -342,6 +342,7 @@ class MainViewController: UIViewController {
 
     let themeManager: ThemeManaging
     let keyValueStore: ThrowingKeyValueStoring
+    let newTabPagePromoCoordinator: NewTabPagePromoCoordinating
     let recentModalPromptStatusProvider: RecentModalPromptStatusProviding?
     let systemSettingsPiPTutorialManager: SystemSettingsPiPTutorialManaging
     let onboardingResumeStepStore: any KeyedStoring<OnboardingStoringKeys>
@@ -500,6 +501,7 @@ class MainViewController: UIViewController {
         toggleModeStorage: ToggleModeStoring = ToggleModeStorage(),
         onboardingResumeStepStore: (any KeyedStoring<OnboardingStoringKeys>)? = nil,
         onboardingManager: OnboardingManaging,
+        newTabPagePromoCoordinator: NewTabPagePromoCoordinating,
         recentModalPromptStatusProvider: RecentModalPromptStatusProviding? = nil
     ) {
         self.remoteMessagingActionHandler = remoteMessagingActionHandler
@@ -555,6 +557,7 @@ class MainViewController: UIViewController {
         self.maliciousSiteProtectionPreferencesManager = maliciousSiteProtectionPreferencesManager
         self.contentScopeExperimentsManager = contentScopeExperimentsManager
         self.keyValueStore = keyValueStore
+        self.newTabPagePromoCoordinator = newTabPagePromoCoordinator
         self.recentModalPromptStatusProvider = recentModalPromptStatusProvider
         self.onboardingResumeStepStore = if let onboardingResumeStepStore { onboardingResumeStepStore } else { UserDefaults.app.keyedStoring() }
         self.customConfigurationURLProvider = customConfigurationURLProvider
@@ -659,6 +662,7 @@ class MainViewController: UIViewController {
             remoteMessagingActionHandler: remoteMessagingActionHandler,
             remoteMessagingImageLoader: remoteMessagingImageLoader,
             remoteMessagingPixelReporter: remoteMessagingPixelReporter,
+            promoCoordinator: newTabPagePromoCoordinator,
             appSettings: appSettings,
             subscriptionManager: subscriptionManager,
             internalUserCommands: internalUserCommands)
@@ -1983,6 +1987,7 @@ class MainViewController: UIViewController {
                                                   remoteMessagingActionHandler: remoteMessagingActionHandler,
                                                   remoteMessagingImageLoader: remoteMessagingImageLoader,
                                                   remoteMessagingPixelReporter: remoteMessagingPixelReporter,
+                                                  promoCoordinator: newTabPagePromoCoordinator,
                                                   appSettings: appSettings,
                                                   faviconsCache: favicons,
                                                   subscriptionManager: subscriptionManager,

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Arbitration/PromoQueueLeaseArbiter.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Arbitration/PromoQueueLeaseArbiter.swift
@@ -29,7 +29,8 @@ struct VisiblePromoIdentity: Hashable {
     let promoID: String
 }
 
-/// Opaque per-acquisition identity that travels with its modal lease through the evaluating, committed, and presentation-active phases, so a callback for an older attempt can be recognised and ignored.
+/// Opaque per-acquisition identity that travels with its modal lease through the evaluating, committed, and
+/// presentation-active phases, so a callback for an older attempt can be recognised and ignored.
 struct PromoQueueModalAttemptIdentity: Hashable {
     fileprivate let id: UUID
 
@@ -77,7 +78,8 @@ protocol PromoQueueLeaseArbitrating: AnyObject {
 
     /// Acquires the modal lease, which succeeds only when there is no modal lease and no visible-promo leases.
     func acquireModalLease() -> PromoQueueModalLeaseAcquisitionResult
-    /// Acquires a visible-promo lease, which succeeds only when there is no modal lease and the identity's `(surfaceID, promoType)` slot is free, so several surfaces may hold leases concurrently but one slot may not hold two.
+    /// Acquires a visible-promo lease, which succeeds only when there is no modal lease and the identity's
+    /// `(surfaceID, promoType)` slot is free, so several surfaces may hold leases concurrently but one slot may not hold two.
     func acquireVisiblePromoLease(for identity: VisiblePromoIdentity) -> PromoQueueVisiblePromoLeaseAcquisitionResult
     /// Clears every lease, so outstanding tokens become no-ops. Used on a live feature-flag transition.
     func invalidateAllLeases()

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Arbitration/PromoQueueLeaseArbiter.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Arbitration/PromoQueueLeaseArbiter.swift
@@ -60,14 +60,21 @@ struct PromoQueueLeaseSnapshot: Equatable {
     }
 }
 
-enum PromoQueueLeaseAcquisitionResult<Lease> {
+enum PromoQueueModalLeaseAcquisitionResult {
     /// The caller now owns the lease and is responsible for releasing it.
-    case acquired(Lease)
-    /// A modal lease already owns the slot. Returned by both acquisitions.
+    case acquired(PromoQueueModalLease)
+    /// A modal lease already owns the slot.
     case blockedByModal
-    /// One or more visible promos own the slot, carried as their identities. Returned only by `acquireModalLease()`.
+    /// One or more visible promos own the slot, carried as their identities.
     case blockedByVisiblePromos(Set<VisiblePromoIdentity>)
-    /// The requested `(surfaceID, promoType)` slot already holds the carried identity, even when the promo ID differs. Returned only by `acquireVisiblePromoLease(for:)`.
+}
+
+enum PromoQueueVisiblePromoLeaseAcquisitionResult {
+    /// The caller now owns the lease and is responsible for releasing it.
+    case acquired(PromoQueueVisiblePromoLease)
+    /// A modal lease already owns the slot.
+    case blockedByModal
+    /// The requested `(surfaceID, promoType)` slot already holds the carried identity, even when the promo ID differs.
     case occupiedSurfaceSlot(VisiblePromoIdentity)
 }
 
@@ -78,9 +85,9 @@ protocol PromoQueueLeaseArbitrating: AnyObject {
     var snapshot: PromoQueueLeaseSnapshot { get }
 
     /// Acquires the modal lease, which succeeds only when there is no modal lease and no visible-promo leases.
-    func acquireModalLease() -> PromoQueueLeaseAcquisitionResult<PromoQueueModalLease>
+    func acquireModalLease() -> PromoQueueModalLeaseAcquisitionResult
     /// Acquires a visible-promo lease, which succeeds only when there is no modal lease and the identity's `(surfaceID, promoType)` slot is free, so several surfaces may hold leases concurrently but one slot may not hold two.
-    func acquireVisiblePromoLease(for identity: VisiblePromoIdentity) -> PromoQueueLeaseAcquisitionResult<PromoQueueVisiblePromoLease>
+    func acquireVisiblePromoLease(for identity: VisiblePromoIdentity) -> PromoQueueVisiblePromoLeaseAcquisitionResult
     /// Advances the generation and clears every lease, so outstanding tokens become no-ops. Used on a live feature-flag transition.
     func invalidateAllLeases()
 }
@@ -155,7 +162,7 @@ final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
         )
     }
 
-    func acquireModalLease() -> PromoQueueLeaseAcquisitionResult<PromoQueueModalLease> {
+    func acquireModalLease() -> PromoQueueModalLeaseAcquisitionResult {
         guard modalLease == nil else {
             return .blockedByModal
         }
@@ -181,7 +188,7 @@ final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
         return .acquired(lease)
     }
 
-    func acquireVisiblePromoLease(for identity: VisiblePromoIdentity) -> PromoQueueLeaseAcquisitionResult<PromoQueueVisiblePromoLease> {
+    func acquireVisiblePromoLease(for identity: VisiblePromoIdentity) -> PromoQueueVisiblePromoLeaseAcquisitionResult {
         guard modalLease == nil else {
             return .blockedByModal
         }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Arbitration/PromoQueueLeaseArbiter.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Arbitration/PromoQueueLeaseArbiter.swift
@@ -1,0 +1,236 @@
+//
+//  PromoQueueLeaseArbiter.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+enum PromoType: Hashable {
+    case remoteMessage
+}
+
+struct VisiblePromoIdentity: Hashable {
+    let surfaceID: UUID
+    let promoType: PromoType
+    let promoID: String
+}
+
+struct PromoQueueLeaseGeneration: Hashable {
+    fileprivate let id: UUID
+
+    fileprivate init() {
+        id = UUID()
+    }
+}
+
+struct PromoQueueModalAttemptIdentity: Hashable {
+    fileprivate let id: UUID
+
+    fileprivate init() {
+        id = UUID()
+    }
+}
+
+struct PromoQueueLeaseSnapshot: Equatable {
+    let generation: PromoQueueLeaseGeneration
+    let modalAttemptIdentity: PromoQueueModalAttemptIdentity?
+    let visiblePromoIdentities: Set<VisiblePromoIdentity>
+
+    var hasModalLease: Bool {
+        modalAttemptIdentity != nil
+    }
+
+    var visiblePromoCount: Int {
+        visiblePromoIdentities.count
+    }
+}
+
+enum PromoQueueLeaseAcquisitionResult<Lease> {
+    case acquired(Lease)
+    case blockedByModal
+    case blockedByVisiblePromos(Set<VisiblePromoIdentity>)
+    case occupiedSurfaceSlot(VisiblePromoIdentity)
+}
+
+@MainActor
+protocol PromoQueueLeaseArbitrating: AnyObject {
+    var snapshot: PromoQueueLeaseSnapshot { get }
+
+    func acquireModalLease() -> PromoQueueLeaseAcquisitionResult<PromoQueueModalLease>
+    func acquireVisiblePromoLease(for identity: VisiblePromoIdentity) -> PromoQueueLeaseAcquisitionResult<PromoQueueVisiblePromoLease>
+    func invalidateAllLeases()
+}
+
+@MainActor
+final class PromoQueueModalLease {
+    let attemptIdentity: PromoQueueModalAttemptIdentity
+
+    private var releaseHandler: (() -> Void)?
+
+    fileprivate init(
+        attemptIdentity: PromoQueueModalAttemptIdentity,
+        releaseHandler: @escaping () -> Void
+    ) {
+        self.attemptIdentity = attemptIdentity
+        self.releaseHandler = releaseHandler
+    }
+
+    func release() {
+        let releaseHandler = releaseHandler
+        self.releaseHandler = nil
+        releaseHandler?()
+    }
+}
+
+@MainActor
+final class PromoQueueVisiblePromoLease {
+    private var releaseHandler: (() -> Void)?
+
+    fileprivate init(releaseHandler: @escaping () -> Void) {
+        self.releaseHandler = releaseHandler
+    }
+
+    func release() {
+        let releaseHandler = releaseHandler
+        self.releaseHandler = nil
+        releaseHandler?()
+    }
+}
+
+@MainActor
+final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
+    private struct ModalLeaseRecord {
+        let id: UUID
+        let generation: PromoQueueLeaseGeneration
+        let attemptIdentity: PromoQueueModalAttemptIdentity
+    }
+
+    private struct VisiblePromoSlot: Hashable {
+        let surfaceID: UUID
+        let promoType: PromoType
+
+        init(identity: VisiblePromoIdentity) {
+            surfaceID = identity.surfaceID
+            promoType = identity.promoType
+        }
+    }
+
+    private struct VisiblePromoLeaseRecord {
+        let id: UUID
+        let generation: PromoQueueLeaseGeneration
+        let identity: VisiblePromoIdentity
+    }
+
+    private var generation = PromoQueueLeaseGeneration()
+    private var modalLease: ModalLeaseRecord?
+    private var visiblePromoLeases = [VisiblePromoSlot: VisiblePromoLeaseRecord]()
+
+    var snapshot: PromoQueueLeaseSnapshot {
+        PromoQueueLeaseSnapshot(
+            generation: generation,
+            modalAttemptIdentity: modalLease?.attemptIdentity,
+            visiblePromoIdentities: Set(visiblePromoLeases.values.map(\.identity))
+        )
+    }
+
+    func acquireModalLease() -> PromoQueueLeaseAcquisitionResult<PromoQueueModalLease> {
+        guard modalLease == nil else {
+            return .blockedByModal
+        }
+
+        guard visiblePromoLeases.isEmpty else {
+            return .blockedByVisiblePromos(Set(visiblePromoLeases.values.map(\.identity)))
+        }
+
+        let leaseID = UUID()
+        let leaseGeneration = generation
+        let attemptIdentity = PromoQueueModalAttemptIdentity()
+        modalLease = ModalLeaseRecord(
+            id: leaseID,
+            generation: leaseGeneration,
+            attemptIdentity: attemptIdentity
+        )
+
+        let lease = PromoQueueModalLease(
+            attemptIdentity: attemptIdentity,
+            releaseHandler: { [weak self] in
+                self?.releaseModalLease(id: leaseID, generation: leaseGeneration)
+            }
+        )
+        return .acquired(lease)
+    }
+
+    func acquireVisiblePromoLease(for identity: VisiblePromoIdentity) -> PromoQueueLeaseAcquisitionResult<PromoQueueVisiblePromoLease> {
+        guard modalLease == nil else {
+            return .blockedByModal
+        }
+
+        let slot = VisiblePromoSlot(identity: identity)
+        if let existingLease = visiblePromoLeases[slot] {
+            return .occupiedSurfaceSlot(existingLease.identity)
+        }
+
+        let leaseID = UUID()
+        let leaseGeneration = generation
+        visiblePromoLeases[slot] = VisiblePromoLeaseRecord(
+            id: leaseID,
+            generation: leaseGeneration,
+            identity: identity
+        )
+
+        let lease = PromoQueueVisiblePromoLease { [weak self] in
+            self?.releaseVisiblePromoLease(
+                for: slot,
+                id: leaseID,
+                generation: leaseGeneration
+            )
+        }
+        return .acquired(lease)
+    }
+
+    func invalidateAllLeases() {
+        generation = PromoQueueLeaseGeneration()
+        modalLease = nil
+        visiblePromoLeases.removeAll()
+    }
+
+    private func releaseModalLease(id: UUID, generation: PromoQueueLeaseGeneration) {
+        guard let modalLease,
+              modalLease.id == id,
+              modalLease.generation == generation,
+              generation == self.generation else {
+            return
+        }
+
+        self.modalLease = nil
+    }
+
+    private func releaseVisiblePromoLease(
+        for slot: VisiblePromoSlot,
+        id: UUID,
+        generation: PromoQueueLeaseGeneration
+    ) {
+        guard let visiblePromoLease = visiblePromoLeases[slot],
+              visiblePromoLease.id == id,
+              visiblePromoLease.generation == generation,
+              generation == self.generation else {
+            return
+        }
+
+        visiblePromoLeases[slot] = nil
+    }
+}

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Arbitration/PromoQueueLeaseArbiter.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Arbitration/PromoQueueLeaseArbiter.swift
@@ -37,6 +37,7 @@ struct PromoQueueLeaseGeneration: Hashable {
     }
 }
 
+/// Opaque per-acquisition identity that travels with its modal lease through the evaluating, committed, and presentation-active phases, so a callback for an older attempt can be recognised and ignored.
 struct PromoQueueModalAttemptIdentity: Hashable {
     fileprivate let id: UUID
 
@@ -60,18 +61,27 @@ struct PromoQueueLeaseSnapshot: Equatable {
 }
 
 enum PromoQueueLeaseAcquisitionResult<Lease> {
+    /// The caller now owns the lease and is responsible for releasing it.
     case acquired(Lease)
+    /// A modal lease already owns the slot. Returned by both acquisitions.
     case blockedByModal
+    /// One or more visible promos own the slot, carried as their identities. Returned only by `acquireModalLease()`.
     case blockedByVisiblePromos(Set<VisiblePromoIdentity>)
+    /// The requested `(surfaceID, promoType)` slot already holds the carried identity, even when the promo ID differs. Returned only by `acquireVisiblePromoLease(for:)`.
     case occupiedSurfaceSlot(VisiblePromoIdentity)
 }
 
+/// The single mutual-exclusion authority for promo slots. It owns no provider policy, RMF selection, cooldown, or persistent history.
 @MainActor
 protocol PromoQueueLeaseArbitrating: AnyObject {
+    /// Read-only view of the current leases, for tests and the debug screen.
     var snapshot: PromoQueueLeaseSnapshot { get }
 
+    /// Acquires the modal lease, which succeeds only when there is no modal lease and no visible-promo leases.
     func acquireModalLease() -> PromoQueueLeaseAcquisitionResult<PromoQueueModalLease>
+    /// Acquires a visible-promo lease, which succeeds only when there is no modal lease and the identity's `(surfaceID, promoType)` slot is free, so several surfaces may hold leases concurrently but one slot may not hold two.
     func acquireVisiblePromoLease(for identity: VisiblePromoIdentity) -> PromoQueueLeaseAcquisitionResult<PromoQueueVisiblePromoLease>
+    /// Advances the generation and clears every lease, so outstanding tokens become no-ops. Used on a live feature-flag transition.
     func invalidateAllLeases()
 }
 
@@ -115,7 +125,6 @@ final class PromoQueueVisiblePromoLease {
 final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
     private struct ModalLeaseRecord {
         let id: UUID
-        let generation: PromoQueueLeaseGeneration
         let attemptIdentity: PromoQueueModalAttemptIdentity
     }
 
@@ -131,7 +140,6 @@ final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
 
     private struct VisiblePromoLeaseRecord {
         let id: UUID
-        let generation: PromoQueueLeaseGeneration
         let identity: VisiblePromoIdentity
     }
 
@@ -161,7 +169,6 @@ final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
         let attemptIdentity = PromoQueueModalAttemptIdentity()
         modalLease = ModalLeaseRecord(
             id: leaseID,
-            generation: leaseGeneration,
             attemptIdentity: attemptIdentity
         )
 
@@ -188,7 +195,6 @@ final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
         let leaseGeneration = generation
         visiblePromoLeases[slot] = VisiblePromoLeaseRecord(
             id: leaseID,
-            generation: leaseGeneration,
             identity: identity
         )
 
@@ -209,9 +215,9 @@ final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
     }
 
     private func releaseModalLease(id: UUID, generation: PromoQueueLeaseGeneration) {
+        // `id` proves the stored record is this token's; `generation` rejects a token minted before an invalidation.
         guard let modalLease,
               modalLease.id == id,
-              modalLease.generation == generation,
               generation == self.generation else {
             return
         }
@@ -224,9 +230,9 @@ final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
         id: UUID,
         generation: PromoQueueLeaseGeneration
     ) {
+        // `id` proves the record in this slot is this token's; `generation` rejects a token minted before an invalidation.
         guard let visiblePromoLease = visiblePromoLeases[slot],
               visiblePromoLease.id == id,
-              visiblePromoLease.generation == generation,
               generation == self.generation else {
             return
         }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Arbitration/PromoQueueLeaseArbiter.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Arbitration/PromoQueueLeaseArbiter.swift
@@ -29,14 +29,6 @@ struct VisiblePromoIdentity: Hashable {
     let promoID: String
 }
 
-struct PromoQueueLeaseGeneration: Hashable {
-    fileprivate let id: UUID
-
-    fileprivate init() {
-        id = UUID()
-    }
-}
-
 /// Opaque per-acquisition identity that travels with its modal lease through the evaluating, committed, and presentation-active phases, so a callback for an older attempt can be recognised and ignored.
 struct PromoQueueModalAttemptIdentity: Hashable {
     fileprivate let id: UUID
@@ -47,7 +39,6 @@ struct PromoQueueModalAttemptIdentity: Hashable {
 }
 
 struct PromoQueueLeaseSnapshot: Equatable {
-    let generation: PromoQueueLeaseGeneration
     let modalAttemptIdentity: PromoQueueModalAttemptIdentity?
     let visiblePromoIdentities: Set<VisiblePromoIdentity>
 
@@ -88,7 +79,7 @@ protocol PromoQueueLeaseArbitrating: AnyObject {
     func acquireModalLease() -> PromoQueueModalLeaseAcquisitionResult
     /// Acquires a visible-promo lease, which succeeds only when there is no modal lease and the identity's `(surfaceID, promoType)` slot is free, so several surfaces may hold leases concurrently but one slot may not hold two.
     func acquireVisiblePromoLease(for identity: VisiblePromoIdentity) -> PromoQueueVisiblePromoLeaseAcquisitionResult
-    /// Advances the generation and clears every lease, so outstanding tokens become no-ops. Used on a live feature-flag transition.
+    /// Clears every lease, so outstanding tokens become no-ops. Used on a live feature-flag transition.
     func invalidateAllLeases()
 }
 
@@ -130,9 +121,11 @@ final class PromoQueueVisiblePromoLease {
 
 @MainActor
 final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
+    /// `token` is weak so that a lease whose owner dropped it without calling `release()` can be reclaimed. It cannot
+    /// retain the token: the acquirer owns the lease, and a strong reference here would keep every lease alive forever.
     private struct ModalLeaseRecord {
-        let id: UUID
         let attemptIdentity: PromoQueueModalAttemptIdentity
+        weak var token: PromoQueueModalLease?
     }
 
     private struct VisiblePromoSlot: Hashable {
@@ -145,24 +138,31 @@ final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
         }
     }
 
+    /// `id` is minted per acquisition but `identity` is not: the same `(surfaceID, promoType, promoID)` may hold the
+    /// slot again while an earlier token is still armed, so release has to be keyed on `id` rather than on `identity`.
+    ///
+    /// `token` is weak for the same reason as `ModalLeaseRecord.token`.
     private struct VisiblePromoLeaseRecord {
         let id: UUID
         let identity: VisiblePromoIdentity
+        weak var token: PromoQueueVisiblePromoLease?
     }
 
-    private var generation = PromoQueueLeaseGeneration()
     private var modalLease: ModalLeaseRecord?
     private var visiblePromoLeases = [VisiblePromoSlot: VisiblePromoLeaseRecord]()
 
+    /// Prunes before reading so neither the debug screen nor a caller can observe a lease whose token is already gone.
     var snapshot: PromoQueueLeaseSnapshot {
-        PromoQueueLeaseSnapshot(
-            generation: generation,
+        pruneLeasesWithDeallocatedTokens()
+        return PromoQueueLeaseSnapshot(
             modalAttemptIdentity: modalLease?.attemptIdentity,
             visiblePromoIdentities: Set(visiblePromoLeases.values.map(\.identity))
         )
     }
 
     func acquireModalLease() -> PromoQueueModalLeaseAcquisitionResult {
+        pruneLeasesWithDeallocatedTokens()
+
         guard modalLease == nil else {
             return .blockedByModal
         }
@@ -171,24 +171,23 @@ final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
             return .blockedByVisiblePromos(Set(visiblePromoLeases.values.map(\.identity)))
         }
 
-        let leaseID = UUID()
-        let leaseGeneration = generation
         let attemptIdentity = PromoQueueModalAttemptIdentity()
-        modalLease = ModalLeaseRecord(
-            id: leaseID,
-            attemptIdentity: attemptIdentity
-        )
-
         let lease = PromoQueueModalLease(
             attemptIdentity: attemptIdentity,
             releaseHandler: { [weak self] in
-                self?.releaseModalLease(id: leaseID, generation: leaseGeneration)
+                self?.releaseModalLease(attemptIdentity: attemptIdentity)
             }
+        )
+        modalLease = ModalLeaseRecord(
+            attemptIdentity: attemptIdentity,
+            token: lease
         )
         return .acquired(lease)
     }
 
     func acquireVisiblePromoLease(for identity: VisiblePromoIdentity) -> PromoQueueVisiblePromoLeaseAcquisitionResult {
+        pruneLeasesWithDeallocatedTokens()
+
         guard modalLease == nil else {
             return .blockedByModal
         }
@@ -199,48 +198,53 @@ final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
         }
 
         let leaseID = UUID()
-        let leaseGeneration = generation
+        let lease = PromoQueueVisiblePromoLease { [weak self] in
+            self?.releaseVisiblePromoLease(for: slot, id: leaseID)
+        }
         visiblePromoLeases[slot] = VisiblePromoLeaseRecord(
             id: leaseID,
-            identity: identity
+            identity: identity,
+            token: lease
         )
-
-        let lease = PromoQueueVisiblePromoLease { [weak self] in
-            self?.releaseVisiblePromoLease(
-                for: slot,
-                id: leaseID,
-                generation: leaseGeneration
-            )
-        }
         return .acquired(lease)
     }
 
     func invalidateAllLeases() {
-        generation = PromoQueueLeaseGeneration()
         modalLease = nil
         visiblePromoLeases.removeAll()
     }
 
-    private func releaseModalLease(id: UUID, generation: PromoQueueLeaseGeneration) {
-        // `id` proves the stored record is this token's; `generation` rejects a token minted before an invalidation.
+    /// Reclaims leases whose token deallocated without `release()`, so a dropped token cannot wedge the arbiter for the
+    /// rest of the session: one leaked visible-promo token would otherwise block every launch modal, and a leaked modal
+    /// token would block every visible promo, with no timeout and no recovery.
+    ///
+    /// A `deinit` on the token would be the obvious alternative, but the token is `@MainActor` and `deinit` is
+    /// implicitly nonisolated, so it cannot call `release()` synchronously; hopping to the main actor instead would make
+    /// release asynchronous and its ordering nondeterministic. Pruning is plain synchronous main-actor code, and every
+    /// caller reaches the arbiter through an entry point that prunes first.
+    private func pruneLeasesWithDeallocatedTokens() {
+        if let modalLease, modalLease.token == nil {
+            self.modalLease = nil
+        }
+
+        visiblePromoLeases = visiblePromoLeases.filter { $0.value.token != nil }
+    }
+
+    private func releaseModalLease(attemptIdentity: PromoQueueModalAttemptIdentity) {
+        // `attemptIdentity` is minted per acquisition, so matching it proves the stored record is this token's. A token
+        // whose record was cleared, by release or by an invalidation, cannot match whatever replaced it.
         guard let modalLease,
-              modalLease.id == id,
-              generation == self.generation else {
+              modalLease.attemptIdentity == attemptIdentity else {
             return
         }
 
         self.modalLease = nil
     }
 
-    private func releaseVisiblePromoLease(
-        for slot: VisiblePromoSlot,
-        id: UUID,
-        generation: PromoQueueLeaseGeneration
-    ) {
-        // `id` proves the record in this slot is this token's; `generation` rejects a token minted before an invalidation.
+    private func releaseVisiblePromoLease(for slot: VisiblePromoSlot, id: UUID) {
+        // `id` proves the record in this slot is this token's, so a token for message A cannot release message B.
         guard let visiblePromoLease = visiblePromoLeases[slot],
-              visiblePromoLease.id == id,
-              generation == self.generation else {
+              visiblePromoLease.id == id else {
             return
         }
 

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Factory/ModalPromptCoordinationFactory.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Factory/ModalPromptCoordinationFactory.swift
@@ -72,7 +72,9 @@ enum ModalPromptCoordinationFactory {
                 subscriptionPromoExistingUser: subscriptionPromoExistingUserModalPromptProvider,
                 whatsNew: whatsNewModalPromptProvider,
                 cookiePopupProtectionOptIn: cookiePopupProtectionOptInModalPromptProvider
-            )
+            ),
+            featureFlagger: dependency.featureFlagger,
+            promoQueueLeaseArbiter: dependency.promoQueueLeaseArbiter
         )
     }
 
@@ -118,6 +120,7 @@ extension ModalPromptCoordinationFactory {
         let keyValueFileStoreService: ThrowingKeyValueStoring
         let privacyConfigurationManager: PrivacyConfigurationManaging
         let featureFlagger: FeatureFlagger
+        let promoQueueLeaseArbiter: PromoQueueLeaseArbitrating
         let whatsNewRepository: WhatsNewMessageRepository
         let remoteMessagingActionHandler: RemoteMessagingActionHandling
         let remoteMessagingPixelReporter: RemoteMessagingPixelReporting

--- a/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
@@ -24,6 +24,8 @@ protocol ModalPromptCoordinationManaging {
     var didPresentModalPromptThisSession: Bool { get }
 
     func presentModalPromptIfNeeded(from presenter: ModalPromptPresenter)
+    func promoQueueWillTransition(to targetState: PromoQueueFeatureTargetState)
+    func promoQueueDidTransition(to targetState: PromoQueueFeatureTargetState)
 }
 
 /// Manages the coordination and presentation of modal prompts based on priority and cooldown rules.
@@ -40,6 +42,7 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
     private let cooldownManager: PromptCooldownManaging
     private let scheduler: ModalPromptScheduling
     private let onboardingStatusProvider: ContextualDaxDialogStatusProvider
+    private let promoQueueLeaseArbiter: PromoQueueLeaseArbitrating
 
     private(set) var didPresentModalPromptThisSession = false
 
@@ -47,12 +50,22 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
         providers: [any ModalPromptProvider],
         cooldownManager: PromptCooldownManaging,
         onboardingStatusProvider: ContextualDaxDialogStatusProvider,
+        promoQueueLeaseArbiter: PromoQueueLeaseArbitrating,
         modalPromptScheduling: ModalPromptScheduling = ModalPromptScheduler()
     ) {
         self.providers = providers
         self.cooldownManager = cooldownManager
         self.onboardingStatusProvider = onboardingStatusProvider
+        self.promoQueueLeaseArbiter = promoQueueLeaseArbiter
         self.scheduler = modalPromptScheduling
+    }
+
+    func promoQueueWillTransition(to targetState: PromoQueueFeatureTargetState) {
+        // Step 4 adds target-specific attempt cancellation and exact-root handling.
+    }
+
+    func promoQueueDidTransition(to targetState: PromoQueueFeatureTargetState) {
+        // Steps 4–5 add target-specific re-adoption and retry behavior.
     }
 
     /// Attempts to present a modal prompt if one is eligible.

--- a/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
@@ -22,10 +22,51 @@ import UIKit
 @MainActor
 protocol ModalPromptCoordinationManaging {
     var didPresentModalPromptThisSession: Bool { get }
+    var didActuallyPresentModalPromptThisSession: Bool { get }
+    var hasActiveOrPendingModalAttempt: Bool { get }
+    var modalAttemptPhase: ModalPromptAttemptPhase { get }
 
     func presentModalPromptIfNeeded(from presenter: ModalPromptPresenter)
+    func presentModalPromptIfNeeded(
+        from presenter: ModalPromptPresenter,
+        with lease: PromoQueueModalLease
+    ) -> ModalPromptLeaseDisposition
+    func reconcilePresentedModal() -> Bool
     func promoQueueWillTransition(to targetState: PromoQueueFeatureTargetState)
     func promoQueueDidTransition(to targetState: PromoQueueFeatureTargetState)
+}
+
+enum ModalPromptLeaseDisposition: Equatable {
+    case retained
+    case released
+}
+
+enum ModalPromptAttemptPhase: Equatable {
+    case idle
+    case evaluating(PromoQueueModalAttemptIdentity)
+    case committed(PromoQueueModalAttemptIdentity)
+    case presentationActive(PromoQueueModalAttemptIdentity)
+}
+
+@MainActor
+protocol ModalPromptRootAttachmentChecking {
+    func isAttached(_ root: UIViewController) -> Bool
+    func isAttached(_ root: UIViewController, to intendedPresenter: UIViewController?) -> Bool
+}
+
+struct ModalPromptRootAttachmentChecker: ModalPromptRootAttachmentChecking {
+    func isAttached(_ root: UIViewController) -> Bool {
+        root.isBeingPresented || root.presentingViewController != nil || root.viewIfLoaded?.window != nil
+    }
+
+    func isAttached(_ root: UIViewController, to intendedPresenter: UIViewController?) -> Bool {
+        guard isAttached(root), let intendedPresenter else {
+            return isAttached(root)
+        }
+
+        return root.presentingViewController === intendedPresenter
+            || intendedPresenter.presentedViewController === root
+    }
 }
 
 /// Manages the coordination and presentation of modal prompts based on priority and cooldown rules.
@@ -38,34 +79,95 @@ protocol ModalPromptCoordinationManaging {
 /// The manager does NOT handle app-lifecycle level concerns like launch source checking. Those are handled by the `ModalPromptsCoordinationService`.
 @MainActor
 final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
+    private struct CoordinatedAttempt {
+        let lease: PromoQueueModalLease
+    }
+
+    private struct CommittedAttempt {
+        let attempt: CoordinatedAttempt
+        let configuration: ModalPromptConfiguration
+        let provider: any ModalPromptProvider
+    }
+
+    private enum AttemptState {
+        case idle
+        case evaluating(CoordinatedAttempt)
+        case committed(CommittedAttempt)
+        case presentationActive(CoordinatedAttempt, exactRoot: UIViewController)
+    }
+
     private let providers: [any ModalPromptProvider]
     private let cooldownManager: PromptCooldownManaging
     private let scheduler: ModalPromptScheduling
     private let onboardingStatusProvider: ContextualDaxDialogStatusProvider
     private let promoQueueLeaseArbiter: PromoQueueLeaseArbitrating
+    private let rootAttachmentChecker: ModalPromptRootAttachmentChecking
 
-    private(set) var didPresentModalPromptThisSession = false
+    private var attemptState = AttemptState.idle
+    private var legacyActiveAttemptIDs = Set<UUID>()
+    private var lastSelectedExactRoot: UIViewController?
+    private weak var lastSelectedPresentationHost: UIViewController?
+
+    private(set) var didActuallyPresentModalPromptThisSession = false
+
+    var didPresentModalPromptThisSession: Bool {
+        didActuallyPresentModalPromptThisSession || hasActiveOrPendingModalAttempt
+    }
+
+    var hasActiveOrPendingModalAttempt: Bool {
+        !legacyActiveAttemptIDs.isEmpty || modalAttemptPhase != .idle
+    }
+
+    var modalAttemptPhase: ModalPromptAttemptPhase {
+        switch attemptState {
+        case .idle:
+            return .idle
+        case .evaluating(let attempt):
+            return .evaluating(attempt.lease.attemptIdentity)
+        case .committed(let committedAttempt):
+            return .committed(committedAttempt.attempt.lease.attemptIdentity)
+        case .presentationActive(let attempt, _):
+            return .presentationActive(attempt.lease.attemptIdentity)
+        }
+    }
 
     init(
         providers: [any ModalPromptProvider],
         cooldownManager: PromptCooldownManaging,
         onboardingStatusProvider: ContextualDaxDialogStatusProvider,
         promoQueueLeaseArbiter: PromoQueueLeaseArbitrating,
-        modalPromptScheduling: ModalPromptScheduling = ModalPromptScheduler()
+        modalPromptScheduling: ModalPromptScheduling = ModalPromptScheduler(),
+        rootAttachmentChecker: ModalPromptRootAttachmentChecking? = nil
     ) {
         self.providers = providers
         self.cooldownManager = cooldownManager
         self.onboardingStatusProvider = onboardingStatusProvider
         self.promoQueueLeaseArbiter = promoQueueLeaseArbiter
         self.scheduler = modalPromptScheduling
+        self.rootAttachmentChecker = rootAttachmentChecker ?? ModalPromptRootAttachmentChecker()
     }
 
     func promoQueueWillTransition(to targetState: PromoQueueFeatureTargetState) {
-        // Step 4 adds target-specific attempt cancellation and exact-root handling.
+        legacyActiveAttemptIDs.removeAll()
+        releaseCoordinationAttempt()
     }
 
     func promoQueueDidTransition(to targetState: PromoQueueFeatureTargetState) {
-        // Steps 4–5 add target-specific re-adoption and retry behavior.
+        guard targetState == .enabled,
+              let lastSelectedExactRoot,
+              rootAttachmentChecker.isAttached(
+                lastSelectedExactRoot,
+                to: lastSelectedPresentationHost
+              ) else {
+            return
+        }
+
+        guard case .acquired(let lease) = promoQueueLeaseArbiter.acquireModalLease() else {
+            return
+        }
+
+        let attempt = CoordinatedAttempt(lease: lease)
+        attemptState = .presentationActive(attempt, exactRoot: lastSelectedExactRoot)
     }
 
     /// Attempts to present a modal prompt if one is eligible.
@@ -82,24 +184,41 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
         guard !cooldownManager.isInCooldownPeriod else {
             let cooldownInfo = cooldownManager.cooldownInfo
             let lastPresentationDate = cooldownInfo.lastPresentationDate.flatMap(String.init) ?? "-"
-            Logger.modalPrompt.debug("[Modal Prompt Coordination] - Is in cooldown period. Last presentation: \(lastPresentationDate, privacy: .public) Can Present modal again: \(cooldownInfo.nextPresentationDate, privacy: .public)")
+            Logger.modalPrompt.debug(
+                """
+                [Modal Prompt Coordination] - Is in cooldown period. Last presentation: \(lastPresentationDate, privacy: .public) \
+                Can Present modal again: \(cooldownInfo.nextPresentationDate, privacy: .public)
+                """
+            )
             return
         }
 
         let isOnboardingComplete = onboardingStatusProvider.hasSeenOnboarding
         for provider in providers {
             guard provider.isEligibleToPresent(isOnboardingComplete: isOnboardingComplete) else {
-                Logger.modalPrompt.debug("[Modal Prompt Coordination] - \(type(of: provider)) is not eligible to present (isOnboardingComplete: \(isOnboardingComplete)).")
+                Logger.modalPrompt.debug(
+                    """
+                    [Modal Prompt Coordination] - \(type(of: provider)) is not eligible to present \
+                    (isOnboardingComplete: \(isOnboardingComplete)).
+                    """
+                )
                 continue
             }
             guard let modalPromptConfiguration = provider.provideModalPrompt() else { continue }
 
-            // Set at commit time (not in the present completion) so the sync banner can't slip in
-            // during the schedule + present-animation window; the completion reflects actual presentation.
-            didPresentModalPromptThisSession = true
+            let scheduledAttemptID = UUID()
+            lastSelectedExactRoot = modalPromptConfiguration.viewController
+            legacyActiveAttemptIDs.insert(scheduledAttemptID)
             Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal from \(type(of: provider))")
-            presentModalPrompt(modalPromptConfiguration: modalPromptConfiguration, from: presenter) { [weak self] in
-                self?.saveModalPromptLastPresentationDate()
+            presentLegacyModalPrompt(
+                modalPromptConfiguration: modalPromptConfiguration,
+                from: presenter,
+                scheduledAttemptID: scheduledAttemptID
+            ) { [weak self] in
+                guard let self else { return }
+                self.legacyActiveAttemptIDs.remove(scheduledAttemptID)
+                self.didActuallyPresentModalPromptThisSession = true
+                self.saveModalPromptLastPresentationDate()
                 provider.didPresentModal()
             }
             return
@@ -107,20 +226,151 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
 
         Logger.modalPrompt.debug("[Modal Prompt Coordination] - No provider is eligible to present a modal.")
     }
+
+    func presentModalPromptIfNeeded(
+        from presenter: ModalPromptPresenter,
+        with lease: PromoQueueModalLease
+    ) -> ModalPromptLeaseDisposition {
+        guard modalAttemptPhase == .idle else {
+            assertionFailure("A coordinated modal lease cannot replace an active modal attempt.")
+            lease.release()
+            return .released
+        }
+
+        let attempt = CoordinatedAttempt(lease: lease)
+        attemptState = .evaluating(attempt)
+
+        guard !cooldownManager.isInCooldownPeriod else {
+            let cooldownInfo = cooldownManager.cooldownInfo
+            let lastPresentationDate = cooldownInfo.lastPresentationDate.flatMap(String.init) ?? "-"
+            Logger.modalPrompt.debug(
+                """
+                [Modal Prompt Coordination] - Is in cooldown period. Last presentation: \(lastPresentationDate, privacy: .public) \
+                Can Present modal again: \(cooldownInfo.nextPresentationDate, privacy: .public)
+                """
+            )
+            releaseCoordinationAttempt()
+            return .released
+        }
+
+        let isOnboardingComplete = onboardingStatusProvider.hasSeenOnboarding
+        for provider in providers {
+            guard provider.isEligibleToPresent(isOnboardingComplete: isOnboardingComplete) else {
+                Logger.modalPrompt.debug(
+                    """
+                    [Modal Prompt Coordination] - \(type(of: provider)) is not eligible to present \
+                    (isOnboardingComplete: \(isOnboardingComplete)).
+                    """
+                )
+                continue
+            }
+            guard let modalPromptConfiguration = provider.provideModalPrompt() else { continue }
+
+            lastSelectedExactRoot = modalPromptConfiguration.viewController
+            let committedAttempt = CommittedAttempt(
+                attempt: attempt,
+                configuration: modalPromptConfiguration,
+                provider: provider
+            )
+            attemptState = .committed(committedAttempt)
+            Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal from \(type(of: provider))")
+            presentCoordinatedModal(committedAttempt, from: presenter)
+            return .retained
+        }
+
+        Logger.modalPrompt.debug("[Modal Prompt Coordination] - No provider is eligible to present a modal.")
+        releaseCoordinationAttempt()
+        return .released
+    }
+
+    /// Releases a coordinated modal only after the exact selected root is no longer attached.
+    ///
+    /// A child presented by that root does not affect this check because attachment is evaluated
+    /// against the retained root itself rather than the topmost view controller.
+    func reconcilePresentedModal() -> Bool {
+        guard case .presentationActive(let attempt, let exactRoot) = attemptState,
+              !rootAttachmentChecker.isAttached(exactRoot) else {
+            return false
+        }
+
+        attemptState = .idle
+        attempt.lease.release()
+        return true
+    }
 }
 
 // MARK: - Private
 
 private extension ModalPromptCoordinationManager {
 
-    func presentModalPrompt(modalPromptConfiguration: ModalPromptConfiguration, from presenter: ModalPromptPresenter, completion: @escaping (() -> Void)) {
-        scheduler.schedule(after: 0.1) {
-            if let presented = presenter.presentedViewController, presented is OmniBarEditingStateViewController, !presented.isBeingDismissed {
-                Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal on top of OmniBarEditingStateViewController")
-                presented.present(modalPromptConfiguration.viewController, animated: modalPromptConfiguration.animated, completion: completion)
-            } else {
-                presenter.present(modalPromptConfiguration.viewController, animated: modalPromptConfiguration.animated, completion: completion)
+    private func presentCoordinatedModal(_ committedAttempt: CommittedAttempt, from presenter: ModalPromptPresenter) {
+        scheduler.schedule(after: 0.1) { [weak self] in
+            guard let self,
+                  case .committed(let currentAttempt) = self.attemptState,
+                  currentAttempt.attempt.lease.attemptIdentity == committedAttempt.attempt.lease.attemptIdentity else {
+                return
             }
+
+            self.attemptState = .presentationActive(
+                committedAttempt.attempt,
+                exactRoot: committedAttempt.configuration.viewController
+            )
+            self.performPresentation(
+                modalPromptConfiguration: committedAttempt.configuration,
+                from: presenter
+            ) { [weak self] in
+                self?.didActuallyPresentModalPromptThisSession = true
+                self?.saveModalPromptLastPresentationDate()
+                committedAttempt.provider.didPresentModal()
+            }
+        }
+    }
+
+    func presentLegacyModalPrompt(
+        modalPromptConfiguration: ModalPromptConfiguration,
+        from presenter: ModalPromptPresenter,
+        scheduledAttemptID: UUID,
+        completion: @escaping (() -> Void)
+    ) {
+        scheduler.schedule(after: 0.1) { [weak self] in
+            guard let self,
+                  self.legacyActiveAttemptIDs.contains(scheduledAttemptID) else {
+                return
+            }
+
+            self.performPresentation(
+                modalPromptConfiguration: modalPromptConfiguration,
+                from: presenter,
+                completion: completion
+            )
+        }
+    }
+
+    func performPresentation(
+        modalPromptConfiguration: ModalPromptConfiguration,
+        from presenter: ModalPromptPresenter,
+        completion: @escaping (() -> Void)
+    ) {
+        if let presented = presenter.presentedViewController, presented is OmniBarEditingStateViewController, !presented.isBeingDismissed {
+            Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal on top of OmniBarEditingStateViewController")
+            lastSelectedPresentationHost = presented
+            presented.present(modalPromptConfiguration.viewController, animated: modalPromptConfiguration.animated, completion: completion)
+        } else {
+            lastSelectedPresentationHost = presenter.modalPromptPresentationViewController
+            presenter.present(modalPromptConfiguration.viewController, animated: modalPromptConfiguration.animated, completion: completion)
+        }
+    }
+
+    func releaseCoordinationAttempt() {
+        switch attemptState {
+        case .idle:
+            return
+        case .evaluating(let attempt), .presentationActive(let attempt, _):
+            attemptState = .idle
+            attempt.lease.release()
+        case .committed(let committedAttempt):
+            attemptState = .idle
+            committedAttempt.attempt.lease.release()
         }
     }
 

--- a/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
@@ -48,21 +48,11 @@ enum ModalPromptAttemptPhase: Equatable {
 @MainActor
 protocol ModalPromptRootAttachmentChecking {
     func isAttached(_ root: UIViewController) -> Bool
-    func isAttached(_ root: UIViewController, to intendedPresenter: UIViewController?) -> Bool
 }
 
 struct ModalPromptRootAttachmentChecker: ModalPromptRootAttachmentChecking {
     func isAttached(_ root: UIViewController) -> Bool {
         root.isBeingPresented || root.presentingViewController != nil || root.viewIfLoaded?.window != nil
-    }
-
-    func isAttached(_ root: UIViewController, to intendedPresenter: UIViewController?) -> Bool {
-        guard isAttached(root), let intendedPresenter else {
-            return isAttached(root)
-        }
-
-        return root.presentingViewController === intendedPresenter
-            || intendedPresenter.presentedViewController === root
     }
 }
 
@@ -76,6 +66,11 @@ struct ModalPromptRootAttachmentChecker: ModalPromptRootAttachmentChecking {
 /// The manager does NOT handle app-lifecycle level concerns like launch source checking. Those are handled by the `ModalPromptsCoordinationService`.
 @MainActor
 final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
+    private struct SelectedPrompt {
+        let configuration: ModalPromptConfiguration
+        let provider: any ModalPromptProvider
+    }
+
     private struct CoordinatedAttempt {
         let lease: PromoQueueModalLease
     }
@@ -103,7 +98,6 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
     private var attemptState = AttemptState.idle
     private var legacyActiveAttemptIDs = Set<UUID>()
     private weak var lastSelectedExactRoot: UIViewController?
-    private weak var lastSelectedPresentationHost: UIViewController?
 
     private(set) var didActuallyPresentModalPromptThisSession = false
 
@@ -158,10 +152,7 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
     func promoQueueDidTransition(to targetState: PromoQueueFeatureTargetState) {
         guard targetState == .enabled,
               let lastSelectedExactRoot,
-              rootAttachmentChecker.isAttached(
-                lastSelectedExactRoot,
-                to: lastSelectedPresentationHost
-              ) else {
+              rootAttachmentChecker.isAttached(lastSelectedExactRoot) else {
             return
         }
 
@@ -184,50 +175,23 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
     ///
     /// - Parameter presenter: The view controller to present from.
     func presentModalPromptIfNeeded(from presenter: ModalPromptPresenter) {
-        guard !cooldownManager.isInCooldownPeriod else {
-            let cooldownInfo = cooldownManager.cooldownInfo
-            let lastPresentationDate = cooldownInfo.lastPresentationDate.flatMap(String.init) ?? "-"
-            Logger.modalPrompt.debug(
-                """
-                [Modal Prompt Coordination] - Is in cooldown period. Last presentation: \(lastPresentationDate, privacy: .public) \
-                Can Present modal again: \(cooldownInfo.nextPresentationDate, privacy: .public)
-                """
-            )
-            return
+        guard let selectedPrompt = selectModalPrompt() else { return }
+
+        let scheduledAttemptID = UUID()
+        lastSelectedExactRoot = selectedPrompt.configuration.viewController
+        legacyActiveAttemptIDs.insert(scheduledAttemptID)
+        Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal from \(type(of: selectedPrompt.provider))")
+        presentLegacyModalPrompt(
+            modalPromptConfiguration: selectedPrompt.configuration,
+            from: presenter,
+            scheduledAttemptID: scheduledAttemptID
+        ) { [weak self] in
+            guard let self else { return }
+            self.legacyActiveAttemptIDs.remove(scheduledAttemptID)
+            self.didActuallyPresentModalPromptThisSession = true
+            self.saveModalPromptLastPresentationDate()
+            selectedPrompt.provider.didPresentModal()
         }
-
-        let isOnboardingComplete = onboardingStatusProvider.hasSeenOnboarding
-        for provider in providers {
-            guard provider.isEligibleToPresent(isOnboardingComplete: isOnboardingComplete) else {
-                Logger.modalPrompt.debug(
-                    """
-                    [Modal Prompt Coordination] - \(type(of: provider)) is not eligible to present \
-                    (isOnboardingComplete: \(isOnboardingComplete)).
-                    """
-                )
-                continue
-            }
-            guard let modalPromptConfiguration = provider.provideModalPrompt() else { continue }
-
-            let scheduledAttemptID = UUID()
-            lastSelectedExactRoot = modalPromptConfiguration.viewController
-            legacyActiveAttemptIDs.insert(scheduledAttemptID)
-            Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal from \(type(of: provider))")
-            presentLegacyModalPrompt(
-                modalPromptConfiguration: modalPromptConfiguration,
-                from: presenter,
-                scheduledAttemptID: scheduledAttemptID
-            ) { [weak self] in
-                guard let self else { return }
-                self.legacyActiveAttemptIDs.remove(scheduledAttemptID)
-                self.didActuallyPresentModalPromptThisSession = true
-                self.saveModalPromptLastPresentationDate()
-                provider.didPresentModal()
-            }
-            return
-        }
-
-        Logger.modalPrompt.debug("[Modal Prompt Coordination] - No provider is eligible to present a modal.")
     }
 
     func presentModalPromptIfNeeded(
@@ -243,47 +207,21 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
         let attempt = CoordinatedAttempt(lease: lease)
         attemptState = .evaluating(attempt)
 
-        guard !cooldownManager.isInCooldownPeriod else {
-            let cooldownInfo = cooldownManager.cooldownInfo
-            let lastPresentationDate = cooldownInfo.lastPresentationDate.flatMap(String.init) ?? "-"
-            Logger.modalPrompt.debug(
-                """
-                [Modal Prompt Coordination] - Is in cooldown period. Last presentation: \(lastPresentationDate, privacy: .public) \
-                Can Present modal again: \(cooldownInfo.nextPresentationDate, privacy: .public)
-                """
-            )
+        guard let selectedPrompt = selectModalPrompt() else {
             releaseCoordinationAttempt()
             return .released
         }
 
-        let isOnboardingComplete = onboardingStatusProvider.hasSeenOnboarding
-        for provider in providers {
-            guard provider.isEligibleToPresent(isOnboardingComplete: isOnboardingComplete) else {
-                Logger.modalPrompt.debug(
-                    """
-                    [Modal Prompt Coordination] - \(type(of: provider)) is not eligible to present \
-                    (isOnboardingComplete: \(isOnboardingComplete)).
-                    """
-                )
-                continue
-            }
-            guard let modalPromptConfiguration = provider.provideModalPrompt() else { continue }
-
-            lastSelectedExactRoot = modalPromptConfiguration.viewController
-            let committedAttempt = CommittedAttempt(
-                attempt: attempt,
-                configuration: modalPromptConfiguration,
-                provider: provider
-            )
-            attemptState = .committed(committedAttempt)
-            Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal from \(type(of: provider))")
-            presentCoordinatedModal(committedAttempt, from: presenter)
-            return .retained
-        }
-
-        Logger.modalPrompt.debug("[Modal Prompt Coordination] - No provider is eligible to present a modal.")
-        releaseCoordinationAttempt()
-        return .released
+        lastSelectedExactRoot = selectedPrompt.configuration.viewController
+        let committedAttempt = CommittedAttempt(
+            attempt: attempt,
+            configuration: selectedPrompt.configuration,
+            provider: selectedPrompt.provider
+        )
+        attemptState = .committed(committedAttempt)
+        Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal from \(type(of: selectedPrompt.provider))")
+        presentCoordinatedModal(committedAttempt, from: presenter)
+        return .retained
     }
 
     /// Releases a coordinated modal only after the exact selected root is no longer attached.
@@ -305,6 +243,39 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
 // MARK: - Private
 
 private extension ModalPromptCoordinationManager {
+
+    func selectModalPrompt() -> SelectedPrompt? {
+        guard !cooldownManager.isInCooldownPeriod else {
+            let cooldownInfo = cooldownManager.cooldownInfo
+            let lastPresentationDate = cooldownInfo.lastPresentationDate.flatMap(String.init) ?? "-"
+            Logger.modalPrompt.debug(
+                """
+                [Modal Prompt Coordination] - Is in cooldown period. Last presentation: \(lastPresentationDate, privacy: .public) \
+                Can Present modal again: \(cooldownInfo.nextPresentationDate, privacy: .public)
+                """
+            )
+            return nil
+        }
+
+        let isOnboardingComplete = onboardingStatusProvider.hasSeenOnboarding
+        for provider in providers {
+            guard provider.isEligibleToPresent(isOnboardingComplete: isOnboardingComplete) else {
+                Logger.modalPrompt.debug(
+                    """
+                    [Modal Prompt Coordination] - \(type(of: provider)) is not eligible to present \
+                    (isOnboardingComplete: \(isOnboardingComplete)).
+                    """
+                )
+                continue
+            }
+            guard let configuration = provider.provideModalPrompt() else { continue }
+
+            return SelectedPrompt(configuration: configuration, provider: provider)
+        }
+
+        Logger.modalPrompt.debug("[Modal Prompt Coordination] - No provider is eligible to present a modal.")
+        return nil
+    }
 
     private func presentCoordinatedModal(_ committedAttempt: CommittedAttempt, from presenter: ModalPromptPresenter) {
         scheduler.schedule(after: 0.1) { [weak self] in
@@ -356,10 +327,8 @@ private extension ModalPromptCoordinationManager {
     ) {
         if let presented = presenter.presentedViewController, presented is OmniBarEditingStateViewController, !presented.isBeingDismissed {
             Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal on top of OmniBarEditingStateViewController")
-            lastSelectedPresentationHost = presented
             presented.present(modalPromptConfiguration.viewController, animated: modalPromptConfiguration.animated, completion: completion)
         } else {
-            lastSelectedPresentationHost = presenter.modalPromptPresentationViewController
             presenter.present(modalPromptConfiguration.viewController, animated: modalPromptConfiguration.animated, completion: completion)
         }
     }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
@@ -22,9 +22,6 @@ import UIKit
 @MainActor
 protocol ModalPromptCoordinationManaging {
     var didPresentModalPromptThisSession: Bool { get }
-    var didActuallyPresentModalPromptThisSession: Bool { get }
-    var hasActiveOrPendingModalAttempt: Bool { get }
-    var modalAttemptPhase: ModalPromptAttemptPhase { get }
 
     func presentModalPromptIfNeeded(from presenter: ModalPromptPresenter)
     func presentModalPromptIfNeeded(
@@ -105,7 +102,7 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
 
     private var attemptState = AttemptState.idle
     private var legacyActiveAttemptIDs = Set<UUID>()
-    private var lastSelectedExactRoot: UIViewController?
+    private weak var lastSelectedExactRoot: UIViewController?
     private weak var lastSelectedPresentationHost: UIViewController?
 
     private(set) var didActuallyPresentModalPromptThisSession = false
@@ -147,8 +144,14 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
         self.rootAttachmentChecker = rootAttachmentChecker ?? ModalPromptRootAttachmentChecker()
     }
 
+    /// Clears legacy and coordinated modal bookkeeping before the feature state flips.
+    ///
+    /// The cleanup is intentionally direction-independent, so `targetState` is not consulted here: both directions
+    /// must drop the other path's in-flight bookkeeping. The parameter is kept because transition callbacks carry
+    /// the target state by design.
     func promoQueueWillTransition(to targetState: PromoQueueFeatureTargetState) {
         legacyActiveAttemptIDs.removeAll()
+        latchActualPresentationHistoryIfPresentationActive()
         releaseCoordinationAttempt()
     }
 
@@ -359,6 +362,22 @@ private extension ModalPromptCoordinationManager {
             lastSelectedPresentationHost = presenter.modalPromptPresentationViewController
             presenter.present(modalPromptConfiguration.viewController, animated: modalPromptConfiguration.animated, completion: completion)
         }
+    }
+
+    /// Records an attempt that is already presenting as actual session history before a feature transition tears it down.
+    ///
+    /// The manager only enters `.presentationActive` after `present(_:animated:completion:)` has been called, so the modal
+    /// is on screen — or animating in — even when UIKit has not run the presentation completion yet. That makes it a
+    /// presented attempt, not a pre-presentation cancellation: only `.evaluating` and `.committed` are pre-presentation
+    /// cancellations, and those must keep clearing suppression. Latching here keeps `didPresentModalPromptThisSession`
+    /// true across the transition so no other promo can slip in underneath a visible modal.
+    ///
+    /// This must not be shared with `reconcilePresentedModal()`, which also clears a `.presentationActive` attempt: there,
+    /// a real presentation has already latched the flag from its completion, and a presentation UIKit refused genuinely
+    /// never appeared.
+    func latchActualPresentationHistoryIfPresentationActive() {
+        guard case .presentationActive = attemptState else { return }
+        didActuallyPresentModalPromptThisSession = true
     }
 
     func releaseCoordinationAttempt() {

--- a/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
@@ -52,15 +52,12 @@ protocol ModalPromptRootAttachmentChecking {
 
 struct ModalPromptRootAttachmentChecker: ModalPromptRootAttachmentChecking {
 
-    /// A root in the middle of its dismissal transition counts as detached.
+    /// A root remains attached throughout dismissal while UIKit still presents it or keeps its view in a window.
     ///
-    /// UIKit keeps both `presentingViewController` and the view's window non-nil for the whole dismissal animation, so
-    /// every other attachment term still fires while the modal is on its way out. Calling such a root attached would
-    /// retain the modal lease for one more checkpoint and defer a waiting promo by that checkpoint for nothing. The rest
-    /// of the subsystem already treats a dismissing controller as gone, so the dismissal flag wins over every disjunct.
+    /// `isBeingDismissed` becomes true at the start of the animation, before the modal has left the screen. The concrete
+    /// presentation and window relationships are the source of truth so the modal lease cannot be released while the
+    /// outgoing root can still overlap a newly admitted promo.
     func isAttached(_ root: UIViewController) -> Bool {
-        guard !root.isBeingDismissed else { return false }
-
         return root.isBeingPresented || root.presentingViewController != nil || root.viewIfLoaded?.window != nil
     }
 }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
@@ -51,8 +51,17 @@ protocol ModalPromptRootAttachmentChecking {
 }
 
 struct ModalPromptRootAttachmentChecker: ModalPromptRootAttachmentChecking {
+
+    /// A root in the middle of its dismissal transition counts as detached.
+    ///
+    /// UIKit keeps both `presentingViewController` and the view's window non-nil for the whole dismissal animation, so
+    /// every other attachment term still fires while the modal is on its way out. Calling such a root attached would
+    /// retain the modal lease for one more checkpoint and defer a waiting promo by that checkpoint for nothing. The rest
+    /// of the subsystem already treats a dismissing controller as gone, so the dismissal flag wins over every disjunct.
     func isAttached(_ root: UIViewController) -> Bool {
-        root.isBeingPresented || root.presentingViewController != nil || root.viewIfLoaded?.window != nil
+        guard !root.isBeingDismissed else { return false }
+
+        return root.isBeingPresented || root.presentingViewController != nil || root.viewIfLoaded?.window != nil
     }
 }
 
@@ -81,11 +90,24 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
         let provider: any ModalPromptProvider
     }
 
+    /// Weak holder for a presented modal root, since an enum payload cannot itself be `weak`.
+    ///
+    /// Checkpoints are sparse — foreground and NTP promo admission — so a strong payload would leave the manager the
+    /// sole owner of a dismissed modal's whole view hierarchy for as long as the user keeps browsing. The providers that
+    /// keep the presented controller keep it weakly for the same reason.
+    private final class PresentedModalRoot {
+        weak var viewController: UIViewController?
+
+        init(_ viewController: UIViewController) {
+            self.viewController = viewController
+        }
+    }
+
     private enum AttemptState {
         case idle
         case evaluating(CoordinatedAttempt)
         case committed(CommittedAttempt)
-        case presentationActive(CoordinatedAttempt, exactRoot: UIViewController)
+        case presentationActive(CoordinatedAttempt, exactRoot: PresentedModalRoot)
     }
 
     private let providers: [any ModalPromptProvider]
@@ -97,7 +119,12 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
 
     private var attemptState = AttemptState.idle
     private var legacyActiveAttemptIDs = Set<UUID>()
-    private weak var lastSelectedExactRoot: UIViewController?
+
+    /// The exact root of the most recent modal the manager actually handed to UIKit, on either path.
+    ///
+    /// Recorded at presentation time rather than selection time: its only reader re-adopts a modal that is genuinely on
+    /// screen when the feature turns on, and a root that was merely selected has nothing on screen to re-adopt.
+    private weak var lastPresentedExactRoot: UIViewController?
 
     private(set) var didActuallyPresentModalPromptThisSession = false
 
@@ -145,14 +172,14 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
     /// the target state by design.
     func promoQueueWillTransition(to targetState: PromoQueueFeatureTargetState) {
         legacyActiveAttemptIDs.removeAll()
-        latchActualPresentationHistoryIfPresentationActive()
+        latchActualPresentationHistoryIfModalIsAttached()
         releaseCoordinationAttempt()
     }
 
     func promoQueueDidTransition(to targetState: PromoQueueFeatureTargetState) {
         guard targetState == .enabled,
-              let lastSelectedExactRoot,
-              rootAttachmentChecker.isAttached(lastSelectedExactRoot) else {
+              let lastPresentedExactRoot,
+              rootAttachmentChecker.isAttached(lastPresentedExactRoot) else {
             return
         }
 
@@ -161,7 +188,7 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
         }
 
         let attempt = CoordinatedAttempt(lease: lease)
-        attemptState = .presentationActive(attempt, exactRoot: lastSelectedExactRoot)
+        attemptState = .presentationActive(attempt, exactRoot: PresentedModalRoot(lastPresentedExactRoot))
     }
 
     /// Attempts to present a modal prompt if one is eligible.
@@ -178,7 +205,6 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
         guard let selectedPrompt = selectModalPrompt() else { return }
 
         let scheduledAttemptID = UUID()
-        lastSelectedExactRoot = selectedPrompt.configuration.viewController
         legacyActiveAttemptIDs.insert(scheduledAttemptID)
         Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal from \(type(of: selectedPrompt.provider))")
         presentLegacyModalPrompt(
@@ -186,10 +212,12 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
             from: presenter,
             scheduledAttemptID: scheduledAttemptID
         ) { [weak self] in
-            guard let self else { return }
-            self.legacyActiveAttemptIDs.remove(scheduledAttemptID)
-            self.didActuallyPresentModalPromptThisSession = true
-            self.saveModalPromptLastPresentationDate()
+            // Each manager-side statement is individually optional so a deallocated manager cannot swallow the
+            // provider's own "mark as shown" hook — without it a provider such as win-back would offer the same prompt
+            // again. This mirrors the coordinated completion below.
+            self?.legacyActiveAttemptIDs.remove(scheduledAttemptID)
+            self?.didActuallyPresentModalPromptThisSession = true
+            self?.saveModalPromptLastPresentationDate()
             selectedPrompt.provider.didPresentModal()
         }
     }
@@ -212,7 +240,6 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
             return .released
         }
 
-        lastSelectedExactRoot = selectedPrompt.configuration.viewController
         let committedAttempt = CommittedAttempt(
             attempt: attempt,
             configuration: selectedPrompt.configuration,
@@ -227,10 +254,12 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
     /// Releases a coordinated modal only after the exact selected root is no longer attached.
     ///
     /// A child presented by that root does not affect this check because attachment is evaluated
-    /// against the retained root itself rather than the topmost view controller.
+    /// against the observed root itself rather than the topmost view controller. A root that has already been
+    /// deallocated counts as not attached, so a lease can never outlive the modal it was taken for.
     func reconcilePresentedModal() -> Bool {
-        guard case .presentationActive(let attempt, let exactRoot) = attemptState,
-              !rootAttachmentChecker.isAttached(exactRoot) else {
+        guard case .presentationActive(let attempt, let exactRoot) = attemptState else { return false }
+
+        if let root = exactRoot.viewController, rootAttachmentChecker.isAttached(root) {
             return false
         }
 
@@ -244,7 +273,7 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
 
 private extension ModalPromptCoordinationManager {
 
-    func selectModalPrompt() -> SelectedPrompt? {
+    private func selectModalPrompt() -> SelectedPrompt? {
         guard !cooldownManager.isInCooldownPeriod else {
             let cooldownInfo = cooldownManager.cooldownInfo
             let lastPresentationDate = cooldownInfo.lastPresentationDate.flatMap(String.init) ?? "-"
@@ -287,7 +316,7 @@ private extension ModalPromptCoordinationManager {
 
             self.attemptState = .presentationActive(
                 committedAttempt.attempt,
-                exactRoot: committedAttempt.configuration.viewController
+                exactRoot: PresentedModalRoot(committedAttempt.configuration.viewController)
             )
             self.performPresentation(
                 modalPromptConfiguration: committedAttempt.configuration,
@@ -320,11 +349,17 @@ private extension ModalPromptCoordinationManager {
         }
     }
 
+    /// Hands the selected root to UIKit, and records it as the last root the manager presented.
+    ///
+    /// Both the legacy and the coordinated path funnel through here, so the recording covers the flag-off legacy path
+    /// too, which is what a later disabled-to-enabled transition needs in order to re-adopt an already visible modal.
     func performPresentation(
         modalPromptConfiguration: ModalPromptConfiguration,
         from presenter: ModalPromptPresenter,
         completion: @escaping (() -> Void)
     ) {
+        lastPresentedExactRoot = modalPromptConfiguration.viewController
+
         if let presented = presenter.presentedViewController, presented is OmniBarEditingStateViewController, !presented.isBeingDismissed {
             Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal on top of OmniBarEditingStateViewController")
             presented.present(modalPromptConfiguration.viewController, animated: modalPromptConfiguration.animated, completion: completion)
@@ -333,19 +368,26 @@ private extension ModalPromptCoordinationManager {
         }
     }
 
-    /// Records an attempt that is already presenting as actual session history before a feature transition tears it down.
+    /// Records an attempt whose modal is genuinely on screen as actual session history before a feature transition tears
+    /// it down.
     ///
-    /// The manager only enters `.presentationActive` after `present(_:animated:completion:)` has been called, so the modal
-    /// is on screen — or animating in — even when UIKit has not run the presentation completion yet. That makes it a
-    /// presented attempt, not a pre-presentation cancellation: only `.evaluating` and `.committed` are pre-presentation
-    /// cancellations, and those must keep clearing suppression. Latching here keeps `didPresentModalPromptThisSession`
-    /// true across the transition so no other promo can slip in underneath a visible modal.
+    /// `.presentationActive` is entered *before* `present(_:animated:completion:)` is called, so the state alone does not
+    /// prove the modal ever appeared: UIKit can silently refuse the call and never run the presentation completion.
+    /// Attachment of the exact selected root is the only evidence available here, so the latch is gated on the same
+    /// predicate the rest of the class uses. An attached root makes this a presented attempt, and keeping
+    /// `didPresentModalPromptThisSession` true across the transition stops another promo slipping in underneath a visible
+    /// modal. Everything else is a pre-presentation cancellation — `.evaluating`, `.committed`, and a refused presentation
+    /// alike — and must keep clearing suppression so the session is not falsely marked as having shown a modal.
     ///
-    /// This must not be shared with `reconcilePresentedModal()`, which also clears a `.presentationActive` attempt: there,
-    /// a real presentation has already latched the flag from its completion, and a presentation UIKit refused genuinely
-    /// never appeared.
-    func latchActualPresentationHistoryIfPresentationActive() {
-        guard case .presentationActive = attemptState else { return }
+    /// This must not be shared with `reconcilePresentedModal()`, which clears a `.presentationActive` attempt on the
+    /// opposite answer: there a real presentation has already latched the flag from its completion.
+    func latchActualPresentationHistoryIfModalIsAttached() {
+        guard case .presentationActive(_, let exactRoot) = attemptState,
+              let root = exactRoot.viewController,
+              rootAttachmentChecker.isAttached(root) else {
+            return
+        }
+
         didActuallyPresentModalPromptThisSession = true
     }
 

--- a/iOS/DuckDuckGo/NewTabPageMessagesModel.swift
+++ b/iOS/DuckDuckGo/NewTabPageMessagesModel.swift
@@ -34,6 +34,7 @@ final class NewTabPageMessagesModel: ObservableObject {
     private let messageActionHandler: RemoteMessagingActionHandling
     private let imageLoader: RemoteMessagingImageLoading
     private let pixelReporter: RemoteMessagingPixelReporting?
+    private let promoCoordinator: NewTabPagePromoCoordinating
     private let isOpenedAfterIdle: () -> Bool
 
     init(homePageMessagesConfiguration: HomePageMessagesConfiguration,
@@ -43,6 +44,7 @@ final class NewTabPageMessagesModel: ObservableObject {
          messageActionHandler: RemoteMessagingActionHandling,
          imageLoader: RemoteMessagingImageLoading,
          pixelReporter: RemoteMessagingPixelReporting? = nil,
+         promoCoordinator: NewTabPagePromoCoordinating,
          isOpenedAfterIdle: @escaping () -> Bool = { false }) {
         self.homePageMessagesConfiguration = homePageMessagesConfiguration
         self.notificationCenter = notificationCenter
@@ -51,6 +53,7 @@ final class NewTabPageMessagesModel: ObservableObject {
         self.messageActionHandler = messageActionHandler
         self.imageLoader = imageLoader
         self.pixelReporter = pixelReporter
+        self.promoCoordinator = promoCoordinator
         self.isOpenedAfterIdle = isOpenedAfterIdle
     }
 

--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -305,7 +305,8 @@ private struct Metrics {
                 homeMessages: []
             ),
             messageActionHandler: RemoteMessagingActionHandler(),
-            imageLoader: PreviewImageLoader()
+            imageLoader: PreviewImageLoader(),
+            promoCoordinator: PreviewNewTabPagePromoCoordinator()
         ),
         favoritesViewModel: FavoritesPreviewModel()
     )
@@ -330,7 +331,8 @@ private struct Metrics {
                 ]
             ),
             messageActionHandler: RemoteMessagingActionHandler(),
-            imageLoader: PreviewImageLoader()
+            imageLoader: PreviewImageLoader(),
+            promoCoordinator: PreviewNewTabPagePromoCoordinator()
         ),
         favoritesViewModel: FavoritesPreviewModel()
     )
@@ -344,7 +346,8 @@ private struct Metrics {
                 homeMessages: []
             ),
             messageActionHandler: RemoteMessagingActionHandler(),
-            imageLoader: PreviewImageLoader()
+            imageLoader: PreviewImageLoader(),
+            promoCoordinator: PreviewNewTabPagePromoCoordinator()
         ),
         favoritesViewModel: FavoritesPreviewModel(favorites: [])
     )
@@ -358,10 +361,16 @@ private struct Metrics {
                 homeMessages: []
             ),
             messageActionHandler: RemoteMessagingActionHandler(),
-            imageLoader: PreviewImageLoader()
+            imageLoader: PreviewImageLoader(),
+            promoCoordinator: PreviewNewTabPagePromoCoordinator()
         ),
         favoritesViewModel: FavoritesPreviewModel()
     )
+}
+
+@MainActor
+private final class PreviewNewTabPagePromoCoordinator: NewTabPagePromoCoordinating {
+    let promoQueueFeatureState = PromoQueueFeatureState.disabled
 }
 
 private final class PreviewMessagesConfiguration: HomePageMessagesConfiguration {

--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -368,9 +368,25 @@ private struct Metrics {
     )
 }
 
+/// An inert, always-disabled promo coordinator for SwiftUI previews.
 @MainActor
 private final class PreviewNewTabPagePromoCoordinator: NewTabPagePromoCoordinating {
     let promoQueueFeatureState = PromoQueueFeatureState.disabled
+
+    func admitVisiblePromo(_ identity: VisiblePromoIdentity) -> VisiblePromoAdmissionResult {
+        .featureDisabled
+    }
+
+    func releaseVisiblePromoLease(_ lease: PromoQueueVisiblePromoLease) {
+        lease.release()
+    }
+
+    func registerVisiblePromoRetry(
+        for surfaceID: UUID,
+        target: NewTabPagePromoRetrying
+    ) -> NewTabPagePromoRetryRegistration {
+        NewTabPagePromoRetryRegistration()
+    }
 }
 
 private final class PreviewMessagesConfiguration: HomePageMessagesConfiguration {

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -99,6 +99,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
          remoteMessagingActionHandler: RemoteMessagingActionHandling,
          remoteMessagingImageLoader: RemoteMessagingImageLoading,
          remoteMessagingPixelReporter: RemoteMessagingPixelReporting? = nil,
+         promoCoordinator: NewTabPagePromoCoordinating,
          appSettings: AppSettings,
          faviconsCache: FavoritesFaviconCaching,
          subscriptionManager: any SubscriptionManager,
@@ -131,6 +132,7 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
                                                 messageActionHandler: remoteMessagingActionHandler,
                                                 imageLoader: remoteMessagingImageLoader,
                                                 pixelReporter: remoteMessagingPixelReporter,
+                                                promoCoordinator: promoCoordinator,
                                                 isOpenedAfterIdle: { [weak viewModel] in viewModel?.openedAfterIdle ?? false })
 
         super.init(rootView: NewTabPageView(isFocussedState: isFocussedState,

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -201,6 +201,7 @@ class SuggestionTrayViewController: UIViewController {
         let remoteMessagingActionHandler: RemoteMessagingActionHandling
         let remoteMessagingImageLoader: RemoteMessagingImageLoading
         let remoteMessagingPixelReporter: RemoteMessagingPixelReporting?
+        let promoCoordinator: NewTabPagePromoCoordinating
         let appSettings: AppSettings
         let subscriptionManager: any SubscriptionManager
         let internalUserCommands: URLBasedDebugCommands
@@ -486,6 +487,7 @@ class SuggestionTrayViewController: UIViewController {
             remoteMessagingActionHandler: dependencies.remoteMessagingActionHandler,
             remoteMessagingImageLoader: dependencies.remoteMessagingImageLoader,
             remoteMessagingPixelReporter: dependencies.remoteMessagingPixelReporter,
+            promoCoordinator: dependencies.promoCoordinator,
             appSettings: dependencies.appSettings,
             faviconsCache: dependencies.faviconsCache,
             subscriptionManager: dependencies.subscriptionManager,

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -312,6 +312,7 @@ final class MainCoordinator {
                                         darkReaderFeatureSettings: darkReaderFeatureSettings,
                                         toggleModeStorage: toggleModeStorage,
                                         onboardingManager: onboardingManager,
+                                        newTabPagePromoCoordinator: modalPromptCoordinationService,
                                         recentModalPromptStatusProvider: modalPromptCoordinationService)
 
         setupWebExtensions(privacyConfigurationManager: privacyConfigurationManager)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -764,6 +764,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
             remoteMessagingActionHandler: ntpDeps.remoteMessagingActionHandler,
             remoteMessagingImageLoader: ntpDeps.remoteMessagingImageLoader,
             remoteMessagingPixelReporter: ntpDeps.remoteMessagingPixelReporter,
+            promoCoordinator: ntpDeps.promoCoordinator,
             appSettings: ntpDeps.appSettings,
             faviconsCache: ntpDeps.faviconsCache,
             subscriptionManager: ntpDeps.subscriptionManager,

--- a/iOS/DuckDuckGoTests/AppServices/ModalPromptCoordinationServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/ModalPromptCoordinationServiceTests.swift
@@ -195,6 +195,9 @@ final class ModalPromptCoordinationServiceTests {
 
     // MARK: - Promo Queue Admission
 
+    // The arbiter reclaims a lease whose token has deallocated, so a test that needs a lease to keep holding its slot
+    // must bind the token and keep it alive for as long as the assertions depend on it. Discarding it is not inert.
+
     @available(iOS 16, *)
     @Test("Enabled Modal Evaluation Acquires Lease Before Calling Manager", .timeLimit(.minutes(1)))
     func whenPromoQueueIsEnabledThenManagerReceivesAcquiredLease() {
@@ -225,7 +228,7 @@ final class ModalPromptCoordinationServiceTests {
             promoType: .remoteMessage,
             promoID: "rmf"
         )
-        guard case .acquired = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: visibleIdentity) else {
+        guard case .acquired(let visibleLease) = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: visibleIdentity) else {
             Issue.record("Expected visible promo lease acquisition")
             return
         }
@@ -240,6 +243,7 @@ final class ModalPromptCoordinationServiceTests {
 
         #expect(!managerMock.didCallPresentModalPromptIfNeeded)
         #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities == [visibleIdentity])
+        _ = visibleLease
     }
 
     @available(iOS 16, *)
@@ -263,7 +267,7 @@ final class ModalPromptCoordinationServiceTests {
             promoType: .remoteMessage,
             promoID: "rmf"
         )
-        guard case .acquired = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: visibleIdentity) else {
+        guard case .acquired(let visibleLease) = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: visibleIdentity) else {
             Issue.record("Expected visible promo lease acquisition")
             return
         }
@@ -281,6 +285,7 @@ final class ModalPromptCoordinationServiceTests {
 
         #expect(!provider.didCallProvideModalPrompt)
         #expect(!presenterMock.didCallPresent)
+        _ = visibleLease
     }
 
     @available(iOS 16, *)
@@ -304,7 +309,7 @@ final class ModalPromptCoordinationServiceTests {
     }
 
     @available(iOS 16, *)
-    @Test("Released Modal Lease Retries Two Active Registrations Once Without Recursion", .timeLimit(.minutes(1)))
+    @Test("Released Modal Lease Does Not Retry Active Registrations A Second Time", .timeLimit(.minutes(1)))
     func whenManagerReleasesModalLeaseThenActiveRegistrationsRetryOnce() {
         featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
         launchSourceManagerMock.source = .standard
@@ -316,38 +321,22 @@ final class ModalPromptCoordinationServiceTests {
             featureFlagger: featureFlaggerMock,
             promoQueueLeaseArbiter: promoQueueLeaseArbiter
         )
-        let firstSurfaceID = UUID()
-        let secondSurfaceID = UUID()
+        // Both surfaces are genuinely active but have nothing left to admit, which is what lets the evaluation reach the
+        // manager at all: a surface that claimed the slot in the pre-gate pass would block the modal lease instead.
         let firstTarget = MockNewTabPagePromoRetryTarget()
         let secondTarget = MockNewTabPagePromoRetryTarget()
-        firstTarget.isActiveForPromoRetry = false
-        secondTarget.isActiveForPromoRetry = false
-        managerMock.onPresentCoordinated = {
-            firstTarget.isActiveForPromoRetry = true
-            secondTarget.isActiveForPromoRetry = true
-        }
-        firstTarget.onRetry = { [weak self] in
-            guard let self else { return }
-            _ = sut.admitVisiblePromo(
-                VisiblePromoIdentity(surfaceID: firstSurfaceID, promoType: .remoteMessage, promoID: "first")
-            )
-        }
-        secondTarget.onRetry = { [weak self] in
-            guard let self else { return }
-            _ = sut.admitVisiblePromo(
-                VisiblePromoIdentity(surfaceID: secondSurfaceID, promoType: .remoteMessage, promoID: "second")
-            )
-        }
-        let firstRegistration = sut.registerVisiblePromoRetry(for: firstSurfaceID, target: firstTarget)
-        let secondRegistration = sut.registerVisiblePromoRetry(for: secondSurfaceID, target: secondTarget)
-        _ = (firstRegistration, secondRegistration)
+        let firstRegistration = sut.registerVisiblePromoRetry(for: UUID(), target: firstTarget)
+        let secondRegistration = sut.registerVisiblePromoRetry(for: UUID(), target: secondTarget)
 
         sut.presentModalPromptIfNeeded(from: presenterMock)
 
+        // The pre-gate pass is the only pass. A synchronous `.released` decision sees exactly the arbiter state that
+        // pass already saw, so retrying on it would refresh RMF selection from the store twice on one foreground.
         #expect(firstTarget.retryCount == 1)
         #expect(secondTarget.retryCount == 1)
-        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoCount == 2)
         #expect(managerMock.didCallPresentModalPromptIfNeeded)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        _ = (firstRegistration, secondRegistration)
     }
 
     @available(iOS 16, *)
@@ -372,11 +361,17 @@ final class ModalPromptCoordinationServiceTests {
         let otherSurfaceID = UUID()
         let triggeringTarget = MockNewTabPagePromoRetryTarget()
         let otherTarget = MockNewTabPagePromoRetryTarget()
+        // A real NTP surface keeps the token it was admitted with, and the arbiter reclaims a slot whose token has
+        // deallocated, so the retried surface has to keep its token for the slot to stay taken.
+        var otherSurfaceLease: PromoQueueVisiblePromoLease?
         otherTarget.onRetry = { [weak self] in
             guard let self else { return }
-            _ = sut.admitVisiblePromo(
+            let admission = sut.admitVisiblePromo(
                 VisiblePromoIdentity(surfaceID: otherSurfaceID, promoType: .remoteMessage, promoID: "other")
             )
+            if case .acquired(let lease) = admission {
+                otherSurfaceLease = lease
+            }
         }
         let triggeringRegistration = sut.registerVisiblePromoRetry(
             for: triggeringSurfaceID,
@@ -398,6 +393,7 @@ final class ModalPromptCoordinationServiceTests {
         }
         #expect(triggeringTarget.retryCount == 0)
         #expect(otherTarget.retryCount == 1)
+        #expect(otherSurfaceLease != nil)
         #expect(promoQueueLeaseArbiter.snapshot.visiblePromoCount == 2)
     }
 
@@ -425,6 +421,128 @@ final class ModalPromptCoordinationServiceTests {
 
         #expect(firstTarget.retryCount == 0)
         #expect(replacementTarget.retryCount == 1)
+    }
+
+    // MARK: - Visible Promo Admission Results
+
+    @available(iOS 16, *)
+    @Test("Disabled Feature Refuses Visible Promo Admission Without Arbitrating", .timeLimit(.minutes(1)))
+    func whenPromoQueueIsDisabledThenVisibleAdmissionIsRefusedWithoutTakingALease() {
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+
+        let result = sut.admitVisiblePromo(
+            VisiblePromoIdentity(surfaceID: UUID(), promoType: .remoteMessage, promoID: "rmf")
+        )
+
+        guard case .featureDisabled = result else {
+            Issue.record("Expected admission to be refused while the promo queue flag is off")
+            return
+        }
+        // The refusal has to come before arbitration, not through it. An NTP holding a coordination lease with the flag
+        // off would make `acquireModalLease` answer `.blockedByVisiblePromos` and silently suppress every launch modal
+        // for flag-off users, so the modal slot must still be free afterwards.
+        #expect(managerMock.reconcilePresentedModalCallCount == 0)
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities.isEmpty)
+        guard case .acquired(let modalLease) = promoQueueLeaseArbiter.acquireModalLease() else {
+            Issue.record("Expected the modal slot to stay free for the legacy launch modal path")
+            return
+        }
+        _ = modalLease
+    }
+
+    @available(iOS 16, *)
+    @Test("Coordinated Modal Attempt Blocks Visible Promo Admission", .timeLimit(.minutes(1)))
+    func whenModalAttemptOwnsSlotThenVisibleAdmissionIsBlockedByModal() {
+        featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+        guard case .acquired(let modalLease) = promoQueueLeaseArbiter.acquireModalLease() else {
+            Issue.record("Expected modal lease acquisition")
+            return
+        }
+
+        let result = sut.admitVisiblePromo(
+            VisiblePromoIdentity(surfaceID: UUID(), promoType: .remoteMessage, promoID: "rmf")
+        )
+
+        guard case .blockedByModal = result else {
+            Issue.record("Expected a coordinated modal attempt to block visible promo admission")
+            return
+        }
+        // Admission reconciles the exact modal root before asking the arbiter, so a modal that has already gone away
+        // cannot keep blocking; here it has not, so the refusal stands and no visible lease is taken.
+        #expect(managerMock.reconcilePresentedModalCallCount == 1)
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities.isEmpty)
+        _ = modalLease
+    }
+
+    @available(iOS 16, *)
+    @Test("Occupied Surface Slot Refuses A Second Promo And Names Its Occupant", .timeLimit(.minutes(1)))
+    func whenSurfaceSlotIsOccupiedThenVisibleAdmissionCarriesTheOccupyingIdentity() {
+        featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+        let surfaceID = UUID()
+        let occupyingIdentity = VisiblePromoIdentity(surfaceID: surfaceID, promoType: .remoteMessage, promoID: "first")
+        guard case .acquired(let occupyingLease) = sut.admitVisiblePromo(occupyingIdentity) else {
+            Issue.record("Expected the first visible promo to be admitted")
+            return
+        }
+
+        let result = sut.admitVisiblePromo(
+            VisiblePromoIdentity(surfaceID: surfaceID, promoType: .remoteMessage, promoID: "second")
+        )
+
+        guard case .occupiedSurfaceSlot(let reportedIdentity) = result else {
+            Issue.record("Expected the occupied surface slot to refuse a second promo")
+            return
+        }
+        // The refusal names the promo that actually holds the slot, not the one that asked for it.
+        #expect(reportedIdentity == occupyingIdentity)
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities == [occupyingIdentity])
+        _ = occupyingLease
+    }
+
+    @available(iOS 16, *)
+    @Test("Releasing A Visible Promo Lease Frees Its Surface Slot", .timeLimit(.minutes(1)))
+    func whenVisiblePromoLeaseIsReleasedThenTheSurfaceSlotIsReacquirable() {
+        featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+        let identity = VisiblePromoIdentity(surfaceID: UUID(), promoType: .remoteMessage, promoID: "rmf")
+        guard case .acquired(let lease) = sut.admitVisiblePromo(identity) else {
+            Issue.record("Expected the visible promo to be admitted")
+            return
+        }
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities == [identity])
+
+        sut.releaseVisiblePromoLease(lease)
+
+        // Withdrawing a promo has to hand the slot back, so the same surface can admit the next message for it.
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities.isEmpty)
+        guard case .acquired(let reacquiredLease) = sut.admitVisiblePromo(identity) else {
+            Issue.record("Expected the freed surface slot to be re-acquirable")
+            return
+        }
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities == [identity])
+        _ = reacquiredLease
     }
 
     // MARK: - Promo Queue Feature State
@@ -455,17 +573,31 @@ final class ModalPromptCoordinationServiceTests {
             featureFlagger: featureFlaggerMock,
             promoQueueLeaseArbiter: promoQueueLeaseArbiter
         )
-        let initialGeneration = promoQueueLeaseArbiter.snapshot.generation
+        let outstandingIdentity = VisiblePromoIdentity(
+            surfaceID: UUID(),
+            promoType: .remoteMessage,
+            promoID: "rmf"
+        )
+        guard case .acquired(let outstandingLease) = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: outstandingIdentity) else {
+            Issue.record("Expected visible promo lease acquisition")
+            return
+        }
 
         featureFlaggerMock.triggerUpdate()
         await waitForFeatureFlagUpdateDelivery()
         #expect(managerMock.promoQueueWillTransitionTargets.isEmpty)
-        #expect(promoQueueLeaseArbiter.snapshot.generation == initialGeneration)
+        // A deduplicated update never reaches the arbiter, so the outstanding lease survives it.
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities == [outstandingIdentity])
 
         featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
         featureFlaggerMock.triggerUpdate()
         await waitForFeatureFlagUpdateDelivery()
-        let enabledGeneration = promoQueueLeaseArbiter.snapshot.generation
+        // The one effective change transitions, and a transition invalidates every lease.
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities.isEmpty)
+        guard case .acquired(let reacquiredLease) = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: outstandingIdentity) else {
+            Issue.record("Expected visible promo lease acquisition after the transition")
+            return
+        }
         featureFlaggerMock.triggerUpdate()
         await waitForFeatureFlagUpdateDelivery()
 
@@ -473,8 +605,8 @@ final class ModalPromptCoordinationServiceTests {
         #expect(managerMock.promoQueueDidTransitionTargets == [.enabled])
         #expect(sut.promoQueueFeatureState == .enabled)
         #expect(featureFlaggerMock.updatesPublisherSubscriptionCount == 1)
-        #expect(enabledGeneration != initialGeneration)
-        #expect(promoQueueLeaseArbiter.snapshot.generation == enabledGeneration)
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities == [outstandingIdentity])
+        _ = (outstandingLease, reacquiredLease)
     }
 
     @available(iOS 16, *)
@@ -539,6 +671,47 @@ final class ModalPromptCoordinationServiceTests {
                 .transitioning(to: .disabled),
             ]
         )
+        #expect(sut.promoQueueFeatureState == .disabled)
+    }
+
+    @available(iOS 16, *)
+    @Test("Promo Queue Transition Barrier Rejects Visible Promo Admission In Both Directions", .timeLimit(.minutes(1)))
+    func whenTransitionCallbacksAdmitVisiblePromoThenAdmissionWaitsForBarrier() async {
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+
+        var admissionAttemptsDuringCallbacks = 0
+        var refusalsDuringCallbacks = 0
+        let admitDuringTransition: @MainActor (PromoQueueFeatureTargetState) -> Void = { [weak self] _ in
+            guard let self else { return }
+            admissionAttemptsDuringCallbacks += 1
+            let result = sut.admitVisiblePromo(
+                VisiblePromoIdentity(surfaceID: UUID(), promoType: .remoteMessage, promoID: "rmf")
+            )
+            if case .unavailableDuringTransition = result {
+                refusalsDuringCallbacks += 1
+            }
+        }
+        managerMock.onPromoQueueWillTransition = admitDuringTransition
+        managerMock.onPromoQueueDidTransition = admitDuringTransition
+
+        featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
+        featureFlaggerMock.triggerUpdate()
+        await waitForFeatureFlagUpdateDelivery()
+        featureFlaggerMock.enabledFeatureFlags = []
+        featureFlaggerMock.triggerUpdate()
+        await waitForFeatureFlagUpdateDelivery()
+
+        // Both callbacks of both transitions re-enter admission, and every one of the four must be refused: only the
+        // transition routine's own re-adoption and retry steps may mutate arbiter state while the barrier is up.
+        #expect(admissionAttemptsDuringCallbacks == 4)
+        #expect(refusalsDuringCallbacks == 4)
+        #expect(managerMock.reconcilePresentedModalCallCount == 0)
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities.isEmpty)
         #expect(sut.promoQueueFeatureState == .disabled)
     }
 

--- a/iOS/DuckDuckGoTests/AppServices/ModalPromptCoordinationServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/ModalPromptCoordinationServiceTests.swift
@@ -20,6 +20,8 @@
 import UIKit
 import Foundation
 import Combine
+import Core
+import PrivacyConfig
 import Testing
 import PersistenceTestingUtils
 @testable import DuckDuckGo
@@ -565,6 +567,29 @@ final class ModalPromptCoordinationServiceTests {
     }
 
     @available(iOS 16, *)
+    @Test("Promo Queue State Is Re-read After Feature Subscription Is Established", .timeLimit(.minutes(1)))
+    func whenPromoQueueChangesDuringFeatureSubscriptionThenSubscribedStateWins() {
+        let featureFlagger = PromoQueueSubscriptionHookFeatureFlagger()
+        featureFlagger.onUpdatesPublisherSubscription = { [weak featureFlagger] in
+            featureFlagger?.isPromoQueueEnabled = true
+            featureFlagger?.triggerUpdate()
+        }
+
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlagger,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+
+        #expect(sut.promoQueueFeatureState == .enabled)
+        #expect(managerMock.promoQueueWillTransitionTargets == [.enabled])
+        #expect(managerMock.promoQueueDidTransitionTargets == [.enabled])
+        #expect(featureFlagger.updatesPublisherSubscriptionCount == 1)
+        #expect(featureFlagger.promoQueueReadCount == 2)
+    }
+
+    @available(iOS 16, *)
     @Test("Promo Queue Feature Updates Are Deduplicated", .timeLimit(.minutes(1)))
     func whenFeatureFlagPublishesDuplicateValuesThenOnlyEffectiveChangesTransition() async {
         sut = ModalPromptCoordinationService(
@@ -825,6 +850,58 @@ private final class MockDismissingViewController: UIViewController {
     override var isBeingDismissed: Bool {
         get { _isBeingDismissed }
         set { _isBeingDismissed = newValue }
+    }
+}
+
+private final class PromoQueueSubscriptionHookFeatureFlagger: FeatureFlagger {
+    var internalUserDecider: InternalUserDecider = DefaultInternalUserDecider(store: MockInternalUserStoring())
+    var localOverrides: FeatureFlagLocalOverriding?
+    var allActiveExperiments: Experiments = [:]
+    var isPromoQueueEnabled = false
+    var onUpdatesPublisherSubscription: (() -> Void)?
+    private(set) var updatesPublisherSubscriptionCount = 0
+    private(set) var promoQueueReadCount = 0
+
+    private let updatesSubject = PassthroughSubject<Void, Never>()
+
+    var updatesPublisher: AnyPublisher<Void, Never> {
+        Deferred { [weak self] () -> AnyPublisher<Void, Never> in
+            guard let self else {
+                return Empty(completeImmediately: false).eraseToAnyPublisher()
+            }
+
+            updatesPublisherSubscriptionCount += 1
+            onUpdatesPublisherSubscription?()
+            return updatesSubject.eraseToAnyPublisher()
+        }
+        .eraseToAnyPublisher()
+    }
+
+    func triggerUpdate() {
+        updatesSubject.send()
+    }
+
+    func isFeatureOn<Flag: FeatureFlagDescribing>(for featureFlag: Flag, allowOverride: Bool) -> Bool {
+        guard featureFlag.rawValue == FeatureFlag.promoQueue.rawValue else {
+            return false
+        }
+
+        promoQueueReadCount += 1
+        return isPromoQueueEnabled
+    }
+
+    func resolveCohort<Flag: FeatureFlagDescribing>(
+        for featureFlag: Flag,
+        allowOverride: Bool
+    ) -> (any FeatureFlagCohortDescribing)? {
+        nil
+    }
+
+    func assignedCohort<Flag: FeatureFlagDescribing>(
+        for featureFlag: Flag,
+        allowOverride: Bool
+    ) -> (any FeatureFlagCohortDescribing)? {
+        nil
     }
 }
 

--- a/iOS/DuckDuckGoTests/AppServices/ModalPromptCoordinationServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/ModalPromptCoordinationServiceTests.swift
@@ -193,6 +193,233 @@ final class ModalPromptCoordinationServiceTests {
         #expect(!managerMock.didCallPresentModalPromptIfNeeded)
     }
 
+    // MARK: - Promo Queue Admission
+
+    @Test("Enabled Modal Evaluation Acquires Lease Before Calling Manager")
+    func whenPromoQueueIsEnabledThenManagerReceivesAcquiredLease() {
+        featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
+        launchSourceManagerMock.source = .standard
+        presenterMock.presentedViewController = nil
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+
+        #expect(managerMock.capturedModalLease != nil)
+        #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
+    }
+
+    @Test("Visible Promo Denial Does Not Reach Modal Manager")
+    func whenVisiblePromoOwnsSlotThenModalManagerIsNotCalled() throws {
+        featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
+        launchSourceManagerMock.source = .standard
+        presenterMock.presentedViewController = nil
+        let visibleIdentity = VisiblePromoIdentity(
+            surfaceID: UUID(),
+            promoType: .remoteMessage,
+            promoID: "rmf"
+        )
+        guard case .acquired = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: visibleIdentity) else {
+            Issue.record("Expected visible promo lease acquisition")
+            return
+        }
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+
+        #expect(!managerMock.didCallPresentModalPromptIfNeeded)
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities == [visibleIdentity])
+    }
+
+    @Test("Visible Promo Denial Never Queries A Real Provider Chain")
+    func whenVisiblePromoOwnsSlotThenProvidersAreNotQueried() throws {
+        featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
+        launchSourceManagerMock.source = .standard
+        presenterMock.presentedViewController = nil
+        let provider = MockModalPromptProvider()
+        let providers = ModalPromptProviders(
+            newAddressBarPicker: provider,
+            defaultBrowser: provider,
+            winBackOffer: provider,
+            subscriptionPromo: provider,
+            subscriptionPromoExistingUser: provider,
+            whatsNew: provider,
+            cookiePopupProtectionOptIn: provider
+        )
+        let visibleIdentity = VisiblePromoIdentity(
+            surfaceID: UUID(),
+            promoType: .remoteMessage,
+            promoID: "rmf"
+        )
+        guard case .acquired = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: visibleIdentity) else {
+            Issue.record("Expected visible promo lease acquisition")
+            return
+        }
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            keyValueStore: try MockKeyValueFileStore(),
+            contextualOnboardingStatusProvider: contextualOnboardingMock,
+            privacyConfigManager: MockPrivacyConfigurationManager(),
+            providers: providers,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+
+        #expect(!provider.didCallProvideModalPrompt)
+        #expect(!presenterMock.didCallPresent)
+    }
+
+    @Test("Disabled Modal Evaluation Uses Legacy Manager Path Without Lease")
+    func whenPromoQueueIsDisabledThenLegacyManagerPathIsUnchanged() {
+        launchSourceManagerMock.source = .standard
+        presenterMock.presentedViewController = nil
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+
+        #expect(managerMock.didCallPresentModalPromptIfNeeded)
+        #expect(managerMock.capturedModalLease == nil)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(managerMock.reconcilePresentedModalCallCount == 0)
+    }
+
+    @Test("Released Modal Lease Retries Two Active Registrations Once Without Recursion")
+    func whenManagerReleasesModalLeaseThenActiveRegistrationsRetryOnce() {
+        featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
+        launchSourceManagerMock.source = .standard
+        presenterMock.presentedViewController = nil
+        managerMock.coordinatedPresentationDisposition = .released
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+        let firstSurfaceID = UUID()
+        let secondSurfaceID = UUID()
+        let firstTarget = MockNewTabPagePromoRetryTarget()
+        let secondTarget = MockNewTabPagePromoRetryTarget()
+        firstTarget.isActiveForPromoRetry = false
+        secondTarget.isActiveForPromoRetry = false
+        managerMock.onPresentCoordinated = {
+            firstTarget.isActiveForPromoRetry = true
+            secondTarget.isActiveForPromoRetry = true
+        }
+        firstTarget.onRetry = { [weak self] in
+            guard let self else { return }
+            _ = sut.admitVisiblePromo(
+                VisiblePromoIdentity(surfaceID: firstSurfaceID, promoType: .remoteMessage, promoID: "first")
+            )
+        }
+        secondTarget.onRetry = { [weak self] in
+            guard let self else { return }
+            _ = sut.admitVisiblePromo(
+                VisiblePromoIdentity(surfaceID: secondSurfaceID, promoType: .remoteMessage, promoID: "second")
+            )
+        }
+        let firstRegistration = sut.registerVisiblePromoRetry(for: firstSurfaceID, target: firstTarget)
+        let secondRegistration = sut.registerVisiblePromoRetry(for: secondSurfaceID, target: secondTarget)
+        _ = (firstRegistration, secondRegistration)
+
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+
+        #expect(firstTarget.retryCount == 1)
+        #expect(secondTarget.retryCount == 1)
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoCount == 2)
+        #expect(managerMock.didCallPresentModalPromptIfNeeded)
+    }
+
+    @Test("Visible Admission Checkpoint Admits Triggering Surface Before Retrying Other Surface")
+    func whenVisibleAdmissionReleasesDetachedModalThenTriggeringSurfaceWinsBeforeRetrySnapshot() {
+        featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+        guard case .acquired(let modalLease) = promoQueueLeaseArbiter.acquireModalLease() else {
+            Issue.record("Expected modal lease acquisition")
+            return
+        }
+        managerMock.reconcilePresentedModalResult = true
+        managerMock.onReconcilePresentedModal = {
+            modalLease.release()
+        }
+        let triggeringSurfaceID = UUID()
+        let otherSurfaceID = UUID()
+        let triggeringTarget = MockNewTabPagePromoRetryTarget()
+        let otherTarget = MockNewTabPagePromoRetryTarget()
+        otherTarget.onRetry = { [weak self] in
+            guard let self else { return }
+            _ = sut.admitVisiblePromo(
+                VisiblePromoIdentity(surfaceID: otherSurfaceID, promoType: .remoteMessage, promoID: "other")
+            )
+        }
+        let triggeringRegistration = sut.registerVisiblePromoRetry(
+            for: triggeringSurfaceID,
+            target: triggeringTarget
+        )
+        let otherRegistration = sut.registerVisiblePromoRetry(
+            for: otherSurfaceID,
+            target: otherTarget
+        )
+        _ = (triggeringRegistration, otherRegistration)
+
+        let result = sut.admitVisiblePromo(
+            VisiblePromoIdentity(surfaceID: triggeringSurfaceID, promoType: .remoteMessage, promoID: "trigger")
+        )
+
+        guard case .acquired = result else {
+            Issue.record("Expected triggering visible promo to acquire before retries")
+            return
+        }
+        #expect(triggeringTarget.retryCount == 0)
+        #expect(otherTarget.retryCount == 1)
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoCount == 2)
+    }
+
+    @Test("Stale Registration Cannot Remove Or Invoke Its Replacement")
+    func whenRegistrationIsReplacedThenOldTokenCannotRemoveReplacement() {
+        featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+        let surfaceID = UUID()
+        let firstTarget = MockNewTabPagePromoRetryTarget()
+        let replacementTarget = MockNewTabPagePromoRetryTarget()
+        let firstRegistration = sut.registerVisiblePromoRetry(for: surfaceID, target: firstTarget)
+        let replacementRegistration = sut.registerVisiblePromoRetry(for: surfaceID, target: replacementTarget)
+
+        firstRegistration.deregister()
+        launchSourceManagerMock.source = .URL
+        presenterMock.presentedViewController = nil
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+        _ = replacementRegistration
+
+        #expect(firstTarget.retryCount == 0)
+        #expect(replacementTarget.retryCount == 1)
+    }
+
     // MARK: - Promo Queue Feature State
 
     @Test("Initial Promo Queue State Is Seeded Before Subscription Updates")
@@ -414,6 +641,18 @@ private final class MockDismissingViewController: UIViewController {
     override var isBeingDismissed: Bool {
         get { _isBeingDismissed }
         set { _isBeingDismissed = newValue }
+    }
+}
+
+@MainActor
+private final class MockNewTabPagePromoRetryTarget: NewTabPagePromoRetrying {
+    var isActiveForPromoRetry = true
+    var onRetry: (@MainActor () -> Void)?
+    private(set) var retryCount = 0
+
+    func retryVisiblePromoAdmission() {
+        retryCount += 1
+        onRetry?()
     }
 }
 

--- a/iOS/DuckDuckGoTests/AppServices/ModalPromptCoordinationServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/ModalPromptCoordinationServiceTests.swift
@@ -195,7 +195,8 @@ final class ModalPromptCoordinationServiceTests {
 
     // MARK: - Promo Queue Admission
 
-    @Test("Enabled Modal Evaluation Acquires Lease Before Calling Manager")
+    @available(iOS 16, *)
+    @Test("Enabled Modal Evaluation Acquires Lease Before Calling Manager", .timeLimit(.minutes(1)))
     func whenPromoQueueIsEnabledThenManagerReceivesAcquiredLease() {
         featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
         launchSourceManagerMock.source = .standard
@@ -213,7 +214,8 @@ final class ModalPromptCoordinationServiceTests {
         #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
     }
 
-    @Test("Visible Promo Denial Does Not Reach Modal Manager")
+    @available(iOS 16, *)
+    @Test("Visible Promo Denial Does Not Reach Modal Manager", .timeLimit(.minutes(1)))
     func whenVisiblePromoOwnsSlotThenModalManagerIsNotCalled() throws {
         featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
         launchSourceManagerMock.source = .standard
@@ -240,7 +242,8 @@ final class ModalPromptCoordinationServiceTests {
         #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities == [visibleIdentity])
     }
 
-    @Test("Visible Promo Denial Never Queries A Real Provider Chain")
+    @available(iOS 16, *)
+    @Test("Visible Promo Denial Never Queries A Real Provider Chain", .timeLimit(.minutes(1)))
     func whenVisiblePromoOwnsSlotThenProvidersAreNotQueried() throws {
         featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
         launchSourceManagerMock.source = .standard
@@ -280,7 +283,8 @@ final class ModalPromptCoordinationServiceTests {
         #expect(!presenterMock.didCallPresent)
     }
 
-    @Test("Disabled Modal Evaluation Uses Legacy Manager Path Without Lease")
+    @available(iOS 16, *)
+    @Test("Disabled Modal Evaluation Uses Legacy Manager Path Without Lease", .timeLimit(.minutes(1)))
     func whenPromoQueueIsDisabledThenLegacyManagerPathIsUnchanged() {
         launchSourceManagerMock.source = .standard
         presenterMock.presentedViewController = nil
@@ -299,7 +303,8 @@ final class ModalPromptCoordinationServiceTests {
         #expect(managerMock.reconcilePresentedModalCallCount == 0)
     }
 
-    @Test("Released Modal Lease Retries Two Active Registrations Once Without Recursion")
+    @available(iOS 16, *)
+    @Test("Released Modal Lease Retries Two Active Registrations Once Without Recursion", .timeLimit(.minutes(1)))
     func whenManagerReleasesModalLeaseThenActiveRegistrationsRetryOnce() {
         featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
         launchSourceManagerMock.source = .standard
@@ -345,7 +350,8 @@ final class ModalPromptCoordinationServiceTests {
         #expect(managerMock.didCallPresentModalPromptIfNeeded)
     }
 
-    @Test("Visible Admission Checkpoint Admits Triggering Surface Before Retrying Other Surface")
+    @available(iOS 16, *)
+    @Test("Visible Admission Checkpoint Admits Triggering Surface Before Retrying Other Surface", .timeLimit(.minutes(1)))
     func whenVisibleAdmissionReleasesDetachedModalThenTriggeringSurfaceWinsBeforeRetrySnapshot() {
         featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
         sut = ModalPromptCoordinationService(
@@ -395,7 +401,8 @@ final class ModalPromptCoordinationServiceTests {
         #expect(promoQueueLeaseArbiter.snapshot.visiblePromoCount == 2)
     }
 
-    @Test("Stale Registration Cannot Remove Or Invoke Its Replacement")
+    @available(iOS 16, *)
+    @Test("Stale Registration Cannot Remove Or Invoke Its Replacement", .timeLimit(.minutes(1)))
     func whenRegistrationIsReplacedThenOldTokenCannotRemoveReplacement() {
         featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
         sut = ModalPromptCoordinationService(
@@ -422,7 +429,8 @@ final class ModalPromptCoordinationServiceTests {
 
     // MARK: - Promo Queue Feature State
 
-    @Test("Initial Promo Queue State Is Seeded Before Subscription Updates")
+    @available(iOS 16, *)
+    @Test("Initial Promo Queue State Is Seeded Before Subscription Updates", .timeLimit(.minutes(1)))
     func whenPromoQueueIsInitiallyEnabledThenInitialStateIsEnabled() {
         featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
         sut = ModalPromptCoordinationService(
@@ -435,10 +443,11 @@ final class ModalPromptCoordinationServiceTests {
         #expect(sut.promoQueueFeatureState == .enabled)
         #expect(managerMock.promoQueueWillTransitionTargets.isEmpty)
         #expect(managerMock.promoQueueDidTransitionTargets.isEmpty)
-        #expect(featureFlaggerMock.updatesPublisherAccessCount == 1)
+        #expect(featureFlaggerMock.updatesPublisherSubscriptionCount == 1)
     }
 
-    @Test("Promo Queue Feature Updates Are Deduplicated")
+    @available(iOS 16, *)
+    @Test("Promo Queue Feature Updates Are Deduplicated", .timeLimit(.minutes(1)))
     func whenFeatureFlagPublishesDuplicateValuesThenOnlyEffectiveChangesTransition() async {
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
@@ -463,12 +472,13 @@ final class ModalPromptCoordinationServiceTests {
         #expect(managerMock.promoQueueWillTransitionTargets == [.enabled])
         #expect(managerMock.promoQueueDidTransitionTargets == [.enabled])
         #expect(sut.promoQueueFeatureState == .enabled)
-        #expect(featureFlaggerMock.updatesPublisherAccessCount == 1)
+        #expect(featureFlaggerMock.updatesPublisherSubscriptionCount == 1)
         #expect(enabledGeneration != initialGeneration)
         #expect(promoQueueLeaseArbiter.snapshot.generation == enabledGeneration)
     }
 
-    @Test("Promo Queue Feature Subscription Is Cancelled With Service")
+    @available(iOS 16, *)
+    @Test("Promo Queue Feature Subscription Is Cancelled With Service", .timeLimit(.minutes(1)))
     func whenServiceIsReleasedThenFeatureUpdatesStop() async {
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
@@ -489,7 +499,8 @@ final class ModalPromptCoordinationServiceTests {
         #expect(managerMock.promoQueueDidTransitionTargets.isEmpty)
     }
 
-    @Test("Promo Queue Transition Barrier Rejects Reentrant Modal Evaluation In Both Directions")
+    @available(iOS 16, *)
+    @Test("Promo Queue Transition Barrier Rejects Reentrant Modal Evaluation In Both Directions", .timeLimit(.minutes(1)))
     func whenTransitionCallbacksReenterModalEvaluationThenEvaluationWaitsForBarrier() async {
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,

--- a/iOS/DuckDuckGoTests/AppServices/ModalPromptCoordinationServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/ModalPromptCoordinationServiceTests.swift
@@ -31,6 +31,8 @@ final class ModalPromptCoordinationServiceTests {
     private let contextualOnboardingMock: MockContextualOnboardingStatusProvider
     private let managerMock: MockModalPromptCoordinationManager
     private let presenterMock: MockModalPromptPresenter
+    private let featureFlaggerMock: MockFeatureFlagger
+    private let promoQueueLeaseArbiter: PromoQueueLeaseArbiter
     private var sut: ModalPromptCoordinationService!
 
     init() {
@@ -38,6 +40,8 @@ final class ModalPromptCoordinationServiceTests {
         contextualOnboardingMock = MockContextualOnboardingStatusProvider(hasSeenOnboarding: true)
         managerMock = MockModalPromptCoordinationManager()
         presenterMock = MockModalPromptPresenter()
+        featureFlaggerMock = MockFeatureFlagger()
+        promoQueueLeaseArbiter = PromoQueueLeaseArbiter()
     }
 
     // MARK: - Launch Source Checks
@@ -55,7 +59,9 @@ final class ModalPromptCoordinationServiceTests {
         presenterMock.presentedViewController = nil
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            modalPromptCoordinationManager: managerMock
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
         )
 
         // WHEN
@@ -72,7 +78,9 @@ final class ModalPromptCoordinationServiceTests {
         presenterMock.presentedViewController = nil
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            modalPromptCoordinationManager: managerMock
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
         )
 
         // WHEN
@@ -93,7 +101,9 @@ final class ModalPromptCoordinationServiceTests {
         presenterMock.presentedViewController = alreadyPresentedVC
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            modalPromptCoordinationManager: managerMock
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
         )
 
         // WHEN
@@ -110,7 +120,9 @@ final class ModalPromptCoordinationServiceTests {
         presenterMock.presentedViewController = nil
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            modalPromptCoordinationManager: managerMock
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
         )
 
         // WHEN
@@ -129,7 +141,9 @@ final class ModalPromptCoordinationServiceTests {
         presenterMock.presentedViewController = dismissingVC
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            modalPromptCoordinationManager: managerMock
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
         )
 
         // WHEN
@@ -148,7 +162,9 @@ final class ModalPromptCoordinationServiceTests {
         )
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            modalPromptCoordinationManager: managerMock
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
         )
 
         // WHEN
@@ -165,7 +181,9 @@ final class ModalPromptCoordinationServiceTests {
         presenterMock.presentedViewController = UIViewController()
         sut = ModalPromptCoordinationService(
             launchSourceManager: launchSourceManagerMock,
-            modalPromptCoordinationManager: managerMock
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
         )
 
         // WHEN
@@ -173,6 +191,117 @@ final class ModalPromptCoordinationServiceTests {
 
         // THEN
         #expect(!managerMock.didCallPresentModalPromptIfNeeded)
+    }
+
+    // MARK: - Promo Queue Feature State
+
+    @Test("Initial Promo Queue State Is Seeded Before Subscription Updates")
+    func whenPromoQueueIsInitiallyEnabledThenInitialStateIsEnabled() {
+        featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+
+        #expect(sut.promoQueueFeatureState == .enabled)
+        #expect(managerMock.promoQueueWillTransitionTargets.isEmpty)
+        #expect(managerMock.promoQueueDidTransitionTargets.isEmpty)
+        #expect(featureFlaggerMock.updatesPublisherAccessCount == 1)
+    }
+
+    @Test("Promo Queue Feature Updates Are Deduplicated")
+    func whenFeatureFlagPublishesDuplicateValuesThenOnlyEffectiveChangesTransition() async {
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+        let initialGeneration = promoQueueLeaseArbiter.snapshot.generation
+
+        featureFlaggerMock.triggerUpdate()
+        await waitForFeatureFlagUpdateDelivery()
+        #expect(managerMock.promoQueueWillTransitionTargets.isEmpty)
+        #expect(promoQueueLeaseArbiter.snapshot.generation == initialGeneration)
+
+        featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
+        featureFlaggerMock.triggerUpdate()
+        await waitForFeatureFlagUpdateDelivery()
+        let enabledGeneration = promoQueueLeaseArbiter.snapshot.generation
+        featureFlaggerMock.triggerUpdate()
+        await waitForFeatureFlagUpdateDelivery()
+
+        #expect(managerMock.promoQueueWillTransitionTargets == [.enabled])
+        #expect(managerMock.promoQueueDidTransitionTargets == [.enabled])
+        #expect(sut.promoQueueFeatureState == .enabled)
+        #expect(featureFlaggerMock.updatesPublisherAccessCount == 1)
+        #expect(enabledGeneration != initialGeneration)
+        #expect(promoQueueLeaseArbiter.snapshot.generation == enabledGeneration)
+    }
+
+    @Test("Promo Queue Feature Subscription Is Cancelled With Service")
+    func whenServiceIsReleasedThenFeatureUpdatesStop() async {
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+        weak var weakService = sut
+
+        sut = nil
+        #expect(weakService == nil)
+
+        featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
+        featureFlaggerMock.triggerUpdate()
+        await waitForFeatureFlagUpdateDelivery()
+
+        #expect(managerMock.promoQueueWillTransitionTargets.isEmpty)
+        #expect(managerMock.promoQueueDidTransitionTargets.isEmpty)
+    }
+
+    @Test("Promo Queue Transition Barrier Rejects Reentrant Modal Evaluation In Both Directions")
+    func whenTransitionCallbacksReenterModalEvaluationThenEvaluationWaitsForBarrier() async {
+        sut = ModalPromptCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+        launchSourceManagerMock.source = .standard
+        presenterMock.presentedViewController = nil
+
+        var statesObservedDuringCallbacks = [PromoQueueFeatureState]()
+        managerMock.onPromoQueueWillTransition = { [weak self] _ in
+            guard let self else { return }
+            statesObservedDuringCallbacks.append(sut.promoQueueFeatureState)
+            sut.presentModalPromptIfNeeded(from: presenterMock)
+        }
+        managerMock.onPromoQueueDidTransition = { [weak self] _ in
+            guard let self else { return }
+            statesObservedDuringCallbacks.append(sut.promoQueueFeatureState)
+            sut.presentModalPromptIfNeeded(from: presenterMock)
+        }
+
+        featureFlaggerMock.enabledFeatureFlags = [.promoQueue]
+        featureFlaggerMock.triggerUpdate()
+        await waitForFeatureFlagUpdateDelivery()
+        featureFlaggerMock.enabledFeatureFlags = []
+        featureFlaggerMock.triggerUpdate()
+        await waitForFeatureFlagUpdateDelivery()
+
+        #expect(managerMock.callCount == 0)
+        #expect(
+            statesObservedDuringCallbacks == [
+                .transitioning(to: .enabled),
+                .transitioning(to: .enabled),
+                .transitioning(to: .disabled),
+                .transitioning(to: .disabled),
+            ]
+        )
+        #expect(sut.promoQueueFeatureState == .disabled)
     }
 
     @Test(
@@ -210,7 +339,9 @@ final class ModalPromptCoordinationServiceTests {
             keyValueStore: keyValueStore,
             contextualOnboardingStatusProvider: contextualOnboardingMock,
             privacyConfigManager: privacyConfigManager,
-            providers: providers
+            providers: providers,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
         )
 
         // WHEN
@@ -223,6 +354,14 @@ final class ModalPromptCoordinationServiceTests {
                 #expect(provider.didCallProvideModalPrompt, "Provider \(providerPriority) should be checked")
             } else {
                 #expect(!provider.didCallProvideModalPrompt, "Provider \(providerPriority) should not be checked")
+            }
+        }
+    }
+
+    private func waitForFeatureFlagUpdateDelivery() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
             }
         }
     }

--- a/iOS/DuckDuckGoTests/Configuration/PromoQueueFeatureFlagTests.swift
+++ b/iOS/DuckDuckGoTests/Configuration/PromoQueueFeatureFlagTests.swift
@@ -18,11 +18,27 @@
 //
 
 import Core
+import Foundation
+import Persistence
+import PersistenceTestingUtils
 import PrivacyConfig
+import PrivacyConfigTestsUtils
 import Testing
 
 @Suite("Promo Queue Feature Flag")
 struct PromoQueueFeatureFlagTests {
+
+    /// `DefaultFeatureFlagger` trips a debug assertion when it is built under a unit-test run type,
+    /// which this target is (its product is `UnitTests.xctest`), unless this opt-in is present.
+    /// The real flagger is required here: a mock flagger cannot exercise the privacy-config
+    /// resolution path that decides whether `.promoQueue` is on, which is the whole point of these
+    /// tests. The variable is deliberately never unset — clearing it would race with the parallel
+    /// test runner, and all it does is relax a debug assertion.
+    init() {
+        setenv("TESTS_FEATUREFLAGGER_MODE", "1", 1)
+    }
+
+    // MARK: - Flag declaration
 
     @available(iOS 16, *)
     @Test("Promo queue is disabled by default", .timeLimit(.minutes(1)))
@@ -48,5 +64,121 @@ struct PromoQueueFeatureFlagTests {
     @Test("Promo queue supports local overriding", .timeLimit(.minutes(1)))
     func whenInspectingPromoQueueThenLocalOverridingIsSupported() {
         #expect(FeatureFlag.promoQueue.supportsLocalOverriding)
+    }
+
+    // MARK: - Resolution through the privacy configuration
+
+    /// Guards the test below from passing for the wrong reason: `.featureMissing` is the only state
+    /// in which `isSubfeatureEnabled` consults the flag's `defaultValue` at all. If the promo queue
+    /// entry ever lands in the embedded config, the `.disabled` default stops being what decides.
+    @available(iOS 16, *)
+    @Test("Embedded privacy config ships no promo queue entry, so the flag default is what decides", .timeLimit(.minutes(1)))
+    func whenReadingEmbeddedPrivacyConfigThenPromoQueueSubfeatureIsMissing() throws {
+        let privacyConfig = try makeEmbeddedPrivacyConfiguration()
+
+        guard case .disabled(.featureMissing) = privacyConfig.stateFor(PromoQueueSubfeature.featureEnabled) else {
+            Issue.record("Expected the embedded privacy config to omit the promo queue subfeature")
+            return
+        }
+    }
+
+    @available(iOS 16, *)
+    @Test("Promo queue resolves to off against the privacy config the app ships with", .timeLimit(.minutes(1)))
+    func whenPrivacyConfigOmitsPromoQueueThenFeatureIsOff() throws {
+        let featureFlagger = makeFeatureFlagger(privacyConfig: try makeEmbeddedPrivacyConfiguration())
+
+        #expect(featureFlagger.isFeatureOn(.promoQueue) == false)
+    }
+
+    @available(iOS 16, *)
+    @Test("Promo queue resolves to on once the privacy config enables the subfeature", .timeLimit(.minutes(1)))
+    func whenPrivacyConfigEnablesPromoQueueSubfeatureThenFeatureIsOn() throws {
+        let privacyConfig = try makePrivacyConfiguration(promoQueueSubfeatureState: PrivacyConfigurationData.State.enabled)
+        let featureFlagger = makeFeatureFlagger(privacyConfig: privacyConfig)
+
+        #expect(featureFlagger.isFeatureOn(.promoQueue))
+    }
+
+    @available(iOS 16, *)
+    @Test("Promo queue resolves to off when the privacy config disables the subfeature", .timeLimit(.minutes(1)))
+    func whenPrivacyConfigDisablesPromoQueueSubfeatureThenFeatureIsOff() throws {
+        let privacyConfig = try makePrivacyConfiguration(promoQueueSubfeatureState: PrivacyConfigurationData.State.disabled)
+        let featureFlagger = makeFeatureFlagger(privacyConfig: privacyConfig)
+
+        #expect(featureFlagger.isFeatureOn(.promoQueue) == false)
+    }
+
+    // MARK: - Local overriding
+
+    /// The behavioural counterpart to `whenInspectingPromoQueueThenLocalOverridingIsSupported`: were
+    /// `.promoQueue`'s `Config` to pass `supportsLocalOverriding: false`, `FeatureFlagLocalOverrides`
+    /// would refuse both the toggle and the lookup, and the flag would stay off.
+    @available(iOS 16, *)
+    @Test("An internal user can turn promo queue on with a local override", .timeLimit(.minutes(1)))
+    func whenInternalUserOverridesPromoQueueThenFeatureIsOn() throws {
+        let privacyConfigManager = MockPrivacyConfigurationManager()
+        privacyConfigManager.privacyConfig = try makeEmbeddedPrivacyConfiguration()
+
+        let localOverrides = FeatureFlagLocalOverrides(
+            keyValueStore: MockKeyValueStore(),
+            actionHandler: FeatureFlagOverridesPublishingHandler<FeatureFlag>()
+        )
+        let featureFlagger = DefaultFeatureFlagger(
+            internalUserDecider: MockInternalUserDecider(isInternalUser: true),
+            privacyConfigManager: privacyConfigManager,
+            localOverrides: localOverrides,
+            experimentManager: nil,
+            for: FeatureFlag.self
+        )
+
+        #expect(featureFlagger.isFeatureOn(.promoQueue) == false)
+
+        localOverrides.toggleOverride(for: FeatureFlag.promoQueue)
+
+        #expect(featureFlagger.isFeatureOn(.promoQueue))
+    }
+
+    // MARK: - Helpers
+
+    private func makeFeatureFlagger(privacyConfig: PrivacyConfiguration) -> DefaultFeatureFlagger {
+        let privacyConfigManager = MockPrivacyConfigurationManager()
+        privacyConfigManager.privacyConfig = privacyConfig
+
+        return DefaultFeatureFlagger(
+            internalUserDecider: MockInternalUserDecider(),
+            privacyConfigManager: privacyConfigManager,
+            experimentManager: nil
+        )
+    }
+
+    /// The privacy configuration the app actually ships, so "disabled by default" is asserted against
+    /// production data rather than a hand-written stand-in.
+    private func makeEmbeddedPrivacyConfiguration() throws -> AppPrivacyConfiguration {
+        let data = try PrivacyConfigurationData(data: AppPrivacyConfigurationDataProvider().embeddedData)
+        return makePrivacyConfiguration(data: data)
+    }
+
+    private func makePrivacyConfiguration(promoQueueSubfeatureState: String) throws -> AppPrivacyConfiguration {
+        let subfeature = try #require(PrivacyConfigurationData.PrivacyFeature.Feature(json: ["state": promoQueueSubfeatureState]))
+        let promoQueueFeature = PrivacyConfigurationData.PrivacyFeature(
+            state: PrivacyConfigurationData.State.enabled,
+            exceptions: [],
+            features: [PromoQueueSubfeature.featureEnabled.rawValue: subfeature]
+        )
+        let data = PrivacyConfigurationData(
+            features: [PrivacyFeature.promoQueue.rawValue: promoQueueFeature],
+            unprotectedTemporary: [],
+            trackerAllowlist: [:]
+        )
+        return makePrivacyConfiguration(data: data)
+    }
+
+    private func makePrivacyConfiguration(data: PrivacyConfigurationData) -> AppPrivacyConfiguration {
+        AppPrivacyConfiguration(
+            data: data,
+            identifier: "promo-queue-tests",
+            localProtection: MockDomainsProtectionStore(),
+            internalUserDecider: MockInternalUserDecider()
+        )
     }
 }

--- a/iOS/DuckDuckGoTests/Configuration/PromoQueueFeatureFlagTests.swift
+++ b/iOS/DuckDuckGoTests/Configuration/PromoQueueFeatureFlagTests.swift
@@ -18,13 +18,30 @@
 //
 
 import Core
+import Foundation
+import Persistence
+import PersistenceTestingUtils
 import PrivacyConfig
+import PrivacyConfigTestsUtils
 import Testing
 
 @Suite("Promo Queue Feature Flag")
 struct PromoQueueFeatureFlagTests {
 
-    @Test("Promo queue is disabled by default")
+    /// `DefaultFeatureFlagger` trips a debug assertion when it is built under a unit-test run type,
+    /// which this target is (its product is `UnitTests.xctest`), unless this opt-in is present.
+    /// The real flagger is required here: a mock flagger cannot exercise the privacy-config
+    /// resolution path that decides whether `.promoQueue` is on, which is the whole point of these
+    /// tests. The variable is deliberately never unset — clearing it would race with the parallel
+    /// test runner, and all it does is relax a debug assertion.
+    init() {
+        setenv("TESTS_FEATUREFLAGGER_MODE", "1", 1)
+    }
+
+    // MARK: - Flag declaration
+
+    @available(iOS 16, *)
+    @Test("Promo queue is disabled by default", .timeLimit(.minutes(1)))
     func whenInspectingPromoQueueThenDefaultIsDisabled() {
         guard case .disabled = FeatureFlag.promoQueue.defaultValue else {
             Issue.record("Expected promo queue to be disabled by default")
@@ -32,7 +49,8 @@ struct PromoQueueFeatureFlagTests {
         }
     }
 
-    @Test("Promo queue maps to the remote-releasable promo queue subfeature")
+    @available(iOS 16, *)
+    @Test("Promo queue maps to the remote-releasable promo queue subfeature", .timeLimit(.minutes(1)))
     func whenInspectingPromoQueueThenSourceIsRemoteReleasablePromoQueueSubfeature() {
         guard case .remoteReleasable(let subfeature) = FeatureFlag.promoQueue.source else {
             Issue.record("Expected promo queue to use a remote-releasable source")
@@ -42,8 +60,119 @@ struct PromoQueueFeatureFlagTests {
         #expect(subfeature as? PromoQueueSubfeature == .featureEnabled)
     }
 
-    @Test("Promo queue supports local overriding")
-    func whenInspectingPromoQueueThenLocalOverridingIsSupported() {
-        #expect(FeatureFlag.promoQueue.supportsLocalOverriding)
+    // MARK: - Resolution through the privacy configuration
+
+    /// Guards the test below from passing for the wrong reason: `.featureMissing` is the only state
+    /// in which `isSubfeatureEnabled` consults the flag's `defaultValue` at all. If the promo queue
+    /// entry ever lands in the embedded config, the `.disabled` default stops being what decides.
+    @available(iOS 16, *)
+    @Test("Embedded privacy config ships no promo queue entry, so the flag default is what decides", .timeLimit(.minutes(1)))
+    func whenReadingEmbeddedPrivacyConfigThenPromoQueueSubfeatureIsMissing() throws {
+        let privacyConfig = try makeEmbeddedPrivacyConfiguration()
+
+        guard case .disabled(.featureMissing) = privacyConfig.stateFor(PromoQueueSubfeature.featureEnabled) else {
+            Issue.record("Expected the embedded privacy config to omit the promo queue subfeature")
+            return
+        }
+    }
+
+    @available(iOS 16, *)
+    @Test("Promo queue resolves to off against the privacy config the app ships with", .timeLimit(.minutes(1)))
+    func whenPrivacyConfigOmitsPromoQueueThenFeatureIsOff() throws {
+        let featureFlagger = makeFeatureFlagger(privacyConfig: try makeEmbeddedPrivacyConfiguration())
+
+        #expect(featureFlagger.isFeatureOn(.promoQueue) == false)
+    }
+
+    @available(iOS 16, *)
+    @Test("Promo queue resolves to on once the privacy config enables the subfeature", .timeLimit(.minutes(1)))
+    func whenPrivacyConfigEnablesPromoQueueSubfeatureThenFeatureIsOn() throws {
+        let privacyConfig = try makePrivacyConfiguration(promoQueueSubfeatureState: PrivacyConfigurationData.State.enabled)
+        let featureFlagger = makeFeatureFlagger(privacyConfig: privacyConfig)
+
+        #expect(featureFlagger.isFeatureOn(.promoQueue))
+    }
+
+    @available(iOS 16, *)
+    @Test("Promo queue resolves to off when the privacy config disables the subfeature", .timeLimit(.minutes(1)))
+    func whenPrivacyConfigDisablesPromoQueueSubfeatureThenFeatureIsOff() throws {
+        let privacyConfig = try makePrivacyConfiguration(promoQueueSubfeatureState: PrivacyConfigurationData.State.disabled)
+        let featureFlagger = makeFeatureFlagger(privacyConfig: privacyConfig)
+
+        #expect(featureFlagger.isFeatureOn(.promoQueue) == false)
+    }
+
+    // MARK: - Local overriding
+
+    /// The behavioural form of "promo queue supports local overriding": were `.promoQueue`'s `Config`
+    /// to pass `supportsLocalOverriding: false`, `FeatureFlagLocalOverrides` would refuse both the
+    /// toggle and the lookup, and the flag would stay off.
+    @available(iOS 16, *)
+    @Test("An internal user can turn promo queue on with a local override", .timeLimit(.minutes(1)))
+    func whenInternalUserOverridesPromoQueueThenFeatureIsOn() throws {
+        let privacyConfigManager = MockPrivacyConfigurationManager()
+        privacyConfigManager.privacyConfig = try makeEmbeddedPrivacyConfiguration()
+
+        let localOverrides = FeatureFlagLocalOverrides(
+            keyValueStore: MockKeyValueStore(),
+            actionHandler: FeatureFlagOverridesPublishingHandler<FeatureFlag>()
+        )
+        let featureFlagger = DefaultFeatureFlagger(
+            internalUserDecider: MockInternalUserDecider(isInternalUser: true),
+            privacyConfigManager: privacyConfigManager,
+            localOverrides: localOverrides,
+            experimentManager: nil,
+            for: FeatureFlag.self
+        )
+
+        #expect(featureFlagger.isFeatureOn(.promoQueue) == false)
+
+        localOverrides.toggleOverride(for: FeatureFlag.promoQueue)
+
+        #expect(featureFlagger.isFeatureOn(.promoQueue))
+    }
+
+    // MARK: - Helpers
+
+    private func makeFeatureFlagger(privacyConfig: PrivacyConfiguration) -> DefaultFeatureFlagger {
+        let privacyConfigManager = MockPrivacyConfigurationManager()
+        privacyConfigManager.privacyConfig = privacyConfig
+
+        return DefaultFeatureFlagger(
+            internalUserDecider: MockInternalUserDecider(),
+            privacyConfigManager: privacyConfigManager,
+            experimentManager: nil
+        )
+    }
+
+    /// The privacy configuration the app actually ships, so "disabled by default" is asserted against
+    /// production data rather than a hand-written stand-in.
+    private func makeEmbeddedPrivacyConfiguration() throws -> AppPrivacyConfiguration {
+        let data = try PrivacyConfigurationData(data: AppPrivacyConfigurationDataProvider().embeddedData)
+        return makePrivacyConfiguration(data: data)
+    }
+
+    private func makePrivacyConfiguration(promoQueueSubfeatureState: String) throws -> AppPrivacyConfiguration {
+        let subfeature = try #require(PrivacyConfigurationData.PrivacyFeature.Feature(json: ["state": promoQueueSubfeatureState]))
+        let promoQueueFeature = PrivacyConfigurationData.PrivacyFeature(
+            state: PrivacyConfigurationData.State.enabled,
+            exceptions: [],
+            features: [PromoQueueSubfeature.featureEnabled.rawValue: subfeature]
+        )
+        let data = PrivacyConfigurationData(
+            features: [PrivacyFeature.promoQueue.rawValue: promoQueueFeature],
+            unprotectedTemporary: [],
+            trackerAllowlist: [:]
+        )
+        return makePrivacyConfiguration(data: data)
+    }
+
+    private func makePrivacyConfiguration(data: PrivacyConfigurationData) -> AppPrivacyConfiguration {
+        AppPrivacyConfiguration(
+            data: data,
+            identifier: "promo-queue-tests",
+            localProtection: MockDomainsProtectionStore(),
+            internalUserDecider: MockInternalUserDecider()
+        )
     }
 }

--- a/iOS/DuckDuckGoTests/Configuration/PromoQueueFeatureFlagTests.swift
+++ b/iOS/DuckDuckGoTests/Configuration/PromoQueueFeatureFlagTests.swift
@@ -18,25 +18,12 @@
 //
 
 import Core
-import Foundation
-import Persistence
-import PersistenceTestingUtils
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 import Testing
 
 @Suite("Promo Queue Feature Flag")
 struct PromoQueueFeatureFlagTests {
-
-    /// `DefaultFeatureFlagger` trips a debug assertion when it is built under a unit-test run type,
-    /// which this target is (its product is `UnitTests.xctest`), unless this opt-in is present.
-    /// The real flagger is required here: a mock flagger cannot exercise the privacy-config
-    /// resolution path that decides whether `.promoQueue` is on, which is the whole point of these
-    /// tests. The variable is deliberately never unset — clearing it would race with the parallel
-    /// test runner, and all it does is relax a debug assertion.
-    init() {
-        setenv("TESTS_FEATUREFLAGGER_MODE", "1", 1)
-    }
 
     // MARK: - Flag declaration
 
@@ -66,11 +53,6 @@ struct PromoQueueFeatureFlagTests {
         #expect(FeatureFlag.promoQueue.supportsLocalOverriding)
     }
 
-    // MARK: - Resolution through the privacy configuration
-
-    /// Guards the test below from passing for the wrong reason: `.featureMissing` is the only state
-    /// in which `isSubfeatureEnabled` consults the flag's `defaultValue` at all. If the promo queue
-    /// entry ever lands in the embedded config, the `.disabled` default stops being what decides.
     @available(iOS 16, *)
     @Test("Embedded privacy config ships no promo queue entry, so the flag default is what decides", .timeLimit(.minutes(1)))
     func whenReadingEmbeddedPrivacyConfigThenPromoQueueSubfeatureIsMissing() throws {
@@ -82,94 +64,12 @@ struct PromoQueueFeatureFlagTests {
         }
     }
 
-    @available(iOS 16, *)
-    @Test("Promo queue resolves to off against the privacy config the app ships with", .timeLimit(.minutes(1)))
-    func whenPrivacyConfigOmitsPromoQueueThenFeatureIsOff() throws {
-        let featureFlagger = makeFeatureFlagger(privacyConfig: try makeEmbeddedPrivacyConfiguration())
-
-        #expect(featureFlagger.isFeatureOn(.promoQueue) == false)
-    }
-
-    @available(iOS 16, *)
-    @Test("Promo queue resolves to on once the privacy config enables the subfeature", .timeLimit(.minutes(1)))
-    func whenPrivacyConfigEnablesPromoQueueSubfeatureThenFeatureIsOn() throws {
-        let privacyConfig = try makePrivacyConfiguration(promoQueueSubfeatureState: PrivacyConfigurationData.State.enabled)
-        let featureFlagger = makeFeatureFlagger(privacyConfig: privacyConfig)
-
-        #expect(featureFlagger.isFeatureOn(.promoQueue))
-    }
-
-    @available(iOS 16, *)
-    @Test("Promo queue resolves to off when the privacy config disables the subfeature", .timeLimit(.minutes(1)))
-    func whenPrivacyConfigDisablesPromoQueueSubfeatureThenFeatureIsOff() throws {
-        let privacyConfig = try makePrivacyConfiguration(promoQueueSubfeatureState: PrivacyConfigurationData.State.disabled)
-        let featureFlagger = makeFeatureFlagger(privacyConfig: privacyConfig)
-
-        #expect(featureFlagger.isFeatureOn(.promoQueue) == false)
-    }
-
-    // MARK: - Local overriding
-
-    /// The behavioural counterpart to `whenInspectingPromoQueueThenLocalOverridingIsSupported`: were
-    /// `.promoQueue`'s `Config` to pass `supportsLocalOverriding: false`, `FeatureFlagLocalOverrides`
-    /// would refuse both the toggle and the lookup, and the flag would stay off.
-    @available(iOS 16, *)
-    @Test("An internal user can turn promo queue on with a local override", .timeLimit(.minutes(1)))
-    func whenInternalUserOverridesPromoQueueThenFeatureIsOn() throws {
-        let privacyConfigManager = MockPrivacyConfigurationManager()
-        privacyConfigManager.privacyConfig = try makeEmbeddedPrivacyConfiguration()
-
-        let localOverrides = FeatureFlagLocalOverrides(
-            keyValueStore: MockKeyValueStore(),
-            actionHandler: FeatureFlagOverridesPublishingHandler<FeatureFlag>()
-        )
-        let featureFlagger = DefaultFeatureFlagger(
-            internalUserDecider: MockInternalUserDecider(isInternalUser: true),
-            privacyConfigManager: privacyConfigManager,
-            localOverrides: localOverrides,
-            experimentManager: nil,
-            for: FeatureFlag.self
-        )
-
-        #expect(featureFlagger.isFeatureOn(.promoQueue) == false)
-
-        localOverrides.toggleOverride(for: FeatureFlag.promoQueue)
-
-        #expect(featureFlagger.isFeatureOn(.promoQueue))
-    }
-
     // MARK: - Helpers
-
-    private func makeFeatureFlagger(privacyConfig: PrivacyConfiguration) -> DefaultFeatureFlagger {
-        let privacyConfigManager = MockPrivacyConfigurationManager()
-        privacyConfigManager.privacyConfig = privacyConfig
-
-        return DefaultFeatureFlagger(
-            internalUserDecider: MockInternalUserDecider(),
-            privacyConfigManager: privacyConfigManager,
-            experimentManager: nil
-        )
-    }
 
     /// The privacy configuration the app actually ships, so "disabled by default" is asserted against
     /// production data rather than a hand-written stand-in.
     private func makeEmbeddedPrivacyConfiguration() throws -> AppPrivacyConfiguration {
         let data = try PrivacyConfigurationData(data: AppPrivacyConfigurationDataProvider().embeddedData)
-        return makePrivacyConfiguration(data: data)
-    }
-
-    private func makePrivacyConfiguration(promoQueueSubfeatureState: String) throws -> AppPrivacyConfiguration {
-        let subfeature = try #require(PrivacyConfigurationData.PrivacyFeature.Feature(json: ["state": promoQueueSubfeatureState]))
-        let promoQueueFeature = PrivacyConfigurationData.PrivacyFeature(
-            state: PrivacyConfigurationData.State.enabled,
-            exceptions: [],
-            features: [PromoQueueSubfeature.featureEnabled.rawValue: subfeature]
-        )
-        let data = PrivacyConfigurationData(
-            features: [PrivacyFeature.promoQueue.rawValue: promoQueueFeature],
-            unprotectedTemporary: [],
-            trackerAllowlist: [:]
-        )
         return makePrivacyConfiguration(data: data)
     }
 

--- a/iOS/DuckDuckGoTests/Configuration/PromoQueueFeatureFlagTests.swift
+++ b/iOS/DuckDuckGoTests/Configuration/PromoQueueFeatureFlagTests.swift
@@ -1,0 +1,49 @@
+//
+//  PromoQueueFeatureFlagTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Core
+import PrivacyConfig
+import Testing
+
+@Suite("Promo Queue Feature Flag")
+struct PromoQueueFeatureFlagTests {
+
+    @Test("Promo queue is disabled by default")
+    func whenInspectingPromoQueueThenDefaultIsDisabled() {
+        guard case .disabled = FeatureFlag.promoQueue.defaultValue else {
+            Issue.record("Expected promo queue to be disabled by default")
+            return
+        }
+    }
+
+    @Test("Promo queue maps to the remote-releasable promo queue subfeature")
+    func whenInspectingPromoQueueThenSourceIsRemoteReleasablePromoQueueSubfeature() {
+        guard case .remoteReleasable(let subfeature) = FeatureFlag.promoQueue.source else {
+            Issue.record("Expected promo queue to use a remote-releasable source")
+            return
+        }
+
+        #expect(subfeature as? PromoQueueSubfeature == .featureEnabled)
+    }
+
+    @Test("Promo queue supports local overriding")
+    func whenInspectingPromoQueueThenLocalOverridingIsSupported() {
+        #expect(FeatureFlag.promoQueue.supportsLocalOverriding)
+    }
+}

--- a/iOS/DuckDuckGoTests/Configuration/PromoQueueFeatureFlagTests.swift
+++ b/iOS/DuckDuckGoTests/Configuration/PromoQueueFeatureFlagTests.swift
@@ -18,27 +18,11 @@
 //
 
 import Core
-import Foundation
-import Persistence
-import PersistenceTestingUtils
 import PrivacyConfig
-import PrivacyConfigTestsUtils
 import Testing
 
 @Suite("Promo Queue Feature Flag")
 struct PromoQueueFeatureFlagTests {
-
-    /// `DefaultFeatureFlagger` trips a debug assertion when it is built under a unit-test run type,
-    /// which this target is (its product is `UnitTests.xctest`), unless this opt-in is present.
-    /// The real flagger is required here: a mock flagger cannot exercise the privacy-config
-    /// resolution path that decides whether `.promoQueue` is on, which is the whole point of these
-    /// tests. The variable is deliberately never unset — clearing it would race with the parallel
-    /// test runner, and all it does is relax a debug assertion.
-    init() {
-        setenv("TESTS_FEATUREFLAGGER_MODE", "1", 1)
-    }
-
-    // MARK: - Flag declaration
 
     @available(iOS 16, *)
     @Test("Promo queue is disabled by default", .timeLimit(.minutes(1)))
@@ -60,119 +44,9 @@ struct PromoQueueFeatureFlagTests {
         #expect(subfeature as? PromoQueueSubfeature == .featureEnabled)
     }
 
-    // MARK: - Resolution through the privacy configuration
-
-    /// Guards the test below from passing for the wrong reason: `.featureMissing` is the only state
-    /// in which `isSubfeatureEnabled` consults the flag's `defaultValue` at all. If the promo queue
-    /// entry ever lands in the embedded config, the `.disabled` default stops being what decides.
     @available(iOS 16, *)
-    @Test("Embedded privacy config ships no promo queue entry, so the flag default is what decides", .timeLimit(.minutes(1)))
-    func whenReadingEmbeddedPrivacyConfigThenPromoQueueSubfeatureIsMissing() throws {
-        let privacyConfig = try makeEmbeddedPrivacyConfiguration()
-
-        guard case .disabled(.featureMissing) = privacyConfig.stateFor(PromoQueueSubfeature.featureEnabled) else {
-            Issue.record("Expected the embedded privacy config to omit the promo queue subfeature")
-            return
-        }
-    }
-
-    @available(iOS 16, *)
-    @Test("Promo queue resolves to off against the privacy config the app ships with", .timeLimit(.minutes(1)))
-    func whenPrivacyConfigOmitsPromoQueueThenFeatureIsOff() throws {
-        let featureFlagger = makeFeatureFlagger(privacyConfig: try makeEmbeddedPrivacyConfiguration())
-
-        #expect(featureFlagger.isFeatureOn(.promoQueue) == false)
-    }
-
-    @available(iOS 16, *)
-    @Test("Promo queue resolves to on once the privacy config enables the subfeature", .timeLimit(.minutes(1)))
-    func whenPrivacyConfigEnablesPromoQueueSubfeatureThenFeatureIsOn() throws {
-        let privacyConfig = try makePrivacyConfiguration(promoQueueSubfeatureState: PrivacyConfigurationData.State.enabled)
-        let featureFlagger = makeFeatureFlagger(privacyConfig: privacyConfig)
-
-        #expect(featureFlagger.isFeatureOn(.promoQueue))
-    }
-
-    @available(iOS 16, *)
-    @Test("Promo queue resolves to off when the privacy config disables the subfeature", .timeLimit(.minutes(1)))
-    func whenPrivacyConfigDisablesPromoQueueSubfeatureThenFeatureIsOff() throws {
-        let privacyConfig = try makePrivacyConfiguration(promoQueueSubfeatureState: PrivacyConfigurationData.State.disabled)
-        let featureFlagger = makeFeatureFlagger(privacyConfig: privacyConfig)
-
-        #expect(featureFlagger.isFeatureOn(.promoQueue) == false)
-    }
-
-    // MARK: - Local overriding
-
-    /// The behavioural form of "promo queue supports local overriding": were `.promoQueue`'s `Config`
-    /// to pass `supportsLocalOverriding: false`, `FeatureFlagLocalOverrides` would refuse both the
-    /// toggle and the lookup, and the flag would stay off.
-    @available(iOS 16, *)
-    @Test("An internal user can turn promo queue on with a local override", .timeLimit(.minutes(1)))
-    func whenInternalUserOverridesPromoQueueThenFeatureIsOn() throws {
-        let privacyConfigManager = MockPrivacyConfigurationManager()
-        privacyConfigManager.privacyConfig = try makeEmbeddedPrivacyConfiguration()
-
-        let localOverrides = FeatureFlagLocalOverrides(
-            keyValueStore: MockKeyValueStore(),
-            actionHandler: FeatureFlagOverridesPublishingHandler<FeatureFlag>()
-        )
-        let featureFlagger = DefaultFeatureFlagger(
-            internalUserDecider: MockInternalUserDecider(isInternalUser: true),
-            privacyConfigManager: privacyConfigManager,
-            localOverrides: localOverrides,
-            experimentManager: nil,
-            for: FeatureFlag.self
-        )
-
-        #expect(featureFlagger.isFeatureOn(.promoQueue) == false)
-
-        localOverrides.toggleOverride(for: FeatureFlag.promoQueue)
-
-        #expect(featureFlagger.isFeatureOn(.promoQueue))
-    }
-
-    // MARK: - Helpers
-
-    private func makeFeatureFlagger(privacyConfig: PrivacyConfiguration) -> DefaultFeatureFlagger {
-        let privacyConfigManager = MockPrivacyConfigurationManager()
-        privacyConfigManager.privacyConfig = privacyConfig
-
-        return DefaultFeatureFlagger(
-            internalUserDecider: MockInternalUserDecider(),
-            privacyConfigManager: privacyConfigManager,
-            experimentManager: nil
-        )
-    }
-
-    /// The privacy configuration the app actually ships, so "disabled by default" is asserted against
-    /// production data rather than a hand-written stand-in.
-    private func makeEmbeddedPrivacyConfiguration() throws -> AppPrivacyConfiguration {
-        let data = try PrivacyConfigurationData(data: AppPrivacyConfigurationDataProvider().embeddedData)
-        return makePrivacyConfiguration(data: data)
-    }
-
-    private func makePrivacyConfiguration(promoQueueSubfeatureState: String) throws -> AppPrivacyConfiguration {
-        let subfeature = try #require(PrivacyConfigurationData.PrivacyFeature.Feature(json: ["state": promoQueueSubfeatureState]))
-        let promoQueueFeature = PrivacyConfigurationData.PrivacyFeature(
-            state: PrivacyConfigurationData.State.enabled,
-            exceptions: [],
-            features: [PromoQueueSubfeature.featureEnabled.rawValue: subfeature]
-        )
-        let data = PrivacyConfigurationData(
-            features: [PrivacyFeature.promoQueue.rawValue: promoQueueFeature],
-            unprotectedTemporary: [],
-            trackerAllowlist: [:]
-        )
-        return makePrivacyConfiguration(data: data)
-    }
-
-    private func makePrivacyConfiguration(data: PrivacyConfigurationData) -> AppPrivacyConfiguration {
-        AppPrivacyConfiguration(
-            data: data,
-            identifier: "promo-queue-tests",
-            localProtection: MockDomainsProtectionStore(),
-            internalUserDecider: MockInternalUserDecider()
-        )
+    @Test("Promo queue supports local overriding", .timeLimit(.minutes(1)))
+    func whenInspectingPromoQueueThenLocalOverridingIsSupported() {
+        #expect(FeatureFlag.promoQueue.supportsLocalOverriding)
     }
 }

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
@@ -659,6 +659,74 @@ final class ModalPromptCoordinationManagerTests {
     }
 
     @available(iOS 16, *)
+    @Test("Dismissing Root Retains Lease Until UIKit Detaches It", .timeLimit(.minutes(1)))
+    func whenPresentedRootIsBeingDismissedThenLeaseBlocksAdmissionUntilDetachment() async throws {
+        // GIVEN
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let exactRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(
+            viewController: exactRoot,
+            animated: false
+        )
+        let presentationHost = UIKitModalPromptPresenter()
+        let window = makeKeyWindow(withRoot: presentationHost)
+        defer { window.isHidden = true }
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        let lease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presentationHost, with: lease)
+        schedulerMock.executeScheduledBlock()
+        #expect(exactRoot.presentingViewController === presentationHost)
+        #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+
+        let waitingPromoIdentity = VisiblePromoIdentity(
+            surfaceID: UUID(),
+            promoType: .remoteMessage,
+            promoID: "waiting-promo"
+        )
+
+        // WHEN dismissal starts but UIKit still presents and windows the exact root.
+        await withCheckedContinuation { continuation in
+            exactRoot.dismiss(animated: true) {
+                continuation.resume()
+            }
+
+            // THEN the modal still owns the lease and blocks a waiting visible promo for the whole animation.
+            #expect(exactRoot.isBeingDismissed)
+            #expect(exactRoot.presentingViewController === presentationHost)
+            #expect(exactRoot.viewIfLoaded?.window != nil)
+            #expect(!sut.reconcilePresentedModal())
+            #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+            guard case .blockedByModal = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: waitingPromoIdentity) else {
+                Issue.record("Expected the dismissing modal to keep blocking visible promo admission")
+                return
+            }
+        }
+
+        // WHEN UIKit has completed dismissal and removed every attachment relationship.
+        #expect(!exactRoot.isBeingPresented)
+        #expect(exactRoot.presentingViewController == nil)
+        #expect(exactRoot.viewIfLoaded?.window == nil)
+
+        // THEN reconciliation releases the modal lease and the waiting promo can be admitted.
+        #expect(sut.reconcilePresentedModal())
+        #expect(sut.modalAttemptPhase == .idle)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        guard case .acquired(let visiblePromoLease) = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: waitingPromoIdentity) else {
+            Issue.record("Expected visible promo admission after the dismissed modal detached")
+            return
+        }
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities == [waitingPromoIdentity])
+        _ = visiblePromoLease
+    }
+
+    @available(iOS 16, *)
     @Test("Deallocated Presented Root Releases The Modal Lease", .timeLimit(.minutes(1)))
     func whenPresentedRootIsDeallocatedThenReconciliationReleasesLease() throws {
         // GIVEN
@@ -1080,8 +1148,8 @@ final class ModalPromptRootAttachmentCheckerTests {
     }
 
     @available(iOS 16, *)
-    @Test("Root Being Dismissed Is Not Attached", .timeLimit(.minutes(1)))
-    func whenRootIsBeingDismissedThenAttachmentCheckFails() async {
+    @Test("Root Being Dismissed Stays Attached Until Dismissal Completes", .timeLimit(.minutes(1)))
+    func whenRootIsBeingDismissedThenAttachmentCheckPassesUntilDetachment() async {
         // GIVEN
         let presenter = UIViewController()
         let window = makeKeyWindow(withRoot: presenter)
@@ -1097,14 +1165,23 @@ final class ModalPromptRootAttachmentCheckerTests {
         }
         #expect(sut.isAttached(root))
 
-        // WHEN
-        root.dismiss(animated: true, completion: nil)
+        // WHEN dismissal starts.
+        await withCheckedContinuation { continuation in
+            root.dismiss(animated: true) {
+                continuation.resume()
+            }
 
-        // THEN — UIKit still reports the root as presented and windowed for the whole dismissal animation, so only the
-        // dismissal flag distinguishes a modal on its way out from one that is staying.
-        #expect(root.isBeingDismissed)
-        #expect(root.presentingViewController === presenter)
-        #expect(root.viewIfLoaded?.window != nil)
+            // THEN UIKit's presentation and window relationships keep the outgoing root attached during the animation.
+            #expect(root.isBeingDismissed)
+            #expect(root.presentingViewController === presenter)
+            #expect(root.viewIfLoaded?.window != nil)
+            #expect(sut.isAttached(root))
+        }
+
+        // THEN the root becomes detached only after UIKit completes the dismissal.
+        #expect(!root.isBeingPresented)
+        #expect(root.presentingViewController == nil)
+        #expect(root.viewIfLoaded?.window == nil)
         #expect(!sut.isAttached(root))
     }
 
@@ -1177,6 +1254,9 @@ private final class DeferredCompletionModalPromptPresenter: ModalPromptPresenter
         completion?()
     }
 }
+
+@MainActor
+private final class UIKitModalPromptPresenter: UIViewController, ModalPromptPresenter {}
 
 /// Models attachment as the set of exact root identities that the test considers attached.
 ///

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
@@ -28,12 +28,14 @@ final class ModalPromptCoordinationManagerTests {
     private let cooldownManagerMock: MockPromptCooldownManager
     private let schedulerMock: MockModalPromptScheduler
     private let presenterMock: MockModalPromptPresenter
+    private let promoQueueLeaseArbiter: PromoQueueLeaseArbiter
     private var sut: ModalPromptCoordinationManager!
 
     init() {
         cooldownManagerMock = MockPromptCooldownManager()
         schedulerMock = MockModalPromptScheduler()
         presenterMock = MockModalPromptPresenter()
+        promoQueueLeaseArbiter = PromoQueueLeaseArbiter()
     }
 
     // MARK: - Cooldown Period Tests
@@ -47,6 +49,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
         #expect(!presenterMock.didCallPresent)
@@ -71,6 +74,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
         #expect(!presenterMock.didCallPresent)
@@ -102,6 +106,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [firstProvider, secondProvider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 
@@ -129,6 +134,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [firstProvider, secondProvider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 
@@ -160,6 +166,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [firstProvider, secondProvider, thirdProvider, fourthProvider, fifthProvider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 
@@ -194,6 +201,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [firstProvider, secondProvider, thirdProvider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 
@@ -228,6 +236,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 
@@ -260,6 +269,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 
@@ -282,6 +292,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 
@@ -302,6 +313,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 
@@ -329,6 +341,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
         #expect(!cooldownManagerMock.didCallRecordLastPromptPresentationTimestamp)
@@ -351,6 +364,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
         #expect(!sut.didPresentModalPromptThisSession)
@@ -372,6 +386,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 
@@ -392,6 +407,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 
@@ -412,6 +428,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 
@@ -436,6 +453,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 
@@ -458,6 +476,7 @@ final class ModalPromptCoordinationManagerTests {
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
@@ -487,6 +487,42 @@ final class ModalPromptCoordinationManagerTests {
     }
 
     @available(iOS 16, *)
+    @Test("Coordinated Selection Preserves Onboarding Eligibility And Provider Order", .timeLimit(.minutes(1)))
+    func whenCoordinatedProvidersHaveDifferentEligibilityThenFirstEligiblePromptIsSelected() {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let ineligibleProvider = MockModalPromptProvider()
+        ineligibleProvider.isEligibleToPresentResult = false
+        let selectedProvider = MockModalPromptProvider()
+        selectedProvider.isEligibleToPresentResult = true
+        let lowerPriorityProvider = MockModalPromptProvider()
+        lowerPriorityProvider.isEligibleToPresentResult = true
+        sut = ModalPromptCoordinationManager(
+            providers: [ineligibleProvider, selectedProvider, lowerPriorityProvider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: false),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        let lease = acquireModalLease()
+
+        let disposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+
+        #expect(disposition == .retained)
+        #expect(ineligibleProvider.capturedIsOnboardingComplete == false)
+        #expect(!ineligibleProvider.didCallProvideModalPrompt)
+        #expect(selectedProvider.capturedIsOnboardingComplete == false)
+        #expect(selectedProvider.didCallProvideModalPrompt)
+        #expect(lowerPriorityProvider.capturedIsOnboardingComplete == nil)
+        #expect(!lowerPriorityProvider.didCallProvideModalPrompt)
+
+        schedulerMock.executeScheduledBlock()
+
+        #expect(!ineligibleProvider.didCallDidPresentModal)
+        #expect(selectedProvider.didCallDidPresentModal)
+        #expect(!lowerPriorityProvider.didCallDidPresentModal)
+    }
+
+    @available(iOS 16, *)
     @Test("Same Lease Attempt Moves From Committed To Presentation Active", .timeLimit(.minutes(1)))
     func whenCoordinatedPromptIsSelectedThenSameAttemptIdentityMovesThroughPhases() {
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
@@ -663,27 +699,29 @@ final class ModalPromptCoordinationManagerTests {
     }
 
     @available(iOS 16, *)
-    @Test("Enabling Re-Adopts Root Attached To The Recorded Presentation Host", .timeLimit(.minutes(1)))
-    func whenLegacyRootIsAttachedToRecordedHostThenEnablingReAdoptsModalLease() {
+    @Test("Enabling Re-Adopts Exact Root Attached To A Different Host", .timeLimit(.minutes(1)))
+    func whenLegacyRootIsAttachedToAnotherHostThenEnablingReAdoptsModalLease() {
         // GIVEN
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider()
         let exactRoot = UIViewController()
         provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
-        let presentationHost = UIViewController()
-        presenterMock.modalPromptPresentationViewController = presentationHost
-        let attachmentChecker = MockModalPromptRootAttachmentChecker()
-        attachmentChecker.markAttached(exactRoot, presentedBy: presentationHost)
+        presenterMock.modalPromptPresentationViewController = UIViewController()
         sut = ModalPromptCoordinationManager(
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
             promoQueueLeaseArbiter: promoQueueLeaseArbiter,
-            modalPromptScheduling: schedulerMock,
-            rootAttachmentChecker: attachmentChecker
+            modalPromptScheduling: schedulerMock
         )
         sut.presentModalPromptIfNeeded(from: presenterMock)
         schedulerMock.executeScheduledBlock()
+
+        let actualPresentationHost = UIViewController()
+        let window = makeKeyWindow(withRoot: actualPresentationHost)
+        defer { window.isHidden = true }
+        actualPresentationHost.present(exactRoot, animated: false, completion: nil)
+        #expect(exactRoot.presentingViewController === actualPresentationHost)
 
         // WHEN
         sut.promoQueueWillTransition(to: .enabled)
@@ -693,45 +731,9 @@ final class ModalPromptCoordinationManagerTests {
         // THEN
         #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
         guard case .presentationActive = sut.modalAttemptPhase else {
-            Issue.record("Expected a root attached to the recorded presentation host to be re-adopted")
+            Issue.record("Expected the attached exact root to be re-adopted regardless of its presentation host")
             return
         }
-    }
-
-    @available(iOS 16, *)
-    @Test("Enabling Does Not Re-Adopt Root Attached To A Different Host", .timeLimit(.minutes(1)))
-    func whenLegacyRootIsAttachedToAnotherHostThenEnablingDoesNotReAdoptModalLease() {
-        // GIVEN
-        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
-        let provider = MockModalPromptProvider()
-        let exactRoot = UIViewController()
-        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
-        let presentationHost = UIViewController()
-        presenterMock.modalPromptPresentationViewController = presentationHost
-        let attachmentChecker = MockModalPromptRootAttachmentChecker()
-        // The root is attached, but to a controller the manager never presented from: a legacy-path modal that is
-        // still visible somewhere else must not be re-adopted underneath, or an RMF could be admitted below it.
-        let unrelatedHost = UIViewController()
-        attachmentChecker.markAttached(exactRoot, presentedBy: unrelatedHost)
-        sut = ModalPromptCoordinationManager(
-            providers: [provider],
-            cooldownManager: cooldownManagerMock,
-            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
-            modalPromptScheduling: schedulerMock,
-            rootAttachmentChecker: attachmentChecker
-        )
-        sut.presentModalPromptIfNeeded(from: presenterMock)
-        schedulerMock.executeScheduledBlock()
-
-        // WHEN
-        sut.promoQueueWillTransition(to: .enabled)
-        promoQueueLeaseArbiter.invalidateAllLeases()
-        sut.promoQueueDidTransition(to: .enabled)
-
-        // THEN
-        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
-        #expect(sut.modalAttemptPhase == .idle)
     }
 
     @available(iOS 16, *)
@@ -836,44 +838,24 @@ final class ModalPromptRootAttachmentCheckerTests {
     }
 
     @available(iOS 16, *)
-    @Test("Root Presented By The Intended Presenter Is Attached To It", .timeLimit(.minutes(1)))
-    func whenRootIsPresentedByIntendedPresenterThenRoutedCheckPasses() {
+    @Test("Presented Root Is Attached", .timeLimit(.minutes(1)))
+    func whenRootIsPresentedThenAttachmentCheckPasses() {
         // GIVEN
-        let intendedPresenter = UIViewController()
-        let window = makeKeyWindow(withRoot: intendedPresenter)
+        let presenter = UIViewController()
+        let window = makeKeyWindow(withRoot: presenter)
         defer { window.isHidden = true }
         let root = UIViewController()
 
         // WHEN
-        intendedPresenter.present(root, animated: false, completion: nil)
+        presenter.present(root, animated: false, completion: nil)
 
-        // THEN — the UIKit relationship is asserted first, so the verdict below cannot pass for the wrong reason.
-        #expect(root.presentingViewController === intendedPresenter)
-        #expect(intendedPresenter.presentedViewController === root)
-        #expect(sut.isAttached(root, to: intendedPresenter))
-    }
-
-    @available(iOS 16, *)
-    @Test("Root Presented By Another Controller Is Not Attached To The Intended Presenter", .timeLimit(.minutes(1)))
-    func whenRootIsPresentedByAnotherControllerThenRoutedCheckFails() {
-        // GIVEN
-        let actualPresenter = UIViewController()
-        let window = makeKeyWindow(withRoot: actualPresenter)
-        defer { window.isHidden = true }
-        let root = UIViewController()
-        let unrelatedIntendedPresenter = UIViewController()
-
-        // WHEN
-        actualPresenter.present(root, animated: false, completion: nil)
-
-        // THEN — the root really is attached, so only the routed check can reject it.
-        #expect(root.presentingViewController === actualPresenter)
+        // THEN
+        #expect(root.presentingViewController === presenter)
         #expect(sut.isAttached(root))
-        #expect(!sut.isAttached(root, to: unrelatedIntendedPresenter))
     }
 
     @available(iOS 16, *)
-    @Test("Root Presenting Its Own Child Stays Attached To Its Presenter", .timeLimit(.minutes(1)))
+    @Test("Root Presenting Its Own Child Stays Attached", .timeLimit(.minutes(1)))
     func whenRootPresentsNestedChildThenRootRemainsAttached() {
         // GIVEN
         let intendedPresenter = UIViewController()
@@ -891,46 +873,19 @@ final class ModalPromptRootAttachmentCheckerTests {
         #expect(root.presentedViewController === nestedChild)
         #expect(nestedChild.presentingViewController === root)
         #expect(sut.isAttached(root))
-        #expect(sut.isAttached(root, to: intendedPresenter))
     }
 
     @available(iOS 16, *)
-    @Test("Missing Intended Presenter Falls Back To The Plain Attachment Check", .timeLimit(.minutes(1)))
-    func whenIntendedPresenterIsNilThenPlainAttachmentCheckDecides() {
+    @Test("Detached Root Is Not Attached", .timeLimit(.minutes(1)))
+    func whenRootIsNotAttachedThenAttachmentCheckFails() {
         // GIVEN
-        let actualPresenter = UIViewController()
-        let window = makeKeyWindow(withRoot: actualPresenter)
-        defer { window.isHidden = true }
-        let attachedRoot = UIViewController()
-        let detachedRoot = UIViewController()
-
-        // WHEN
-        actualPresenter.present(attachedRoot, animated: false, completion: nil)
-
-        // THEN
-        #expect(attachedRoot.presentingViewController === actualPresenter)
-        #expect(sut.isAttached(attachedRoot, to: nil) == sut.isAttached(attachedRoot))
-        #expect(sut.isAttached(attachedRoot, to: nil))
-        #expect(sut.isAttached(detachedRoot, to: nil) == sut.isAttached(detachedRoot))
-        #expect(!sut.isAttached(detachedRoot, to: nil))
-    }
-
-    @available(iOS 16, *)
-    @Test("Detached Root Is Never Attached, With Or Without An Intended Presenter", .timeLimit(.minutes(1)))
-    func whenRootIsNotAttachedThenNoIntendedPresenterMakesItAttached() {
-        // GIVEN
-        let intendedPresenter = UIViewController()
-        let window = makeKeyWindow(withRoot: intendedPresenter)
-        defer { window.isHidden = true }
         let root = UIViewController()
 
-        // THEN — nothing ever presented the root, so no intended presenter can make it count as attached.
+        // THEN
         #expect(!root.isBeingPresented)
         #expect(root.presentingViewController == nil)
         #expect(root.viewIfLoaded?.window == nil)
         #expect(!sut.isAttached(root))
-        #expect(!sut.isAttached(root, to: intendedPresenter))
-        #expect(!sut.isAttached(root, to: nil))
     }
 
     /// Stands up a visible window so UIKit accepts synchronous, unanimated presentations from `root`.
@@ -967,9 +922,9 @@ private final class DeferredCompletionModalPromptPresenter: ModalPromptPresenter
     }
 }
 
-/// Models attachment as data the test owns: which roots count as attached, and which controller presents each of them.
+/// Models attachment as the set of exact root identities that the test considers attached.
 ///
-/// `queriedRoots` records the controller the manager actually asked about, so a test can pin the *subject* of the
+/// `queriedRoots` records the root the manager actually asked about, so a test can pin the *subject* of the
 /// predicate and not merely its answer — a check resolved against a topmost controller instead of the retained exact
 /// root asks about a different object even when both are on screen.
 @MainActor
@@ -977,17 +932,9 @@ private final class MockModalPromptRootAttachmentChecker: ModalPromptRootAttachm
     var attachedRoots = Set<ObjectIdentifier>()
 
     private(set) var queriedRoots: [ObjectIdentifier] = []
-    private var presentationHosts: [ObjectIdentifier: ObjectIdentifier] = [:]
 
-    /// Marks `root` as attached, optionally recording the controller presenting it so the routed check can match on it.
-    ///
-    /// A root marked without a host is attached only to the host-agnostic check, which is how a root observed on the
-    /// legacy path with no recorded presentation host behaves.
-    func markAttached(_ root: UIViewController, presentedBy host: UIViewController? = nil) {
+    func markAttached(_ root: UIViewController) {
         attachedRoots.insert(ObjectIdentifier(root))
-        if let host {
-            presentationHosts[ObjectIdentifier(root)] = ObjectIdentifier(host)
-        }
     }
 
     func didQuery(_ root: UIViewController) -> Bool {
@@ -997,12 +944,5 @@ private final class MockModalPromptRootAttachmentChecker: ModalPromptRootAttachm
     func isAttached(_ root: UIViewController) -> Bool {
         queriedRoots.append(ObjectIdentifier(root))
         return attachedRoots.contains(ObjectIdentifier(root))
-    }
-
-    func isAttached(_ root: UIViewController, to intendedPresenter: UIViewController?) -> Bool {
-        guard isAttached(root) else { return false }
-        guard let intendedPresenter else { return true }
-
-        return presentationHosts[ObjectIdentifier(root)] == ObjectIdentifier(intendedPresenter)
     }
 }

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
@@ -440,6 +440,185 @@ final class ModalPromptCoordinationManagerTests {
         #expect(!cooldownManagerMock.didCallRecordLastPromptPresentationTimestamp)
     }
 
+    // MARK: - Promo Queue Attempt Phases
+
+    @Test("Coordinated Cooldown Releases Lease Without Querying Providers")
+    func whenCoordinatedAttemptIsInCooldownThenLeaseIsReleasedSynchronously() {
+        cooldownManagerMock.cooldownInfoToReturn = .inCoolDown
+        let provider = MockModalPromptProvider()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        let lease = acquireModalLease()
+
+        let disposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+
+        #expect(disposition == .released)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(sut.modalAttemptPhase == .idle)
+        #expect(!provider.didCallProvideModalPrompt)
+    }
+
+    @Test("Coordinated No Provider Releases Lease")
+    func whenNoCoordinatedProviderReturnsPromptThenLeaseIsReleasedSynchronously() {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider(shouldReturnPrompt: false)
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        let lease = acquireModalLease()
+
+        let disposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+
+        #expect(disposition == .released)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(provider.didCallProvideModalPrompt)
+        #expect(!sut.hasActiveOrPendingModalAttempt)
+    }
+
+    @Test("Same Lease Attempt Moves From Committed To Presentation Active")
+    func whenCoordinatedPromptIsSelectedThenSameAttemptIdentityMovesThroughPhases() {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        let lease = acquireModalLease()
+
+        let disposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+
+        #expect(disposition == .retained)
+        #expect(sut.modalAttemptPhase == .committed(lease.attemptIdentity))
+        #expect(!sut.didActuallyPresentModalPromptThisSession)
+        #expect(sut.didPresentModalPromptThisSession)
+
+        schedulerMock.executeScheduledBlock()
+
+        #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+        #expect(sut.didActuallyPresentModalPromptThisSession)
+        #expect(promoQueueLeaseArbiter.snapshot.modalAttemptIdentity == lease.attemptIdentity)
+    }
+
+    @Test("Nested Child Does Not Release Exact Selected Root")
+    func whenSelectedRootPresentsNestedChildThenReconciliationRetainsLease() {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let exactRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
+        let attachmentChecker = MockModalPromptRootAttachmentChecker()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock,
+            rootAttachmentChecker: attachmentChecker
+        )
+        let lease = acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+        schedulerMock.executeScheduledBlock()
+        attachmentChecker.attachedRoots.insert(ObjectIdentifier(exactRoot))
+        let nestedChild = UIViewController()
+        attachmentChecker.topmostViewController = nestedChild
+
+        #expect(!sut.reconcilePresentedModal())
+        #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
+
+        attachmentChecker.attachedRoots.remove(ObjectIdentifier(exactRoot))
+
+        #expect(sut.reconcilePresentedModal())
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+    }
+
+    @Test("Disable Releases Coordination But Preserves Actual History And Visible Controller")
+    func whenFeatureDisablesAfterPresentationThenHistoryAndUIKitModalRemain() {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        let lease = acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+        schedulerMock.executeScheduledBlock()
+        let presentedRoot = presenterMock.capturedViewController
+
+        sut.promoQueueWillTransition(to: .disabled)
+
+        #expect(sut.modalAttemptPhase == .idle)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(sut.didActuallyPresentModalPromptThisSession)
+        #expect(presenterMock.capturedViewController === presentedRoot)
+    }
+
+    @Test("Enabling Re-Adopts Attached Root Observed On Legacy Path")
+    func whenLegacyRootIsAttachedThenEnablingReAdoptsModalLease() {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let exactRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
+        let attachmentChecker = MockModalPromptRootAttachmentChecker()
+        attachmentChecker.attachedRoots.insert(ObjectIdentifier(exactRoot))
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock,
+            rootAttachmentChecker: attachmentChecker
+        )
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+        schedulerMock.executeScheduledBlock()
+
+        sut.promoQueueWillTransition(to: .enabled)
+        promoQueueLeaseArbiter.invalidateAllLeases()
+        sut.promoQueueDidTransition(to: .enabled)
+
+        #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
+        guard case .presentationActive = sut.modalAttemptPhase else {
+            Issue.record("Expected attached legacy root to be re-adopted as presentation active")
+            return
+        }
+    }
+
+    @Test("Enabling Invalidates Legacy Delayed Presentation")
+    func whenFeatureEnablesDuringLegacyDelayThenStaleClosureCannotPresent() {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+
+        sut.promoQueueWillTransition(to: .enabled)
+        promoQueueLeaseArbiter.invalidateAllLeases()
+        sut.promoQueueDidTransition(to: .enabled)
+        schedulerMock.executeScheduledBlock()
+
+        #expect(!presenterMock.didCallPresent)
+        #expect(!sut.hasActiveOrPendingModalAttempt)
+        #expect(!sut.didActuallyPresentModalPromptThisSession)
+    }
+
     // MARK: - OmniBarEditingState Present-On-Top Tests
 
     @Test("Check Modal Is Presented On Top When Non-OmniBar ViewController Is Presented")
@@ -487,5 +666,27 @@ final class ModalPromptCoordinationManagerTests {
         // THEN
         #expect(presenterMock.didCallPresent)
         #expect(provider.didCallDidPresentModal)
+    }
+
+    private func acquireModalLease() -> PromoQueueModalLease {
+        guard case .acquired(let lease) = promoQueueLeaseArbiter.acquireModalLease() else {
+            Issue.record("Expected modal lease acquisition")
+            fatalError("Expected modal lease acquisition")
+        }
+        return lease
+    }
+}
+
+@MainActor
+private final class MockModalPromptRootAttachmentChecker: ModalPromptRootAttachmentChecking {
+    var attachedRoots = Set<ObjectIdentifier>()
+    var topmostViewController: UIViewController?
+
+    func isAttached(_ root: UIViewController) -> Bool {
+        attachedRoots.contains(ObjectIdentifier(root))
+    }
+
+    func isAttached(_ root: UIViewController, to intendedPresenter: UIViewController?) -> Bool {
+        isAttached(root)
     }
 }

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
@@ -355,28 +355,6 @@ final class ModalPromptCoordinationManagerTests {
     }
 
     @available(iOS 16, *)
-    @Test("Check Session Flag Is Set After Successful Presentation", .timeLimit(.minutes(1)))
-    func whenModalIsPresentedThenSessionFlagIsSet() {
-        // GIVEN
-        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
-        let provider = MockModalPromptProvider()
-        sut = ModalPromptCoordinationManager(
-            providers: [provider],
-            cooldownManager: cooldownManagerMock,
-            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
-            modalPromptScheduling: schedulerMock
-        )
-        #expect(!sut.didPresentModalPromptThisSession)
-
-        // WHEN
-        sut.presentModalPromptIfNeeded(from: presenterMock)
-
-        // THEN
-        #expect(sut.didPresentModalPromptThisSession)
-    }
-
-    @available(iOS 16, *)
     @Test("Check Session Flag Survives The Legacy Presentation Completion", .timeLimit(.minutes(1)))
     func whenLegacyPresentationCompletesThenSessionFlagRemainsSet() {
         // GIVEN

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
@@ -377,6 +377,34 @@ final class ModalPromptCoordinationManagerTests {
     }
 
     @available(iOS 16, *)
+    @Test("Check Session Flag Survives The Legacy Presentation Completion", .timeLimit(.minutes(1)))
+    func whenLegacyPresentationCompletesThenSessionFlagRemainsSet() {
+        // GIVEN
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+        // Held up by the in-flight legacy attempt alone: UIKit has not presented anything yet.
+        #expect(sut.didPresentModalPromptThisSession)
+        #expect(!sut.didActuallyPresentModalPromptThisSession)
+
+        // WHEN the scheduled presentation runs, the completion clears that in-flight attempt — so it has to latch
+        // actual session history in the same breath or suppression collapses exactly as the modal appears.
+        schedulerMock.executeScheduledBlock()
+
+        // THEN
+        #expect(sut.didActuallyPresentModalPromptThisSession)
+        #expect(sut.didPresentModalPromptThisSession)
+        #expect(provider.didCallDidPresentModal)
+    }
+
+    @available(iOS 16, *)
     @Test("Check Session Flag Is Not Set When No Modal Is Presented", .timeLimit(.minutes(1)))
     func whenNoModalIsPresentedThenSessionFlagIsNotSet() {
         // GIVEN
@@ -444,7 +472,7 @@ final class ModalPromptCoordinationManagerTests {
 
     @available(iOS 16, *)
     @Test("Coordinated Cooldown Releases Lease Without Querying Providers", .timeLimit(.minutes(1)))
-    func whenCoordinatedAttemptIsInCooldownThenLeaseIsReleasedSynchronously() {
+    func whenCoordinatedAttemptIsInCooldownThenLeaseIsReleasedSynchronously() throws {
         cooldownManagerMock.cooldownInfoToReturn = .inCoolDown
         let provider = MockModalPromptProvider()
         sut = ModalPromptCoordinationManager(
@@ -454,7 +482,7 @@ final class ModalPromptCoordinationManagerTests {
             promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
-        let lease = acquireModalLease()
+        let lease = try acquireModalLease()
 
         let disposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
 
@@ -466,7 +494,7 @@ final class ModalPromptCoordinationManagerTests {
 
     @available(iOS 16, *)
     @Test("Coordinated No Provider Releases Lease", .timeLimit(.minutes(1)))
-    func whenNoCoordinatedProviderReturnsPromptThenLeaseIsReleasedSynchronously() {
+    func whenNoCoordinatedProviderReturnsPromptThenLeaseIsReleasedSynchronously() throws {
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider(shouldReturnPrompt: false)
         sut = ModalPromptCoordinationManager(
@@ -476,7 +504,7 @@ final class ModalPromptCoordinationManagerTests {
             promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
-        let lease = acquireModalLease()
+        let lease = try acquireModalLease()
 
         let disposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
 
@@ -487,8 +515,10 @@ final class ModalPromptCoordinationManagerTests {
     }
 
     @available(iOS 16, *)
-    @Test("Coordinated Selection Preserves Onboarding Eligibility And Provider Order", .timeLimit(.minutes(1)))
-    func whenCoordinatedProvidersHaveDifferentEligibilityThenFirstEligiblePromptIsSelected() {
+    @Test("Coordinated Selection Respects Provider Eligibility And Order", .timeLimit(.minutes(1)))
+    func whenCoordinatedProvidersHaveDifferentEligibilityThenFirstEligiblePromptIsSelected() throws {
+        // Every provider here forces its own answer, so this covers the eligibility gate and provider order only. The
+        // onboarding gate itself is covered separately, by a provider that uses the protocol's default implementation.
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let ineligibleProvider = MockModalPromptProvider()
         ineligibleProvider.isEligibleToPresentResult = false
@@ -503,7 +533,7 @@ final class ModalPromptCoordinationManagerTests {
             promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
-        let lease = acquireModalLease()
+        let lease = try acquireModalLease()
 
         let disposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
 
@@ -523,8 +553,38 @@ final class ModalPromptCoordinationManagerTests {
     }
 
     @available(iOS 16, *)
+    @Test("Coordinated Selection Gates A Default-Gated Provider On Incomplete Onboarding", .timeLimit(.minutes(1)))
+    func whenOnboardingIsIncompleteThenDefaultGatedCoordinatedProviderIsNotAsked() throws {
+        // GIVEN a provider that leaves `isEligibleToPresent(isOnboardingComplete:)` to the protocol's default
+        // implementation, which is what every real provider does.
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: false),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        let lease = try acquireModalLease()
+
+        // WHEN
+        let disposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+
+        // THEN — incomplete onboarding gates the provider out before it is ever asked for a prompt, and the lease goes
+        // straight back so a waiting promo is not blocked by an attempt that can never present.
+        #expect(disposition == .released)
+        #expect(provider.capturedIsOnboardingComplete == false)
+        #expect(!provider.didCallProvideModalPrompt)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(sut.modalAttemptPhase == .idle)
+        #expect(!sut.hasActiveOrPendingModalAttempt)
+        #expect(!schedulerMock.didCallSchedule)
+    }
+
+    @available(iOS 16, *)
     @Test("Same Lease Attempt Moves From Committed To Presentation Active", .timeLimit(.minutes(1)))
-    func whenCoordinatedPromptIsSelectedThenSameAttemptIdentityMovesThroughPhases() {
+    func whenCoordinatedPromptIsSelectedThenSameAttemptIdentityMovesThroughPhases() throws {
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider()
         sut = ModalPromptCoordinationManager(
@@ -534,7 +594,7 @@ final class ModalPromptCoordinationManagerTests {
             promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
-        let lease = acquireModalLease()
+        let lease = try acquireModalLease()
 
         let disposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
 
@@ -552,7 +612,7 @@ final class ModalPromptCoordinationManagerTests {
 
     @available(iOS 16, *)
     @Test("Nested Child Does Not Release Exact Selected Root", .timeLimit(.minutes(1)))
-    func whenSelectedRootPresentsNestedChildThenReconciliationRetainsLease() {
+    func whenSelectedRootPresentsNestedChildThenReconciliationRetainsLease() throws {
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider()
         let exactRoot = UIViewController()
@@ -566,7 +626,7 @@ final class ModalPromptCoordinationManagerTests {
             modalPromptScheduling: schedulerMock,
             rootAttachmentChecker: attachmentChecker
         )
-        let lease = acquireModalLease()
+        let lease = try acquireModalLease()
         _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
         schedulerMock.executeScheduledBlock()
 
@@ -599,8 +659,54 @@ final class ModalPromptCoordinationManagerTests {
     }
 
     @available(iOS 16, *)
+    @Test("Deallocated Presented Root Releases The Modal Lease", .timeLimit(.minutes(1)))
+    func whenPresentedRootIsDeallocatedThenReconciliationReleasesLease() throws {
+        // GIVEN
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let scheduler = BlockReleasingModalPromptScheduler()
+        let attachmentChecker = MockModalPromptRootAttachmentChecker()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: scheduler,
+            rootAttachmentChecker: attachmentChecker
+        )
+        let lease = try acquireModalLease()
+        weak var weakExactRoot: UIViewController?
+
+        autoreleasepool {
+            var exactRoot: UIViewController! = UIViewController()
+            weakExactRoot = exactRoot
+            provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
+            attachmentChecker.markAttached(exactRoot)
+
+            _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+            scheduler.executeAndReleaseScheduledBlock()
+
+            #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+            #expect(!sut.reconcilePresentedModal())
+            #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
+
+            // WHEN every fixture reference is dropped, the manager is the only thing that could keep the root alive.
+            provider.modalConfigurationToReturn = nil
+            presenterMock.reset()
+            exactRoot = nil
+        }
+
+        // THEN — the presented modal is gone, so its lease must be released rather than pinned until the next
+        // foreground, and the manager must not be the last owner of the whole view-controller hierarchy.
+        #expect(weakExactRoot == nil)
+        #expect(sut.reconcilePresentedModal())
+        #expect(sut.modalAttemptPhase == .idle)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+    }
+
+    @available(iOS 16, *)
     @Test("Disable Releases Coordination But Preserves Actual History And Visible Controller", .timeLimit(.minutes(1)))
-    func whenFeatureDisablesAfterPresentationThenHistoryAndUIKitModalRemain() {
+    func whenFeatureDisablesAfterPresentationThenHistoryAndUIKitModalRemain() throws {
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider()
         sut = ModalPromptCoordinationManager(
@@ -610,7 +716,7 @@ final class ModalPromptCoordinationManagerTests {
             promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
-        let lease = acquireModalLease()
+        let lease = try acquireModalLease()
         _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
         schedulerMock.executeScheduledBlock()
         let presentedRoot = presenterMock.capturedViewController
@@ -625,25 +731,34 @@ final class ModalPromptCoordinationManagerTests {
 
     @available(iOS 16, *)
     @Test("Disable During Present Animation Preserves Actual History", .timeLimit(.minutes(1)))
-    func whenFeatureDisablesDuringPresentAnimationThenActualHistoryIsPreserved() {
+    func whenFeatureDisablesDuringPresentAnimationThenActualHistoryIsPreserved() throws {
         // GIVEN
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider()
+        let exactRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
         let deferredPresenter = DeferredCompletionModalPromptPresenter()
+        // This test's premise is that the modal really is on screen animating in. The deferred presenter cannot
+        // reproduce that on its own — it never hands the root to UIKit — so the checker states the premise explicitly
+        // instead of leaving it to whatever the real attachment predicate happens to answer for a detached controller.
+        let attachmentChecker = MockModalPromptRootAttachmentChecker()
+        attachmentChecker.markAttached(exactRoot)
         sut = ModalPromptCoordinationManager(
             providers: [provider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
             promoQueueLeaseArbiter: promoQueueLeaseArbiter,
-            modalPromptScheduling: schedulerMock
+            modalPromptScheduling: schedulerMock,
+            rootAttachmentChecker: attachmentChecker
         )
-        let lease = acquireModalLease()
+        let lease = try acquireModalLease()
         _ = sut.presentModalPromptIfNeeded(from: deferredPresenter, with: lease)
         schedulerMock.executeScheduledBlock()
         let presentedRoot = deferredPresenter.capturedViewController
 
         // The presentation is in flight: the modal is on screen but UIKit has not run the completion yet.
         #expect(deferredPresenter.didCallPresent)
+        #expect(presentedRoot === exactRoot)
         #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
         #expect(!sut.didActuallyPresentModalPromptThisSession)
         #expect(sut.didPresentModalPromptThisSession)
@@ -665,6 +780,46 @@ final class ModalPromptCoordinationManagerTests {
         #expect(sut.modalAttemptPhase == .idle)
         #expect(sut.didPresentModalPromptThisSession)
         #expect(provider.didCallDidPresentModal)
+    }
+
+    @available(iOS 16, *)
+    @Test("Disable After Refused Presentation Does Not Latch Actual History", .timeLimit(.minutes(1)))
+    func whenPresentationWasRefusedThenDisablingDoesNotLatchActualHistory() throws {
+        // GIVEN
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let exactRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
+        // UIKit silently refused the presentation: `present` was called, the root never became attached, and the
+        // completion never runs. The attempt still reaches `.presentationActive` because that happens before `present`.
+        let deferredPresenter = DeferredCompletionModalPromptPresenter()
+        let attachmentChecker = MockModalPromptRootAttachmentChecker()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock,
+            rootAttachmentChecker: attachmentChecker
+        )
+        let lease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: deferredPresenter, with: lease)
+        schedulerMock.executeScheduledBlock()
+
+        #expect(deferredPresenter.didCallPresent)
+        #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+        #expect(!sut.didActuallyPresentModalPromptThisSession)
+
+        // WHEN
+        sut.promoQueueWillTransition(to: .disabled)
+
+        // THEN — the transition consults attachment for the exact selected root, and a modal that never appeared must
+        // not suppress every other promo for the rest of the session.
+        #expect(attachmentChecker.didQuery(exactRoot))
+        #expect(sut.modalAttemptPhase == .idle)
+        #expect(!sut.didActuallyPresentModalPromptThisSession)
+        #expect(!sut.didPresentModalPromptThisSession)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
     }
 
     @available(iOS 16, *)
@@ -706,7 +861,6 @@ final class ModalPromptCoordinationManagerTests {
         let provider = MockModalPromptProvider()
         let exactRoot = UIViewController()
         provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
-        presenterMock.modalPromptPresentationViewController = UIViewController()
         sut = ModalPromptCoordinationManager(
             providers: [provider],
             cooldownManager: cooldownManagerMock,
@@ -734,6 +888,46 @@ final class ModalPromptCoordinationManagerTests {
             Issue.record("Expected the attached exact root to be re-adopted regardless of its presentation host")
             return
         }
+    }
+
+    @available(iOS 16, *)
+    @Test("Enabling Does Not Re-Adopt A Root That Was Only Selected", .timeLimit(.minutes(1)))
+    func whenSelectedRootWasNeverPresentedThenEnablingDoesNotReAdoptModalLease() throws {
+        // GIVEN
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let exactRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
+        // The root would satisfy the attachment predicate, so only the absence of an actual presentation can stop the
+        // manager re-adopting it.
+        let attachmentChecker = MockModalPromptRootAttachmentChecker()
+        attachmentChecker.markAttached(exactRoot)
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock,
+            rootAttachmentChecker: attachmentChecker
+        )
+        let lease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+
+        // The prompt is selected and committed, but its scheduled presentation never runs.
+        #expect(sut.modalAttemptPhase == .committed(lease.attemptIdentity))
+        #expect(!presenterMock.didCallPresent)
+
+        // WHEN
+        sut.promoQueueWillTransition(to: .enabled)
+        promoQueueLeaseArbiter.invalidateAllLeases()
+        sut.promoQueueDidTransition(to: .enabled)
+
+        // THEN — nothing ever reached the screen, so there is nothing to re-adopt: the manager must not park itself in
+        // `.presentationActive` holding the modal lease, and must not even consider the merely selected root.
+        #expect(sut.modalAttemptPhase == .idle)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(!sut.hasActiveOrPendingModalAttempt)
+        #expect(!attachmentChecker.didQuery(exactRoot))
     }
 
     @available(iOS 16, *)
@@ -809,10 +1003,9 @@ final class ModalPromptCoordinationManagerTests {
         #expect(provider.didCallDidPresentModal)
     }
 
-    private func acquireModalLease() -> PromoQueueModalLease {
+    private func acquireModalLease() throws -> PromoQueueModalLease {
         guard case .acquired(let lease) = promoQueueLeaseArbiter.acquireModalLease() else {
-            Issue.record("Expected modal lease acquisition")
-            fatalError("Expected modal lease acquisition")
+            throw TestError.expectedAcquiredLease
         }
         return lease
     }
@@ -856,23 +1049,63 @@ final class ModalPromptRootAttachmentCheckerTests {
 
     @available(iOS 16, *)
     @Test("Root Presenting Its Own Child Stays Attached", .timeLimit(.minutes(1)))
-    func whenRootPresentsNestedChildThenRootRemainsAttached() {
+    func whenRootPresentsNestedChildThenRootRemainsAttached() async {
         // GIVEN
         let intendedPresenter = UIViewController()
         let window = makeKeyWindow(withRoot: intendedPresenter)
         defer { window.isHidden = true }
         let root = UIViewController()
         let nestedChild = UIViewController()
+        // Wait on UIKit's own presentation completion rather than a delay. A nested `present` requested while the
+        // outer presentation is still in flight is refused, leaving `root.presentedViewController` nil — so the
+        // nesting this test draws its conclusion from would never be established.
+        await withCheckedContinuation { continuation in
+            intendedPresenter.present(root, animated: false) {
+                continuation.resume()
+            }
+        }
 
         // WHEN
-        intendedPresenter.present(root, animated: false, completion: nil)
-        root.present(nestedChild, animated: false, completion: nil)
+        await withCheckedContinuation { continuation in
+            root.present(nestedChild, animated: false) {
+                continuation.resume()
+            }
+        }
 
         // THEN — a child flow presented by the root does not detach the root itself.
         #expect(root.presentingViewController === intendedPresenter)
         #expect(root.presentedViewController === nestedChild)
         #expect(nestedChild.presentingViewController === root)
         #expect(sut.isAttached(root))
+    }
+
+    @available(iOS 16, *)
+    @Test("Root Being Dismissed Is Not Attached", .timeLimit(.minutes(1)))
+    func whenRootIsBeingDismissedThenAttachmentCheckFails() async {
+        // GIVEN
+        let presenter = UIViewController()
+        let window = makeKeyWindow(withRoot: presenter)
+        defer { window.isHidden = true }
+        let root = UIViewController()
+        // Wait on UIKit's own presentation completion rather than a delay. `isBeingDismissed` is only raised once the
+        // presentation transition has finished; a dismissal requested while the presentation is still in flight is
+        // coalesced into it and never raises the flag, which would make this test pass for the wrong reason.
+        await withCheckedContinuation { continuation in
+            presenter.present(root, animated: false) {
+                continuation.resume()
+            }
+        }
+        #expect(sut.isAttached(root))
+
+        // WHEN
+        root.dismiss(animated: true, completion: nil)
+
+        // THEN — UIKit still reports the root as presented and windowed for the whole dismissal animation, so only the
+        // dismissal flag distinguishes a modal on its way out from one that is staying.
+        #expect(root.isBeingDismissed)
+        #expect(root.presentingViewController === presenter)
+        #expect(root.viewIfLoaded?.window != nil)
+        #expect(!sut.isAttached(root))
     }
 
     @available(iOS 16, *)
@@ -899,11 +1132,34 @@ final class ModalPromptRootAttachmentCheckerTests {
     }
 }
 
+private enum TestError: Error {
+    case expectedAcquiredLease
+}
+
+/// A scheduler that drops its scheduled block as soon as it has run.
+///
+/// `MockModalPromptScheduler` keeps the executed block forever, and that block strongly captures the committed attempt
+/// and therefore the modal root. A retention test needs the fixture to stop being an owner so that only the manager
+/// remains a candidate.
+private final class BlockReleasingModalPromptScheduler: ModalPromptScheduling {
+    private var scheduledBlock: (@MainActor () -> Void)?
+
+    func schedule(after delay: TimeInterval, execute: @escaping @MainActor () -> Void) {
+        scheduledBlock = execute
+    }
+
+    @MainActor
+    func executeAndReleaseScheduledBlock() {
+        let block = scheduledBlock
+        scheduledBlock = nil
+        block?()
+    }
+}
+
 /// A presenter that withholds the UIKit presentation completion so an attempt can be observed mid-animation.
 @MainActor
 private final class DeferredCompletionModalPromptPresenter: ModalPromptPresenter {
     var presentedViewController: UIViewController?
-    var modalPromptPresentationViewController: UIViewController?
 
     private(set) var didCallPresent = false
     private(set) var capturedViewController: UIViewController?

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
@@ -442,7 +442,8 @@ final class ModalPromptCoordinationManagerTests {
 
     // MARK: - Promo Queue Attempt Phases
 
-    @Test("Coordinated Cooldown Releases Lease Without Querying Providers")
+    @available(iOS 16, *)
+    @Test("Coordinated Cooldown Releases Lease Without Querying Providers", .timeLimit(.minutes(1)))
     func whenCoordinatedAttemptIsInCooldownThenLeaseIsReleasedSynchronously() {
         cooldownManagerMock.cooldownInfoToReturn = .inCoolDown
         let provider = MockModalPromptProvider()
@@ -463,7 +464,8 @@ final class ModalPromptCoordinationManagerTests {
         #expect(!provider.didCallProvideModalPrompt)
     }
 
-    @Test("Coordinated No Provider Releases Lease")
+    @available(iOS 16, *)
+    @Test("Coordinated No Provider Releases Lease", .timeLimit(.minutes(1)))
     func whenNoCoordinatedProviderReturnsPromptThenLeaseIsReleasedSynchronously() {
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider(shouldReturnPrompt: false)
@@ -484,7 +486,8 @@ final class ModalPromptCoordinationManagerTests {
         #expect(!sut.hasActiveOrPendingModalAttempt)
     }
 
-    @Test("Same Lease Attempt Moves From Committed To Presentation Active")
+    @available(iOS 16, *)
+    @Test("Same Lease Attempt Moves From Committed To Presentation Active", .timeLimit(.minutes(1)))
     func whenCoordinatedPromptIsSelectedThenSameAttemptIdentityMovesThroughPhases() {
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider()
@@ -511,7 +514,8 @@ final class ModalPromptCoordinationManagerTests {
         #expect(promoQueueLeaseArbiter.snapshot.modalAttemptIdentity == lease.attemptIdentity)
     }
 
-    @Test("Nested Child Does Not Release Exact Selected Root")
+    @available(iOS 16, *)
+    @Test("Nested Child Does Not Release Exact Selected Root", .timeLimit(.minutes(1)))
     func whenSelectedRootPresentsNestedChildThenReconciliationRetainsLease() {
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider()
@@ -529,20 +533,37 @@ final class ModalPromptCoordinationManagerTests {
         let lease = acquireModalLease()
         _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
         schedulerMock.executeScheduledBlock()
-        attachmentChecker.attachedRoots.insert(ObjectIdentifier(exactRoot))
+
+        // Give the selected root a real child presentation. The window exists only so UIKit accepts the nesting:
+        // without it `exactRoot.presentedViewController` stays nil and a topmost walk would resolve straight back to
+        // the exact root, leaving the two implementations indistinguishable.
+        let window = makeKeyWindow(withRoot: exactRoot)
+        defer { window.isHidden = true }
         let nestedChild = UIViewController()
-        attachmentChecker.topmostViewController = nestedChild
+        exactRoot.present(nestedChild, animated: false, completion: nil)
+
+        // Assert the UIKit nesting the rest of the test depends on before drawing conclusions from it.
+        #expect(exactRoot.presentedViewController === nestedChild)
+        #expect(nestedChild.presentingViewController === exactRoot)
+
+        // Only the exact root is attached as far as coordination is concerned: the child is never registered, so an
+        // implementation that consulted the topmost controller would report the attempt finished and drop the lease.
+        attachmentChecker.markAttached(exactRoot)
 
         #expect(!sut.reconcilePresentedModal())
         #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(attachmentChecker.didQuery(exactRoot))
+        #expect(!attachmentChecker.didQuery(nestedChild))
 
+        // The lease is released only once the retained root itself goes away, child presentation or not.
         attachmentChecker.attachedRoots.remove(ObjectIdentifier(exactRoot))
 
         #expect(sut.reconcilePresentedModal())
         #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
     }
 
-    @Test("Disable Releases Coordination But Preserves Actual History And Visible Controller")
+    @available(iOS 16, *)
+    @Test("Disable Releases Coordination But Preserves Actual History And Visible Controller", .timeLimit(.minutes(1)))
     func whenFeatureDisablesAfterPresentationThenHistoryAndUIKitModalRemain() {
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider()
@@ -566,7 +587,52 @@ final class ModalPromptCoordinationManagerTests {
         #expect(presenterMock.capturedViewController === presentedRoot)
     }
 
-    @Test("Enabling Re-Adopts Attached Root Observed On Legacy Path")
+    @available(iOS 16, *)
+    @Test("Disable During Present Animation Preserves Actual History", .timeLimit(.minutes(1)))
+    func whenFeatureDisablesDuringPresentAnimationThenActualHistoryIsPreserved() {
+        // GIVEN
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let deferredPresenter = DeferredCompletionModalPromptPresenter()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        let lease = acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: deferredPresenter, with: lease)
+        schedulerMock.executeScheduledBlock()
+        let presentedRoot = deferredPresenter.capturedViewController
+
+        // The presentation is in flight: the modal is on screen but UIKit has not run the completion yet.
+        #expect(deferredPresenter.didCallPresent)
+        #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+        #expect(!sut.didActuallyPresentModalPromptThisSession)
+        #expect(sut.didPresentModalPromptThisSession)
+
+        // WHEN
+        sut.promoQueueWillTransition(to: .disabled)
+
+        // THEN
+        #expect(sut.modalAttemptPhase == .idle)
+        #expect(sut.didActuallyPresentModalPromptThisSession)
+        #expect(sut.didPresentModalPromptThisSession)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(deferredPresenter.capturedViewController === presentedRoot)
+
+        // WHEN the withheld UIKit completion finally lands, session history stays latched.
+        deferredPresenter.completePendingPresentation()
+
+        // THEN
+        #expect(sut.modalAttemptPhase == .idle)
+        #expect(sut.didPresentModalPromptThisSession)
+        #expect(provider.didCallDidPresentModal)
+    }
+
+    @available(iOS 16, *)
+    @Test("Enabling Re-Adopts Attached Root Observed On Legacy Path", .timeLimit(.minutes(1)))
     func whenLegacyRootIsAttachedThenEnablingReAdoptsModalLease() {
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider()
@@ -596,7 +662,80 @@ final class ModalPromptCoordinationManagerTests {
         }
     }
 
-    @Test("Enabling Invalidates Legacy Delayed Presentation")
+    @available(iOS 16, *)
+    @Test("Enabling Re-Adopts Root Attached To The Recorded Presentation Host", .timeLimit(.minutes(1)))
+    func whenLegacyRootIsAttachedToRecordedHostThenEnablingReAdoptsModalLease() {
+        // GIVEN
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let exactRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
+        let presentationHost = UIViewController()
+        presenterMock.modalPromptPresentationViewController = presentationHost
+        let attachmentChecker = MockModalPromptRootAttachmentChecker()
+        attachmentChecker.markAttached(exactRoot, presentedBy: presentationHost)
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock,
+            rootAttachmentChecker: attachmentChecker
+        )
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+        schedulerMock.executeScheduledBlock()
+
+        // WHEN
+        sut.promoQueueWillTransition(to: .enabled)
+        promoQueueLeaseArbiter.invalidateAllLeases()
+        sut.promoQueueDidTransition(to: .enabled)
+
+        // THEN
+        #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
+        guard case .presentationActive = sut.modalAttemptPhase else {
+            Issue.record("Expected a root attached to the recorded presentation host to be re-adopted")
+            return
+        }
+    }
+
+    @available(iOS 16, *)
+    @Test("Enabling Does Not Re-Adopt Root Attached To A Different Host", .timeLimit(.minutes(1)))
+    func whenLegacyRootIsAttachedToAnotherHostThenEnablingDoesNotReAdoptModalLease() {
+        // GIVEN
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let exactRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
+        let presentationHost = UIViewController()
+        presenterMock.modalPromptPresentationViewController = presentationHost
+        let attachmentChecker = MockModalPromptRootAttachmentChecker()
+        // The root is attached, but to a controller the manager never presented from: a legacy-path modal that is
+        // still visible somewhere else must not be re-adopted underneath, or an RMF could be admitted below it.
+        let unrelatedHost = UIViewController()
+        attachmentChecker.markAttached(exactRoot, presentedBy: unrelatedHost)
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock,
+            rootAttachmentChecker: attachmentChecker
+        )
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+        schedulerMock.executeScheduledBlock()
+
+        // WHEN
+        sut.promoQueueWillTransition(to: .enabled)
+        promoQueueLeaseArbiter.invalidateAllLeases()
+        sut.promoQueueDidTransition(to: .enabled)
+
+        // THEN
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(sut.modalAttemptPhase == .idle)
+    }
+
+    @available(iOS 16, *)
+    @Test("Enabling Invalidates Legacy Delayed Presentation", .timeLimit(.minutes(1)))
     func whenFeatureEnablesDuringLegacyDelayThenStaleClosureCannotPresent() {
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider()
@@ -675,18 +814,195 @@ final class ModalPromptCoordinationManagerTests {
         }
         return lease
     }
+
+    /// Stands up a visible window so UIKit accepts synchronous, unanimated presentations from `root`.
+    ///
+    /// Callers must hide the returned window again so it does not stay key for later tests.
+    private func makeKeyWindow(withRoot root: UIViewController) -> UIWindow {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = root
+        window.makeKeyAndVisible()
+        return window
+    }
 }
 
 @MainActor
+@Suite("Modal Prompt Coordination - Root Attachment Checker")
+final class ModalPromptRootAttachmentCheckerTests {
+    private let sut: ModalPromptRootAttachmentChecker
+
+    init() {
+        sut = ModalPromptRootAttachmentChecker()
+    }
+
+    @available(iOS 16, *)
+    @Test("Root Presented By The Intended Presenter Is Attached To It", .timeLimit(.minutes(1)))
+    func whenRootIsPresentedByIntendedPresenterThenRoutedCheckPasses() {
+        // GIVEN
+        let intendedPresenter = UIViewController()
+        let window = makeKeyWindow(withRoot: intendedPresenter)
+        defer { window.isHidden = true }
+        let root = UIViewController()
+
+        // WHEN
+        intendedPresenter.present(root, animated: false, completion: nil)
+
+        // THEN — the UIKit relationship is asserted first, so the verdict below cannot pass for the wrong reason.
+        #expect(root.presentingViewController === intendedPresenter)
+        #expect(intendedPresenter.presentedViewController === root)
+        #expect(sut.isAttached(root, to: intendedPresenter))
+    }
+
+    @available(iOS 16, *)
+    @Test("Root Presented By Another Controller Is Not Attached To The Intended Presenter", .timeLimit(.minutes(1)))
+    func whenRootIsPresentedByAnotherControllerThenRoutedCheckFails() {
+        // GIVEN
+        let actualPresenter = UIViewController()
+        let window = makeKeyWindow(withRoot: actualPresenter)
+        defer { window.isHidden = true }
+        let root = UIViewController()
+        let unrelatedIntendedPresenter = UIViewController()
+
+        // WHEN
+        actualPresenter.present(root, animated: false, completion: nil)
+
+        // THEN — the root really is attached, so only the routed check can reject it.
+        #expect(root.presentingViewController === actualPresenter)
+        #expect(sut.isAttached(root))
+        #expect(!sut.isAttached(root, to: unrelatedIntendedPresenter))
+    }
+
+    @available(iOS 16, *)
+    @Test("Root Presenting Its Own Child Stays Attached To Its Presenter", .timeLimit(.minutes(1)))
+    func whenRootPresentsNestedChildThenRootRemainsAttached() {
+        // GIVEN
+        let intendedPresenter = UIViewController()
+        let window = makeKeyWindow(withRoot: intendedPresenter)
+        defer { window.isHidden = true }
+        let root = UIViewController()
+        let nestedChild = UIViewController()
+
+        // WHEN
+        intendedPresenter.present(root, animated: false, completion: nil)
+        root.present(nestedChild, animated: false, completion: nil)
+
+        // THEN — a child flow presented by the root does not detach the root itself.
+        #expect(root.presentingViewController === intendedPresenter)
+        #expect(root.presentedViewController === nestedChild)
+        #expect(nestedChild.presentingViewController === root)
+        #expect(sut.isAttached(root))
+        #expect(sut.isAttached(root, to: intendedPresenter))
+    }
+
+    @available(iOS 16, *)
+    @Test("Missing Intended Presenter Falls Back To The Plain Attachment Check", .timeLimit(.minutes(1)))
+    func whenIntendedPresenterIsNilThenPlainAttachmentCheckDecides() {
+        // GIVEN
+        let actualPresenter = UIViewController()
+        let window = makeKeyWindow(withRoot: actualPresenter)
+        defer { window.isHidden = true }
+        let attachedRoot = UIViewController()
+        let detachedRoot = UIViewController()
+
+        // WHEN
+        actualPresenter.present(attachedRoot, animated: false, completion: nil)
+
+        // THEN
+        #expect(attachedRoot.presentingViewController === actualPresenter)
+        #expect(sut.isAttached(attachedRoot, to: nil) == sut.isAttached(attachedRoot))
+        #expect(sut.isAttached(attachedRoot, to: nil))
+        #expect(sut.isAttached(detachedRoot, to: nil) == sut.isAttached(detachedRoot))
+        #expect(!sut.isAttached(detachedRoot, to: nil))
+    }
+
+    @available(iOS 16, *)
+    @Test("Detached Root Is Never Attached, With Or Without An Intended Presenter", .timeLimit(.minutes(1)))
+    func whenRootIsNotAttachedThenNoIntendedPresenterMakesItAttached() {
+        // GIVEN
+        let intendedPresenter = UIViewController()
+        let window = makeKeyWindow(withRoot: intendedPresenter)
+        defer { window.isHidden = true }
+        let root = UIViewController()
+
+        // THEN — nothing ever presented the root, so no intended presenter can make it count as attached.
+        #expect(!root.isBeingPresented)
+        #expect(root.presentingViewController == nil)
+        #expect(root.viewIfLoaded?.window == nil)
+        #expect(!sut.isAttached(root))
+        #expect(!sut.isAttached(root, to: intendedPresenter))
+        #expect(!sut.isAttached(root, to: nil))
+    }
+
+    /// Stands up a visible window so UIKit accepts synchronous, unanimated presentations from `root`.
+    ///
+    /// Callers must hide the returned window again so it does not stay key for later tests.
+    private func makeKeyWindow(withRoot root: UIViewController) -> UIWindow {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = root
+        window.makeKeyAndVisible()
+        return window
+    }
+}
+
+/// A presenter that withholds the UIKit presentation completion so an attempt can be observed mid-animation.
+@MainActor
+private final class DeferredCompletionModalPromptPresenter: ModalPromptPresenter {
+    var presentedViewController: UIViewController?
+    var modalPromptPresentationViewController: UIViewController?
+
+    private(set) var didCallPresent = false
+    private(set) var capturedViewController: UIViewController?
+    private var pendingCompletion: (() -> Void)?
+
+    func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?) {
+        didCallPresent = true
+        capturedViewController = viewControllerToPresent
+        pendingCompletion = completion
+    }
+
+    func completePendingPresentation() {
+        let completion = pendingCompletion
+        pendingCompletion = nil
+        completion?()
+    }
+}
+
+/// Models attachment as data the test owns: which roots count as attached, and which controller presents each of them.
+///
+/// `queriedRoots` records the controller the manager actually asked about, so a test can pin the *subject* of the
+/// predicate and not merely its answer — a check resolved against a topmost controller instead of the retained exact
+/// root asks about a different object even when both are on screen.
+@MainActor
 private final class MockModalPromptRootAttachmentChecker: ModalPromptRootAttachmentChecking {
     var attachedRoots = Set<ObjectIdentifier>()
-    var topmostViewController: UIViewController?
+
+    private(set) var queriedRoots: [ObjectIdentifier] = []
+    private var presentationHosts: [ObjectIdentifier: ObjectIdentifier] = [:]
+
+    /// Marks `root` as attached, optionally recording the controller presenting it so the routed check can match on it.
+    ///
+    /// A root marked without a host is attached only to the host-agnostic check, which is how a root observed on the
+    /// legacy path with no recorded presentation host behaves.
+    func markAttached(_ root: UIViewController, presentedBy host: UIViewController? = nil) {
+        attachedRoots.insert(ObjectIdentifier(root))
+        if let host {
+            presentationHosts[ObjectIdentifier(root)] = ObjectIdentifier(host)
+        }
+    }
+
+    func didQuery(_ root: UIViewController) -> Bool {
+        queriedRoots.contains(ObjectIdentifier(root))
+    }
 
     func isAttached(_ root: UIViewController) -> Bool {
-        attachedRoots.contains(ObjectIdentifier(root))
+        queriedRoots.append(ObjectIdentifier(root))
+        return attachedRoots.contains(ObjectIdentifier(root))
     }
 
     func isAttached(_ root: UIViewController, to intendedPresenter: UIViewController?) -> Bool {
-        isAttached(root)
+        guard isAttached(root) else { return false }
+        guard let intendedPresenter else { return true }
+
+        return presentationHosts[ObjectIdentifier(root)] == ObjectIdentifier(intendedPresenter)
     }
 }

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
@@ -25,6 +25,9 @@ import Testing
 @Suite("Promo Queue Lease Arbiter")
 struct PromoQueueLeaseArbiterTests {
 
+    // The arbiter reclaims a lease whose token has deallocated, so a test that needs a lease to keep holding its slot
+    // must bind the token and keep it alive for as long as the assertions depend on it.
+
     @available(iOS 16, *)
     @Test("Modal lease can be acquired from idle", .timeLimit(.minutes(1)))
     func acquireModalLeaseFromIdle() throws {
@@ -43,10 +46,11 @@ struct PromoQueueLeaseArbiterTests {
         let arbiter = PromoQueueLeaseArbiter()
         let identity = makeVisiblePromoIdentity()
 
-        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: identity))
+        let lease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: identity))
 
         #expect(!arbiter.snapshot.hasModalLease)
         #expect(arbiter.snapshot.visiblePromoIdentities == [identity])
+        _ = lease
     }
 
     @available(iOS 16, *)
@@ -55,8 +59,8 @@ struct PromoQueueLeaseArbiterTests {
         let arbiter = PromoQueueLeaseArbiter()
         let firstIdentity = makeVisiblePromoIdentity(promoID: "first")
         let secondIdentity = makeVisiblePromoIdentity(promoID: "second")
-        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: firstIdentity))
-        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: secondIdentity))
+        let firstLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: firstIdentity))
+        let secondLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: secondIdentity))
 
         let result = arbiter.acquireModalLease()
 
@@ -66,13 +70,14 @@ struct PromoQueueLeaseArbiterTests {
         }
         #expect(identities == [firstIdentity, secondIdentity])
         #expect(!arbiter.snapshot.hasModalLease)
+        _ = (firstLease, secondLease)
     }
 
     @available(iOS 16, *)
     @Test("Modal lease blocks visible promo acquisition", .timeLimit(.minutes(1)))
     func modalLeaseBlocksVisiblePromoAcquisition() throws {
         let arbiter = PromoQueueLeaseArbiter()
-        _ = try acquiredLease(from: arbiter.acquireModalLease())
+        let modalLease = try acquiredLease(from: arbiter.acquireModalLease())
 
         let result = arbiter.acquireVisiblePromoLease(for: makeVisiblePromoIdentity())
 
@@ -81,13 +86,14 @@ struct PromoQueueLeaseArbiterTests {
             return
         }
         #expect(arbiter.snapshot.visiblePromoIdentities.isEmpty)
+        _ = modalLease
     }
 
     @available(iOS 16, *)
     @Test("Existing modal lease blocks another modal acquisition", .timeLimit(.minutes(1)))
     func modalLeaseBlocksAnotherModalAcquisition() throws {
         let arbiter = PromoQueueLeaseArbiter()
-        _ = try acquiredLease(from: arbiter.acquireModalLease())
+        let modalLease = try acquiredLease(from: arbiter.acquireModalLease())
 
         let result = arbiter.acquireModalLease()
 
@@ -96,6 +102,7 @@ struct PromoQueueLeaseArbiterTests {
             return
         }
         #expect(arbiter.snapshot.hasModalLease)
+        _ = modalLease
     }
 
     @available(iOS 16, *)
@@ -111,11 +118,12 @@ struct PromoQueueLeaseArbiterTests {
             promoID: "message"
         )
 
-        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: firstIdentity))
-        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: secondIdentity))
+        let firstLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: firstIdentity))
+        let secondLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: secondIdentity))
 
         #expect(arbiter.snapshot.visiblePromoIdentities == [firstIdentity, secondIdentity])
         #expect(arbiter.snapshot.visiblePromoCount == 2)
+        _ = (firstLease, secondLease)
     }
 
     @available(iOS 16, *)
@@ -131,7 +139,7 @@ struct PromoQueueLeaseArbiterTests {
             surfaceID: surfaceID,
             promoID: "message-b"
         )
-        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: firstIdentity))
+        let firstLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: firstIdentity))
 
         let result = arbiter.acquireVisiblePromoLease(for: secondIdentity)
 
@@ -141,6 +149,7 @@ struct PromoQueueLeaseArbiterTests {
         }
         #expect(occupyingIdentity == firstIdentity)
         #expect(arbiter.snapshot.visiblePromoIdentities == [firstIdentity])
+        _ = firstLease
     }
 
     @available(iOS 16, *)
@@ -148,7 +157,7 @@ struct PromoQueueLeaseArbiterTests {
     func visiblePromoCannotAcquireOccupiedSlotTwice() throws {
         let arbiter = PromoQueueLeaseArbiter()
         let identity = makeVisiblePromoIdentity()
-        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: identity))
+        let lease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: identity))
 
         let result = arbiter.acquireVisiblePromoLease(for: identity)
 
@@ -158,6 +167,7 @@ struct PromoQueueLeaseArbiterTests {
         }
         #expect(occupyingIdentity == identity)
         #expect(arbiter.snapshot.visiblePromoCount == 1)
+        _ = lease
     }
 
     @available(iOS 16, *)
@@ -167,11 +177,12 @@ struct PromoQueueLeaseArbiterTests {
         let firstIdentity = makeVisiblePromoIdentity(promoID: "first")
         let secondIdentity = makeVisiblePromoIdentity(promoID: "second")
         let firstLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: firstIdentity))
-        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: secondIdentity))
+        let secondLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: secondIdentity))
 
         firstLease.release()
 
         #expect(arbiter.snapshot.visiblePromoIdentities == [secondIdentity])
+        _ = secondLease
     }
 
     @available(iOS 16, *)
@@ -184,8 +195,9 @@ struct PromoQueueLeaseArbiterTests {
         lease.release()
 
         #expect(!arbiter.snapshot.hasModalLease)
-        _ = try acquiredLease(from: arbiter.acquireModalLease())
+        let reacquiredLease = try acquiredLease(from: arbiter.acquireModalLease())
         #expect(arbiter.snapshot.hasModalLease)
+        _ = reacquiredLease
     }
 
     @available(iOS 16, *)
@@ -199,8 +211,9 @@ struct PromoQueueLeaseArbiterTests {
         lease.release()
 
         #expect(arbiter.snapshot.visiblePromoIdentities.isEmpty)
-        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: identity))
+        let reacquiredLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: identity))
         #expect(arbiter.snapshot.visiblePromoIdentities == [identity])
+        _ = reacquiredLease
     }
 
     @available(iOS 16, *)
@@ -218,7 +231,7 @@ struct PromoQueueLeaseArbiterTests {
         )
         let staleLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: staleIdentity))
         arbiter.invalidateAllLeases()
-        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: currentIdentity))
+        let currentLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: currentIdentity))
 
         staleLease.release()
 
@@ -229,6 +242,7 @@ struct PromoQueueLeaseArbiterTests {
             return
         }
         #expect(identities == [currentIdentity])
+        _ = currentLease
     }
 
     @available(iOS 16, *)
@@ -261,25 +275,108 @@ struct PromoQueueLeaseArbiterTests {
         )
         let oldLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: oldIdentity))
         arbiter.invalidateAllLeases()
-        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: newIdentity))
+        let newLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: newIdentity))
 
         oldLease.release()
 
         #expect(arbiter.snapshot.visiblePromoIdentities == [newIdentity])
+        _ = newLease
     }
 
     @available(iOS 16, *)
-    @Test("Invalidation advances generation and clears all leases", .timeLimit(.minutes(1)))
-    func invalidationAdvancesGenerationAndClearsLeases() throws {
+    @Test("Invalidation clears all leases and leaves outstanding tokens inert", .timeLimit(.minutes(1)))
+    func invalidationClearsLeasesAndLeavesOutstandingTokensInert() throws {
         let arbiter = PromoQueueLeaseArbiter()
-        let initialGeneration = arbiter.snapshot.generation
-        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: makeVisiblePromoIdentity()))
+        let outstandingLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: makeVisiblePromoIdentity()))
 
         arbiter.invalidateAllLeases()
 
-        #expect(arbiter.snapshot.generation != initialGeneration)
         #expect(!arbiter.snapshot.hasModalLease)
         #expect(arbiter.snapshot.visiblePromoIdentities.isEmpty)
+        // The cleared slot is immediately re-acquirable and the outstanding token cannot clear what replaced it.
+        let modalLease = try acquiredLease(from: arbiter.acquireModalLease())
+        outstandingLease.release()
+        #expect(arbiter.snapshot.modalAttemptIdentity == modalLease.attemptIdentity)
+    }
+
+    @available(iOS 16, *)
+    @Test("A stale visible promo token cannot release the next lease on its slot after a refresh", .timeLimit(.minutes(1)))
+    func staleVisiblePromoTokenCannotReleaseRefreshedLeaseOnItsSlot() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let surfaceID = UUID()
+        let staleIdentity = makeVisiblePromoIdentity(
+            surfaceID: surfaceID,
+            promoID: "message-a"
+        )
+        let currentIdentity = makeVisiblePromoIdentity(
+            surfaceID: surfaceID,
+            promoID: "message-b"
+        )
+        let staleLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: staleIdentity))
+        staleLease.release()
+        let currentLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: currentIdentity))
+
+        staleLease.release()
+
+        #expect(arbiter.snapshot.visiblePromoIdentities == [currentIdentity])
+        let result = arbiter.acquireModalLease()
+        guard case .blockedByVisiblePromos(let identities) = result else {
+            Issue.record("Expected the refreshed visible promo lease to keep blocking modal acquisition")
+            return
+        }
+        #expect(identities == [currentIdentity])
+        _ = currentLease
+    }
+
+    @available(iOS 16, *)
+    @Test("An old token cannot release a re-acquisition of its own identity after invalidation", .timeLimit(.minutes(1)))
+    func oldVisiblePromoTokenCannotReleaseReacquisitionOfSameIdentity() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let identity = makeVisiblePromoIdentity()
+        let oldLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: identity))
+        arbiter.invalidateAllLeases()
+        let currentLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: identity))
+
+        oldLease.release()
+
+        #expect(arbiter.snapshot.visiblePromoIdentities == [identity])
+        _ = currentLease
+    }
+
+    @available(iOS 16, *)
+    @Test("A dropped visible promo token stops blocking modal acquisition", .timeLimit(.minutes(1)))
+    func droppedVisiblePromoTokenStopsBlockingModalAcquisition() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let identity = makeVisiblePromoIdentity()
+        do {
+            let droppedLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: identity))
+            #expect(arbiter.snapshot.visiblePromoIdentities == [identity])
+            _ = droppedLease
+        }
+
+        // The token left scope without `release()`, which must not wedge the modal slot for the rest of the session.
+        #expect(arbiter.snapshot.visiblePromoIdentities.isEmpty)
+        let modalLease = try acquiredLease(from: arbiter.acquireModalLease())
+        #expect(arbiter.snapshot.modalAttemptIdentity == modalLease.attemptIdentity)
+        _ = modalLease
+    }
+
+    @available(iOS 16, *)
+    @Test("A dropped modal token stops blocking visible promo acquisition", .timeLimit(.minutes(1)))
+    func droppedModalTokenStopsBlockingVisiblePromoAcquisition() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        do {
+            let droppedLease = try acquiredLease(from: arbiter.acquireModalLease())
+            #expect(arbiter.snapshot.hasModalLease)
+            _ = droppedLease
+        }
+
+        let identity = makeVisiblePromoIdentity()
+        let visibleLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: identity))
+
+        #expect(!arbiter.snapshot.hasModalLease)
+        #expect(arbiter.snapshot.visiblePromoIdentities == [identity])
+        _ = visibleLease
     }
 
     private func makeVisiblePromoIdentity(

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
@@ -1,0 +1,287 @@
+//
+//  PromoQueueLeaseArbiterTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+@testable import DuckDuckGo
+
+@MainActor
+@Suite("Promo Queue Lease Arbiter")
+struct PromoQueueLeaseArbiterTests {
+
+    @Test("Modal lease can be acquired from idle")
+    func acquireModalLeaseFromIdle() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+
+        let lease = try acquiredLease(from: arbiter.acquireModalLease())
+
+        #expect(arbiter.snapshot.hasModalLease)
+        #expect(arbiter.snapshot.modalAttemptIdentity == lease.attemptIdentity)
+        #expect(arbiter.snapshot.visiblePromoIdentities.isEmpty)
+    }
+
+    @Test("Visible promo lease can be acquired from idle")
+    func acquireVisiblePromoLeaseFromIdle() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let identity = makeVisiblePromoIdentity()
+
+        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: identity))
+
+        #expect(!arbiter.snapshot.hasModalLease)
+        #expect(arbiter.snapshot.visiblePromoIdentities == [identity])
+    }
+
+    @Test("Visible promos block modal acquisition with their identities")
+    func visiblePromosBlockModalAcquisition() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let firstIdentity = makeVisiblePromoIdentity(promoID: "first")
+        let secondIdentity = makeVisiblePromoIdentity(promoID: "second")
+        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: firstIdentity))
+        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: secondIdentity))
+
+        let result = arbiter.acquireModalLease()
+
+        guard case .blockedByVisiblePromos(let identities) = result else {
+            Issue.record("Expected modal acquisition to be blocked by visible promos")
+            return
+        }
+        #expect(identities == [firstIdentity, secondIdentity])
+        #expect(!arbiter.snapshot.hasModalLease)
+    }
+
+    @Test("Modal lease blocks visible promo acquisition")
+    func modalLeaseBlocksVisiblePromoAcquisition() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        _ = try acquiredLease(from: arbiter.acquireModalLease())
+
+        let result = arbiter.acquireVisiblePromoLease(for: makeVisiblePromoIdentity())
+
+        guard case .blockedByModal = result else {
+            Issue.record("Expected visible promo acquisition to be blocked by the modal")
+            return
+        }
+        #expect(arbiter.snapshot.visiblePromoIdentities.isEmpty)
+    }
+
+    @Test("Existing modal lease blocks another modal acquisition")
+    func modalLeaseBlocksAnotherModalAcquisition() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        _ = try acquiredLease(from: arbiter.acquireModalLease())
+
+        let result = arbiter.acquireModalLease()
+
+        guard case .blockedByModal = result else {
+            Issue.record("Expected modal acquisition to be blocked by the existing modal")
+            return
+        }
+        #expect(arbiter.snapshot.hasModalLease)
+    }
+
+    @Test("The same visible promo can hold leases on different surfaces")
+    func sameVisiblePromoCanHoldLeasesOnDifferentSurfaces() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let firstIdentity = makeVisiblePromoIdentity(
+            surfaceID: UUID(),
+            promoID: "message"
+        )
+        let secondIdentity = makeVisiblePromoIdentity(
+            surfaceID: UUID(),
+            promoID: "message"
+        )
+
+        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: firstIdentity))
+        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: secondIdentity))
+
+        #expect(arbiter.snapshot.visiblePromoIdentities == [firstIdentity, secondIdentity])
+        #expect(arbiter.snapshot.visiblePromoCount == 2)
+    }
+
+    @Test("A surface and promo type slot cannot hold two messages")
+    func visiblePromoSlotCannotHoldTwoMessages() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let surfaceID = UUID()
+        let firstIdentity = makeVisiblePromoIdentity(
+            surfaceID: surfaceID,
+            promoID: "message-a"
+        )
+        let secondIdentity = makeVisiblePromoIdentity(
+            surfaceID: surfaceID,
+            promoID: "message-b"
+        )
+        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: firstIdentity))
+
+        let result = arbiter.acquireVisiblePromoLease(for: secondIdentity)
+
+        guard case .occupiedSurfaceSlot(let occupyingIdentity) = result else {
+            Issue.record("Expected visible promo acquisition to be blocked by the occupied surface slot")
+            return
+        }
+        #expect(occupyingIdentity == firstIdentity)
+        #expect(arbiter.snapshot.visiblePromoIdentities == [firstIdentity])
+    }
+
+    @Test("The same message cannot acquire its occupied surface slot twice")
+    func visiblePromoCannotAcquireOccupiedSlotTwice() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let identity = makeVisiblePromoIdentity()
+        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: identity))
+
+        let result = arbiter.acquireVisiblePromoLease(for: identity)
+
+        guard case .occupiedSurfaceSlot(let occupyingIdentity) = result else {
+            Issue.record("Expected duplicate visible promo acquisition to be blocked by the occupied surface slot")
+            return
+        }
+        #expect(occupyingIdentity == identity)
+        #expect(arbiter.snapshot.visiblePromoCount == 1)
+    }
+
+    @Test("Releasing one visible promo does not release another")
+    func releasingVisiblePromoDoesNotReleaseAnother() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let firstIdentity = makeVisiblePromoIdentity(promoID: "first")
+        let secondIdentity = makeVisiblePromoIdentity(promoID: "second")
+        let firstLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: firstIdentity))
+        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: secondIdentity))
+
+        firstLease.release()
+
+        #expect(arbiter.snapshot.visiblePromoIdentities == [secondIdentity])
+    }
+
+    @Test("Releasing a modal lease more than once is harmless")
+    func duplicateModalReleaseIsHarmless() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let lease = try acquiredLease(from: arbiter.acquireModalLease())
+
+        lease.release()
+        lease.release()
+
+        #expect(!arbiter.snapshot.hasModalLease)
+        _ = try acquiredLease(from: arbiter.acquireModalLease())
+        #expect(arbiter.snapshot.hasModalLease)
+    }
+
+    @Test("Releasing a visible promo lease more than once is harmless")
+    func duplicateVisiblePromoReleaseIsHarmless() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let identity = makeVisiblePromoIdentity()
+        let lease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: identity))
+
+        lease.release()
+        lease.release()
+
+        #expect(arbiter.snapshot.visiblePromoIdentities.isEmpty)
+        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: identity))
+        #expect(arbiter.snapshot.visiblePromoIdentities == [identity])
+    }
+
+    @Test("A released token cannot release a newer lease for the same slot")
+    func staleVisiblePromoReleaseDoesNotReleaseNewLease() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let surfaceID = UUID()
+        let firstIdentity = makeVisiblePromoIdentity(
+            surfaceID: surfaceID,
+            promoID: "message-a"
+        )
+        let secondIdentity = makeVisiblePromoIdentity(
+            surfaceID: surfaceID,
+            promoID: "message-b"
+        )
+        let firstLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: firstIdentity))
+        firstLease.release()
+        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: secondIdentity))
+
+        firstLease.release()
+
+        #expect(arbiter.snapshot.visiblePromoIdentities == [secondIdentity])
+    }
+
+    @Test("Old modal token cannot release a lease acquired after invalidation")
+    func oldModalTokenCannotReleaseNewLeaseAfterInvalidation() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let oldLease = try acquiredLease(from: arbiter.acquireModalLease())
+        arbiter.invalidateAllLeases()
+        let newLease = try acquiredLease(from: arbiter.acquireModalLease())
+
+        oldLease.release()
+
+        #expect(arbiter.snapshot.hasModalLease)
+        #expect(newLease.attemptIdentity != oldLease.attemptIdentity)
+        #expect(arbiter.snapshot.modalAttemptIdentity == newLease.attemptIdentity)
+    }
+
+    @Test("Old visible promo token cannot release a lease acquired after invalidation")
+    func oldVisiblePromoTokenCannotReleaseNewLeaseAfterInvalidation() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let surfaceID = UUID()
+        let oldIdentity = makeVisiblePromoIdentity(
+            surfaceID: surfaceID,
+            promoID: "message-a"
+        )
+        let newIdentity = makeVisiblePromoIdentity(
+            surfaceID: surfaceID,
+            promoID: "message-b"
+        )
+        let oldLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: oldIdentity))
+        arbiter.invalidateAllLeases()
+        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: newIdentity))
+
+        oldLease.release()
+
+        #expect(arbiter.snapshot.visiblePromoIdentities == [newIdentity])
+    }
+
+    @Test("Invalidation advances generation and clears all leases")
+    func invalidationAdvancesGenerationAndClearsLeases() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        let initialGeneration = arbiter.snapshot.generation
+        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: makeVisiblePromoIdentity()))
+
+        arbiter.invalidateAllLeases()
+
+        #expect(arbiter.snapshot.generation != initialGeneration)
+        #expect(!arbiter.snapshot.hasModalLease)
+        #expect(arbiter.snapshot.visiblePromoIdentities.isEmpty)
+    }
+
+    private func makeVisiblePromoIdentity(
+        surfaceID: UUID = UUID(),
+        promoID: String = "message"
+    ) -> VisiblePromoIdentity {
+        VisiblePromoIdentity(
+            surfaceID: surfaceID,
+            promoType: .remoteMessage,
+            promoID: promoID
+        )
+    }
+
+    private func acquiredLease<Lease>(
+        from result: PromoQueueLeaseAcquisitionResult<Lease>
+    ) throws -> Lease {
+        guard case .acquired(let lease) = result else {
+            throw TestError.expectedAcquiredLease
+        }
+        return lease
+    }
+}
+
+private enum TestError: Error {
+    case expectedAcquiredLease
+}

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
@@ -300,35 +300,6 @@ struct PromoQueueLeaseArbiterTests {
     }
 
     @available(iOS 16, *)
-    @Test("A stale visible promo token cannot release the next lease on its slot after a refresh", .timeLimit(.minutes(1)))
-    func staleVisiblePromoTokenCannotReleaseRefreshedLeaseOnItsSlot() throws {
-        let arbiter = PromoQueueLeaseArbiter()
-        let surfaceID = UUID()
-        let staleIdentity = makeVisiblePromoIdentity(
-            surfaceID: surfaceID,
-            promoID: "message-a"
-        )
-        let currentIdentity = makeVisiblePromoIdentity(
-            surfaceID: surfaceID,
-            promoID: "message-b"
-        )
-        let staleLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: staleIdentity))
-        staleLease.release()
-        let currentLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: currentIdentity))
-
-        staleLease.release()
-
-        #expect(arbiter.snapshot.visiblePromoIdentities == [currentIdentity])
-        let result = arbiter.acquireModalLease()
-        guard case .blockedByVisiblePromos(let identities) = result else {
-            Issue.record("Expected the refreshed visible promo lease to keep blocking modal acquisition")
-            return
-        }
-        #expect(identities == [currentIdentity])
-        _ = currentLease
-    }
-
-    @available(iOS 16, *)
     @Test("An old token cannot release a re-acquisition of its own identity after invalidation", .timeLimit(.minutes(1)))
     func oldVisiblePromoTokenCannotReleaseReacquisitionOfSameIdentity() throws {
         let arbiter = PromoQueueLeaseArbiter()

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
@@ -25,7 +25,8 @@ import Testing
 @Suite("Promo Queue Lease Arbiter")
 struct PromoQueueLeaseArbiterTests {
 
-    @Test("Modal lease can be acquired from idle")
+    @available(iOS 16, *)
+    @Test("Modal lease can be acquired from idle", .timeLimit(.minutes(1)))
     func acquireModalLeaseFromIdle() throws {
         let arbiter = PromoQueueLeaseArbiter()
 
@@ -36,7 +37,8 @@ struct PromoQueueLeaseArbiterTests {
         #expect(arbiter.snapshot.visiblePromoIdentities.isEmpty)
     }
 
-    @Test("Visible promo lease can be acquired from idle")
+    @available(iOS 16, *)
+    @Test("Visible promo lease can be acquired from idle", .timeLimit(.minutes(1)))
     func acquireVisiblePromoLeaseFromIdle() throws {
         let arbiter = PromoQueueLeaseArbiter()
         let identity = makeVisiblePromoIdentity()
@@ -47,7 +49,8 @@ struct PromoQueueLeaseArbiterTests {
         #expect(arbiter.snapshot.visiblePromoIdentities == [identity])
     }
 
-    @Test("Visible promos block modal acquisition with their identities")
+    @available(iOS 16, *)
+    @Test("Visible promos block modal acquisition with their identities", .timeLimit(.minutes(1)))
     func visiblePromosBlockModalAcquisition() throws {
         let arbiter = PromoQueueLeaseArbiter()
         let firstIdentity = makeVisiblePromoIdentity(promoID: "first")
@@ -65,7 +68,8 @@ struct PromoQueueLeaseArbiterTests {
         #expect(!arbiter.snapshot.hasModalLease)
     }
 
-    @Test("Modal lease blocks visible promo acquisition")
+    @available(iOS 16, *)
+    @Test("Modal lease blocks visible promo acquisition", .timeLimit(.minutes(1)))
     func modalLeaseBlocksVisiblePromoAcquisition() throws {
         let arbiter = PromoQueueLeaseArbiter()
         _ = try acquiredLease(from: arbiter.acquireModalLease())
@@ -79,7 +83,8 @@ struct PromoQueueLeaseArbiterTests {
         #expect(arbiter.snapshot.visiblePromoIdentities.isEmpty)
     }
 
-    @Test("Existing modal lease blocks another modal acquisition")
+    @available(iOS 16, *)
+    @Test("Existing modal lease blocks another modal acquisition", .timeLimit(.minutes(1)))
     func modalLeaseBlocksAnotherModalAcquisition() throws {
         let arbiter = PromoQueueLeaseArbiter()
         _ = try acquiredLease(from: arbiter.acquireModalLease())
@@ -93,7 +98,8 @@ struct PromoQueueLeaseArbiterTests {
         #expect(arbiter.snapshot.hasModalLease)
     }
 
-    @Test("The same visible promo can hold leases on different surfaces")
+    @available(iOS 16, *)
+    @Test("The same visible promo can hold leases on different surfaces", .timeLimit(.minutes(1)))
     func sameVisiblePromoCanHoldLeasesOnDifferentSurfaces() throws {
         let arbiter = PromoQueueLeaseArbiter()
         let firstIdentity = makeVisiblePromoIdentity(
@@ -112,7 +118,8 @@ struct PromoQueueLeaseArbiterTests {
         #expect(arbiter.snapshot.visiblePromoCount == 2)
     }
 
-    @Test("A surface and promo type slot cannot hold two messages")
+    @available(iOS 16, *)
+    @Test("A surface and promo type slot cannot hold two messages", .timeLimit(.minutes(1)))
     func visiblePromoSlotCannotHoldTwoMessages() throws {
         let arbiter = PromoQueueLeaseArbiter()
         let surfaceID = UUID()
@@ -136,7 +143,8 @@ struct PromoQueueLeaseArbiterTests {
         #expect(arbiter.snapshot.visiblePromoIdentities == [firstIdentity])
     }
 
-    @Test("The same message cannot acquire its occupied surface slot twice")
+    @available(iOS 16, *)
+    @Test("The same message cannot acquire its occupied surface slot twice", .timeLimit(.minutes(1)))
     func visiblePromoCannotAcquireOccupiedSlotTwice() throws {
         let arbiter = PromoQueueLeaseArbiter()
         let identity = makeVisiblePromoIdentity()
@@ -152,7 +160,8 @@ struct PromoQueueLeaseArbiterTests {
         #expect(arbiter.snapshot.visiblePromoCount == 1)
     }
 
-    @Test("Releasing one visible promo does not release another")
+    @available(iOS 16, *)
+    @Test("Releasing one visible promo does not release another", .timeLimit(.minutes(1)))
     func releasingVisiblePromoDoesNotReleaseAnother() throws {
         let arbiter = PromoQueueLeaseArbiter()
         let firstIdentity = makeVisiblePromoIdentity(promoID: "first")
@@ -165,7 +174,8 @@ struct PromoQueueLeaseArbiterTests {
         #expect(arbiter.snapshot.visiblePromoIdentities == [secondIdentity])
     }
 
-    @Test("Releasing a modal lease more than once is harmless")
+    @available(iOS 16, *)
+    @Test("Releasing a modal lease more than once is harmless", .timeLimit(.minutes(1)))
     func duplicateModalReleaseIsHarmless() throws {
         let arbiter = PromoQueueLeaseArbiter()
         let lease = try acquiredLease(from: arbiter.acquireModalLease())
@@ -178,7 +188,8 @@ struct PromoQueueLeaseArbiterTests {
         #expect(arbiter.snapshot.hasModalLease)
     }
 
-    @Test("Releasing a visible promo lease more than once is harmless")
+    @available(iOS 16, *)
+    @Test("Releasing a visible promo lease more than once is harmless", .timeLimit(.minutes(1)))
     func duplicateVisiblePromoReleaseIsHarmless() throws {
         let arbiter = PromoQueueLeaseArbiter()
         let identity = makeVisiblePromoIdentity()
@@ -192,28 +203,36 @@ struct PromoQueueLeaseArbiterTests {
         #expect(arbiter.snapshot.visiblePromoIdentities == [identity])
     }
 
-    @Test("A released token cannot release a newer lease for the same slot")
-    func staleVisiblePromoReleaseDoesNotReleaseNewLease() throws {
+    @available(iOS 16, *)
+    @Test("A stale visible promo token cannot open the modal gate for the slot it no longer owns", .timeLimit(.minutes(1)))
+    func staleVisiblePromoTokenCannotOpenModalGate() throws {
         let arbiter = PromoQueueLeaseArbiter()
         let surfaceID = UUID()
-        let firstIdentity = makeVisiblePromoIdentity(
+        let staleIdentity = makeVisiblePromoIdentity(
             surfaceID: surfaceID,
             promoID: "message-a"
         )
-        let secondIdentity = makeVisiblePromoIdentity(
+        let currentIdentity = makeVisiblePromoIdentity(
             surfaceID: surfaceID,
             promoID: "message-b"
         )
-        let firstLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: firstIdentity))
-        firstLease.release()
-        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: secondIdentity))
+        let staleLease = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: staleIdentity))
+        arbiter.invalidateAllLeases()
+        _ = try acquiredLease(from: arbiter.acquireVisiblePromoLease(for: currentIdentity))
 
-        firstLease.release()
+        staleLease.release()
 
-        #expect(arbiter.snapshot.visiblePromoIdentities == [secondIdentity])
+        #expect(arbiter.snapshot.visiblePromoIdentities == [currentIdentity])
+        let result = arbiter.acquireModalLease()
+        guard case .blockedByVisiblePromos(let identities) = result else {
+            Issue.record("Expected the surviving visible promo lease to keep blocking modal acquisition")
+            return
+        }
+        #expect(identities == [currentIdentity])
     }
 
-    @Test("Old modal token cannot release a lease acquired after invalidation")
+    @available(iOS 16, *)
+    @Test("Old modal token cannot release a lease acquired after invalidation", .timeLimit(.minutes(1)))
     func oldModalTokenCannotReleaseNewLeaseAfterInvalidation() throws {
         let arbiter = PromoQueueLeaseArbiter()
         let oldLease = try acquiredLease(from: arbiter.acquireModalLease())
@@ -227,7 +246,8 @@ struct PromoQueueLeaseArbiterTests {
         #expect(arbiter.snapshot.modalAttemptIdentity == newLease.attemptIdentity)
     }
 
-    @Test("Old visible promo token cannot release a lease acquired after invalidation")
+    @available(iOS 16, *)
+    @Test("Old visible promo token cannot release a lease acquired after invalidation", .timeLimit(.minutes(1)))
     func oldVisiblePromoTokenCannotReleaseNewLeaseAfterInvalidation() throws {
         let arbiter = PromoQueueLeaseArbiter()
         let surfaceID = UUID()
@@ -248,7 +268,8 @@ struct PromoQueueLeaseArbiterTests {
         #expect(arbiter.snapshot.visiblePromoIdentities == [newIdentity])
     }
 
-    @Test("Invalidation advances generation and clears all leases")
+    @available(iOS 16, *)
+    @Test("Invalidation advances generation and clears all leases", .timeLimit(.minutes(1)))
     func invalidationAdvancesGenerationAndClearsLeases() throws {
         let arbiter = PromoQueueLeaseArbiter()
         let initialGeneration = arbiter.snapshot.generation

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
@@ -293,9 +293,18 @@ struct PromoQueueLeaseArbiterTests {
         )
     }
 
-    private func acquiredLease<Lease>(
-        from result: PromoQueueLeaseAcquisitionResult<Lease>
-    ) throws -> Lease {
+    private func acquiredLease(
+        from result: PromoQueueModalLeaseAcquisitionResult
+    ) throws -> PromoQueueModalLease {
+        guard case .acquired(let lease) = result else {
+            throw TestError.expectedAcquiredLease
+        }
+        return lease
+    }
+
+    private func acquiredLease(
+        from result: PromoQueueVisiblePromoLeaseAcquisitionResult
+    ) throws -> PromoQueueVisiblePromoLease {
         guard case .acquired(let lease) = result else {
             throw TestError.expectedAcquiredLease
         }

--- a/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -24,6 +24,7 @@ import DDGSync
 
 @testable import DuckDuckGo
 
+@MainActor
 final class NewTabPageMessagesModelTests: XCTestCase {
  
     private var messagesConfiguration: HomePageMessagesConfigurationMock!
@@ -336,8 +337,14 @@ final class NewTabPageMessagesModelTests: XCTestCase {
                                 pixelFiring: PixelFiringMock.self,
                                 messageActionHandler: remoteMessageActionHandler,
                                 imageLoader: MockRemoteMessagingImageLoader(),
+                                promoCoordinator: MockNewTabPagePromoCoordinator(),
                                 isOpenedAfterIdle: { isOpenedAfterIdle })
     }
+}
+
+@MainActor
+private final class MockNewTabPagePromoCoordinator: NewTabPagePromoCoordinating {
+    let promoQueueFeatureState = PromoQueueFeatureState.disabled
 }
 
 extension NewTabPageMessagesModelTests: MessageNavigationDelegate {

--- a/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -342,11 +342,6 @@ final class NewTabPageMessagesModelTests: XCTestCase {
     }
 }
 
-@MainActor
-private final class MockNewTabPagePromoCoordinator: NewTabPagePromoCoordinating {
-    let promoQueueFeatureState = PromoQueueFeatureState.disabled
-}
-
 extension NewTabPageMessagesModelTests: MessageNavigationDelegate {
 
     func segueToSettingsAIChat(openedFromSERPSettingsButton: Bool, presentationStyle: PresentationContext.Style) {

--- a/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
+++ b/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
@@ -35,6 +35,7 @@ final class ModalPromptCoordinationManagerIntegrationTests {
     private let cooldownManager: PromptCooldownManager
     private let schedulerMock: ImmediateScheduler
     private let presenterMock: MockModalPromptPresenter
+    private let promoQueueLeaseArbiter: PromoQueueLeaseArbiter
     private var sut: ModalPromptCoordinationManager!
 
     init() throws {
@@ -53,6 +54,7 @@ final class ModalPromptCoordinationManagerIntegrationTests {
         )
         schedulerMock = ImmediateScheduler()
         presenterMock = MockModalPromptPresenter()
+        promoQueueLeaseArbiter = PromoQueueLeaseArbiter()
     }
 
     @Test("Check Is In Cooldown After Presenting Prompt")
@@ -63,6 +65,7 @@ final class ModalPromptCoordinationManagerIntegrationTests {
             providers: [provider],
             cooldownManager: cooldownManager,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
         #expect(!cooldownManager.isInCooldownPeriod)
@@ -86,6 +89,7 @@ final class ModalPromptCoordinationManagerIntegrationTests {
             providers: [firstProvider],
             cooldownManager: cooldownManager,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
         #expect(cooldownManager.isInCooldownPeriod)
@@ -113,6 +117,7 @@ final class ModalPromptCoordinationManagerIntegrationTests {
             providers: [firstProvider],
             cooldownManager: cooldownManager,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
         #expect(cooldownManager.isInCooldownPeriod)
@@ -143,6 +148,7 @@ final class ModalPromptCoordinationManagerIntegrationTests {
             providers: [provider1, provider2, provider3],
             cooldownManager: cooldownManager,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 
@@ -201,6 +207,7 @@ final class ModalPromptCoordinationManagerIntegrationTests {
             providers: [provider1, provider2],
             cooldownManager: cooldownManager,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
 
@@ -241,6 +248,7 @@ final class ModalPromptCoordinationManagerIntegrationTests {
             providers: [provider],
             cooldownManager: cooldownManager,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
         let presentationTime = timeTraveller.getDate()
@@ -263,6 +271,7 @@ final class ModalPromptCoordinationManagerIntegrationTests {
             providers: [provider],
             cooldownManager: cooldownManager,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
         var lastPresentationTime = timeTraveller.getDate()
@@ -312,6 +321,7 @@ final class ModalPromptCoordinationManagerIntegrationTests {
             providers: [provider],
             cooldownManager: cooldownManager,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
         let presentationTime = timeTraveller.getDate()

--- a/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
+++ b/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
@@ -350,7 +350,8 @@ final class ModalPromptCoordinationManagerIntegrationTests {
 
     // MARK: - Promo Queue Lease Integration
 
-    @Test("Coordinated Presentation Retains Lease And Records Cooldown")
+    @available(iOS 16, *)
+    @Test("Coordinated Presentation Retains Lease And Records Cooldown", .timeLimit(.minutes(1)))
     func whenCoordinatedPromptPresentsThenLeaseAndPersistentCooldownAreRetained() throws {
         let provider = MockModalPromptProvider()
         sut = ModalPromptCoordinationManager(
@@ -378,7 +379,8 @@ final class ModalPromptCoordinationManagerIntegrationTests {
         #expect(storedTimestamp == timeTraveller.getDate().timeIntervalSince1970)
     }
 
-    @Test("Coordinated Cooldown Denial Releases Lease Before Provider Evaluation")
+    @available(iOS 16, *)
+    @Test("Coordinated Cooldown Denial Releases Lease Before Provider Evaluation", .timeLimit(.minutes(1)))
     func whenPersistentCooldownBlocksCoordinatedAttemptThenLeaseIsReleased() {
         cooldownStore.lastPresentationTimestamp = timeTraveller.getDate().timeIntervalSince1970
         let provider = MockModalPromptProvider()

--- a/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
+++ b/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
@@ -347,6 +347,60 @@ final class ModalPromptCoordinationManagerIntegrationTests {
         #expect(cooldownManager.isInCooldownPeriod)
         #expect(cooldownManager.cooldownInfo.lastPresentationDate == pastTime)
     }
+
+    // MARK: - Promo Queue Lease Integration
+
+    @Test("Coordinated Presentation Retains Lease And Records Cooldown")
+    func whenCoordinatedPromptPresentsThenLeaseAndPersistentCooldownAreRetained() throws {
+        let provider = MockModalPromptProvider()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManager,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        guard case .acquired(let lease) = promoQueueLeaseArbiter.acquireModalLease() else {
+            Issue.record("Expected modal lease acquisition")
+            return
+        }
+
+        let disposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+
+        #expect(disposition == .retained)
+        #expect(promoQueueLeaseArbiter.snapshot.modalAttemptIdentity == lease.attemptIdentity)
+        #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+        #expect(sut.didActuallyPresentModalPromptThisSession)
+        #expect(cooldownManager.isInCooldownPeriod)
+        let storedTimestamp = try keyValueStore.object(
+            forKey: PromptCooldownKeyValueFilesStore.StorageKey.lastPromptShownTimestamp
+        ) as? TimeInterval
+        #expect(storedTimestamp == timeTraveller.getDate().timeIntervalSince1970)
+    }
+
+    @Test("Coordinated Cooldown Denial Releases Lease Before Provider Evaluation")
+    func whenPersistentCooldownBlocksCoordinatedAttemptThenLeaseIsReleased() {
+        cooldownStore.lastPresentationTimestamp = timeTraveller.getDate().timeIntervalSince1970
+        let provider = MockModalPromptProvider()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManager,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        guard case .acquired(let lease) = promoQueueLeaseArbiter.acquireModalLease() else {
+            Issue.record("Expected modal lease acquisition")
+            return
+        }
+
+        let disposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+
+        #expect(disposition == .released)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(!provider.didCallProvideModalPrompt)
+        #expect(!presenterMock.didCallPresent)
+    }
 }
 
 // MARK: - Helpers

--- a/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
+++ b/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
@@ -38,6 +38,7 @@ private class MockURLBasedDebugCommands: URLBasedDebugCommands {
     }
 }
 
+@MainActor
 final class NewTabPageControllerDaxDialogTests: XCTestCase {
 
     var variantManager: CapturingVariantManager!

--- a/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
+++ b/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
@@ -278,11 +278,6 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
     }
 }
 
-@MainActor
-private final class MockNewTabPagePromoCoordinator: NewTabPagePromoCoordinating {
-    let promoQueueFeatureState = PromoQueueFeatureState.disabled
-}
-
 class CapturingVariantManager: VariantManager {
     var currentVariant: Variant?
     var capturedFeatureName: FeatureName?

--- a/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
+++ b/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
@@ -67,6 +67,7 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
             faviconLoader: EmptyFaviconLoading(),
             remoteMessagingActionHandler: MockRemoteMessagingActionHandler(),
             remoteMessagingImageLoader: MockRemoteMessagingImageLoader(),
+            promoCoordinator: MockNewTabPagePromoCoordinator(),
             appSettings: AppSettingsMock(),
             faviconsCache: Favicons(),
             subscriptionManager: SubscriptionManagerMock(),
@@ -118,6 +119,7 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
             faviconLoader: EmptyFaviconLoading(),
             remoteMessagingActionHandler: MockRemoteMessagingActionHandler(),
             remoteMessagingImageLoader: MockRemoteMessagingImageLoader(),
+            promoCoordinator: MockNewTabPagePromoCoordinator(),
             appSettings: AppSettingsMock(),
             faviconsCache: Favicons(),
             subscriptionManager: SubscriptionManagerMock(),
@@ -273,6 +275,11 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
         let specs: [DaxDialogs.HomeScreenSpec] = [.initial, .subsequent, .final, .addFavorite]
         return specs.randomElement()!
     }
+}
+
+@MainActor
+private final class MockNewTabPagePromoCoordinator: NewTabPagePromoCoordinating {
+    let promoQueueFeatureState = PromoQueueFeatureState.disabled
 }
 
 class CapturingVariantManager: VariantManager {

--- a/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
+++ b/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
@@ -220,7 +220,8 @@ private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibi
             privacyStats: MockPrivacyStats(),
             whatsNewRepository: MockWhatsNewMessageRepository(scheduledRemoteMessage: nil),
             darkReaderFeatureSettings: MockDarkReaderFeatureSettings(),
-            onboardingManager: OnboardingManagerMock()
+            onboardingManager: OnboardingManagerMock(),
+            newTabPagePromoCoordinator: MockOnboardingNewTabPagePromoCoordinator()
         )
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()
@@ -278,4 +279,9 @@ private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibi
         XCTAssertTrue(contextualOnboardingLogicMock.didCallEnableAddFavoriteFlow)
     }
 
+}
+
+@MainActor
+private final class MockOnboardingNewTabPagePromoCoordinator: NewTabPagePromoCoordinating {
+    let promoQueueFeatureState = PromoQueueFeatureState.disabled
 }

--- a/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
+++ b/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
@@ -221,7 +221,7 @@ private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibi
             whatsNewRepository: MockWhatsNewMessageRepository(scheduledRemoteMessage: nil),
             darkReaderFeatureSettings: MockDarkReaderFeatureSettings(),
             onboardingManager: OnboardingManagerMock(),
-            newTabPagePromoCoordinator: MockOnboardingNewTabPagePromoCoordinator()
+            newTabPagePromoCoordinator: MockNewTabPagePromoCoordinator()
         )
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()
@@ -279,9 +279,4 @@ private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibi
         XCTAssertTrue(contextualOnboardingLogicMock.didCallEnableAddFavoriteFlow)
     }
 
-}
-
-@MainActor
-private final class MockOnboardingNewTabPagePromoCoordinator: NewTabPagePromoCoordinating {
-    let promoQueueFeatureState = PromoQueueFeatureState.disabled
 }

--- a/iOS/SharedTestUtils/Mocks/BrowserServiceKit/MockFeatureFlagger.swift
+++ b/iOS/SharedTestUtils/Mocks/BrowserServiceKit/MockFeatureFlagger.swift
@@ -29,7 +29,9 @@ final class MockFeatureFlagger: FeatureFlagger {
     var enabledFeatureFlags: [FeatureFlag] = []
 
     private let updatesSubject = PassthroughSubject<Void, Never>()
+    private(set) var updatesPublisherAccessCount = 0
     var updatesPublisher: AnyPublisher<Void, Never> {
+        updatesPublisherAccessCount += 1
         updatesSubject.eraseToAnyPublisher()
     }
 

--- a/iOS/SharedTestUtils/Mocks/BrowserServiceKit/MockFeatureFlagger.swift
+++ b/iOS/SharedTestUtils/Mocks/BrowserServiceKit/MockFeatureFlagger.swift
@@ -29,10 +29,20 @@ final class MockFeatureFlagger: FeatureFlagger {
     var enabledFeatureFlags: [FeatureFlag] = []
 
     private let updatesSubject = PassthroughSubject<Void, Never>()
-    private(set) var updatesPublisherAccessCount = 0
+
+    /// The number of subscriptions established on `updatesPublisher`.
+    ///
+    /// Driven by Combine when a subscriber actually attaches, not by reads of `updatesPublisher`,
+    /// so storing the publisher and subscribing twice counts twice, while composing a chain that
+    /// reads the property once and subscribes once counts once.
+    private(set) var updatesPublisherSubscriptionCount = 0
+
     var updatesPublisher: AnyPublisher<Void, Never> {
-        updatesPublisherAccessCount += 1
-        return updatesSubject.eraseToAnyPublisher()
+        updatesSubject
+            .handleEvents(receiveSubscription: { [weak self] _ in
+                self?.updatesPublisherSubscriptionCount += 1
+            })
+            .eraseToAnyPublisher()
     }
 
     /// Call this method in tests to trigger the updates publisher

--- a/iOS/SharedTestUtils/Mocks/BrowserServiceKit/MockFeatureFlagger.swift
+++ b/iOS/SharedTestUtils/Mocks/BrowserServiceKit/MockFeatureFlagger.swift
@@ -32,7 +32,7 @@ final class MockFeatureFlagger: FeatureFlagger {
     private(set) var updatesPublisherAccessCount = 0
     var updatesPublisher: AnyPublisher<Void, Never> {
         updatesPublisherAccessCount += 1
-        updatesSubject.eraseToAnyPublisher()
+        return updatesSubject.eraseToAnyPublisher()
     }
 
     /// Call this method in tests to trigger the updates publisher

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptCoordinationManager.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptCoordinationManager.swift
@@ -28,6 +28,15 @@ final class MockModalPromptCoordinationManager: ModalPromptCoordinationManaging 
     private(set) var promoQueueWillTransitionTargets = [PromoQueueFeatureTargetState]()
     private(set) var promoQueueDidTransitionTargets = [PromoQueueFeatureTargetState]()
     var didPresentModalPromptThisSession = false
+    var didActuallyPresentModalPromptThisSession = false
+    var hasActiveOrPendingModalAttempt = false
+    var modalAttemptPhase = ModalPromptAttemptPhase.idle
+    var coordinatedPresentationDisposition = ModalPromptLeaseDisposition.retained
+    var reconcilePresentedModalResult = false
+    private(set) var capturedModalLease: PromoQueueModalLease?
+    private(set) var reconcilePresentedModalCallCount = 0
+    var onPresentCoordinated: (@MainActor () -> Void)?
+    var onReconcilePresentedModal: (@MainActor () -> Void)?
     var onPromoQueueWillTransition: (@MainActor (PromoQueueFeatureTargetState) -> Void)?
     var onPromoQueueDidTransition: (@MainActor (PromoQueueFeatureTargetState) -> Void)?
 
@@ -35,6 +44,27 @@ final class MockModalPromptCoordinationManager: ModalPromptCoordinationManaging 
         didCallPresentModalPromptIfNeeded = true
         capturedPresenter = presenter
         callCount += 1
+    }
+
+    func presentModalPromptIfNeeded(
+        from presenter: ModalPromptPresenter,
+        with lease: PromoQueueModalLease
+    ) -> ModalPromptLeaseDisposition {
+        didCallPresentModalPromptIfNeeded = true
+        capturedPresenter = presenter
+        capturedModalLease = lease
+        callCount += 1
+        onPresentCoordinated?()
+        if coordinatedPresentationDisposition == .released {
+            lease.release()
+        }
+        return coordinatedPresentationDisposition
+    }
+
+    func reconcilePresentedModal() -> Bool {
+        reconcilePresentedModalCallCount += 1
+        onReconcilePresentedModal?()
+        return reconcilePresentedModalResult
     }
 
     func promoQueueWillTransition(to targetState: PromoQueueFeatureTargetState) {

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptCoordinationManager.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptCoordinationManager.swift
@@ -25,11 +25,25 @@ final class MockModalPromptCoordinationManager: ModalPromptCoordinationManaging 
     private(set) var didCallPresentModalPromptIfNeeded = false
     private(set) var capturedPresenter: ModalPromptPresenter?
     private(set) var callCount = 0
+    private(set) var promoQueueWillTransitionTargets = [PromoQueueFeatureTargetState]()
+    private(set) var promoQueueDidTransitionTargets = [PromoQueueFeatureTargetState]()
     var didPresentModalPromptThisSession = false
+    var onPromoQueueWillTransition: (@MainActor (PromoQueueFeatureTargetState) -> Void)?
+    var onPromoQueueDidTransition: (@MainActor (PromoQueueFeatureTargetState) -> Void)?
 
     func presentModalPromptIfNeeded(from presenter: ModalPromptPresenter) {
         didCallPresentModalPromptIfNeeded = true
         capturedPresenter = presenter
         callCount += 1
+    }
+
+    func promoQueueWillTransition(to targetState: PromoQueueFeatureTargetState) {
+        promoQueueWillTransitionTargets.append(targetState)
+        onPromoQueueWillTransition?(targetState)
+    }
+
+    func promoQueueDidTransition(to targetState: PromoQueueFeatureTargetState) {
+        promoQueueDidTransitionTargets.append(targetState)
+        onPromoQueueDidTransition?(targetState)
     }
 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptCoordinationManager.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptCoordinationManager.swift
@@ -28,9 +28,6 @@ final class MockModalPromptCoordinationManager: ModalPromptCoordinationManaging 
     private(set) var promoQueueWillTransitionTargets = [PromoQueueFeatureTargetState]()
     private(set) var promoQueueDidTransitionTargets = [PromoQueueFeatureTargetState]()
     var didPresentModalPromptThisSession = false
-    var didActuallyPresentModalPromptThisSession = false
-    var hasActiveOrPendingModalAttempt = false
-    var modalAttemptPhase = ModalPromptAttemptPhase.idle
     var coordinatedPresentationDisposition = ModalPromptLeaseDisposition.retained
     var reconcilePresentedModalResult = false
     private(set) var capturedModalLease: PromoQueueModalLease?

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptPresenter.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptPresenter.swift
@@ -23,6 +23,7 @@ import UIKit
 @MainActor
 final class MockModalPromptPresenter: ModalPromptPresenter {
     var presentedViewController: UIViewController?
+    var modalPromptPresentationViewController: UIViewController?
 
     private(set) var didCallPresent = false
     private(set) var capturedViewController: UIViewController?

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptPresenter.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptPresenter.swift
@@ -23,7 +23,6 @@ import UIKit
 @MainActor
 final class MockModalPromptPresenter: ModalPromptPresenter {
     var presentedViewController: UIViewController?
-    var modalPromptPresentationViewController: UIViewController?
 
     private(set) var didCallPresent = false
     private(set) var capturedViewController: UIViewController?

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptProvider.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptProvider.swift
@@ -23,9 +23,11 @@ import UIKit
 @MainActor
 final class MockModalPromptProvider: ModalPromptProvider {
     var modalConfigurationToReturn: ModalPromptConfiguration?
+    var isEligibleToPresentResult: Bool?
 
     private(set) var didCallProvideModalPrompt = false
     private(set) var didCallDidPresentModal = false
+    private(set) var capturedIsOnboardingComplete: Bool?
 
     init(shouldReturnPrompt: Bool = true) {
         if shouldReturnPrompt {
@@ -41,6 +43,11 @@ final class MockModalPromptProvider: ModalPromptProvider {
         return modalConfigurationToReturn
     }
 
+    func isEligibleToPresent(isOnboardingComplete: Bool) -> Bool {
+        capturedIsOnboardingComplete = isOnboardingComplete
+        return isEligibleToPresentResult ?? isOnboardingComplete
+    }
+
     func didPresentModal() {
         didCallDidPresentModal = true
     }
@@ -48,5 +55,6 @@ final class MockModalPromptProvider: ModalPromptProvider {
     func reset() {
         didCallProvideModalPrompt = false
         didCallDidPresentModal = false
+        capturedIsOnboardingComplete = nil
     }
 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptProvider.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptProvider.swift
@@ -56,5 +56,6 @@ final class MockModalPromptProvider: ModalPromptProvider {
         didCallProvideModalPrompt = false
         didCallDidPresentModal = false
         capturedIsOnboardingComplete = nil
+        isEligibleToPresentResult = nil
     }
 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockNewTabPagePromoCoordinator.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockNewTabPagePromoCoordinator.swift
@@ -1,0 +1,53 @@
+//
+//  MockNewTabPagePromoCoordinator.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import DuckDuckGo
+
+@MainActor
+final class MockNewTabPagePromoCoordinator: NewTabPagePromoCoordinating {
+    var promoQueueFeatureState: PromoQueueFeatureState
+    var admitVisiblePromoResult: VisiblePromoAdmissionResult = .featureDisabled
+
+    private(set) var admittedIdentities = [VisiblePromoIdentity]()
+    private(set) var releasedLeases = [PromoQueueVisiblePromoLease]()
+    private(set) var registeredRetrySurfaceIDs = [UUID]()
+
+    init(promoQueueFeatureState: PromoQueueFeatureState = .disabled) {
+        self.promoQueueFeatureState = promoQueueFeatureState
+    }
+
+    func admitVisiblePromo(_ identity: VisiblePromoIdentity) -> VisiblePromoAdmissionResult {
+        admittedIdentities.append(identity)
+        return admitVisiblePromoResult
+    }
+
+    func releaseVisiblePromoLease(_ lease: PromoQueueVisiblePromoLease) {
+        releasedLeases.append(lease)
+        lease.release()
+    }
+
+    func registerVisiblePromoRetry(
+        for surfaceID: UUID,
+        target: NewTabPagePromoRetrying
+    ) -> NewTabPagePromoRetryRegistration {
+        registeredRetrySurfaceIDs.append(surfaceID)
+        return NewTabPagePromoRetryRegistration()
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1216967536463627?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1216624996708289?focus=true
CC:

### Description
Introduces the first of three promo queue changes behind a disabled-by-default flag. This slice establishes shared cross-surface admission and integrates the launch-modal side; lifecycle and NTP rendering follow in later PRs.

### Testing Steps
- Run the focused promo queue flag, arbiter, service, and manager tests → all pass.
- No changes to current behavior with promoQueue flag off

### Impact
Low: the new behavior is disabled by default.

#### What could go wrong?
Existing modal prompts could be incorrectly blocked → mitigated by the legacy feature-off path and focused state-machine tests.

### Quality Considerations
No persistent state or user data is added. Coordination remains app-scoped and main-actor-bound.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
