### PR TITLE
macOS: add a leading Duck.ai logo to the Prompt Bar

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -4722,8 +4722,8 @@
 		FB07BAD20000000000000603 /* PromptBarOmnibarContentLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000403 /* PromptBarOmnibarContentLayoutTests.swift */; };
 		FB07BAD20000000000000504 /* PromptBarPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000404 /* PromptBarPresenterTests.swift */; };
 		FB07BAD20000000000000604 /* PromptBarPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000404 /* PromptBarPresenterTests.swift */; };
-		FB07BAD20000000000000505 /* AIChatOmnibarBrandLogoLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000405 /* AIChatOmnibarBrandLogoLayoutTests.swift */; };
-		FB07BAD20000000000000605 /* AIChatOmnibarBrandLogoLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000405 /* AIChatOmnibarBrandLogoLayoutTests.swift */; };
+		FB07BAD20000000000000505 /* AIChatOmnibarDuckAILogoLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000405 /* AIChatOmnibarDuckAILogoLayoutTests.swift */; };
+		FB07BAD20000000000000605 /* AIChatOmnibarDuckAILogoLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000405 /* AIChatOmnibarDuckAILogoLayoutTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -7234,7 +7234,7 @@
 		FB07BAD20000000000000402 /* EphemeralPromptDraftStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EphemeralPromptDraftStoreTests.swift; sourceTree = "<group>"; };
 		FB07BAD20000000000000403 /* PromptBarOmnibarContentLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarOmnibarContentLayoutTests.swift; sourceTree = "<group>"; };
 		FB07BAD20000000000000404 /* PromptBarPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPresenterTests.swift; sourceTree = "<group>"; };
-		FB07BAD20000000000000405 /* AIChatOmnibarBrandLogoLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarBrandLogoLayoutTests.swift; sourceTree = "<group>"; };
+		FB07BAD20000000000000405 /* AIChatOmnibarDuckAILogoLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarDuckAILogoLayoutTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -8182,7 +8182,7 @@
 			children = (
 				FB07BAD20000000000000402 /* EphemeralPromptDraftStoreTests.swift */,
 				FB07BAD20000000000000401 /* DuckAIPromptSurfaceTests.swift */,
-				FB07BAD20000000000000405 /* AIChatOmnibarBrandLogoLayoutTests.swift */,
+				FB07BAD20000000000000405 /* AIChatOmnibarDuckAILogoLayoutTests.swift */,
 				FB07BAE20000000000000001 /* DuckAIPromptPixelFiringTests.swift */,
 				BB027E8B2FBB4D3A009B4FE4 /* DuckAiVoiceChatShieldScopeTests.swift */,
 				BBC277902FB2367300756A85 /* DuckAiVoiceChatFailureHandlerTests.swift */,
@@ -16631,7 +16631,7 @@
 				FB07BAD20000000000000503 /* PromptBarOmnibarContentLayoutTests.swift in Sources */,
 				FB07BAD20000000000000502 /* EphemeralPromptDraftStoreTests.swift in Sources */,
 				FB07BAD20000000000000501 /* DuckAIPromptSurfaceTests.swift in Sources */,
-				FB07BAD20000000000000505 /* AIChatOmnibarBrandLogoLayoutTests.swift in Sources */,
+				FB07BAD20000000000000505 /* AIChatOmnibarDuckAILogoLayoutTests.swift in Sources */,
 				FB07BAE20000000000000002 /* DuckAIPromptPixelFiringTests.swift in Sources */,
 				FB07BAD10000000000000026 /* PromptBarPromptSubmitterTests.swift in Sources */,
 				FB07BAD10000000000000020 /* PromptBarCoordinatorTests.swift in Sources */,
@@ -18981,7 +18981,7 @@
 				FB07BAD20000000000000603 /* PromptBarOmnibarContentLayoutTests.swift in Sources */,
 				FB07BAD20000000000000602 /* EphemeralPromptDraftStoreTests.swift in Sources */,
 				FB07BAD20000000000000601 /* DuckAIPromptSurfaceTests.swift in Sources */,
-				FB07BAD20000000000000605 /* AIChatOmnibarBrandLogoLayoutTests.swift in Sources */,
+				FB07BAD20000000000000605 /* AIChatOmnibarDuckAILogoLayoutTests.swift in Sources */,
 				FB07BAE20000000000000003 /* DuckAIPromptPixelFiringTests.swift in Sources */,
 				FB07BAD10000000000000025 /* PromptBarPromptSubmitterTests.swift in Sources */,
 				FB07BAD1000000000000001F /* PromptBarCoordinatorTests.swift in Sources */,

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -4722,6 +4722,8 @@
 		FB07BAD20000000000000603 /* PromptBarOmnibarContentLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000403 /* PromptBarOmnibarContentLayoutTests.swift */; };
 		FB07BAD20000000000000504 /* PromptBarPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000404 /* PromptBarPresenterTests.swift */; };
 		FB07BAD20000000000000604 /* PromptBarPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000404 /* PromptBarPresenterTests.swift */; };
+		FB07BAD20000000000000505 /* AIChatOmnibarBrandLogoLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000405 /* AIChatOmnibarBrandLogoLayoutTests.swift */; };
+		FB07BAD20000000000000605 /* AIChatOmnibarBrandLogoLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000405 /* AIChatOmnibarBrandLogoLayoutTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -7232,6 +7234,7 @@
 		FB07BAD20000000000000402 /* EphemeralPromptDraftStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EphemeralPromptDraftStoreTests.swift; sourceTree = "<group>"; };
 		FB07BAD20000000000000403 /* PromptBarOmnibarContentLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarOmnibarContentLayoutTests.swift; sourceTree = "<group>"; };
 		FB07BAD20000000000000404 /* PromptBarPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPresenterTests.swift; sourceTree = "<group>"; };
+		FB07BAD20000000000000405 /* AIChatOmnibarBrandLogoLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatOmnibarBrandLogoLayoutTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -8179,6 +8182,7 @@
 			children = (
 				FB07BAD20000000000000402 /* EphemeralPromptDraftStoreTests.swift */,
 				FB07BAD20000000000000401 /* DuckAIPromptSurfaceTests.swift */,
