### PR TITLE
Align search & app_use baseline retention windows (iOS/macOS)

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PixelExperimentKit/PixelExperimentKit.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelExperimentKit/PixelExperimentKit.swift
@@ -143,12 +143,12 @@ extension PixelKit {
     ///   must occur before the pixel is fired.
     public static func fireSearchExperimentPixels() {
         let valueConversionDictionary: [NumberOfActions: [ConversionWindow]] = [
-            1: [0...0, 1...1, 2...2, 3...3, 4...4, 5...5, 6...6, 7...7, 5...7],
-            4: [5...7, 8...15],
-            6: [5...7, 8...15],
-            11: [5...7, 8...15],
-            21: [5...7, 8...15],
-            30: [5...7, 8...15]
+            1: [0...0, 1...1, 2...2, 3...3, 4...4, 5...5, 6...6, 7...7, 5...7, 8...14],
+            4: [5...7, 8...14],
+            6: [5...7, 8...14],
+            11: [5...7, 8...14],
+            21: [5...7, 8...14],
+            30: [5...7, 8...14]
         ]
         guard let featureFlagger = ExperimentConfig.featureFlagger else {
             assertionFailure("PixelKit is not configured for experiments")
@@ -172,12 +172,7 @@ extension PixelKit {
     ///   must occur before the pixel is fired.
     public static func fireAppRetentionExperimentPixels() {
         let valueConversionDictionary: [NumberOfActions: [ConversionWindow]] = [
-            1: [1...1, 2...2, 3...3, 4...4, 5...5, 6...6, 7...7, 5...7],
-            4: [5...7, 8...15],
-            6: [5...7, 8...15],
-            11: [5...7, 8...15],
-            21: [5...7, 8...15],
-            30: [5...7, 8...15]
+            1: [1...1, 2...2, 3...3, 4...4, 5...5, 6...6, 7...7, 5...7, 8...14]
         ]
         guard let featureFlagger = ExperimentConfig.featureFlagger else {
             assertionFailure("PixelKit is not configured for experiments")

--- a/SharedPackages/BrowserServicesKit/Tests/PixelExperimentKitTests/PixelExperimentKitTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelExperimentKitTests/PixelExperimentKitTests.swift
@@ -382,7 +382,7 @@ final class PixelExperimentKitTests: XCTestCase {
 
         mockFeatureFlagger.experiments = [subfeatureID: experimentData8]
         PixelKit.fireSearchExperimentPixels()
-        XCTAssertEqual(firedEvent.count, 0) // Nothing
+        XCTAssertEqual(firedEvent.count, 1) // Fires 1 8-14
     }
 
     func testFireSearchExperimentPixels_WithValue4() {
@@ -429,12 +429,12 @@ final class PixelExperimentKitTests: XCTestCase {
         clearEvents()
 
         mockFeatureFlagger.experiments = [subfeatureID: experimentData8]
-        PixelKit.fireSearchExperimentPixels() // Nothing
-        PixelKit.fireSearchExperimentPixels() // Nothing
-        PixelKit.fireSearchExperimentPixels() // Nothing
-        XCTAssertEqual(firedEventSet.count, 0)
-        PixelKit.fireSearchExperimentPixels() // Fires 4 8-15
+        PixelKit.fireSearchExperimentPixels() // Fires 1 8-14
+        PixelKit.fireSearchExperimentPixels() // Nothing new
+        PixelKit.fireSearchExperimentPixels() // Nothing new
         XCTAssertEqual(firedEventSet.count, 1)
+        PixelKit.fireSearchExperimentPixels() // Fires 4 8-14
+        XCTAssertEqual(firedEventSet.count, 2)
         clearEvents()
 
         mockFeatureFlagger.experiments = [subfeatureID: experimentData15]
@@ -442,8 +442,8 @@ final class PixelExperimentKitTests: XCTestCase {
         PixelKit.fireSearchExperimentPixels() // Nothing
         PixelKit.fireSearchExperimentPixels() // Nothing
         XCTAssertEqual(firedEventSet.count, 0)
-        PixelKit.fireSearchExperimentPixels() // Fires 4 8-15
-        XCTAssertEqual(firedEventSet.count, 1)
+        PixelKit.fireSearchExperimentPixels() // Nothing
+        XCTAssertEqual(firedEventSet.count, 0)
         clearEvents()
 
         mockFeatureFlagger.experiments = [subfeatureID: experimentData16]
@@ -499,21 +499,25 @@ final class PixelExperimentKitTests: XCTestCase {
             }
         )
 
-        // Verify no pixel fired for the second experiment (outside conversion window)
+        // Verify the second experiment (enrolled 10 days ago) fires its value=1 8-14 pixel on the first call
         XCTAssertNotNil(mockPixelStore.store)
-        XCTAssertFalse(
+        XCTAssertTrue(
             firedEvent.contains {
-                $0.name == "experiment_metrics_\(subfeatureID2)_\(cohort2)"
+                $0.name == "experiment_metrics_\(subfeatureID2)_\(cohort2)" &&
+                $0.parameters?[PixelKit.Constants.valueKey] == "1" &&
+                $0.parameters?[PixelKit.Constants.conversionWindowDaysKey] == "8-14"
             }
         )
 
-        // Verify no pixel fired that after 4 reps second experiment pixel is sent(outside conversion window)
+        // Verify the value=4 threshold pixel for the second experiment fires once its 4-call threshold is reached
         PixelKit.fireSearchExperimentPixels()
         PixelKit.fireSearchExperimentPixels()
         PixelKit.fireSearchExperimentPixels()
         XCTAssertTrue(
             firedEvent.contains {
-                $0.name == "experiment_metrics_\(subfeatureID2)_\(cohort2)"
+                $0.name == "experiment_metrics_\(subfeatureID2)_\(cohort2)" &&
+                $0.parameters?[PixelKit.Constants.valueKey] == "4" &&
+                $0.parameters?[PixelKit.Constants.conversionWindowDaysKey] == "8-14"
             }
         )
     }
@@ -561,21 +565,13 @@ final class PixelExperimentKitTests: XCTestCase {
             }
         )
 
-        // Verify no pixel fired for the second experiment (outside conversion window)
+        // Verify the second experiment (enrolled 10 days ago) fires its value=1 8-14 pixel
         XCTAssertNotNil(mockPixelStore.store)
-        XCTAssertFalse(
-            firedEvent.contains {
-                $0.name == "experiment_metrics_\(subfeatureID2)_\(cohort2)"
-            }
-        )
-
-        // Verify no pixel fired that after 4 reps second experiment pixel is sent(outside conversion window)
-        PixelKit.fireAppRetentionExperimentPixels()
-        PixelKit.fireAppRetentionExperimentPixels()
-        PixelKit.fireAppRetentionExperimentPixels()
         XCTAssertTrue(
             firedEvent.contains {
-                $0.name == "experiment_metrics_\(subfeatureID2)_\(cohort2)"
+                $0.name == "experiment_metrics_\(subfeatureID2)_\(cohort2)" &&
+                $0.parameters?[PixelKit.Constants.valueKey] == "1" &&
+                $0.parameters?[PixelKit.Constants.conversionWindowDaysKey] == "8-14"
             }
         )
     }

--- a/SharedPackages/BrowserServicesKit/Tests/PixelExperimentKitTests/PixelExperimentKitTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelExperimentKitTests/PixelExperimentKitTests.swift
@@ -330,6 +330,8 @@ final class PixelExperimentKitTests: XCTestCase {
         let enrollmentDate6 = Date().addingTimeInterval(-6 * 24 * 60 * 60) // 6 days ago
         let enrollmentDate7 = Date().addingTimeInterval(-7 * 24 * 60 * 60) // 7 days ago
         let enrollmentDate8 = Date().addingTimeInterval(-8 * 24 * 60 * 60) // 8 days ago
+        let enrollmentDate14 = Date().addingTimeInterval(-14 * 24 * 60 * 60) // 14 days ago
+        let enrollmentDate15 = Date().addingTimeInterval(-15 * 24 * 60 * 60) // 15 days ago
         let experimentData0 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate0)
         let experimentData1 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate1)
         let experimentData2 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate2)
@@ -339,6 +341,8 @@ final class PixelExperimentKitTests: XCTestCase {
         let experimentData6 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate6)
         let experimentData7 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate7)
         let experimentData8 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate8)
+        let experimentData14 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate14)
+        let experimentData15 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate15)
 
         mockFeatureFlagger.experiments = [subfeatureID: experimentData0]
         PixelKit.fireSearchExperimentPixels()
