### PR TITLE
macOS: add Prompt Bar pixels mirroring the address bar's Duck.ai pixels

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -4710,6 +4710,8 @@
 		FB07BAD20000000000000307 /* EphemeralPromptDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000007 /* EphemeralPromptDraftStore.swift */; };
 		FB07BAD20000000000000208 /* PromptBarPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000008 /* PromptBarPixelHandler.swift */; };
 		FB07BAD20000000000000308 /* PromptBarPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000008 /* PromptBarPixelHandler.swift */; };
+		FB07BAD2000000000000020A /* PromptBarPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD2000000000000000A /* PromptBarPixel.swift */; };
+		FB07BAD2000000000000030A /* PromptBarPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD2000000000000000A /* PromptBarPixel.swift */; };
 		FB07BAD20000000000000209 /* PromptBarContentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000009 /* PromptBarContentFactory.swift */; };
 		FB07BAD20000000000000309 /* PromptBarContentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000009 /* PromptBarContentFactory.swift */; };
 		FB07BAD20000000000000501 /* DuckAIPromptSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000401 /* DuckAIPromptSurfaceTests.swift */; };
@@ -7219,6 +7221,7 @@
 				FB07BAD10000000000000021 /* PromptBarPromptSubmitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPromptSubmitter.swift; sourceTree = "<group>"; };
 				FB07BAD10000000000000024 /* PromptBarPromptSubmitterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPromptSubmitterTests.swift; sourceTree = "<group>"; };
 				FB07BAD20000000000000008 /* PromptBarPixelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPixelHandler.swift; sourceTree = "<group>"; };
+		FB07BAD2000000000000000A /* PromptBarPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPixel.swift; sourceTree = "<group>"; };
 		FB07BAD20000000000000009 /* PromptBarContentFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarContentFactory.swift; sourceTree = "<group>"; };
 		FB07BAD20000000000000001 /* DuckAIPromptSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIPromptSurface.swift; sourceTree = "<group>"; };
 		FB07BAD20000000000000002 /* DuckAIPromptDraftStoring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIPromptDraftStoring.swift; sourceTree = "<group>"; };
@@ -13471,6 +13474,7 @@
 		FB07BAD00000000000000031 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				FB07BAD2000000000000000A /* PromptBarPixel.swift */,
 				FB07BAD20000000000000008 /* PromptBarPixelHandler.swift */,
 				FB07BAD00000000000000002 /* PromptBarPreferencesPersistor.swift */,
 				FB07BAD00000000000000003 /* PromptBarPreferences.swift */,
@@ -15244,6 +15248,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FB07BAD2000000000000020A /* PromptBarPixel.swift in Sources */,
 				FB07BAD20000000000000209 /* PromptBarContentFactory.swift in Sources */,
 				FB07BAD20000000000000208 /* PromptBarPixelHandler.swift in Sources */,
 				FB07BAD20000000000000207 /* EphemeralPromptDraftStore.swift in Sources */,
@@ -17607,6 +17612,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FB07BAD2000000000000030A /* PromptBarPixel.swift in Sources */,
 				FB07BAD20000000000000309 /* PromptBarContentFactory.swift in Sources */,
 				FB07BAD20000000000000308 /* PromptBarPixelHandler.swift in Sources */,
 				FB07BAD20000000000000307 /* EphemeralPromptDraftStore.swift in Sources */,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1578,6 +1578,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         fireDailyFireWindowConfigurationPixels()
         fireDailyAIChatEnabledPixel()
         fireDailyAIFeaturesStatePixel()
+        fireDailyPromptBarStatePixel()
         fireDailyAdBlockingPixel()
         fireDailyAutoClearOnExitEnabledPixel()
 
@@ -1628,6 +1629,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func fireDailyAIChatEnabledPixel() {
         PixelKit.fire(AIChatPixel.aiChatIsEnabled(isEnabled: aiChatPreferences.isAIFeaturesEnabled), frequency: .daily)
+    }
+
+    /// The settings toggles only cover users who touch a setting; this sizes the enabled base.
+    @MainActor
+    private func fireDailyPromptBarStatePixel() {
+        guard featureFlagger.isFeatureOn(.macosPromptBar) else { return }
+
+        PixelKit.fire(PromptBarPixel.state(shortcutEnabled: promptBarPreferences.isKeyboardShortcutEnabled,
+                                           menuBarIconEnabled: promptBarPreferences.isMenuBarIconVisible),
+                      frequency: .daily)
     }
 
     /// Once-daily snapshot of the three AI settings + the derived "no AI" state, across the active base.
@@ -2469,7 +2480,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             promptBarMenuBarController = PromptBarMenuBarController()
         }
         promptBarMenuBarController?.onClick = { [weak self] in
-            self?.promptBarCoordinator?.togglePromptBar()
+            self?.promptBarCoordinator?.togglePromptBar(source: .menuBarIcon)
         }
 
         // Applied synchronously: a deferred first update lets the icon appear at

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarCoordinator.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarCoordinator.swift
@@ -51,9 +51,10 @@ final class PromptBarCoordinator {
             }
     }
 
