### PR TITLE
Exclude os_log_fault diagnostics from macOS crash reporting

### DIFF
--- a/macOS/LocalPackages/CrashReporting/Sources/CrashReporting/CrashReport.swift
+++ b/macOS/LocalPackages/CrashReporting/Sources/CrashReporting/CrashReport.swift
@@ -33,6 +33,10 @@ protocol CrashReport: CrashReportPresenting {
 
     /// The date the crash report file was created, used as a proxy for when the crash occurred.
     var creationDate: Date? { get }
+
+    /// `true` when the report is a non-fatal diagnostic filed via `os_log_fault` rather than a crash.
+    /// The process kept running, so these must not be counted, uploaded, or prompted for as crashes.
+    var isSimulated: Bool { get }
 }
 
 final class LegacyCrashReport: CrashReport {
@@ -91,6 +95,9 @@ final class LegacyCrashReport: CrashReport {
 
     let appVersion: String? = nil
     let bundleID: String? = nil
+
+    // `os_log_fault` diagnostics are only ever written in the JSON (`.ips`) format.
+    let isSimulated = false
 
     var creationDate: Date? { fileManager.fileCreationDate(url: url) }
 }
@@ -170,6 +177,11 @@ final class JSONCrashReport: CrashReport {
             return nil
         }
         return version
+    }
+
+    // Written as `"is_simulated":1`; NSNumber also accepts a boolean should the type ever change.
+    var isSimulated: Bool {
+        (headerJSON?["is_simulated"] as? NSNumber)?.boolValue ?? false
     }
 
     var creationDate: Date? { fileManager.fileCreationDate(url: url) }

