### PR TITLE
iOS: Figma colour palette update

### DIFF
--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
@@ -318,6 +318,8 @@ struct DefaultColorPalette: ColorPaletteDefinition {
 
     static func dynamicColor(for singleUseColor: SingleUseColor) -> DynamicColor {
         switch singleUseColor {
+        case .groupedListContentBackground:
+            return dynamicColor(for: DesignSystemColor.surface)
         case .controlWidgetBackground:
             return DynamicColor(staticColor: .x818387)
         case .unifiedFeedbackFieldBackground:

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/RebrandedColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/RebrandedColorPalette.swift
@@ -102,7 +102,12 @@ struct RebrandedColorPalette: ColorPaletteDefinition {
     }
 
     static func dynamicColor(for singleUseColor: SingleUseColor) -> DynamicColor {
-        DefaultColorPalette.dynamicColor(for: singleUseColor)
+        switch singleUseColor {
+        case .groupedListContentBackground:
+            return dynamicColor(for: DesignSystemColor.surfaceTertiary)
+        default:
+            return DefaultColorPalette.dynamicColor(for: singleUseColor)
+        }
     }
 }
 

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/RebrandedColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/RebrandedColorPalette.swift
@@ -58,8 +58,44 @@ struct RebrandedColorPalette: ColorPaletteDefinition {
             return DynamicColor(lightColor: RebrandingColor.Red.red70, darkColor: RebrandingColor.Red.red60)
         case .destructiveGlowPrimary:
             return DynamicColor(lightColor: Color(0xE5244B).opacity(0.2), darkColor: Color(0xEE6D87).opacity(0.2))
-        case .surfaceSecondary:
+        case .background, .panel:
+            return DynamicColor(lightHex: 0xF8F8F8, darkHex: 0x212121)
+        case .surface, .surfaceSecondary:
             return DynamicColor(lightHex: 0xFCFCFC, darkHex: 0x2B2B2B)
+        case .surfaceTertiary:
+            return DynamicColor(lightHex: 0xFFFFFF, darkHex: 0x333333)
+        case .surfaceCanvas:
+            return DynamicColor(lightHex: 0xFDFDFD, darkHex: 0x1C1C1C)
+        case .backdrop:
+            return DynamicColor(lightHex: 0xE4E4E4, darkHex: 0x050505)
+        case .decorationPrimary:
+            return DynamicColor(lightHex: 0x000000, lightOpacity: 0.09, darkHex: 0xFFFFFF, darkOpacity: 0.12)
+        case .decorationSecondary:
+            return DynamicColor(lightHex: 0x000000, lightOpacity: 0.16, darkHex: 0xFFFFFF, darkOpacity: 0.2)
+        case .decorationTertiary:
+            return DynamicColor(lightHex: 0x000000, lightOpacity: 0.24, darkHex: 0xFFFFFF, darkOpacity: 0.32)
+        case .textPrimary:
+            return DynamicColor(lightHex: 0x000000, lightOpacity: 0.96, darkHex: 0xFFFFFF, darkOpacity: 1)
+        case .textSecondary:
+            return DynamicColor(lightHex: 0x000000, lightOpacity: 0.6, darkHex: 0xFFFFFF, darkOpacity: 0.7)
+        case .textTertiary:
+            return DynamicColor(lightHex: 0x000000, lightOpacity: 0.36, darkHex: 0xFFFFFF, darkOpacity: 0.4)
+        case .icons:
+            return DynamicColor(lightHex: 0x000000, lightOpacity: 0.84, darkHex: 0xFFFFFF, darkOpacity: 0.78)
+        case .iconsSecondary:
+            return DynamicColor(lightHex: 0x000000, lightOpacity: 0.6, darkHex: 0xFFFFFF, darkOpacity: 0.48)
+        case .controlsFillPrimary:
+            return DynamicColor(lightHex: 0x000000, lightOpacity: 0.06, darkHex: 0xFFFFFF, darkOpacity: 0.06)
+        case .controlsFillSecondary:
+            return DynamicColor(lightHex: 0x000000, lightOpacity: 0.09, darkHex: 0xFFFFFF, darkOpacity: 0.09)
+        case .controlsFillTertiary:
+            return DynamicColor(lightHex: 0x000000, lightOpacity: 0.12, darkHex: 0xFFFFFF, darkOpacity: 0.12)
+        case .shadowPrimary:
+            return DynamicColor(lightHex: 0x000000, lightOpacity: 0.05, darkHex: 0x000000, darkOpacity: 0.16)
+        case .shadowSecondary:
+            return DynamicColor(lightHex: 0x000000, lightOpacity: 0.08, darkHex: 0x000000, darkOpacity: 0.24)
+        case .shadowTertiary:
+            return DynamicColor(lightHex: 0x000000, lightOpacity: 0.16, darkHex: 0x000000, darkOpacity: 0.32)
         default:
             return DefaultColorPalette.dynamicColor(for: designSystemColor)
         }

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
@@ -25,6 +25,11 @@ public enum SingleUseColor {
     case fireModeAccent
 
 #if os(iOS)
+    /// Background for grouped-list rows and visually associated inline cards.
+    /// Temporary compatibility token; replace with `.surfaceTertiary` when the
+    /// legacy palette and app-rebranding feature flag are removed.
+    case groupedListContentBackground
+
     case controlWidgetBackground
     case unifiedFeedbackFieldBackground
     case privacyDashboardBackground

--- a/iOS/AutofillCredentialProvider/CredentialProvider/CredentialProviderList/CredentialProviderListViewController.swift
+++ b/iOS/AutofillCredentialProvider/CredentialProvider/CredentialProviderList/CredentialProviderListViewController.swift
@@ -320,7 +320,7 @@ extension CredentialProviderListViewController: UITableViewDataSource {
                 fatalError("Could not dequeue cell")
             }
             cell.item = items[indexPath.row]
-            cell.backgroundColor = UIColor(designSystemColor: .surface)
+            cell.backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
 
             cell.disclosureButtonTapped = { [weak self] in
                 let item = items[indexPath.row]

--- a/iOS/AutofillCredentialProvider/CredentialProvider/CredentialProviderListDetails/CredentialProviderListDetailsView.swift
+++ b/iOS/AutofillCredentialProvider/CredentialProvider/CredentialProviderListDetails/CredentialProviderListDetailsView.swift
@@ -167,7 +167,7 @@ private struct Header: View {
         .frame(minHeight: Constants.viewHeight)
         .frame(maxWidth: .infinity)
         .contentShape(Rectangle())
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         .listRowInsets(Constants.insets)
     }
 }

--- a/iOS/DuckDuckGo/AIChat/AIChatHistoryCell.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatHistoryCell.swift
@@ -62,11 +62,11 @@ final class AIChatHistoryCell: UITableViewCell {
         // Explicit `backgroundColor` keeps the `.insetGrouped` rounded-corner mask
         // attached through swipe gestures (without it the last row's bottom corner
         // flashes square mid-swipe). Bookmarks' cells do the same.
-        backgroundColor = UIColor(designSystemColor: .surface)
+        backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
         // Keep the surface background when selected (the multi-select checkmark indicates
         // selection) instead of the default grey highlight blending the row into the list.
         let selectedBackground = UIView()
-        selectedBackground.backgroundColor = UIColor(designSystemColor: .surface)
+        selectedBackground.backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
         selectedBackgroundView = selectedBackground
 
         contentView.addSubview(iconImageView)

--- a/iOS/DuckDuckGo/AIChat/AIChatHistoryNoResultsCell.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatHistoryNoResultsCell.swift
@@ -40,7 +40,7 @@ final class AIChatHistoryNoResultsCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        backgroundColor = UIColor(designSystemColor: .surface)
+        backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
         selectionStyle = .none
         contentView.addSubview(label)
         NSLayoutConstraint.activate([

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/ChatHistory/AIChatHistoryListViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/ChatHistory/AIChatHistoryListViewController.swift
@@ -366,7 +366,7 @@ final class AIChatHistoryListViewController: UIViewController {
         config.imageToTextPadding = Constants.iconTextSpacing
 
         cell.contentConfiguration = config
-        cell.backgroundColor = UIColor(designSystemColor: .surface)
+        cell.backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
 
         configureDeleteActionIfNeeded(cell: cell, chat: chat)
     }
@@ -398,7 +398,7 @@ final class AIChatHistoryListViewController: UIViewController {
         config.imageToTextPadding = Constants.iconTextSpacing
 
         cell.contentConfiguration = config
-        cell.backgroundColor = UIColor(designSystemColor: .surface)
+        cell.backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
 
         // The "View all chats" row never offers per-row deletion.
         if let cell = cell as? DuckAISuggestionTableViewCell {

--- a/iOS/DuckDuckGo/AutoClearSettingsView.swift
+++ b/iOS/DuckDuckGo/AutoClearSettingsView.swift
@@ -136,7 +136,7 @@ private struct TimingOptionRow: View {
         }
         .buttonStyle(.plain)
         .frame(maxWidth: .infinity)
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         .accessibilityLabel(label)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }

--- a/iOS/DuckDuckGo/AutofillDeleteButtonCell.swift
+++ b/iOS/DuckDuckGo/AutofillDeleteButtonCell.swift
@@ -48,7 +48,7 @@ struct AutofillDeleteButtonCell: View {
             })
             .foregroundColor(Color.red)
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }}
 
 #Preview {

--- a/iOS/DuckDuckGo/AutofillExtensionPromotion/AutofillExtensionPromotionHeaderView.swift
+++ b/iOS/DuckDuckGo/AutofillExtensionPromotion/AutofillExtensionPromotionHeaderView.swift
@@ -69,7 +69,7 @@ struct AutofillExtensionPromotionHeaderView: View {
         }
         .background(
             RoundedRectangle(cornerRadius: ContainerMetrics.cornerRadius)
-                .foregroundColor(Color(designSystemColor: .surface))
+                .foregroundColor(Color(singleUseColor: .groupedListContentBackground))
                 .shadow(color: .black.opacity(0.08), radius: 12, x: 0, y: 8)
         )
         .onAppear {

--- a/iOS/DuckDuckGo/AutofillExtensionSettings/AutofillExtensionSettingsView.swift
+++ b/iOS/DuckDuckGo/AutofillExtensionSettings/AutofillExtensionSettingsView.swift
@@ -54,7 +54,7 @@ struct AutofillExtensionSettingsView: View {
                 }
 
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         }
         .applyInsetGroupedListStyle()
         .sheet(isPresented: $viewModel.isShowingActivationView) {

--- a/iOS/DuckDuckGo/AutofillLoginDetailsHeaderView.swift
+++ b/iOS/DuckDuckGo/AutofillLoginDetailsHeaderView.swift
@@ -50,7 +50,7 @@ struct AutofillLoginDetailsHeaderView: View {
         .frame(minHeight: Constants.viewHeight)
         .frame(maxWidth: .infinity)
         .contentShape(Rectangle())
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         .listRowInsets(Constants.insets)
     }
 }

--- a/iOS/DuckDuckGo/AutofillLoginDetailsView.swift
+++ b/iOS/DuckDuckGo/AutofillLoginDetailsView.swift
@@ -49,12 +49,12 @@ struct AutofillLoginDetailsView: View {
             switch viewModel.viewMode {
             case .edit:
                 editingContentView
-                    .listRowBackground(Color(designSystemColor: .surface))
+                    .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             case .view:
                 viewingContentView
             case .new:
                 editingContentView
-                    .listRowBackground(Color(designSystemColor: .surface))
+                    .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             }
         }
         .simultaneousGesture(

--- a/iOS/DuckDuckGo/AutofillLoginListViewController.swift
+++ b/iOS/DuckDuckGo/AutofillLoginListViewController.swift
@@ -888,7 +888,7 @@ final class AutofillLoginListViewController: UIViewController {
         let cell = tableView.dequeueCell(ofType: AutofillListItemTableViewCell.self, for: indexPath)
         cell.item = item
         cell.accessoryType = .disclosureIndicator
-        cell.backgroundColor = UIColor(designSystemColor: .surface)
+        cell.backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
         return cell
     }
 
@@ -905,7 +905,7 @@ final class AutofillLoginListViewController: UIViewController {
             Pixel.fire(pixel: .autofillLoginsReportConfirmationPromptDisplayed)
         })
         cell.embed(in: self, withView: contentView)
-        cell.backgroundColor = UIColor(designSystemColor: .surface)
+        cell.backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
         cell.selectionStyle = .none
         return cell
     }

--- a/iOS/DuckDuckGo/AutofillSettingsView.swift
+++ b/iOS/DuckDuckGo/AutofillSettingsView.swift
@@ -42,7 +42,7 @@ struct AutofillSettingsView: View {
                     }
                 }
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
 
             if viewModel.showCreditCards {
                 Section(header: Text(UserText.autofillSettingsAskToSaveAndAutofill),
@@ -55,13 +55,13 @@ struct AutofillSettingsView: View {
                                       title: UserText.autofillCreditCardListTitle)
                     }
                 }
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             } else {
                 Section(footer: PasswordFooterView(viewModel: viewModel)) {
                     ToggleRowView(toggleStatus: $viewModel.savePasswordsEnabled,
                                   title: UserText.autofillSettingsAskToSaveAndAutofill)
                 }
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             }
             
             Section(header: Text(UserText.autofillSettingsImportPasswordsSectionHeader).foregroundColor(.secondary)) {
@@ -104,7 +104,7 @@ struct AutofillSettingsView: View {
                     }
                 }
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
 
             if viewModel.showExtensionSettings || viewModel.shouldShowNeverPromptReset() {
                 Section(header: Text(UserText.autofillSettingsOptionsSectionHeader).foregroundColor(.secondary)) {
@@ -138,7 +138,7 @@ struct AutofillSettingsView: View {
                         }
                     }
                 }
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             }
 
         }