+				FB07BAD20000000000000405 /* AIChatOmnibarBrandLogoLayoutTests.swift */,
 				FB07BAE20000000000000001 /* DuckAIPromptPixelFiringTests.swift */,
 				BB027E8B2FBB4D3A009B4FE4 /* DuckAiVoiceChatShieldScopeTests.swift */,
 				BBC277902FB2367300756A85 /* DuckAiVoiceChatFailureHandlerTests.swift */,
@@ -16627,6 +16631,7 @@
 				FB07BAD20000000000000503 /* PromptBarOmnibarContentLayoutTests.swift in Sources */,
 				FB07BAD20000000000000502 /* EphemeralPromptDraftStoreTests.swift in Sources */,
 				FB07BAD20000000000000501 /* DuckAIPromptSurfaceTests.swift in Sources */,
+				FB07BAD20000000000000505 /* AIChatOmnibarBrandLogoLayoutTests.swift in Sources */,
 				FB07BAE20000000000000002 /* DuckAIPromptPixelFiringTests.swift in Sources */,
 				FB07BAD10000000000000026 /* PromptBarPromptSubmitterTests.swift in Sources */,
 				FB07BAD10000000000000020 /* PromptBarCoordinatorTests.swift in Sources */,
@@ -18976,6 +18981,7 @@
 				FB07BAD20000000000000603 /* PromptBarOmnibarContentLayoutTests.swift in Sources */,
 				FB07BAD20000000000000602 /* EphemeralPromptDraftStoreTests.swift in Sources */,
 				FB07BAD20000000000000601 /* DuckAIPromptSurfaceTests.swift in Sources */,
+				FB07BAD20000000000000605 /* AIChatOmnibarBrandLogoLayoutTests.swift in Sources */,
 				FB07BAE20000000000000003 /* DuckAIPromptPixelFiringTests.swift in Sources */,
 				FB07BAD10000000000000025 /* PromptBarPromptSubmitterTests.swift in Sources */,
 				FB07BAD1000000000000001F /* PromptBarCoordinatorTests.swift in Sources */,

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
@@ -35,13 +35,9 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
         static let dividerTopOffset: CGFloat = -10.0
         static let placeholderLeadingOffset: CGFloat = 10
         static let placeholderLegacyLeadingOffset: CGFloat = 9
-        /// Where the prompt's glyphs start: `textContainerInset.width` plus the container's
-        /// line-fragment padding. Unlike the placeholder's offset, it doesn't shift with the theme.
         static let textLeadingOffset: CGFloat = 10
         static let brandLogoSize: CGFloat = 24
         static let brandLogoToTextSpacing: CGFloat = 12
-        /// The logo takes the prompt's own text-leading position, so the text moves right by the
-        /// logo's width plus the gap after it.
         static let brandLogoTextIndent: CGFloat = brandLogoSize + brandLogoToTextSpacing
     }
 
@@ -215,9 +211,6 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
         let placeholderLeadingConstant = themeManager.isAppRebranded ? Constants.placeholderLeadingOffset : Constants.placeholderLegacyLeadingOffset
 
         let showsBrandLogo = omnibarController.surface.showsBrandLogo
-        // Indenting the scroll view, not `textContainerInset`: the text container tracks the text
-        // view's width, so an inset would be taken off the trailing edge too and wrap the text early
-        // under the submit button.
         let textIndent = showsBrandLogo ? Constants.brandLogoTextIndent : 0
 
         NSLayoutConstraint.activate([
@@ -251,19 +244,16 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
         }
     }
 
-    /// Sits where the prompt text would otherwise start, centred on its first line.
     private func setUpBrandLogo() {
         brandLogoView.translatesAutoresizingMaskIntoConstraints = false
         brandLogoView.image = DesignSystemImages.Color.Size24.duckAI
         brandLogoView.imageScaling = .scaleProportionallyUpOrDown
-        /// Clicks on the mark focus the prompt rather than dead-zoning, as they do on the placeholder.
         brandLogoView.hitTestForwardingTarget = textView
         brandLogoView.setAccessibilityElement(false)
         containerView.addSubview(brandLogoView)
 
         NSLayoutConstraint.activate([
             brandLogoView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: Constants.textLeadingOffset),
-            /// The placeholder hides once there's text, but a hidden view still anchors layout.
             brandLogoView.centerYAnchor.constraint(equalTo: placeholderLabel.centerYAnchor),
             brandLogoView.widthAnchor.constraint(equalToConstant: Constants.brandLogoSize),
             brandLogoView.heightAnchor.constraint(equalToConstant: Constants.brandLogoSize)
@@ -734,8 +724,6 @@ private final class ClickThroughLabel: NSTextField {
     }
 }
 
-/// `NSImageView` that forwards mouse hits the way `ClickThroughLabel` does, so the branding mark
-/// never intercepts a click meant for the prompt behind it.
 private final class ClickThroughImageView: NSImageView {
     weak var hitTestForwardingTarget: NSView?
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
@@ -20,6 +20,7 @@ import Cocoa
 import Combine
 import AIChat
 import AppKitExtensions
+import DesignResourcesKitIcons
 import PixelKit
 import PrivacyConfig
 
@@ -34,6 +35,14 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
         static let dividerTopOffset: CGFloat = -10.0
         static let placeholderLeadingOffset: CGFloat = 10
         static let placeholderLegacyLeadingOffset: CGFloat = 9
+        /// Where the prompt's glyphs start: `textContainerInset.width` plus the container's
+        /// line-fragment padding. Unlike the placeholder's offset, it doesn't shift with the theme.
+        static let textLeadingOffset: CGFloat = 10
+        static let brandLogoSize: CGFloat = 24
+        static let brandLogoToTextSpacing: CGFloat = 12
+        /// The logo takes the prompt's own text-leading position, so the text moves right by the
+        /// logo's width plus the gap after it.
+        static let brandLogoTextIndent: CGFloat = brandLogoSize + brandLogoToTextSpacing
     }
 
     private let backgroundView = MouseBlockingBackgroundView()
@@ -44,6 +53,7 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
     private let textContainer = NSTextContainer()
     private let textView: FocusableTextView
     private let placeholderLabel = ClickThroughLabel(labelWithString: "")
+    private let brandLogoView = ClickThroughImageView()
     private let dividerView = ColorView(frame: .zero)
     private let omnibarController: AIChatOmnibarController
     /// Coordinator for the `@`-mention tab picker. `nil` until the first detected token, so
@@ -204,6 +214,12 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
 
         let placeholderLeadingConstant = themeManager.isAppRebranded ? Constants.placeholderLeadingOffset : Constants.placeholderLegacyLeadingOffset
 
+        let showsBrandLogo = omnibarController.surface.showsBrandLogo
+        // Indenting the scroll view, not `textContainerInset`: the text container tracks the text
+        // view's width, so an inset would be taken off the trailing edge too and wrap the text early
+        // under the submit button.
+        let textIndent = showsBrandLogo ? Constants.brandLogoTextIndent : 0
+
         NSLayoutConstraint.activate([
             backgroundView.topAnchor.constraint(equalTo: view.topAnchor),
             backgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -216,7 +232,7 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
             containerView.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor),
 
             scrollView.topAnchor.constraint(equalTo: containerView.topAnchor),
-            scrollView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: textIndent),
             scrollView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -Constants.bottomPadding),
 