--- a/macOS/LocalPackages/CrashReporting/Sources/CrashReporting/CrashReportReader.swift
+++ b/macOS/LocalPackages/CrashReporting/Sources/CrashReporting/CrashReportReader.swift
@@ -72,6 +72,7 @@ public final class CrashReportReader {
         return filteredPaths
             .compactMap(crashReport(from:))
             .filter(matchesBundleID)
+            .filter { !$0.isSimulated }
     }
 
     private func isCrashReportPath(_ path: URL) -> Bool {

--- a/macOS/LocalPackages/CrashReporting/Tests/CrashReportingTests/CrashReportReaderTests.swift
+++ b/macOS/LocalPackages/CrashReporting/Tests/CrashReportingTests/CrashReportReaderTests.swift
@@ -137,6 +137,50 @@ struct CrashReportReaderTests {
         #expect(reports.first?.url.lastPathComponent == "DuckDuckGo-valid.ips")
     }
 
+    @Test("When report is an ExcUserFault_ simulated diagnostic, it is ignored", .timeLimit(.minutes(1)))
+    func whenReportIsExcUserFaultItIsIgnored() throws {
+        let fileManager = MockFileManager()
+        let now = Date()
+
+        try writeReport(named: "DuckDuckGo-valid.ips", contents: sampleIPSReport(), in: FileManager.userDiagnosticReports, creationDate: now.addingTimeInterval(-60), fileManager: fileManager)
+        try writeReport(named: "ExcUserFault_DuckDuckGo-2026-07-29-154234.ips", contents: sampleSimulatedIPSReport(), in: FileManager.userDiagnosticReports, creationDate: now.addingTimeInterval(-60), fileManager: fileManager)
+
+        let reader = makeReader(now: now, fileManager: fileManager)
+        let reports = reader.getCrashReports(since: now.addingTimeInterval(-120))
+
+        #expect(reports.count == 1)
+        #expect(reports.first?.url.lastPathComponent == "DuckDuckGo-valid.ips")
+    }
+
+    @Test("When report is flagged is_simulated, it is ignored regardless of filename", .timeLimit(.minutes(1)))
+    func whenReportIsFlaggedSimulatedItIsIgnored() throws {
+        let fileManager = MockFileManager()
+        let now = Date()
+
+        try writeReport(named: "DuckDuckGo-valid.ips", contents: sampleIPSReport(), in: FileManager.userDiagnosticReports, creationDate: now.addingTimeInterval(-60), fileManager: fileManager)
+        try writeReport(named: "DuckDuckGo-simulated.ips", contents: sampleSimulatedIPSReport(), in: FileManager.userDiagnosticReports, creationDate: now.addingTimeInterval(-60), fileManager: fileManager)
+
+        let reader = makeReader(now: now, fileManager: fileManager)
+        let reports = reader.getCrashReports(since: now.addingTimeInterval(-120))
+
+        #expect(reports.count == 1)
+        #expect(reports.first?.url.lastPathComponent == "DuckDuckGo-valid.ips")
+    }
+
+    @Test("When only simulated reports exist, no report is surfaced for pixels, upload or prompt", .timeLimit(.minutes(1)))
+    func whenOnlySimulatedReportsExistNoneAreSurfaced() throws {
+        let fileManager = MockFileManager()
+        let now = Date()
+
+        try writeReport(named: "ExcUserFault_DuckDuckGo-2026-07-29-154234.ips", contents: sampleSimulatedIPSReport(), in: FileManager.userDiagnosticReports, creationDate: now.addingTimeInterval(-60), fileManager: fileManager)
+        try writeReport(named: "DuckDuckGo-simulated.ips", contents: sampleSimulatedIPSReport(), in: FileManager.userDiagnosticReports, creationDate: now.addingTimeInterval(-60), fileManager: fileManager)
+
+        let reader = makeReader(now: now, fileManager: fileManager)
+
+        #expect(reader.getCrashReports(since: now.addingTimeInterval(-120)).isEmpty)
+        #expect(reader.hasNewCrashReport(forBundleIdentifier: appBundleIdentifier, since: now.addingTimeInterval(-120)) == false)
+    }
+
     // MARK: - Helpers
 
     private func writeReport(named name: String,
@@ -165,6 +209,13 @@ struct CrashReportReaderTests {
 
     private func sampleLegacyReport() -> String {
         "Process: DuckDuckGo [123]"
+    }
+
+    /// Mirrors the header macOS writes for an `os_log_fault` diagnostic: same shape as a crash
+    /// report, plus `"is_simulated":1`.
+    private func sampleSimulatedIPSReport() throws -> String {
+        try sampleIPSReport()
+            .replacingOccurrences(of: "{\"app_name\"", with: "{\"is_simulated\":1,\"app_name\"")
     }
 
     private func loadExampleCrashReportContents() throws -> String {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1217076871494606?focus=true
Tech Design URL:
CC:

### Description

macOS writes a diagnostic report for every `os_log_fault` a framework emits, flagged `is_simulated: 1` — but the process never terminated. `CrashReportReader` filtered only on file extension and filename, so these counted toward the `m_mac_crash` pixel, uploaded as crash reports, and showed the crash-report consent prompt to users whose app hadn't crashed. Now dropped at the reader, which covers all three. Driven by WebKit faulting on macOS 26.6 via `NetworkProcessProxy::didReceiveInvalidMessage`; Safari faults identically on the same build, so the fault itself is an OS regression, not ours.

### Testing Steps
1. Run the `CrashReportingTests` suite in Xcode — 3 new reader tests cover the `is_simulated` flag and the prompt path.
2. On macOS 26.6, put an `ExcUserFault_DuckDuckGo-*.ips` carrying the app's bundle ID into `~/Library/Logs/DiagnosticReports/`.
3. Relaunch — no consent prompt, no crash pixel. A genuine crash report still prompts.

### Impact
Low. Narrows which diagnostic files count as crashes; genuine crash reports are untouched.

#### What could go wrong?
A real crash report misclassified as simulated would go unreported → `is_simulated` is only set by the OS on non-fatal faults, and the seven pre-existing reader tests still assert real reports pass through.

### Quality Considerations
Only covers the Sparkle/DMG path. The App Store build collects via MetricKit (`CrashCollection`), which has no `is_simulated` field and needs its own predicate — not in this PR.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows which diagnostic files count as crashes; real reports without `is_simulated` still pass through, with regression tests for existing reader behavior.
> 
> **Overview**
> macOS **`.ips`** diagnostics from **`os_log_fault`** (often **`ExcUserFault_*`**, header **`is_simulated: 1`**) were treated like real crashes because **`CrashReportReader`** only matched extension and filename. That drove **`m_mac_crash`** pixels, uploads, and the crash-report consent prompt when the app had not actually terminated.
> 
> This PR adds **`isSimulated`** on **`CrashReport`** — **`JSONCrashReport`** reads **`is_simulated`** from the IPS header; legacy **`.crash`** reports stay **`false`** — and **`CrashReportReader.getCrashReports`** drops simulated reports. That single path covers **`CrashReporter`** and **`hasNewCrashReport`** (consent / unclean-exit detection). Three reader tests cover **`ExcUserFault_`** filenames, the flag regardless of name, and the empty prompt path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a704f98bc32b78b04786bea66b5ea9c6a31c526d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->