--- a/iOS/DuckDuckGo/AutofillSurveyView.swift
+++ b/iOS/DuckDuckGo/AutofillSurveyView.swift
@@ -72,7 +72,7 @@ struct AutofillSurveyView: View {
             .padding(ContainerMetrics.closeButtonPadding - CloseButtonStyle.Constant.padding)
         }
         .background(RoundedRectangle(cornerRadius: 8.0)
-            .foregroundColor(Color(designSystemColor: .surface))
+            .foregroundColor(Color(singleUseColor: .groupedListContentBackground))
         )
         .padding([.horizontal, .top], 20)
         .padding(.bottom, 30)

--- a/iOS/DuckDuckGo/BookmarkDetailsCell.swift
+++ b/iOS/DuckDuckGo/BookmarkDetailsCell.swift
@@ -34,7 +34,7 @@ class BookmarkDetailsCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        backgroundColor = UIColor(designSystemColor: .surface)
+        backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
         separatorView.backgroundColor = UIColor(designSystemColor: .lines)
         faviconImageView.round(corners: .allCorners, radius: Constant.faviconCornerRadius)
     }

--- a/iOS/DuckDuckGo/BookmarkFolderCell.swift
+++ b/iOS/DuckDuckGo/BookmarkFolderCell.swift
@@ -34,7 +34,7 @@ class BookmarkFolderCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        backgroundColor = UIColor(designSystemColor: .surface)
+        backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
         folderImageView.tintColor = UIColor(designSystemColor: .icons)
         title.textColor = UIColor(designSystemColor: .textPrimary)
     }

