### PR TITLE
Fix macOS UI test failures from aiChatChromeMenuButton default-on

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -361,6 +361,7 @@
 		31224EF12F9F9922008E0118 /* BurnerDuckAiStorageRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31224EF02F9F9922008E0118 /* BurnerDuckAiStorageRegistry.swift */; };
 		31224EF22F9F9922008E0118 /* BurnerDuckAiStorageRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31224EF02F9F9922008E0118 /* BurnerDuckAiStorageRegistry.swift */; };
 		312613A82DB16F01009F9420 /* AIChatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312613A72DB16EFE009F9420 /* AIChatTests.swift */; };
+		31AC0DE100000000000A0002 /* AIChatMenuButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AC0DE100000000000A0001 /* AIChatMenuButtonTests.swift */; };
 		31267C692B640C4200FEF811 /* DataBrokerProtectionFeatureGatekeeper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C5FFB82AF64D120008A79F /* DataBrokerProtectionFeatureGatekeeper.swift */; };
 		31267C6A2B640C4B00FEF811 /* DataBrokerProtectionFeatureDisabler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3199C6F82AF94F5B002A7BA1 /* DataBrokerProtectionFeatureDisabler.swift */; };
 		31267C6B2B640C5200FEF811 /* DataBrokerProtectionAppEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3199C6FC2AF97367002A7BA1 /* DataBrokerProtectionAppEvents.swift */; };
@@ -5137,6 +5138,7 @@
 		311B262628E73E0A00FD181A /* TabShadowConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabShadowConfig.swift; sourceTree = "<group>"; };
 		31224EF02F9F9922008E0118 /* BurnerDuckAiStorageRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BurnerDuckAiStorageRegistry.swift; sourceTree = "<group>"; };
 		312613A72DB16EFE009F9420 /* AIChatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTests.swift; sourceTree = "<group>"; };
+		31AC0DE100000000000A0001 /* AIChatMenuButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatMenuButtonTests.swift; sourceTree = "<group>"; };
 		312E63962D9D821500806E2A /* AIChatURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatURL.swift; sourceTree = "<group>"; };
 		3135647A2D9EB8E800BF4B5D /* AIChatAddressBarPromptExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatAddressBarPromptExtractor.swift; sourceTree = "<group>"; };
 		3135647D2D9EBB9900BF4B5D /* AIChatAddressBarPromptExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatAddressBarPromptExtractorTests.swift; sourceTree = "<group>"; };
@@ -9899,6 +9901,7 @@
 				844905422E54A3600054F4FD /* AddressBarSpoofingUITests.swift */,
 				844905402E54A3540054F4FD /* AddressBarUITests.swift */,
 				312613A72DB16EFE009F9420 /* AIChatTests.swift */,
+				31AC0DE100000000000A0001 /* AIChatMenuButtonTests.swift */,
 				31DE49202EE2299500F3940A /* AIChatMultilinePasteTests.swift */,
 				31DE49222EE2299500F3940A /* AIChatOmnibarTests.swift */,
 				F72808BE3E5BF485C31627B8 /* AIChatSettingsTests.swift */,
@@ -17513,6 +17516,7 @@
 				BBBB65402C77BB9400E69AC6 /* BookmarkSearchTests.swift in Sources */,
 				65EE7C622E3297A5009FD83B /* DuckPlayerTests.swift in Sources */,
 				312613A82DB16F01009F9420 /* AIChatTests.swift in Sources */,
+				31AC0DE100000000000A0002 /* AIChatMenuButtonTests.swift in Sources */,
 				56A054532C2592CE007D8FAB /* OnboardingUITests.swift in Sources */,
 				8449053F2E549B6D0054F4FD /* StringExtensions.swift in Sources */,
 				EE9D81C32BC57A3700338BE3 /* StateRestorationTests.swift in Sources */,