@@ -383,6 +387,16 @@ final class PixelExperimentKitTests: XCTestCase {
         mockFeatureFlagger.experiments = [subfeatureID: experimentData8]
         PixelKit.fireSearchExperimentPixels()
         XCTAssertEqual(firedEvent.count, 1) // Fires 1 8-14
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData14]
+        PixelKit.fireSearchExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 1) // Fires 1 8-14 (last day in window)
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData15]
+        PixelKit.fireSearchExperimentPixels()
+        XCTAssertEqual(firedEvent.count, 0) // Nothing (just past the 8-14 window)
     }
 
     func testFireSearchExperimentPixels_WithValue4() {
@@ -392,14 +406,14 @@ final class PixelExperimentKitTests: XCTestCase {
         let enrollmentDate5 = Date().addingTimeInterval(-5 * 24 * 60 * 60) // 5 days ago
         let enrollmentDate7 = Date().addingTimeInterval(-7 * 24 * 60 * 60) // 7 days ago
         let enrollmentDate8 = Date().addingTimeInterval(-8 * 24 * 60 * 60) // 8 days ago
+        let enrollmentDate14 = Date().addingTimeInterval(-14 * 24 * 60 * 60) // 14 days ago
         let enrollmentDate15 = Date().addingTimeInterval(-15 * 24 * 60 * 60) // 15 days ago
-        let enrollmentDate16 = Date().addingTimeInterval(-16 * 24 * 60 * 60) // 16 days ago
         let experimentData4 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate4)
         let experimentData5 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate5)
         let experimentData7 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate7)
         let experimentData8 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate8)