--- a/iOS/DuckDuckGo/BookmarkFoldersTableViewController.swift
+++ b/iOS/DuckDuckGo/BookmarkFoldersTableViewController.swift
@@ -141,7 +141,7 @@ class BookmarkFoldersViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         
-        cell.backgroundColor = UIColor(designSystemColor: .surface)
+        cell.backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
     }
 
     func folderSelectorCell(_ tableView: UITableView, forIndexPath indexPath: IndexPath) -> UITableViewCell {
@@ -287,7 +287,7 @@ class FavoriteCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        backgroundColor = UIColor(designSystemColor: .surface)
+        backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
         iconImageView.image = DesignSystemImages.Color.Size24.favorite
         iconImageView.tintColor = UIColor(designSystemColor: .icons)
         label.textColor = UIColor(designSystemColor: .textPrimary)
@@ -301,7 +301,7 @@ class BookmarksDeleteButtonCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        backgroundColor = UIColor(designSystemColor: .surface)
+        backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
         deleteButton.textColor = UIColor(designSystemColor: .buttonsDeleteGhostText)
     }
 }
@@ -314,7 +314,7 @@ class AddFolderCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        backgroundColor = UIColor(designSystemColor: .surface)
+        backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
         iconImageView.image = DesignSystemImages.Glyphs.Size24.folderAdd
         iconImageView.tintColor = UIColor(designSystemColor: .icons)
         label.textColor = UIColor(designSystemColor: .textPrimary)

--- a/iOS/DuckDuckGo/BookmarksTextFieldCell.swift
+++ b/iOS/DuckDuckGo/BookmarksTextFieldCell.swift
@@ -26,7 +26,7 @@ class BookmarksTextFieldCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        backgroundColor = UIColor(designSystemColor: .surface)
+        backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
     }
 
 

