### PR TITLE
Fix test_chat_tab_new_chat for native chat-history page

### DIFF
--- a/.maestro/unified_toggle_input/test_chat_tab_new_chat.yaml
+++ b/.maestro/unified_toggle_input/test_chat_tab_new_chat.yaml
@@ -10,15 +10,15 @@ name: test_chat_tab_new_chat
 - runFlow:
     file: ../shared/open_chat_tab.yaml
 
-# "Recent chats" opens the chat panel, which exposes the new-chat actions
-# (verified on-device: New Chat / New Voice Chat / New Image are all present here).
+# "Recent chats" opens the native chat-history page. On a fresh install it has no
+# history, so it shows the empty state with the "Open Duck.ai" call to action.
 - tapOn: "Recent chats"
-- assertVisible: "New Chat"
-- assertVisible: "New Voice Chat"
-- assertVisible: "New Image"
+- assertVisible: "Chats"
+- assertVisible: "No recent chats"
+- assertVisible: "Open Duck.ai"
 
-# Start a new chat — the panel closes and the chat tab remains open.
-- tapOn: "New Chat"
+# Start a new chat — the page closes and the chat tab remains open.
+- tapOn: "Open Duck.ai"
 - assertVisible: "Close tab"
 - assertVisible:
     id: "AIChat.Toolbar.Button.ModelChip"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1217015976318033
Tech Design URL:
CC:

### Description
The `test_chat_tab_new_chat` end-to-end flow was failing because tapping "Recent chats" no longer opens the web sidebar (with New Chat / New Voice Chat / New Image actions) — it now opens the native chat-history page. On a fresh install that page has no history and shows its empty state, so the flow now asserts against the native page and starts a new chat via the "Open Duck.ai" call to action.

### Testing Steps
1. Run the flow against a booted simulator with the app installed:
   `maestro --udid=<sim-uuid> test -e ONBOARDING_COMPLETED=true -e APP_VARIANT= .maestro/unified_toggle_input/test_chat_tab_new_chat.yaml`
2. The flow opens the Duck.ai chat tab, taps "Recent chats" → the native "Chats" page appears showing "No recent chats" and "Open Duck.ai".
3. Tapping "Open Duck.ai" starts a new chat → the page dismisses and the chat tab remains open with the model chip visible. Flow passes.

### Impact
None (test-only change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro YAML change; no production code or runtime behavior affected.
> 
> **Overview**
> Updates the **`test_chat_tab_new_chat`** Maestro flow so it matches the current Duck.ai UX: **"Recent chats"** now opens the **native chat-history** screen instead of the old web sidebar with **New Chat** / **New Voice Chat** / **New Image**.
> 
> On a fresh install the history page shows the empty state (**Chats**, **No recent chats**, **Open Duck.ai**). The test asserts those strings and starts a new chat by tapping **Open Duck.ai**, then verifies the chat tab stays open with the model chip visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3698a314e9b65b5b5aafecb3e822e8c42f73395e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->