### PR TITLE
iOS: Fix invalid & missing Search Token (Dindex) requests

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -312,7 +312,7 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
 
     /// NA experiment: search token to speed up SERP by combining Index/Deep responses.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216365830146824
-    case searchTokenExperiment
+    case searchTokenExperimentV2
 
     /// NA Experiment: tailor the onboarding flow based on the user's download reason.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216491579842691?focus=true

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -500,7 +500,7 @@ public enum FeatureFlag: String {
 
     /// NA experiment: attach a search token to speed up SERP by combining Index/Deep responses.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216365830146824
-    case searchTokenExperiment
+    case searchTokenExperimentV2
 
     /// NA Experiment: tailor the onboarding flow based on the user's download reason.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216491579842691?focus=true
@@ -793,8 +793,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .disabled)
         case .uiTestExperiment:
             Config(source: .disabled, cohortType: UITestExperimentCohort.self)
-        case .searchTokenExperiment:
-            Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.searchTokenExperiment), cohortType: SearchTokenExperimentCohort.self)
+        case .searchTokenExperimentV2:
+            Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.searchTokenExperimentV2), cohortType: SearchTokenExperimentCohort.self)
         case .onboardingFlowByDownloadReasonExperiment:
             Config(source: .disabled, cohortType: OnboardingFlowByDownloadReasonExperimentCohort.self)
         case .monthlyFreeTrialExperiment:

