### PR TITLE
[iOS] Fix V1 pairing stuck on Connecting screen in simplified sync setup V2

### DIFF
--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -603,10 +603,10 @@ extension SyncSettingsViewController: SyncConnectionControllerDelegate {
 
     func controllerDidCompleteAccountConnection(shouldShowSyncEnabled: Bool, setupSource: SyncSetupSource, codeSource: SyncCodeSource) {
         sendSetupEndedSuccessfullyPixel(setupSource: setupSource, codeSource: codeSource)
-        guard shouldShowSyncEnabled else { return }
         if useSimplifiedLayoutV2 {
             presentSuccessScreen(isRecovery: false)
         } else {
+            guard shouldShowSyncEnabled else { return }
             self.viewModel.$devices
                 .removeDuplicates()
                 .dropFirst()

--- a/iOS/DuckDuckGoTests/SyncSettingsViewControllerErrorTests.swift
+++ b/iOS/DuckDuckGoTests/SyncSettingsViewControllerErrorTests.swift
@@ -369,6 +369,26 @@ final class SyncSettingsViewControllerErrorTests: XCTestCase {
     }
 
     @MainActor
+    func testWhenV1ConnectCreatesAccountWithSimplifiedV2LayoutThenCompletionShowsSuccess() {
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.simplifiedSyncSetupV2])
+        let spyVC = SpySyncSettingsViewController(
+            syncService: ddgSyncing,
+            syncBookmarksAdapter: syncBookmarksAdapter,
+            syncCredentialsAdapter: syncCredentialsAdapter,
+            syncCreditCardsAdapter: syncCreditCardsAdapter,
+            syncPausedStateManager: errorHandler,
+            featureFlagger: featureFlagger,
+            syncAutoRestoreHandler: syncAutoRestoreHandler
+        )
+        spyVC.viewModel.connectingSheetPhase = .connecting(isRecovery: false)
+
+        spyVC.controllerDidCreateSyncAccount(shouldShowSyncEnabled: true)
+        spyVC.controllerDidCompleteAccountConnection(shouldShowSyncEnabled: false, setupSource: .connect, codeSource: .qrCode)
+
+        XCTAssertEqual(spyVC.viewModel.connectingSheetPhase, .connecting(isRecovery: false, isFinishing: true))
+    }
+
+    @MainActor
     func testWhenLegacyConnectURLPairingInfoIsPresentThenPairingIsSilentlyDropped() throws {
         let syncCode = SyncCode(recovery: nil,
                                 connect: SyncCode.ConnectCode(deviceId: "device-id", secretKey: Data("secret".utf8)),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216949290163338

### Description
With sync disabled on both devices, scanning a V1 pairing code on the new simplified V2 sync UI left the user stuck on the "Connecting" screen. This moves an early-return guard so the simplified V2 layout always advances to the success screen after the account connects.

### Testing Steps
1. Disable the `simplifiedSyncSetupV2` and `syncCanShowV2ConnectCode` flags so a V1 code is generated, but keep the simplified V2 UI active on the scanning device.
2. With sync off on both devices, on device A open Sync → show the QR/connect code.
3. On device B, scan device A's V1 code → the Connecting screen should advance to the success screen (previously it hung on "Connecting").

### Impact
Low — bug fix to an edge case in the sync pairing flow, covered by a new unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small control-flow change in sync pairing UI completion, scoped to simplified V2 layout with legacy V1 codes; legacy path unchanged and covered by a new unit test.
> 
> **Overview**
> Fixes the simplified sync setup V2 UI staying on **Connecting** when pairing completes via a **V1** connect code (sync off on both devices, V2 UI on the scanner).
> 
> In `controllerDidCompleteAccountConnection`, the early return on `shouldShowSyncEnabled == false` used to run before the V2 path, so completion never called `presentSuccessScreen`. That guard now applies only to the legacy flow (wait for devices, then toast); with `useSimplifiedLayoutV2`, completion always advances to the success screen.
> 
> Adds `testWhenV1ConnectCreatesAccountWithSimplifiedV2LayoutThenCompletionShowsSuccess` to assert the connecting sheet moves to the finishing state when account creation and connection complete with `shouldShowSyncEnabled: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ff46b7ced0f51b877f2fe4fe9325bc68ff6fb79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->