### PR TITLE
[macOS] Fix subscription pixel validation

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -493,6 +493,18 @@
                 "type": "string",
                 "description": "The funnel that led to the subscription flow"
             },
+            {
+                "key": "context.name",
+                "type": "string",
+                "description": "Legacy location of the funnel name, replaced by feature.data.ext.funnel_name in 1.181.0.",
+                "examples": [
+                    "funnel_app_macos",
+                    "funnel_appsettings_macos",
+                    "funnel_appmenu_macos",
+                    "funnel_freescan_macos",
+                    "funnel_toolbar_macos"
+                ]
+            },
             "channel"
         ]
     },


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1217095668561746?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

This PR fixes subscription pixel validation for macOS. See https://app.asana.com/1/137249556945/task/1217090909855135?focus=true for more.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Check that the change looks good compared to the [Asana task](https://app.asana.com/1/137249556945/task/1217090909855135?focus=true).

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to pixel definitions; no runtime app logic or user data handling.
> 
> **Overview**
> Fixes **macOS subscription pixel validation** by registering the legacy **`context.name`** parameter on **`m_mac_wide_subscription_purchase`**.
> 
> Funnel attribution moved to **`feature.data.ext.funnel_name`** in 1.181.0, but events can still include **`context.name`** (e.g. `funnel_app_macos`, `funnel_appmenu_macos`). Without this entry in `subscription.json5`, those payloads fail schema validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22e5ab169628d74bd525bce629f6eddcdd1b1524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->