--- a/iOS/DuckDuckGo/CreditCardManagement/List/AutofillCreditCardListView.swift
+++ b/iOS/DuckDuckGo/CreditCardManagement/List/AutofillCreditCardListView.swift
@@ -52,7 +52,7 @@ struct AutofillCreditCardListView: View {
                             }
                         }
                     }
-                    .listRowBackground(Color(designSystemColor: .surface))
+                    .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
                 }
                 .applyInsetGroupedListStyle()
             }

--- a/iOS/DuckDuckGo/DataImport/Hub/DataImportHubView.swift
+++ b/iOS/DuckDuckGo/DataImport/Hub/DataImportHubView.swift
@@ -35,7 +35,7 @@ struct DataImportHubView: View {
                 } header: {
                     sectionHeader(for: section)
                 }
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             }
         }
         .applyInsetGroupedListStyle()

--- a/iOS/DuckDuckGo/DataImport/Hub/ImportSourceDetailView.swift
+++ b/iOS/DuckDuckGo/DataImport/Hub/ImportSourceDetailView.swift
@@ -45,7 +45,7 @@ struct ImportSourceDetailView: View {
                     .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
                     .listRowSeparator(.hidden)
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
 
             if let bottomSection = source.bottomSection {
                 Section {
@@ -53,7 +53,7 @@ struct ImportSourceDetailView: View {
                 } header: {
                     Text(UserText.importDetailDoneExportingHeader)
                 }
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             }
         }
         .applyInsetGroupedListStyle()

--- a/iOS/DuckDuckGo/DebugScreensViewController.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewController.swift
@@ -64,9 +64,9 @@ struct DebugScreensView: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                 }
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
                 DebugTogglesView(model: model)
-                    .listRowBackground(Color(designSystemColor: .surface))
+                    .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
 
                 if !model.pinnedScreens.isEmpty {
                     DebugScreensListView(model: model, sectionTitle: "Pinned", screens: model.pinnedScreens)
@@ -77,7 +77,7 @@ struct DebugScreensView: View {
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
 
                 DebugScreensListView(model: model, sectionTitle: "Screens", screens: model.unpinnedScreens)
                 DebugScreensListView(model: model, sectionTitle: "Actions", screens: model.actions)
@@ -122,7 +122,7 @@ struct DebugScreensView: View {
                             }
                         }
                     }
-                    .listRowBackground(Color(designSystemColor: .surface))
+                    .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
                 }
             }
         }
@@ -179,7 +179,7 @@ struct DebugScreensListView: View {
                     }
                 }
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         } header: {
             Text(verbatim: sectionTitle)
         }

--- a/iOS/DuckDuckGo/ImportPromotion/ImportPromotionHeaderView.swift
+++ b/iOS/DuckDuckGo/ImportPromotion/ImportPromotionHeaderView.swift
@@ -78,7 +78,7 @@ struct ImportPromotionHeaderView: View {
             .padding(ContainerMetrics.closeButtonPadding - CloseButtonStyle.Constant.padding)
         }
         .background(RoundedRectangle(cornerRadius: ContainerMetrics.cornerRadius)
-            .foregroundColor(Color(designSystemColor: .surface))
+            .foregroundColor(Color(singleUseColor: .groupedListContentBackground))
         )
         .onAppear {
             isAnimating = true

--- a/iOS/DuckDuckGo/ListBasedPicker.swift
+++ b/iOS/DuckDuckGo/ListBasedPicker.swift
@@ -70,7 +70,7 @@ struct ListBasedPicker<T: Hashable, Footer: View>: View {
                                 .opacity(selectedOption == option ? 1 : 0)
                         }
                     }