--- a/iOS/Core/StatisticsLoader.swift
+++ b/iOS/Core/StatisticsLoader.swift
@@ -72,7 +72,7 @@ public class StatisticsLoader {
     static func fireSearchTokenExperimentPixels(metric: String) {
         for threshold in [1, 4, 6, 11, 21, 30] {
             PixelKit.fireExperimentPixelIfThresholdReached(
-                for: iOSBrowserConfigSubfeature.searchTokenExperiment.rawValue,
+                for: iOSBrowserConfigSubfeature.searchTokenExperimentV2.rawValue,
                 metric: metric,
                 conversionWindowDays: 1...4,
                 threshold: threshold

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5862,8 +5862,8 @@ extension MainViewController: NewTabPageControllerDelegate {
 
 extension MainViewController: TabDelegate {
 
-    func searchToken(for tab: TabViewController) -> String? {
-        searchTokenFetcher.retrieveToken()
+    func searchToken(for tab: TabViewController, userAgent: String) -> String? {
+        searchTokenFetcher.retrieveToken(matching: userAgent)
     }
 
     var isEmailProtectionSignedIn: Bool {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5333,7 +5333,9 @@ extension MainViewController: OmniBarDelegate {
         guard searchTokenExperiment.cohort == .treatment else { return }
         // Match the SERP navigation's UA exactly (the token is UA-bound): the tab's desktop state + a
         // duckduckgo.com URL, resolved through the same `agent(forUrl:isDesktop:)` the WebView uses.
-        let isDesktop = currentTab?.tabModel.isDesktop ?? false
+        // Fall back to the same default a new tab would use (`isLargeWidth`, i.e. desktop on iPad)
+        // so a nil `currentTab` doesn't warm a mobile UA the SERP then navigates as desktop.
+        let isDesktop = currentTab?.tabModel.isDesktop ?? AppWidthObserver.shared.isLargeWidth
         let userAgent = DefaultUserAgentManager.shared.userAgent(isDesktop: isDesktop, url: .ddg)
         Task { await searchTokenFetcher.fetchIfNeeded(userAgent: userAgent) }
     }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5864,7 +5864,13 @@ extension MainViewController: NewTabPageControllerDelegate {
 extension MainViewController: TabDelegate {
 
     func searchToken(for tab: TabViewController) -> String? {
-        searchTokenFetcher.retrieveToken()
+        if let token = searchTokenFetcher.retrieveToken() {
+            return token
+        } else {
+            // No live token for this SERP nav — warm now so a follow-up request finds one.
+            warmSearchTokenIfEligible()
+            return nil
+        }
     }
 
     var isEmailProtectionSignedIn: Bool {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2203,6 +2203,7 @@ class MainViewController: UIViewController {
             tabs: tabManager.allTabsModel.tabs,
             browsingMode: tabManager.currentBrowsingMode.pixelParamValue)
         skipSERPFlow = true
+        warmSearchTokenIfEligible()
 
         /// Dismiss any keyboard restored by WKWebView when returning to foreground
         /// with the tab switcher visible. The tab switcher uses .overCurrentContext so

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5332,10 +5332,10 @@ extension MainViewController: OmniBarDelegate {
     /// the fetcher's refresh-ahead window coalesces redundant triggers.
     func warmSearchTokenIfEligible() {
         guard searchTokenExperiment.cohort == .treatment else { return }
-        // Match the SERP navigation's UA exactly (the token is UA-bound): the tab's desktop state + a
-        // duckduckgo.com URL, resolved through the same `agent(forUrl:isDesktop:)` the WebView uses.
-        // Fall back to the same default a new tab would use (`isLargeWidth`, i.e. desktop on iPad)
-        // so a nil `currentTab` doesn't warm a mobile UA the SERP then navigates as desktop.
+        // The token is UA-bound. Warm it with the UA the SERP navigation will use: the tab's desktop
+        // state resolved through the same `agent(forUrl:isDesktop:)` the WebView applies. With no current
+        // tab (e.g. an empty new tab) fall back to the same default a new tab uses (`Tab.init` sets
+        // `desktop = isLargeWidth`, Tab.swift:156) so iPad, which navigates desktop, requests a desktop token.
         let isDesktop = currentTab?.tabModel.isDesktop ?? AppWidthObserver.shared.isLargeWidth
         let userAgent = DefaultUserAgentManager.shared.userAgent(isDesktop: isDesktop, url: .ddg)
         Task { await searchTokenFetcher.fetchIfNeeded(userAgent: userAgent) }
@@ -5863,8 +5863,8 @@ extension MainViewController: NewTabPageControllerDelegate {
 
 extension MainViewController: TabDelegate {
 
-    func searchToken(for tab: TabViewController, userAgent: String) -> String? {
-        searchTokenFetcher.retrieveToken(matching: userAgent)
+    func searchToken(for tab: TabViewController) -> String? {
+        searchTokenFetcher.retrieveToken()
     }
 
     var isEmailProtectionSignedIn: Bool {

--- a/iOS/DuckDuckGo/SearchToken/SearchTokenDebugView.swift
+++ b/iOS/DuckDuckGo/SearchToken/SearchTokenDebugView.swift
@@ -36,7 +36,7 @@ struct SearchTokenDebugView: View {
             Section {
                 NavigationLink {
                     ExperimentCohortView(viewModel: FeatureFlagsSettingViewModel(),
-                                         experiment: FeatureFlag.searchTokenExperiment)
+                                         experiment: FeatureFlag.searchTokenExperimentV2)
                 } label: {
                     Text(verbatim: "Experiment cohort override")
                 }

--- a/iOS/DuckDuckGo/SearchToken/SearchTokenExperiment.swift
+++ b/iOS/DuckDuckGo/SearchToken/SearchTokenExperiment.swift
@@ -36,11 +36,11 @@ struct SearchTokenExperiment {
     /// Resolves — and thereby enrols — the cohort for an eligible new user. No-op for returning users.
     func enrollIfEligible() {
         guard statisticsStore.variant != VariantIOS.returningUser.name else { return }
-        _ = featureFlagger.resolveCohort(for: FeatureFlag.searchTokenExperiment)
+        _ = featureFlagger.resolveCohort(for: FeatureFlag.searchTokenExperimentV2)
     }
 
     /// The assigned cohort, or `nil` when not enrolled.
     var cohort: FeatureFlag.SearchTokenExperimentCohort? {
-        featureFlagger.assignedCohort(for: FeatureFlag.searchTokenExperiment) as? FeatureFlag.SearchTokenExperimentCohort
+        featureFlagger.assignedCohort(for: FeatureFlag.searchTokenExperimentV2) as? FeatureFlag.SearchTokenExperimentCohort
     }
 }

--- a/iOS/DuckDuckGo/SearchToken/SearchTokenExperimentSettings.swift
+++ b/iOS/DuckDuckGo/SearchToken/SearchTokenExperimentSettings.swift
@@ -48,7 +48,7 @@ struct SearchTokenExperimentSettings {
     }
 
     private func seconds(forKey key: String) -> TimeInterval? {
-        guard let json = privacyConfigurationManager.privacyConfig.settings(for: iOSBrowserConfigSubfeature.searchTokenExperiment),
+        guard let json = privacyConfigurationManager.privacyConfig.settings(for: iOSBrowserConfigSubfeature.searchTokenExperimentV2),
               let data = json.data(using: .utf8),
               let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let value = dict[key] as? NSNumber else {

--- a/iOS/DuckDuckGo/SearchToken/SearchTokenFetcher.swift
+++ b/iOS/DuckDuckGo/SearchToken/SearchTokenFetcher.swift
@@ -29,7 +29,7 @@ import os.log
 ///
 /// - `fetchIfNeeded(userAgent:)` fetches only when there is no live token or the current token is within
 ///   `window` seconds of expiry (refresh-ahead), and coalesces concurrent triggers into one request.
-/// - `retrieveToken()` returns the cached token synchronously while it is still within its TTL, else `nil`.
+/// - `retrieveToken(matching:)` returns the cached token if it was minted for the given UA and is still within its TTL, else `nil`.
 final class SearchTokenFetcher {
 
     private let requester: SearchTokenRequesting
@@ -39,6 +39,7 @@ final class SearchTokenFetcher {
 
     private let lock = NSLock()
     private var cachedToken: String?
+    private var cachedUserAgent: String?
     private var fetchedAt: Date?
     private var isFetching = false
 
@@ -53,9 +54,9 @@ final class SearchTokenFetcher {
     }
 
     /// The cached token while it is still within its TTL, otherwise `nil`. Synchronous, non-blocking.
-    func retrieveToken() -> String? {
+    func retrieveToken(matching userAgent: String) -> String? {
         lock.lock(); defer { lock.unlock() }
-        guard let cachedToken, let fetchedAt else { // Token Exists
+        guard let cachedToken, let fetchedAt, cachedUserAgent == userAgent else { // Token exists for this UA
             return nil
         }
         guard now().timeIntervalSince(fetchedAt) < ttlProvider() else { // Token is valid
@@ -70,12 +71,12 @@ final class SearchTokenFetcher {
     /// All locking is confined to the synchronous helpers below; the lock is never touched across the
     /// `await`, keeping this async-safe.
     func fetchIfNeeded(userAgent: String) async {
-        guard beginFetching() else { return }
+        guard beginFetching(userAgent: userAgent) else { return }
         defer { endFetching() }
 
         do {
             let token = try await requester.requestToken(userAgent: userAgent)
-            store(token: token)
+            store(token: token, userAgent: userAgent)
             Logger.general.debug("SearchToken: fetched (len=\(token.count, privacy: .public))")
         } catch {
             Logger.general.debug("SearchToken: fetch failed: \(error.localizedDescription, privacy: .public)")
@@ -86,10 +87,10 @@ final class SearchTokenFetcher {
 
     /// Marks a fetch as in flight and returns whether the caller should proceed. Skips if a fetch is
     /// already running or the current token still has more than `window` seconds of life.
-    private func beginFetching() -> Bool {
+    private func beginFetching(userAgent: String) -> Bool {
         lock.lock(); defer { lock.unlock() }
         if isFetching { return false }
-        if let fetchedAt, cachedToken != nil, // Token exists
+        if let fetchedAt, cachedToken != nil, cachedUserAgent == userAgent, // Fresh token already cached for this UA
            ttlProvider() - now().timeIntervalSince(fetchedAt) > windowProvider() { // Token is fresh
             return false
         }
@@ -97,9 +98,10 @@ final class SearchTokenFetcher {
         return true
     }
 
-    private func store(token: String) {
+    private func store(token: String, userAgent: String) {
         lock.lock(); defer { lock.unlock() }
         cachedToken = token
+        cachedUserAgent = userAgent
         fetchedAt = now()
     }
 

--- a/iOS/DuckDuckGo/SearchToken/SearchTokenFetcher.swift
+++ b/iOS/DuckDuckGo/SearchToken/SearchTokenFetcher.swift
@@ -78,7 +78,7 @@ final class SearchTokenFetcher {
 
         do {
             let token = try await requester.requestToken(userAgent: userAgent)
-            store(token: token, userAgent: userAgent)
+            cache(token: token, userAgent: userAgent)
             Logger.general.debug("SearchToken: fetched (len=\(token.count, privacy: .public))")
         } catch {
             Logger.general.debug("SearchToken: fetch failed: \(error.localizedDescription, privacy: .public)")
@@ -101,7 +101,7 @@ final class SearchTokenFetcher {
         return true
     }
 
-    private func store(token: String, userAgent: String) {
+    private func cache(token: String, userAgent: String) {
         lock.lock(); defer { lock.unlock() }
         cachedToken = token
         cachedUserAgent = userAgent

--- a/iOS/DuckDuckGo/SearchToken/SearchTokenFetcher.swift
+++ b/iOS/DuckDuckGo/SearchToken/SearchTokenFetcher.swift
@@ -27,9 +27,11 @@ import os.log
 /// via a single `NSLock` held only for cache reads/writes, never across the network call. The network
 /// request itself is delegated to an injected `SearchTokenRequesting`.
 ///
-/// - `fetchIfNeeded(userAgent:)` fetches only when there is no live token or the current token is within
-///   `window` seconds of expiry (refresh-ahead), and coalesces concurrent triggers into one request.
-/// - `retrieveToken(matching:)` returns the cached token if it was minted for the given UA and is still within its TTL, else `nil`.
+/// - `fetchIfNeeded(userAgent:)` fetches when there is no live token, the current token is within `window`
+///   seconds of expiry (refresh-ahead), or the cached token was minted for a different UA; concurrent
+///   triggers coalesce into one request.
+/// - `retrieveToken()` returns the cached token while within its TTL
+/// else `nil`. Only fetching is UA-aware; retrieval never withholds a live token.
 final class SearchTokenFetcher {
 
     private let requester: SearchTokenRequesting
@@ -54,9 +56,9 @@ final class SearchTokenFetcher {
     }
 
     /// The cached token while it is still within its TTL, otherwise `nil`. Synchronous, non-blocking.
-    func retrieveToken(matching userAgent: String) -> String? {
+    func retrieveToken() -> String? {
         lock.lock(); defer { lock.unlock() }
-        guard let cachedToken, let fetchedAt, cachedUserAgent == userAgent else { // Token exists for this UA
+        guard let cachedToken, let fetchedAt else { // Token exists
             return nil
         }
         guard now().timeIntervalSince(fetchedAt) < ttlProvider() else { // Token is valid
@@ -85,8 +87,9 @@ final class SearchTokenFetcher {
 
     // MARK: - Synchronous, lock-guarded state transitions
 
-    /// Marks a fetch as in flight and returns whether the caller should proceed. Skips if a fetch is
-    /// already running or the current token still has more than `window` seconds of life.
+    /// Marks a fetch as in flight and returns whether the caller should proceed. Skips only if a fetch is
+    /// already running, or a fresh token is already cached *for this same UA*; a UA change forces a refetch
+    /// so the cached token tracks the current desktop/mobile state.
     private func beginFetching(userAgent: String) -> Bool {
         lock.lock(); defer { lock.unlock() }
         if isFetching { return false }

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -35,7 +35,7 @@ protocol TabDelegate: AnyObject {
 
     /// The current cached search token, or nil if none is live. Used by the SERP interceptor
     /// to attach `X-DDG-Search-Token` for the treatment cohort of the Search Token experiment.
-    func searchToken(for tab: TabViewController) -> String?
+    func searchToken(for tab: TabViewController, userAgent: String) -> String?
 
     func tabDidRequestNewTab(_ tab: TabViewController)
 
@@ -195,6 +195,6 @@ extension TabDelegate {
 
     func tab(_ tab: TabViewController, didFailDuckAINavigationFor url: URL, error: Error) {}
 
-    func searchToken(for tab: TabViewController) -> String? { nil }
+    func searchToken(for tab: TabViewController, userAgent: String) -> String? { nil }
 
 }

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -35,7 +35,7 @@ protocol TabDelegate: AnyObject {
 
     /// The current cached search token, or nil if none is live. Used by the SERP interceptor
     /// to attach `X-DDG-Search-Token` for the treatment cohort of the Search Token experiment.
-    func searchToken(for tab: TabViewController, userAgent: String) -> String?
+    func searchToken(for tab: TabViewController) -> String?
 
     func tabDidRequestNewTab(_ tab: TabViewController)
 
@@ -195,6 +195,6 @@ extension TabDelegate {
 
     func tab(_ tab: TabViewController, didFailDuckAINavigationFor url: URL, error: Error) {}
 
-    func searchToken(for tab: TabViewController, userAgent: String) -> String? { nil }
+    func searchToken(for tab: TabViewController) -> String? { nil }
 
 }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2889,7 +2889,7 @@ extension TabViewController: WKNavigationDelegate {
            navigationAction.navigationType != .backForward,
            let url = navigationAction.request.url,
            SerpSearchTokenInterceptor.isSerpURL(url),
-           let cohort = featureFlagger.assignedCohort(for: FeatureFlag.searchTokenExperiment) as? FeatureFlag.SearchTokenExperimentCohort {
+           let cohort = featureFlagger.assignedCohort(for: FeatureFlag.searchTokenExperimentV2) as? FeatureFlag.SearchTokenExperimentCohort {
             let token = cohort == .treatment ? delegate?.searchToken(for: self) : nil
             if let signalled = SerpSearchTokenInterceptor.signalledRequest(for: modifiedRequest,
                                                                            cohort: cohort,

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2890,6 +2890,9 @@ extension TabViewController: WKNavigationDelegate {
            let url = navigationAction.request.url,
            SerpSearchTokenInterceptor.isSerpURL(url),
            let cohort = featureFlagger.assignedCohort(for: FeatureFlag.searchTokenExperimentV2) as? FeatureFlag.SearchTokenExperimentCohort {
+            // Pin the UA this SERP navigation will send so it can't inherit a stale `customUserAgent`
+            // from a prior (non-DDG) navigation. Matches the UA the token was warmed against.
+            webView.customUserAgent = userAgentManager.userAgent(isDesktop: tabModel.isDesktop, url: url)
             let token = cohort == .treatment ? delegate?.searchToken(for: self) : nil
             if let signalled = SerpSearchTokenInterceptor.signalledRequest(for: modifiedRequest,
                                                                            cohort: cohort,

--- a/iOS/DuckDuckGoTests/SearchToken/SearchTokenFetcherTests.swift
+++ b/iOS/DuckDuckGoTests/SearchToken/SearchTokenFetcherTests.swift
@@ -26,7 +26,7 @@ final class SearchTokenFetcherTests: XCTestCase {
 
     func testRetrieveReturnsNilWhenEmpty() {
         let sut = SearchTokenFetcher(requester: MockSearchTokenRequester())
-        XCTAssertNil(sut.retrieveToken(matching: "UA"))
+        XCTAssertNil(sut.retrieveToken())
     }
 
     func testRetrieveReturnsTokenWhileAlive() async {
@@ -36,7 +36,7 @@ final class SearchTokenFetcherTests: XCTestCase {
         let sut = SearchTokenFetcher(requester: requester, ttlProvider: { 300 }, now: clock.now)
         await sut.fetchIfNeeded(userAgent: "UA") // caches "abc" at t0
         clock.advance(299) // still within TTL
-        XCTAssertEqual(sut.retrieveToken(matching: "UA"), "abc")
+        XCTAssertEqual(sut.retrieveToken(), "abc")
     }
 
     func testRetrieveReturnsNilAfterExpiry() async {
@@ -46,7 +46,7 @@ final class SearchTokenFetcherTests: XCTestCase {
         let sut = SearchTokenFetcher(requester: requester, ttlProvider: { 300 }, now: clock.now)
         await sut.fetchIfNeeded(userAgent: "UA") // caches "abc" at t0
         clock.advance(300) // exactly TTL -> expired
-        XCTAssertNil(sut.retrieveToken(matching: "UA"))
+        XCTAssertNil(sut.retrieveToken())
     }
 
     // MARK: fetch success
@@ -59,32 +59,33 @@ final class SearchTokenFetcherTests: XCTestCase {
 
         await sut.fetchIfNeeded(userAgent: "UA/1.0")
 
-        XCTAssertEqual(sut.retrieveToken(matching: "UA/1.0"), "tok-123")
+        XCTAssertEqual(sut.retrieveToken(), "tok-123")
         XCTAssertEqual(requester.lastUserAgent, "UA/1.0")
     }
 
-    // MARK: UA scoping
+    // MARK: no UA guard
 
-    func testRetrieveReturnsNilWhenUserAgentDiffers() async {
+    func testRetrieveReturnsTokenRegardlessOfMintUserAgent() async {
         let clock = Clock(Date(timeIntervalSince1970: 1000))
         let requester = MockSearchTokenRequester()
         requester.tokenToReturn = "abc"
         let sut = SearchTokenFetcher(requester: requester, ttlProvider: { 300 }, now: clock.now)
-        await sut.fetchIfNeeded(userAgent: "mobile-UA") // token bound to the mobile UA
-        XCTAssertNil(sut.retrieveToken(matching: "desktop-UA")) // mismatched UA -> not returned
-        XCTAssertEqual(sut.retrieveToken(matching: "mobile-UA"), "abc")
+        await sut.fetchIfNeeded(userAgent: "mint-UA")
+        XCTAssertEqual(sut.retrieveToken(), "abc")
     }
 
-    func testDifferentUserAgentIsNotSkippedByFreshness() async {
+    // MARK: UA-aware refetch
+
+    func testDifferentUserAgentForcesRefetchDespiteFreshness() async {
         let clock = Clock(Date(timeIntervalSince1970: 1000))
         let requester = MockSearchTokenRequester()
         requester.tokenToReturn = "mobile-tok"
         let sut = SearchTokenFetcher(requester: requester, ttlProvider: { 300 }, windowProvider: { 120 }, now: clock.now)
         await sut.fetchIfNeeded(userAgent: "mobile-UA") // fresh token for mobile UA (callCount 1)
         requester.tokenToReturn = "desktop-tok"
-        await sut.fetchIfNeeded(userAgent: "desktop-UA") // different UA must fetch despite freshness
+        await sut.fetchIfNeeded(userAgent: "desktop-UA") // different UA must refetch despite freshness
         XCTAssertEqual(requester.callCount, 2)
-        XCTAssertEqual(sut.retrieveToken(matching: "desktop-UA"), "desktop-tok")
+        XCTAssertEqual(sut.retrieveToken(), "desktop-tok")
     }
 
     // MARK: refresh-ahead skip window
@@ -98,7 +99,7 @@ final class SearchTokenFetcherTests: XCTestCase {
         clock.advance(100) // remaining 200 > window 120 -> skip
         await sut.fetchIfNeeded(userAgent: "UA")
         XCTAssertEqual(requester.callCount, 1) // second call skipped
-        XCTAssertEqual(sut.retrieveToken(matching: "UA"), "fresh")
+        XCTAssertEqual(sut.retrieveToken(), "fresh")
     }
 
     func testFetchesWhenWithinWindow() async {
@@ -111,7 +112,7 @@ final class SearchTokenFetcherTests: XCTestCase {
         requester.tokenToReturn = "new"
         await sut.fetchIfNeeded(userAgent: "UA")
         XCTAssertEqual(requester.callCount, 2)
-        XCTAssertEqual(sut.retrieveToken(matching: "UA"), "new")
+        XCTAssertEqual(sut.retrieveToken(), "new")
     }
 
     // MARK: coalescing + failure
@@ -144,11 +145,11 @@ final class SearchTokenFetcherTests: XCTestCase {
         clock.advance(200) // within window -> attempts a fetch
         requester.error = URLError(.notConnectedToInternet)
         await sut.fetchIfNeeded(userAgent: "UA")
-        XCTAssertEqual(sut.retrieveToken(matching: "UA"), "old") // failed fetch keeps the previous token
+        XCTAssertEqual(sut.retrieveToken(), "old") // failed fetch keeps the previous token
 
         // The failed fetch must NOT reset fetchedAt: advancing past the ORIGINAL t0 expiry must expire it.
         clock.advance(101) // total 301 since t0 > ttl 300
-        XCTAssertNil(sut.retrieveToken(matching: "UA"))
+        XCTAssertNil(sut.retrieveToken())
     }
 }
 

--- a/iOS/DuckDuckGoTests/SearchToken/SearchTokenFetcherTests.swift
+++ b/iOS/DuckDuckGoTests/SearchToken/SearchTokenFetcherTests.swift
@@ -26,7 +26,7 @@ final class SearchTokenFetcherTests: XCTestCase {
 
     func testRetrieveReturnsNilWhenEmpty() {
         let sut = SearchTokenFetcher(requester: MockSearchTokenRequester())
-        XCTAssertNil(sut.retrieveToken())
+        XCTAssertNil(sut.retrieveToken(matching: "UA"))
     }
 
     func testRetrieveReturnsTokenWhileAlive() async {
@@ -36,7 +36,7 @@ final class SearchTokenFetcherTests: XCTestCase {
         let sut = SearchTokenFetcher(requester: requester, ttlProvider: { 300 }, now: clock.now)
         await sut.fetchIfNeeded(userAgent: "UA") // caches "abc" at t0
         clock.advance(299) // still within TTL
-        XCTAssertEqual(sut.retrieveToken(), "abc")
+        XCTAssertEqual(sut.retrieveToken(matching: "UA"), "abc")
     }
 
     func testRetrieveReturnsNilAfterExpiry() async {
@@ -46,7 +46,7 @@ final class SearchTokenFetcherTests: XCTestCase {
         let sut = SearchTokenFetcher(requester: requester, ttlProvider: { 300 }, now: clock.now)
         await sut.fetchIfNeeded(userAgent: "UA") // caches "abc" at t0
         clock.advance(300) // exactly TTL -> expired
-        XCTAssertNil(sut.retrieveToken())
+        XCTAssertNil(sut.retrieveToken(matching: "UA"))
     }
 
     // MARK: fetch success
@@ -59,8 +59,32 @@ final class SearchTokenFetcherTests: XCTestCase {
 
         await sut.fetchIfNeeded(userAgent: "UA/1.0")
 
-        XCTAssertEqual(sut.retrieveToken(), "tok-123")
+        XCTAssertEqual(sut.retrieveToken(matching: "UA/1.0"), "tok-123")
         XCTAssertEqual(requester.lastUserAgent, "UA/1.0")
+    }
+
+    // MARK: UA scoping
+
+    func testRetrieveReturnsNilWhenUserAgentDiffers() async {
+        let clock = Clock(Date(timeIntervalSince1970: 1000))
+        let requester = MockSearchTokenRequester()
+        requester.tokenToReturn = "abc"
+        let sut = SearchTokenFetcher(requester: requester, ttlProvider: { 300 }, now: clock.now)
+        await sut.fetchIfNeeded(userAgent: "mobile-UA") // token bound to the mobile UA
+        XCTAssertNil(sut.retrieveToken(matching: "desktop-UA")) // mismatched UA -> not returned
+        XCTAssertEqual(sut.retrieveToken(matching: "mobile-UA"), "abc")
+    }
+
+    func testDifferentUserAgentIsNotSkippedByFreshness() async {
+        let clock = Clock(Date(timeIntervalSince1970: 1000))
+        let requester = MockSearchTokenRequester()
+        requester.tokenToReturn = "mobile-tok"
+        let sut = SearchTokenFetcher(requester: requester, ttlProvider: { 300 }, windowProvider: { 120 }, now: clock.now)
+        await sut.fetchIfNeeded(userAgent: "mobile-UA") // fresh token for mobile UA (callCount 1)
+        requester.tokenToReturn = "desktop-tok"
+        await sut.fetchIfNeeded(userAgent: "desktop-UA") // different UA must fetch despite freshness
+        XCTAssertEqual(requester.callCount, 2)
+        XCTAssertEqual(sut.retrieveToken(matching: "desktop-UA"), "desktop-tok")
     }
 
     // MARK: refresh-ahead skip window
@@ -74,7 +98,7 @@ final class SearchTokenFetcherTests: XCTestCase {
         clock.advance(100) // remaining 200 > window 120 -> skip
         await sut.fetchIfNeeded(userAgent: "UA")
         XCTAssertEqual(requester.callCount, 1) // second call skipped
-        XCTAssertEqual(sut.retrieveToken(), "fresh")
+        XCTAssertEqual(sut.retrieveToken(matching: "UA"), "fresh")
     }
 
     func testFetchesWhenWithinWindow() async {
@@ -87,7 +111,7 @@ final class SearchTokenFetcherTests: XCTestCase {
         requester.tokenToReturn = "new"
         await sut.fetchIfNeeded(userAgent: "UA")
         XCTAssertEqual(requester.callCount, 2)
-        XCTAssertEqual(sut.retrieveToken(), "new")
+        XCTAssertEqual(sut.retrieveToken(matching: "UA"), "new")
     }
 
     // MARK: coalescing + failure
@@ -120,11 +144,11 @@ final class SearchTokenFetcherTests: XCTestCase {
         clock.advance(200) // within window -> attempts a fetch
         requester.error = URLError(.notConnectedToInternet)
         await sut.fetchIfNeeded(userAgent: "UA")
-        XCTAssertEqual(sut.retrieveToken(), "old") // failed fetch keeps the previous token
+        XCTAssertEqual(sut.retrieveToken(matching: "UA"), "old") // failed fetch keeps the previous token
 
         // The failed fetch must NOT reset fetchedAt: advancing past the ORIGINAL t0 expiry must expire it.
         clock.advance(101) // total 301 since t0 > ttl 300
-        XCTAssertNil(sut.retrieveToken())
+        XCTAssertNil(sut.retrieveToken(matching: "UA"))
     }
 }
 

--- a/iOS/WebViewUnitTests/UserAgentTests.swift
+++ b/iOS/WebViewUnitTests/UserAgentTests.swift
@@ -149,6 +149,19 @@ final class UserAgentTests: XCTestCase {
         XCTAssertEqual(ExpectedAgent.desktopFallback, testee.agent(forUrl: Constants.url, isDesktop: true, privacyConfig: privacyConfig))
     }
     
+    // The token is warmed against `.ddg` while the SERP interceptor pins `agent(forUrl: <serp url>)`.
+    // Both are the same host, and every URL-keyed branch (omit/default/fixed sites) is host-based, so
+    // the two must resolve to an identical UA — otherwise the warmed token's UA would not match the SERP's.
+    func testSameHostUrlsResolveToIdenticalUserAgent() {
+        let testee = UserAgent(defaultAgent: DefaultAgent.mobile, privacyConfig: privacyConfig)
+        let ddgHome = URL(string: "https://duckduckgo.com")!
+        let ddgSerp = URL(string: "https://duckduckgo.com/?q=test&ia=web")!
+        for isDesktop in [true, false] {
+            XCTAssertEqual(testee.agent(forUrl: ddgHome, isDesktop: isDesktop, privacyConfig: privacyConfig),
+                           testee.agent(forUrl: ddgSerp, isDesktop: isDesktop, privacyConfig: privacyConfig))
+        }
+    }
+
     func testWhenDomainDoesNotSupportApplicationComponentThenApplicationIsOmittedFromUa() {
         let testee = UserAgent(defaultAgent: DefaultAgent.mobile, privacyConfig: privacyConfig)
         XCTAssertEqual(ExpectedAgent.mobileNoApplication, testee.agent(forUrl: Constants.noAppUrl, isDesktop: false, privacyConfig: privacyConfig))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217093200725389

### Description

The Search Token (Dindex) experiment attaches a short-lived, UA-bound token to variant-b SERP requests so the backend can serve a faster combined Index/Deep response. Backend analysis surfaced two issues degrading the experiment — **invalid tokens** (token minted under one User-Agent but presented on a SERP request sending a different UA) and **missing tokens** (variant-b SERP requests arriving with `dindexexp=b` but no token). This PR addresses both and resets the experiment.

**Invalid tokens (UA mismatch)**
- **Empty iPad tabs:** the warm fell back to a mobile UA (`?? false`) when there was no current tab, but a fresh iPad tab navigates the SERP in desktop mode — so the token was minted mobile and the SERP went out desktop. Warm now falls back to `AppWidthObserver.shared.isLargeWidth`, the same default `Tab.init` uses, so the warmed UA matches the tab the SERP will use.
- **UA-aware fetching:** the fetcher now tracks the UA a token was minted for and refetches when the warm UA changes (desktop/mobile switch), keeping the cached token aligned to the current mode.
- **Always attach the token:** retrieval no longer withholds the token when the current UA differs from the mint UA. The live token is always attached, so the backend keeps visibility on any residual mismatch (invalid-token) cases instead of the client silently dropping them. Only *fetching* is UA-aware; retrieval is unconditional.

**Missing tokens (cold cache on non-omnibar SERP paths)**
- The token was only ever warmed on address-bar focus, so every non-omnibar path to a SERP (external links, widgets, share extension, bookmarks/NTP favorites, session restore) plus the cold-start race hit the interceptor with a cold cache and attached nothing. Warming now also runs **on app foreground** (covers cold launch and every resume, preceding those entry points) and **reactively on a cache miss** at attach time (warm-on-miss, so the next request finds a token).

**Reset experiment**
- Renamed the subfeature/flag `searchTokenExperiment` → `searchTokenExperimentV2` so the corrected client starts fresh cohort assignment and analysis rather than mixing with previously contaminated data.

### Testing Steps

Prereq: a proxy (Proxyman/Charles) with SSL enabled for `duckduckgo.com` and the token host (`links.duckduckgo.com`). Force the treatment cohort via **Settings → Debug → Search Token → Experiment cohort override → treatment** (the flag is now `searchTokenExperimentV2`).

1. **iPhone, omnibar search:** fresh new tab → tap the address bar → type a query → search. Confirm the token request and the SERP request carry the **same** `User-Agent`, and the SERP request includes the `X-DDG-Search-Token` header and `dindexexp=b`.
2. **iPad (full screen), empty tab:** fresh new tab → search. Confirm both the token request and the SERP request go out with the **desktop (Macintosh)** UA and match, and the token is attached.
3. **Desktop mode:** on any page toggle **Desktop Site** on, then search. Confirm token and SERP UAs are both desktop and match.
4. **Foreground warming:** force-quit the app, relaunch, and reach a SERP via a **non-omnibar** path (external `duckduckgo.com` link, widget, share extension, or a bookmark/NTP favorite). Confirm the **token request goes out** on foreground.
5. **Control cohort:** switch the override to control and search. Confirm the SERP request has `dindexexp=a` and **no** `X-DDG-Search-Token` header.

### Impact and Risks

**Low.** All behavior is cohort-gated to the Search Token experiment's treatment arm; control and non-enrolled users are unaffected. The only always-on change is the `searchTokenExperimentV2` rename, which resets cohort assignment (intended). Extra warming is bounded by the fetcher's coalescing (skips in-flight/fresh tokens), so `/search-token` traffic stays low. A missing or mismatched token is a safe no-op on the client — the SERP still loads, just without the speed-up — and mismatches are now intentionally surfaced to the backend rather than hidden.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are gated to the search-token experiment treatment cohort; the v2 rename intentionally resets assignment. Extra token fetches are coalesced by the fetcher, and SERP loads safely without a token.
> 
> **Overview**
> Fixes **invalid** (UA-mismatched) and **missing** search tokens on treatment SERP navigations for the Dindex experiment, and resets the experiment as **`searchTokenExperimentV2`** so cohorts and metrics start clean.
> 
> **UA alignment:** `SearchTokenFetcher` records the UA used to mint the token and refetches when the warm UA changes (e.g. desktop/mobile), while **`retrieveToken()`** still returns any live cached token so mismatches stay visible to the backend. Token warming uses **`AppWidthObserver.shared.isLargeWidth`** when there is no current tab (iPad empty-tab desktop SERP). On SERP attach, **`TabViewController`** sets **`webView.customUserAgent`** to match the warmed token path.
> 
> **Missing tokens:** Warming runs on **app foreground** in addition to omnibar focus, and **`searchToken(for:)`** triggers **`warmSearchTokenIfEligible()`** on a cache miss so the next navigation can attach a token. Experiment pixels and enrollment now target **`searchTokenExperimentV2`** / **`iOSBrowserConfigSubfeature.searchTokenExperimentV2`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7216feb82f293d378a9fc82a62657a85500217d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->