### PR TITLE
EventHub for Apple #3: iOS EventHub integration

### DIFF
--- a/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubConsentRequirement.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubConsentRequirement.swift
@@ -34,3 +34,21 @@ public protocol EventHubConsentRequirement {
     /// requirement that never seeds a value would stall telemetry filtering for every feature.
     var isGrantedPublisher: AnyPublisher<Bool, Never> { get }
 }
+
+/// The config-name sets behind each consent group, shared by every platform that gates them.
+///
+/// These live here rather than in the platform apps on purpose: every name must byte-match a
+/// server-side `telemetry` key, and a mismatch fails *open* — the entry is never stripped, so its
+/// telemetry would be collected without consent. One list can be reviewed against the server config
+/// once; a per-platform copy each would double the chance of a silent drift.
+public enum EventHubGatedConfigNames {
+
+    /// The `telemetry` config names gated behind the YouTube analytics opt-in.
+    public static let youTubeAdBlockingTelemetry: Set<String> = [
+        "webTelemetry_youtube_adBlocker_day",
+        "webTelemetry_youtube_playabilityError_day",
+        "webTelemetry_youtube_videoAd_day",
+        "webTelemetry_youtube_staticAd_day",
+        "webTelemetry_youtube_buffering_day"
+    ]
+}

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -2089,21 +2089,6 @@ extension Pixel {
 extension Pixel.Event: Equatable {}
 
 extension Pixel.Event {
-    /// Maps a C-S-S `webEvent` `type` string to the matching pixel case.
-    /// Returns `nil` for unknown types so the caller can no-op.
-    public static func adBlockingDetectedEvent(type: String) -> Pixel.Event? {
-        switch type {
-        case "youtube_adBlocker": return .webExtensionAdBlockingDetectedAdBlockerDaily
-        case "youtube_playabilityError": return .webExtensionAdBlockingDetectedPlayabilityErrorDaily
-        case "youtube_videoAd": return .webExtensionAdBlockingDetectedVideoAdDaily
-        case "youtube_staticAd": return .webExtensionAdBlockingDetectedStaticAdDaily
-        case "youtube_buffering": return .webExtensionAdBlockingDetectedBufferingDaily
-        default: return nil
-        }
-    }
-}
-
-extension Pixel.Event {
 
     public var name: String {
         switch self {

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2630,6 +2630,16 @@
 		FBA1C0DE0000000000000009 /* IPadDuckAIControlValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE000000000000000A /* IPadDuckAIControlValues.swift */; };
 		FD555C0BE82E630360DC2E5A /* ToggleModeStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090D90640A2B1A529EDBAAB /* ToggleModeStorage.swift */; };
 		FE1A2B3C0001000100010001 /* AIChatRAGTool+ToolbarChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1A2B3C0001000100010002 /* AIChatRAGTool+ToolbarChip.swift */; };
+		EE7B00000000000000000007 /* EventHub in Frameworks */ = {isa = PBXBuildFile; productRef = EE7B00000000000000000002 /* EventHub */; };
+		EE7B00000000000000000008 /* EventHub in Frameworks */ = {isa = PBXBuildFile; productRef = EE7B00000000000000000003 /* EventHub */; };
+		EE7B00000000000000000009 /* EventHub in Frameworks */ = {isa = PBXBuildFile; productRef = EE7B00000000000000000004 /* EventHub */; };
+		EE7B0000000000000000000A /* EventHub in Frameworks */ = {isa = PBXBuildFile; productRef = EE7B00000000000000000005 /* EventHub */; };
+		EE7B0000000000000000000B /* EventHub in Frameworks */ = {isa = PBXBuildFile; productRef = EE7B00000000000000000006 /* EventHub */; };
+		EE7B00000000000000000013 /* EventHubService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7B0000000000000000000E /* EventHubService.swift */; };
+		EE7B00000000000000000014 /* IOSEventHubPixelFiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7B0000000000000000000F /* IOSEventHubPixelFiring.swift */; };
+		EE7B00000000000000000015 /* YouTubeAdBlockingTelemetryConsentRequirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7B00000000000000000010 /* YouTubeAdBlockingTelemetryConsentRequirement.swift */; };
+		EE7B00000000000000000016 /* IOSEventHubPixelFiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7B00000000000000000011 /* IOSEventHubPixelFiringTests.swift */; };
+		EE7B00000000000000000017 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7B00000000000000000012 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -5414,6 +5424,12 @@
 		FBA1C0DE000000000000000A /* IPadDuckAIControlValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPadDuckAIControlValues.swift; sourceTree = "<group>"; };
 		FD63EDD2D1E5E97F3084B04F /* SearchTokenRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchTokenRequest.swift; sourceTree = "<group>"; };
 		FE1A2B3C0001000100010002 /* AIChatRAGTool+ToolbarChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AIChatRAGTool+ToolbarChip.swift"; sourceTree = "<group>"; };
+		EE7B00000000000000000001 /* EventHub */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = EventHub; path = ../SharedPackages/EventHub; sourceTree = SOURCE_ROOT; };
+		EE7B0000000000000000000E /* EventHubService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHubService.swift; sourceTree = "<group>"; };
+		EE7B0000000000000000000F /* IOSEventHubPixelFiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSEventHubPixelFiring.swift; sourceTree = "<group>"; };
+		EE7B00000000000000000010 /* YouTubeAdBlockingTelemetryConsentRequirement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeAdBlockingTelemetryConsentRequirement.swift; sourceTree = "<group>"; };
+		EE7B00000000000000000011 /* IOSEventHubPixelFiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSEventHubPixelFiringTests.swift; sourceTree = "<group>"; };
+		EE7B00000000000000000012 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubeAdBlockingTelemetryConsentRequirementTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -5484,6 +5500,7 @@
 				F4D7F634298C00C3006C3AE9 /* FindInPageIOSJSSupport in Frameworks */,
 				4B94B79E2D4831D90014AAB8 /* SyncUI-iOS in Frameworks */,
 				DA46CDBDABEE6B9945F597C3 /* AIChatDebugServer in Frameworks */,
+				EE7B00000000000000000007 /* EventHub in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5510,6 +5527,7 @@
 				374E760C2EF56D7F00F8AADE /* PrivacyConfigTestsUtils in Frameworks */,
 				84EFBCCC2D817CB500706739 /* InlineSnapshotTesting in Frameworks */,
 				4BC95EA72D74178C002FAB32 /* ContentBlocking in Frameworks */,
+				EE7B00000000000000000008 /* EventHub in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5552,6 +5570,7 @@
 				4BC95EBB2D7417E9002FAB32 /* Subscription in Frameworks */,
 				4BC95EB92D7417E0002FAB32 /* ContentBlocking in Frameworks */,
 				374E760E2EF56D9100F8AADE /* PrivacyConfigTestsUtils in Frameworks */,
+				EE7B00000000000000000009 /* EventHub in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5594,6 +5613,7 @@
 				4BC95EB52D7417D2002FAB32 /* BrowserServicesKitTestsUtils in Frameworks */,
 				98424A9A2CED4F430071C7DB /* Subscription in Frameworks */,
 				98424A9D2CED4F430071C7DB /* Common in Frameworks */,
+				EE7B0000000000000000000B /* EventHub in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5618,6 +5638,7 @@
 				98E564842DE8DE3F00E6E75F /* Common in Frameworks */,
 				98E5648A2DE8DE5F00E6E75F /* DDGSync in Frameworks */,
 				9FB19C7E2E94A28700B651B1 /* RemoteMessagingTestsUtils in Frameworks */,
+				EE7B0000000000000000000A /* EventHub in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6415,6 +6436,7 @@
 				4BC5E8602E174B6A00391C19 /* DesignResourcesKit */,
 				BB631D142DE0D8B70099977D /* DesignResourcesKitIcons */,
 				31794BFF2821DFB600F18633 /* DuckUI */,
+				EE7B00000000000000000001 /* EventHub */,
 				9F292C522F342B1200441F7A /* MetricBuilder */,
 				85B6ABB62DE5E4CC009C85C7 /* Onboarding */,
 				8518F12C2F742F7600B53C75 /* ScreenTimeDataCleaner */,
@@ -7657,6 +7679,7 @@
 				EE3B98EA2A9634CC002F63A0 /* DuckDuckGoAlpha.entitlements */,
 				4B4A6D122F0EC5620074444F /* DuckDuckGoExperimental.entitlements */,
 				D63FF8922C1B67D1006DE24D /* DuckPlayer */,
+				EE7B0000000000000000000C /* EventHub */,
 				C159DF052A430B36007834BB /* EmailProtection */,
 				3157B43627F4C8380042D3D7 /* Favicons */,
 				839F119520DBC489007CD8C2 /* Feedback */,
@@ -7721,6 +7744,7 @@
 				F1BDDC012C340DDF00459306 /* SyncUI */,
 				F12D98401F266B30003C2EE3 /* DuckDuckGo */,
 				F1E092B31E92A6B900732CCC /* Core */,
+				EE7B0000000000000000000D /* EventHub */,
 				F17843E81F36226700390DCD /* MockFiles */,
 				84E341AC1E2F7EFB00BDBA6F /* Info.plist */,
 				BEA13CC2BC37C33434640638 /* WebViewInputAccessoryTests.swift */,
@@ -11775,6 +11799,25 @@
 			name = HomeMessages;
 			sourceTree = "<group>";
 		};
+		EE7B0000000000000000000C /* EventHub */ = {
+			isa = PBXGroup;
+			children = (
+				EE7B0000000000000000000E /* EventHubService.swift */,
+				EE7B0000000000000000000F /* IOSEventHubPixelFiring.swift */,
+				EE7B00000000000000000010 /* YouTubeAdBlockingTelemetryConsentRequirement.swift */,
+			);
+			path = EventHub;
+			sourceTree = "<group>";
+		};
+		EE7B0000000000000000000D /* EventHub */ = {
+			isa = PBXGroup;
+			children = (
+				EE7B00000000000000000011 /* IOSEventHubPixelFiringTests.swift */,
+				EE7B00000000000000000012 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift */,
+			);
+			path = EventHub;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -11898,6 +11941,7 @@
 				315E39642F86ABEE00D2289D /* DebugServer */,
 				3C12C8760D7AF6C888DAD36A /* AIChatDebugServer */,
 				5B7CA46A2FAE693000D69C83 /* ICSParser */,
+				EE7B00000000000000000002 /* EventHub */,
 			);
 			productName = DuckDuckGo;
 			productReference = 84E341921E2F7EFB00BDBA6F /* DuckDuckGo.app */;
