### PR TITLE
[iOS] Fix `m_browsing-mode_switched` pixel definition

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/fire-mode.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/fire-mode.json5
@@ -13,7 +13,7 @@
                 "key": "source",
                 "description": "The entry point that triggered the mode switch",
                 "type": "string",
-                "enum": ["tab_selection", "long_press_tabs_icon", "long_press_link", "tab_switcher_long_press", "key_command"]
+                "enum": ["tab_selection", "long_press_tabs_icon", "long_press_link", "tab_switcher_long_press", "key_command", "ai_chat_header_plus_menu"]
             }
         ]
     },

--- a/iOS/PixelDefinitions/pixels/definitions/fire-mode.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/fire-mode.json5
@@ -13,7 +13,14 @@
                 "key": "source",
                 "description": "The entry point that triggered the mode switch",
                 "type": "string",
-                "enum": ["tab_selection", "long_press_tabs_icon", "long_press_link", "tab_switcher_long_press", "key_command", "ai_chat_header_plus_menu"]
+                "enum": [
+                    "tab_selection",
+                    "long_press_tabs_icon",
+                    "long_press_link",
+                    "tab_switcher_long_press",
+                    "key_command",
+                    "ai_chat_header_plus_menu"
+                ]
             }
         ]
     },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1217093480349676?focus=true

### Description

The `m_browsing-mode_switched` pixel was failing live validation with `/source must be equal to one of the allowed values`.

The PR adds `ai_chat_header_plus_menu` to the pixel scheme, which was missing.

### Testing Steps

No testing needed. Make sure CI passes.

### Impact and Risks

**Low.** Adds one value to an existing pixel parameter's allowed-values enum. No code paths change; it only widens schema validation to accept a value the app already fires. No risk to users.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only change to a pixel enum; no runtime logic or user-facing behavior changes.
> 
> **Overview**
> Fixes live validation failures for **`m_browsing-mode_switched`** when **`source`** is **`ai_chat_header_plus_menu`** (error: `/source must be equal to one of the allowed values`).
> 
> Adds **`ai_chat_header_plus_menu`** to the **`source`** parameter enum in **`fire-mode.json5`**, matching **`FireModeSwitchSource.aiChatHeaderPlusMenu`** already used in the app. The diff also reformats the enum list for readability; allowed values are unchanged aside from the new entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a52ea5f77a2f9640fcc145a114e5eb3890581b8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->