### PR TITLE
[macOS] Allow channel param on 2 pixels failing live validation

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
@@ -41,7 +41,7 @@
         "owners": ["miasma13"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_aichat_translation_source_link_clicked": {
         "description": "Fired when user clicks the website link on a translation prompt in Duck.ai tab or sidebar",

--- a/macOS/PixelDefinitions/pixels/definitions/autoconsent.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/autoconsent.json5
@@ -271,6 +271,6 @@
         "owners": ["miasma13"],
         "triggers": ["other"],
         "suffixes": [],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203936086921904/task/1217107963996243?focus=true
Tech Design URL: N/A
CC:

### Description
Two macOS pixels failed live validation with "must NOT have additional properties. Found extra property 'channel'". Both were missing `channel` from their declared parameters, even though PixelKit attaches it to every pixel on non-production builds. Added it to bring the definitions in line with the other ~280 macOS pixels that already declare it.

Pixels fixed:
- `m_mac_aichat_translate_text`
- `m_mac_autoconsent_popover-autodismissed_daily`

### Testing Steps
-

### Impact
None — pixel definition metadata only, no app code changes.

### Quality Considerations
`channel` was already defined in `pixels/params_dictionary.json5`, so no new parameter was introduced and no privacy surface changed. Prettier formatting check passes.

Note: I could not run `npm run validate-pixel-defs` locally — the installed `@duckduckgo/pixel-schema` is 1.0.8 while `macOS/package.json` pins `v2.1.3`, and 1.0.8 expects the pre-`pixels/` flat layout so it errors before validating. Pre-existing and unrelated to this diff; CI runs the pinned version.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pixel definition metadata only; no app code or new parameters beyond declaring an already-attached field.
> 
> **Overview**
> Fixes live pixel validation failures for **`m_mac_aichat_translate_text`** and **`m_mac_autoconsent_popover-autodismissed_daily`** by adding the existing **`channel`** parameter to each definition’s `parameters` list.
> 
> On non-production macOS builds, PixelKit already sends **`channel`** (`canary` / `dev` per `params_dictionary.json5`); these two entries were the only ones in their files still omitting it, which triggered “extra property 'channel'” errors. No runtime or emission behavior changes—metadata only, aligned with the rest of the macOS pixel catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c8b1595c23d9929a551acd45324c02b17bba3df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->