### PR TITLE
[iOS] Keep QR sheet shown under sync pairing confirmation alert

### DIFF
--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -719,8 +719,6 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
     }
 
     private func presentPairingV2ConfirmationAlert(message: String) async -> Bool {
-        await dismissSyncCodeSheetIfPresented()
-
         return await withCheckedContinuation { continuation in
             let alert = UIAlertController(title: UserText.syncPairingV2ConfirmationTitle, message: message, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: UserText.actionCancel, style: .cancel) { _ in
@@ -742,16 +740,6 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
             topController = presented
         }
         return topController
-    }
-
-    private func dismissSyncCodeSheetIfPresented() async {
-        guard let scanCodeViewModel, scanCodeViewModel.isShowingSyncCodeSheet else { return }
-        await withCheckedContinuation { continuation in
-            scanCodeViewModel.onSyncCodeSheetDismissed = {
-                continuation.resume()
-            }
-            scanCodeViewModel.isShowingSyncCodeSheet = false
-        }
     }
 
     private func pairingV2DisplayName(for peerName: String?) -> String {

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/ScanOrPasteCodeViewModel.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/ScanOrPasteCodeViewModel.swift
@@ -75,8 +75,6 @@ public class ScanOrPasteCodeViewModel: ObservableObject {
 
     @Published public var isShowingSyncCodeSheet = false
 
-    public var onSyncCodeSheetDismissed: (() -> Void)?
-
     var canSubmitManualCode: Bool {
         manuallyEnteredCode?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
     }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/ScanQRCodeViewV2.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/ScanQRCodeViewV2.swift
@@ -66,10 +66,7 @@ public struct ScanQRCodeViewV2: View {
                 }
             }
         }
-        .sheet(isPresented: $model.isShowingSyncCodeSheet, onDismiss: {
-            model.onSyncCodeSheetDismissed?()
-            model.onSyncCodeSheetDismissed = nil
-        }) {
+        .sheet(isPresented: $model.isShowingSyncCodeSheet) {
             SyncCodeSheetView(model: model)
         }
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216995755287941?focus=true

### Description
In the simplified V2 sync UI, when your device presents its QR code (shown in a modal sheet) and another device scans it, the "Sync now?" pairing confirmation used to dismiss the QR sheet before appearing — which revealed the camera underneath and made the alert look like it popped up on the scanner. Now the confirmation is shown on top of the QR sheet, so the QR stays visible until the flow dismisses the whole scanner stack, matching the V1 behavior.

Only the presenting (being-scanned) device is affected; the scanning device already dismissed its scanner before this confirmation, so its behavior is unchanged.

### Testing Steps
Requires two devices, both with `simplifiedSyncSetupV2` and `syncCanShowV2ConnectCode` on.
1. On device A, open Sync → Sync with Another Device → tap the QR button to show your code.
2. On device B, scan device A's QR code.
3. On device A → the "Sync now?" confirmation appears on top of the QR code (previously it jumped back to the camera). Confirm → the scanner dismisses and the flow continues to the Connecting/Success screens.

### Impact
Low — visual fix to the sync pairing confirmation on the presenting device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to sync pairing presentation on the device showing its QR code; no auth or sync protocol logic changes.
> 
> **Overview**
> On the **presenting** device in simplified V2 sync, the “Sync now?” pairing confirmation no longer dismisses the QR code sheet before the alert appears.
> 
> **`presentPairingV2ConfirmationAlert`** no longer calls **`dismissSyncCodeSheetIfPresented()`**, and that helper plus **`onSyncCodeSheetDismissed`** on **`ScanOrPasteCodeViewModel`** are removed. The QR sheet’s SwiftUI **`onDismiss`** callback is dropped so the sheet stays up while **`UIAlertController`** is shown from the topmost presenter—matching V1 and avoiding the camera flashing under the alert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c92ae47c6911cae72b5e0683cc0e5734abeb1a0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->