### PR TITLE
[iOS] [MacOS] [Subscription] Add missing subscription funnel pixels

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionFreemiumPixels.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionFreemiumPixels.swift
@@ -32,6 +32,7 @@ public class DataBrokerProtectionFreemiumPixelHandler: EventMapping<DataBrokerPr
                     .newTabScanClickCount,
                     .newTabResultsClickCount,
                     .newTabNoResultsClickCount,
+                    .overFlowScanImpressionCount,
                     .overFlowScanCount,
                     .overFlowResultsCount:
                 PixelKit.fire(event, frequency: .standard)
@@ -68,6 +69,8 @@ public enum DataBrokerProtectionFreemiumPixels: PixelKitEvent {
     case newTabNoResultsClickCount
     case newTabNoResultsDismiss
     // Overflow menu
+    case overFlowScanImpression
+    case overFlowScanImpressionCount
     case overFlowScan
     case overFlowScanCount
     case overFlowResults
@@ -110,6 +113,10 @@ public enum DataBrokerProtectionFreemiumPixels: PixelKitEvent {
             return "dbp-free_newtab_no-results_click_c"
         case .newTabNoResultsDismiss:
             return "dbp-free_newtab_no-results_dismiss_u"
+        case .overFlowScanImpression:
+            return "dbp-free_overflow_scan_impression_u"
+        case .overFlowScanImpressionCount:
+            return "dbp-free_overflow_scan_impression_c"
         case .overFlowScan:
             return "dbp-free_overflow_scan_u"
         case .overFlowScanCount:
@@ -146,6 +153,8 @@ public enum DataBrokerProtectionFreemiumPixels: PixelKitEvent {
                 .newTabNoResultsClick,
                 .newTabNoResultsClickCount,
                 .newTabNoResultsDismiss,
+                .overFlowScanImpression,
+                .overFlowScanImpressionCount,
                 .overFlowScan,
                 .overFlowScanCount,
                 .overFlowResults,

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -34,31 +34,39 @@ import VPN
 struct VPNEntryPoint {
     let screenSource: VPNConnectionWideEventData.ScreenSource
     let subscriptionFunnelOrigin: SubscriptionFunnelOrigin
+    let subscriptionFunnelClickPixel: SubscriptionPixel
 
     static let toolbar = VPNEntryPoint(
         screenSource: .toolbar,
-        subscriptionFunnelOrigin: .toolbarVPN)
+        subscriptionFunnelOrigin: .toolbarVPN,
+        subscriptionFunnelClickPixel: .subscriptionVPNToolbarClick)
 
     static let addressBar = VPNEntryPoint(
         screenSource: .addressBar,
-        subscriptionFunnelOrigin: .addressBarVPN)
+        subscriptionFunnelOrigin: .addressBarVPN,
+        subscriptionFunnelClickPixel: .subscriptionVPNAddressBarClick)
 
     static let widget = VPNEntryPoint(
         screenSource: .widget,
-        subscriptionFunnelOrigin: .widgetVPN)
+        subscriptionFunnelOrigin: .widgetVPN,
+        subscriptionFunnelClickPixel: .subscriptionVPNWidgetClick)
 
     static let shortcut = VPNEntryPoint(
         screenSource: .shortcut,
-        subscriptionFunnelOrigin: .shortcutVPN)
+        subscriptionFunnelOrigin: .shortcutVPN,
+        subscriptionFunnelClickPixel: .subscriptionVPNShortcutClick)
 
     static let notification = VPNEntryPoint(
         screenSource: .notification,
-        subscriptionFunnelOrigin: .notificationVPN)
+        subscriptionFunnelOrigin: .notificationVPN,
+        subscriptionFunnelClickPixel: .subscriptionVPNNotificationClick)
 
     private init(screenSource: VPNConnectionWideEventData.ScreenSource,
-                 subscriptionFunnelOrigin: SubscriptionFunnelOrigin) {
+                 subscriptionFunnelOrigin: SubscriptionFunnelOrigin,
+                 subscriptionFunnelClickPixel: SubscriptionPixel) {
         self.screenSource = screenSource
         self.subscriptionFunnelOrigin = subscriptionFunnelOrigin
+        self.subscriptionFunnelClickPixel = subscriptionFunnelClickPixel
     }
 }
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1118,8 +1118,8 @@ class MainViewController: UIViewController {
 
     func presentNetworkProtectionStatusSettingsModal(entryPoint: VPNEntryPoint, scrollToStrictRouting: Bool = false) {
         Task {
-            let canShowVPNInUI = (try? await subscriptionManager.isFeatureIncludedInSubscription(.networkProtection)) ?? false
-            if canShowVPNInUI {
+            if let canShowVPNInUI = try? await subscriptionManager.isFeatureIncludedInSubscription(.networkProtection),
+               canShowVPNInUI {
                 segueToVPN(source: entryPoint.screenSource, scrollToStrictRouting: scrollToStrictRouting)
             } else {
                 PixelKit.fire(entryPoint.subscriptionFunnelClickPixel, frequency: .dailyAndCount)

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -349,6 +349,10 @@ class MainViewController: UIViewController {
 
     private var duckPlayerEntryPointVisible = false
     private var subscriptionManager = AppDependencyProvider.shared.subscriptionManager
+
+    // Ensure the VPN entry-point impression pixels fire at most once per app launch.
+    private var didFireVPNToolbarImpressionPixel = false
+    private var didFireVPNAddressBarImpressionPixel = false
     
     private let daxEasterEggPresenter: DaxEasterEggPresenting
     private let daxEasterEggLogoStore: DaxEasterEggLogoStoring
@@ -1114,10 +1118,11 @@ class MainViewController: UIViewController {
 
     func presentNetworkProtectionStatusSettingsModal(entryPoint: VPNEntryPoint, scrollToStrictRouting: Bool = false) {
         Task {
-            if let canShowVPNInUI = try? await subscriptionManager.isFeatureIncludedInSubscription(.networkProtection),
-               canShowVPNInUI {
+            let canShowVPNInUI = (try? await subscriptionManager.isFeatureIncludedInSubscription(.networkProtection)) ?? false
+            if canShowVPNInUI {
                 segueToVPN(source: entryPoint.screenSource, scrollToStrictRouting: scrollToStrictRouting)
             } else {
+                PixelKit.fire(entryPoint.subscriptionFunnelClickPixel, frequency: .dailyAndCount)
                 segueToDuckDuckGoSubscription(origin: entryPoint.subscriptionFunnelOrigin.rawValue)
             }
         }
@@ -7617,6 +7622,13 @@ extension MainViewController {
     func applyCustomizationForAddressBar(_ state: MobileCustomization.State) {
         omniBar.refreshCustomizableButton()
         if state.isEnabled {
+            if !isNewTabPageVisible, state.currentAddressBarButton == .vpn, !didFireVPNAddressBarImpressionPixel {
+                didFireVPNAddressBarImpressionPixel = true
+                Task {
+                    let isSubscriptionActive = (try? await subscriptionManager.getSubscription())?.isActive
+                    PixelKit.fire(SubscriptionPixel.subscriptionVPNAddressBarImpression(isSubscriptionActive: isSubscriptionActive), frequency: .dailyAndCount)
+                }
+            }
             omniBar.barView.customizableButton.menu = UIMenu(children: [
                 UIAction(title: "Customize", image: DesignSystemImages.Glyphs.Size16.options) { [weak self] _ in
                     self?.segueToCustomizeAddressBarSettings()
@@ -7683,6 +7695,14 @@ extension MainViewController {
 
         if let omniBarFireButton = viewCoordinator.omniBar.barView.fireButton as? BrowserChromeButton {
             customizeFireButton(omniBarFireButton, state: state)
+        }
+
+        if !isNewTabPageVisible, state.isEnabled, state.currentToolbarButton == .vpn, !didFireVPNToolbarImpressionPixel {
+            didFireVPNToolbarImpressionPixel = true
+            Task {
+                let isSubscriptionActive = (try? await subscriptionManager.getSubscription())?.isActive
+                PixelKit.fire(SubscriptionPixel.subscriptionVPNToolbarImpression(isSubscriptionActive: isSubscriptionActive), frequency: .dailyAndCount)
+            }
         }
     }
 

--- a/iOS/DuckDuckGo/Subscription/Pixels/SubscriptionPixel.swift
+++ b/iOS/DuckDuckGo/Subscription/Pixels/SubscriptionPixel.swift
@@ -37,6 +37,14 @@ enum SubscriptionPixel: PixelKitEvent {
     case subscriptionKeychainManagerDeallocatedWithBacklog(SubscriptionPixelHandler.Source)
     case subscriptionKeychainManagerDataWroteFromBacklog(SubscriptionPixelHandler.Source)
     case subscriptionKeychainManagerFailedToWriteDataFromBacklog(SubscriptionPixelHandler.Source)
+    // VPN Subscription Funnel Entry Points
+    case subscriptionVPNToolbarImpression(isSubscriptionActive: Bool?)
+    case subscriptionVPNToolbarClick
+    case subscriptionVPNAddressBarImpression(isSubscriptionActive: Bool?)
+    case subscriptionVPNAddressBarClick
+    case subscriptionVPNWidgetClick
+    case subscriptionVPNShortcutClick
+    case subscriptionVPNNotificationClick
 
     var name: String {
         switch self {
@@ -53,6 +61,14 @@ enum SubscriptionPixel: PixelKitEvent {
         case .subscriptionKeychainManagerDeallocatedWithBacklog: return "m_privacy-pro_keychain_manager_deallocated_with_backlog"
         case .subscriptionKeychainManagerDataWroteFromBacklog: return "m_privacy-pro_keychain_manager_data_wrote_from_backlog"
         case .subscriptionKeychainManagerFailedToWriteDataFromBacklog: return "m_privacy-pro_keychain_manager_failed_to_write_data_from_backlog"
+            // VPN Subscription Funnel Entry Points
+        case .subscriptionVPNToolbarImpression: return "subscription_vpn_toolbar_impression"
+        case .subscriptionVPNToolbarClick: return "subscription_vpn_toolbar_click"
+        case .subscriptionVPNAddressBarImpression: return "subscription_vpn_address-bar_impression"
+        case .subscriptionVPNAddressBarClick: return "subscription_vpn_address-bar_click"
+        case .subscriptionVPNWidgetClick: return "subscription_vpn_widget_click"
+        case .subscriptionVPNShortcutClick: return "subscription_vpn_shortcut_click"
+        case .subscriptionVPNNotificationClick: return "subscription_vpn_notification_click"
         }
     }
 
@@ -60,6 +76,14 @@ enum SubscriptionPixel: PixelKitEvent {
         static let policyCacheKey = "policycache"
         static let sourceKey = "source"
         static let platformKey = "platform"
+        static let vpnSubscriptionActiveKey = "vpnSubscriptionActive"
+    }
+
+    private static func vpnSubscriptionActiveValue(_ isSubscriptionActive: Bool?) -> String {
+        guard let isSubscriptionActive else {
+            return "no_subscription"
+        }
+        return String(isSubscriptionActive)
     }
 
     var parameters: [String: String]? {
@@ -75,6 +99,9 @@ enum SubscriptionPixel: PixelKitEvent {
         case .subscriptionAuthV2GetTokensError(let policy, let source, _):
             return [SubscriptionPixelsDefaults.policyCacheKey: policy.description,
                     SubscriptionPixelsDefaults.sourceKey: source.rawValue]
+        case .subscriptionVPNToolbarImpression(let isSubscriptionActive),
+                .subscriptionVPNAddressBarImpression(let isSubscriptionActive):
+            return [SubscriptionPixelsDefaults.vpnSubscriptionActiveKey: Self.vpnSubscriptionActiveValue(isSubscriptionActive)]
         default:
             return nil
         }
@@ -92,7 +119,14 @@ enum SubscriptionPixel: PixelKitEvent {
                 .subscriptionKeychainManagerDataAddedToTheBacklog,
                 .subscriptionKeychainManagerDeallocatedWithBacklog,
                 .subscriptionKeychainManagerDataWroteFromBacklog,
-                .subscriptionKeychainManagerFailedToWriteDataFromBacklog:
+                .subscriptionKeychainManagerFailedToWriteDataFromBacklog,
+                .subscriptionVPNToolbarImpression,
+                .subscriptionVPNToolbarClick,
+                .subscriptionVPNAddressBarImpression,
+                .subscriptionVPNAddressBarClick,
+                .subscriptionVPNWidgetClick,
+                .subscriptionVPNShortcutClick,
+                .subscriptionVPNNotificationClick:
             return [.pixelSource]
         }
     }

--- a/iOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -76,6 +76,57 @@
         ]
     },
 
+    // VPN Subscription Funnel Entry Points
+    "subscription_vpn_toolbar_impression": {
+        "description": "Fired when the customizable toolbar VPN button is presented to the user (customization enabled and VPN selected as the toolbar button).",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource", "vpnSubscriptionActive"]
+    },
+    "subscription_vpn_toolbar_click": {
+        "description": "Fired when a non-subscriber taps the customizable toolbar VPN button and is redirected into the subscription funnel.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["user_submitted"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "subscription_vpn_address-bar_impression": {
+        "description": "Fired when the customizable address-bar VPN button is presented to the user (customization enabled and VPN selected as the address-bar button).",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource", "vpnSubscriptionActive"]
+    },
+    "subscription_vpn_address-bar_click": {
+        "description": "Fired when a non-subscriber taps the customizable address-bar VPN button and is redirected into the subscription funnel.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["user_submitted"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "subscription_vpn_widget_click": {
+        "description": "Fired when a non-subscriber taps the VPN widget entry point and is redirected into the subscription funnel.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["user_submitted"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "subscription_vpn_shortcut_click": {
+        "description": "Fired when a non-subscriber taps the VPN app shortcut entry point and is redirected into the subscription funnel.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["user_submitted"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "subscription_vpn_notification_click": {
+        "description": "Fired when a non-subscriber taps the VPN notification entry point and is redirected into the subscription funnel.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["user_submitted"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+
     // Pending Transaction Recovery
     "m_privacy-pro_purchase_success_after_pending_transaction": {
         "description": "Fired when a subscription purchase succeeds after previously being in a pending transaction state (e.g., Ask to Buy was approved)",

--- a/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -716,6 +716,9 @@ final class MoreOptionsMenu: NSMenu, NSMenuDelegate {
         freemiumDBPItem.target = self
         freemiumDBPItem.action = #selector(openFreemiumDBP(_:))
 
+        dataBrokerProtectionFreemiumPixelHandler.fire(DataBrokerProtectionFreemiumPixels.overFlowScanImpressionCount)
+        dataBrokerProtectionFreemiumPixelHandler.fire(DataBrokerProtectionFreemiumPixels.overFlowScanImpression)
+
         addItem(freemiumDBPItem)
     }
 

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsCardsPixelHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsCardsPixelHandler.swift
@@ -42,6 +42,9 @@ protocol NewTabPageNextStepsCardsPixelHandling {
     /// Fires the `GeneralPixel.defaultRequestedFromHomepageSetupView` pixel.
     func fireDefaultBrowserRequestedPixel()
 
+    /// Fires the `SubscriptionPixel.subscriptionNewTabPageNextStepsCardShown` pixel.
+    func fireSubscriptionCardShownPixel()
+
     /// Fires the `SubscriptionPixel.subscriptionNewTabPageNextStepsCardClicked` pixel.
     func fireSubscriptionCardClickedPixel()
 
@@ -106,6 +109,10 @@ final class NewTabPageNextStepsCardsPixelHandler: NewTabPageNextStepsCardsPixelH
 
     func fireDefaultBrowserRequestedPixel() {
         pixelHandler(GeneralPixel.defaultRequestedFromHomepageSetupView, .standard, true)
+    }
+
+    func fireSubscriptionCardShownPixel() {
+        pixelHandler(SubscriptionPixel.subscriptionNewTabPageNextStepsCardShown, .dailyAndCount, true)
     }
 
     func fireSubscriptionCardClickedPixel() {

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsSingleCardProvider.swift
@@ -249,6 +249,9 @@ final class NewTabPageNextStepsSingleCardProvider: NewTabPageNextStepsCardsProvi
         if let card = cards.first {
             pixelHandler.fireNextStepsCardShownPixels([card])
             pixelHandler.fireAddToDockPresentedPixelIfNeeded([card])
+            if card == .subscription {
+                pixelHandler.fireSubscriptionCardShownPixel()
+            }
         }
     }
 }

--- a/macOS/DuckDuckGo/Statistics/SubscriptionPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/SubscriptionPixel.swift
@@ -137,6 +137,7 @@ enum SubscriptionPixel: PixelKitEvent {
     case subscriptionEntrySettingsSubscriptionClick
 
     // New Tab Page Next Steps Card
+    case subscriptionNewTabPageNextStepsCardShown
     case subscriptionNewTabPageNextStepsCardClicked
     case subscriptionNewTabPageNextStepsCardDismissed
 
@@ -253,6 +254,7 @@ enum SubscriptionPixel: PixelKitEvent {
         case .subscriptionEntrySettingsImpression: return "m_mac_\(appDistribution)_subscription_settings_impression"
         case .subscriptionEntrySettingsSubscriptionClick: return "m_mac_\(appDistribution)_subscription_settings_subscription_click"
             // New Tab Page Next Steps Card
+        case .subscriptionNewTabPageNextStepsCardShown: return "privacy-pro_new_tab_page_next_steps_card_shown"
         case .subscriptionNewTabPageNextStepsCardClicked: return "m_mac_\(appDistribution)_privacy-pro_new_tab_page_next_steps_card_clicked"
         case .subscriptionNewTabPageNextStepsCardDismissed: return "m_mac_\(appDistribution)_privacy-pro_new_tab_page_next_steps_card_dismissed"
             // Free Trial Journey
@@ -380,6 +382,7 @@ enum SubscriptionPixel: PixelKitEvent {
                 .subscriptionWinBackOfferNewTabPageShown,
                 .subscriptionWinBackOfferNewTabPageCTAClicked,
                 .subscriptionWinBackOfferNewTabPageDismissed,
+                .subscriptionNewTabPageNextStepsCardShown,
                 .subscriptionNewTabPageNextStepsCardClicked,
                 .subscriptionNewTabPageNextStepsCardDismissed,
                 .subscriptionEntryAppMenuImpression,

--- a/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -1172,6 +1172,20 @@
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource"]
     },
+    "dbp-free_overflow_scan_impression_u": {
+        "description": "Fires once per user when the Personal Information Removal entry is presented in the More Options menu (whenever the freemium DBP feature is available).",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "dbp-free_overflow_scan_impression_c": {
+        "description": "Fires every time the Personal Information Removal entry is presented in the More Options menu (whenever the freemium DBP feature is available). Counted variant of dbp-free_overflow_scan_impression_u.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
     "dbp-free_overflow_scan_u": {
         "description": "Fires once per user when they click the Personal Information Removal entry in the More Options menu, before any scan has been completed (pre-scan state).",
         "owners": ["hanyutang-sandra"],

--- a/macOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -825,6 +825,13 @@
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
+    "privacy-pro_new_tab_page_next_steps_card_shown": {
+        "description": "Fired when the subscription Next Steps card is shown on the New Tab Page. Uses feature-grouped naming (no m_/mac/distribution prefix); platform is derived from the request client header and App-Store-vs-direct distribution from the pixelSource parameter.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
 
     // Free Trial Journey Pixels - App Store Distribution
     "m_mac_store_privacy-pro_freetrial_start": {

--- a/macOS/UnitTests/NewTabPage/MockNewTabPageNextStepsCardsPixelHandler.swift
+++ b/macOS/UnitTests/NewTabPage/MockNewTabPageNextStepsCardsPixelHandler.swift
@@ -27,6 +27,7 @@ final class MockNewTabPageNextStepsCardsPixelHandler: NewTabPageNextStepsCardsPi
     private(set) var fireNextStepsCardDismissedPixelCalledWith: NewTabPageDataModel.CardID?
     private(set) var fireAddedToDockPixelCalled = false
     private(set) var fireDefaultBrowserRequestedPixelCalled = false
+    private(set) var fireSubscriptionCardShownPixelCalled = false
     private(set) var fireSubscriptionCardClickedPixelCalled = false
     private(set) var fireSubscriptionCardDismissedPixelCalled = false
 
@@ -52,6 +53,10 @@ final class MockNewTabPageNextStepsCardsPixelHandler: NewTabPageNextStepsCardsPi
 
     func fireDefaultBrowserRequestedPixel() {
         fireDefaultBrowserRequestedPixelCalled = true
+    }
+
+    func fireSubscriptionCardShownPixel() {
+        fireSubscriptionCardShownPixelCalled = true
     }
 
     func fireSubscriptionCardClickedPixel() {

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
@@ -643,6 +643,27 @@ final class NewTabPageNextStepsSingleCardProviderTests: XCTestCase {
         XCTAssertEqual(pixelHandler.fireAddToDockPresentedPixelIfNeededCalledWith, [.addAppToDockMac])
     }
 
+    @MainActor
+    func testWhenWillDisplayCardsIsCalledWithSubscriptionFirstThenSubscriptionShownPixelIsFired() {
+        let testProvider = createProvider()
+        let cards: [NewTabPageDataModel.CardID] = [.subscription, .emailProtection, .bringStuff]
+
+        testProvider.willDisplayCards(cards)
+
+        XCTAssertEqual(pixelHandler.fireNextStepsCardShownPixelsCalledWith, [.subscription])
+        XCTAssertTrue(pixelHandler.fireSubscriptionCardShownPixelCalled)
+    }
+
+    @MainActor
+    func testWhenWillDisplayCardsIsCalledWithSubscriptionNotFirstThenSubscriptionShownPixelIsNotFired() {
+        let testProvider = createProvider()
+        let cards: [NewTabPageDataModel.CardID] = [.emailProtection, .subscription, .bringStuff]
+
+        testProvider.willDisplayCards(cards)
+
+        XCTAssertFalse(pixelHandler.fireSubscriptionCardShownPixelCalled)
+    }
+
     // MARK: - Edge Cases
 
     func testWhenAllCardsArePermanentlyDismissedThenCardsListIsEmpty() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217023348670860?focus=true

### Description
- iOS: Add subscription entry-point impression & click pixels for the toolbar and address bar
- iOS: Add subscription entry-point click pixels for widget, shortcut, and notification
- macOS: Add the subscription Next Steps card shown pixel
- macOS: Add freemium DBP overflow scan impression pixels
- Add/update the corresponding pixel definition JSON5 entries on both platforms.

### Testing Steps
- iOS: Enable the VPN toolbar/address bar button as a non-subscriber; navigate away from the New Tab Page and confirm the impression pixel fires once per launch, and the click pixel fires when tapping into the subscription funnel.
- iOS: Repeat as a subscriber and verify the impression pixel carries the correct subscription-active parameter and routing goes to the VPN screen (no funnel click pixel).
- macOS: Open a New Tab Page where the subscription Next Steps card is first and confirm the card shown pixel fires.
- macOS: Open the More Options menu with freemium DBP available and confirm the overflow scan impression pixels fire.

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- Impression pixels could over- or under-count if firing conditions are wrong. Mitigated by once-per-launch guards and the New Tab Page visibility check.

### Quality Considerations
- Monitoring/analytics: This is analytics-only instrumentation; no user-facing behavior change.
- Privacy/security: Subscription-active state is encoded as a coarse string with a `no_subscription` case; no PII added.

### Notes to Reviewer
- Reviewer will be assigned manually after creation.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes with no user-facing behavior; impression guards limit over-counting risk.
> 
> **Overview**
> Adds **analytics-only** instrumentation for subscription and freemium DBP entry points on iOS and macOS, with matching pixel definition JSON5 updates.
> 
> **iOS:** When customization shows VPN on the toolbar or address bar (not on New Tab), **once-per-launch** impression pixels fire with a coarse `vpnSubscriptionActive` parameter. Non-subscribers who tap those VPN entry points (or widget, shortcut, notification) now fire dedicated **click** pixels before routing into the subscription funnel via `VPNEntryPoint.subscriptionFunnelClickPixel` in `presentNetworkProtectionStatusSettingsModal`.
> 
> **macOS:** When the subscription Next Steps card is the **first** card shown on the New Tab Page, a new **card shown** pixel fires (`dailyAndCount`). Freemium DBP overflow menu items now fire **scan impression** unique and count pixels when the Personal Information Removal entry is added to More Options.
> 
> Unit tests cover subscription card shown firing only when the subscription card is first in the display list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5af6e3bfe5607913e2e7db2c00acabfa52c0d7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->