@@ -228,6 +244,29 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
 
             placeholderLabel.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: placeholderLeadingConstant),
             placeholderLabel.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 9),
+        ])
+
+        if showsBrandLogo {
+            setUpBrandLogo()
+        }
+    }
+
+    /// Sits where the prompt text would otherwise start, centred on its first line.
+    private func setUpBrandLogo() {
+        brandLogoView.translatesAutoresizingMaskIntoConstraints = false
+        brandLogoView.image = DesignSystemImages.Color.Size24.duckAI
+        brandLogoView.imageScaling = .scaleProportionallyUpOrDown
+        /// Clicks on the mark focus the prompt rather than dead-zoning, as they do on the placeholder.
+        brandLogoView.hitTestForwardingTarget = textView
+        brandLogoView.setAccessibilityElement(false)
+        containerView.addSubview(brandLogoView)
+
+        NSLayoutConstraint.activate([
+            brandLogoView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: Constants.textLeadingOffset),
+            /// The placeholder hides once there's text, but a hidden view still anchors layout.
+            brandLogoView.centerYAnchor.constraint(equalTo: placeholderLabel.centerYAnchor),
+            brandLogoView.widthAnchor.constraint(equalToConstant: Constants.brandLogoSize),
+            brandLogoView.heightAnchor.constraint(equalToConstant: Constants.brandLogoSize)
         ])
     }
 
@@ -688,6 +727,16 @@ protocol FocusableTextViewNavigationDelegate: AnyObject {
 /// Used for the prompt placeholder: clicks on the placeholder area hit-test to the text view so the prompt takes focus,
 /// rather than falling through the empty scroll-view area to the address bar behind (which would switch to search mode).
 private final class ClickThroughLabel: NSTextField {
+    weak var hitTestForwardingTarget: NSView?
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        return hitTestForwardingTarget ?? nil
+    }
+}
+
+/// `NSImageView` that forwards mouse hits the way `ClickThroughLabel` does, so the branding mark
+/// never intercepts a click meant for the prompt behind it.
+private final class ClickThroughImageView: NSImageView {
     weak var hitTestForwardingTarget: NSView?
 
     override func hitTest(_ point: NSPoint) -> NSView? {

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
@@ -39,6 +39,7 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
         static let duckAILogoSize: CGFloat = 24
         static let duckAILogoToTextSpacing: CGFloat = 12
         static let duckAILogoLeadingOffset: CGFloat = 5
+        static let duckAILogoLegacyLeadingOffset: CGFloat = 3
     }
 
     private let backgroundView = MouseBlockingBackgroundView()
@@ -256,8 +257,10 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
         duckAILogoView.setAccessibilityElement(false)
         containerView.addSubview(duckAILogoView)
 
+        let leadingConstant = themeManager.isAppRebranded ? Constants.duckAILogoLeadingOffset : Constants.duckAILogoLegacyLeadingOffset
+
         NSLayoutConstraint.activate([
-            duckAILogoView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: Constants.duckAILogoLeadingOffset),
+            duckAILogoView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: leadingConstant),
             duckAILogoView.centerYAnchor.constraint(equalTo: placeholderLabel.centerYAnchor),
             duckAILogoView.widthAnchor.constraint(equalToConstant: Constants.duckAILogoSize),
             duckAILogoView.heightAnchor.constraint(equalToConstant: Constants.duckAILogoSize)

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
@@ -38,7 +38,7 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
         static let textLeadingOffset: CGFloat = 10
         static let duckAILogoSize: CGFloat = 24
         static let duckAILogoToTextSpacing: CGFloat = 12
-        static let duckAILogoTextIndent: CGFloat = duckAILogoSize + duckAILogoToTextSpacing
+        static let duckAILogoLeadingOffset: CGFloat = 5
     }
 
     private let backgroundView = MouseBlockingBackgroundView()
@@ -211,7 +211,14 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
         let placeholderLeadingConstant = themeManager.isAppRebranded ? Constants.placeholderLeadingOffset : Constants.placeholderLegacyLeadingOffset
 
         let showsDuckAILogo = omnibarController.surface.showsDuckAILogo
-        let textIndent = showsDuckAILogo ? Constants.duckAILogoTextIndent : 0
+        if showsDuckAILogo {
+            setUpDuckAILogo()
+        }
+
+        let scrollViewLeading = showsDuckAILogo
+            ? scrollView.leadingAnchor.constraint(equalTo: duckAILogoView.trailingAnchor,
+                                                  constant: Constants.duckAILogoToTextSpacing - Constants.textLeadingOffset)
+            : scrollView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor)
 
         NSLayoutConstraint.activate([
             backgroundView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -225,7 +232,7 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
             containerView.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor),
 
             scrollView.topAnchor.constraint(equalTo: containerView.topAnchor),
-            scrollView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: textIndent),
+            scrollViewLeading,
             scrollView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -Constants.bottomPadding),
 