--- a/macOS/UITests/AIChatMenuButtonTests.swift
+++ b/macOS/UITests/AIChatMenuButtonTests.swift
@@ -120,8 +120,8 @@ class AIChatMenuButtonTests: UITestCase {
     func test_menu_onNewTabPage_showsOpenSidebar_andOpensSidebar() {
         // We start on NTP after enforceSingleWindow.
         openDropdown()
-        XCTAssertEqual(sidebarMenuItem.label, MenuTitles.openSidebar,
-                       "On the new-tab page the sidebar item should read 'Open Sidebar'")
+        XCTAssertTrue(app.menuItems[MenuTitles.openSidebar].exists,
+                      "On the new-tab page the sidebar item should read 'Open Sidebar'")
         sidebarMenuItem.click()
 
         XCTAssertTrue(detachButton.waitForExistence(timeout: UITests.Timeouts.elementExistence),
@@ -134,8 +134,8 @@ class AIChatMenuButtonTests: UITestCase {
         addressBarTextField.typeURL(UITests.simpleServedPage(titled: "Ask About Page Test"))
 
         openDropdown()
-        XCTAssertEqual(sidebarMenuItem.label, MenuTitles.askAboutPage,
-                       "On a web page the sidebar item should read 'Ask About Page'")
+        XCTAssertTrue(app.menuItems[MenuTitles.askAboutPage].exists,
+                      "On a web page the sidebar item should read 'Ask About Page'")
         sidebarMenuItem.click()
 
         XCTAssertTrue(detachButton.waitForExistence(timeout: UITests.Timeouts.elementExistence),
@@ -150,7 +150,7 @@ class AIChatMenuButtonTests: UITestCase {
         let tabsBefore = app.tabGroups.matching(identifier: "Tabs").radioButtons.count
 
         openDropdown()
-        XCTAssertEqual(newChatMenuItem.label, MenuTitles.newChat)
+        XCTAssertTrue(app.menuItems[MenuTitles.newChat].exists, "Dropdown should contain a New Chat item")
         newChatMenuItem.click()
 
         let tabsAfter = app.tabGroups.matching(identifier: "Tabs").radioButtons.count
@@ -164,15 +164,15 @@ class AIChatMenuButtonTests: UITestCase {
     func test_menu_whenChatOpen_showsCloseSidebar_andCloses() {
         // Open the sidebar first (NTP → "Open Sidebar").
         openDropdown()
-        XCTAssertEqual(sidebarMenuItem.label, MenuTitles.openSidebar)
+        XCTAssertTrue(app.menuItems[MenuTitles.openSidebar].exists)
         sidebarMenuItem.click()
         XCTAssertTrue(detachButton.waitForExistence(timeout: UITests.Timeouts.elementExistence),
                       "Sidebar should be open before testing close")
 
         // Re-open the dropdown: the item should now offer to close the sidebar.
         openDropdown()
-        XCTAssertEqual(sidebarMenuItem.label, MenuTitles.closeSidebar,
-                       "With a chat open the sidebar item should read 'Close Sidebar'")
+        XCTAssertTrue(app.menuItems[MenuTitles.closeSidebar].exists,
+                      "With a chat open the sidebar item should read 'Close Sidebar'")
         sidebarMenuItem.click()
 
         XCTAssertTrue(detachButton.waitForNonExistence(timeout: UITests.Timeouts.elementExistence),
@@ -188,8 +188,8 @@ class AIChatMenuButtonTests: UITestCase {
         let hideItem = app.menuItems[MenuItemIdentifiers.hideDuckAI].firstMatch
         XCTAssertTrue(hideItem.waitForExistence(timeout: UITests.Timeouts.elementExistence),
                       "Context menu should offer to hide the Ask Duck.ai button")
-        XCTAssertEqual(hideItem.label, MenuTitles.hideAskDuckAI,
-                       "The hide item should use the 'Ask Duck.ai' wording in menu-button layout")
+        XCTAssertTrue(app.menuItems[MenuTitles.hideAskDuckAI].exists,
+                      "The hide item should use the 'Ask Duck.ai' wording in menu-button layout")
         hideItem.click()
 
         XCTAssertTrue(pillButton.waitForNonExistence(timeout: UITests.Timeouts.elementExistence),

--- a/macOS/UITests/AIChatMenuButtonTests.swift
+++ b/macOS/UITests/AIChatMenuButtonTests.swift
@@ -1,0 +1,207 @@
+//
+//  AIChatMenuButtonTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+/// Coverage for the single "Ask Duck.ai" pill layout (aiChatChromeMenuButton ON, the shipping default).
+/// The split-button layout is covered by `AIChatTests` with the flag forced off.
+class AIChatMenuButtonTests: UITestCase {
+    private var addressBarTextField: XCUIElement!
+
+    private enum Identifiers {
+        /// The pill reuses the split-button title-button identifier; clicking it opens the dropdown.
+        static let pillButton = "TabBarViewController.duckAIChromeTitleButton"
+        /// The split sidebar sub-button, force-hidden in menu-button layout.
+        static let sidebarButton = "TabBarViewController.duckAIChromeSidebarButton"
+        static let showDuckAIButtonInTabBarToggle = "Preferences.AIChat.showDuckAIButtonInTabBarToggle"
+        static let detachButton = "AIChatViewController.detachButton"
+    }
+
+    /// Dropdown / context-menu item identifiers (AppKit derives these from the @objc action selector names).
+    private enum MenuItemIdentifiers {
+        static let newChat = "duckAIMenuNewChatAction"
+        static let sidebar = "duckAIMenuSidebarAction"
+        static let hideDuckAI = "hideDuckAITitleButtonAction"
+    }
+
+    /// Menu-item titles (from UserText); the sidebar item's title is state-dependent.
+    private enum MenuTitles {
+        static let newChat = "New Chat"
+        static let askAboutPage = "Ask About Page"
+        static let openSidebar = "Open Sidebar"
+        static let closeSidebar = "Close Sidebar"
+        static let hideAskDuckAI = "Hide Ask Duck.ai Button"
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        continueAfterFailure = false
+        app = XCUIApplication.setUp(featureFlags: [
+            "aiChatChromeSidebar": true,
+            "aiChatSidebarFloating": true,
+            "aiChatChromeMenuButton": true // the layout under test
+        ])
+
+        addressBarTextField = app.addressBar
+        app.enforceSingleWindow()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        app.terminate()
+    }
+
+    // MARK: - Helpers
+
+    private var pillButton: XCUIElement {
+        app.buttons[Identifiers.pillButton].firstMatch
+    }
+
+    private var newChatMenuItem: XCUIElement {
+        app.menuItems[MenuItemIdentifiers.newChat].firstMatch
+    }
+
+    private var sidebarMenuItem: XCUIElement {
+        app.menuItems[MenuItemIdentifiers.sidebar].firstMatch
+    }
+
+    private var detachButton: XCUIElement {
+        app.buttons[Identifiers.detachButton]
+    }
+
+    /// Clicks the pill to present its dropdown and waits for the items to appear.
+    private func openDropdown() {
+        XCTAssertTrue(pillButton.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Ask Duck.ai pill should exist in menu-button layout")
+        pillButton.click()
+        XCTAssertTrue(newChatMenuItem.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Clicking the pill should present the dropdown")
+    }
+
+    private func dismissMenu() {
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
+    // MARK: - Layout
+
+    func test_menuButtonLayout_showsPill_andHidesSidebarSubButton() {
+        XCTAssertTrue(pillButton.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Ask Duck.ai pill should exist")
+        // The split sidebar sub-button is force-hidden in this layout.
+        XCTAssertFalse(app.buttons[Identifiers.sidebarButton].isHittable,
+                       "The split sidebar sub-button should not be shown in menu-button layout")
+    }
+
+    // MARK: - Dropdown
+
+    func test_pillClick_opensDropdown_withNewChatAndSidebarItems() {
+        openDropdown()
+        XCTAssertTrue(newChatMenuItem.exists, "Dropdown should contain a New Chat item")
+        XCTAssertTrue(sidebarMenuItem.exists, "Dropdown should contain the sidebar item")
+        dismissMenu()
+    }
+
+    /// On the new-tab page there's nothing to attach, so the sidebar item reads "Open Sidebar".
+    func test_menu_onNewTabPage_showsOpenSidebar_andOpensSidebar() {
+        // We start on NTP after enforceSingleWindow.
+        openDropdown()
+        XCTAssertEqual(sidebarMenuItem.label, MenuTitles.openSidebar,
+                       "On the new-tab page the sidebar item should read 'Open Sidebar'")
+        sidebarMenuItem.click()
+
+        XCTAssertTrue(detachButton.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Clicking 'Open Sidebar' should open the docked sidebar")
+    }
+
+    /// On a real web page the sidebar item reads "Ask About Page" and opens the sidebar.
+    /// (The page-content attachment itself is covered by unit tests.)
+    func test_menu_onWebsite_showsAskAboutPage_andOpensSidebar() {
+        addressBarTextField.typeURL(UITests.simpleServedPage(titled: "Ask About Page Test"))
+
+        openDropdown()
+        XCTAssertEqual(sidebarMenuItem.label, MenuTitles.askAboutPage,
+                       "On a web page the sidebar item should read 'Ask About Page'")
+        sidebarMenuItem.click()
+
+        XCTAssertTrue(detachButton.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Clicking 'Ask About Page' should open the docked sidebar")
+    }
+
+    // MARK: - New Chat
+
+    func test_menu_newChat_opensNewTab() {
+        addressBarTextField.typeURL(UITests.simpleServedPage(titled: "New Chat Test"))
+
+        let tabsBefore = app.tabGroups.matching(identifier: "Tabs").radioButtons.count
+
+        openDropdown()
+        XCTAssertEqual(newChatMenuItem.label, MenuTitles.newChat)
+        newChatMenuItem.click()
+
+        let tabsAfter = app.tabGroups.matching(identifier: "Tabs").radioButtons.count
+        XCTAssertEqual(tabsAfter, tabsBefore + 1,
+                       "Clicking 'New Chat' should open a new Duck.ai tab")
+    }
+
+    // MARK: - Close Sidebar
+
+    /// With a chat already presented the sidebar item becomes "Close Sidebar" and closes it.
+    func test_menu_whenChatOpen_showsCloseSidebar_andCloses() {
+        // Open the sidebar first (NTP → "Open Sidebar").
+        openDropdown()
+        XCTAssertEqual(sidebarMenuItem.label, MenuTitles.openSidebar)
+        sidebarMenuItem.click()
+        XCTAssertTrue(detachButton.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Sidebar should be open before testing close")
+
+        // Re-open the dropdown: the item should now offer to close the sidebar.
+        openDropdown()
+        XCTAssertEqual(sidebarMenuItem.label, MenuTitles.closeSidebar,
+                       "With a chat open the sidebar item should read 'Close Sidebar'")
+        sidebarMenuItem.click()
+
+        XCTAssertTrue(detachButton.waitForNonExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Clicking 'Close Sidebar' should close the sidebar")
+    }
+
+    // MARK: - Context Menu
+
+    func test_contextMenu_hideAskDuckAIButton() {
+        XCTAssertTrue(pillButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+
+        pillButton.rightClick()
+        let hideItem = app.menuItems[MenuItemIdentifiers.hideDuckAI].firstMatch
+        XCTAssertTrue(hideItem.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Context menu should offer to hide the Ask Duck.ai button")
+        XCTAssertEqual(hideItem.label, MenuTitles.hideAskDuckAI,
+                       "The hide item should use the 'Ask Duck.ai' wording in menu-button layout")
+        hideItem.click()
+
+        XCTAssertTrue(pillButton.waitForNonExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Pill should be hidden after using the context menu")
+
+        // Re-enable via settings and confirm it returns.
+        addressBarTextField.typeURL(URL(string: "duck://settings/aichat")!)
+        let toggle = app.checkBoxes[Identifiers.showDuckAIButtonInTabBarToggle]
+        XCTAssertTrue(toggle.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+        XCTAssertFalse(toggle.isOn, "Settings toggle should reflect the hidden state")
+        toggle.click()
+        XCTAssertTrue(pillButton.waitForExistence(timeout: UITests.Timeouts.elementExistence),
+                      "Pill should reappear after re-enabling in settings")
+    }
+}

--- a/macOS/UITests/AIChatSettingsTests.swift
+++ b/macOS/UITests/AIChatSettingsTests.swift
@@ -34,7 +34,7 @@ class AIChatSettingsTests: UITestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         continueAfterFailure = false
-        app = XCUIApplication.setUp(featureFlags: ["aiChatChromeSidebar": true, "aiChatSidebarFloating": true])
+        app = XCUIApplication.setUp(featureFlags: ["aiChatChromeSidebar": true, "aiChatSidebarFloating": true, "aiChatChromeMenuButton": false])
 
         addressBarTextField = app.addressBar
         app.enforceSingleWindow()

--- a/macOS/UITests/AIChatTests.swift
+++ b/macOS/UITests/AIChatTests.swift
@@ -50,7 +50,7 @@ class AIChatTests: UITestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         continueAfterFailure = false
-        app = XCUIApplication.setUp(featureFlags: ["aiChatChromeSidebar": true, "aiChatSidebarFloating": true])
+        app = XCUIApplication.setUp(featureFlags: ["aiChatChromeSidebar": true, "aiChatSidebarFloating": true, "aiChatChromeMenuButton": false])
 
         addressBarTextField = app.addressBar
         app.enforceSingleWindow()

--- a/macOS/UITests/TabSuspensionTests.swift
+++ b/macOS/UITests/TabSuspensionTests.swift
@@ -29,7 +29,8 @@ class TabSuspensionTests: UITestCase {
             "tabSuspension": true,
             "tabSuspensionDebugging": true,
             "aiChatChromeSidebar": true,  // sidebar and floating sidebar feature flags
-            "aiChatSidebarFloating": true // are required for testing AI Chat sidebar suspension
+            "aiChatSidebarFloating": true, // are required for testing AI Chat sidebar suspension
+            "aiChatChromeMenuButton": false // keep the split sidebar button; this test clicks it directly
         ])
         app.openNewWindow()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1215556915315562?focus=true
Tech Design URL: N/A
CC:

### Description

The scheduled `macOS - UI Tests` run on `main` started failing right after #6027 merged. This PR fixes the existing UI tests and adds coverage for new functionality

### Testing Steps

1. On `main` the scheduled UI test run has `AIChatTests`, `AIChatSettingsTests`, `TabSuspensionTests` failing → with this branch they pass.
2. CI runs the new `AIChatMenuButtonTests` suite (flag on) → passes.

### Impact

None — test-only change (plus the pbxproj entry wiring the new test file into the UI Tests target).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No production code changes; only UI test launch flags, a new test suite, and Xcode project entries.
> 
> **Overview**
> **Test-only** fix for scheduled macOS UI failures after `aiChatChromeMenuButton` became the default: the tab bar shows a single **Ask Duck.ai** pill instead of the split Duck.ai + sidebar controls that older suites assumed.
> 
> Existing **`AIChatTests`**, **`AIChatSettingsTests`**, and **`TabSuspensionTests`** now launch with **`aiChatChromeMenuButton: false`** so they still exercise the split-button fallback (same pattern as other launch feature-flag overrides).
> 
> Adds **`AIChatMenuButtonTests`** with the flag on: pill vs hidden sidebar sub-button, dropdown actions (New Chat, Open Sidebar / Ask About Page / Close Sidebar), and hide/show via the pill context menu and AI Chat settings toggle. The new file is wired into the UI Tests target in the Xcode project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6032b149a8bc56408b7af44512213a3820bc838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->