### PR TITLE
iOS: Additional Duck.ai impression and click pixels

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1696,6 +1696,10 @@ extension Pixel {
         case aiChatContextualAutoAttachDAU
         case aiChatIsEnabledDaily
 
+        // MARK: Duck.ai subscription funnel (frontend-reported entry points)
+        case aiChatSubscriptionFunnelImpression
+        case aiChatSubscriptionFunnelClick
+
         case duckAiNativeStorageMigrationDoneUnique(key: String)
         case duckAiNativeStorageMigrationDoneCount(key: String)
         case duckAiNativeStorageMigrationDoneBlankCount
@@ -3630,6 +3634,11 @@ extension Pixel.Event {
         case .aiChatExperimentalAddressBarIsEnabledDaily: return "m_aichat_experimental_address_bar_is_enabled_daily"
         case .aiChatContextualAutoAttachDAU: return "m_aichat_contextual_auto_attach_dau"
         case .aiChatIsEnabledDaily: return "m_aichat_is_enabled_daily"
+
+        // The hyphen inside these snake_case names is deliberate: it matches the macOS names so a single
+        // query answers both platforms.
+        case .aiChatSubscriptionFunnelImpression: return "m_aichat_subscription-funnel_impression"
+        case .aiChatSubscriptionFunnelClick: return "m_aichat_subscription-funnel_click"
 
         // AI Features telemetry: no `m_` prefix so the wire names are identical to macOS.
         case .aiFeaturesStateDaily: return "ai_features_state_daily"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1887,6 +1887,7 @@ extension Pixel {
         case unifiedToggleInputStopGenerationTapped
         case unifiedToggleInputSubscriptionUpsellTriggered
         case unifiedToggleInputChatHeaderUpgradeTapped
+        case unifiedToggleInputChatHeaderUpgradeShown
         case unifiedToggleInputPromptSubmitted
         case unifiedToggleInputShowModelPicker
         case unifiedToggleInputSubmitChangeModel
@@ -3821,6 +3822,7 @@ extension Pixel.Event {
         case .unifiedToggleInputStopGenerationTapped: return "m_aichat_unified_input_stop_generation_tapped"
         case .unifiedToggleInputSubscriptionUpsellTriggered: return "m_aichat_unified_input_subscription_upsell_triggered"
         case .unifiedToggleInputChatHeaderUpgradeTapped: return "m_aichat_unified_input_chat_header_upgrade_tapped"
+        case .unifiedToggleInputChatHeaderUpgradeShown: return "m_aichat_unified_input_chat_header_upgrade_shown"
         case .unifiedToggleInputPromptSubmitted: return "m_aichat_unified_input_prompt_submitted"
         case .unifiedToggleInputShowModelPicker: return "aichat_unified_input_show_model_picker"
         case .unifiedToggleInputSubmitChangeModel: return "aichat_unified_input_submit_change_model"

--- a/iOS/DuckDuckGo/AIChat/AIChatPixelMetricHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatPixelMetricHandler.swift
@@ -20,6 +20,7 @@
 import Foundation
 import AIChat
 import Core
+import Subscription
 
 // MARK: - Protocol
 
@@ -38,13 +39,51 @@ final class AIChatPixelMetricHandler: AIChatPixelMetricHandling {
     private let pixelFiring: PixelFiring.Type
     private let timestampParameterKey = "delta-timestamp-minutes"
 
-    private let metricToEventMap: [AIChatMetricName: Pixel.Event] = [
+    static let metricToEventMap: [AIChatMetricName: Pixel.Event] = [
         .userDidSubmitPrompt: .aiChatMetricSentPromptOngoingChat,
         .userDidSubmitFirstPrompt: .aiChatMetricStartNewConversation,
         .userDidOpenHistory: .aiChatMetricOpenHistory,
         .userDidSelectFirstHistoryItem: .aiChatMetricOpenMostRecentHistoryChat,
         .userDidCreateNewChat: .aiChatMetricStartNewConversationButtonClicked,
         .userDidTapKeyboardReturnKey: .aiChatMetricDuckAIKeyboardReturnPressed
+    ]
+
+    /// Subscription-funnel metrics: metric name → the pixel to fire and the `origin` value identifying the
+    /// entry point. Each of the ten frontend-reported entry points contributes a view metric (impression)
+    /// and a click metric (click).
+    ///
+    /// `userDidViewFreePlanBadge` and `userDidClickFreePlanUpgradeButton` are **deliberately absent**. That
+    /// entry point is native on iOS.
+    static let funnelMetricToPixelMap: [AIChatMetricName: (event: Pixel.Event, origin: SubscriptionFunnelOrigin)] = [
+        .userDidViewAiSidebarUpgradeButton: (.aiChatSubscriptionFunnelImpression, .duckAIAiSidebar),
+        .userDidClickAiSidebarUpgradeButton: (.aiChatSubscriptionFunnelClick, .duckAIAiSidebar),
+
+        .userDidViewActivateSubscriptionBanner: (.aiChatSubscriptionFunnelImpression, .duckAIActivateSubscription),
+        .userDidClickActivateSubscriptionButton: (.aiChatSubscriptionFunnelClick, .duckAIActivateSubscription),
+
+        .userDidViewFreeLimitMessage: (.aiChatSubscriptionFunnelImpression, .duckAIFreeLimit),
+        .userDidClickFreeLimitSubscribeLink: (.aiChatSubscriptionFunnelClick, .duckAIFreeLimit),
+
+        .userDidViewImageGenerationLimitMessage: (.aiChatSubscriptionFunnelImpression, .duckAIImageGenerationLimit),
+        .userDidClickImageGenerationLimitSubscribeButton: (.aiChatSubscriptionFunnelClick, .duckAIImageGenerationLimit),
+
+        .userDidViewPlusLimitMessage: (.aiChatSubscriptionFunnelImpression, .duckAIPlusLimit),
+        .userDidClickPlusLimitUpgradeLink: (.aiChatSubscriptionFunnelClick, .duckAIPlusLimit),
+
+        .userDidViewPromotionCard: (.aiChatSubscriptionFunnelImpression, .duckAIPromotionCard),
+        .userDidClickPromotionCardButton: (.aiChatSubscriptionFunnelClick, .duckAIPromotionCard),
+
+        .userDidViewSettingsSubscribeButton: (.aiChatSubscriptionFunnelImpression, .duckAISettings),
+        .userDidClickSettingsSubscribeButton: (.aiChatSubscriptionFunnelClick, .duckAISettings),
+
+        .userDidViewProUpgradeDisclaimerBanner: (.aiChatSubscriptionFunnelImpression, .duckAIDisclaimerBanner),
+        .userDidClickProUpgradeDisclaimerBannerButton: (.aiChatSubscriptionFunnelClick, .duckAIDisclaimerBanner),
+
+        .userDidViewVoiceChatLimitModal: (.aiChatSubscriptionFunnelImpression, .duckAIVoiceChatLimit),
+        .userDidClickVoiceChatLimitModalSubscribeButton: (.aiChatSubscriptionFunnelClick, .duckAIVoiceChatLimit),
+
+        .userDidViewVoiceChatDurationLimitModal: (.aiChatSubscriptionFunnelImpression, .duckAIVoiceChatDurationLimit),
+        .userDidClickVoiceChatDurationLimitModalSubscribeButton: (.aiChatSubscriptionFunnelClick, .duckAIVoiceChatDurationLimit)
     ]
 
     // MARK: - Initialization
@@ -62,16 +101,21 @@ final class AIChatPixelMetricHandler: AIChatPixelMetricHandling {
     }
 
     func firePixelWithMetric(_ metric: AIChatMetric) {
-        guard let event = metricToEventMap[metric.metricName] else {
+        if let event = Self.metricToEventMap[metric.metricName] {
+            var parameters: [String: String] = [:]
+            if metric.shouldIncludeTimestampParameters {
+                parameters = timestampParameters ?? [:]
+            }
+
+            pixelFiring.fire(event, withAdditionalParameters: parameters)
             return
         }
 
-        var parameters: [String: String] = [:]
-        if metric.shouldIncludeTimestampParameters {
-            parameters = timestampParameters ?? [:]
+        if let funnelPixel = Self.funnelMetricToPixelMap[metric.metricName] {
+            pixelFiring.fire(funnelPixel.event,
+                             withAdditionalParameters: [AttributionParameter.origin: funnelPixel.origin.rawValue])
+            return
         }
-        
-        pixelFiring.fire(event, withAdditionalParameters: parameters)
     }
 
     // MARK: - Private Helpers

--- a/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatTabChatHeaderView.swift
@@ -32,6 +32,7 @@ protocol AIChatTabChatHeaderViewDelegate: AnyObject {
     func aiChatTabChatHeaderDidTapNewSearch()
     func aiChatTabChatHeaderDidTapNewFireTab()
     func aiChatTabChatHeaderDidTapTabSwitcher()
+    func aiChatTabChatHeaderUpgradePlateDidBecomeVisible()
 }
 
 final class AIChatTabChatHeaderView: UIView {
@@ -67,13 +68,39 @@ final class AIChatTabChatHeaderView: UIView {
         var isVoiceSessionActive: Bool = false
         /// Hides the free/upgrade title during the Duck.ai fire onboarding step.
         var isOnboardingLocked: Bool = false
+        /// Visibility of the enclosing Duck.ai tab-header container.
+        var isContainerVisible: Bool = false
     }
 
     private var state = ViewState() {
         didSet {
             guard state != oldValue else { return }
             applyState()
+            notifyDelegateIfUpgradePlateBecameVisible()
         }
+    }
+
+    private var wasUpgradePlateVisible = false
+
+    /// `nil` subscription state means unresolved, not free — hence the explicit `== false`.
+    private var isTitleContainerVisible: Bool {
+        !state.isOnboardingLocked && state.isSubscriptionActive == false
+    }
+
+    private var isTitleHolderVisible: Bool {
+        !state.isVoiceSessionActive
+    }
+
+    private var isUpgradePlateVisible: Bool {
+        state.isContainerVisible && isTitleHolderVisible && isTitleContainerVisible
+    }
+
+    private func notifyDelegateIfUpgradePlateBecameVisible() {
+        let isVisible = isUpgradePlateVisible
+        guard isVisible != wasUpgradePlateVisible else { return }
+        wasUpgradePlateVisible = isVisible
+        guard isVisible else { return }
+        delegate?.aiChatTabChatHeaderUpgradePlateDidBecomeVisible()
     }
 
     private lazy var closeButton: UIButton = makeIconButton(
@@ -368,6 +395,10 @@ final class AIChatTabChatHeaderView: UIView {
         state.isSubscriptionActive = isSubscriptionActive
     }
 
+    func setContainerVisible(_ visible: Bool) {
+        state.isContainerVisible = visible
+    }
+
     /// Hide title, chat-list pill, and close button during voice — voice owns its own dismiss UI.
     func setVoiceSessionActive(_ active: Bool) {
         state.isVoiceSessionActive = active
@@ -393,10 +424,10 @@ final class AIChatTabChatHeaderView: UIView {
 
     private func applyState() {
         // During fire onboarding, hide the free/upgrade title to avoid distraction.
-        titleContainer.isHidden = state.isOnboardingLocked || state.isSubscriptionActive != false
+        titleContainer.isHidden = !isTitleContainerVisible
         paidTitleStack.isHidden = state.isSubscriptionActive != true
         let voiceActive = state.isVoiceSessionActive
-        titleHolder.isHidden = voiceActive
+        titleHolder.isHidden = !isTitleHolderVisible
         // Hide each pill (and its button inside it) together so the surrounding glass pill
         // background also disappears during voice sessions. Voice mode owns its own dismiss UI.
         chatListButtonPill.isHidden = voiceActive

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -47,6 +47,7 @@ class MainViewCoordinator {
     var suggestionTrayContainer: UIView!
     var tabBarContainer: UIView!
     var aiChatTabChatHeaderContainer: UIView!
+    weak var aiChatTabChatHeaderView: AIChatTabChatHeaderView?
     var unifiedToggleInputContainer: UIView!
     var aiTabCollapsedTopSeparator: UIView!
     private var aiTabCollapsedTopSeparatorLogicallyVisible = false
@@ -570,12 +571,14 @@ class MainViewCoordinator {
 
     func showAIChatTabChatHeader() {
         aiChatTabChatHeaderContainer.isHidden = false
+        aiChatTabChatHeaderView?.setContainerVisible(true)
         guard isNavigationChromeHidden else { return }
         setContentContainerTopAnchorMode(.aiChatHeader)
     }
 
     func hideAIChatTabChatHeader() {
         aiChatTabChatHeaderContainer.isHidden = true
+        aiChatTabChatHeaderView?.setContainerVisible(false)
         guard isNavigationChromeHidden else { return }
         setContentContainerTopAnchorMode(.safeArea)
     }

--- a/iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
+++ b/iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
@@ -57,6 +57,10 @@ enum SubscriptionFunnelOrigin: String {
     /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213994750860310
     case duckAIReasoningPicker = "funnel_duckai_ios__reasoningpicker"
 
+    /// User entered the funnel via the native "Free Plan / Upgrade" plate in the Duck.ai tab header.
+    /// https://app.asana.com/1/137249556945/project/414235014887631/task/1216395339071576?focus=true
+    case duckAIFreeLabel = "funnel_duckai_ios__freelabel"
+
     // MARK: - Win-Back Offer Origins
     
     /// User entered via win-back offer launch prompt

--- a/iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
+++ b/iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
@@ -61,6 +61,49 @@ enum SubscriptionFunnelOrigin: String {
     /// https://app.asana.com/1/137249556945/project/414235014887631/task/1216395339071576?focus=true
     case duckAIFreeLabel = "funnel_duckai_ios__freelabel"
 
+    // MARK: - Duck.ai Funnel Origins (frontend-reported)
+
+    /// Frontend-reported: the upgrade button in the Duck.ai web sidebar.
+    /// https://app.asana.com/1/137249556945/task/1216395339071576
+    case duckAIAiSidebar = "funnel_duckai_ios__aisidebar"
+
+    /// Frontend-reported: the "activate subscription" banner shown when a paid model is loaded on the free
+    /// tier or with an invalid auth token.
+    /// https://app.asana.com/1/137249556945/task/1216395339071576
+    case duckAIActivateSubscription = "funnel_duckai_ios__activatesubscription"
+
+    /// Frontend-reported: the free-tier quota-limit message.
+    /// https://app.asana.com/1/137249556945/task/1216395339071576
+    case duckAIFreeLimit = "funnel_duckai_ios__freelimit"
+
+    /// Frontend-reported: the image-generation quota-limit message.
+    /// https://app.asana.com/1/137249556945/task/1216395339071576
+    case duckAIImageGenerationLimit = "funnel_duckai_ios__imagegenerationlimit"
+
+    /// Frontend-reported: the Plus-tier quota-limit message.
+    /// https://app.asana.com/1/137249556945/task/1216395339071576
+    case duckAIPlusLimit = "funnel_duckai_ios__pluslimit"
+
+    /// Frontend-reported: the subscription promotion card at the bottom of a new chat.
+    /// https://app.asana.com/1/137249556945/task/1216395339071576
+    case duckAIPromotionCard = "funnel_duckai_ios__promotioncard"
+
+    /// Frontend-reported: the "Subscribe to DuckDuckGo" button in Duck.ai settings.
+    /// https://app.asana.com/1/137249556945/task/1216395339071576
+    case duckAISettings = "funnel_duckai_ios__settings"
+
+    /// Frontend-reported: the Pro-upgrade disclaimer banner shown to Plus-tier users reaching a Pro model.
+    /// https://app.asana.com/1/137249556945/task/1216395339071576
+    case duckAIDisclaimerBanner = "funnel_duckai_ios__disclaimerbanner"
+
+    /// Frontend-reported: the voice-chat quota-limit modal.
+    /// https://app.asana.com/1/137249556945/task/1216395339071576
+    case duckAIVoiceChatLimit = "funnel_duckai_ios__voicechatlimit"
+
+    /// Frontend-reported: the voice-chat duration-limit modal.
+    /// https://app.asana.com/1/137249556945/task/1216395339071576
+    case duckAIVoiceChatDurationLimit = "funnel_duckai_ios__voicechatdurationlimit"
+
     // MARK: - Win-Back Offer Origins
     
     /// User entered via win-back offer launch prompt

--- a/iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
+++ b/iOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
@@ -46,16 +46,16 @@ enum SubscriptionFunnelOrigin: String {
     case addressBarModelPicker = "funnel_addressbar_ios__modelpicker"
 
     /// User entered the funnel by tapping a gated reasoning level in the Unified Toggle Input reasoning picker from the address bar.
-    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213994750860310
-    case addressBarReasoningPicker = "funnel_addressbar_ios__reasoningpicker"
+    /// https://app.asana.com/1/137249556945/project/414235014887631/task/1216243794936344?focus=true
+    case addressBarReasoningPicker = "funnel_addressbar_ios__reasoningdropdown"
 
     /// User entered the funnel by tapping a gated model in the Unified Toggle Input model picker from the Duck.ai tab.
     /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213994750860310
     case duckAIModelPicker = "funnel_duckai_ios__modelpicker"
 
     /// User entered the funnel by tapping a gated reasoning level in the Unified Toggle Input reasoning picker from the Duck.ai tab.
-    /// https://app.asana.com/1/137249556945/project/1207260194172075/task/1213994750860310
-    case duckAIReasoningPicker = "funnel_duckai_ios__reasoningpicker"
+    /// https://app.asana.com/1/137249556945/project/414235014887631/task/1216243794936344?focus=true
+    case duckAIReasoningPicker = "funnel_duckai_ios__reasoningdropdown"
 
     /// User entered the funnel via the native "Free Plan / Upgrade" plate in the Duck.ai tab header.
     /// https://app.asana.com/1/137249556945/project/414235014887631/task/1216395339071576?focus=true

--- a/iOS/DuckDuckGo/UnifiedToggleInput/DuckAISubscriptionUpsellPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/DuckAISubscriptionUpsellPresenter.swift
@@ -102,11 +102,24 @@ struct DuckAISubscriptionUpsellPresenter: DuckAISubscriptionUpselling {
         )
     }
 
+    func presentPurchaseFlow(origin: SubscriptionFunnelOrigin) {
+        notificationCenter.post(
+            name: .settingsDeepLinkNotification,
+            object: SettingsViewModel.SettingsDeepLinkSection.subscriptionFlow(
+                redirectURLComponents: makeRedirectURLComponents(origin: origin)
+            )
+        )
+    }
+
     private func makeRedirectURLComponents(source: SubscriptionFlowSource, isAITabState: Bool) -> URLComponents {
+        makeRedirectURLComponents(origin: origin(for: source, isAITabState: isAITabState))
+    }
+
+    private func makeRedirectURLComponents(origin: SubscriptionFunnelOrigin) -> URLComponents {
         var components = URLComponents()
         components.queryItems = [
             URLQueryItem(name: "featurePage", value: Self.subscriptionFeaturePage),
-            URLQueryItem(name: AttributionParameter.origin, value: origin(for: source, isAITabState: isAITabState).rawValue)
+            URLQueryItem(name: AttributionParameter.origin, value: origin.rawValue)
         ]
         return components
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1364,12 +1364,10 @@ extension MainViewController: AIChatTabChatHeaderViewDelegate {
 
     func aiChatTabChatHeaderDidTapUpgrade() {
         if let subscriptionState = unifiedToggleInputCoordinator?.subscriptionState, !subscriptionState.hasActiveSubscription {
-            Pixel.fire(pixel: .unifiedToggleInputChatHeaderUpgradeTapped)
+            Pixel.fire(pixel: .unifiedToggleInputChatHeaderUpgradeTapped,
+                       withAdditionalParameters: [AttributionParameter.origin: SubscriptionFunnelOrigin.duckAIFreeLabel.rawValue])
         }
-        NotificationCenter.default.post(
-            name: .settingsDeepLinkNotification,
-            object: SettingsViewModel.SettingsDeepLinkSection.subscriptionFlow()
-        )
+        DuckAISubscriptionUpsellPresenter().presentPurchaseFlow(origin: .duckAIFreeLabel)
     }
 
     /// Close the chat tab. Selection follows the tab-switcher rule; chat is recoverable via Duck.ai → Recent chats.

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -834,6 +834,7 @@ private extension MainViewController {
             isFireMode: tabManager.currentBrowsingMode == .fire
         )
         self.aiChatTabChatHeaderView = headerView
+        viewCoordinator.aiChatTabChatHeaderView = headerView
     }
 
     func refreshAIChatTabChatHeaderSubscriptionState() {
@@ -1354,6 +1355,11 @@ extension MainViewController: AIChatTabChatHeaderViewDelegate {
             unifiedToggleInputCoordinator?.showCollapsed()
             currentTab?.submitToggleSidebarAction()
         }
+    }
+
+    func aiChatTabChatHeaderUpgradePlateDidBecomeVisible() {
+        Pixel.fire(pixel: .unifiedToggleInputChatHeaderUpgradeShown,
+                   withAdditionalParameters: [AttributionParameter.origin: SubscriptionFunnelOrigin.duckAIFreeLabel.rawValue])
     }
 
     func aiChatTabChatHeaderDidTapUpgrade() {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatPixelMetricHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatPixelMetricHandlerTests.swift
@@ -167,12 +167,76 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
         // Given
         handler = AIChatPixelMetricHandler(timeElapsedInMinutes: nil, pixelFiring: PixelFiringMock.self)
 
-        // When
-        let validMetric = AIChatMetric(metricName: .userDidSubmitPrompt)
-        handler.firePixelWithMetric(validMetric)
+        // When - a metric name in neither the engagement nor the funnel table
+        handler.firePixelWithMetric(AIChatMetric(metricName: .userDidAcceptTermsAndConditions))
 
         // Then
-        XCTAssertEqual(PixelFiringMock.allPixelsFired.count, 1)
+        XCTAssertTrue(PixelFiringMock.allPixelsFired.isEmpty)
+    }
+
+    // MARK: - Subscription Funnel Map Tests
+
+    /// No metric may be mapped twice: a funnel metric added to the engagement table would fire the wrong
+    /// pixel, and a metric in both tables would be a latent double-count.
+    func testEngagementAndFunnelTablesHaveDisjointKeys() {
+        let engagementKeys = Set(AIChatPixelMetricHandler.metricToEventMap.keys)
+        let funnelKeys = Set(AIChatPixelMetricHandler.funnelMetricToPixelMap.keys)
+
+        XCTAssertTrue(engagementKeys.isDisjoint(with: funnelKeys),
+                      "Overlapping keys: \(engagementKeys.intersection(funnelKeys))")
+    }
+
+    func testFunnelMapDeliberatelyOmitsFreePlanBadgeMetrics() {
+        let funnelKeys = Set(AIChatPixelMetricHandler.funnelMetricToPixelMap.keys)
+
+        XCTAssertFalse(funnelKeys.contains(.userDidViewFreePlanBadge))
+        XCTAssertFalse(funnelKeys.contains(.userDidClickFreePlanUpgradeButton))
+    }
+
+    func testFirePixelWithMetricForFunnelMetricsFiresPairWithOrigin() {
+        // Given
+        let testCases: [(origin: String, view: AIChatMetricName, click: AIChatMetricName)] = [
+            ("funnel_duckai_ios__aisidebar", .userDidViewAiSidebarUpgradeButton, .userDidClickAiSidebarUpgradeButton),
+            ("funnel_duckai_ios__activatesubscription", .userDidViewActivateSubscriptionBanner, .userDidClickActivateSubscriptionButton),
+            ("funnel_duckai_ios__freelimit", .userDidViewFreeLimitMessage, .userDidClickFreeLimitSubscribeLink),
+            ("funnel_duckai_ios__imagegenerationlimit", .userDidViewImageGenerationLimitMessage, .userDidClickImageGenerationLimitSubscribeButton),
+            ("funnel_duckai_ios__pluslimit", .userDidViewPlusLimitMessage, .userDidClickPlusLimitUpgradeLink),
+            ("funnel_duckai_ios__promotioncard", .userDidViewPromotionCard, .userDidClickPromotionCardButton),
+            ("funnel_duckai_ios__settings", .userDidViewSettingsSubscribeButton, .userDidClickSettingsSubscribeButton),
+            ("funnel_duckai_ios__disclaimerbanner", .userDidViewProUpgradeDisclaimerBanner, .userDidClickProUpgradeDisclaimerBannerButton),
+            ("funnel_duckai_ios__voicechatlimit", .userDidViewVoiceChatLimitModal, .userDidClickVoiceChatLimitModalSubscribeButton),
+            ("funnel_duckai_ios__voicechatdurationlimit", .userDidViewVoiceChatDurationLimitModal, .userDidClickVoiceChatDurationLimitModalSubscribeButton)
+        ]
+        XCTAssertEqual(testCases.count * 2, AIChatPixelMetricHandler.funnelMetricToPixelMap.count,
+                       "The funnel table gained or lost entries this test does not cover")
+
+        // A non-nil elapsed time proves the funnel branch does not inherit the engagement branch's timestamp
+        handler = AIChatPixelMetricHandler(timeElapsedInMinutes: 7, pixelFiring: PixelFiringMock.self)
+
+        for testCase in testCases {
+            // When
+            PixelFiringMock.tearDown()
+            handler.firePixelWithMetric(AIChatMetric(metricName: testCase.view))
+
+            // Then
+            XCTAssertEqual(PixelFiringMock.allPixelsFired.count, 1, "\(testCase.origin) view")
+            XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.aiChatSubscriptionFunnelImpression.name)
+            XCTAssertEqual(PixelFiringMock.lastParams, ["origin": testCase.origin])
+
+            // When
+            PixelFiringMock.tearDown()
+            handler.firePixelWithMetric(AIChatMetric(metricName: testCase.click))
+
+            // Then
+            XCTAssertEqual(PixelFiringMock.allPixelsFired.count, 1, "\(testCase.origin) click")
+            XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.aiChatSubscriptionFunnelClick.name)
+            XCTAssertEqual(PixelFiringMock.lastParams, ["origin": testCase.origin])
+        }
+    }
+
+    func testSubscriptionFunnelPixelNames() {
+        XCTAssertEqual(Pixel.Event.aiChatSubscriptionFunnelImpression.name, "m_aichat_subscription-funnel_impression")
+        XCTAssertEqual(Pixel.Event.aiChatSubscriptionFunnelClick.name, "m_aichat_subscription-funnel_click")
     }
 
     // MARK: - Integration Tests

--- a/iOS/DuckDuckGoTests/AIChat/AIChatTabChatHeaderViewTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatTabChatHeaderViewTests.swift
@@ -94,4 +94,159 @@ final class AIChatTabChatHeaderViewTests: XCTestCase {
         XCTAssertEqual(header.closeButtonPill.alpha, 1, accuracy: 0.001)
         XCTAssertEqual(header.chatListButtonPill.alpha, 1, accuracy: 0.001)
     }
+
+    // MARK: - Upgrade plate impressions
+
+    /// Fresh header with an unresolved subscription state and a hidden container — the state the view is
+    /// in right after construction, before either the coordinator or the feature check has said anything.
+    private func makeHeaderWithSpyDelegate() -> (AIChatTabChatHeaderView, SpyAIChatTabChatHeaderViewDelegate) {
+        let header = AIChatTabChatHeaderView(frame: CGRect(x: 0, y: 0, width: 390, height: 60))
+        let delegate = SpyAIChatTabChatHeaderViewDelegate()
+        header.delegate = delegate
+        return (header, delegate)
+    }
+
+    func testUpgradePlate_becomesVisible_notifiesDelegateOnce() {
+        let (header, delegate) = makeHeaderWithSpyDelegate()
+
+        header.setContainerVisible(true)
+        header.configure(isSubscriptionActive: false)
+
+        XCTAssertEqual(delegate.upgradePlateDidBecomeVisibleCount, 1)
+    }
+
+    func testUpgradePlate_repeatedStateRefreshes_doNotNotifyAgain() {
+        let (header, delegate) = makeHeaderWithSpyDelegate()
+        header.setContainerVisible(true)
+        header.configure(isSubscriptionActive: false)
+
+        // Stands in for what a session actually does: prompt submissions and navigations re-run the
+        // subscription refresh and the tab-icon refresh without changing effective visibility.
+        header.configure(isSubscriptionActive: false)
+        header.setContainerVisible(true)
+        header.setTabIconState(count: 4, hasUnread: true, isFireMode: false)
+        header.configure(isSubscriptionActive: false)
+
+        XCTAssertEqual(delegate.upgradePlateDidBecomeVisibleCount, 1,
+                       "Repeated writes that leave effective visibility unchanged must not re-fire the impression")
+    }
+
+    func testUpgradePlate_stateChurnWhileContainerHidden_thenShown_notifiesOnce() {
+        let (header, delegate) = makeHeaderWithSpyDelegate()
+
+        // Each of these changes the view state while the plate stays off screen, so none of them is an
+        // appearance. Only the container showing up is.
+        header.configure(isSubscriptionActive: false)
+        header.setVoiceSessionActive(true)
+        header.setVoiceSessionActive(false)
+        header.setOnboardingLocked(true)
+        header.setOnboardingLocked(false)
+        XCTAssertEqual(delegate.upgradePlateDidBecomeVisibleCount, 0)
+
+        header.setContainerVisible(true)
+
+        XCTAssertEqual(delegate.upgradePlateDidBecomeVisibleCount, 1)
+    }
+
+    func testUpgradePlate_containerHiddenThenShown_notifiesAgain() {
+        let (header, delegate) = makeHeaderWithSpyDelegate()
+        header.setContainerVisible(true)
+        header.configure(isSubscriptionActive: false)
+
+        header.setContainerVisible(false)
+        header.setContainerVisible(true)
+
+        XCTAssertEqual(delegate.upgradePlateDidBecomeVisibleCount, 2,
+                       "Leaving and re-entering the Duck.ai tab is a second appearance")
+    }
+
+    func testUpgradePlate_voiceSession_suppressesThenReNotifiesOnExit() {
+        let (header, delegate) = makeHeaderWithSpyDelegate()
+        header.setContainerVisible(true)
+        header.configure(isSubscriptionActive: false)
+
+        header.setVoiceSessionActive(true)
+        XCTAssertEqual(delegate.upgradePlateDidBecomeVisibleCount, 1, "Entering voice must not fire")
+
+        header.setVoiceSessionActive(false)
+        XCTAssertEqual(delegate.upgradePlateDidBecomeVisibleCount, 2, "Leaving voice re-shows the plate")
+    }
+
+    func testUpgradePlate_titleHolderHidden_neverNotifiesEvenWhenContainerVisible() {
+        let (header, delegate) = makeHeaderWithSpyDelegate()
+
+        header.setVoiceSessionActive(true)
+        header.setContainerVisible(true)
+        header.configure(isSubscriptionActive: false)
+
+        XCTAssertTrue(header.titleHolder.isHidden)
+        XCTAssertEqual(delegate.upgradePlateDidBecomeVisibleCount, 0,
+                       "The container flag alone must not fire while nothing is on screen")
+    }
+
+    func testUpgradePlate_unresolvedSubscriptionState_doesNotNotify_thenNotifiesOnceOnResolvingInactive() {
+        let (header, delegate) = makeHeaderWithSpyDelegate()
+
+        header.setContainerVisible(true)
+        XCTAssertEqual(delegate.upgradePlateDidBecomeVisibleCount, 0,
+                       "An unresolved subscription state renders a blank slot, not the plate")
+
+        header.configure(isSubscriptionActive: false)
+
+        XCTAssertEqual(delegate.upgradePlateDidBecomeVisibleCount, 1)
+    }
+
+    func testUpgradePlate_subscriptionResolvesActive_doesNotNotify() {
+        let (header, delegate) = makeHeaderWithSpyDelegate()
+
+        header.setContainerVisible(true)
+        header.configure(isSubscriptionActive: true)
+
+        XCTAssertEqual(delegate.upgradePlateDidBecomeVisibleCount, 0)
+    }
+
+    func testUpgradePlate_onboardingLocked_doesNotNotify_thenNotifiesOnceOnUnlock() {
+        let (header, delegate) = makeHeaderWithSpyDelegate()
+
+        header.setOnboardingLocked(true)
+        header.setContainerVisible(true)
+        header.configure(isSubscriptionActive: false)
+        XCTAssertEqual(delegate.upgradePlateDidBecomeVisibleCount, 0,
+                       "The fire onboarding step hides the plate, so there is nothing to count")
+
+        header.setOnboardingLocked(false)
+
+        XCTAssertEqual(delegate.upgradePlateDidBecomeVisibleCount, 1,
+                       "Finishing onboarding reveals the plate — that is its first appearance")
+    }
+
+    func testUpgradePlate_subscriptionResolvesBeforeContainerAppears_notifiesOnce() {
+        let (header, delegate) = makeHeaderWithSpyDelegate()
+
+        header.configure(isSubscriptionActive: false)
+        header.setContainerVisible(true)
+
+        XCTAssertEqual(delegate.upgradePlateDidBecomeVisibleCount, 1,
+                       "Which of the two arrives first must not change the count — the subscription check is async")
+    }
+}
+
+private final class SpyAIChatTabChatHeaderViewDelegate: AIChatTabChatHeaderViewDelegate {
+
+    private(set) var upgradePlateDidBecomeVisibleCount = 0
+
+    func aiChatTabChatHeaderUpgradePlateDidBecomeVisible() {
+        upgradePlateDidBecomeVisibleCount += 1
+    }
+
+    func aiChatTabChatHeaderDidTapChatList() {}
+    func aiChatTabChatHeaderDidTapUpgrade() {}
+    func aiChatTabChatHeaderDidTapClose() {}
+    func aiChatTabChatHeaderDidTapNewChat() {}
+    func aiChatTabChatHeaderDidTapNewVoiceChat() {}
+    func aiChatTabChatHeaderDidTapNewImage() {}
+    func aiChatTabChatHeaderDidTapNewTab() {}
+    func aiChatTabChatHeaderDidTapNewSearch() {}
+    func aiChatTabChatHeaderDidTapNewFireTab() {}
+    func aiChatTabChatHeaderDidTapTabSwitcher() {}
 }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -1043,3 +1043,74 @@ extension AIChatUserScriptHandlerTests {
         XCTAssertEqual(configValues?.supportsNativePrompt, false)
     }
 }
+
+// MARK: - Subscription Funnel Bridge Tests
+
+/// Forwards decoded metrics into the real pixel metric handler, so a test can drive the whole path from the
+/// frontend's raw `reportMetric` payload through to the fired pixel.
+private final class MetricForwardingHandler: AIChatMetricReportingHandling {
+
+    private let pixelMetricHandler: AIChatPixelMetricHandler
+
+    init(pixelMetricHandler: AIChatPixelMetricHandler) {
+        self.pixelMetricHandler = pixelMetricHandler
+    }
+
+    func didReportMetric(_ metric: AIChatMetric) {
+        pixelMetricHandler.firePixelWithMetric(metric)
+    }
+}
+
+extension AIChatUserScriptHandlerTests {
+
+    func testWhenFrontendReportsFunnelMetricThenFunnelPixelFiresWithOrigin() async {
+        // Given
+        let testCases: [(metricName: String, pixel: Pixel.Event, origin: String)] = [
+            ("userDidViewAiSidebarUpgradeButton", .aiChatSubscriptionFunnelImpression, "funnel_duckai_ios__aisidebar"),
+            ("userDidClickAiSidebarUpgradeButton", .aiChatSubscriptionFunnelClick, "funnel_duckai_ios__aisidebar"),
+            ("userDidViewActivateSubscriptionBanner", .aiChatSubscriptionFunnelImpression, "funnel_duckai_ios__activatesubscription"),
+            ("userDidClickActivateSubscriptionButton", .aiChatSubscriptionFunnelClick, "funnel_duckai_ios__activatesubscription"),
+            ("userDidViewFreeLimitMessage", .aiChatSubscriptionFunnelImpression, "funnel_duckai_ios__freelimit"),
+            ("userDidClickFreeLimitSubscribeLink", .aiChatSubscriptionFunnelClick, "funnel_duckai_ios__freelimit"),
+            ("userDidViewImageGenerationLimitMessage", .aiChatSubscriptionFunnelImpression, "funnel_duckai_ios__imagegenerationlimit"),
+            ("userDidClickImageGenerationLimitSubscribeButton", .aiChatSubscriptionFunnelClick, "funnel_duckai_ios__imagegenerationlimit"),
+            ("userDidViewPlusLimitMessage", .aiChatSubscriptionFunnelImpression, "funnel_duckai_ios__pluslimit"),
+            ("userDidClickPlusLimitUpgradeLink", .aiChatSubscriptionFunnelClick, "funnel_duckai_ios__pluslimit"),
+            ("userDidViewPromotionCard", .aiChatSubscriptionFunnelImpression, "funnel_duckai_ios__promotioncard"),
+            ("userDidClickPromotionCardButton", .aiChatSubscriptionFunnelClick, "funnel_duckai_ios__promotioncard"),
+            ("userDidViewSettingsSubscribeButton", .aiChatSubscriptionFunnelImpression, "funnel_duckai_ios__settings"),
+            ("userDidClickSettingsSubscribeButton", .aiChatSubscriptionFunnelClick, "funnel_duckai_ios__settings"),
+            ("userDidViewProUpgradeDisclaimerBanner", .aiChatSubscriptionFunnelImpression, "funnel_duckai_ios__disclaimerbanner"),
+            ("userDidClickProUpgradeDisclaimerBannerButton", .aiChatSubscriptionFunnelClick, "funnel_duckai_ios__disclaimerbanner"),
+            ("userDidViewVoiceChatLimitModal", .aiChatSubscriptionFunnelImpression, "funnel_duckai_ios__voicechatlimit"),
+            ("userDidClickVoiceChatLimitModalSubscribeButton", .aiChatSubscriptionFunnelClick, "funnel_duckai_ios__voicechatlimit"),
+            ("userDidViewVoiceChatDurationLimitModal", .aiChatSubscriptionFunnelImpression, "funnel_duckai_ios__voicechatdurationlimit"),
+            ("userDidClickVoiceChatDurationLimitModalSubscribeButton", .aiChatSubscriptionFunnelClick, "funnel_duckai_ios__voicechatdurationlimit")
+        ]
+        XCTAssertEqual(testCases.count, AIChatPixelMetricHandler.funnelMetricToPixelMap.count,
+                       "The funnel map gained or lost entries this test does not cover")
+
+        // The injected mapper turns a decode failure into an observable event rather than a silent drop
+        aiChatUserScriptHandler = makeAIChatUserScriptHandler(aiChatUserScriptErrorEventMapper: mockUserScriptErrorEventMapper)
+
+        // A non-nil elapsed time proves the funnel path adds no timestamp parameter of its own
+        let forwardingHandler = MetricForwardingHandler(
+            pixelMetricHandler: AIChatPixelMetricHandler(timeElapsedInMinutes: 7, pixelFiring: PixelFiringMock.self)
+        )
+        aiChatUserScriptHandler.setMetricReportingHandler(forwardingHandler)
+
+        for testCase in testCases {
+            PixelFiringMock.tearDown()
+
+            // When
+            _ = await aiChatUserScriptHandler.reportMetric(params: ["metricName": testCase.metricName],
+                                                           message: MockUserScriptMessage(name: "test", body: [:]))
+
+            // Then
+            XCTAssertTrue(mockUserScriptErrorEventMapper.events.isEmpty, "\(testCase.metricName) failed to decode")
+            XCTAssertEqual(PixelFiringMock.allPixelsFired.count, 1, testCase.metricName)
+            XCTAssertEqual(PixelFiringMock.lastPixelName, testCase.pixel.name, testCase.metricName)
+            XCTAssertEqual(PixelFiringMock.lastParams, ["origin": testCase.origin], testCase.metricName)
+        }
+    }
+}

--- a/iOS/DuckDuckGoTests/PixelTests.swift
+++ b/iOS/DuckDuckGoTests/PixelTests.swift
@@ -65,6 +65,7 @@ class PixelTests: XCTestCase {
             (.unifiedToggleInputStopGenerationTapped, "m_aichat_unified_input_stop_generation_tapped"),
             (.unifiedToggleInputSubscriptionUpsellTriggered, "m_aichat_unified_input_subscription_upsell_triggered"),
             (.unifiedToggleInputChatHeaderUpgradeTapped, "m_aichat_unified_input_chat_header_upgrade_tapped"),
+            (.unifiedToggleInputChatHeaderUpgradeShown, "m_aichat_unified_input_chat_header_upgrade_shown"),
             (.unifiedToggleInputPromptSubmitted, "m_aichat_unified_input_prompt_submitted"),
             (.unifiedToggleInputShowModelPicker, "aichat_unified_input_show_model_picker"),
             (.unifiedToggleInputSubmitChangeModel, "aichat_unified_input_submit_change_model"),

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISubscriptionUpsellPresenterTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISubscriptionUpsellPresenterTests.swift
@@ -44,7 +44,7 @@ final class DuckAISubscriptionUpsellPresenterTests: XCTestCase {
                 return false
             }
             return self.hasQueryItem(in: components, name: "featurePage", value: "duckai")
-                && self.hasQueryItem(in: components, name: "origin", value: "funnel_addressbar_ios__reasoningpicker")
+                && self.hasQueryItem(in: components, name: "origin", value: "funnel_addressbar_ios__reasoningdropdown")
         }
 
         sut.presentPurchaseFlow(source: .reasoningPicker, isAITabState: false)
@@ -58,7 +58,7 @@ final class DuckAISubscriptionUpsellPresenterTests: XCTestCase {
                   case .subscriptionPlanChangeFlow(let components) = deepLink else {
                 return false
             }
-            return self.hasQueryItem(in: components, name: "origin", value: "funnel_addressbar_ios__reasoningpicker")
+            return self.hasQueryItem(in: components, name: "origin", value: "funnel_addressbar_ios__reasoningdropdown")
         }
 
         sut.presentUpgradeFlow(source: .reasoningPicker, isAITabState: false)
@@ -72,7 +72,7 @@ final class DuckAISubscriptionUpsellPresenterTests: XCTestCase {
                   case .subscriptionFlow(let components) = deepLink else {
                 return false
             }
-            return self.hasQueryItem(in: components, name: "origin", value: "funnel_duckai_ios__reasoningpicker")
+            return self.hasQueryItem(in: components, name: "origin", value: "funnel_duckai_ios__reasoningdropdown")
         }
 
         sut.presentPurchaseFlow(source: .reasoningPicker, isAITabState: true)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISubscriptionUpsellPresenterTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/DuckAISubscriptionUpsellPresenterTests.swift
@@ -94,6 +94,21 @@ final class DuckAISubscriptionUpsellPresenterTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    func testPresentPurchaseFlowFromChatHeaderPlateCarriesFeaturePageAndFreeLabelOrigin() {
+        let expectation = expectation(forNotification: .settingsDeepLinkNotification, object: nil, notificationCenter: notificationCenter) { notification in
+            guard let deepLink = notification.object as? SettingsViewModel.SettingsDeepLinkSection,
+                  case .subscriptionFlow(let components) = deepLink else {
+                return false
+            }
+            return self.hasQueryItem(in: components, name: "featurePage", value: "duckai")
+                && self.hasQueryItem(in: components, name: "origin", value: "funnel_duckai_ios__freelabel")
+        }
+
+        sut.presentPurchaseFlow(origin: .duckAIFreeLabel)
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     // MARK: - Helpers
 
     private func hasQueryItem(in components: URLComponents?, name: String, value: String) -> Bool {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputReasoningTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputReasoningTests.swift
@@ -158,7 +158,7 @@ final class UnifiedToggleInputReasoningTests: XCTestCase {
                 return false
             }
             return self.hasQueryItem(in: components, name: "featurePage", value: "duckai")
-                && self.hasQueryItem(in: components, name: "origin", value: "funnel_addressbar_ios__reasoningpicker")
+                && self.hasQueryItem(in: components, name: "origin", value: "funnel_addressbar_ios__reasoningdropdown")
         }
 
         sut.handleReasoningModeSelection(.extendedReasoning)
@@ -184,7 +184,7 @@ final class UnifiedToggleInputReasoningTests: XCTestCase {
                 return false
             }
             return self.hasQueryItem(in: components, name: "featurePage", value: "duckai")
-                && self.hasQueryItem(in: components, name: "origin", value: "funnel_addressbar_ios__reasoningpicker")
+                && self.hasQueryItem(in: components, name: "origin", value: "funnel_addressbar_ios__reasoningdropdown")
         }
 
         sut.handleReasoningModeSelection(.extendedReasoning)

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_subscription_funnel.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_subscription_funnel.json5
@@ -1,0 +1,37 @@
+// https://app.asana.com/1/137249556945/project/414235014887631/task/1211744626927520?focus=true
+{
+    "m_aichat_subscription-funnel_impression": {
+        "description": "Fires when the Duck.ai web frontend reports that a subscription entry point became visible.",
+        "owners": ["pikorddg"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "origin",
+                "description": "Duck.ai subscription entry point that was shown.",
+                "type": "string",
+                "enum": [
+                    "funnel_duckai_ios__aisidebar", "funnel_duckai_ios__activatesubscription", "funnel_duckai_ios__freelimit", "funnel_duckai_ios__imagegenerationlimit", "funnel_duckai_ios__pluslimit", "funnel_duckai_ios__promotioncard", "funnel_duckai_ios__settings", "funnel_duckai_ios__disclaimerbanner","funnel_duckai_ios__voicechatlimit", "funnel_duckai_ios__voicechatdurationlimit"
+                ]
+            }
+        ]
+    },
+    "m_aichat_subscription-funnel_click": {
+        "description": "Fires when the Duck.ai web frontend reports that the user tapped a subscription entry point.",
+        "owners": ["pikorddg"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "origin",
+                "description": "Duck.ai subscription entry point that was tapped.",
+                "type": "string",
+                "enum": [
+                    "funnel_duckai_ios__aisidebar", "funnel_duckai_ios__activatesubscription", "funnel_duckai_ios__freelimit", "funnel_duckai_ios__imagegenerationlimit", "funnel_duckai_ios__pluslimit", "funnel_duckai_ios__promotioncard", "funnel_duckai_ios__settings", "funnel_duckai_ios__disclaimerbanner","funnel_duckai_ios__voicechatlimit", "funnel_duckai_ios__voicechatdurationlimit"
+                ]
+            }
+        ]
+    }
+}

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_subscription_funnel.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_subscription_funnel.json5
@@ -12,7 +12,16 @@
                 "description": "Duck.ai subscription entry point that was shown.",
                 "type": "string",
                 "enum": [
-                    "funnel_duckai_ios__aisidebar", "funnel_duckai_ios__activatesubscription", "funnel_duckai_ios__freelimit", "funnel_duckai_ios__imagegenerationlimit", "funnel_duckai_ios__pluslimit", "funnel_duckai_ios__promotioncard", "funnel_duckai_ios__settings", "funnel_duckai_ios__disclaimerbanner","funnel_duckai_ios__voicechatlimit", "funnel_duckai_ios__voicechatdurationlimit"
+                    "funnel_duckai_ios__aisidebar",
+                    "funnel_duckai_ios__activatesubscription",
+                    "funnel_duckai_ios__freelimit",
+                    "funnel_duckai_ios__imagegenerationlimit",
+                    "funnel_duckai_ios__pluslimit",
+                    "funnel_duckai_ios__promotioncard",
+                    "funnel_duckai_ios__settings",
+                    "funnel_duckai_ios__disclaimerbanner",
+                    "funnel_duckai_ios__voicechatlimit",
+                    "funnel_duckai_ios__voicechatdurationlimit"
                 ]
             }
         ]
@@ -29,7 +38,16 @@
                 "description": "Duck.ai subscription entry point that was tapped.",
                 "type": "string",
                 "enum": [
-                    "funnel_duckai_ios__aisidebar", "funnel_duckai_ios__activatesubscription", "funnel_duckai_ios__freelimit", "funnel_duckai_ios__imagegenerationlimit", "funnel_duckai_ios__pluslimit", "funnel_duckai_ios__promotioncard", "funnel_duckai_ios__settings", "funnel_duckai_ios__disclaimerbanner","funnel_duckai_ios__voicechatlimit", "funnel_duckai_ios__voicechatdurationlimit"
+                    "funnel_duckai_ios__aisidebar",
+                    "funnel_duckai_ios__activatesubscription",
+                    "funnel_duckai_ios__freelimit",
+                    "funnel_duckai_ios__imagegenerationlimit",
+                    "funnel_duckai_ios__pluslimit",
+                    "funnel_duckai_ios__promotioncard",
+                    "funnel_duckai_ios__settings",
+                    "funnel_duckai_ios__disclaimerbanner",
+                    "funnel_duckai_ios__voicechatlimit",
+                    "funnel_duckai_ios__voicechatdurationlimit"
                 ]
             }
         ]

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -262,11 +262,19 @@
         ]
     },
     "m_aichat_unified_input_chat_header_upgrade_tapped": {
-        "description": "Fires when the user taps the Upgrade label in the AI Chat tab header. The header is only shown to users without an active subscription.",
+        "description": "Fires when the user taps the Upgrade label in the AI Chat tab header.",
         "owners": ["pikorddg"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "origin",
+                "description": "Origin value for the Duck.ai tab-header upgrade label tap.",
+                "type": "string",
+                "enum": ["funnel_duckai_ios__freelabel"]
+            }
+        ]
     },
     "m_aichat_unified_input_chat_header_upgrade_shown": {
         "description": "Fires each time the 'Free Plan / Upgrade' label in the Duck.ai tab header becomes visible.",

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -271,7 +271,7 @@
         ]
     },
     "m_aichat_unified_input_chat_header_upgrade_tapped": {
-        "description": "Fires when the user taps the Upgrade label in the AI Chat tab header.",
+        "description": "Fires when the user taps the Upgrade label in the AI Chat tab header. The header is only shown to users without an active subscription.",
         "owners": ["pikorddg"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -268,6 +268,21 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
+    "m_aichat_unified_input_chat_header_upgrade_shown": {
+        "description": "Fires each time the 'Free Plan / Upgrade' label in the Duck.ai tab header becomes visible.",
+        "owners": ["pikorddg"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "origin",
+                "description": "Origin value for the Duck.ai tab-header upgrade label impression.",
+                "type": "string",
+                "enum": ["funnel_duckai_ios__freelabel"]
+            }
+        ]
+    },
     "m_autocomplete_duckai_click_website": {
         "description": "Fires when user clicks on a website suggestion in the Duck.ai autocomplete suggestion list.",
         "owners": ["pikorddg"],

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -118,7 +118,13 @@
                 "key": "origin",
                 "description": "Origin value for the reasoning effort picker impression.",
                 "type": "string",
-                "enum": ["funnel_addressbar_ios__reasoningpicker", "funnel_duckai_ios__reasoningpicker"]
+                "enum": [
+                    "funnel_addressbar_ios__reasoningdropdown",
+                    "funnel_duckai_ios__reasoningdropdown",
+                    // Shipped from 7.228.0 until the rename to ...__reasoningdropdown; kept so historic data validates.
+                    "funnel_addressbar_ios__reasoningpicker",
+                    "funnel_duckai_ios__reasoningpicker"
+                ]
             }
         ]
     },
@@ -254,8 +260,11 @@
                 "type": "string",
                 "enum": [
                     "funnel_addressbar_ios__modelpicker",
-                    "funnel_addressbar_ios__reasoningpicker",
+                    "funnel_addressbar_ios__reasoningdropdown",
                     "funnel_duckai_ios__modelpicker",
+                    "funnel_duckai_ios__reasoningdropdown",
+                    // Shipped from 7.228.0 until the rename to ...__reasoningdropdown; kept so historic data validates.
+                    "funnel_addressbar_ios__reasoningpicker",
                     "funnel_duckai_ios__reasoningpicker"
                 ]
             }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1216395339071576?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->
Adds iOS telemetry for [Duck.ai](http://duck.ai/) subscription-funnel entry points, including the native Free Plan / Upgrade header, so impressions and clicks carry consistent origins. Also aligns reasoning-picker origins with the `reasoningdropdown` analytics naming.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. As a free user, open [Duck.ai](http://duck.ai/) and verify the Free Plan / Upgrade label fires `m_aichat_unified_input_chat_header_upgrade_shown` when shown and `m_aichat_unified_input_chat_header_upgrade_tapped` when tapped, both with `origin=funnel_duckai_ios__freelabel`.
2. Open the reasoning picker and verify the emitted `origin` uses `reasoningdropdown`, not `reasoningpicker`.
- All other pixels are FE-drive. One of the subscription-funnel signal was manually checked successfully; unit tests cover the remaining mapped metrics.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low — incorrect mappings could skew funnel analytics without affecting browser behavior.

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes with broad unit/integration coverage; wrong mappings could skew funnel data without affecting app behavior or purchases.
> 
> **Overview**
> Adds iOS telemetry for Duck.ai subscription entry points so impressions and taps share consistent **`origin`** values across native UI and web-reported metrics.
> 
> **Web frontend funnel:** New pixels `m_aichat_subscription-funnel_impression` and `m_aichat_subscription-funnel_click` (macOS-aligned wire names) fire when the Duck.ai web layer reports metrics via `reportMetric`. `AIChatPixelMetricHandler` maps ten view/click pairs (sidebar, limits, promotion card, settings, etc.) to those events with the matching `SubscriptionFunnelOrigin`; the native Free Plan header metrics are intentionally excluded from that map.
> 
> **Native tab header:** The Free Plan / Upgrade plate fires `m_aichat_unified_input_chat_header_upgrade_shown` when it becomes visible and adds **`origin=funnel_duckai_ios__freelabel`** on shown/tapped; upgrade now routes through `DuckAISubscriptionUpsellPresenter.presentPurchaseFlow` with that origin. Header visibility tracking avoids duplicate impressions across voice, onboarding, and container show/hide.
> 
> **Naming alignment:** Reasoning-picker funnel origins switch from `reasoningpicker` to **`reasoningdropdown`** in code and pixel definitions (legacy enum values kept for historic validation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 192fa8acaf77867947c1f7cc6b2300c687211fef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->