### PR TITLE
iOS: Update 7.231.0 release notes

### DIFF
--- a/iOS/fastlane/metadata/default/release_notes.txt
+++ b/iOS/fastlane/metadata/default/release_notes.txt
@@ -1,2 +1,1 @@
-• The new “Copy Clean Link” option lets you copy a version of the page URL without unnecessary parameters added by the site. Find “Copy Clean Link” in the browser menu.
-• This update includes various other improvements and bug fixes, including a few address bar usability improvements.
+• Bug fixes and other improvements.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216899902878335
Tech Design URL: N/A
CC:

### Description
Replaces the iOS App Store release notes with the generic "Bug fixes and other improvements." line for 7.231.0, since there's no new user-facing feature to announce in this release.

### Testing Steps
1. Open `iOS/fastlane/metadata/default/release_notes.txt` → it contains a single bullet: "• Bug fixes and other improvements."

### Impact
None — App Store metadata only, no code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> App Store metadata text only; no runtime or security impact.
> 
> **Overview**
> Updates **iOS App Store release notes** for **7.231.0** by replacing the previous two bullets (Copy Clean Link and general improvements) with the standard single line: **"Bug fixes and other improvements."**
> 
> No app code changes—only `iOS/fastlane/metadata/default/release_notes.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4077d2a8bef24d36c83bbfc00589302b6fbc013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->