### PR TITLE
[iOS] remove preview preventing long press menu from supporting swipe

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -1708,9 +1708,7 @@ extension DefaultOmniBarView: UIContextMenuInteractionDelegate {
     func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
         guard let menu = longPressMenuProvider?() else { return nil }
 
-        return UIContextMenuConfiguration(identifier: nil, previewProvider: { [weak self] in
-            self?.makeLongPressMenuPreviewController()
-        }) { _ in
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { _ in
             menu
         }
     }
@@ -1719,49 +1717,6 @@ extension DefaultOmniBarView: UIContextMenuInteractionDelegate {
                                 willDisplayMenuFor configuration: UIContextMenuConfiguration,
                                 animator: UIContextMenuInteractionAnimating?) {
         onLongPressMenuDisplayed?()
-    }
-
-    private func makeLongPressMenuPreviewController() -> UIViewController? {
-        OmniBarLongPressPreviewViewController(sourceView: searchContainer)
-    }
-}
-
-private final class OmniBarLongPressPreviewViewController: UIViewController {
-
-    private let sourceView: UIView
-
-    init(sourceView: UIView) {
-        self.sourceView = sourceView
-        super.init(nibName: nil, bundle: nil)
-        preferredContentSize = sourceView.bounds.size
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func loadView() {
-        let containerView = UIView(frame: CGRect(origin: .zero, size: preferredContentSize))
-        containerView.backgroundColor = .clear
-        containerView.clipsToBounds = false
-        view = containerView
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        guard let snapshotView = sourceView.snapshotView(afterScreenUpdates: false) else { return }
-
-        snapshotView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(snapshotView)
-
-        NSLayoutConstraint.activate([
-            snapshotView.topAnchor.constraint(equalTo: view.topAnchor),
-            snapshotView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            snapshotView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            snapshotView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1216997854555013?focus=true
Tech Design URL:
CC:

### Description
The long press menu on the address bar lost its swipe gesture support due to the custom preview.

### Testing Steps
1. Long press the address bar and confirm that you can long press - swipe - release to execute an action. 
2. In both top and bottom positions ensure the 'move bar' functions correctly
3. Smoke test the omnibar generally.
4. Validate iOS 18
5. Ensure works on iPad (move bar not available)

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Some unexpected UI on some version of iOS

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized omnibar context-menu UI only; main risk is slightly different preview appearance on some iOS versions, not menu logic or navigation.
> 
> **Overview**
> Removes the **custom context-menu preview** on the address bar long-press menu so UIKit can use its default presentation again.
> 
> `UIContextMenuConfiguration` now sets `previewProvider` to `nil` instead of building an `OmniBarLongPressPreviewViewController` that snapshot’d `searchContainer`. That preview class and `makeLongPressMenuPreviewController()` are deleted entirely.
> 
> **Why:** the snapshot preview blocked the **long press → swipe → release** path for choosing a menu action (including move-bar and related omnibar actions). Menu contents and `onLongPressMenuDisplayed` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 485e8214690448fd25b37c28132b018a3a625b91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->