-    func togglePromptBar() {
+    /// - Parameter source: The entry point that asked, which is what the visibility pixels report.
+    func togglePromptBar(source: PromptBarPresentationSource) {
         guard featureFlagger.isFeatureOn(.macosPromptBar) else { return }
-        presenter.toggle()
+        presenter.toggle(source: source)
     }
 
     private func applyShortcut(_ shortcut: PromptBarShortcut?) {
@@ -65,7 +66,7 @@ final class PromptBarCoordinator {
         shortcutRegistrar.register(shortcut) { [weak self] in
             // The Carbon handler is nonisolated.
             Task { @MainActor in
-                self?.togglePromptBar()
+                self?.togglePromptBar(source: .keyboardShortcut)
             }
         }
     }

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPresenter.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarPresenter.swift
@@ -18,13 +18,56 @@
 
 import AppKit
 import Combine
+import PixelKit
+
+/// Which entry point put the bar on screen. Each reports its own pixel, and re-triggering the same
+/// one while the bar is up is what closes it.
+enum PromptBarPresentationSource: Equatable, CaseIterable {
+    case keyboardShortcut
+    case menuBarIcon
+
+    var shownPixel: PromptBarPixel {
+        switch self {
+        case .keyboardShortcut: .shownFromShortcut
+        case .menuBarIcon: .shownFromMenuBarIcon
+        }
+    }
+
+    var toggleDismissReason: PromptBarDismissReason {
+        switch self {
+        case .keyboardShortcut: .shortcutToggle
+        case .menuBarIcon: .menuBarIconToggle
+        }
+    }
+}
+
+/// Why the bar closed. Only the reasons that leave the prompt unsent are reported — the submit
+/// pixels already cover the rest.
+enum PromptBarDismissReason: Equatable {
+    /// A prompt, URL or voice session was handed off.
+    case submission
+    case escape
+    case clickOutside
+    case shortcutToggle
+    case menuBarIconToggle
+
+    var cancellation: PromptBarCancellationReason? {
+        switch self {
+        case .submission: nil
+        case .escape: .escape
+        case .clickOutside: .clickOutside
+        case .shortcutToggle: .shortcutToggle
+        case .menuBarIconToggle: .menuBarIcon
+        }
+    }
+}
 
 @MainActor
 protocol PromptBarPresenting: AnyObject {
     var isVisible: Bool { get }
-    func show()
-    func dismiss()
-    func toggle()
+    func show(source: PromptBarPresentationSource)
+    func dismiss(reason: PromptBarDismissReason)
+    func toggle(source: PromptBarPresentationSource)
 }
 
 @MainActor
@@ -33,6 +76,7 @@ final class PromptBarPresenter: PromptBarPresenting {
     private let content: PromptBarContentHosting
     private let screenProvider: PromptBarScreenProviding
     private let makeWindow: (NSRect) -> PromptBarWindow
+    private let firePixel: (PromptBarPixel) -> Void
 
     private var window: PromptBarWindow?
     private var resignKeyCancellable: AnyCancellable?
@@ -44,28 +88,30 @@ final class PromptBarPresenter: PromptBarPresenting {
     // `screenProvider` has no default value: defaults are evaluated nonisolated, and the provider is @MainActor.
     init(content: PromptBarContentHosting,
          screenProvider: PromptBarScreenProviding? = nil,
-         makeWindow: @escaping (NSRect) -> PromptBarWindow = { PromptBarWindow(contentRect: $0) }) {
+         makeWindow: @escaping (NSRect) -> PromptBarWindow = { PromptBarWindow(contentRect: $0) },
+         firePixel: @escaping (PromptBarPixel) -> Void = { PixelKit.fire($0, frequency: .dailyAndCount, includeAppVersionParameter: true) }) {
         self.content = content
         self.screenProvider = screenProvider ?? MouseLocationScreenProvider()
         self.makeWindow = makeWindow
+        self.firePixel = firePixel
 
         self.content.onSubmit = { [weak self] in
-            self?.dismiss()
+            self?.dismiss(reason: .submission)
         }
         self.content.onPreferredWindowContentSizeChanged = { [weak self] size in
             self?.resizeWindow(toContentSize: size)
         }
     }
 
-    func toggle() {
+    func toggle(source: PromptBarPresentationSource) {
         if isVisible {
-            dismiss()
+            dismiss(reason: source.toggleDismissReason)
         } else {
-            show()
+            show(source: source)
         }
     }
 
-    func show() {
+    func show(source: PromptBarPresentationSource) {
         content.prepareForPresentation()
 
         let window = existingWindowOrNew()
@@ -80,15 +126,23 @@ final class PromptBarPresenter: PromptBarPresenting {
         content.focusPromptEditor()
         // Per presentation, not per window: `dismiss()` tears this down.
         subscribeToResignKey(of: window)
+
+        firePixel(source.shownPixel)
     }
 
-    func dismiss() {
+    func dismiss(reason: PromptBarDismissReason) {
         // Visibility, not just existence: submitting reports through two delegate callbacks and so
         // asks to dismiss twice, and `resetAfterDismissal` must not run against a torn-down bar.
         guard let window, window.isVisible else { return }
+        // Read before `resetAfterDismissal()` clears the draft.
+        let hadText = content.hasPromptText
         resignKeyCancellable = nil
         window.orderOut(nil)
         content.resetAfterDismissal()
+
+        if let cancellation = reason.cancellation {
+            firePixel(.dismissedWithoutSubmission(reason: cancellation, hadText: hadText))
+        }
     }
 
     private func existingWindowOrNew() -> PromptBarWindow {
@@ -101,7 +155,7 @@ final class PromptBarPresenter: PromptBarPresenting {
         let window = makeWindow(initialFrame)
         window.contentViewController = content.viewController
         window.onCancel = { [weak self] in
-            self?.dismiss()
+            self?.dismiss(reason: .escape)
         }
         self.window = window
         return window
@@ -113,7 +167,7 @@ final class PromptBarPresenter: PromptBarPresenting {
             .publisher(for: NSWindow.didResignKeyNotification, object: window)
             .sink { [weak self] _ in
                 guard let self, !self.content.isPresentingAuxiliaryUI else { return }
-                self.dismiss()
+                self.dismiss(reason: .clickOutside)
             }
     }
 

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixel.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixel.swift
@@ -1,0 +1,230 @@
+//
+//  PromptBarPixel.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import PixelKit
+
+/// Pixels for the Prompt Bar surface.
+///
+/// Every name is prefixed `aichat_promptbar_`, so the whole surface is one
+/// `LIKE 'm_mac_aichat_promptbar%'`. The mirrored cases keep the tail of their `aichat_addressbar_*`
+/// counterpart, so the two surfaces compare token for token — see `PromptBarPixelHandler` for the
+/// mapping and the events the Prompt Bar deliberately can't produce.
+enum PromptBarPixel: PixelKitEvent {
+
+    // MARK: - Mirrored from the address bar
+
+    /// Event Trigger: User submits a prompt from the Prompt Bar
+    case submitPrompt
+
+    /// Event Trigger: User submits a URL from the Prompt Bar
+    case submitURL
+
+    /// Event Trigger: User submits a prompt that includes one or more image attachments
+    case submitWithImage(imageCount: Int)
+
+    /// Event Trigger: User submits a prompt that includes one or more file attachments
+    case submitWithFiles(fileCount: Int)
+
+    /// Event Trigger: User attaches an image via the file picker
+    case imageAttached
+
+    /// Event Trigger: User removes an attached image
+    case imageRemoved
+
+    /// Event Trigger: User attaches a file (PDF etc.) via the file picker
+    case fileAttached
+
+    /// Event Trigger: User removes an attached file (PDF etc.) by clicking the × on the carousel card
+    case fileRemoved
+
+    /// Event Trigger: A file the user picked failed validation and was rejected
+    case fileValidationFailed(reason: String)
+
+    /// Event Trigger: User activates image generation mode via the Tools menu
+    case imageGenerationActivated
+
+    /// Event Trigger: User dismisses the image generation chip (× button)
+    case imageGenerationDeactivated
+
+    /// Event Trigger: User submits a prompt while image generation mode is active
+    case imageGenerationSubmitted
+
+    /// Event Trigger: User activates web search mode via the Tools menu
+    case webSearchActivated
+
+    /// Event Trigger: User dismisses the web search chip (× button)
+    case webSearchDeactivated
+
+    /// Event Trigger: User submits a prompt while web search mode is active
+    case webSearchSubmitted
+
+    /// Event Trigger: User selects a model from the model picker menu
+    case modelSelected
+
+    /// Event Trigger: User selects a reasoning effort from the picker
+    case reasoningEffortSelected
+
+    /// Event Trigger: User opens a new voice Duck.ai chat from the Prompt Bar
+    case newVoiceChat
+
+    // MARK: - Prompt Bar only
+
+    /// Event Trigger: The Prompt Bar is presented by the global keyboard shortcut
+    case shownFromShortcut
+
+    /// Event Trigger: The Prompt Bar is presented by clicking the menu bar icon
+    case shownFromMenuBarIcon
+
+    /// Event Trigger: The Prompt Bar closes without a prompt, URL or voice session being handed off.
+    /// `hadText` tells an abandoned prompt from an exploratory open.
+    case dismissedWithoutSubmission(reason: PromptBarCancellationReason, hadText: Bool)
+
+    /// Event Trigger: The Prompt Bar keyboard shortcut setting is turned on
+    case settingsShortcutTurnedOn
+
+    /// Event Trigger: The Prompt Bar keyboard shortcut setting is turned off
+    case settingsShortcutTurnedOff
+
+    /// Event Trigger: The Prompt Bar menu bar icon setting is turned on
+    case settingsMenuBarIconTurnedOn
+
+    /// Event Trigger: The Prompt Bar menu bar icon setting is turned off
+    case settingsMenuBarIconTurnedOff
+
+    /// Event Trigger: The recorded key combination changes, including a reset to the default.
+    /// Never carries the combination itself.
+    case settingsShortcutChanged
+
+    /// Event Trigger: Fires daily when the app becomes active, reporting both Prompt Bar settings.
+    /// The on/off pixels only cover users who touch a setting; this one sizes the enabled base.
+    case state(shortcutEnabled: Bool, menuBarIconEnabled: Bool)
+
+    // MARK: -
+
+    var name: String {
+        switch self {
+        case .submitPrompt:
+            return "aichat_promptbar_submit_prompt"
+        case .submitURL:
+            return "aichat_promptbar_submit_url"
+        case .submitWithImage:
+            return "aichat_promptbar_submit_with_image"
+        case .submitWithFiles:
+            return "aichat_promptbar_submit_with_files"
+        case .imageAttached:
+            return "aichat_promptbar_image_attached"
+        case .imageRemoved:
+            return "aichat_promptbar_image_removed"
+        case .fileAttached:
+            return "aichat_promptbar_file_attached"
+        case .fileRemoved:
+            return "aichat_promptbar_file_removed"
+        case .fileValidationFailed:
+            return "aichat_promptbar_file_validation_failed"
+        case .imageGenerationActivated:
+            return "aichat_promptbar_image_generation_activated"
+        case .imageGenerationDeactivated:
+            return "aichat_promptbar_image_generation_deactivated"
+        case .imageGenerationSubmitted:
+            return "aichat_promptbar_image_generation_submitted"
+        case .webSearchActivated:
+            return "aichat_promptbar_web_search_activated"
+        case .webSearchDeactivated:
+            return "aichat_promptbar_web_search_deactivated"
+        case .webSearchSubmitted:
+            return "aichat_promptbar_web_search_submitted"
+        case .modelSelected:
+            return "aichat_promptbar_model_selected"
+        case .reasoningEffortSelected:
+            return "aichat_promptbar_reasoning_effort_selected"
+        case .newVoiceChat:
+            return "aichat_promptbar_new_voice_chat"
+        case .shownFromShortcut:
+            return "aichat_promptbar_shown_shortcut"
+        case .shownFromMenuBarIcon:
+            return "aichat_promptbar_shown_menu_bar_icon"
+        case .dismissedWithoutSubmission:
+            return "aichat_promptbar_dismissed_without_submission"
+        case .settingsShortcutTurnedOn:
+            return "aichat_promptbar_settings_shortcut_on"
+        case .settingsShortcutTurnedOff:
+            return "aichat_promptbar_settings_shortcut_off"
+        case .settingsMenuBarIconTurnedOn:
+            return "aichat_promptbar_settings_menu_bar_icon_on"
+        case .settingsMenuBarIconTurnedOff:
+            return "aichat_promptbar_settings_menu_bar_icon_off"
+        case .settingsShortcutChanged:
+            return "aichat_promptbar_settings_shortcut_changed"
+        case .state:
+            return "aichat_promptbar_state"
+        }
+    }
+
+    var parameters: [String: String]? {
+        switch self {
+        case .submitPrompt,
+                .submitURL,
+                .imageAttached,
+                .imageRemoved,
+                .fileAttached,
+                .fileRemoved,
+                .imageGenerationActivated,
+                .imageGenerationDeactivated,
+                .imageGenerationSubmitted,
+                .webSearchActivated,
+                .webSearchDeactivated,
+                .webSearchSubmitted,
+                .modelSelected,
+                .reasoningEffortSelected,
+                .newVoiceChat,
+                .shownFromShortcut,
+                .shownFromMenuBarIcon,
+                .settingsShortcutTurnedOn,
+                .settingsShortcutTurnedOff,
+                .settingsMenuBarIconTurnedOn,
+                .settingsMenuBarIconTurnedOff,
+                .settingsShortcutChanged:
+            return nil
+        case .submitWithImage(let imageCount):
+            return ["imageCount": String(imageCount)]
+        case .submitWithFiles(let fileCount):
+            return ["fileCount": String(fileCount)]
+        case .fileValidationFailed(let reason):
+            return ["reason": reason]
+        case .dismissedWithoutSubmission(let reason, let hadText):
+            return ["reason": reason.rawValue, "had_text": String(hadText)]
+        case .state(let shortcutEnabled, let menuBarIconEnabled):
+            return ["shortcut_enabled": String(shortcutEnabled),
+                    "menu_bar_icon_enabled": String(menuBarIconEnabled)]
+        }
+    }
+
+    /// Matches the address bar pixels, so a surface breakdown stays comparable.
+    var standardParameters: [PixelKitStandardParameter]? {
+        [.pixelSource]
+    }
+}
+
+/// The `reason` parameter on `aichat_promptbar_dismissed_without_submission`.
+enum PromptBarCancellationReason: String, Equatable, CaseIterable {
+    case escape
+    case clickOutside = "click_outside"
+    case shortcutToggle = "shortcut_toggle"
+    case menuBarIcon = "menu_bar_icon"
+}

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixelHandler.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixelHandler.swift
@@ -17,10 +17,55 @@
 //
 
 import Foundation
+import PixelKit
 
-/// Deliberately inert: reusing the `aiChatAddressBar*` names would fold the Prompt Bar's numbers
-/// into the address bar's, and the Prompt Bar has no definitions of its own yet.
+/// Reports the shared prompt events under the Prompt Bar's own names, so its numbers stay separable
+/// from the address bar's rather than folding into them.
 struct PromptBarPixelHandler: DuckAIPromptPixelFiring {
 
-    func fire(_ event: DuckAIPromptPixelEvent) {}
+    func fire(_ event: DuckAIPromptPixelEvent) {
+        guard let pixel = Self.promptBarPixel(for: event) else { return }
+
+        switch pixel {
+        case .newVoiceChat:
+            // The frequency its address bar counterpart uses.
+            PixelKit.fire(pixel, frequency: .dailyAndStandard, includeAppVersionParameter: true)
+        default:
+            PixelKit.fire(pixel, frequency: .dailyAndCount, includeAppVersionParameter: true)
+        }
+    }
+
+    /// `nil` for events this surface can't produce, per `DuckAIPromptSurface`: page context (tab and
+    /// `@`-mention attachments), Customize Responses and the subscription upsell are all off on the
+    /// Prompt Bar, so counting them would define a pixel that never fires.
+    static func promptBarPixel(for event: DuckAIPromptPixelEvent) -> PromptBarPixel? {
+        switch event {
+        case .promptSubmitted: .submitPrompt
+        case .urlSubmitted: .submitURL
+        case .imageGenerationSubmitted: .imageGenerationSubmitted
+        case .webSearchSubmitted: .webSearchSubmitted
+        case .submittedWithImages(let count): .submitWithImage(imageCount: count)
+        case .submittedWithFiles(let count): .submitWithFiles(fileCount: count)
+        case .imageGenerationActivated: .imageGenerationActivated
+        case .imageGenerationDeactivated: .imageGenerationDeactivated
+        case .webSearchActivated: .webSearchActivated
+        case .webSearchDeactivated: .webSearchDeactivated
+        case .imageAttached: .imageAttached
+        case .imageRemoved: .imageRemoved
+        case .fileAttached: .fileAttached
+        case .fileRemoved: .fileRemoved
+        case .fileValidationFailed(let reason): .fileValidationFailed(reason: reason)
+        case .modelSelected: .modelSelected
+        case .reasoningEffortSelected: .reasoningEffortSelected
+        case .voiceChatOpened: .newVoiceChat
+        case .submittedWithTabs,
+                .tabAttachmentRemoved,
+                .tabPickerShown,
+                .tabChosen,
+                .tabPickerCanceled,
+                .customizeResponsesOpened,
+                .subscriptionUpsellTriggered:
+            nil
+        }
+    }
 }

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarContentHosting.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarContentHosting.swift
@@ -27,6 +27,10 @@ protocol PromptBarContentHosting: AnyObject {
     /// True while a menu, file picker or modal is up: those take key away, and must not dismiss the bar.
     var isPresentingAuxiliaryUI: Bool { get }
 
+    /// Whether the prompt holds anything the user typed. Read at dismissal to tell an abandoned
+    /// prompt from an exploratory open.
+    var hasPromptText: Bool { get }
+
     /// Not `preferredContentSize`, which would collide with the `NSViewController` property conformers inherit.
     var preferredWindowContentSize: NSSize { get }
 

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarOmnibarContentViewController.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarOmnibarContentViewController.swift
@@ -215,6 +215,11 @@ extension PromptBarOmnibarContentViewController: PromptBarContentHosting {
         isMenuTracking || view.window?.attachedSheet != nil || NSApp.modalWindow != nil
     }
 
+    /// Attachments don't count: this reports the text field alone.
+    var hasPromptText: Bool {
+        !draftStore.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     var preferredWindowContentSize: NSSize {
         // Wrapping depends on the final width, so resolve pending layout before measuring.
         if isViewLoaded {

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarPreferencesView.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarPreferencesView.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import PixelKit
 import PreferencesUI_macOS
 import SwiftUI
 
@@ -29,14 +30,28 @@ struct PromptBarPreferencesView: View {
                                       isOn: $preferences.isMenuBarIconVisible,
                                       spacing: 4)
         .accessibilityIdentifier("Preferences.AIChat.promptBarMenuBarIconToggle")
+        .onChange(of: preferences.isMenuBarIconVisible) { isVisible in
+            fire(isVisible ? .settingsMenuBarIconTurnedOn : .settingsMenuBarIconTurnedOff)
+        }
 
         ToggleMenuItem(UserText.promptBarKeyboardShortcutToggle,
                        isOn: $preferences.isKeyboardShortcutEnabled)
         .accessibilityIdentifier("Preferences.AIChat.promptBarKeyboardShortcutToggle")
+        .onChange(of: preferences.isKeyboardShortcutEnabled) { isEnabled in
+            fire(isEnabled ? .settingsShortcutTurnedOn : .settingsShortcutTurnedOff)
+        }
 
         PromptBarShortcutRecorderView(shortcut: $preferences.keyboardShortcut)
             .disabled(!preferences.isKeyboardShortcutEnabled)
             .padding(.leading, 19)
             .padding(.bottom, 4)
+            // Covers both recording a new combo and resetting to the default; the combo itself is never sent.
+            .onChange(of: preferences.keyboardShortcut) { _ in
+                fire(.settingsShortcutChanged)
+            }
+    }
+
+    private func fire(_ pixel: PromptBarPixel) {
+        PixelKit.fire(pixel, frequency: .dailyAndCount, includeAppVersionParameter: true)
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_promptbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_promptbar_pixels.json5
@@ -1,0 +1,254 @@
+// Duck.ai Prompt Bar: the floating bar opened by the global keyboard shortcut or the menu bar icon.
+// Names mirror their m_mac_aichat_addressbar_* counterparts so the two prompt surfaces can be
+// compared directly; the Prompt Bar-only pixels at the end cover its own lifecycle and settings.
+{
+    "m_mac_aichat_promptbar_submit_prompt": {
+        "description": "Fired when user submits a prompt from the Prompt Bar",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_submit_url": {
+        "description": "Fired when user submits a URL from the Prompt Bar",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_submit_with_image": {
+        "description": "Fired when user submits a prompt from the Prompt Bar that includes one or more image attachments",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "imageCount",
+                "type": "integer",
+                "description": "Number of images attached to the submitted prompt"
+            }
+        ]
+    },
+    "m_mac_aichat_promptbar_submit_with_files": {
+        "description": "Fired when user submits a prompt from the Prompt Bar that includes one or more file (PDF etc.) attachments",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "fileCount",
+                "type": "integer",
+                "description": "Number of files attached to the submitted prompt"
+            }
+        ]
+    },
+    "m_mac_aichat_promptbar_image_attached": {
+        "description": "Fired when user attaches an image via the file picker in the Prompt Bar",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_image_removed": {
+        "description": "Fired when user removes an attached image in the Prompt Bar",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_file_attached": {
+        "description": "Fired when user attaches a file (PDF etc.) via the file picker in the Prompt Bar",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_file_removed": {
+        "description": "Fired when user removes an attached file (PDF etc.) in the Prompt Bar by clicking the × on the carousel card",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_file_validation_failed": {
+        "description": "Fired when a file picked for the Prompt Bar is rejected at pick-time by the attachment validator (too large, over the total-size budget, too many pages, unsupported type, encrypted, or unreadable)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "reason",
+                "description": "Reason for the file validation failure.",
+                "type": "string",
+                "enum": ["size_exceeded", "count_exceeded", "unsupported_type", "encrypted", "unreadable", "other"]
+            }
+        ]
+    },
+    "m_mac_aichat_promptbar_image_generation_activated": {
+        "description": "Fired when user selects the Create Image tool in the Prompt Bar to enter image generation mode",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_image_generation_deactivated": {
+        "description": "Fired when user dismisses the Prompt Bar's image generation chip (X button)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_image_generation_submitted": {
+        "description": "Fired when user submits a prompt from the Prompt Bar while image generation mode is active",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_web_search_activated": {
+        "description": "Fired when user selects the Web Search tool in the Prompt Bar to enter web search mode",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_web_search_deactivated": {
+        "description": "Fired when user dismisses the Prompt Bar's web search chip (X button)",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_web_search_submitted": {
+        "description": "Fired when user submits a prompt from the Prompt Bar while web search mode is active",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_model_selected": {
+        "description": "Fired when user selects a model from the Prompt Bar's model picker menu",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_reasoning_effort_selected": {
+        "description": "Fired when user selects a reasoning effort from the Prompt Bar's picker",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_new_voice_chat": {
+        "description": "Fired when user opens a new Duck.ai voice chat from the Prompt Bar",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_standard"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_shown_shortcut": {
+        "description": "Fired when the Prompt Bar is presented by pressing the global keyboard shortcut",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_shown_menu_bar_icon": {
+        "description": "Fired when the Prompt Bar is presented by clicking the Duck.ai menu bar icon",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_dismissed_without_submission": {
+        "description": "Fired when the Prompt Bar closes without a prompt, URL or voice session being handed off. Together with the shown pixels this measures how often an open converts into a Duck.ai request",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "reason",
+                "description": "How the Prompt Bar was dismissed. Menus, file pickers and modals taking focus are excluded from click_outside.",
+                "type": "string",
+                "enum": ["escape", "click_outside", "shortcut_toggle", "menu_bar_icon"]
+            },
+            {
+                "key": "had_text",
+                "description": "Whether the prompt field held non-whitespace text at dismissal, separating an abandoned prompt from an exploratory open. Attachments alone do not set it.",
+                "type": "string",
+                "enum": ["true", "false"]
+            }
+        ]
+    },
+    "m_mac_aichat_promptbar_settings_shortcut_on": {
+        "description": "Fired when the Prompt Bar keyboard shortcut setting is turned on in Settings → AI Features",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_settings_shortcut_off": {
+        "description": "Fired when the Prompt Bar keyboard shortcut setting is turned off in Settings → AI Features",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_settings_menu_bar_icon_on": {
+        "description": "Fired when the Prompt Bar menu bar icon setting is turned on in Settings → AI Features",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_settings_menu_bar_icon_off": {
+        "description": "Fired when the Prompt Bar menu bar icon setting is turned off in Settings → AI Features",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_settings_shortcut_changed": {
+        "description": "Fired when the recorded Prompt Bar key combination changes, including a reset to the default. The combination itself is never sent — this only reports that the default did not suit the user",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_state": {
+        "description": "Daily pixel reporting both Prompt Bar settings, so the enabled share of the active base is measurable rather than only the users who touch a setting",
+        "owners": ["Bunn"],
+        "triggers": ["startup"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "shortcut_enabled",
+                "description": "Whether the global keyboard shortcut setting is currently on",
+                "type": "string",
+                "enum": ["true", "false"]
+            },
+            {
+                "key": "menu_bar_icon_enabled",
+                "description": "Whether the menu bar icon setting is currently on",
+                "type": "string",
+                "enum": ["true", "false"]
+            }
+        ]
+    }
+}

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_promptbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_promptbar_pixels.json5
@@ -28,7 +28,9 @@
             {
                 "key": "imageCount",
                 "type": "integer",
-                "description": "Number of images attached to the submitted prompt"
+                "description": "Number of images attached to the submitted prompt",
+                "minimum": 1,
+                "maximum": 4
             }
         ]
     },
@@ -44,7 +46,9 @@
             {
                 "key": "fileCount",
                 "type": "integer",
-                "description": "Number of files attached to the submitted prompt"
+                "description": "Number of files attached to the submitted prompt",
+                "minimum": 1,
+                "maximum": 6
             }
         ]
     },

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_promptbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_promptbar_pixels.json5
@@ -188,8 +188,7 @@
             {
                 "key": "had_text",
                 "description": "Whether the prompt field held non-whitespace text at dismissal, separating an abandoned prompt from an exploratory open. Attachments alone do not set it.",
-                "type": "string",
-                "enum": ["true", "false"]
+                "type": "boolean"
             }
         ]
     },
@@ -240,14 +239,12 @@
             {
                 "key": "shortcut_enabled",
                 "description": "Whether the global keyboard shortcut setting is currently on",
-                "type": "string",
-                "enum": ["true", "false"]
+                "type": "boolean"
             },
             {
                 "key": "menu_bar_icon_enabled",
                 "description": "Whether the menu bar icon setting is currently on",
-                "type": "string",
-                "enum": ["true", "false"]
+                "type": "boolean"
             }
         ]
     }

