### PR TITLE
[iOS] Turn on Simplified Sync Setup V2 feature flag by default

### DIFF
--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -880,7 +880,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .syncCanShowV2ConnectCode:
             Config(source: .remoteReleasable(SyncSubfeature.canShowV2ConnectCode))
         case .simplifiedSyncSetupV2:
-            Config(source: .remoteReleasable(SyncSubfeature.simplifiedSyncSetupV2))
+            Config(defaultValue: .enabled, source: .remoteReleasable(SyncSubfeature.simplifiedSyncSetupV2))
         case .blankSnapshotCaching:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.blankSnapshotCaching))
         case .systemFindInPage:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1216981810116834

### Description
Turns on the `simplifiedSyncSetupV2` feature flag by default so the Simplified Sync Setup V2 flow is available to all users. Remote privacy config can still override it.

### Testing Steps
1. Build and run the iOS app (no local override / fresh privacy config).
2. Go to Settings → Sync & Backup → Sync with Another Device → the Simplified Sync Setup V2 screens are shown.

### Impact
Medium — enables a new sync setup flow for all users; still gated behind a remotely-releasable subfeature that can disable it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