-                    .listRowBackground(Color(designSystemColor: .surface))
+                    .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
                 }
             } header: {
                 if let sectionHeader {

--- a/iOS/DuckDuckGo/ListBasedPickerWithHeaderImage.swift
+++ b/iOS/DuckDuckGo/ListBasedPickerWithHeaderImage.swift
@@ -63,7 +63,7 @@ struct ListBasedPickerWithHeaderImage<T: Hashable>: View {
                     headerImage
                     Spacer()
                 }
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
 
                 ForEach(options, id: \.self) { option in
                     HStack {
@@ -80,7 +80,7 @@ struct ListBasedPickerWithHeaderImage<T: Hashable>: View {
                             .foregroundStyle(Color(designSystemColor: .accentPrimary))
                             .opacity(selectedOption == option ? 1 : 0)
                     }
-                    .listRowBackground(Color(designSystemColor: .surface))
+                    .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
                 }
                 .navigationTitle(Text(title))
             }

--- a/iOS/DuckDuckGo/LogViewer/LogFilterViewController.swift
+++ b/iOS/DuckDuckGo/LogViewer/LogFilterViewController.swift
@@ -193,7 +193,7 @@ extension LogFilterViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
-        cell.backgroundColor = UIColor(designSystemColor: .surface)
+        cell.backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
         cell.textLabel?.textColor = UIColor(designSystemColor: .textPrimary)
         cell.detailTextLabel?.textColor = UIColor(designSystemColor: .textSecondary)
         

--- a/iOS/DuckDuckGo/LogViewer/LogViewerViewController.swift
+++ b/iOS/DuckDuckGo/LogViewer/LogViewerViewController.swift
@@ -297,7 +297,7 @@ private class LogEntryTableViewCell: UITableViewCell {
     }
     
     private func setupUI() {
-        backgroundColor = UIColor(designSystemColor: .surface)
+        backgroundColor = UIColor(singleUseColor: .groupedListContentBackground)
 
         messageLabel.translatesAutoresizingMaskIntoConstraints = false
         messageLabel.font = UIFont.daxBodyRegular()

--- a/iOS/DuckDuckGo/NetworkProtectionDNSSettingsView.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionDNSSettingsView.swift
@@ -50,7 +50,7 @@ struct NetworkProtectionDNSSettingsView: View {
                             .foregroundColor(.init(designSystemColor: .textSecondary))
                     }
                 }
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
                 .onChange(of: viewModel.isCustomDNSSelected) { _ in
                     viewModel.updateApplyButtonState()
                 }
@@ -102,7 +102,7 @@ struct NetworkProtectionDNSSettingsView: View {
             Text(UserText.vpnSettingDNSSectionDisclaimer)
                 .foregroundColor(.init(designSystemColor: .textSecondary))
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         .onAppear {
             isCustomDNSServerFocused = true
         }

--- a/iOS/DuckDuckGo/NetworkProtectionStatusView.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionStatusView.swift
@@ -139,7 +139,7 @@ struct NetworkProtectionStatusView: View {
             header()
         }
         .increaseHeaderProminence()
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
 
         Section {
             if #available(iOS 18.0, *) {
@@ -154,7 +154,7 @@ struct NetworkProtectionStatusView: View {
                     .padding(.horizontal, 3)
             }
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -254,7 +254,7 @@ struct NetworkProtectionStatusView: View {
             Text(statusModel.isNetPEnabled ? UserText.vpnLocationConnected : UserText.vpnLocationSelected)
                 .foregroundColor(.init(designSystemColor: .textSecondary))
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
 
         Section {
             if #available(iOS 18.0, *) {
@@ -263,7 +263,7 @@ struct NetworkProtectionStatusView: View {
                     .padding(.horizontal, 3)
             }
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -318,7 +318,7 @@ struct NetworkProtectionStatusView: View {
         } header: {
             Text(UserText.netPStatusViewConnectionDetails).foregroundColor(.init(designSystemColor: .textSecondary))
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -335,7 +335,7 @@ struct NetworkProtectionStatusView: View {
         } header: {
             Text(UserText.netPStatusViewSettingsSectionTitle).foregroundColor(.init(designSystemColor: .textSecondary))
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -363,7 +363,7 @@ struct NetworkProtectionStatusView: View {
         } header: {
             Text(UserText.vpnAbout).foregroundColor(.init(designSystemColor: .textSecondary))
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -606,7 +606,7 @@ private struct NetworkProtectionErrorView: View {
                     .foregroundColor(.primary)
             }
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 }
 
@@ -623,7 +623,7 @@ private struct NetworkProtectionLocationItemView: View {
             Text(title)
                 .daxBodyRegular()
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 }
 
@@ -641,7 +641,7 @@ private struct NetworkProtectionConnectionDetailView: View {
                 .daxBodyRegular()
                 .foregroundColor(.init(designSystemColor: .textSecondary))
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 }
 
@@ -671,7 +671,7 @@ private struct NetworkProtectionThroughputItemView: View {
                 .daxBodyRegular()
                 .foregroundColor(.init(designSystemColor: .textSecondary))
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 }
 

--- a/iOS/DuckDuckGo/NetworkProtectionUIElements.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionUIElements.swift
@@ -82,7 +82,7 @@ struct NetworkProtectionUIElements {
                     .daxFootnoteRegular()
                     .padding(.top, 6)
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         }
     }
 

--- a/iOS/DuckDuckGo/NetworkProtectionVPNLocationView.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionVPNLocationView.swift
@@ -62,7 +62,7 @@ struct NetworkProtectionVPNLocationView: View {
                 .daxFootnoteRegular()
                 .padding(.top, 6)
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -90,7 +90,7 @@ struct NetworkProtectionVPNLocationView: View {
                 .foregroundStyle(Color(designSystemColor: .textPrimary))
         }
         .animation(.default, value: model.state.isLoading)
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 }
 

--- a/iOS/DuckDuckGo/NetworkProtectionVPNSettingsView.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionVPNSettingsView.swift
@@ -149,7 +149,7 @@ struct NetworkProtectionVPNSettingsView: View {
                     .foregroundColor(.init(designSystemColor: .textSecondary))
             }
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -180,7 +180,7 @@ struct NetworkProtectionVPNSettingsView: View {
                 .daxFootnoteRegular()
                 .foregroundColor(.init(designSystemColor: .textSecondary))
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     private var copySupportInfoIcon: Image {
@@ -273,7 +273,7 @@ struct NetworkProtectionVPNSettingsView: View {
                 .daxFootnoteRegular()
                 .padding(.top, 6)
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -289,7 +289,7 @@ struct NetworkProtectionVPNSettingsView: View {
                 .daxFootnoteRegular()
                 .padding(.top, 6)
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -311,7 +311,7 @@ struct NetworkProtectionVPNSettingsView: View {
                 .daxFootnoteRegular()
                 .padding(.top, 6)
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -357,7 +357,7 @@ struct NetworkProtectionVPNSettingsView: View {
             } header: {
                 Text(UserText.netPVPNShortcutsSectionHeader)
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         }
     }
 }

--- a/iOS/DuckDuckGo/PrivateSearchView.swift
+++ b/iOS/DuckDuckGo/PrivateSearchView.swift
@@ -35,9 +35,9 @@ struct PrivateSearchView: View {
     var body: some View {
         List {
             SettingsDescriptionView(content: description)
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             PrivateSearchViewSettings()
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         }
         .applySettingsListModifiers(title: UserText.privateSearch,
                                     displayMode: .inline,
@@ -74,7 +74,7 @@ struct PrivateSearchViewSettings: View {
                 SettingsCellView(label: UserText.moreSearchSettings,
                                  subtitle: UserText.moreSearchSettingsExplanation)
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         }
     }
 }

--- a/iOS/DuckDuckGo/SettingsAIChatShortcutsView.swift
+++ b/iOS/DuckDuckGo/SettingsAIChatShortcutsView.swift
@@ -155,7 +155,7 @@ struct SettingsAIChatShortcutsView: View {
                 } header: {
                     Text(UserText.duckAIShortcutsSectionHeader)
                 }
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             }
         }
     }

--- a/iOS/DuckDuckGo/SettingsAIFeaturesView.swift
+++ b/iOS/DuckDuckGo/SettingsAIFeaturesView.swift
@@ -129,7 +129,7 @@ private struct SettingsAINativeFeaturesView: AIFeaturesSettingsRowProviding {
             } header: {
                 Text(UserText.settingsDuckAiSectionHeader)
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         }
 
         // Always shown: the button disables all AI while any is on, then greys out
@@ -150,7 +150,7 @@ private struct SettingsAINativeFeaturesView: AIFeaturesSettingsRowProviding {
         } footer: {
             Text(viewModel.isAllAIDisabled ? UserText.settingsAiFeaturesDisableAllFooterDisabled : UserText.settingsAiFeaturesDisableAllFooter)
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 }
 

--- a/iOS/DuckDuckGo/SettingsAppearanceView.swift
+++ b/iOS/DuckDuckGo/SettingsAppearanceView.swift
@@ -164,7 +164,7 @@ struct SettingsAppearanceView: View {
             }
 
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
 
     }
 
@@ -184,7 +184,7 @@ struct SettingsAppearanceView: View {
                 SettingsCellView(label: UserText.mobileCustomizationToolbarTitle, accessory: .rightDetail(UserText.mobileCustomizationNoneOptionShort))
             }
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
 
     }
 

--- a/iOS/DuckDuckGo/SettingsCell.swift
+++ b/iOS/DuckDuckGo/SettingsCell.swift
@@ -136,7 +136,7 @@ struct SettingsCellView: View, Identifiable {
             }
         }
         .frame(maxWidth: .infinity)
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     private var cellContent: some View {
@@ -330,7 +330,7 @@ struct SettingsPickerCellView<T: Hashable & CustomStringConvertible>: View {
             }
             .fixedSize()
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     private var pickerSelectionLabel: some View {
@@ -412,7 +412,7 @@ struct SettingsCustomCell<Content: View>: View {
                 cellContent
             }
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     private var cellContent: some View {

--- a/iOS/DuckDuckGo/SettingsGeneralView.swift
+++ b/iOS/DuckDuckGo/SettingsGeneralView.swift
@@ -153,7 +153,7 @@ struct SettingsGeneralView: View {
                     SettingsCellView(label: UserText.settingsAutoplayLabel,
                                      accessory: .rightDetail(viewModel.state.autoplayBlockingMode.description))
                 }
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             }
 
         }

--- a/iOS/DuckDuckGo/SettingsRootView.swift
+++ b/iOS/DuckDuckGo/SettingsRootView.swift
@@ -69,21 +69,21 @@ struct SettingsRootView: View {
             if #available(iOS 18.2, *) {
                 if viewModel.shouldShowSetAsDefaultBrowser || viewModel.shouldShowImportPasswords {
                     SettingsCompleteSetupView()
-                        .listRowBackground(Color(designSystemColor: .surface))
+                        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
                 }
             }
             SettingsPrivacyProtectionsView()
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             SettingsSubscriptionView().environmentObject(subscriptionNavigationCoordinator)
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             SettingsMainSettingsView()
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             SettingsNextStepsView()
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             SettingsOthersView()
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             SettingsDebugView()
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         }
         .navigationBarTitle(UserText.settingsTitle, displayMode: .inline)
         .navigationBarItems(trailing: Button(UserText.navigationTitleDone) {

--- a/iOS/DuckDuckGo/SettingsYouTubeAdBlockingView.swift
+++ b/iOS/DuckDuckGo/SettingsYouTubeAdBlockingView.swift
@@ -62,7 +62,7 @@ struct SettingsYouTubeAdBlockingView: View {
                 if viewModel.isYouTubeAdBlockingRemotelyDisabled {
                     Section(header: Text(UserText.adBlockingYouTubeSectionHeader)) {
                         remotelyDisabledRow
-                            .listRowBackground(Color(designSystemColor: .surface))
+                            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
                     }
                 } else if viewModel.isYouTubeAdBlockingDisclosureHidden {
                     Section(header: Text(UserText.adBlockingYouTubeSectionHeader),
@@ -84,7 +84,7 @@ struct SettingsYouTubeAdBlockingView: View {
                 ) {
                     SettingsCellView(label: UserText.duckPlayerFeatureName)
                 }
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
                 .disabled(viewModel.shouldDisplayDuckPlayerContingencyMessage)
             }
         }

--- a/iOS/DuckDuckGo/Subscription/Feedback/UnifiedFeedbackRootView.swift
+++ b/iOS/DuckDuckGo/Subscription/Feedback/UnifiedFeedbackRootView.swift
@@ -146,14 +146,14 @@ struct UnifiedFeedbackCategoryView<Category: FeedbackCategoryProviding, Destinat
                                 .foregroundColor(.init(designSystemColor: .textPrimary))
                         }
                         .tag(option.rawValue)
-                        .listRowBackground(Color(designSystemColor: .surface))
+                        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
                     }
                 } header: {
                     Text(prompt)
                         .font(.caption)
                 }
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         }
         .applyInsetGroupedListStyle()
         .navigationTitle(title)

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
@@ -117,7 +117,7 @@ struct SubscriptionSettingsViewV2: View {
                     .daxBodyRegular()
                     .foregroundColor(Color(designSystemColor: .textPrimary))
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
 
             // Row 2: Upgrade button with chevron
             if let tierName = viewModel.firstAvailableUpgradeTier {
@@ -451,7 +451,7 @@ struct SubscriptionSettingsViewV2: View {
                 .padding(.vertical, -10)
             if viewModel.state.cancelPendingDowngradeDetails != nil {
                 downgradeBanner
-                    .listRowBackground(Color(designSystemColor: .surface))
+                    .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             }
             if viewModel.shouldShowUpgrade {
                 upgradeSection
@@ -611,7 +611,7 @@ struct SubscriptionSettingsViewV2: View {
                         .daxBodyRegular()
                         .foregroundColor(Color(designSystemColor: .textPrimary))
                 }
-                .listRowBackground(Color(designSystemColor: .surface))
+                .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
 
                 // Row 2: Cancel downgrade button
                 SettingsCustomCell(content: {

--- a/iOS/DuckDuckGo/SyncPromoView.swift
+++ b/iOS/DuckDuckGo/SyncPromoView.swift
@@ -81,7 +81,7 @@ struct SyncPromoView: View {
         }
         .background(
             RoundedRectangle(cornerRadius: ContainerMetrics.cornerRadius)
-                .foregroundColor(Color(designSystemColor: .surface))
+                .foregroundColor(Color(singleUseColor: .groupedListContentBackground))
         )
         .padding(.horizontal, 20)
         .padding(.bottom, 12)

--- a/iOS/DuckDuckGo/Theme+DesignSystem.swift
+++ b/iOS/DuckDuckGo/Theme+DesignSystem.swift
@@ -29,7 +29,7 @@ extension Theme {
     var barBackgroundColor: UIColor { UIColor(designSystemColor: .panel) }
     var barTintColor: UIColor { UIColor(designSystemColor: .icons) }
     var browsingMenuBackgroundColor: UIColor { UIColor(designSystemColor: .surface) }
-    var tableCellBackgroundColor: UIColor { UIColor(designSystemColor: .surface) }
+    var tableCellBackgroundColor: UIColor { UIColor(singleUseColor: .groupedListContentBackground) }
     var tabSwitcherCellBackgroundColor: UIColor { UIColor(designSystemColor: .surface) }
     var searchBarTextPlaceholderColor: UIColor { UIColor(designSystemColor: .textSecondary) }
     

--- a/iOS/LocalPackages/DuckUI/Sources/DuckUI/DuckUIDebugMenuView.swift
+++ b/iOS/LocalPackages/DuckUI/Sources/DuckUI/DuckUIDebugMenuView.swift
@@ -39,7 +39,7 @@ public struct DuckUIDebugMenuView: View {
                     IOSButtonsDebugView()
                 }
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
 
             Section(header: Text(verbatim: "Typography")) {
                 row("Text Styles", title: "Text Styles") {
@@ -49,7 +49,7 @@ public struct DuckUIDebugMenuView: View {
                     AppFontGallery()
                 }
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         }
         .navigationTitle("DuckUI")
     }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/AutoRestoreSettingsView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/AutoRestoreSettingsView.swift
@@ -42,7 +42,7 @@ struct AutoRestoreSettingsView: View {
                     .foregroundColor(Color(designSystemColor: .textPrimary))
                     .disabled(model.isAutoRestoreUpdating)
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         }
         .navigationTitle(UserText.autoRestoreScreenTitle)
         .navigationBarTitleDisplayMode(.inline)

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/ManageDeviceViewV2.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/ManageDeviceViewV2.swift
@@ -118,7 +118,7 @@ struct ManageDeviceViewV2: View {
                 }
                 .accessibility(identifier: "deviceName")
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     private var syncToggleSection: some View {
@@ -138,7 +138,7 @@ struct ManageDeviceViewV2: View {
         } footer: {
             Text(UserText.simplifiedManageDeviceTurnOffFooter)
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     private var syncToggleBinding: Binding<Bool> {
@@ -173,7 +173,7 @@ struct ManageDeviceViewV2: View {
         } footer: {
             Text(UserText.simplifiedManageDeviceRemoveFooter)
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         .alert(UserText.removeDeviceTitle, isPresented: $isShowingRemoveConfirmation) {
             Button(UserText.cancelButton, role: .cancel) {}
             Button(UserText.removeDeviceButton, role: .destructive) {

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SimplifiedSyncSettingsView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SimplifiedSyncSettingsView.swift
@@ -220,7 +220,7 @@ extension SimplifiedSyncSettingsView {
             .animation(.easeInOut(duration: 0.3), value: model.isBusy)
             .disabled(model.isBusy || (!model.isSyncEnabled && !model.isAccountCreationAvailable))
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -260,7 +260,7 @@ extension SimplifiedSyncSettingsView {
         } header: {
             Text(UserText.simplifiedAlreadySetUpSectionHeader)
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -282,7 +282,7 @@ extension SimplifiedSyncSettingsView {
             }
             .buttonStyle(.plain)
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 }
 
@@ -424,7 +424,7 @@ extension SimplifiedSyncSettingsView {
                 model.delegate?.refreshDevices(clearDevices: false)
             }
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -506,7 +506,7 @@ extension SimplifiedSyncSettingsView {
         .onAppear {
             model.delegate?.updateOptions()
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     // MARK: Recovery
@@ -548,7 +548,7 @@ extension SimplifiedSyncSettingsView {
             Text(LocalizedStringKey(String(format: UserText.simplifiedRecoverySectionFooterFormat, "ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/sync-and-backup/recovery-codes-and-troubleshooting#does-my-sync--backup-data-ever-expire")))
                 .tint(Color(designSystemColor: .accentPrimary))
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     // MARK: Delete
@@ -562,6 +562,6 @@ extension SimplifiedSyncSettingsView {
                 Text(UserText.simplifiedDeleteSyncDataButton)
             }
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 }

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SimplifiedSyncSettingsViewV2.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SimplifiedSyncSettingsViewV2.swift
@@ -225,13 +225,13 @@ extension SimplifiedSyncSettingsViewV2 {
             .animation(.easeInOut(duration: 0.3), value: model.isBusy)
             .disabled(model.isBusy || (!model.isSyncEnabled && !model.isAccountCreationAvailable))
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
 
         if !model.isSyncEnabled {
             Section {
                 syncWithAnotherDeviceButton
             }
-            .listRowBackground(Color(designSystemColor: .surface))
+            .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
         }
     }
 
@@ -275,7 +275,7 @@ extension SimplifiedSyncSettingsViewV2 {
         } header: {
             Text(UserText.simplifiedRecoverSyncedDataSectionHeader)
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -294,7 +294,7 @@ extension SimplifiedSyncSettingsViewV2 {
         } header: {
             Text(UserText.simplifiedDownloadSectionHeader)
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 }
 
@@ -421,7 +421,7 @@ extension SimplifiedSyncSettingsViewV2 {
                 model.delegate?.refreshDevices(clearDevices: false)
             }
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     @ViewBuilder
@@ -536,7 +536,7 @@ extension SimplifiedSyncSettingsViewV2 {
         .onAppear {
             model.delegate?.updateOptions()
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     // MARK: Recovery
@@ -590,7 +590,7 @@ extension SimplifiedSyncSettingsViewV2 {
             Text(LocalizedStringKey(String(format: UserText.simplifiedRecoverySectionFooterFormat, "ddgQuickLink://duckduckgo.com/duckduckgo-help-pages/sync-and-backup/recovery-codes-and-troubleshooting#does-my-sync--backup-data-ever-expire")))
                 .tint(Color(designSystemColor: .accentPrimary))
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     // MARK: Delete
@@ -604,7 +604,7 @@ extension SimplifiedSyncSettingsViewV2 {
                 Text(UserText.simplifiedDeleteSyncDataButton)
             }
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 }
 

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncSuccessViewV2.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncSuccessViewV2.swift
@@ -152,7 +152,7 @@ struct SyncSuccessViewV2: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     private var autoRestoreSection: some View {
@@ -163,7 +163,7 @@ struct SyncSuccessViewV2: View {
                 .foregroundColor(Color(designSystemColor: .textPrimary))
                 .disabled(model.isAutoRestoreUpdating)
         }
-        .listRowBackground(Color(designSystemColor: .surface))
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217007650852231
Tech Design URL:
CC:

### Description

This PR updates the rebranded iOS colour palette to the latest Figma values. This isn't a fully automatically synced palette, but a stop-gap solution where we just update the rebranded palette with the latest colours. In a future update we can make changes so that the palettes have a more similar structure and naming to Figma's palettes, so syncing values becomes simpler.

This PR also updates the background color of grouped list content, from the old `surface` (which was actually Figma's `surfaceSecondary`) to `surfaceTertiary`. This is because the contrast between cells and the table background was too low if we continued to use `surfaceSecondary`. I've dropped in a temporary `singleUserColor` to wrap this change at the moment, but in a future update and when we remove the flag we can clean things up.

Some screenshots:

| Appearance | Bookmarks | Menu | Private Search | Settings | Sync |
|---|---|---|---|---|---|
| <img alt="appearance-light" src="https://github.com/user-attachments/assets/6f959d44-9d81-46b2-ac84-243980c9c89a" /> | <img alt="bookmarks-light" src="https://github.com/user-attachments/assets/884693d3-f3fc-434c-bcbb-915af103541f" /> | <img alt="menu-light" src="https://github.com/user-attachments/assets/e43c9409-8270-47a8-9eda-607f5c1cd20f" /> | <img alt="privateSearch-light" src="https://github.com/user-attachments/assets/878acc03-5b1d-4688-86e0-c569acdf57a3" /> | <img alt="settings-light" src="https://github.com/user-attachments/assets/9e7c08e1-8d36-40b8-8deb-56c0278e34b1" /> | <img alt="sync-light" src="https://github.com/user-attachments/assets/eed5a7e2-7dd2-4f02-8502-16894edc8083" /> |
| <img alt="appearance-dark" src="https://github.com/user-attachments/assets/d21de09c-a6d2-4a6b-8739-12b40e389474" /> | <img alt="bookmarks-dark" src="https://github.com/user-attachments/assets/874bab78-4534-4e9c-a4e7-6d773c3dce35" /> | <img alt="menu-dark" src="https://github.com/user-attachments/assets/85e6976e-bc14-473a-b751-fbd637cbebe1" /> | <img alt="privateSearch-dark" src="https://github.com/user-attachments/assets/1f83d9b0-6784-49cf-b836-40721cf661bb" /> | <img alt="settings-dark" src="https://github.com/user-attachments/assets/ec7ea828-c312-4892-bf8a-3c5cf9cfa2df" /> | <img alt="sync-dark" src="https://github.com/user-attachments/assets/ae6e8bfe-a91d-440f-a802-1a03cb846af0" /> |


### Testing Steps

1. Smoke test settings screens, and pick some other areas affected by these changes. The difference in colour between panel / row backgrounds and their parent view's backgrounds should be similar to the existing release.
   - Settings, autofill / sync screens, bookmarks, sync promos, etc.

### Impact

Low: Minor visual changes, small bug fixes, improvement to existing features

Low in that it's just visual, but could make prominent app surfaces look worse if done incorrectly.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide visual-only sweep across major app surfaces; wrong palette mapping could flatten grouped-list contrast or regress rebranded appearance, but no logic or security impact.
> 
> **Overview**
> Updates the **rebranded** iOS color palette to latest Figma values for core surfaces, text, icons, controls, shadows, and decorations, while unmapped tokens still fall through to the default palette.
> 
> Introduces **`SingleUseColor.groupedListContentBackground`** as a temporary bridge: legacy palette maps it to **`surface`**; rebranded maps it to **`surfaceTertiary`** so inset-grouped rows read brighter against the list chrome. **`Theme.tableCellBackgroundColor`** uses the same token.
> 
> Across settings, autofill, bookmarks, sync, VPN, AI chat history, promos, and related UI, row/card backgrounds move from **`Color(designSystemColor: .surface)`** / **`UIColor(designSystemColor: .surface)`** to the new single-use color so rebranded contrast fixes apply without changing legacy row color yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5242f355d445ce11e08757ede8fe34f2582f41bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->