@@ -238,10 +245,6 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
             placeholderLabel.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: placeholderLeadingConstant),
             placeholderLabel.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 9),
         ])
-
-        if showsDuckAILogo {
-            setUpDuckAILogo()
-        }
     }
 
     private func setUpDuckAILogo() {
@@ -249,11 +252,12 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
         duckAILogoView.image = DesignSystemImages.Color.Size24.duckAI
         duckAILogoView.imageScaling = .scaleProportionallyUpOrDown
         duckAILogoView.hitTestForwardingTarget = textView
+        duckAILogoView.setAccessibilityIdentifier("AIChatOmnibarTextContainerViewController.duckAILogoView")
         duckAILogoView.setAccessibilityElement(false)
         containerView.addSubview(duckAILogoView)
 
         NSLayoutConstraint.activate([
-            duckAILogoView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: Constants.textLeadingOffset),
+            duckAILogoView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: Constants.duckAILogoLeadingOffset),
             duckAILogoView.centerYAnchor.constraint(equalTo: placeholderLabel.centerYAnchor),
             duckAILogoView.widthAnchor.constraint(equalToConstant: Constants.duckAILogoSize),
             duckAILogoView.heightAnchor.constraint(equalToConstant: Constants.duckAILogoSize)

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
@@ -240,11 +240,11 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
         ])
 
         if showsBrandLogo {
-            setUpBrandLogo()
+            setUpDuckAILogo()
         }
     }
 
-    private func setUpBrandLogo() {
+    private func setUpDuckAILogo() {
         brandLogoView.translatesAutoresizingMaskIntoConstraints = false
         brandLogoView.image = DesignSystemImages.Color.Size24.duckAI
         brandLogoView.imageScaling = .scaleProportionallyUpOrDown

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
@@ -36,9 +36,9 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
         static let placeholderLeadingOffset: CGFloat = 10
         static let placeholderLegacyLeadingOffset: CGFloat = 9
         static let textLeadingOffset: CGFloat = 10
-        static let brandLogoSize: CGFloat = 24
-        static let brandLogoToTextSpacing: CGFloat = 12
-        static let brandLogoTextIndent: CGFloat = brandLogoSize + brandLogoToTextSpacing
+        static let duckAILogoSize: CGFloat = 24
+        static let duckAILogoToTextSpacing: CGFloat = 12
+        static let duckAILogoTextIndent: CGFloat = duckAILogoSize + duckAILogoToTextSpacing
     }
 
     private let backgroundView = MouseBlockingBackgroundView()
@@ -49,7 +49,7 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
     private let textContainer = NSTextContainer()
     private let textView: FocusableTextView
     private let placeholderLabel = ClickThroughLabel(labelWithString: "")
-    private let brandLogoView = ClickThroughImageView()
+    private let duckAILogoView = ClickThroughImageView()
     private let dividerView = ColorView(frame: .zero)
     private let omnibarController: AIChatOmnibarController
     /// Coordinator for the `@`-mention tab picker. `nil` until the first detected token, so
@@ -210,8 +210,8 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
 
         let placeholderLeadingConstant = themeManager.isAppRebranded ? Constants.placeholderLeadingOffset : Constants.placeholderLegacyLeadingOffset
 
-        let showsBrandLogo = omnibarController.surface.showsBrandLogo
-        let textIndent = showsBrandLogo ? Constants.brandLogoTextIndent : 0
+        let showsDuckAILogo = omnibarController.surface.showsDuckAILogo
+        let textIndent = showsDuckAILogo ? Constants.duckAILogoTextIndent : 0
 
         NSLayoutConstraint.activate([
             backgroundView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -239,24 +239,24 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
             placeholderLabel.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 9),
         ])
 
-        if showsBrandLogo {
+        if showsDuckAILogo {
             setUpDuckAILogo()
         }
     }
 
     private func setUpDuckAILogo() {
-        brandLogoView.translatesAutoresizingMaskIntoConstraints = false
-        brandLogoView.image = DesignSystemImages.Color.Size24.duckAI
-        brandLogoView.imageScaling = .scaleProportionallyUpOrDown
-        brandLogoView.hitTestForwardingTarget = textView
-        brandLogoView.setAccessibilityElement(false)
-        containerView.addSubview(brandLogoView)
+        duckAILogoView.translatesAutoresizingMaskIntoConstraints = false
+        duckAILogoView.image = DesignSystemImages.Color.Size24.duckAI
+        duckAILogoView.imageScaling = .scaleProportionallyUpOrDown
+        duckAILogoView.hitTestForwardingTarget = textView
+        duckAILogoView.setAccessibilityElement(false)
+        containerView.addSubview(duckAILogoView)
 
         NSLayoutConstraint.activate([
-            brandLogoView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: Constants.textLeadingOffset),
-            brandLogoView.centerYAnchor.constraint(equalTo: placeholderLabel.centerYAnchor),
-            brandLogoView.widthAnchor.constraint(equalToConstant: Constants.brandLogoSize),
-            brandLogoView.heightAnchor.constraint(equalToConstant: Constants.brandLogoSize)
+            duckAILogoView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: Constants.textLeadingOffset),
+            duckAILogoView.centerYAnchor.constraint(equalTo: placeholderLabel.centerYAnchor),
+            duckAILogoView.widthAnchor.constraint(equalToConstant: Constants.duckAILogoSize),
+            duckAILogoView.heightAnchor.constraint(equalToConstant: Constants.duckAILogoSize)
         ])
     }
 

--- a/macOS/DuckDuckGo/AIChat/PromptInput/DuckAIPromptSurface.swift
+++ b/macOS/DuckDuckGo/AIChat/PromptInput/DuckAIPromptSurface.swift
@@ -67,6 +67,14 @@ extension DuckAIPromptSurface {
         }
     }
 
