### PR TITLE
macOS: Suppress Duck.ai chat suggestions in Fire Window address bar

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -91,6 +91,10 @@ final class AIChatOmnibarController {
     private let featureFlagger: FeatureFlagger
     private let searchPreferencesPersistor: SearchPreferencesPersistor
     private let suggestionsReader: AIChatSuggestionsReading?
+    /// Burner (Fire Window) omnibars run an isolated Duck.ai session, so persisted chat-history
+    /// suggestions from the regular session can't be opened here. When true, suggestions are
+    /// suppressed entirely — see `isSuggestionsEnabled`.
+    private let isBurner: Bool
     private let modelsService: AIChatModelsProviding
     private let subscriptionManager: any SubscriptionManager
     private let subscriptionUpsellPresenter: AIChatOmnibarSubscriptionUpselling
@@ -148,7 +152,8 @@ final class AIChatOmnibarController {
     /// Whether the suggestions feature is enabled.
     /// Requires both the feature flag and the autocomplete setting to be on.
     var isSuggestionsEnabled: Bool {
-        surface.supportsSuggestions
+        !isBurner
+            && surface.supportsSuggestions
             && featureFlagger.isFeatureOn(.aiChatSuggestions)
             && searchPreferencesPersistor.showAutocompleteSuggestions
     }
@@ -264,6 +269,7 @@ final class AIChatOmnibarController {
         featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
         searchPreferencesPersistor: SearchPreferencesPersistor = SearchPreferencesUserDefaultsPersistor(),
         suggestionsReader: AIChatSuggestionsReading? = nil,
+        isBurner: Bool = false,
         preferences: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),
         modelsService: AIChatModelsProviding = AIChatModelsService(),
         subscriptionManager: any SubscriptionManager = Application.appDelegate.subscriptionManager,
@@ -282,6 +288,7 @@ final class AIChatOmnibarController {
         self.featureFlagger = featureFlagger
         self.searchPreferencesPersistor = searchPreferencesPersistor
         self.suggestionsReader = suggestionsReader
+        self.isBurner = isBurner
         self.preferences = preferences
         self.modelsService = modelsService
         self.subscriptionManager = subscriptionManager

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -329,6 +329,9 @@ final class MainViewController: NSViewController {
             origin: WindowPromptOrigin(tabCollectionViewModel: tabCollectionViewModel),
             pixelHandler: AddressBarPromptPixelHandler(),
             suggestionsReader: suggestionsReader,
+            // Fire Windows run an isolated Duck.ai session; persisted chat-history suggestions
+            // from the regular session can't be opened here, so suppress them.
+            isBurner: tabCollectionViewModel.isBurner,
             preferences: NSApp.delegateTyped.aiChatPreferencesPersistor
         )
 

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -94,6 +94,26 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         super.tearDown()
     }
 
+    /// Builds a controller with the shared mocks and a chosen burner mode. Used by the
+    /// suggestions tests to compare Fire Window vs regular behavior with identical inputs.
+    private func makeController(isBurner: Bool) -> AIChatOmnibarController {
+        AIChatOmnibarController(
+            aiChatTabOpener: mockTabOpener,
+            surface: .addressBar,
+            draftSource: TabPromptDraftSource(tabCollectionViewModel: tabCollectionViewModel),
+            origin: WindowPromptOrigin(tabCollectionViewModel: tabCollectionViewModel),
+            pixelHandler: AddressBarPromptPixelHandler(),
+            featureFlagger: featureFlagger,
+            searchPreferencesPersistor: searchPreferencesPersistor,
+            isBurner: isBurner,
+            preferences: mockPreferences,
+            modelsService: mockModelsService,
+            subscriptionManager: mockSubscriptionManager,
+            subscriptionUpsellPresenter: mockSubscriptionUpsellPresenter,
+            badgeImpressionPersistor: mockBadgeImpressionPersistor
+        )
+    }
+
     // MARK: - URL Navigation Tests
 
     func testWhenValidURLIsSubmitted_ThenDelegateReceivesNavigationRequest() {
@@ -313,6 +333,28 @@ final class AIChatOmnibarControllerTests: XCTestCase {
 
         // Then
         XCTAssertFalse(controller.isSuggestionsEnabled)
+    }
+
+    func testWhenBurnerWindow_ThenSuggestionsDisabled_EvenWithFeatureFlagAndAutocompleteEnabled() {
+        // Given a Fire Window omnibar with suggestions otherwise fully enabled.
+        featureFlagger.featuresStub[FeatureFlag.aiChatSuggestions.rawValue] = true
+        searchPreferencesPersistor.showAutocompleteSuggestions = true
+        let burnerController = makeController(isBurner: true)
+
+        // Then a Fire Window runs an isolated Duck.ai session, so chat-history suggestions
+        // (which can't be opened here) are suppressed regardless of the flag and setting.
+        XCTAssertFalse(burnerController.isSuggestionsEnabled)
+    }
+
+    func testWhenNonBurnerWindow_ThenSuggestionsEnabled_WithFeatureFlagAndAutocompleteEnabled() {
+        // Given the same preconditions but a regular window, the burner gate is the only
+        // difference from the case above.
+        featureFlagger.featuresStub[FeatureFlag.aiChatSuggestions.rawValue] = true
+        searchPreferencesPersistor.showAutocompleteSuggestions = true
+        let regularController = makeController(isBurner: false)
+
+        // Then
+        XCTAssertTrue(regularController.isSuggestionsEnabled)
     }
 
     // MARK: - Model Selection Tests

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -94,8 +94,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         super.tearDown()
     }
 
-    /// Builds a controller with the shared mocks and a chosen burner mode. Used by the
-    /// suggestions tests to compare Fire Window vs regular behavior with identical inputs.
+    // Builds a controller with the shared mocks and a chosen burner mode.
     private func makeController(isBurner: Bool) -> AIChatOmnibarController {
         AIChatOmnibarController(
             aiChatTabOpener: mockTabOpener,
@@ -336,19 +335,17 @@ final class AIChatOmnibarControllerTests: XCTestCase {
     }
 
     func testWhenBurnerWindow_ThenSuggestionsDisabled_EvenWithFeatureFlagAndAutocompleteEnabled() {
-        // Given a Fire Window omnibar with suggestions otherwise fully enabled.
+        // Given
         featureFlagger.featuresStub[FeatureFlag.aiChatSuggestions.rawValue] = true
         searchPreferencesPersistor.showAutocompleteSuggestions = true
         let burnerController = makeController(isBurner: true)
 
-        // Then a Fire Window runs an isolated Duck.ai session, so chat-history suggestions
-        // (which can't be opened here) are suppressed regardless of the flag and setting.
+        // Then
         XCTAssertFalse(burnerController.isSuggestionsEnabled)
     }
 
     func testWhenNonBurnerWindow_ThenSuggestionsEnabled_WithFeatureFlagAndAutocompleteEnabled() {
-        // Given the same preconditions but a regular window, the burner gate is the only
-        // difference from the case above.
+        // Given
         featureFlagger.featuresStub[FeatureFlag.aiChatSuggestions.rawValue] = true
         searchPreferencesPersistor.showAutocompleteSuggestions = true
         let regularController = makeController(isBurner: false)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1217024438585970

### Description

A Fire Window runs an isolated Duck.ai session, but the address bar was still showing Duck.ai chat-history suggestions from the regular window's session. Those suggestions couldn't be opened, the chats don't exist in the Fire Window, and surfacing persisted history in a burner window goes against what Fire Window is for. This PR suppresses those chat suggestions in Fire Windows. Regular windows are unchanged.


### Testing Steps
1. In a regular window, make sure you have existing Duck.ai chats. Focus the address bar → switch to Duck.ai mode → chat suggestions appear and open normally.
2. Open a Fire Window → focus the address bar → switch to Duck.ai mode → no chat suggestions appear.
3. Open one or two more Fire Windows and repeat step 2 → none of them show chat suggestions.

### Impact
Low — bug fix, address-bar suggestions only.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Address-bar suggestion gating only; regular windows unchanged and behavior is covered by unit tests.
> 
> **Overview**
> Fixes Fire Window Duck.ai omnibar showing **chat-history suggestions from the regular session** that can't be opened in the isolated burner session.
> 
> `AIChatOmnibarController` now takes an **`isBurner`** flag (default `false`). **`isSuggestionsEnabled`** requires `!isBurner` in addition to the existing surface, feature flag, and autocomplete checks. **`MainViewController`** passes **`tabCollectionViewModel.isBurner`** when building the address-bar controller.
> 
> Unit tests cover burner vs non-burner behavior when suggestions flags and autocomplete are enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac150136bb5711f60b431537f407cc123c9aaf6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->