--- a/macOS/UnitTests/AIChat/DuckAIPromptPixelFiringTests.swift
+++ b/macOS/UnitTests/AIChat/DuckAIPromptPixelFiringTests.swift
@@ -53,6 +53,36 @@ final class DuckAIPromptPixelFiringTests: XCTestCase {
         (.voiceChatOpened, nil)
     ]
 
+    /// `nil` where `DuckAIPromptSurface` turns the feature off for the Prompt Bar — page context,
+    /// Customize Responses and the subscription upsell. Same rule as above: add a row per case.
+    private static let promptBarMapping: [(event: DuckAIPromptPixelEvent, pixel: PromptBarPixel?)] = [
+        (.promptSubmitted, .submitPrompt),
+        (.urlSubmitted, .submitURL),
+        (.imageGenerationSubmitted, .imageGenerationSubmitted),
+        (.webSearchSubmitted, .webSearchSubmitted),
+        (.submittedWithImages(count: 2), .submitWithImage(imageCount: 2)),
+        (.submittedWithFiles(count: 3), .submitWithFiles(fileCount: 3)),
+        (.submittedWithTabs(count: 4), nil),
+        (.imageGenerationActivated, .imageGenerationActivated),
+        (.imageGenerationDeactivated, .imageGenerationDeactivated),
+        (.webSearchActivated, .webSearchActivated),
+        (.webSearchDeactivated, .webSearchDeactivated),
+        (.customizeResponsesOpened, nil),
+        (.imageAttached, .imageAttached),
+        (.imageRemoved, .imageRemoved),
+        (.fileAttached, .fileAttached),
+        (.fileRemoved, .fileRemoved),
+        (.fileValidationFailed(reason: "tooLarge"), .fileValidationFailed(reason: "tooLarge")),
+        (.tabAttachmentRemoved, nil),
+        (.tabPickerShown, nil),
+        (.tabChosen, nil),
+        (.tabPickerCanceled, nil),
+        (.modelSelected, .modelSelected),
+        (.reasoningEffortSelected, .reasoningEffortSelected),
+        (.subscriptionUpsellTriggered(currentTier: "free", requiredTier: "plus", flowType: "modal"), nil),
+        (.voiceChatOpened, .newVoiceChat)
+    ]
+
     func testWhenAddressBarHandlerMapsAnEvent_ThenItKeepsThePixelItFiredBefore() {
         for (event, expected) in Self.addressBarMapping {
             let mapped = AddressBarPromptPixelHandler.addressBarPixel(for: event)
@@ -62,7 +92,29 @@ final class DuckAIPromptPixelFiringTests: XCTestCase {
         }
     }
 
-    func testWhenPromptBarHandlerFiresEveryEvent_ThenNothingReachesPixelKit() {
+    func testWhenPromptBarHandlerMapsAnEvent_ThenItReportsUnderItsOwnName() {
+        for (event, expected) in Self.promptBarMapping {
+            let mapped = PromptBarPixelHandler.promptBarPixel(for: event)
+
+            XCTAssertEqual(mapped?.name, expected?.name, "Wrong pixel name for \(event)")
+            XCTAssertEqual(mapped?.parameters, expected?.parameters, "Wrong pixel parameters for \(event)")
+        }
+    }
+
+    /// The two surfaces must never share a name, or the Prompt Bar's numbers fold into the address
+    /// bar's and the comparison the prefix exists for becomes impossible.
+    func testWhenBothHandlersMapTheSameEvent_ThenTheNamesDiffer() {
+        for (event, promptBarPixel) in Self.promptBarMapping {
+            guard let promptBarPixel,
+                  let addressBarPixel = AddressBarPromptPixelHandler.addressBarPixel(for: event) else { continue }
+
+            XCTAssertNotEqual(promptBarPixel.name, addressBarPixel.name, "Shared pixel name for \(event)")
+            XCTAssertTrue(promptBarPixel.name.hasPrefix("aichat_promptbar_"),
+                          "\(promptBarPixel.name) is not under the Prompt Bar prefix")
+        }
+    }
+
+    func testWhenPromptBarHandlerFiresAnUnsupportedEvent_ThenNothingReachesPixelKit() {
         var firedNames: [String] = []
         PixelKit.setUp(dryRun: false,
                        appVersion: "1.0.0",
@@ -75,11 +127,11 @@ final class DuckAIPromptPixelFiringTests: XCTestCase {
         defer { PixelKit.tearDown() }
 
         let handler = PromptBarPixelHandler()
-        for (event, _) in Self.addressBarMapping {
+        for (event, pixel) in Self.promptBarMapping where pixel == nil {
             handler.fire(event)
         }
 
         XCTAssertTrue(firedNames.isEmpty,
-                      "The Prompt Bar handler must stay silent, but fired: \(firedNames)")
+                      "Events the Prompt Bar can't produce must stay silent, but fired: \(firedNames)")
     }
 }

--- a/macOS/UnitTests/PromptBar/PromptBarCoordinatorTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarCoordinatorTests.swift
@@ -68,11 +68,13 @@ private final class MockGlobalShortcutRegistrar: GlobalShortcutRegistering {
 private final class MockPromptBarPresenter: PromptBarPresenting {
     var isVisible = false
     private(set) var toggleCallCount = 0
+    private(set) var toggleSources: [PromptBarPresentationSource] = []
 
-    func show() { isVisible = true }
-    func dismiss() { isVisible = false }
-    func toggle() {
+    func show(source: PromptBarPresentationSource) { isVisible = true }
+    func dismiss(reason: PromptBarDismissReason) { isVisible = false }
+    func toggle(source: PromptBarPresentationSource) {
         toggleCallCount += 1
+        toggleSources.append(source)
         isVisible.toggle()
     }
 }
@@ -182,16 +184,37 @@ final class PromptBarCoordinatorTests: XCTestCase {
     func testWhenTogglingThenPresenterIsToggled() {
         let (coordinator, _, _, presenter) = makeCoordinator()
 
-        coordinator.togglePromptBar()
+        coordinator.togglePromptBar(source: .menuBarIcon)
 
         XCTAssertEqual(presenter.toggleCallCount, 1)
         XCTAssertTrue(presenter.isVisible)
     }
 
+    /// The source decides which visibility pixel is reported, so it has to survive the hop.
+    func testWhenTogglingThenTheEntryPointIsPassedThrough() {
+        let (coordinator, _, _, presenter) = makeCoordinator()
+
+        coordinator.togglePromptBar(source: .menuBarIcon)
+        coordinator.togglePromptBar(source: .keyboardShortcut)
+
+        XCTAssertEqual(presenter.toggleSources, [.menuBarIcon, .keyboardShortcut])
+    }
+
+    func testWhenTheShortcutIsPressedThenItTogglesAsTheKeyboardShortcut() async {
+        let (coordinator, _, registrar, presenter) = makeCoordinator(persistor: .optedIn)
+        coordinator.start()
+
+        registrar.simulateShortcutPressed()
+        // The handler hops to the main actor; this queues behind it, so awaiting it means it ran.
+        await Task { @MainActor in }.value
+
+        XCTAssertEqual(presenter.toggleSources, [.keyboardShortcut])
+    }
+
     func testWhenFeatureFlagIsOffThenTogglingDoesNothing() {
         let (coordinator, _, _, presenter) = makeCoordinator(isFeatureOn: false)
 
-        coordinator.togglePromptBar()
+        coordinator.togglePromptBar(source: .keyboardShortcut)
 
         XCTAssertEqual(presenter.toggleCallCount, 0)
     }

--- a/macOS/UnitTests/PromptBar/PromptBarPresenterTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarPresenterTests.swift
@@ -26,6 +26,7 @@ final class PromptBarPresenterTests: XCTestCase {
     private var content: MockPromptBarContent!
     private var presenter: PromptBarPresenter!
     private var windows: [StubPromptBarWindow] = []
+    private var firedPixels: [PromptBarPixel] = []
 
     override func setUp() {
         super.setUp()
@@ -37,28 +38,32 @@ final class PromptBarPresenterTests: XCTestCase {
                 let window = StubPromptBarWindow(contentRect: rect)
                 self?.windows.append(window)
                 return window
+            },
+            firePixel: { [weak self] pixel in
+                self?.firedPixels.append(pixel)
             }
         )
     }
 
     override func tearDown() {
         windows = []
+        firedPixels = []
         presenter = nil
         content = nil
         super.tearDown()
     }
 
     func testWhenShownThenTheBarIsVisibleAndPreparedOnce() {
-        presenter.show()
+        presenter.show(source: .keyboardShortcut)
 
         XCTAssertTrue(presenter.isVisible)
         XCTAssertEqual(content.prepareCount, 1)
     }
 
     func testWhenDismissedThenTheContentIsResetOnce() {
-        presenter.show()
+        presenter.show(source: .keyboardShortcut)
 
-        presenter.dismiss()
+        presenter.dismiss(reason: .escape)
 
         XCTAssertFalse(presenter.isVisible)
         XCTAssertEqual(content.resetCount, 1)
@@ -67,29 +72,97 @@ final class PromptBarPresenterTests: XCTestCase {
     /// Submitting reports through both `requestsSubmissionOf` and `didSubmit`, so the host asks to
     /// dismiss twice. The second must not tear down an already-dismissed bar.
     func testWhenDismissedTwiceThenTheContentIsResetOnlyOnce() {
-        presenter.show()
+        presenter.show(source: .keyboardShortcut)
 
-        presenter.dismiss()
-        presenter.dismiss()
+        presenter.dismiss(reason: .submission)
+        presenter.dismiss(reason: .submission)
 
         XCTAssertEqual(content.resetCount, 1)
     }
 
     func testWhenDismissedWithoutBeingShownThenTheContentIsNotReset() {
-        presenter.dismiss()
+        presenter.dismiss(reason: .escape)
 
         XCTAssertEqual(content.resetCount, 0)
     }
 
     func testWhenShownAgainAfterDismissalThenItReusesTheWindowAndResetsAgainOnDismissal() {
-        presenter.show()
-        presenter.dismiss()
+        presenter.show(source: .keyboardShortcut)
+        presenter.dismiss(reason: .escape)
 
-        presenter.show()
-        presenter.dismiss()
+        presenter.show(source: .keyboardShortcut)
+        presenter.dismiss(reason: .escape)
 
         XCTAssertEqual(windows.count, 1, "The panel is reused rather than rebuilt per presentation")
         XCTAssertEqual(content.resetCount, 2)
+    }
+
+    // MARK: - Pixels
+
+    func testWhenShownFromEachSourceThenThatSourcesPixelIsReported() {
+        presenter.show(source: .keyboardShortcut)
+        presenter.dismiss(reason: .submission)
+        presenter.show(source: .menuBarIcon)
+
+        XCTAssertEqual(firedPixels.map(\.name), [PromptBarPixel.shownFromShortcut.name,
+                                                 PromptBarPixel.shownFromMenuBarIcon.name])
+    }
+
+    func testWhenDismissedAfterSubmittingThenNoCancellationIsReported() {
+        presenter.show(source: .keyboardShortcut)
+        firedPixels = []
+
+        presenter.dismiss(reason: .submission)
+
+        XCTAssertTrue(firedPixels.isEmpty, "Submitting is covered by the submit pixels, but fired: \(firedPixels.map(\.name))")
+    }
+
+    func testWhenDismissedWithoutSubmittingThenEachReasonIsReported() {
+        let expected: [(PromptBarDismissReason, PromptBarCancellationReason)] = [
+            (.escape, .escape),
+            (.clickOutside, .clickOutside),
+            (.shortcutToggle, .shortcutToggle),
+            (.menuBarIconToggle, .menuBarIcon)
+        ]
+
+        for (dismissReason, cancellationReason) in expected {
+            presenter.show(source: .keyboardShortcut)
+            firedPixels = []
+
+            presenter.dismiss(reason: dismissReason)
+
+            XCTAssertEqual(firedPixels.map(\.name), [PromptBarPixel.dismissedWithoutSubmission(reason: cancellationReason, hadText: false).name])
+            XCTAssertEqual(firedPixels.first?.parameters?["reason"], cancellationReason.rawValue)
+        }
+    }
+
+    /// The draft is cleared by `resetAfterDismissal()`, so the flag has to be read before that runs.
+    func testWhenDismissedWithTypedTextThenHadTextIsReported() {
+        content.hasPromptText = true
+        presenter.show(source: .keyboardShortcut)
+        firedPixels = []
+
+        presenter.dismiss(reason: .clickOutside)
+
+        XCTAssertEqual(firedPixels.first?.parameters?["had_text"], "true")
+    }
+
+    func testWhenDismissedWithAnEmptyPromptThenHadTextIsFalse() {
+        presenter.show(source: .keyboardShortcut)
+        firedPixels = []
+
+        presenter.dismiss(reason: .clickOutside)
+
+        XCTAssertEqual(firedPixels.first?.parameters?["had_text"], "false")
+    }
+
+    func testWhenToggledWhileVisibleThenTheEntryPointIsTheCancellationReason() {
+        presenter.toggle(source: .menuBarIcon)
+        firedPixels = []
+
+        presenter.toggle(source: .menuBarIcon)
+
+        XCTAssertEqual(firedPixels.first?.parameters?["reason"], PromptBarCancellationReason.menuBarIcon.rawValue)
     }
 }
 
@@ -135,6 +208,7 @@ private final class MockPromptBarContent: PromptBarContentHosting {
     let hostedViewController = NSViewController()
 
     var isPresentingAuxiliaryUI = false
+    var hasPromptText = false
     var preferredWindowContentSize = NSSize(width: 680, height: 80)
     var onPreferredWindowContentSizeChanged: ((NSSize) -> Void)?
     var onSubmit: (() -> Void)?


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216829777310880?focus=true
Tech Design URL:
CC:

### Description
Pixels for shared Duck.ai prompt events under `aichat_promptbar_*` names, mirroring the tail of each `aichat_addressbar_*` counterpart

### Testing Steps
(Easiest way to test, filter logs by aichat_promptbar_ and do do a smoke test on the change and see if the pixels are being fired as expected)

1. Enable `macosPromptBar`, then in Settings → AI Features toggle both Prompt Bar checkboxes and record a new shortcut — expect `m_mac_aichat_promptbar_settings_shortcut_on`/`_off`, `..._menu_bar_icon_on`/`_off` and `..._settings_shortcut_changed`.
2. Open the bar with the shortcut and again with the menu bar icon (`..._shown_shortcut` / `..._shown_menu_bar_icon`), then dismiss each way — Esc, clicking outside, and re-triggering the same entry point — and confirm `..._dismissed_without_submission` carries the matching `reason` plus `had_text=true` only when text was typed.
3. Submit a prompt, attach an image and a file, and switch model / reasoning effort / Create Image / Web Search — expect the `aichat_promptbar_*` twin of each address bar pixel, and no `..._dismissed_without_submission` on a submit.

### Impact and Risks
Low

#### What could go wrong?
A dismissal path could be mis-attributed — most plausibly a submission also counting as a `click_outside` cancel — which would overstate abandonment without affecting behaviour.

### Notes to Reviewer
The two surfaces' mappings are table-driven in `DuckAIPromptPixelFiringTests`; a new `DuckAIPromptPixelEvent` case needs a row added to each table by hand, since associated values rule out `CaseIterable`. Settings pixels sit under the `aichat_promptbar_` prefix rather than joining the `aichat_settings_addressbar_*` family, so every Prompt Bar pixel is one `LIKE 'm_mac_aichat_promptbar%'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes with no auth, data, or core behavior impact; mis-attributed dismissals could skew abandonment metrics but not user-facing behavior.
> 
> **Overview**
> Adds a dedicated **`aichat_promptbar_*`** pixel surface so Duck.ai usage from the floating Prompt Bar is measurable separately from the address bar, with parallel names for apples-to-apples comparison.
> 
> **`PromptBarPixelHandler`** now maps shared `DuckAIPromptPixelEvent` cases to those names (tab attach, customize responses, and subscription upsell stay unmapped). **`PromptBarPresenter`** reports show/dismiss lifecycle pixels keyed by entry point (shortcut vs menu bar icon), including **`dismissed_without_submission`** with `reason` and `had_text` when the user closes without submitting. Settings toggles and shortcut changes fire their own pixels; **`AppDelegate`** adds a daily **`state`** pixel when the feature flag is on.
> 
> Pixel definitions land in **`aichat_promptbar_pixels.json5`**; unit tests extend the table-driven mapping tests and presenter/coordinator coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a2b50164ecb0a1bd23710f9f7adfe614c813297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->