### PR TITLE
[macOS] Restore Intel architecture removal for UI test builds

### DIFF
--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -110,16 +110,6 @@ jobs:
       branch: ${{ inputs.branch || github.ref_name }}
 
     steps:
-    - name: Validate architecture selection
-      env:
-        BUILD_ARM64_ONLY: ${{ inputs.build-arm64-only }}
-        RELEASE_TYPE: ${{ github.event.inputs.release-type || inputs.release-type }}
-      run: |
-        if [[ "$BUILD_ARM64_ONLY" == "true" && "$RELEASE_TYPE" != "review" && "$RELEASE_TYPE" != "sandbox-review" ]]; then
-          echo "::error::Arm64-only archives are limited to review builds. Release and alpha archives must remain universal."
-          exit 1
-        fi
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -132,6 +122,16 @@ jobs:
       with:
         submodules: recursive
         ref: ${{ inputs.commit-sha || env.branch }}
+
+    - name: Validate architecture selection
+      env:
+        BUILD_ARM64_ONLY: ${{ inputs.build-arm64-only }}
+        RELEASE_TYPE: ${{ github.event.inputs.release-type || inputs.release-type }}
+      run: |
+        if [[ "$BUILD_ARM64_ONLY" == "true" && "$RELEASE_TYPE" != "review" && "$RELEASE_TYPE" != "sandbox-review" ]]; then
+          echo "::error::Arm64-only archives are limited to review builds. Release and alpha archives must remain universal."
+          exit 1
+        fi
 
     - name: Start measuring duration
       id: start-duration

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -24,6 +24,10 @@ on:
         description: "Asana release task URL"
         required: false
         type: string
+      build-arm64-only:
+        description: "Build arm64 only (review builds only)"
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       release-type:
@@ -52,6 +56,10 @@ on:
         type: string
       skip-notify:
         description: "Skip Mattermost notification"
+        default: false
+        type: boolean
+      build-arm64-only:
+        description: "Build arm64 only (review builds only)"
         default: false
         type: boolean
     secrets:
@@ -102,6 +110,16 @@ jobs:
       branch: ${{ inputs.branch || github.ref_name }}
 
     steps:
+    - name: Validate architecture selection
+      env:
+        BUILD_ARM64_ONLY: ${{ inputs.build-arm64-only }}
+        RELEASE_TYPE: ${{ github.event.inputs.release-type || inputs.release-type }}
+      run: |
+        if [[ "$BUILD_ARM64_ONLY" == "true" && "$RELEASE_TYPE" != "review" && "$RELEASE_TYPE" != "sandbox-review" ]]; then
+          echo "::error::Arm64-only archives are limited to review builds. Release and alpha archives must remain universal."
+          exit 1
+        fi
+
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -216,10 +234,15 @@ jobs:
         APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
         APPLE_API_KEY_ISSUER: ${{ secrets.APPLE_API_KEY_ISSUER }}
         ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+        BUILD_ARM64_ONLY: ${{ inputs.build-arm64-only }}
       run: |
         # import API Key from secrets
         export APPLE_API_KEY_PATH="$RUNNER_TEMP/apple_api_key.pem"
         echo -n "$APPLE_API_KEY_BASE64" | base64 --decode -o $APPLE_API_KEY_PATH
+
+        if [[ "$BUILD_ARM64_ONLY" == "true" ]]; then
+          export EXCLUDED_ARCHS=x86_64
+        fi
 
         if [[ "${{ runner.debug }}" == "1" ]]; then
           ./scripts/archive.sh ${{ env.release-type }} -r
@@ -236,6 +259,22 @@ jobs:
         pixel-name: m_ci_apple_duration_macos_notarized_build
         pixel-params: |
           runner: ${{ env.RUNS_ON }}
+
+    - name: Validate arm64-only review build
+      if: inputs.build-arm64-only
+      run: |
+        app_path="release/${{ env.app-name }}.app"
+        plist_path="${app_path}/Contents/Info.plist"
+        executable_name=$(/usr/libexec/PlistBuddy -c "Print :CFBundleExecutable" "$plist_path")
+        executable_path="${app_path}/Contents/MacOS/${executable_name}"
+        architectures=$(lipo -archs "$executable_path")
+
+        if [[ "$architectures" != "arm64" ]]; then
+          echo "::error::Expected an arm64-only review app, but ${executable_path} contains: ${architectures}"
+          exit 1
+        fi
+
+        echo "Validated arm64-only review app: ${executable_path}"
 
     - name: Validate release build
       if: env.is-official-release == 'true'

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -95,6 +95,7 @@ jobs:
       create-dmg: false
       branch: ${{ inputs.branch || github.sha }}
       skip-notify: true
+      build-arm64-only: true # UI Test runners are Apple Silicon, so their prebuilt app does not need x86_64.
     secrets: inherit
 
   # This job sets up the matrix strategy arguments for the ui-tests jobs

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests App Store CI.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests App Store CI.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "NO">
+      buildImplicitDependencies = "NO"
+      buildArchitectures = "Automatic">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests App Store.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests App Store.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests CI.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests CI.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "NO">
+      buildImplicitDependencies = "NO"
+      buildArchitectures = "Automatic">
    </BuildAction>
    <TestAction
       buildConfiguration = "Review"

--- a/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests.xcscheme
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/xcshareddata/xcschemes/macOS UI Tests.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/macOS/scripts/archive.sh
+++ b/macOS/scripts/archive.sh
@@ -262,6 +262,7 @@ archive_and_export() {
 		CURRENT_PROJECT_VERSION="${build_number}" \
 		RELEASE_PRODUCT_NAME_OVERRIDE=DuckDuckGo \
 		${extra_xcargs:+"${extra_xcargs}"} \
+		${EXCLUDED_ARCHS:+"EXCLUDED_ARCHS=${EXCLUDED_ARCHS}"} \
 		2>&1 \
 		| ${log_formatter}
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1217005061040332?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

This PR restores the change to remove the Intel architecture from review builds, speeding up review times. It fixes the issue where the architecture was being removed from release builds accidentally.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Confirm that the [UI test workflow](https://github.com/duckduckgo/apple-browsers/actions/runs/30492554157/job/90713740184?pr=6091) only built for Apple Silicon - ignore any UI test failures themselves, the suite is flaky lately
2. Make sure that [release build creation](https://github.com/duckduckgo/apple-browsers/actions/runs/30494315400) is not affected

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
3. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and local scheme changes only; guards prevent arm64-only from applying to release/alpha builds.
> 
> **Overview**
> Speeds up **macOS UI test** CI by building **review** app artifacts as **arm64-only**, while keeping **release** and **alpha** archives universal.
> 
> The notarized build workflow adds a `build-arm64-only` input that sets `EXCLUDED_ARCHS=x86_64` during archive (via `archive.sh`). A **pre-build** check fails the job if that flag is used with non-review release types; a **post-build** step runs `lipo` to confirm the app binary is arm64-only when the flag is on. The UI tests workflow enables `build-arm64-only: true` for its prebuilt review app.
> 
> UI test Xcode schemes set `buildArchitectures = "Automatic"` on the build action (scheme metadata only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bab046135bed12f68159756042156b8f22cf2d82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->