### PR TITLE
PIR: Remove dbpRemoteBrokerDelivery feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -373,7 +373,6 @@ public enum DBPSubfeature: String, Equatable, PrivacySubfeature {
     case waitlist
     case waitlistBetaActive
     case freemium
-    case remoteBrokerDelivery
     case foregroundRunningOnAppActive
     case continuedProcessing
     case pirRollout

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/BrokerManaging/RemoteBrokerJSONService.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/BrokerManaging/RemoteBrokerJSONService.swift
@@ -35,7 +35,7 @@ extension FileManager: ZipArchiveHandling {
 }
 
 public final class RemoteBrokerJSONService: BrokerJSONServiceProvider {
-    public typealias FeatureFlagging = RemoteBrokerDeliveryFeatureFlagging & OptOutRetryErrorFeatureFlagging
+    public typealias FeatureFlagging = OptOutRetryErrorFeatureFlagging
 
     enum Error: Swift.Error, CustomNSError {
         case serverError(httpCode: Int?)
@@ -162,12 +162,6 @@ public final class RemoteBrokerJSONService: BrokerJSONServiceProvider {
     public func checkForUpdates(skipsLimiter: Bool) async throws {
         if let runTypeProvider = self.settings as? AppRunTypeProviding, runTypeProvider.runType == .integrationTests {
             Logger.dataBrokerProtection.log("Remote broker delivery not enabled due to run type")
-            return
-        }
-
-        if !featureFlagger.isRemoteBrokerDeliveryFeatureOn {
-            Logger.dataBrokerProtection.log("Remote broker delivery not enabled, skip to local fallback")
-            try? await localBrokerProvider?.checkForUpdates()
             return
         }
 

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Features/DBPFeatureFlagging.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Features/DBPFeatureFlagging.swift
@@ -18,15 +18,10 @@
 
 import Foundation
 
-public typealias DBPFeatureFlagging = RemoteBrokerDeliveryFeatureFlagging
-    & ForegroundRunningFeatureFlagging
+public typealias DBPFeatureFlagging = ForegroundRunningFeatureFlagging
     & ContinuedProcessingFeatureFlagging
     & WebViewUserAgentFeatureFlagging
     & OptOutRetryErrorFeatureFlagging
-
-public protocol RemoteBrokerDeliveryFeatureFlagging {
-    var isRemoteBrokerDeliveryFeatureOn: Bool { get }
-}
 
 public protocol ForegroundRunningFeatureFlagging {
     var isForegroundRunningOnAppActiveFeatureOn: Bool { get }

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -2142,20 +2142,17 @@ public final class MockBrokerProfileJobStatusReportingDelegate: BrokerProfileJob
 }
 
 public final class MockDBPFeatureFlagger: DBPFeatureFlagging, FreemiumPIRFeatureFlagging {
-    public let isRemoteBrokerDeliveryFeatureOn: Bool
     public let isForegroundRunningOnAppActiveFeatureOn: Bool
     public let isContinuedProcessingFeatureOn: Bool
     public let isWebViewUserAgentOn: Bool
     public let isOptOutRetryErrorFrequencyExperimentOn: Bool
     public let isFreemiumPIREnabled: Bool
 
-    public init(isRemoteBrokerDeliveryFeatureOn: Bool = true,
-                isForegroundRunningOnAppActiveFeatureOn: Bool = true,
+    public init(isForegroundRunningOnAppActiveFeatureOn: Bool = true,
                 isContinuedProcessingFeatureOn: Bool = true,
                 isWebViewUserAgentOn: Bool = false,
                 isOptOutRetryErrorFrequencyExperimentOn: Bool = false,
                 isFreemiumPIREnabled: Bool = false) {
-        self.isRemoteBrokerDeliveryFeatureOn = isRemoteBrokerDeliveryFeatureOn
         self.isForegroundRunningOnAppActiveFeatureOn = isForegroundRunningOnAppActiveFeatureOn
         self.isContinuedProcessingFeatureOn = isContinuedProcessingFeatureOn
         self.isWebViewUserAgentOn = isWebViewUserAgentOn

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/RemoteBrokerJSONServiceTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/RemoteBrokerJSONServiceTests.swift
@@ -560,7 +560,6 @@ extension HTTPURLResponse {
                                             headerFields: ["ETag": "something"])!
 }
 
-private class MockFeatureFlagger: RemoteBrokerDeliveryFeatureFlagging, OptOutRetryErrorFeatureFlagging {
-    var isRemoteBrokerDeliveryFeatureOn: Bool { true }
+private class MockFeatureFlagger: OptOutRetryErrorFeatureFlagging {
     var isOptOutRetryErrorFrequencyExperimentOn: Bool { false }
 }

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -112,9 +112,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866711151217
     case adAttributionReporting
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866610480266
-    case dbpRemoteBrokerDelivery
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212258549430653
     case dbpForegroundRunningOnAppActive
 
@@ -628,8 +625,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(AutofillSurveysSubfeature.featureEnabled), supportsLocalOverriding: false)
         case .adAttributionReporting:
             Config(defaultValue: .enabled, source: .remoteReleasable(AdAttributionReportingSubfeature.featureEnabled), supportsLocalOverriding: false)
-        case .dbpRemoteBrokerDelivery:
-            Config(source: .remoteReleasable(DBPSubfeature.remoteBrokerDelivery))
         case .dbpForegroundRunningOnAppActive:
             Config(defaultValue: .enabled, source: .remoteReleasable(DBPSubfeature.foregroundRunningOnAppActive))
         case .dbpContinuedProcessing:

--- a/iOS/DuckDuckGo/AppServices/DBPService.swift
+++ b/iOS/DuckDuckGo/AppServices/DBPService.swift
@@ -187,10 +187,6 @@ final class DBPFeatureFlagger: DBPFeatureFlagging, FreemiumPIRFeatureFlagging {
     private let appDependencies: DependencyProvider
     private let freemiumPIRDebugSettings: FreemiumPIRDebugSettings
 
-    var isRemoteBrokerDeliveryFeatureOn: Bool {
-        appDependencies.featureFlagger.isFeatureOn(.dbpRemoteBrokerDelivery)
-    }
-
     var isForegroundRunningOnAppActiveFeatureOn: Bool {
         appDependencies.featureFlagger.isFeatureOn(.dbpForegroundRunningOnAppActive)
     }

--- a/macOS/DuckDuckGo/DBP/DBPFeatureFlagger.swift
+++ b/macOS/DuckDuckGo/DBP/DBPFeatureFlagger.swift
@@ -26,10 +26,6 @@ import PixelKit
 final class DBPFeatureFlagger: DBPFeatureFlagging {
     fileprivate let featureFlagger: FeatureFlagger
 
-    var isRemoteBrokerDeliveryFeatureOn: Bool {
-        featureFlagger.isFeatureOn(.dbpRemoteBrokerDelivery)
-    }
-
     var isForegroundRunningOnAppActiveFeatureOn: Bool {
         // Not relevant to macOS
         return false

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/Debug/DataBrokerRunCustomJSONView.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/Debug/DataBrokerRunCustomJSONView.swift
@@ -137,7 +137,6 @@ struct DataBrokerRunCustomJSONView: View {
 
     private var dbpFeatureFlagLines: [(name: String, value: String)] {
         [
-            (FeatureFlag.dbpRemoteBrokerDelivery.rawValue, viewModel.featureFlagger.isRemoteBrokerDeliveryFeatureOn.description),
             (FeatureFlag.dbpWebViewUserAgent.rawValue, viewModel.featureFlagger.isWebViewUserAgentOn.description),
         ]
     }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -116,9 +116,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866717382544
     case delayedWebviewPresentation
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866717886474
-    case dbpRemoteBrokerDelivery
-
     /// https://app.asana.com/1/137249556945/project/1206873150423133/task/1213344522599586
     case dbpWebViewUserAgent
 
@@ -576,8 +573,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .disabled)
         case .delayedWebviewPresentation:
             Config(defaultValue: .enabled, source: .remoteReleasable(DelayedWebviewPresentationSubfeature.featureEnabled))
-        case .dbpRemoteBrokerDelivery:
-            Config(source: .remoteReleasable(DBPSubfeature.remoteBrokerDelivery), category: .dbp)
         case .dbpWebViewUserAgent:
             Config(source: .remoteReleasable(DBPSubfeature.webViewUserAgent), supportsLocalOverriding: true, category: .dbp)
         case .dbpOptOutRetryError96Hours:


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866610480266?focus=true
Tech Design URL:
CC:

### Description

Removes remote broker delivery feature flag, which has been enabled since macOS 1.140.0 and iOS 7.180.0

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. CI passes
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact

Low

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag removal with no behavioral change for users already on enabled builds; remote broker JSON updates remain the default path with existing integration-test and rate-limit guards.
> 
> **Overview**
> Removes the **remote broker delivery** feature flag (`dbpRemoteBrokerDelivery` / `DBPSubfeature.remoteBrokerDelivery`) now that it has been enabled in production for some time.
> 
> `RemoteBrokerJSONService.checkForUpdates` no longer gates on the flag or falls back to local-only updates when off—it always runs the remote update path (still skipping integration tests and honoring the rate limiter). The `RemoteBrokerDeliveryFeatureFlagging` protocol and related wiring are deleted from privacy config, iOS/macOS `FeatureFlag`, `DBPFeatureFlagger`, mocks, and the macOS debug UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2320b98e4cd99ca5b378bb6731fb38b5b7903f88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->