+        let experimentData14 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate14)
         let experimentData15 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate15)
-        let experimentData16 = ExperimentData(parentID: "autofill", cohortID: cohort, enrollmentDate: enrollmentDate16)
 
         mockFeatureFlagger.experiments = [subfeatureID: experimentData4]
         PixelKit.fireSearchExperimentPixels() // Fires 1 4-4
@@ -430,23 +444,23 @@ final class PixelExperimentKitTests: XCTestCase {
 
         mockFeatureFlagger.experiments = [subfeatureID: experimentData8]
         PixelKit.fireSearchExperimentPixels() // Fires 1 8-14
-        PixelKit.fireSearchExperimentPixels() // Nothing new
-        PixelKit.fireSearchExperimentPixels() // Nothing new
+        PixelKit.fireSearchExperimentPixels() // Nothing
+        PixelKit.fireSearchExperimentPixels() // Nothing
+        XCTAssertEqual(firedEventSet.count, 1)
+        PixelKit.fireSearchExperimentPixels() // Fires 4 8-14
+        XCTAssertEqual(firedEventSet.count, 2)
+        clearEvents()
+
+        mockFeatureFlagger.experiments = [subfeatureID: experimentData14]
+        PixelKit.fireSearchExperimentPixels() // Fires 1 8-14
+        PixelKit.fireSearchExperimentPixels() // Nothing
+        PixelKit.fireSearchExperimentPixels() // Nothing
         XCTAssertEqual(firedEventSet.count, 1)
         PixelKit.fireSearchExperimentPixels() // Fires 4 8-14
         XCTAssertEqual(firedEventSet.count, 2)
         clearEvents()
 
         mockFeatureFlagger.experiments = [subfeatureID: experimentData15]
-        PixelKit.fireSearchExperimentPixels() // Nothing
-        PixelKit.fireSearchExperimentPixels() // Nothing
-        PixelKit.fireSearchExperimentPixels() // Nothing
-        XCTAssertEqual(firedEventSet.count, 0)
-        PixelKit.fireSearchExperimentPixels() // Nothing
-        XCTAssertEqual(firedEventSet.count, 0)
-        clearEvents()
-
-        mockFeatureFlagger.experiments = [subfeatureID: experimentData16]
         PixelKit.fireSearchExperimentPixels() // Nothing
         PixelKit.fireSearchExperimentPixels() // Nothing
         PixelKit.fireSearchExperimentPixels() // Nothing

--- a/iOS/Core/StatisticsLoader.swift
+++ b/iOS/Core/StatisticsLoader.swift
@@ -53,6 +53,7 @@ public class StatisticsLoader {
          },
          fireSearchExperimentPixels: @escaping () -> Void = {
             PixelKit.fireSearchExperimentPixels()
+            StatisticsLoader.fireLegacySearchRetentionExperimentPixels()
             StatisticsLoader.fireSearchTokenExperimentPixels(metric: "search")
          },
          fireOSDistributionPixel: @escaping (OSDistributionPixel.Metric) -> Void = PixelKit.fireOSDistributionPixel(metric:),
@@ -77,6 +78,28 @@ public class StatisticsLoader {
                 conversionWindowDays: 1...4,
                 threshold: threshold
             )
+        }
+    }
+
+    /// Transitional: preserves the previous 8-15 search window for experiments already running when
+    /// the canonical window was shortened to 8-14, so their in-flight analysis keeps the window it
+    /// started with. Drop each experiment as it is cleaned up, and delete this once none remain.
+    static func fireLegacySearchRetentionExperimentPixels() {
+        let inProgressExperiments = [
+            iOSBrowserConfigSubfeature.searchTokenExperiment.rawValue,
+            iOSBrowserConfigSubfeature.onboardingFlowByDownloadReasonExperiment.rawValue,
+            PrivacyProSubfeature.monthlyFreeTrialExperiment.rawValue,
+            AutoconsentSubfeature.cookiePopupOptInDialogExperiment.rawValue
+        ]
+        for subfeatureID in inProgressExperiments {
+            for threshold in [4, 6, 11, 21, 30] {
+                PixelKit.fireExperimentPixelIfThresholdReached(
+                    for: subfeatureID,
+                    metric: "search",
+                    conversionWindowDays: 8...15,
+                    threshold: threshold
+                )
+            }
         }
     }
 

