### PR TITLE
[iOS/macOS] Clean up logging

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Networking/v1/APIRequestError.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Networking/v1/APIRequestError.swift
@@ -31,7 +31,8 @@ extension APIRequest {
         public var errorDescription: String? {
             switch self {
             case .urlSession(let error):
-                return "URL session error: \(String(describing: error))"
+                let nsError = error as NSError
+                return "URL session error: \(nsError.domain) \(nsError.code)"
             case .invalidResponse:
                 return "Invalid response received."
             case .missingEtagInResponse:

--- a/SharedPackages/BrowserServicesKit/Sources/Networking/v2/APIRequestV2Error.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Networking/v2/APIRequestV2Error.swift
@@ -33,7 +33,8 @@ public enum APIRequestV2Error: DDGError {
     public var description: String {
         switch self {
         case .urlSession(let error):
-            return "URL session error: \(String(describing: error))"
+            let nsError = error as NSError
+            return "URL session error: \(nsError.domain) \(nsError.code)"
         case .invalidResponse:
             return "Invalid response received."
         case .unsatisfiedRequirement(let requirement):

--- a/SharedPackages/VPN/Sources/VPN/Diagnostics/NetworkProtectionError.swift
+++ b/SharedPackages/VPN/Sources/VPN/Diagnostics/NetworkProtectionError.swift
@@ -162,9 +162,26 @@ public enum NetworkProtectionError: LocalizedError, CustomNSError {
     }
 
     public var errorDescription: String? {
-        // This is probably not the most elegant error to show to a user but
-        // it's a great way to get detailed reports for those cases we haven't
-        // provided good descriptions for yet.
-        return "NetworkProtectionError.\(String(describing: self))"
+        switch self {
+        case .failedToCastKeychainValueToData(let field):
+            return "NetworkProtectionError.failedToCastKeychainValueToData(\(field))"
+        case .keychainReadError(let field, let status):
+            return "NetworkProtectionError.keychainReadError(\(field), \(status))"
+        case .keychainWriteError(let field, let status):
+            return "NetworkProtectionError.keychainWriteError(\(field), \(status))"
+        case .keychainUpdateError(let field, let status):
+            return "NetworkProtectionError.keychainUpdateError(\(field), \(status))"
+        case .keychainDeleteError(let status):
+            return "NetworkProtectionError.keychainDeleteError(\(status))"
+        case .wireGuardInvalidState(let reason):
+            return "NetworkProtectionError.wireGuardInvalidState(\(reason))"
+        case .unhandledError(let function, let line, _):
+            return "NetworkProtectionError.unhandledError(\(function), \(line))"
+        default:
+            break
+        }
+
+        let caseName = Mirror(reflecting: self).children.first?.label ?? String(describing: self)
+        return "NetworkProtectionError.\(caseName)"
     }
 }

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -167,12 +167,12 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
 
         public var errorDescription: String? {
             switch self {
-            case .startingTunnelWithoutAuthToken(let internalError):
-                return "Missing auth token at startup: \(internalError.debugDescription)"
+            case .startingTunnelWithoutAuthToken:
+                return "Missing auth token at startup"
             case .vpnAccessRevoked, .vpnAccessRevokedDetectedByMonitorCheck:
                 return "VPN disconnected due to expired subscription"
-            case .couldNotGenerateTunnelConfiguration(let internalError):
-                return "Failed to generate a tunnel configuration: \(internalError.localizedDescription)"
+            case .couldNotGenerateTunnelConfiguration:
+                return "Failed to generate a tunnel configuration"
             case .simulateTunnelFailureError:
                 return "Simulated a tunnel error as requested"
             case .settingsMissing:

--- a/SharedPackages/VPN/Sources/VPN/StartupOptions.swift
+++ b/SharedPackages/VPN/Sources/VPN/StartupOptions.swift
@@ -167,6 +167,17 @@ public struct StartupOptions {
             }
         }
 
+        var stateDescription: String {
+            switch self {
+            case .set:
+                return "set"
+            case .reset:
+                return "reset"
+            case .useExisting:
+                return "useExisting"
+            }
+        }
+
         // MARK: - Equatable
 
         public static func == (lhs: StartupOptions.StoredOption<T>, rhs: StartupOptions.StoredOption<T>) -> Bool {
@@ -231,7 +242,7 @@ public struct StartupOptions {
         """
 #if os(macOS)
         result += """
-            tokenContainer: \(self.tokenContainer),
+            tokenContainer: \(self.tokenContainer.stateDescription),
         """
 #endif
         return result


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1217100073464425?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

This PR cleans up logging and error descriptions.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Check that the logging changes look good

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics-only string changes; tunnel and API behavior unchanged, with underlying errors still attached via NSError user info where applicable.
> 
> **Overview**
> Tightens **error and startup logging** so strings are shorter and less likely to echo nested error payloads or sensitive token data.
> 
> Networking API errors (`APIRequest` v1/v2) now report URL session failures as **NSError domain and code** instead of `String(describing:)` on the wrapped error.
> 
> VPN diagnostics improve **`NetworkProtectionError`** descriptions with explicit formatting for keychain, WireGuard, and unhandled cases; other cases use enum case names via `Mirror` instead of a single `String(describing: self)`.
> 
> **`TunnelError`** user-visible descriptions for missing auth token and tunnel config generation no longer append underlying `debugDescription` / `localizedDescription`; underlying errors remain in **`errorUserInfo`**.
> 
> **`StartupOptions`** tunnel-start logs use **`stateDescription`** for `tokenContainer` (set/reset/useExisting) instead of the full stored-option description that could log token container contents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4899243b85ac9d0ecbd3ab96694a9da04b99d1d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->