### PR TITLE
macOS: simplify Duck.ai menu bar setting copy

### DIFF
--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -675,8 +675,7 @@ struct UserText {
 
     // Prompt Bar (Settings → AI Features)
     static let promptBarKeyboardShortcutToggle = NotLocalizedString("duckai.prompt-bar.keyboard-shortcut.toggle", value: "Open Duck.ai floating window with a keyboard shortcut", comment: "Checkbox in Settings → AI Features that enables the system-wide Duck.ai keyboard shortcut")
-    static let promptBarMenuBarIconToggle = NotLocalizedString("duckai.prompt-bar.menu-bar-icon.toggle", value: "Show Duck.ai in menu bar", comment: "Checkbox in Settings → AI Features that shows the Duck.ai icon in the macOS menu bar")
-    static let promptBarMenuBarIconCaption = NotLocalizedString("duckai.prompt-bar.menu-bar-icon.caption", value: "Adds a menu bar shortcut to open Duck.ai in a floating window", comment: "Caption under the 'Show Duck.ai in menu bar' checkbox describing what the menu bar icon does")
+    static let promptBarMenuBarIconToggle = NotLocalizedString("duckai.prompt-bar.menu-bar-icon.toggle", value: "Show Duck.ai shortcut in menu bar", comment: "Checkbox in Settings → AI Features that shows the Duck.ai icon in the macOS menu bar")
     static let promptBarShortcutRecordingPlaceholder = NotLocalizedString("duckai.prompt-bar.shortcut.recording-placeholder", value: "Type shortcut", comment: "Placeholder shown in the shortcut recorder control while it waits for a key combination")
     static let promptBarShortcutRecordingCancelHint = NotLocalizedString("duckai.prompt-bar.shortcut.recording-cancel-hint", value: "Press **Esc** to cancel", comment: "Hint under the shortcut recorder while recording. 'Esc' is the Escape key; the surrounding asterisks render it bold and must be kept")
     static let promptBarShortcutResetToDefault = NotLocalizedString("duckai.prompt-bar.shortcut.reset-to-default", value: "Reset to default", comment: "Button that reverts the Duck.ai keyboard shortcut to the default combination")

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarPreferencesView.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarPreferencesView.swift
@@ -25,10 +25,8 @@ struct PromptBarPreferencesView: View {
     @ObservedObject var preferences: PromptBarPreferences
 
     var body: some View {
-        ToggleMenuItemWithDescription(UserText.promptBarMenuBarIconToggle,
-                                      UserText.promptBarMenuBarIconCaption,
-                                      isOn: $preferences.isMenuBarIconVisible,
-                                      spacing: 4)
+        ToggleMenuItem(UserText.promptBarMenuBarIconToggle,
+                       isOn: $preferences.isMenuBarIconVisible)
         .accessibilityIdentifier("Preferences.AIChat.promptBarMenuBarIconToggle")
         .onChange(of: preferences.isMenuBarIconVisible) { isVisible in
             fire(isVisible ? .settingsMenuBarIconTurnedOn : .settingsMenuBarIconTurnedOff)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217050814296249?focus=true
Tech Design URL:
CC:

### Description
Renames the AI Features setting to "Show Duck.ai shortcut in menu bar" and removes its subtitle. The row now uses `ToggleMenuItem` instead of `ToggleMenuItemWithDescription`, and the unused caption string was deleted.

### Testing Steps
1. Enable the `macosPromptBar` feature flag and open Settings → AI Features.
2. Confirm the menu bar row reads "Show Duck.ai shortcut in menu bar" with no descriptive text under it.
3. Toggle it off and on and confirm the menu bar icon still appears/disappears accordingly.

### Impact and Risks
Low

#### What could go wrong?
The row's vertical spacing could look slightly off next to the neighbouring keyboard-shortcut controls now that the subtitle is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and layout-only changes in Settings; toggle behavior and analytics hooks are unchanged.
> 
> **Overview**
> Updates the **Show Duck.ai in menu bar** AI Features setting to read **Show Duck.ai shortcut in menu bar** and drops the explanatory subtitle under that row.
> 
> The preferences UI now uses `ToggleMenuItem` instead of `ToggleMenuItemWithDescription`, and the unused `promptBarMenuBarIconCaption` localization entry is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d9d92570f8ef44ecd4b64122502b4bfd3ac582c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->