### PR TITLE
add feature flag for native prompt editing 

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -628,6 +628,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
 
     /// macOS only. System-wide Duck.ai entry point: global keyboard shortcut and menu bar icon.
     case macosPromptBar
+    
+    /// Supports Duck.ai edit prompt from the native input field.
+    case nativePromptEditing
 }
 
 public enum HtmlNewTabPageSubfeature: String, Equatable, PrivacySubfeature {

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -628,7 +628,7 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
 
     /// macOS only. System-wide Duck.ai entry point: global keyboard shortcut and menu bar icon.
     case macosPromptBar
-    
+
     /// Supports Duck.ai edit prompt from the native input field.
     case nativePromptEditing
 }

--- a/iOS/Core/FeatureFlag.swift
+++ b/iOS/Core/FeatureFlag.swift
@@ -516,6 +516,9 @@ public enum FeatureFlag: String {
     /// Moves the iPad tabs bar up into the system window controls row (iOS 26+ resizable windows).
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217015452646368?focus=true
     case iPadTabsBarInWindowControlsRow
+    
+    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1216352541195038?focus=true
+    case nativeAIPromptEditing
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -881,6 +884,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.systemFindInPage))
         case .iPadTabsBarInWindowControlsRow:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.iPadTabsBarInWindowControlsRow))
+        case .nativeAIPromptEditing:
+            Config(defaultValue: .disabled, source: .remoteReleasable(AIChatSubfeature.nativePromptEditing))
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1217051542544053?focus=true

### Description
Adds Feature flag for allow ai chat prompt editing from the native input field

### Testing Steps
1. Open the app and verify that in the debug menu `nativePromptEditing` appears as a FF

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
None: Internal tooling, documentation

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag-only changes with default disabled; no runtime behavior until follow-up work consumes the flag.
> 
> **Overview**
> Introduces remote feature-flag plumbing for **Duck.ai prompt editing from the native input field**, with no product behavior wired in this diff.
> 
> Adds `AIChatSubfeature.nativePromptEditing` under the shared privacy config (`aiChat` feature). On iOS, exposes it as `FeatureFlag.nativeAIPromptEditing` mapped to that subfeature with **default disabled** and remote releasable control (debug menu visibility per PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b21872065425f42a0b2d5c32d4c872b31d0c9d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->