### PR TITLE
Drop vbscript: bookmarks on import

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Bookmarks/BookmarkletExtensions.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Bookmarks/BookmarkletExtensions.swift
@@ -27,10 +27,10 @@ public extension String {
 
     /// URL schemes that are unsafe to import as a bookmark target, because activating the
     /// bookmark would execute embedded content rather than navigate to a page. Used to drop
-    /// such bookmarks during third-party import (e.g. `javascript:`, `data:`).
+    /// such bookmarks during third-party import (e.g. `javascript:`, `data:`, `vbscript:`).
     func hasUnsafeBookmarkImportScheme() -> Bool {
         let value = trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return value.hasPrefix("javascript:") || value.hasPrefix("data:")
+        return value.hasPrefix("javascript:") || value.hasPrefix("data:") || value.hasPrefix("vbscript:")
     }
 
     func toDecodedBookmarklet() -> String? {

--- a/SharedPackages/BrowserServicesKit/Tests/BookmarksTests/BookmarkImportSchemeValidationTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BookmarksTests/BookmarkImportSchemeValidationTests.swift
@@ -27,7 +27,9 @@ struct BookmarkImportSchemeValidationTests {
         "JavaScript:alert(1)",
         "  javascript:alert(1)",
         "data:text/html,<script>alert(1)</script>",
-        "DATA:text/html;base64,AAAA"
+        "DATA:text/html;base64,AAAA",
+        "vbscript:msgbox(1)",
+        "VBScript:msgbox(1)"
     ])
     func unsafeSchemesDetected(urlString: String) {
         #expect(urlString.hasUnsafeBookmarkImportScheme() == true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215922569412521?focus=true

### Description
Security-audit follow-up. When the security team re-tested the file-import validation fix, `vbscript:` bookmarks were still being imported. It's the same class of executable scheme as `javascript:`/`data:` — activating such a bookmark runs script instead of navigating — and was simply missing from the import blocklist. This adds it to the shared `hasUnsafeBookmarkImportScheme()` check, so it's dropped across all import paths on both iOS and macOS.

### Testing Steps
**Disclaimer**: no need to manual test, this is unit tested but if you want in the asana task there is a zip file attached to test.

1. On a clean profile, import a bookmarks HTML file containing a `vbscript:` bookmark alongside a normal `https://` one.
2. The `vbscript:` entry is dropped (reported as failed); the `https://` bookmark imports normally.


### Impact
Low — tightens third-party import validation; no change to normal bookmark exports.