### PR TITLE
[macOS][Pixels] Add missing parameters to debug assertion definition

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/debug_assertion_failure.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/debug_assertion_failure.json5
@@ -10,6 +10,7 @@
             "errorDomain",
             "errorCode",
             "underlyingErrorDomain",
+            "underlyingErrorCode",
             {
                 "key": "message",
                 "description": "The custom message describing the unexpected condition, e.g \"Failed to access Downloads folder\"",

--- a/macOS/PixelDefinitions/pixels/definitions/debug_assertion_failure.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/debug_assertion_failure.json5
@@ -7,6 +7,9 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "errorDomain",
+            "errorCode",
+            "underlyingErrorDomain",
             {
                 "key": "message",
                 "description": "The custom message describing the unexpected condition, e.g \"Failed to access Downloads folder\"",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217090855059289?focus=true
Tech Design URL:
CC:

### Description
The `m_mac_debug_assertion_failure` pixel failed live validation for undeclared parameters `d`, `e`, and `ud`. This declares them in the pixel definition by referencing the matching shared params.

### Testing Steps
1. Check that the parameters added to the definition match the ones missing in the Asana task.

### Impact
**None:** Pixel schema definition only.

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pixel definition metadata only; no runtime or analytics pipeline behavior changes.
> 
> **Overview**
> Updates the **`m_mac_debug_assertion_failure`** pixel schema so live validation accepts the error fields the client already sends (the undeclared **`d`**, **`e`**, and **`ud`** keys from the Asana task).
> 
> The definition now lists the shared **`errorDomain`**, **`errorCode`**, **`underlyingErrorDomain`**, and **`underlyingErrorCode`** parameters alongside **`appVersion`** and **`pixelSource`**, matching how other macOS error pixels are declared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cafdb3cc75583bb2cf1b24eba88afa76b27bd32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->