### PR TITLE
Fix TabSnapshotStore crash when the snapshot directory can't be created

### DIFF
--- a/macOS/DuckDuckGo/TabPreview/Services/TabSnapshotStore.swift
+++ b/macOS/DuckDuckGo/TabPreview/Services/TabSnapshotStore.swift
@@ -84,7 +84,7 @@ final class TabSnapshotStore: TabSnapshotStoring {
                                                         withIntermediateDirectories: true,
                                                         attributes: nil)
             } catch {
-                fatalError("Failed to create directory at \(directoryURL.path)")
+                Logger.tabSnapshots.error("TabSnapshotPersistenceService: Failed to create directory at \(directoryURL.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1217104162098893
Tech Design URL:
CC:

### Description

Fixes the Sentry crashes APPLE-MACOS-D00 / APPLE-MACOS-CZW.

When the browser failed to create the directory it keeps tab snapshots in, it deliberately crashed the app. Given that the rest of the app handles missing the cache gracefully, this PR replaces the crash with logging.

### Testing Steps

N/A

### Impact

Low. Removes a crash on a cache path; the degraded outcome is a tab preview without a thumbnail.

#### What could go wrong?

N/A

### Quality Considerations

N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to error handling on a non-critical cache path; no auth, data, or core navigation impact.
> 
> **Overview**
> **Tab snapshot persistence** no longer terminates the app when `FileManager` cannot create the tab-snapshots cache directory. The failure path in `createDirectoryIfNeeded()` now logs via `Logger.tabSnapshots` (path and localized error) instead of calling `fatalError`, matching how load/persist failures are already handled.
> 
> If creation fails, snapshot writes may still fail silently downstream; tab previews can show without a cached thumbnail rather than crashing (addresses Sentry **APPLE-MACOS-D00** / **APPLE-MACOS-CZW**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fe4ba7fdad712b10f6d28039a6305a1eaae69dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->