### PR TITLE
Fix attributed.metric.subscribed over-reporting paid starts (iOS/macOS)

### DIFF
--- a/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricManager.swift
+++ b/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricManager.swift
@@ -584,8 +584,8 @@ public final class AttributedMetricManager: @unchecked Sendable {
         let monthsActive = Double(QuantisedTimePast.daysBetween(from: subscriptionDate, to: now)) / Double(Constants.daysInAMonth)
         let activeFromMoreThan1Month = monthsActive > 1.0
 
-        if freeTrialPixelSent && !isFreeTrial {
-            // At each app startup, check the subscription state. If the a month=0 pixel was sent, the user is no longer on a free trial, and the state is autoRenewable or notAutoRenewable, send this pixel with month=1.
+        if freeTrialPixelSent && !firstMonthPixelSent && !isFreeTrial {
+            // First launch after a free trial converts to paid: send month=1 once. The !firstMonthPixelSent guard stops it re-firing on every later launch.
             do {
                 let bucket = try bucketModifier.bucket(value: 1, pixelName: .userSubscribed)
                 pixelKit?.fire(AttributedMetricPixel.userSubscribed(origin: originOrInstall.origin,

--- a/SharedPackages/AttributedMetric/Tests/AttributedMetricTests/AttributedMetricManagerTests.swift
+++ b/SharedPackages/AttributedMetric/Tests/AttributedMetricTests/AttributedMetricManagerTests.swift
@@ -961,6 +961,67 @@ final class AttributedMetricManagerTests: XCTestCase {
         XCTAssertEqual(capturedMonth, 2, "Should send bucketed length 2 for month 2+")
     }
 
+    /// A converted free-trial user must emit month=1 (paid start) once, not on every app launch.
+    func testProcessSubscriptionCheck_month1_firesOnceAcrossRestarts() async {
+        let firstFire = XCTestExpectation(description: "month=1 fired")
+        let noSecondFire = XCTestExpectation(description: "month=1 not re-fired")
+        noSecondFire.isInverted = true
+        var month1FireCount = 0
+
+        let fixture = createTestFixture(
+            pixelHandler: { pixelName, _, parameters, _, _, _ in
+                guard pixelName == "attributed_metric_subscribed",
+                      self.extractIntParameter(parameters, key: "month") == 1 else { return }
+                month1FireCount += 1
+                if month1FireCount == 1 { firstFire.fulfill() } else { noSecondFire.fulfill() }
+            },
+            subscriptionStateProvider: SubscriptionStateProviderMock(isFreeTrial: false, isActive: true)
+        )
+        defer { fixture.cleanup() }
+
+        fixture.installDateProvider.installDate = fixture.timeMachine.now()
+        fixture.dataStorage.subscriptionDate = fixture.timeMachine.now()
+        fixture.dataStorage.subscriptionFreeTrialFired = true   // trial pixel sent; user has now converted to paid
+
+        // First launch after conversion → month=1 fires once.
+        fixture.attributionManager.process(trigger: .appDidStart)
+        await fulfillment(of: [firstFire], timeout: 5.0)
+
+        // Next day, another launch → must NOT re-fire month=1.
+        fixture.timeMachine.travel(by: .day, value: 1)
+        fixture.attributionManager.process(trigger: .appDidStart)
+        await fulfillment(of: [noSecondFire], timeout: 2.0)
+
+        XCTAssertEqual(month1FireCount, 1, "month=1 (paid start) must fire once, not on every launch")
+    }
+
+    /// A converted free-trial user (month=1 already sent) must advance to month=2+, not stay stuck on month=1.
+    func testProcessSubscriptionCheck_convertedTrialUser_advancesToMonth2() async {
+        let pixelExpectation = XCTestExpectation(description: "subscription pixel fired")
+        var capturedMonth: Int?
+
+        let fixture = createTestFixture(
+            pixelHandler: { pixelName, _, parameters, _, _, _ in
+                guard pixelName == "attributed_metric_subscribed" else { return }
+                capturedMonth = self.extractIntParameter(parameters, key: "month")
+                pixelExpectation.fulfill()
+            },
+            subscriptionStateProvider: SubscriptionStateProviderMock(isFreeTrial: false, isActive: true)
+        )
+        defer { fixture.cleanup() }
+
+        fixture.installDateProvider.installDate = fixture.timeMachine.now()
+        fixture.dataStorage.subscriptionDate = fixture.timeMachine.now()
+        fixture.dataStorage.subscriptionFreeTrialFired = true   // started on a free trial...
+        fixture.dataStorage.subscriptionMonth1Fired = true      // ...converted, month=1 already sent
+
+        fixture.timeMachine.travel(by: .day, value: 31)         // now active for more than a month
+        fixture.attributionManager.process(trigger: .appDidStart)
+
+        await fulfillment(of: [pixelExpectation], timeout: 5.0)
+        XCTAssertEqual(capturedMonth, 2, "Converted trial user must advance to month=2+, not re-fire month=1")
+    }
+
     // MARK: - Sync Tests
 
     /// Tests sync pixel for valid device counts (< 3 devices)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216262423915726
Tech Design URL: N/A
CC:

### Description
The origin-attributed `attributed.metric.subscribed` pixel over-reported paid-subscription starts (`month=1`) by 10×+.

For a user who started on a free trial and later converted to paid, the app-startup subscription check emitted the paid-start pixel with no guard against having already sent it. So on every subsequent launch it emitted `month=1` again (capped to once per day by daily de-duplication), producing one paid-start per active day indefinitely, and, as a side effect, those users never advanced to the ongoing-month (`month=2+`) signal.

This adds the missing "already sent" guard so the paid-start pixel is emitted exactly once on the first launch after conversion, after which the flow advances to the ongoing-month pixel as intended.

### Testing Steps

Use an alpha build, which uses the StoreKit sandbox

Watch the Xcode console (filter `👾` / subsystem `PixelKit`) for `attributed_metric_subscribed` and check the `month` value (relaunch the app between date changes so the startup check runs):
1. Subscribe with a **free trial** → the pixel fires with **`month=0`** (trial start).
2. Move the **device date** forward past the trial so it converts to paid, then relaunch → the pixel fires with **`month=1`** (paid start).
3. Move the device date forward one more **day** and relaunch → **`month=1` is NOT sent again** (this is the fix; before this change it re-fired daily).
4. Move the device date forward ~a **month** and relaunch → the pixel fires with **`month=2`** (ongoing month).

### Impact

Low — telemetry only. No user-facing behavior and no change to what data is collected. If wrong, the paid-start metric stays inflated.

#### What could go wrong?

- Guard too strict → `month=1` never sent → mitigated by a test asserting it fires exactly once after conversion.
- Converted users fail to advance to `month=2+` → mitigated: the ongoing-month branch is now reachable, and the existing month-2+ test still passes.

### Quality Considerations

- Shared package — one change covers iOS and macOS.
- The ongoing-month (`month=2+`) pixel still fires once per day while the subscription is active; that is a separate signal (not a paid start) and is outside this fix's scope.
- **Not "done" on merge:** the parent task requires validating on post-release production data (re-run the comparison query for `ddg_ios`). Mac can't be cleanly isolated from the OAM/ground-truth query (it shares the Stripe channel with Windows via Sparkle), so a clean Mac figure needs Postgres.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only change in shared AttributedMetric logic; behavior is constrained by new tests and existing month-2+ coverage.
> 
> **Overview**
> Fixes **over-reporting** of `attributed_metric_subscribed` with **`month=1`** (paid start) for users who started on a free trial and later converted to paid.
> 
> On app start, `processSubscriptionCheck` used to emit the paid-start pixel whenever a trial pixel had been sent and the user was no longer on a trial, with **no check** that `month=1` had already been sent. Daily de-duplication capped repeats to once per day, but paid starts could still fire on **every active day**, and those users often never reached the **`month=2+`** ongoing path.
> 
> The startup branch now requires **`!firstMonthPixelSent`** before firing `month=1`, sets **`subscriptionMonth1Fired`** after the first post-conversion fire, and leaves the existing **`month=2+`** branch reachable once month 1 is recorded.
> 
> Two async tests cover **single fire across relaunches** and **advancement to month 2** after conversion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95251d8b1fb1fbc030f42f9fbc6776d6b426ec12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->