### PR TITLE
Improve debug display of import errors

### DIFF
--- a/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
+++ b/macOS/DuckDuckGo/DataImport/Model/DataImportViewModel.swift
@@ -424,6 +424,7 @@ struct DataImportViewModel {
     /// handle recoverable errors (request primary password or file permission)
     @MainActor
     private mutating func handleErrors(_ summary: [DataType: any DataImportError]) -> Bool {
+        guard !summary.isEmpty else { return false }
         errors.append(summary)
         for error in summary.values {
             switch error {

--- a/macOS/DuckDuckGo/DataImport/View/DataImportView.swift
+++ b/macOS/DuckDuckGo/DataImport/View/DataImportView.swift
@@ -58,11 +58,21 @@ struct DataImportView: ModalView {
     @State private var debugViewDisabled: Bool = true
 #endif
 
+    @State private var areErrorsExpanded = false
+
+    private var errorMessages: [String] {
+        model.errors.flatMap { errorsByDataType in
+            DataImport.DataType.allCases.compactMap { dataType in
+                errorsByDataType[dataType].map { "\(dataType.rawValue.uppercased()): \($0)" }
+            }
+        }
+    }
+
     private var shouldShowDebugView: Bool {
 #if DEBUG
-        return !debugViewDisabled
+        return !debugViewDisabled || !errorMessages.isEmpty
 #else
-        return (!model.errors.isEmpty && isInternalUser)
+        return !errorMessages.isEmpty && isInternalUser
 #endif
     }
 
@@ -289,25 +299,13 @@ struct DataImportView: ModalView {
                         .padding(.trailing, 20)
                 }
 
-                if model.errors.count > 0 && isInternalUser {
+                if !errorMessages.isEmpty {
                     Divider()
                 }
 #endif
 
-                if model.errors.count > 0 && isInternalUser {
-                    Text(verbatim: "ERRORS:" as String).bold()
-                        .padding(.top, 10)
-                        .padding(.leading, 20)
-
-                    ForEach(model.errors.indices, id: \.self) { i in
-                        ForEach(Array(model.errors[i].keys), id: \.self) { key in
-                            if let value = model.errors[i][key] {
-                                Text(verbatim: "\(key.rawValue.uppercased()): \(value)").textSelection(.enabled)
-                            }
-                        }
-                    }
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, 10)
+                if !errorMessages.isEmpty {
+                    errorsView(errorMessages)
                 }
             }
             Spacer()
@@ -323,6 +321,37 @@ struct DataImportView: ModalView {
         }
         .padding(10)
         .background(Color(NSColor(red: 1, green: 0, blue: 0, alpha: 0.2)))
+    }
+
+    private func errorsView(_ messages: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Button {
+                areErrorsExpanded.toggle()
+            } label: {
+                HStack(spacing: 4) {
+                    Text(verbatim: messages.count == 1 ? "1 error" : "\(messages.count) errors").bold()
+                    Image(systemName: "chevron.right")
+                        .rotationEffect(.degrees(areErrorsExpanded ? 90 : 0))
+                }
+            }
+            .buttonStyle(.link)
+
+            if areErrorsExpanded {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(messages.indices, id: \.self) { idx in
+                            Text(verbatim: messages[idx])
+                                .textSelection(.enabled)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                }
+                .frame(height: 100)
+            }
+        }
+        .padding(.vertical, 10)
+        .padding(.leading, 20)
     }
 
 #if DEBUG


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211264967278501/task/1213925547238740?focus=true
Tech Design URL:
CC:

### Description

This PR makes a few tweaks to make it easier to view debugging errors on Mac when importing bookmarks / passwords. Previously there was a small, fixed, unscrollable area displayed at the bottom of the import summary screen. Now the view expands to fit the debug area, and the errors themselves are displayed by a disclosure control and are scrollable:

| Header | Header |
|--------|--------|
| <img alt="Screenshot 2026-08-03 at 13 33 01" src="https://github.com/user-attachments/assets/2eeb23c2-9f83-44cb-938c-a90a03640639" /> | <img alt="Screenshot 2026-08-03 at 13 34 34" src="https://github.com/user-attachments/assets/844a3ddd-25a8-4338-9592-0b451279c837" /> | 

### Testing Steps

1. Build and run the Mac app - you must be running a debug build or be an internal user
2. Head to File > Import Bookmarks and Passwords...
3. Choose a file that will cause an error – I created a nonsense CSV file.
4. You should see an error display at the bottom of the view
5. Check you can expand the errors to see their contents
6. Ideally, verify you can't see the error display in a release build when you're not an internal user.

### Impact

None: Internal tooling, documentation

Shouldn't be user facing!
---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect internal/debug import error UI and a small guard in error handling; not user-facing in release for non-internal users.
> 
> **Overview**
> Improves **internal/debug** visibility of Mac data import failures on the import summary screen.
> 
> **View model:** `handleErrors` now returns immediately when the error summary is empty, so empty maps are not appended to `errors`.
> 
> **UI:** Import errors are collected into `errorMessages` and shown behind a **disclosure** (“1 error” / “N errors”) with a **scrollable** (100pt) list and selectable text, instead of a fixed, cramped block. The red debug strip appears when there are errors (DEBUG builds can show errors even when the debug panel is collapsed; release still requires an internal user).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48fc6f52a334e51b8013e063e7bc52775bb47099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->