--- a/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
+++ b/macOS/DuckDuckGo/Statistics/ATB/StatisticsLoader.swift
@@ -23,6 +23,7 @@ import BrowserServicesKit
 import Networking
 import PixelKit
 import PixelExperimentKit
+import PrivacyConfig
 import os.log
 
 final class StatisticsLoader {
@@ -50,7 +51,10 @@ final class StatisticsLoader {
         usageSegmentation: UsageSegmenting = UsageSegmentation(pixelEvents: UsageSegmentation.pixelEvents),
         dockCustomization: DockCustomization = Application.appDelegate.dockCustomization,
         fireAppRetentionExperimentPixels: @escaping () -> Void = PixelKit.fireAppRetentionExperimentPixels,
-        fireSearchExperimentPixels: @escaping () -> Void = PixelKit.fireSearchExperimentPixels
+        fireSearchExperimentPixels: @escaping () -> Void = {
+            PixelKit.fireSearchExperimentPixels()
+            StatisticsLoader.fireLegacySearchRetentionExperimentPixels()
+        }
     ) {
         self.statisticsStore = statisticsStore
         self.emailManager = emailManager
@@ -59,6 +63,27 @@ final class StatisticsLoader {
         self.dockCustomization = dockCustomization
         self.fireSearchExperimentPixels = fireSearchExperimentPixels
         self.fireAppRetentionExperimentPixels = fireAppRetentionExperimentPixels
+    }
+
+    /// Transitional: preserves the previous 8-15 search window for experiments already running when
+    /// the canonical window was shortened to 8-14, so their in-flight analysis keeps the window it
+    /// started with. Drop each experiment as it is cleaned up, and delete this once none remain.
+    static func fireLegacySearchRetentionExperimentPixels() {
+        let inProgressExperiments = [
+            MacOSBrowserConfigSubfeature.onboardingChromeExtension.rawValue,
+            AutoconsentSubfeature.heuristicAction.rawValue,
+            AutoconsentSubfeature.cookiePopupOptInDialogExperiment.rawValue
+        ]
+        for subfeatureID in inProgressExperiments {
+            for threshold in [4, 6, 11, 21, 30] {
+                PixelKit.fireExperimentPixelIfThresholdReached(
+                    for: subfeatureID,
+                    metric: "search",
+                    conversionWindowDays: 8...15,
+                    threshold: threshold
+                )
+            }
+        }
     }
 
     func refreshRetentionAtbOnNavigation(isSearch: Bool,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208889145294658/task/1216723451985943
Tech Design URL:
CC: @miasma13, @alessandroboron , @jozsef-vesza , @rachelmcr , @muodov 

### Description
Aligns the shared search and `app_use` baseline retention metric windows to the single canonical definition agreed in the parent task. These pixels are shared by iOS and macOS.

- **search**: add the `8-14` window to `value=1`; change `8-15` → `8-14` for values `4/6/11/21/30`.
- **app_use**: add the `8-14` window to `value=1`; drop values `4/6/11/21/30` entirely (keep only `value=1`), since there is no meaningful interpretation of app_use count thresholds.

Per the parent task, these ship now, unconditionally.

**Mitigation for in-progress experiments (search only):** shortening `8-15` → `8-14` would remove day-15 data mid-flight from experiments that are already running. To avoid disrupting them, each platform's `StatisticsLoader` gains an ad-hoc `fireLegacySearchRetentionExperimentPixels()` that re-fires the previous `8-15` window (values `4/6/11/21/30`) for the **specific experiments currently declared in the codebase** 

- iOS: `searchTokenExperiment`, `onboardingFlowByDownloadReasonExperiment`, `monthlyFreeTrialExperiment`, `cookiePopupOptInDialogExperiment`
- macOS: `onboardingChromeExtension`, `heuristicAction`, `cookiePopupOptInDialogExperiment`

`fireExperimentPixelIfThresholdReached` already no-ops for any listed experiment that isn't active, so stale entries are harmless. **This helper is temporary — drop each experiment as it is cleaned up, and delete the helper once none remain.** No mitigation is needed for the `app_use ≥4` removal (safe even for running experiments) or for the additive `8-14` window on `value=1`.

### Testing Steps
Metrics-definition change with no user-facing UI. Verified via unit tests:
1. In `SharedPackages/BrowserServicesKit`, run `swift test --filter PixelExperimentKitTests` → all 19 tests pass.

### Impact
Low — internal experiment metrics only; no user-facing behaviour.

### Quality Considerations
- Updated `PixelExperimentKitTests` to reflect the new windows, testing the boundary via enrollment dates (day 14 = last day in the `8-14` window → fires; day 15 = just past it → nothing) rather than by weakening assertions.
- The ad-hoc helpers mirror the existing `fireSearchTokenExperimentPixels` pattern (which is likewise not directly unit-tested); the underlying `8-15` threshold-window behaviour is covered by `PixelExperimentKitTests`.
- The app-layer wiring changes only the default closure in each `StatisticsLoader`; existing `StatisticsLoader` tests inject their own closures, so they are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal experiment metrics and window definitions only; no user-facing behavior or auth/data-path changes.
> 
> **Overview**
> Aligns **search** and **`app_use`** baseline retention experiment pixels to the canonical window definition on iOS and macOS via shared `PixelExperimentKit`.
> 
> For **search**, `value=1` gains an **`8-14`** conversion window, and thresholds **`4/6/11/21/30`** move from **`8-15`** to **`8-14`**. For **`app_use`**, **`value=1`** also gains **`8-14`**, and the higher count thresholds are removed so only **`value=1`** windows fire.
> 
> Because shortening **`8-15`** mid-flight would drop day-15 data for running experiments, iOS and macOS **`StatisticsLoader`** now call a temporary **`fireLegacySearchRetentionExperimentPixels()`** after the canonical search firing. That helper re-fires **`8-15`** for an enumerated list of in-progress subfeatures only (not all active experiments). **`PixelExperimentKitTests`** were updated for **`8-14`** boundaries (day 14 fires, day 15 does not).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45a35d5636eaee540dce5fa345b3df5d99ea8373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