@@ -11937,6 +11981,7 @@
 				374E760B2EF56D7F00F8AADE /* PrivacyConfigTestsUtils */,
 				C118DAD32F1007C6004F403A /* AIChatTestingUtilities */,
 				D1A4C0DE2F210003004E5001 /* Lottie */,
+				EE7B00000000000000000003 /* EventHub */,
 			);
 			productName = DuckDuckGoTests;
 			productReference = 84E341A61E2F7EFB00BDBA6F /* UnitTests.xctest */;
@@ -12010,6 +12055,7 @@
 				CC55B2402E82CD860032E8BD /* BrowserServicesKitTestsUtils */,
 				374E760D2EF56D9100F8AADE /* PrivacyConfigTestsUtils */,
 				4B69239E2F28720300A816B9 /* AIChat */,
+				EE7B00000000000000000004 /* EventHub */,
 			);
 			productName = IntegrationTests;
 			productReference = 85D33FCB25C97B6E002B91A6 /* IntegrationTests.xctest */;
@@ -12088,6 +12134,7 @@
 				F11595D62E8570AF00CC0481 /* AttributedMetric */,
 				374E760F2EF56FAE00F8AADE /* PrivacyConfigTestsUtils */,
 				4B6923A02F28720800A816B9 /* AIChat */,
+				EE7B00000000000000000006 /* EventHub */,
 			);
 			productName = DuckDuckGoTests;
 			productReference = 98424AA92CED4F430071C7DB /* WebViewUnitTests.xctest */;
@@ -12140,6 +12187,7 @@
 				CC55B23E2E82CD650032E8BD /* BrowserServicesKitTestsUtils */,
 				9FB19C7D2E94A28700B651B1 /* RemoteMessagingTestsUtils */,
 				C118DACE2F0EF8A6004F403A /* AIChatTestingUtilities */,
+				EE7B00000000000000000005 /* EventHub */,
 			);
 			productName = SharedStateTests;
 			productReference = 98E5643E2DE8DDA200E6E75F /* SharedStateTests.xctest */;
@@ -14079,6 +14127,9 @@
 				B77369B84928113F87E18ED6 /* SearchTokenRequest.swift in Sources */,
 				BA3A30D2938DDAF625858D3A /* SearchTokenExperimentSettings.swift in Sources */,
 				AF33940B4B7A2549F1C56A04 /* SearchTokenDebugView.swift in Sources */,
+				EE7B00000000000000000013 /* EventHubService.swift in Sources */,
+				EE7B00000000000000000014 /* IOSEventHubPixelFiring.swift in Sources */,
+				EE7B00000000000000000015 /* YouTubeAdBlockingTelemetryConsentRequirement.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14620,6 +14671,8 @@
 				53FC97E1D0E95EA8B6ECD771 /* SearchTokenFetcherTests.swift in Sources */,
 				60F0888B646078A1C54D7C2E /* SearchTokenRequestTests.swift in Sources */,
 				E85300B61A233D45A5D82FFC /* SearchTokenExperimentSettingsTests.swift in Sources */,
+				EE7B00000000000000000016 /* IOSEventHubPixelFiringTests.swift in Sources */,
+				EE7B00000000000000000017 /* YouTubeAdBlockingTelemetryConsentRequirementTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -19032,6 +19085,26 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F4D7F632298C00C3006C3AE9 /* XCRemoteSwiftPackageReference "ios-js-support" */;
 			productName = FindInPageIOSJSSupport;
+		};
+		EE7B00000000000000000002 /* EventHub */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EventHub;
+		};
+		EE7B00000000000000000003 /* EventHub */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EventHub;
+		};
+		EE7B00000000000000000004 /* EventHub */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EventHub;
+		};
+		EE7B00000000000000000005 /* EventHub */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EventHub;
+		};
+		EE7B00000000000000000006 /* EventHub */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EventHub;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/iOS/DuckDuckGo/AdBlocking/AdBlockingDebugView.swift
+++ b/iOS/DuckDuckGo/AdBlocking/AdBlockingDebugView.swift
@@ -199,8 +199,15 @@ struct AdBlockingDebugView: View {
         case let bool?:
             try? storage.set(bool, for: key)
         }
-        if key == \YouTubeAdBlockingKeys.youTubeAnalyticsEnabled {
+        // Both flags gate EventHub telemetry consent, and neither store write is observable, so a change
+        // made here has to be announced the same way the real toggles announce theirs.
+        switch key {
+        case \YouTubeAdBlockingKeys.youTubeAnalyticsEnabled:
             NotificationCenter.default.post(name: YouTubeAdBlockingStorageKeys.youTubeAnalyticsEnabledDidChangeNotification, object: nil)
+        case \YouTubeAdBlockingKeys.youTubeAdBlockingEnabled:
+            NotificationCenter.default.post(name: YouTubeAdBlockingStorageKeys.youTubeAdBlockingEnabledDidChangeNotification, object: nil)
+        default:
+            break
         }
         refresh()
     }

--- a/iOS/DuckDuckGo/AdBlocking/AdBlockingDebugView.swift
+++ b/iOS/DuckDuckGo/AdBlocking/AdBlockingDebugView.swift
@@ -78,33 +78,9 @@ struct AdBlockingDebugView: View {
                 Text(verbatim: "Override the `adBlockingExtension` feature flag from the Feature Flags debug screen to simulate the YouTube Ad Blocking remote-disable contingency state.")
             }
 
-            Section {
-                Button {
-                    clearDetectionPixelDailyStamps()
-                } label: {
-                    Text(verbatim: "Clear today's detection-pixel stamps")
-                }
-            } header: {
-                Text(verbatim: "Detection pixels")
-            } footer: {
-                Text(verbatim: "Clears today's last-fired stamps for the five m_web_extension_adblocking_detected_*_daily pixels so they can fire again today.")
-            }
         }
         .navigationTitle(Text(verbatim: "Ad Blocking"))
         .onAppear(perform: refresh)
-    }
-
-    private func clearDetectionPixelDailyStamps() {
-        let pixels: [Pixel.Event] = [
-            .webExtensionAdBlockingDetectedAdBlockerDaily,
-            .webExtensionAdBlockingDetectedPlayabilityErrorDaily,
-            .webExtensionAdBlockingDetectedVideoAdDaily,
-            .webExtensionAdBlockingDetectedStaticAdDaily,
-            .webExtensionAdBlockingDetectedBufferingDaily
-        ]
-        for pixel in pixels {
-            try? DailyPixel.storage.set(nil, forKey: pixel.name)
-        }
     }
 
     private func triStatePicker(title: String,
@@ -222,6 +198,9 @@ struct AdBlockingDebugView: View {
             try? storage.removeValue(for: key)
         case let bool?:
             try? storage.set(bool, for: key)
+        }
+        if key == \YouTubeAdBlockingKeys.youTubeAnalyticsEnabled {
+            NotificationCenter.default.post(name: YouTubeAdBlockingStorageKeys.youTubeAnalyticsEnabledDidChangeNotification, object: nil)
         }
         refresh()
     }

--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencies.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencies.swift
@@ -55,6 +55,7 @@ struct AppServices {
     let inactivityNotificationSchedulerService: InactivityNotificationSchedulerService
     let wideEventService: WideEventService
     let aiChatService: AIChatService
+    let eventHubService: EventHubService
 
 }
 

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Background.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Background.swift
@@ -65,6 +65,7 @@ struct Background: BackgroundHandling {
         services.autofillService.suspend()
         services.syncService.suspend()
         services.reportingService.suspend()
+        services.eventHubService.suspend()
 
         appDependencies.mainCoordinator.onBackground()
 

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
@@ -161,6 +161,7 @@ struct Foreground: ForegroundHandling {
         services.dbpService.resume()
         services.inactivityNotificationSchedulerService.resume()
         services.wideEventService.resume()
+        services.eventHubService.resume()
         appDependencies.launchSourceManager.handleAppAction(launchAction)
 
         appDependencies.mainCoordinator.onForeground(isFirstForeground: isFirstForeground)

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -171,6 +171,12 @@ struct Launching: LaunchingHandling {
                                                             fireModeStorageController: fireModeStorageController,
                                                             adBlockingAvailability: adBlockingAvailability)
 
+        // Constructed before MainCoordinator: its `eventHub` is threaded down to every tab.
+        let eventHubService = EventHubService(
+            privacyConfigurationManager: contentBlockingService.common.privacyConfigurationManager,
+            keyValueStore: appKeyValueFileStoreService.keyValueFilesStore
+        )
+
         let freemiumPIRDebugSettings = FreemiumPIRDebugSettings(keyValueStore: appKeyValueFileStoreService.keyValueFilesStore)
         let dbpService = DBPService(appDependencies: AppDependencyProvider.shared,
                                     contentBlocking: contentBlockingService.common,
@@ -338,7 +344,8 @@ struct Launching: LaunchingHandling {
                                               whatsNewRepository: whatsNewRepository,
                                               sharedSecureVault: configuration.persistentStoresConfiguration.sharedSecureVault,
                                               wideEvent: AppDependencyProvider.shared.wideEvent,
-                                              onboardingManager: onboardingManager
+                                              onboardingManager: onboardingManager,
+                                              eventHub: eventHubService.eventHub
         )
 
         // MARK: - UI-Dependent Services Setup
@@ -386,7 +393,8 @@ struct Launching: LaunchingHandling {
                                systemSettingsPiPTutorialService: systemSettingsPiPTutorialService,
                                inactivityNotificationSchedulerService: inactivityNotificationSchedulerService,
                                wideEventService: wideEventService,
-                               aiChatService: AIChatService(aiChatSettings: aiChatSettings)
+                               aiChatService: AIChatService(aiChatSettings: aiChatSettings),
+                               eventHubService: eventHubService
         )
 
         // Clean up wide event data at launch

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -172,9 +172,14 @@ struct Launching: LaunchingHandling {
                                                             adBlockingAvailability: adBlockingAvailability)
 
         // Constructed before MainCoordinator: its `eventHub` is threaded down to every tab.
+        // EventHub gets its own store, matching macOS, so its period state never shares a file with app
+        // settings. `try?` — an unopenable store degrades telemetry to in-memory rather than failing launch.
+        let eventHubStore = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            .flatMap { try? KeyValueFileStore(location: $0, name: "EventHubKeyValueStore") }
         let eventHubService = EventHubService(
             privacyConfigurationManager: contentBlockingService.common.privacyConfigurationManager,
-            keyValueStore: appKeyValueFileStoreService.keyValueFilesStore
+            keyValueStore: eventHubStore,
+            consentStore: appKeyValueFileStoreService.keyValueFilesStore
         )
 
         let freemiumPIRDebugSettings = FreemiumPIRDebugSettings(keyValueStore: appKeyValueFileStoreService.keyValueFilesStore)

--- a/iOS/DuckDuckGo/AppServices/ContentBlockingService.swift
+++ b/iOS/DuckDuckGo/AppServices/ContentBlockingService.swift
@@ -64,8 +64,6 @@ final class ContentBlockingService {
                                                                            webExtensionAvailability: webExtensionAvailability)
 
         updating = ContentBlockingUpdating(userScriptsDependencies: userScriptsDependencies,
-                                           duckAiNativeStorageHandler: duckAiNativeStorageHandler,
-                                           keyValueStore: keyValueStore,
-                                           adBlockingAvailability: adBlockingAvailability)
+                                           duckAiNativeStorageHandler: duckAiNativeStorageHandler)
     }
 }

