### PR TITLE
[iOS] extra guards for preview snapshot crash

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6092,16 +6092,10 @@ extension MainViewController: TabDelegate {
         // Capture source tab preview now; otherwise its thumbnail stays stale once we switch to the new tab.
         guard tab.link != nil else { return }
 
-        if floatingUIManager.isFloatingUIEnabled {
-            tab.preparePreview { [weak self, weak tab] image in
-                guard let self, let tab, let image else { return }
-                previewsSource.update(preview: image, forTab: tab.tabModel)
-            }
-            return
+        tab.preparePreviewForTabTransition { [weak self, weak tab] image in
+            guard let self, let tab, let image else { return }
+            previewsSource.update(preview: image, forTab: tab.tabModel)
         }
-
-        guard let image = tab.preparePreviewSync() else { return }
-        previewsSource.update(preview: image, forTab: tab.tabModel)
     }
 
     func tab(_ tab: TabViewController,

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2287,8 +2287,33 @@ extension TabViewController: WKNavigationDelegate {
         }
     }
 
-    // Synchronous capture, used when we must grab the preview before the view is torn down.
-    func preparePreviewSync(afterScreenUpdates: Bool = false) -> UIImage? {
+    func preparePreviewForTabTransition(completion: @escaping (UIImage?) -> Void) {
+        guard let webView else {
+            completion(nil)
+            return
+        }
+
+        let contentInset = webView.scrollView.contentInset
+        let rect = webView.bounds.inset(by: UIEdgeInsets(top: contentInset.top,
+                                                        left: 0,
+                                                        bottom: contentInset.bottom,
+                                                        right: 0))
+        guard rect.width > 0, rect.height > 0 else {
+            completion(nil)
+            return
+        }
+
+        let configuration = WKSnapshotConfiguration()
+        configuration.rect = rect
+        configuration.afterScreenUpdates = false
+        webView.takeSnapshot(with: configuration) { image, _ in
+            DispatchQueue.main.async {
+                completion(image)
+            }
+        }
+    }
+
+    private func preparePreviewSync(afterScreenUpdates: Bool = false) -> UIImage? {
         guard let webView, webView.bounds.height > 0, webView.bounds.width > 0 else { return nil }
 
         let size = CGSize(width: webView.frame.size.width,

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2288,7 +2288,8 @@ extension TabViewController: WKNavigationDelegate {
     }
 
     func preparePreviewForTabTransition(completion: @escaping (UIImage?) -> Void) {
-        guard let webView else {
+        guard let webView,
+              webView.window?.windowScene?.activationState == .foregroundActive else {
             completion(nil)
             return
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1216941269820703?focus=true
Tech Design URL:
CC:

### Description
Changes tab thumbnail capture when a webpage opens a new tab to avoid a system rendering crash. This does not enable feature-gated UI.

### Testing Steps
The reported crash is not reproducible, so these steps verify the affected flow for regressions.

1. Disable Floating UI.
2. Open a webpage containing a link that opens in a new tab.
3. Tap the link → the new tab opens normally.
4. Open the tab switcher → the source tab shows the correct thumbnail.
5. Repeat the flow rapidly → browsing remains responsive without crashing.
6. Background the app before repeating the flow → the app remains stable.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
A snapshot could fail or complete late → the existing cached thumbnail remains available.

A snapshot could be requested while the app is backgrounded → capture is skipped unless the scene is active.

### Quality Considerations
Capture now uses WebKit’s asynchronous snapshot API, avoiding synchronous rendering of out-of-process webpage content. No user data, analytics, or network behavior changes.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to tab-switcher thumbnail capture with graceful nil/fallback to cached previews; no auth, data, or network impact.
> 
> **Overview**
> When a page opens a new tab, **source-tab thumbnail capture** no longer uses synchronous `drawHierarchy` on the web view (except indirectly via other `preparePreview` paths). **`capturePreviewForTab`** always calls the new **`preparePreviewForTabTransition`**, which drops the Floating UI branch and the **`preparePreviewSync`** call for this flow.
> 
> **`preparePreviewForTabTransition`** captures via **`WKWebView.takeSnapshot`** with **`afterScreenUpdates: false`**, skips work when the window scene is not **foreground active**, validates a non-zero visible rect (accounting for scroll **contentInset**), and delivers the image on the main queue. **`preparePreviewSync`** is now **private** and remains for **`preparePreview`** when Floating UI is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39d32ef365c7a5eb372cea9a1b007d87da1b19e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->