+    /// A leading Duck.ai mark, standing in for the branding the browser chrome gives the address bar.
+    var showsBrandLogo: Bool {
+        switch self {
+        case .addressBar: false
+        case .promptBar: true
+        }
+    }
+
     /// Set for surfaces with no window of their own, whose host has to resolve one first. Covers the
     /// voice button too.
     var routesSubmissionThroughHost: Bool {

--- a/macOS/DuckDuckGo/AIChat/PromptInput/DuckAIPromptSurface.swift
+++ b/macOS/DuckDuckGo/AIChat/PromptInput/DuckAIPromptSurface.swift
@@ -67,7 +67,7 @@ extension DuckAIPromptSurface {
         }
     }
 
-    var showsBrandLogo: Bool {
+    var showsDuckAILogo: Bool {
         switch self {
         case .addressBar: false
         case .promptBar: true

--- a/macOS/DuckDuckGo/AIChat/PromptInput/DuckAIPromptSurface.swift
+++ b/macOS/DuckDuckGo/AIChat/PromptInput/DuckAIPromptSurface.swift
@@ -67,7 +67,6 @@ extension DuckAIPromptSurface {
         }
     }
 
-    /// A leading Duck.ai mark, standing in for the branding the browser chrome gives the address bar.
     var showsBrandLogo: Bool {
         switch self {
         case .addressBar: false

--- a/macOS/UnitTests/AIChat/AIChatOmnibarBrandLogoLayoutTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarBrandLogoLayoutTests.swift
@@ -1,0 +1,191 @@
+//
+//  AIChatOmnibarBrandLogoLayoutTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import AppKit
+import FeatureFlags
+import PrivacyConfig
+import PrivacyConfigTestsUtils
+import SubscriptionTestingUtilities
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+@testable import Subscription
+
+/// Lays the real prompt text container out on each surface and measures the result, so the Prompt
+/// Bar's leading Duck.ai mark is pinned as Prompt-Bar-only rather than by reading the constraints back.
+@MainActor
+final class AIChatOmnibarBrandLogoLayoutTests: XCTestCase {
+
+    // MARK: - Prompt Bar
+
+    func testWhenSurfaceIsPromptBarThenTheBrandLogoLeadsThePrompt() {
+        let textViewController = layOutTextContainer(surface: .promptBar)
+
+        guard let logo = brandLogo(in: textViewController.view) else {
+            return XCTFail("No brand logo in the Prompt Bar's prompt")
+        }
+
+        XCTAssertEqual(logo.bounds.width, 24, accuracy: 0.5)
+        XCTAssertEqual(logo.bounds.height, 24, accuracy: 0.5)
+        XCTAssertNotNil(logo.image, "The logo view has no image, so nothing renders")
+    }
+
+    func testWhenSurfaceIsPromptBarThenThePromptTextClearsTheBrandLogo() {
+        let textViewController = layOutTextContainer(surface: .promptBar)
+        let host = textViewController.view
+
+        guard let logo = brandLogo(in: host) else {
+            return XCTFail("No brand logo in the Prompt Bar's prompt")
+        }
+        let logoTrailing = host.convert(NSPoint(x: logo.bounds.maxX, y: 0), from: logo).x
+
+        XCTAssertEqual(textLeading(in: host) - logoTrailing, 12, accuracy: 0.5,
+                       "The prompt text no longer sits a 12pt gap clear of the logo")
+    }
+
+    /// The placeholder and the typed text ride the same scroll view, so they must indent by the same
+    /// amount — otherwise the text jumps sideways on the first keystroke.
+    func testWhenSurfaceIsPromptBarThenThePlaceholderIndentsWithTheText() {
+        let addressBar = layOutTextContainer(surface: .addressBar).view
+        let promptBar = layOutTextContainer(surface: .promptBar).view
+
+        let placeholderIndent = placeholderLeading(in: promptBar) - placeholderLeading(in: addressBar)
+        let textIndent = textLeading(in: promptBar) - textLeading(in: addressBar)
+
+        XCTAssertEqual(placeholderIndent, textIndent, accuracy: 0.5)
+    }
+
+    func testWhenTheBrandLogoIsClickedThenTheHitGoesToThePromptEditor() {
+        let host = layOutTextContainer(surface: .promptBar).view
+
+        guard let logo = brandLogo(in: host) else {
+            return XCTFail("No brand logo in the Prompt Bar's prompt")
+        }
+        let logoCentre = host.convert(NSPoint(x: logo.bounds.midX, y: logo.bounds.midY), from: logo)
+
+        XCTAssertTrue(host.hitTest(logoCentre) is NSTextView,
+                      "Clicking the logo must focus the prompt rather than land on the mark itself")
+    }
+
+    // MARK: - Address bar
+
+    func testWhenSurfaceIsAddressBarThenThereIsNoBrandLogo() {
+        let textViewController = layOutTextContainer(surface: .addressBar)
+
+        XCTAssertNil(brandLogo(in: textViewController.view))
+    }
+
+    /// The regression guard: the address bar's prompt must start exactly where it did before the
+    /// Prompt Bar's logo existed, so its text sits a full logo-indent left of the Prompt Bar's.
+    func testWhenSurfaceIsAddressBarThenThePromptTextIsNotIndented() {
+        let addressBarLeading = textLeading(in: layOutTextContainer(surface: .addressBar).view)
+        let promptBarLeading = textLeading(in: layOutTextContainer(surface: .promptBar).view)
+
+        XCTAssertEqual(promptBarLeading - addressBarLeading, 36, accuracy: 0.5,
+                       "The address bar's prompt has shifted — only the Prompt Bar indents for the logo")
+    }
+
+    // MARK: - Measurement
+
+    /// The x of the first glyph's origin, in the host view's coordinates.
+    private func textLeading(in host: NSView) -> CGFloat {
+        guard let textView = firstDescendant(of: host, ofType: NSTextView.self),
+              let textContainer = textView.textContainer else {
+            XCTFail("No prompt text view in the hierarchy")
+            return 0
+        }
+        let originInTextView = textView.textContainerOrigin.x + textContainer.lineFragmentPadding
+        return host.convert(NSPoint(x: originInTextView, y: 0), from: textView).x
+    }
+
+    private func placeholderLeading(in host: NSView) -> CGFloat {
+        guard let placeholder = firstDescendant(of: host, ofType: NSTextField.self) else {
+            XCTFail("No placeholder label in the hierarchy")
+            return 0
+        }
+        return host.convert(NSPoint(x: placeholder.bounds.minX, y: 0), from: placeholder).x
+    }
+
+    private func brandLogo(in host: NSView) -> NSImageView? {
+        firstDescendant(of: host, ofType: NSImageView.self)
+    }
+
+    private func descendants(of view: NSView) -> [NSView] {
+        view.subviews + view.subviews.flatMap { descendants(of: $0) }
+    }
+
+    private func firstDescendant<T: NSView>(of view: NSView, ofType type: T.Type) -> T? {
+        descendants(of: view).compactMap { $0 as? T }.first
+    }
+
+    // MARK: - Assembly
+
+    private func layOutTextContainer(surface: DuckAIPromptSurface) -> AIChatOmnibarTextContainerViewController {
+        let textViewController = makeTextContainer(surface: surface)
+        let view = textViewController.view
+        view.frame = NSRect(x: 0, y: 0, width: PromptBarPlacement.preferredWidth, height: 80)
+        view.layoutSubtreeIfNeeded()
+        return textViewController
+    }
+
+    private func makeTextContainer(surface: DuckAIPromptSurface) -> AIChatOmnibarTextContainerViewController {
+        let featureFlagger = MockFeatureFlagger()
+        let appearancePreferences = AppearancePreferences(
+            persistor: AppearancePreferencesPersistorMock(),
+            privacyConfigurationManager: MockPrivacyConfigurationManager(),
+            featureFlagger: featureFlagger,
+            aiChatMenuConfig: MockAIChatConfig()
+        )
+        let themeManager = ThemeManager(appearancePreferences: appearancePreferences, featureFlagger: featureFlagger)
+
+        let omnibarController = AIChatOmnibarController(
+            aiChatTabOpener: MockAIChatTabOpener(),
+            surface: surface,
+            draftSource: StaticPromptDraftSource(store: EphemeralPromptDraftStore()),
+            origin: nil,
+            pixelHandler: PromptBarPixelHandler(),
+            featureFlagger: featureFlagger,
+            modelsService: StubAIChatModelsService(),
+            subscriptionManager: SubscriptionManagerMock(),
+            subscriptionUpsellPresenter: StubSubscriptionUpsellPresenter()
+        )
+
+        return AIChatOmnibarTextContainerViewController(
+            omnibarController: omnibarController,
+            themeManager: themeManager,
+            isBurner: false,
+            featureFlagger: featureFlagger
+        )
+    }
+}
+
+// MARK: - Stubs
+
+private struct StubAIChatModelsService: AIChatModelsProviding {
+    func fetchModels() async throws -> AIChatModelsResponse {
+        AIChatModelsResponse(models: [])
+    }
+}
+
+@MainActor
+private struct StubSubscriptionUpsellPresenter: AIChatOmnibarSubscriptionUpselling {
+    func routeGatedSelection(requiredTier: AIChatModelPublicAccessTier,
+                             userTier: AIChatUserTier,
+                             origin: SubscriptionFunnelOrigin) -> Bool { false }
+    func presentSubscriptionActivation() {}
+}

--- a/macOS/UnitTests/AIChat/AIChatOmnibarBrandLogoLayoutTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarBrandLogoLayoutTests.swift
@@ -26,8 +26,6 @@ import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 @testable import Subscription
 
-/// Lays the real prompt text container out on each surface and measures the result, so the Prompt
-/// Bar's leading Duck.ai mark is pinned as Prompt-Bar-only rather than by reading the constraints back.
 @MainActor
 final class AIChatOmnibarBrandLogoLayoutTests: XCTestCase {
 
@@ -58,8 +56,6 @@ final class AIChatOmnibarBrandLogoLayoutTests: XCTestCase {
                        "The prompt text no longer sits a 12pt gap clear of the logo")
     }
 
-    /// The placeholder and the typed text ride the same scroll view, so they must indent by the same
-    /// amount — otherwise the text jumps sideways on the first keystroke.
     func testWhenSurfaceIsPromptBarThenThePlaceholderIndentsWithTheText() {
         let addressBar = layOutTextContainer(surface: .addressBar).view
         let promptBar = layOutTextContainer(surface: .promptBar).view
@@ -90,8 +86,6 @@ final class AIChatOmnibarBrandLogoLayoutTests: XCTestCase {
         XCTAssertNil(brandLogo(in: textViewController.view))
     }
 
-    /// The regression guard: the address bar's prompt must start exactly where it did before the
-    /// Prompt Bar's logo existed, so its text sits a full logo-indent left of the Prompt Bar's.
     func testWhenSurfaceIsAddressBarThenThePromptTextIsNotIndented() {
         let addressBarLeading = textLeading(in: layOutTextContainer(surface: .addressBar).view)
         let promptBarLeading = textLeading(in: layOutTextContainer(surface: .promptBar).view)
@@ -102,7 +96,6 @@ final class AIChatOmnibarBrandLogoLayoutTests: XCTestCase {
 
     // MARK: - Measurement
 
-    /// The x of the first glyph's origin, in the host view's coordinates.
     private func textLeading(in host: NSView) -> CGFloat {
         guard let textView = firstDescendant(of: host, ofType: NSTextView.self),
               let textContainer = textView.textContainer else {

--- a/macOS/UnitTests/AIChat/AIChatOmnibarDuckAILogoLayoutTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarDuckAILogoLayoutTests.swift
@@ -88,10 +88,16 @@ final class AIChatOmnibarDuckAILogoLayoutTests: XCTestCase {
 
     func testWhenSurfaceIsAddressBarThenThePromptTextIsNotIndented() {
         let addressBarLeading = textLeading(in: layOutTextContainer(surface: .addressBar).view)
+
+        XCTAssertEqual(addressBarLeading, 10, accuracy: 0.5,
+                       "The address bar's prompt no longer starts at the text container's own 5pt inset plus 5pt line-fragment padding — only the Prompt Bar indents for the logo")
+    }
+
+    func testWhenSurfaceIsPromptBarThenThePromptTextIsIndentedPastTheAddressBars() {
+        let addressBarLeading = textLeading(in: layOutTextContainer(surface: .addressBar).view)
         let promptBarLeading = textLeading(in: layOutTextContainer(surface: .promptBar).view)
 
-        XCTAssertEqual(promptBarLeading - addressBarLeading, 31, accuracy: 0.5,
-                       "The address bar's prompt has shifted — only the Prompt Bar indents for the logo")
+        XCTAssertGreaterThan(promptBarLeading, addressBarLeading)
     }
 
     // MARK: - Measurement

--- a/macOS/UnitTests/AIChat/AIChatOmnibarDuckAILogoLayoutTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarDuckAILogoLayoutTests.swift
@@ -1,5 +1,5 @@
 //
-//  AIChatOmnibarBrandLogoLayoutTests.swift
+//  AIChatOmnibarDuckAILogoLayoutTests.swift
 //
 //  Copyright © 2026 DuckDuckGo. All rights reserved.
 //
@@ -27,15 +27,15 @@ import XCTest
 @testable import Subscription
 
 @MainActor
-final class AIChatOmnibarBrandLogoLayoutTests: XCTestCase {
+final class AIChatOmnibarDuckAILogoLayoutTests: XCTestCase {
 
     // MARK: - Prompt Bar
 
-    func testWhenSurfaceIsPromptBarThenTheBrandLogoLeadsThePrompt() {
+    func testWhenSurfaceIsPromptBarThenTheDuckAILogoLeadsThePrompt() {
         let textViewController = layOutTextContainer(surface: .promptBar)
 
-        guard let logo = brandLogo(in: textViewController.view) else {
-            return XCTFail("No brand logo in the Prompt Bar's prompt")
+        guard let logo = duckAILogo(in: textViewController.view) else {
+            return XCTFail("No Duck.ai logo in the Prompt Bar's prompt")
         }
 
         XCTAssertEqual(logo.bounds.width, 24, accuracy: 0.5)
@@ -43,12 +43,12 @@ final class AIChatOmnibarBrandLogoLayoutTests: XCTestCase {
         XCTAssertNotNil(logo.image, "The logo view has no image, so nothing renders")
     }
 
-    func testWhenSurfaceIsPromptBarThenThePromptTextClearsTheBrandLogo() {
+    func testWhenSurfaceIsPromptBarThenThePromptTextClearsTheDuckAILogo() {
         let textViewController = layOutTextContainer(surface: .promptBar)
         let host = textViewController.view
 
-        guard let logo = brandLogo(in: host) else {
-            return XCTFail("No brand logo in the Prompt Bar's prompt")
+        guard let logo = duckAILogo(in: host) else {
+            return XCTFail("No Duck.ai logo in the Prompt Bar's prompt")
         }
         let logoTrailing = host.convert(NSPoint(x: logo.bounds.maxX, y: 0), from: logo).x
 
@@ -66,11 +66,11 @@ final class AIChatOmnibarBrandLogoLayoutTests: XCTestCase {
         XCTAssertEqual(placeholderIndent, textIndent, accuracy: 0.5)
     }
 
-    func testWhenTheBrandLogoIsClickedThenTheHitGoesToThePromptEditor() {
+    func testWhenTheDuckAILogoIsClickedThenTheHitGoesToThePromptEditor() {
         let host = layOutTextContainer(surface: .promptBar).view
 
-        guard let logo = brandLogo(in: host) else {
-            return XCTFail("No brand logo in the Prompt Bar's prompt")
+        guard let logo = duckAILogo(in: host) else {
+            return XCTFail("No Duck.ai logo in the Prompt Bar's prompt")
         }
         let logoCentre = host.convert(NSPoint(x: logo.bounds.midX, y: logo.bounds.midY), from: logo)
 
@@ -80,10 +80,10 @@ final class AIChatOmnibarBrandLogoLayoutTests: XCTestCase {
 
     // MARK: - Address bar
 
-    func testWhenSurfaceIsAddressBarThenThereIsNoBrandLogo() {
+    func testWhenSurfaceIsAddressBarThenThereIsNoDuckAILogo() {
         let textViewController = layOutTextContainer(surface: .addressBar)
 
-        XCTAssertNil(brandLogo(in: textViewController.view))
+        XCTAssertNil(duckAILogo(in: textViewController.view))
     }
 
     func testWhenSurfaceIsAddressBarThenThePromptTextIsNotIndented() {
@@ -114,7 +114,7 @@ final class AIChatOmnibarBrandLogoLayoutTests: XCTestCase {
         return host.convert(NSPoint(x: placeholder.bounds.minX, y: 0), from: placeholder).x
     }
 
-    private func brandLogo(in host: NSView) -> NSImageView? {
+    private func duckAILogo(in host: NSView) -> NSImageView? {
         firstDescendant(of: host, ofType: NSImageView.self)
     }
 

--- a/macOS/UnitTests/AIChat/AIChatOmnibarDuckAILogoLayoutTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarDuckAILogoLayoutTests.swift
@@ -90,7 +90,7 @@ final class AIChatOmnibarDuckAILogoLayoutTests: XCTestCase {
         let addressBarLeading = textLeading(in: layOutTextContainer(surface: .addressBar).view)
         let promptBarLeading = textLeading(in: layOutTextContainer(surface: .promptBar).view)
 
-        XCTAssertEqual(promptBarLeading - addressBarLeading, 36, accuracy: 0.5,
+        XCTAssertEqual(promptBarLeading - addressBarLeading, 31, accuracy: 0.5,
                        "The address bar's prompt has shifted — only the Prompt Bar indents for the logo")
     }
 
@@ -115,7 +115,9 @@ final class AIChatOmnibarDuckAILogoLayoutTests: XCTestCase {
     }
 
     private func duckAILogo(in host: NSView) -> NSImageView? {
-        firstDescendant(of: host, ofType: NSImageView.self)
+        descendants(of: host)
+            .compactMap { $0 as? NSImageView }
+            .first { $0.accessibilityIdentifier() == "AIChatOmnibarTextContainerViewController.duckAILogoView" }
     }
 
     private func descendants(of view: NSView) -> [NSView] {

--- a/macOS/UnitTests/AIChat/DuckAIPromptSurfaceTests.swift
+++ b/macOS/UnitTests/AIChat/DuckAIPromptSurfaceTests.swift
@@ -36,6 +36,7 @@ final class DuckAIPromptSurfaceTests: XCTestCase {
         let surface = DuckAIPromptSurface.addressBar
 
         XCTAssertFalse(surface.drawsOwnChrome)
+        XCTAssertFalse(surface.showsBrandLogo)
         XCTAssertFalse(surface.routesSubmissionThroughHost)
     }
 
@@ -57,6 +58,7 @@ final class DuckAIPromptSurfaceTests: XCTestCase {
         let surface = DuckAIPromptSurface.promptBar
 
         XCTAssertTrue(surface.drawsOwnChrome)
+        XCTAssertTrue(surface.showsBrandLogo)
         XCTAssertTrue(surface.routesSubmissionThroughHost)
     }
 }

--- a/macOS/UnitTests/AIChat/DuckAIPromptSurfaceTests.swift
+++ b/macOS/UnitTests/AIChat/DuckAIPromptSurfaceTests.swift
@@ -36,7 +36,7 @@ final class DuckAIPromptSurfaceTests: XCTestCase {
         let surface = DuckAIPromptSurface.addressBar
 
         XCTAssertFalse(surface.drawsOwnChrome)
-        XCTAssertFalse(surface.showsBrandLogo)
+        XCTAssertFalse(surface.showsDuckAILogo)
         XCTAssertFalse(surface.routesSubmissionThroughHost)
     }
 
@@ -58,7 +58,7 @@ final class DuckAIPromptSurfaceTests: XCTestCase {
         let surface = DuckAIPromptSurface.promptBar
 
         XCTAssertTrue(surface.drawsOwnChrome)
-        XCTAssertTrue(surface.showsBrandLogo)
+        XCTAssertTrue(surface.showsDuckAILogo)
         XCTAssertTrue(surface.routesSubmissionThroughHost)
     }
 }

--- a/macOS/UnitTests/PromptBar/PromptBarOmnibarContentLayoutTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarOmnibarContentLayoutTests.swift
@@ -113,7 +113,39 @@ final class PromptBarOmnibarContentLayoutTests: XCTestCase {
         }
     }
 
+    func testWhenTheDuckAILogoIsLaidOutThenItCentresOnTheToolRowsLeadingButton() {
+        let view = content.view
+        _ = layOutAndMeasureGap(prompt: "what is a duck")
+
+        guard let logo = duckAILogo(in: view) else {
+            return XCTFail("No Duck.ai logo in the hierarchy")
+        }
+        guard let leadingButton = leadingControlsRowButton(in: view) else {
+            return XCTFail("No controls row in the hierarchy")
+        }
+
+        let logoCentre = view.convert(NSPoint(x: logo.bounds.midX, y: 0), from: logo).x
+        let buttonLeading = view.convert(NSPoint(x: leadingButton.bounds.minX, y: 0), from: leadingButton).x
+
+        // Half the button's 28pt box: the labelled buttons are wider, so height is the square measure.
+        XCTAssertEqual(logoCentre - buttonLeading, leadingButton.bounds.height / 2, accuracy: 0.5,
+                       "The Duck.ai logo no longer lines up with the attachment button below it")
+    }
+
     // MARK: - Measurement
+
+    private func duckAILogo(in host: NSView) -> NSImageView? {
+        descendants(of: host)
+            .compactMap { $0 as? NSImageView }
+            .first { $0.accessibilityIdentifier() == "AIChatOmnibarTextContainerViewController.duckAILogoView" }
+    }
+
+    private func leadingControlsRowButton(in host: NSView) -> NSView? {
+        controlsRowButtons(in: host).min { lhs, rhs in
+            host.convert(NSPoint(x: lhs.bounds.minX, y: 0), from: lhs).x
+                < host.convert(NSPoint(x: rhs.bounds.minX, y: 0), from: rhs).x
+        }
+    }
 
     /// Distance between the bottom of the laid-out text and the top of the controls row.
     private func layOutAndMeasureGap(prompt: String) -> CGFloat {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217072966361779?focus=true
Tech Design URL:
CC:

### Description
The Prompt Bar now shows the Duck.ai mark at the leading edge of its prompt, with the text indented past it. The address bar's Duck.ai prompt is unchanged — the mark is gated on a new capability in the surface table that shared prompt views already branch on.

### Testing Steps
1. Enable the `macosPromptBar` feature flag, then press ⌥Space → the Prompt Bar opens with the Duck.ai logo left of "Ask anything privately".
2. Type a prompt long enough to wrap to several lines → the logo stays on the first line and every line stays indented past it; click the logo → the prompt takes focus.
3. In a browser window, switch the address bar to Duck.ai mode → no logo, and the prompt text starts exactly where it did before.

### Impact and Risks
Low

#### What could go wrong?
The prompt's leading inset is now surface-dependent, so a mistake there would shift the address bar's Duck.ai prompt text sideways.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout gated by the existing prompt-surface model; the main regression risk is accidentally shifting address-bar prompt leading inset if `showsDuckAILogo` wiring is wrong.
> 
> **Overview**
> The **Prompt Bar** now shows a **24pt Duck.ai logo** ahead of the prompt text and placeholder; the **address bar** Duck.ai prompt is unchanged.
> 
> `DuckAIPromptSurface` gains **`showsDuckAILogo`** (true for `.promptBar`, false for `.addressBar`). `AIChatOmnibarTextContainerViewController` branches on that flag: it lays out a click-through logo (`DesignSystemImages.Color.Size24.duckAI`), anchors the scroll view after the logo with a **12pt** gap, and forwards logo clicks to the text view via `ClickThroughImageView`.
> 
> **Unit tests** cover surface gating, spacing, hit-testing, placeholder alignment, and vertical alignment with the controls row in `PromptBarOmnibarContentLayoutTests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d3d25a807496506102f92f598708e49f6c101ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->