### PR TITLE
[iOS] avoid synchronous chrome layout on bars refresh

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4397,7 +4397,7 @@ extension MainViewController: BrowserChromeDelegate {
 
     func restoreCurrentBarsVisibilityAfterLayoutRefresh() {
         applyBarsVisibilityState(lastChromeVisibilityPercent, postChromeVisibilityNotification: false)
-        view.layoutIfNeeded()
+        view.setNeedsLayout()
     }
 
     // 1.0 - full size, 0.0 - hidden


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1217045967190824?focus=true
Tech Design URL:
CC:

### Description
Avoids a system rendering crash when browser chrome refreshes during page loading or tab transitions, while preserving the current address-bar visibility.

### Testing Steps

1. Disable Floating UI, enable Unified Input Toggle, and place the address bar at the top.
2. Open a content-heavy webpage.
3. Scroll until the address bar is hidden while the page is loading.
4. Wait for loading to finish → the address bar remains hidden.
5. Scroll to reveal the address bar → it appears below the status bar.
6. Rapidly switch and dismiss tabs → chrome remains correctly positioned and the app does not crash.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The address bar could briefly appear or become misplaced after a refresh → mitigated by immediately restoring its existing visibility state and deferring layout to the normal update cycle.

### Quality Considerations
Avoids forcing an immediate full-screen layout and SVG rasterization during hierarchy changes. No privacy, security, analytics, or data-handling impact.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line layout scheduling change in chrome refresh; visibility state is unchanged. Brief chrome misplacement is the main regression risk, mitigated by reapplying visibility before marking layout dirty.
> 
> **Overview**
> **Defers layout** when browser chrome reapplies address-bar visibility after a layout refresh, instead of forcing a synchronous pass on the main view.
> 
> In `restoreCurrentBarsVisibilityAfterLayoutRefresh()`, `view.layoutIfNeeded()` is replaced with `view.setNeedsLayout()`. Visibility is still restored immediately via `applyBarsVisibilityState(lastChromeVisibilityPercent, …)`; only the layout work is scheduled for the normal update cycle.
> 
> This targets crashes tied to forcing full-screen layout and SVG rasterization during hierarchy changes (e.g. page load, tab switches) while the address bar is scrolled away.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc0bcf99450b7ae1df683300f6eee9a3bf6015ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->