--- a/iOS/DuckDuckGo/ContentBlockingUpdating.swift
+++ b/iOS/DuckDuckGo/ContentBlockingUpdating.swift
@@ -23,8 +23,6 @@ import BrowserServicesKit
 import Core
 import Combine
 import CombineExtensions
-import Persistence
-import WebExtensions
 import WebKit
 
 protocol ContentBlockerRulesManagerProtocol: CompiledRuleListsSource {
@@ -43,14 +41,10 @@ public final class ContentBlockingUpdating {
         let rulesUpdate: ContentBlockerRulesManager.UpdateEvent
         let sourceProvider: ScriptSourceProviding
         let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
-        let keyValueStore: ThrowingKeyValueStoring
-        let adBlockingAvailability: AdBlockingAvailabilityProviding
         var makeUserScripts: @MainActor (ScriptSourceProviding) -> UserScripts {
-            { [duckAiNativeStorageHandler, keyValueStore, adBlockingAvailability] sourceProvider in
+            { [duckAiNativeStorageHandler] sourceProvider in
                 UserScripts(with: sourceProvider,
-                            keyValueStore: keyValueStore,
-                            duckAiNativeStorageHandler: duckAiNativeStorageHandler,
-                            adBlockingAvailability: adBlockingAvailability)
+                            duckAiNativeStorageHandler: duckAiNativeStorageHandler)
             }
         }
     }
@@ -61,17 +55,13 @@ public final class ContentBlockingUpdating {
     private(set) var userContentBlockingAssets: AnyPublisher<NewContent, Never>!
 
     init(userScriptsDependencies: DefaultScriptSourceProvider.Dependencies,
-         duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil,
-         keyValueStore: ThrowingKeyValueStoring,
-         adBlockingAvailability: AdBlockingAvailabilityProviding) {
+         duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil) {
 
         let makeValue: (Update) -> NewContent = { rulesUpdate in
             let sourceProvider = DefaultScriptSourceProvider(dependencies: userScriptsDependencies)
             return NewContent(rulesUpdate: rulesUpdate,
                               sourceProvider: sourceProvider,
-                              duckAiNativeStorageHandler: duckAiNativeStorageHandler,
-                              keyValueStore: keyValueStore,
-                              adBlockingAvailability: adBlockingAvailability)
+                              duckAiNativeStorageHandler: duckAiNativeStorageHandler)
         }
 
         func onNotificationWithInitial(_ name: Notification.Name) -> AnyPublisher<Notification, Never> {

--- a/iOS/DuckDuckGo/EventHub/EventHubService.swift
+++ b/iOS/DuckDuckGo/EventHub/EventHubService.swift
@@ -1,0 +1,89 @@
+//
+//  EventHubService.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import EventHub
+import Foundation
+import os.log
+import Persistence
+import PrivacyConfig
+
+/// Owns and wires up the iOS `EventHub` instance: remote-config bridging, persistence, scheduling,
+/// pixel firing, and consent gating. Constructed once during `Launching` and held by `AppServices`.
+final class EventHubService {
+
+    let eventHub: EventHubManaging
+
+    private var cancellables = Set<AnyCancellable>()
+
+    init(privacyConfigurationManager: PrivacyConfigurationManaging, keyValueStore: ThrowingKeyValueStoring) {
+        let parser = EventHubConfigParser()
+        let store = EventHubKeyValueStore(store: keyValueStore, parser: parser)
+
+        let enabledSubject = CurrentValueSubject<Bool, Never>(
+            privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .eventHub))
+        let settingsSubject = CurrentValueSubject<Data?, Never>(
+            Self.settingsData(from: privacyConfigurationManager))
+
+        let settings = EventHubSettings(
+            featureEnabledPublisher: enabledSubject.eraseToAnyPublisher(),
+            featureSettingsPublisher: settingsSubject.eraseToAnyPublisher(),
+            consentRequirements: [
+                YouTubeAdBlockingTelemetryConsentRequirement(keyValueStore: keyValueStore)
+            ]
+        )
+
+        eventHub = EventHub(
+            store: store,
+            parser: parser,
+            settings: settings,
+            scheduler: DispatchQueueEventHubScheduler(queue: DispatchQueue(label: "com.duckduckgo.eventhub.scheduler")),
+            pixelFiring: IOSEventHubPixelFiring()
+        )
+
+        // Pushing the new values is all that is needed: `EventHub` subscribes to both publishers and
+        // re-applies its config whenever either emits, so there is no explicit `onConfigChanged()` call
+        // to keep in sync here. The same holds for consent changes, which reach `EventHub` through
+        // `EventHubSettings`' settings publisher rather than through this subscription.
+        privacyConfigurationManager.updatesPublisher
+            .sink { [weak privacyConfigurationManager] in
+                guard let privacyConfigurationManager else { return }
+                let enabled = privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .eventHub)
+                Logger.eventHub.debug("Remote config updated — pushing to EventHub (enabled=\(enabled, privacy: .public))")
+                enabledSubject.send(enabled)
+                settingsSubject.send(Self.settingsData(from: privacyConfigurationManager))
+            }
+            .store(in: &cancellables)
+    }
+
+    func resume() {
+        eventHub.onAppForegrounded()
+    }
+
+    /// Backgrounding is EventHub's flush boundary. Unlike macOS there is no separate termination hook to
+    /// mirror it: iOS always moves the app to the background before terminating it, so this is reached on
+    /// the way out of every quit.
+    func suspend() {
+        eventHub.onAppBackgrounded()
+    }
+
+    private static func settingsData(from privacyConfigurationManager: PrivacyConfigurationManaging) -> Data? {
+        try? JSONSerialization.data(withJSONObject: privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
+    }
+}

--- a/iOS/DuckDuckGo/EventHub/EventHubService.swift
+++ b/iOS/DuckDuckGo/EventHub/EventHubService.swift
@@ -32,20 +32,30 @@ final class EventHubService {
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(privacyConfigurationManager: PrivacyConfigurationManaging, keyValueStore: ThrowingKeyValueStoring) {
+    /// - Parameters:
+    ///   - keyValueStore: EventHub's own persistence. `nil` if the dedicated store could not be opened;
+    ///     telemetry then runs in memory only.
+    ///   - consentStore: the app store holding the YouTube opt-ins the consent gate reads. Deliberately
+    ///     separate from `keyValueStore`, which holds only EventHub's period state.
+    init(privacyConfigurationManager: PrivacyConfigurationManaging,
+         keyValueStore: ThrowingKeyValueStoring?,
+         consentStore: ThrowingKeyValueStoring) {
+        if keyValueStore == nil {
+            Logger.eventHub.error("Dedicated key value store unavailable — telemetry will not survive a restart")
+        }
         let parser = EventHubConfigParser()
         let store = EventHubKeyValueStore(store: keyValueStore, parser: parser)
 
         let enabledSubject = CurrentValueSubject<Bool, Never>(
             privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .eventHub))
-        let settingsSubject = CurrentValueSubject<Data?, Never>(
-            Self.settingsData(from: privacyConfigurationManager))
+        let settingsSubject = CurrentValueSubject<[String: Any]?, Never>(
+            privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
 
         let settings = EventHubSettings(
             featureEnabledPublisher: enabledSubject.eraseToAnyPublisher(),
             featureSettingsPublisher: settingsSubject.eraseToAnyPublisher(),
             consentRequirements: [
-                YouTubeAdBlockingTelemetryConsentRequirement(keyValueStore: keyValueStore)
+                YouTubeAdBlockingTelemetryConsentRequirement(keyValueStore: consentStore)
             ]
         )
 
@@ -67,7 +77,7 @@ final class EventHubService {
                 let enabled = privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .eventHub)
                 Logger.eventHub.debug("Remote config updated — pushing to EventHub (enabled=\(enabled, privacy: .public))")
                 enabledSubject.send(enabled)
-                settingsSubject.send(Self.settingsData(from: privacyConfigurationManager))
+                settingsSubject.send(privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
             }
             .store(in: &cancellables)
     }
@@ -81,9 +91,5 @@ final class EventHubService {
     /// the way out of every quit.
     func suspend() {
         eventHub.onAppBackgrounded()
-    }
-
-    private static func settingsData(from privacyConfigurationManager: PrivacyConfigurationManaging) -> Data? {
-        try? JSONSerialization.data(withJSONObject: privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
     }
 }

--- a/iOS/DuckDuckGo/EventHub/IOSEventHubPixelFiring.swift
+++ b/iOS/DuckDuckGo/EventHub/IOSEventHubPixelFiring.swift
@@ -1,0 +1,55 @@
+//
+//  IOSEventHubPixelFiring.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import EventHub
+import Foundation
+import os.log
+import PixelKit
+
+/// Fires EventHub-originated pixels through PixelKit, appending iOS' platform and form-factor markers per
+/// the Tech Design's platform-suffix split (`EventHub` itself fires the bare governed config name).
+///
+/// The conformance to `PixelKitEventWithCustomPrefix` with an **empty** `namePrefix` is deliberate, and is
+/// the only combination that produces the name `event_hub.json5` declares. `PixelKit`'s name resolution
+/// has three relevant paths:
+///
+/// - no `PixelKitEventWithCustomPrefix`: on iOS the name is returned untouched, so it would carry no
+///   platform or form-factor marker at all and would not match the declared `platform`/`form_factor`
+///   suffixes.
+/// - `PixelKitEventWithCustomPrefix` with the conventional `"m_"` prefix (what `WideEventFailureEvent`
+///   uses): appends the platform suffix but reintroduces the legacy `m_` prefix these names must not have.
+/// - `PixelKitEventWithCustomPrefix` with `""`: appends `platformSuffix` (`_ios_phone` / `_ios_tablet`,
+///   derived from the `source` given to `PixelKit.setUp`) and prepends nothing. This is what we want.
+struct IOSEventHubPixelFiring: EventHubPixelFiring {
+
+    private struct Event: PixelKitEvent, PixelKitEventWithCustomPrefix {
+        let namePrefix = ""
+        let name: String
+        let parameters: [String: String]?
+        let standardParameters: [PixelKitStandardParameter]? = nil
+    }
+
+    func enqueueFirePixel(named name: String, parameters: [String: String]) {
+        // The governed name, without the platform suffix PixelKit appends when it builds the request.
+        Logger.eventHub.info("PixelKit fire: \(name, privacy: .public) \(parameters, privacy: .public)")
+        // `frequency` stays `.standard`: EventHub has already done the period aggregation, so PixelKit
+        // must not apply a second layer of daily de-duplication on top of it.
+        PixelKit.fire(Event(name: name, parameters: parameters))
+    }
+}

--- a/iOS/DuckDuckGo/EventHub/YouTubeAdBlockingTelemetryConsentRequirement.swift
+++ b/iOS/DuckDuckGo/EventHub/YouTubeAdBlockingTelemetryConsentRequirement.swift
@@ -1,0 +1,61 @@
+//
+//  YouTubeAdBlockingTelemetryConsentRequirement.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import EventHub
+import Foundation
+import Persistence
+
+/// Gates the migrated YouTube ad-blocking-detection telemetry configs behind the user's YouTube
+/// analytics opt-in (`YouTubeAdBlockingKeys.youTubeAnalyticsEnabled`).
+///
+/// The opt-in lives in the app's file-backed key-value store, which — unlike macOS' `UserDefaults` —
+/// deliberately does not conform to `ObservableThrowingKeyValueStoring`, so there is no store-level
+/// change publisher to observe. Writers post `youTubeAnalyticsEnabledDidChangeNotification` instead and
+/// this re-reads the store on each one. `removeDuplicates` keeps a write that lands on the value already
+/// stored — the ad-blocking toggle cascades into this setting whether or not it changes — from
+/// needlessly churning EventHub's config.
+final class YouTubeAdBlockingTelemetryConsentRequirement: EventHubConsentRequirement {
+
+    let consentID = "youTubeAdBlockingAnalytics"
+    let configNames: Set<String>
+    let isGrantedPublisher: AnyPublisher<Bool, Never>
+
+    init(configNames: Set<String> = EventHubGatedConfigNames.youTubeAdBlockingTelemetry,
+         keyValueStore: ThrowingKeyValueStoring,
+         notificationCenter: NotificationCenter = .default) {
+        self.configNames = configNames
+
+        let storage: any ThrowingKeyedStoring<YouTubeAdBlockingKeys> = keyValueStore.throwingKeyedStoring()
+        let isGranted = {
+            (try? storage.value(for: \YouTubeAdBlockingKeys.youTubeAnalyticsEnabled)) ?? false
+        }
+
+        // The store is read at emission time, not here: `prepend` seeds the Void stream so that every
+        // subscriber — whenever it subscribes — gets the value current at that moment, as
+        // `EventHubConsentRequirement` requires.
+        isGrantedPublisher = notificationCenter
+            .publisher(for: YouTubeAdBlockingStorageKeys.youTubeAnalyticsEnabledDidChangeNotification)
+            .map { _ in () }
+            .prepend(())
+            .map { _ in isGranted() }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+}

--- a/iOS/DuckDuckGo/EventHub/YouTubeAdBlockingTelemetryConsentRequirement.swift
+++ b/iOS/DuckDuckGo/EventHub/YouTubeAdBlockingTelemetryConsentRequirement.swift
@@ -23,14 +23,22 @@ import Foundation
 import Persistence
 
 /// Gates the migrated YouTube ad-blocking-detection telemetry configs behind the user's YouTube
-/// analytics opt-in (`YouTubeAdBlockingKeys.youTubeAnalyticsEnabled`).
+/// Ad Blocking *and* analytics opt-ins, matching both the composite check the retired
+/// `WebEventsSubfeature` applied per event and the macOS requirement.
 ///
-/// The opt-in lives in the app's file-backed key-value store, which — unlike macOS' `UserDefaults` —
-/// deliberately does not conform to `ObservableThrowingKeyValueStoring`, so there is no store-level
-/// change publisher to observe. Writers post `youTubeAnalyticsEnabledDidChangeNotification` instead and
-/// this re-reads the store on each one. `removeDuplicates` keeps a write that lands on the value already
-/// stored — the ad-blocking toggle cascades into this setting whether or not it changes — from
-/// needlessly churning EventHub's config.
+/// Both flags are required deliberately, rather than relying on analytics alone. Turning YouTube Ad
+/// Blocking off does clear the analytics opt-in, but on iOS that coupling is an explicit cascade at two
+/// call sites (`SettingsViewModel.setYouTubeAnalyticsEnabled` and
+/// `MainViewController.setYouTubeAdBlockingEnabled`) — even weaker than macOS' `didSet`, since any write
+/// that bypasses them, such as the ad-blocking debug screen, leaves analytics granted. The two flags are
+/// independently writable with no storage-level invariant tying them together, so a consent gate must not
+/// depend on the cascade having run.
+///
+/// Neither flag can be observed directly: they live in the app's file-backed key-value store, which —
+/// unlike macOS' `UserDefaults` — deliberately does not conform to `ObservableThrowingKeyValueStoring`.
+/// Writers post the two `…DidChangeNotification`s instead, and this re-reads both values on either one.
+/// `removeDuplicates` keeps a write that lands on the value already stored from needlessly churning
+/// EventHub's config.
 final class YouTubeAdBlockingTelemetryConsentRequirement: EventHubConsentRequirement {
 
     let consentID = "youTubeAdBlockingAnalytics"
@@ -43,16 +51,25 @@ final class YouTubeAdBlockingTelemetryConsentRequirement: EventHubConsentRequire
         self.configNames = configNames
 
         let storage: any ThrowingKeyedStoring<YouTubeAdBlockingKeys> = keyValueStore.throwingKeyedStoring()
+        // An unset flag counts as withheld. This deliberately ignores the `adBlockingExtensionEnabledByDefault`
+        // rollout default that `AdBlockingAvailability` applies to `youTubeAdBlockingEnabled`: consulting it
+        // here would make consent depend on a remote flag and could fail open, and failing closed only ever
+        // withholds telemetry.
         let isGranted = {
-            (try? storage.value(for: \YouTubeAdBlockingKeys.youTubeAnalyticsEnabled)) ?? false
+            let adBlockingEnabled = (try? storage.value(for: \YouTubeAdBlockingKeys.youTubeAdBlockingEnabled)) ?? false
+            let analyticsEnabled = (try? storage.value(for: \YouTubeAdBlockingKeys.youTubeAnalyticsEnabled)) ?? false
+            return adBlockingEnabled && analyticsEnabled
         }
 
         // The store is read at emission time, not here: `prepend` seeds the Void stream so that every
         // subscriber — whenever it subscribes — gets the value current at that moment, as
         // `EventHubConsentRequirement` requires.
         isGrantedPublisher = notificationCenter
-            .publisher(for: YouTubeAdBlockingStorageKeys.youTubeAnalyticsEnabledDidChangeNotification)
+            .publisher(for: YouTubeAdBlockingStorageKeys.youTubeAdBlockingEnabledDidChangeNotification)
             .map { _ in () }
+            .merge(with: notificationCenter
+                .publisher(for: YouTubeAdBlockingStorageKeys.youTubeAnalyticsEnabledDidChangeNotification)
+                .map { _ in () })
             .prepend(())
             .map { _ in isGranted() }
             .removeDuplicates()

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5933,11 +5933,16 @@ extension MainViewController: TabDelegate {
         let disclosureVisibleAtToggle = (try? storage.value(for: \YouTubeAdBlockingKeys.shouldHideYouTubeAdBlockingDisclosure)) != true
         try? storage.set(enabled, for: \YouTubeAdBlockingKeys.youTubeAdBlockingEnabled)
         if !enabled {
-            try? storage.set(false, for: \YouTubeAdBlockingKeys.youTubeAnalyticsEnabled)
+            setYouTubeAnalyticsEnabled(false, in: storage)
         } else if disclosureVisibleAtToggle {
-            try? storage.set(true, for: \YouTubeAdBlockingKeys.youTubeAnalyticsEnabled)
+            setYouTubeAnalyticsEnabled(true, in: storage)
         }
         NotificationCenter.default.post(name: YouTubeAdBlockingStorageKeys.youTubeAdBlockingEnabledDidChangeNotification, object: nil)
+    }
+
+    private func setYouTubeAnalyticsEnabled(_ enabled: Bool, in storage: any ThrowingKeyedStoring<YouTubeAdBlockingKeys>) {
+        try? storage.set(enabled, for: \YouTubeAdBlockingKeys.youTubeAnalyticsEnabled)
+        NotificationCenter.default.post(name: YouTubeAdBlockingStorageKeys.youTubeAnalyticsEnabledDidChangeNotification, object: nil)
     }
 
     func tabDidEngageWithPage(_ tab: TabViewController) {

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -46,6 +46,11 @@ enum YouTubeAdBlockingStorageKeys: String, StorageKeyDescribing {
     case youTubeAdBlockUnavailableNoticeShown = "com_duckduckgo_ios_youTubeAdBlockUnavailableNoticeShown"
 
     static let youTubeAdBlockingEnabledDidChangeNotification = Notification.Name("youTubeAdBlockingEnabledDidChange")
+
+    /// Posted whenever `youTubeAnalyticsEnabled` is written. The store backing these keys is the
+    /// file-based one, which deliberately exposes no change publisher, so consumers that need to react
+    /// to the opt-in — `YouTubeAdBlockingTelemetryConsentRequirement` — observe this instead.
+    static let youTubeAnalyticsEnabledDidChangeNotification = Notification.Name("youTubeAnalyticsEnabledDidChange")
 }
 
 struct YouTubeAdBlockingKeys: StoringKeys {
@@ -803,6 +808,7 @@ final class SettingsViewModel: ObservableObject {
 
     func setYouTubeAnalyticsEnabled(_ enabled: Bool) {
         try? youTubeAdBlockingStorage.set(enabled, for: \YouTubeAdBlockingKeys.youTubeAnalyticsEnabled)
+        NotificationCenter.default.post(name: YouTubeAdBlockingStorageKeys.youTubeAnalyticsEnabledDidChangeNotification, object: nil)
     }
 
     var isYouTubeAdBlockingDisclosureHidden: Bool {

--- a/iOS/DuckDuckGo/TabManager.swift
+++ b/iOS/DuckDuckGo/TabManager.swift
@@ -21,6 +21,7 @@ import Common
 import FoundationExtensions
 import Core
 import DDGSync
+import EventHub
 import WebKit
 import BrowserServicesKit
 import Persistence
@@ -173,6 +174,9 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
     /// Single app-lifetime instance shared across all tabs, MainViewController, and SettingsViewModel.
     let adBlockingAvailability: AdBlockingAvailabilityProviding
 
+    /// Single app-lifetime instance, handed to every tab so it can report its own web and navigation events.
+    let eventHub: EventHubManaging
+
     weak var delegate: TabDelegate?
     weak var aiChatContentDelegate: AIChatContentHandlingDelegate?
     weak var fireModeDelegate: TabManagerFireModeDelegate?
@@ -218,7 +222,8 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
          duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil,
          duckAiFireModeStorageHandler: DuckAiNativeStorageHandling? = nil,
          toggleModeStorage: ToggleModeStoring = ToggleModeStorage(),
-         adBlockingAvailability: AdBlockingAvailabilityProviding
+         adBlockingAvailability: AdBlockingAvailabilityProviding,
+         eventHub: EventHubManaging
     ) {
         self.duckAiNativeStorageHandler = duckAiNativeStorageHandler
         self.duckAiFireModeStorageHandler = duckAiFireModeStorageHandler
@@ -258,6 +263,7 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
         self.toggleModeStorage = toggleModeStorage
         self.darkReaderFeatureSettings = darkReaderFeatureSettings
         self.adBlockingAvailability = adBlockingAvailability
+        self.eventHub = eventHub
         registerForNotifications()
     }
 
@@ -348,7 +354,8 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
                                                               autoplaySettings: autoplaySettings,
                                                               duckAiNativeStorageHandler: duckAiNativeStorageHandler,
                                                               duckAiFireModeStorageHandler: duckAiFireModeStorageHandler,
-                                                              adBlockingAvailability: adBlockingAvailability)
+                                                              adBlockingAvailability: adBlockingAvailability,
+                                                              eventHub: eventHub)
         controller.applyInheritedAttribution(inheritedAttribution)
         controller.attachWebView(configuration: configuration,
                                  interactionStateData: interactionState,
@@ -479,7 +486,8 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
                                                               autoplaySettings: autoplaySettings,
                                                               duckAiNativeStorageHandler: duckAiNativeStorageHandler,
                                                               duckAiFireModeStorageHandler: duckAiFireModeStorageHandler,
-                                                              adBlockingAvailability: adBlockingAvailability)
+                                                              adBlockingAvailability: adBlockingAvailability,
+                                                              eventHub: eventHub)
         controller.attachWebView(configuration: configCopy,
                                  andLoadRequest: request,
                                  consumeCookies: !currentTabsModel.hasActiveTabs,

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -32,6 +32,7 @@ import Persistence
 import Common
 import FoundationExtensions
 import DDGSync
+import EventHub
 import PrivacyDashboard
 import UserScript
 import ContentBlocking
@@ -499,7 +500,8 @@ class TabViewController: UIViewController {
                                    autoplaySettings: AutoplaySettings,
                                    duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil,
                                    duckAiFireModeStorageHandler: DuckAiNativeStorageHandling? = nil,
-                                   adBlockingAvailability: AdBlockingAvailabilityProviding) -> TabViewController {
+                                   adBlockingAvailability: AdBlockingAvailabilityProviding,
+                                   eventHub: EventHubManaging) -> TabViewController {
 
         return TabViewController(tabModel: model,
                                  privacyConfigurationManager: privacyConfigurationManager,
@@ -534,7 +536,8 @@ class TabViewController: UIViewController {
                                  autoplaySettings: autoplaySettings,
                                  duckAiNativeStorageHandler: duckAiNativeStorageHandler,
                                  duckAiFireModeStorageHandler: duckAiFireModeStorageHandler,
-                                 adBlockingAvailability: adBlockingAvailability)
+                                 adBlockingAvailability: adBlockingAvailability,
+                                 eventHub: eventHub)
     }
 
     private var userContentController: UserContentController {
@@ -544,6 +547,18 @@ class TabViewController: UIViewController {
 
     let historyManager: HistoryManaging
     let adBlockingAvailability: AdBlockingAvailabilityProviding
+
+    let eventHub: EventHubManaging
+
+    /// This tab's EventHub identity. Derived from the tab model's UUID string, so it is stable for the
+    /// tab's lifetime and unique per tab — which is what EventHub's per-tab web-event dedup keys off.
+    private let eventHubTabID: EventHubTabID
+
+    /// Owns this tab's `webEvents` subfeature. Held here rather than on `UserScripts` because
+    /// `UserScripts` is rebuilt on every content-blocking update and carries no tab identity of its own.
+    /// The handler is stateless, so re-registering the same instance with each new content scope script
+    /// is all that is needed.
+    private let eventHubWebEventsHandler: WebEventsHandler
 
     private(set) lazy var adBlockingNavigationHandler: AdBlockingNavigationHandling = {
         return AdBlockingNavigationHandler(
@@ -682,7 +697,8 @@ class TabViewController: UIViewController {
          duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil,
          duckAiFireModeStorageHandler: DuckAiNativeStorageHandling? = nil,
          addressBarURLFilter: AddressBarURLFiltering = AddressBarURLFilter(),
-         adBlockingAvailability: AdBlockingAvailabilityProviding) {
+         adBlockingAvailability: AdBlockingAvailabilityProviding,
+         eventHub: EventHubManaging) {
 
         self.tabModel = tabModel
         self.viewModel = TabViewModel(tab: tabModel, historyManager: historyManager)
@@ -732,6 +748,12 @@ class TabViewController: UIViewController {
         self.duckAiFireModeStorageHandler = duckAiFireModeStorageHandler
         self.addressBarURLFilter = addressBarURLFilter
         self.adBlockingAvailability = adBlockingAvailability
+        self.eventHub = eventHub
+
+        // Captured by value so the handler's provider closure doesn't retain the controller.
+        let eventHubTabID = EventHubTabID(rawValue: UUID(uuidString: tabModel.uid) ?? UUID())
+        self.eventHubTabID = eventHubTabID
+        self.eventHubWebEventsHandler = WebEventsHandler(manager: eventHub, tabIDProvider: { _ in eventHubTabID })
 
         self.productSurfaceTelemetry = productSurfaceTelemetry
 
@@ -1948,6 +1970,7 @@ class TabViewController: UIViewController {
 
     deinit {
         rulesCompilationMonitor.tabWillClose(tabModel.uid)
+        eventHub.onTabClosed(tabID: eventHubTabID)
         removeObservers()
         temporaryDownloadForPreviewedFile?.cancel()
         cleanUpBeforeClosing()
@@ -2201,6 +2224,8 @@ extension TabViewController: WKNavigationDelegate {
         referrerTrimming.onBeginNavigation(to: webView.url)
         adClickAttributionDetection.onStartNavigation(url: webView.url)
         adClickExternalOpenDetector.startNavigation()
+        // Resets this tab's per-tab web-event dedup when the URL changes.
+        eventHub.onNavigationStarted(tabID: eventHubTabID, url: webView.url?.absoluteString ?? "")
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -3906,6 +3931,7 @@ extension TabViewController: UserContentControllerDelegate {
         userScripts.autoconsentUserScript.delegate = self
         userScripts.autoconsentUserScript.management = autoconsentManagement
         userScripts.contentScopeUserScript.delegate = self
+        userScripts.registerEventHubSubfeature(eventHubWebEventsHandler)
         userScripts.serpSettingsUserScript.delegate = self
         userScripts.serpSettingsUserScript.setStore(keyValueStore)
         userScripts.serpSettingsUserScript.webView = webView

--- a/iOS/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerLongPressMenuExtension.swift
@@ -170,7 +170,8 @@ extension TabViewController {
             voiceSearchHelper: voiceSearchHelper,
             darkReaderFeatureSettings: darkReaderFeatureSettings,
             autoplaySettings: autoplaySettings,
-            adBlockingAvailability: adBlockingAvailability)
+            adBlockingAvailability: adBlockingAvailability,
+            eventHub: eventHub)
 
         tabController.isLinkPreview = true
         let configuration = WKWebViewConfiguration.nonPersistent()

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -27,6 +27,7 @@ import Subscription
 import Persistence
 import DDGSync
 import Configuration
+import EventHub
 import SetDefaultBrowserUI
 import SystemSettingsPiPTutorial
 import DataBrokerProtection_iOS
@@ -136,7 +137,8 @@ final class MainCoordinator {
          sharedSecureVault: (any AutofillSecureVault)? = nil,
          syncAutoRestoreDecisionManager: SyncAutoRestoreDecisionManaging = AppDependencyProvider.shared.syncAutoRestoreDecisionManager,
          wideEvent: WideEventManaging,
-         onboardingManager: OnboardingManaging
+         onboardingManager: OnboardingManaging,
+         eventHub: EventHubManaging
     ) throws {
         self.subscriptionManager = subscriptionManager
         self.featureFlagger = featureFlagger
@@ -218,7 +220,8 @@ final class MainCoordinator {
                                 duckAiNativeStorageHandler: contentBlockingService.duckAiNativeStorageHandler,
                                 duckAiFireModeStorageHandler: contentBlockingService.duckAiFireModeStorageHandler,
                                 toggleModeStorage: toggleModeStorage,
-                                adBlockingAvailability: contentBlockingService.adBlockingAvailability)
+                                adBlockingAvailability: contentBlockingService.adBlockingAvailability,
+                                eventHub: eventHub)
         let fireExecutor = FireExecutor(tabManager: tabManager,
                                         websiteDataManager: websiteDataManager,
                                         daxDialogsManager: daxDialogsManager,

--- a/iOS/DuckDuckGo/UserScripts.swift
+++ b/iOS/DuckDuckGo/UserScripts.swift
@@ -20,9 +20,9 @@
 import AIChat
 import BrowserServicesKit
 import Core
+import EventHub
 import os.log
 import Foundation
-import Persistence
 import PrivacyConfig
 import SERPSettings
 import SpecialErrorPages
@@ -61,17 +61,14 @@ final class UserScripts: UserScriptsProvider {
     private(set) var fullScreenVideoScript = FullScreenVideoUserScript()
     private(set) var printingSubfeature = PrintingSubfeature()
     private(set) var trackerProtectionSubfeature = TrackerProtectionSubfeature()
-    let webEventsSubfeature: WebEventsSubfeature
 
     private let isAutoconsentExtensionAvailable: Bool
 
     init(with sourceProvider: ScriptSourceProviding,
          appSettings: AppSettings = AppDependencyProvider.shared.appSettings,
          featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
-         keyValueStore: ThrowingKeyValueStoring,
          duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil,
-         aiChatDebugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings(),
-         adBlockingAvailability: AdBlockingAvailabilityProviding) {
+         aiChatDebugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings()) {
 
         isAutoconsentExtensionAvailable = sourceProvider.webExtensionAvailability?.isAutoconsentExtensionAvailable ?? false
 
@@ -150,23 +147,8 @@ final class UserScripts: UserScriptsProvider {
             featureFlagProvider: subscriptionFeatureFlagAdapter,
             navigationDelegate: subscriptionNavigationHandler,
             debugHost: aiChatDebugSettings.messagePolicyHostname)
-        let youTubeAdBlockingStorage: any ThrowingKeyedStoring<YouTubeAdBlockingKeys> = keyValueStore.throwingKeyedStoring()
-        webEventsSubfeature = WebEventsSubfeature(
-            isUserOptedIn: {
-                let analyticsEnabled = (try? youTubeAdBlockingStorage.value(for: \.youTubeAnalyticsEnabled)) ?? false
-                return adBlockingAvailability.isEnabled && analyticsEnabled
-            },
-            onEvent: { type, loginState in
-                guard let pixel = Pixel.Event.adBlockingDetectedEvent(type: type) else { return }
-                DailyPixel.fire(
-                    pixel: pixel,
-                    withAdditionalParameters: ["loginState": loginState.rawValue]
-                )
-            }
-        )
 
         contentScopeUserScriptIsolated.registerSubfeature(delegate: faviconScript)
-        contentScopeUserScriptIsolated.registerSubfeature(delegate: webEventsSubfeature)
         contentScopeUserScriptIsolated.registerSubfeature(delegate: aiChatUserScript)
         contentScopeUserScriptIsolated.registerSubfeature(delegate: subscriptionUserScript)
         contentScopeUserScriptIsolated.registerSubfeature(delegate: serpSettingsUserScript)
@@ -185,6 +167,13 @@ final class UserScripts: UserScriptsProvider {
         specialErrorPageUserScript = SpecialErrorPageUserScript(localeStrings: SpecialErrorPageUserScript.localeStrings(),
                                                                 languageCode: Locale.current.languageCode ?? "en")
         specialErrorPageUserScript.map { specialPages?.registerSubfeature(delegate: $0) }
+    }
+
+    /// Registers a tab's EventHub `webEvents` handler. Unlike the subfeatures above this one cannot be
+    /// created here: it is per-tab, and `UserScripts` has no tab identity. `TabViewController` owns the
+    /// handler and calls this each time it is handed a new instance of us.
+    func registerEventHubSubfeature(_ handler: WebEventsHandler) {
+        contentScopeUserScriptIsolated.registerSubfeature(delegate: handler)
     }
 
     lazy var userScripts: [UserScript] = {

--- a/iOS/DuckDuckGoTests/ContentBlockingUpdatingTests.swift
+++ b/iOS/DuckDuckGoTests/ContentBlockingUpdatingTests.swift
@@ -61,9 +61,7 @@ final class ContentBlockingUpdatingTests: XCTestCase {
                                                                           contentScopeExperimentsManager: MockContentScopeExperimentManager(),
                                                                           internalUserDecider: MockInternalUserDecider(),
                                                                           syncErrorHandler: CapturingAdapterErrorHandler(),
-                                                                          webExtensionAvailability: nil),
-                                           keyValueStore: UserDefaults(suiteName: "ContentBlockingUpdatingTests")!,
-                                           adBlockingAvailability: StubAdBlockingAvailability())
+                                                                          webExtensionAvailability: nil))
     }
 
     override static func setUp() {

--- a/iOS/DuckDuckGoTests/EventHub/IOSEventHubPixelFiringTests.swift
+++ b/iOS/DuckDuckGoTests/EventHub/IOSEventHubPixelFiringTests.swift
@@ -1,0 +1,88 @@
+//
+//  IOSEventHubPixelFiringTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import PixelKit
+import XCTest
+
+@testable import DuckDuckGo
+
+/// Pins the exact pixel name EventHub telemetry goes out under. PixelKit rewrites names after the fact —
+/// which marker it appends, and whether it prepends the legacy `m_`, depends on how the event declares
+/// itself — so asserting on the name PixelKit actually requests, not the name we pass in, is what keeps
+/// these in sync with `event_hub.json5`.
+final class IOSEventHubPixelFiringTests: XCTestCase {
+
+    private var firedNames: [String] = []
+    private var firedParameters: [[String: String]] = []
+
+    override func setUp() {
+        super.setUp()
+        firedNames = []
+        firedParameters = []
+    }
+
+    override func tearDown() {
+        PixelKit.tearDown()
+        firedNames = []
+        firedParameters = []
+        super.tearDown()
+    }
+
+    func testFiredNameCarriesThePhoneSuffixAndNoLegacyPrefix() {
+        setUpPixelKit(source: .iOS)
+
+        IOSEventHubPixelFiring().enqueueFirePixel(named: "webTelemetry_youtube_staticAd_day", parameters: [:])
+
+        XCTAssertEqual(firedNames, ["webTelemetry_youtube_staticAd_day_ios_phone"])
+    }
+
+    func testFiredNameCarriesTheTabletSuffixOnIPad() {
+        setUpPixelKit(source: .iPadOS)
+
+        IOSEventHubPixelFiring().enqueueFirePixel(named: "webTelemetry_youtube_staticAd_day", parameters: [:])
+
+        XCTAssertEqual(firedNames, ["webTelemetry_youtube_staticAd_day_ios_tablet"])
+    }
+
+    func testParametersArePassedThrough() {
+        setUpPixelKit(source: .iOS)
+
+        IOSEventHubPixelFiring().enqueueFirePixel(named: "some_telemetry",
+                                                 parameters: ["count": "1+", "attributionPeriod": "1769126400"])
+
+        XCTAssertEqual(firedParameters.first?["count"], "1+")
+        XCTAssertEqual(firedParameters.first?["attributionPeriod"], "1769126400")
+    }
+
+    // MARK: - Helpers
+
+    /// `dryRun: false` — PixelKit deliberately skips `fireRequest` entirely when dry-running. `source` is
+    /// what `platformSuffix` reads, so it has to be set explicitly rather than inherited from the device.
+    private func setUpPixelKit(source: PixelKit.Source) {
+        PixelKit.setUp(dryRun: false,
+                       appVersion: "1.0.0",
+                       source: source.rawValue,
+                       session: "test",
+                       defaultHeaders: [:],
+                       defaults: UserDefaults(suiteName: "\(type(of: self))")!) { name, _, parameters, _, _, _ in
+            self.firedNames.append(name)
+            self.firedParameters.append(parameters)
+        }
+    }
+}

--- a/iOS/DuckDuckGoTests/EventHub/YouTubeAdBlockingTelemetryConsentRequirementTests.swift
+++ b/iOS/DuckDuckGoTests/EventHub/YouTubeAdBlockingTelemetryConsentRequirementTests.swift
@@ -25,8 +25,9 @@ import XCTest
 
 @testable import DuckDuckGo
 
-/// Covers the notification bridge this requirement exists for: the store backing the opt-in has no
-/// change publisher, so a revoked opt-in only reaches EventHub if a posted notification makes it re-read.
+/// Covers the two things this requirement exists for: consent needs *both* opt-ins, and neither is
+/// observable — the store has no change publisher, so a revoked opt-in only reaches EventHub if a posted
+/// notification makes it re-read.
 final class YouTubeAdBlockingTelemetryConsentRequirementTests: XCTestCase {
 
     private var store: MockKeyValueFileStore!
@@ -51,48 +52,86 @@ final class YouTubeAdBlockingTelemetryConsentRequirementTests: XCTestCase {
         XCTAssertEqual(makeSUT().configNames, EventHubGatedConfigNames.youTubeAdBlockingTelemetry)
     }
 
-    func testIsGrantedIsFalseWhenTheOptInWasNeverSet() {
+    // MARK: - Both opt-ins required
+
+    func testConsentIsWithheldWhenNeitherOptInIsSet() {
         XCTAssertEqual(record(from: makeSUT()).values, [false])
     }
 
-    func testIsGrantedEmitsTheStoredValueOnSubscribe() throws {
-        try setOptIn(true)
+    func testConsentIsWithheldWhenOnlyAnalyticsIsEnabled() throws {
+        try set(analytics: true)
+
+        XCTAssertEqual(record(from: makeSUT()).values, [false])
+    }
+
+    func testConsentIsWithheldWhenOnlyAdBlockingIsEnabled() throws {
+        try set(adBlocking: true)
+
+        XCTAssertEqual(record(from: makeSUT()).values, [false])
+    }
+
+    func testConsentIsGrantedOnlyWhenBothOptInsAreEnabled() throws {
+        try set(adBlocking: true)
+        try set(analytics: true)
 
         XCTAssertEqual(record(from: makeSUT()).values, [true])
     }
 
-    func testIsGrantedReEmitsWhenTheOptInIsRevoked() throws {
-        try setOptIn(true)
+    // MARK: - Change notifications
+
+    func testRevokingAnalyticsWithdrawsConsent() throws {
+        try set(adBlocking: true)
+        try set(analytics: true)
         let recorder = record(from: makeSUT())
 
-        try setOptIn(false)
-        postChange()
+        try set(analytics: false)
+        post(.analytics)
 
         XCTAssertEqual(recorder.values, [true, false])
     }
 
-    func testIsGrantedReEmitsWhenTheOptInIsGranted() throws {
+    /// The one the analytics-only gate got wrong: turning ad blocking off must withdraw consent even when
+    /// the analytics flag is left behind, granted.
+    func testRevokingAdBlockingWithdrawsConsentEvenWhileAnalyticsStaysEnabled() throws {
+        try set(adBlocking: true)
+        try set(analytics: true)
         let recorder = record(from: makeSUT())
 
-        try setOptIn(true)
-        postChange()
+        try set(adBlocking: false)
+        post(.adBlocking)
+
+        XCTAssertEqual(recorder.values, [true, false])
+    }
+
+    func testGrantingTheSecondOptInGrantsConsent() throws {
+        try set(adBlocking: true)
+        let recorder = record(from: makeSUT())
+
+        try set(analytics: true)
+        post(.analytics)
 
         XCTAssertEqual(recorder.values, [false, true])
     }
 
-    /// The ad-blocking toggle cascades into this setting whether or not the value changes, so a write
-    /// landing on the stored value must not churn EventHub's config.
-    func testWriteThatDoesNotChangeTheValueDoesNotReEmit() throws {
-        try setOptIn(true)
+    /// The ad-blocking toggle cascades into the analytics setting whether or not the value changes, so a
+    /// write landing on the stored value must not churn EventHub's config.
+    func testWriteThatDoesNotChangeTheOutcomeDoesNotReEmit() throws {
+        try set(adBlocking: true)
+        try set(analytics: true)
         let recorder = record(from: makeSUT())
 
-        try setOptIn(true)
-        postChange()
+        try set(analytics: true)
+        post(.analytics)
 
         XCTAssertEqual(recorder.values, [true])
     }
 
     // MARK: - Helpers
+
+    private enum Flag {
+        case adBlocking
+        case analytics
+    }
 
     private func makeSUT() -> YouTubeAdBlockingTelemetryConsentRequirement {
         YouTubeAdBlockingTelemetryConsentRequirement(keyValueStore: store, notificationCenter: notificationCenter)
@@ -108,12 +147,22 @@ final class YouTubeAdBlockingTelemetryConsentRequirementTests: XCTestCase {
         return recorder
     }
 
-    private func setOptIn(_ enabled: Bool) throws {
+    private func set(adBlocking: Bool? = nil, analytics: Bool? = nil) throws {
         let storage: any ThrowingKeyedStoring<YouTubeAdBlockingKeys> = store.throwingKeyedStoring()
-        try storage.set(enabled, for: \YouTubeAdBlockingKeys.youTubeAnalyticsEnabled)
+        if let adBlocking {
+            try storage.set(adBlocking, for: \YouTubeAdBlockingKeys.youTubeAdBlockingEnabled)
+        }
+        if let analytics {
+            try storage.set(analytics, for: \YouTubeAdBlockingKeys.youTubeAnalyticsEnabled)
+        }
     }
 
-    private func postChange() {
-        notificationCenter.post(name: YouTubeAdBlockingStorageKeys.youTubeAnalyticsEnabledDidChangeNotification, object: nil)
+    private func post(_ flag: Flag) {
+        switch flag {
+        case .adBlocking:
+            notificationCenter.post(name: YouTubeAdBlockingStorageKeys.youTubeAdBlockingEnabledDidChangeNotification, object: nil)
+        case .analytics:
+            notificationCenter.post(name: YouTubeAdBlockingStorageKeys.youTubeAnalyticsEnabledDidChangeNotification, object: nil)
+        }
     }
 }

--- a/iOS/DuckDuckGoTests/EventHub/YouTubeAdBlockingTelemetryConsentRequirementTests.swift
+++ b/iOS/DuckDuckGoTests/EventHub/YouTubeAdBlockingTelemetryConsentRequirementTests.swift
@@ -1,0 +1,119 @@
+//
+//  YouTubeAdBlockingTelemetryConsentRequirementTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import EventHub
+import Persistence
+import PersistenceTestingUtils
+import XCTest
+
+@testable import DuckDuckGo
+
+/// Covers the notification bridge this requirement exists for: the store backing the opt-in has no
+/// change publisher, so a revoked opt-in only reaches EventHub if a posted notification makes it re-read.
+final class YouTubeAdBlockingTelemetryConsentRequirementTests: XCTestCase {
+
+    private var store: MockKeyValueFileStore!
+    private var notificationCenter: NotificationCenter!
+    private var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+        store = MockKeyValueFileStore()
+        notificationCenter = NotificationCenter()
+        cancellables = []
+    }
+
+    override func tearDown() {
+        store = nil
+        notificationCenter = nil
+        cancellables = nil
+        super.tearDown()
+    }
+
+    func testGatedConfigNamesDefaultToTheSharedSet() {
+        XCTAssertEqual(makeSUT().configNames, EventHubGatedConfigNames.youTubeAdBlockingTelemetry)
+    }
+
+    func testIsGrantedIsFalseWhenTheOptInWasNeverSet() {
+        XCTAssertEqual(record(from: makeSUT()).values, [false])
+    }
+
+    func testIsGrantedEmitsTheStoredValueOnSubscribe() throws {
+        try setOptIn(true)
+
+        XCTAssertEqual(record(from: makeSUT()).values, [true])
+    }
+
+    func testIsGrantedReEmitsWhenTheOptInIsRevoked() throws {
+        try setOptIn(true)
+        let recorder = record(from: makeSUT())
+
+        try setOptIn(false)
+        postChange()
+
+        XCTAssertEqual(recorder.values, [true, false])
+    }
+
+    func testIsGrantedReEmitsWhenTheOptInIsGranted() throws {
+        let recorder = record(from: makeSUT())
+
+        try setOptIn(true)
+        postChange()
+
+        XCTAssertEqual(recorder.values, [false, true])
+    }
+
+    /// The ad-blocking toggle cascades into this setting whether or not the value changes, so a write
+    /// landing on the stored value must not churn EventHub's config.
+    func testWriteThatDoesNotChangeTheValueDoesNotReEmit() throws {
+        try setOptIn(true)
+        let recorder = record(from: makeSUT())
+
+        try setOptIn(true)
+        postChange()
+
+        XCTAssertEqual(recorder.values, [true])
+    }
+
+    // MARK: - Helpers
+
+    private func makeSUT() -> YouTubeAdBlockingTelemetryConsentRequirement {
+        YouTubeAdBlockingTelemetryConsentRequirement(keyValueStore: store, notificationCenter: notificationCenter)
+    }
+
+    private final class Recorder {
+        var values: [Bool] = []
+    }
+
+    private func record(from sut: YouTubeAdBlockingTelemetryConsentRequirement) -> Recorder {
+        let recorder = Recorder()
+        sut.isGrantedPublisher.sink { recorder.values.append($0) }.store(in: &cancellables)
+        return recorder
+    }
+
+    private func setOptIn(_ enabled: Bool) throws {
+        let storage: any ThrowingKeyedStoring<YouTubeAdBlockingKeys> = store.throwingKeyedStoring()
+        try storage.set(enabled, for: \YouTubeAdBlockingKeys.youTubeAnalyticsEnabled)
+    }
+
+    private func postChange() {
+        notificationCenter.post(name: YouTubeAdBlockingStorageKeys.youTubeAnalyticsEnabledDidChangeNotification, object: nil)
+    }
+}

--- a/iOS/DuckDuckGoTests/TabManagerExternalLaunchTests.swift
+++ b/iOS/DuckDuckGoTests/TabManagerExternalLaunchTests.swift
@@ -253,7 +253,8 @@ final class TabManagerExternalLaunchTests {
             voiceSearchHelper: MockVoiceSearchHelper(),
             launchSourceManager: launchSourceManager,
             darkReaderFeatureSettings: MockDarkReaderFeatureSettings(),
-            adBlockingAvailability: StubAdBlockingAvailability()
+            adBlockingAvailability: StubAdBlockingAvailability(),
+            eventHub: StubEventHub()
         )
     }
 }

--- a/iOS/DuckDuckGoTests/TabManagerTests.swift
+++ b/iOS/DuckDuckGoTests/TabManagerTests.swift
@@ -426,7 +426,8 @@ final class TabManagerTests: XCTestCase {
                           voiceSearchHelper: MockVoiceSearchHelper(),
                           launchSourceManager: launchSourceManager,
                           darkReaderFeatureSettings: MockDarkReaderFeatureSettings(),
-                          adBlockingAvailability: StubAdBlockingAvailability())
+                          adBlockingAvailability: StubAdBlockingAvailability(),
+                          eventHub: StubEventHub())
     }
 
 }

--- a/iOS/PixelDefinitions/pixels/definitions/event_hub.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/event_hub.json5
@@ -1,0 +1,132 @@
+{
+    // Names here are the bare governed config names from the remote `eventHub` settings. EventHub fires
+    // them verbatim; PixelKit appends `_ios_phone` / `_ios_tablet`, which is what the `platform` and
+    // `form_factor` suffixes below declare. Do not add a platform marker to the names themselves, and do
+    // not add an `m_` prefix — see `IOSEventHubPixelFiring` for how both are avoided. macOS declares an
+    // explicit `_macos` suffix instead, because PixelKit resolves names differently on that platform.
+    "webTelemetry_youtube_adBlocker_day": {
+        "description": "Daily bucketed count of YouTube ad-blocker-challenge detections, with the user's login state at detection time. Fired by the eventHub feature at the end of each 1-day period. Successor to the retired m_web_extension_adblocking_detected_ad_blocker_daily pixel.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed detection count for the period (e.g. \"0\", \"1+\")",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "loginState",
+                "type": "string",
+                "description": "User's YouTube login state at detection time, as percent-encoded JSON (e.g. %22logged-in%22)"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_youtube_playabilityError_day": {
+        "description": "Daily bucketed count of YouTube playability-error detections, with the user's login state at detection time. Fired by the eventHub feature at the end of each 1-day period. Successor to the retired m_web_extension_adblocking_detected_playability_error_daily pixel.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed detection count for the period (e.g. \"0\", \"1+\")",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "loginState",
+                "type": "string",
+                "description": "User's YouTube login state at detection time, as percent-encoded JSON (e.g. %22logged-in%22)"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_youtube_videoAd_day": {
+        "description": "Daily bucketed count of YouTube video-ad detections, with the user's login state at detection time. Fired by the eventHub feature at the end of each 1-day period. Successor to the retired m_web_extension_adblocking_detected_video_ad_daily pixel.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed detection count for the period (e.g. \"0\", \"1+\")",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "loginState",
+                "type": "string",
+                "description": "User's YouTube login state at detection time, as percent-encoded JSON (e.g. %22logged-in%22)"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_youtube_staticAd_day": {
+        "description": "Daily bucketed count of YouTube static-ad detections, with the user's login state at detection time. Fired by the eventHub feature at the end of each 1-day period. Successor to the retired m_web_extension_adblocking_detected_static_ad_daily pixel.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed detection count for the period (e.g. \"0\", \"1+\")",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "loginState",
+                "type": "string",
+                "description": "User's YouTube login state at detection time, as percent-encoded JSON (e.g. %22logged-in%22)"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_youtube_buffering_day": {
+        "description": "Daily bucketed count of YouTube playback-buffering detections, with the user's login state at detection time. Fired by the eventHub feature at the end of each 1-day period. Successor to the retired m_web_extension_adblocking_detected_buffering_daily pixel.",
+        "owners": ["miasma13"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed detection count for the period (e.g. \"0\", \"1+\")",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "loginState",
+                "type": "string",
+                "description": "User's YouTube login state at detection time, as percent-encoded JSON (e.g. %22logged-in%22)"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    }
+}

--- a/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
+++ b/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
@@ -143,7 +143,8 @@ private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibi
                                     voiceSearchHelper: MockVoiceSearchHelper(),
                                     launchSourceManager: MockLaunchSourceManager(),
                                     darkReaderFeatureSettings: MockDarkReaderFeatureSettings(),
-                                    adBlockingAvailability: StubAdBlockingAvailability()
+                                    adBlockingAvailability: StubAdBlockingAvailability(),
+                                    eventHub: StubEventHub()
         )
         let fireExecutor = FireExecutor(tabManager: tabManager,
                                         websiteDataManager: mockWebsiteDataManager,

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
@@ -23,6 +23,7 @@ import WebExtensions
 import WebKit
 import BrowserServicesKit
 import BrowserServicesKitTestsUtils
+import EventHub
 import PrivacyDashboard
 import Persistence
 import Subscription
@@ -205,7 +206,8 @@ extension TabViewController {
             voiceSearchHelper: MockVoiceSearchHelper(),
             darkReaderFeatureSettings: MockDarkReaderFeatureSettings(),
             autoplaySettings: MockAutoplaySettings(),
-            adBlockingAvailability: StubAdBlockingAvailability()
+            adBlockingAvailability: StubAdBlockingAvailability(),
+            eventHub: StubEventHub()
         )
         tab.attachWebView(configuration: WKWebViewConfiguration.nonPersistent(), andLoadRequest: nil as URLRequest?, consumeCookies: false, customWebView: customWebView)
         return tab
@@ -294,4 +296,28 @@ final class StubAdBlockingAvailability: AdBlockingAvailabilityProviding {
     var isFeatureSupported: Bool = false
     var isEnabledByUser: Bool = false
     func shouldShowAnimation(for url: URL) -> Bool { false }
+}
+
+/// Records the per-tab signals `TabViewController` reports, so tests can assert on them without
+/// standing up a real `EventHub` (and its store, scheduler and remote-config plumbing).
+final class StubEventHub: EventHubManaging {
+    private(set) var navigationStarts: [(tabID: EventHubTabID, url: String)] = []
+    private(set) var closedTabIDs: [EventHubTabID] = []
+
+    func handleWebEvent(_ webEventData: [String: Any], tabID: EventHubTabID) {}
+    func handleImmediateEvent(_ type: String, data: Encodable?) {}
+    func handleAggregatedEvent(_ type: String, data: Encodable?) {}
+
+    func onNavigationStarted(tabID: EventHubTabID, url: String) {
+        navigationStarts.append((tabID, url))
+    }
+
+    func onTabClosed(tabID: EventHubTabID) {
+        closedTabIDs.append(tabID)
+    }
+
+    func onConfigChanged() {}
+    func isEnabled() -> Bool { false }
+    func onAppForegrounded() {}
+    func onAppBackgrounded() {}
 }

--- a/macOS/DuckDuckGo/EventHub/MacOSEventHubIntegration.swift
+++ b/macOS/DuckDuckGo/EventHub/MacOSEventHubIntegration.swift
@@ -27,17 +27,6 @@ import PrivacyConfig
 /// pixel firing, and consent gating. Constructed once by `AppDelegate`.
 final class MacOSEventHubIntegration {
 
-    /// The `telemetry` config names (keys in the remote eventHub settings) gated behind the YouTube
-    /// analytics opt-in. These must byte-match the server-side config keys: a mismatch fails open — the
-    /// entry is never stripped, so its telemetry would be collected without consent.
-    private static let youTubeAdBlockingTelemetryConfigNames: Set<String> = [
-        "webTelemetry_youtube_adBlocker_day",
-        "webTelemetry_youtube_playabilityError_day",
-        "webTelemetry_youtube_videoAd_day",
-        "webTelemetry_youtube_staticAd_day",
-        "webTelemetry_youtube_buffering_day"
-    ]
-
     let eventHub: EventHubManaging
 
     private var cancellables = Set<AnyCancellable>()
@@ -60,7 +49,7 @@ final class MacOSEventHubIntegration {
             featureEnabledPublisher: enabledSubject.eraseToAnyPublisher(),
             featureSettingsPublisher: settingsSubject.eraseToAnyPublisher(),
             consentRequirements: [
-                YouTubeAdBlockingTelemetryConsentRequirement(configNames: Self.youTubeAdBlockingTelemetryConfigNames)
+                YouTubeAdBlockingTelemetryConsentRequirement()
             ]
         )
 

--- a/macOS/DuckDuckGo/EventHub/YouTubeAdBlockingTelemetryConsentRequirement.swift
+++ b/macOS/DuckDuckGo/EventHub/YouTubeAdBlockingTelemetryConsentRequirement.swift
@@ -36,7 +36,8 @@ final class YouTubeAdBlockingTelemetryConsentRequirement: EventHubConsentRequire
     let configNames: Set<String>
     let isGrantedPublisher: AnyPublisher<Bool, Never>
 
-    init(configNames: Set<String>, store: any ObservableKeyValueStoring = UserDefaults.standard) {
+    init(configNames: Set<String> = EventHubGatedConfigNames.youTubeAdBlockingTelemetry,
+         store: any ObservableKeyValueStoring = UserDefaults.standard) {
         self.configNames = configNames
         let settings: any ObservableKeyedStoring<YouTubeAdBlockingSettings> = store.observableKeyedStoring()
         isGrantedPublisher = settings.publisher(for: \.youTubeAdBlockingEnabled)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216947041711146
Tech Design URL: https://app.asana.com/1/137249556945/project/1203936086921904/task/1216592765148783?focus=true
CC:

### Description
Third in the stack, targeting `michal/event-hub-2`. Wires the EventHub package from #5959 into iOS and moves the five YouTube ad-blocking detection events onto it, retiring the hardcoded path (opt-in check plus event-type-to-pixel mapping compiled into the app). Which events are measured, and how, now comes from remote config instead of an app release.

The behavioural changes match #6054: detections are aggregated into a bucketed daily count fired once per period rather than a pixel per detection, and the opt-ins strip gated entries from the config before EventHub sees them — so withheld consent means the measurement doesn't exist rather than being filtered later.

Both platforms are now on EventHub. Three things differ from the macOS integration, all forced by the platform:

- **No termination hook.** iOS always backgrounds before terminating, so backgrounding alone is a sufficient flush boundary and the macOS quit-flush and missed-first-foreground workarounds both disappear.
- **Pixel naming.** macOS appends `_macos` and opts out of PixelKit's `m_mac_` prefix. iOS needs the platform *and* form-factor markers with no `m_`, which is only achievable by declaring the event as `PixelKitEventWithCustomPrefix` with an empty prefix — that path appends PixelKit's `platformSuffix` while prepending nothing.
- **Consent observation.** The opt-ins live in the file-backed key-value store, which deliberately does not conform to `ObservableThrowingKeyValueStoring`, so there is no publisher to observe. Writers post a change notification and the consent requirement re-reads on either one.

The first commit also hoists the gated config names into the package so both platforms read one list, and the last brings the iOS consent gate in line with #6054's requirement that both the Ad Blocking and analytics opt-ins be granted.

### Testing Steps
Use the setup described in https://app.asana.com/1/137249556945/project/414235014887631/task/1216994836433629?focus=true and the sample test page to trigger the web detector event. Filter the logs by "EventHub" subsystem. Please verify the following:

- [ ] On app launch the feature is reported as enabled and telemetry definitions are being loaded
- [ ] Triggering an event starts the period
- [ ] When app is in foreground the pixel is fired at the period end
- [ ] Triggering an event on a single tab on a single page and reloading it will register it only once (de-dup)
- [ ] Triggering an event on the same page but opened in separate tabs is registered individually
- [ ] Triggering an event on a page, then in the same tab navigating elsewhere, then navigating again to the first page will record the event twice (navigation clears de-dup state)
- [ ] Recorded counts are not cleared by the Fire button
- [ ] Recorded counts are persisted between app relaunch
- [ ] The fired pixel name carries the platform and form-factor markers and no `m_` prefix (`webTelemetry_youtube_<type>_day_ios_phone` / `_ios_tablet`)

### Impact
High — touches per-tab lifecycle code that runs regardless of the feature flag, and the consent gate deciding whether telemetry is collected.

#### What could go wrong?
- Gated config names not byte-matching the server-side telemetry keys → the consent strip silently no-ops and telemetry is collected without opt-in. Still unvalidated on-device, but now one shared list rather than one per platform, so there is a single place to review.
- The per-tab component is created for every tab, so a fault there affects all browsing → mitigated by following the two existing per-tab subfeature registrations in `TabViewController`, and by reporting tab closure from `deinit` so no tab can leak dedup state.
- Pixel names drifting from the definitions, since PixelKit rewrites names → mitigated by tests asserting the name PixelKit actually requests, for both form factors.
- A store write that forgets to post its change notification would leave consent stale, since neither flag is observable → mitigated by routing every write through a single point per flag and by tests covering grant, revoke, and no-op writes.

### Quality Considerations
- Uses PixelKit rather than the legacy `Core.Pixel` path, which #5981 marks as deprecated for new pixels.
- Privacy: consent stripping fails closed, an unset opt-in counts as withheld, and navigation URLs are never logged. Fired parameters (including YouTube login state) are logged at info level — same flag as #6054.
- Removing the old path orphaned `keyValueStore` and `adBlockingAvailability` on `UserScripts.init`; Swift does not warn on unused parameters, so they are removed along with the plumbing that fed them. The ad-blocking debug screen's "clear detection-pixel stamps" button is also removed — nothing fires those pixels any more, so it silently did nothing.
- Not addressed here, deferred to a follow-up now that both platforms are migrated: `WebEventsSubfeature` in BrowserServicesKit has no remaining consumers, and the five iOS plus five macOS stale definitions and their enum cases are still in place.
- As in #5959, the package suite isn't in a scheme test plan, so CI won't run its 128 tests — local `swift test` only.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes per-tab browsing lifecycle and telemetry consent gating; a gated-config name mismatch or missed analytics notification could collect or withhold telemetry incorrectly.
> 
> **Overview**
> **Wires EventHub into iOS** and **retires** the in-app `WebEventsSubfeature` path that mapped each YouTube detection to a `DailyPixel` via `Pixel.Event.adBlockingDetectedEvent`. YouTube ad-blocking measurements now come from **remote EventHub config**, are **aggregated per period**, and fire through **`IOSEventHubPixelFiring`** (PixelKit with an empty custom prefix so names get `_ios_phone` / `_ios_tablet` without `m_`).
> 
> **`EventHubService`** is created at launch with a dedicated key-value store, privacy-config publishers, and **`YouTubeAdBlockingTelemetryConsentRequirement`** (both Ad Blocking and analytics opt-ins must be granted; consent updates via **`youTubeAnalyticsEnabledDidChange`** notifications because the file store is not observable). Foreground/background hooks flush and resume EventHub; **`eventHub`** is passed through **`TabManager`** / **`TabViewController`** with per-tab **`WebEventsHandler`**, navigation-start dedup reset, and tab-close cleanup.
> 
> **Shared `EventHubGatedConfigNames`** in the EventHub package replaces per-platform name lists (macOS consent requirement defaults to the same set). **`event_hub.json5`** declares the five successor pixels; the ad-blocking debug “clear detection-pixel stamps” UI and related **`UserScripts`** / **`ContentBlockingUpdating`** plumbing for the old path are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d3fd937122adbad2468b4981370256c7742650e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->