### PR TITLE
[iOS] Delete flag createFireproofFaviconUpdaterSecureVaultInBackground

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -355,7 +355,6 @@ public enum AutofillSubfeature: String, PrivacySubfeature {
     case inputFocusApi
     case canPromoteImportPasswordsInPasswordManagement
     case canPromoteImportPasswordsInBrowser
-    case createFireproofFaviconUpdaterSecureVaultInBackground
     case autofillExtensionSettings
     case canPromoteAutofillExtensionInBrowser
     case canPromoteAutofillExtensionInPasswordManagement

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -202,9 +202,6 @@ public enum FeatureFlag: String {
     /// This is off by default.  We can turn it on to get daily pixels of users's widget usage for a short time.
     case widgetReporting
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866467213996
-    case createFireproofFaviconUpdaterSecureVaultInBackground
-
     /// Local inactivity provisional notifications delivered to Notification Center.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866471590692
     case inactivityNotification
@@ -686,8 +683,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(DBPSubfeature.pirRollout))
         case .widgetReporting:
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.widgetReporting), supportsLocalOverriding: false)
-        case .createFireproofFaviconUpdaterSecureVaultInBackground:
-            Config(defaultValue: .enabled, source: .remoteReleasable(AutofillSubfeature.createFireproofFaviconUpdaterSecureVaultInBackground))
         case .inactivityNotification:
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.inactivityNotification))
         case .daxEasterEggLogos:

--- a/iOS/DuckDuckGo/FireproofFaviconUpdater.swift
+++ b/iOS/DuckDuckGo/FireproofFaviconUpdater.swift
@@ -97,10 +97,6 @@ class FireproofFaviconUpdater: NSObject, FaviconUserScriptDelegate {
         favicons.loadFavicon(forDomain: host, fromURL: faviconURL, intoCache: .tabs) { [weak self] image in
             guard let self = self else { return }
             self.tab.didUpdateFavicon()
-            guard featureFlagger.isFeatureOn(.createFireproofFaviconUpdaterSecureVaultInBackground) else {
-                legacyReplaceFireproofFaviconIfNecessary(image, forHost: host)
-                return
-            }
             replaceFireproofFaviconIfNecessary(image, forHost: host)
         }
     }
@@ -181,41 +177,6 @@ class FireproofFaviconUpdater: NSObject, FaviconUserScriptDelegate {
             let autofillLoginExists = await autofillLoginExists(for: domain)
             guard !autofillLoginExists else { return }
             favicons.removeBookmarkFavicon(forDomain: domain)
-        }
-    }
-
-    // MARK: Legacy flow
-    // To be deleted with createFireproofFaviconUpdaterSecureVaultInBackground FeatureFlag
-
-    private func legacyReplaceFireproofFaviconIfNecessary(_ image: UIImage?, forHost host: String) {
-        guard self.bookmarkExists(for: host) || self.legacyAutofillLoginExists(for: host),
-              let image = image else { return }
-
-        self.favicons.replaceFireproofFavicon(forDomain: host, withImage: image)
-    }
-
-    private func legacyInitSecureVault() -> (any AutofillSecureVault)? {
-        if featureFlagger.isFeatureOn(.autofillCredentialInjecting) && AutofillSettingStatus.isAutofillEnabledInSettings {
-            if secureVault == nil {
-                // Fallback: Create new instance if shared one was not injected
-                Logger.general.info("FireproofFaviconUpdater creating fallback SecureVault instance (legacy)")
-                secureVault = try? AutofillSecureVaultFactory.makeVault(reporter: SecureVaultReporter())
-            }
-            return secureVault
-        }
-        return nil
-    }
-
-    private func legacyAutofillLoginExists(for domain: String) -> Bool {
-        guard let secureVault = legacyInitSecureVault() else {
-            return false
-        }
-
-        do {
-            let accounts = try secureVault.accounts()
-            return accounts.contains(where: { $0.domain == domain })
-        } catch {
-            return false
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462886803403/task/1211866467213996?focus=true
Tech Design URL:
CC:

### Description
- Removes the fully rolled-out flag and obsolete fallback for retaining favicons for bookmarked sites and saved logins.
- Keeps the non-blocking credential-store flow as the standard behaviour.

### Testing Steps
1. Enable Autofill and save a login for a non-bookmarked site with a favicon.
2. Visit the site and confirm its favicon appears in the tab.
3. Open the saved login in Passwords → the site favicon is displayed.
4. Bookmark another site and visit it → its favicon is displayed in Bookmarks.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change is limited to always using async secure-vault checks for fireproof favicons; if that path misbehaves there is no remote flag to revert to the legacy synchronous flow.
> 
> **Overview**
> Removes the **`createFireproofFaviconUpdaterSecureVaultInBackground`** feature flag and its legacy fallback path in fireproof favicon handling.
> 
> **`FireproofFaviconUpdater`** no longer branches on the flag after a tab favicon loads: it always uses **`replaceFireproofFaviconIfNecessary`**, which checks bookmarks synchronously and uses an async **`autofillLoginExists`** path with **`initSecureVault`** (including **`Task.detached`** vault creation when needed). The deleted legacy helpers performed synchronous secure-vault access on the main thread.
> 
> The flag is removed from **`AutofillSubfeature`**, the iOS **`FeatureFlag`** enum, and its privacy-config mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 683fca1228e9c990c1f616bc046065dcfb2533a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->