### PR TITLE
Remove v3 onboarding support

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -205,9 +205,6 @@ public enum MacOSBrowserConfigSubfeature: String, PrivacySubfeature {
 
     case screenTimeCleaning
 
-    /// https://app.asana.com/1/137249556945/project/1211264967278501/task/1211806114021633?focus=true
-    case onboardingRebranding
-
     /// Option to install Chrome extension during onboarding (DMG only)
     case onboardingChromeExtension
 

--- a/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/Rebranding/ContextualDaxDialogsProvider.swift
+++ b/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/Rebranding/ContextualDaxDialogsProvider.swift
@@ -18,16 +18,12 @@
 
 import SwiftUI
 import Onboarding
-import FeatureFlags
-import PrivacyConfig
 
 final class ContextualDaxDialogsProvider: ContextualDaxDialogsFactory {
-    private let featureFlagger: FeatureFlagger
     private let legacyDaxDialogsFactory: ContextualDaxDialogsFactory
     private let rebrandedDaxDialogsFactory: ContextualDaxDialogsFactory
 
     convenience init(
-        featureFlagger: FeatureFlagger,
         onboardingPixelReporter: OnboardingPixelReporting = OnboardingPixelReporter(),
         fireCoordinator: FireCoordinator
     ) {
@@ -40,18 +36,15 @@ final class ContextualDaxDialogsProvider: ContextualDaxDialogsFactory {
             fireCoordinator: fireCoordinator
         )
         self.init(
-            featureFlagger: featureFlagger,
             legacyDaxDialogsFactory: legacyFactory,
             rebrandedDaxDialogsFactory: rebrandedFactory
         )
     }
 
     init(
-        featureFlagger: FeatureFlagger,
         legacyDaxDialogsFactory: ContextualDaxDialogsFactory,
         rebrandedDaxDialogsFactory: ContextualDaxDialogsFactory
     ) {
-        self.featureFlagger = featureFlagger
         self.legacyDaxDialogsFactory = legacyDaxDialogsFactory
         self.rebrandedDaxDialogsFactory = rebrandedDaxDialogsFactory
     }
@@ -59,7 +52,7 @@ final class ContextualDaxDialogsProvider: ContextualDaxDialogsFactory {
     private var factory: ContextualDaxDialogsFactory {
         // Rebranded panel layout breaks on macOS 12 and below. For now, we'll just
         // ensure we show the legacy contextual dialogs on those versions.
-        if #available(macOS 13.0, *), featureFlagger.isFeatureOn(.onboardingRebranding) {
+        if #available(macOS 13.0, *) {
             rebrandedDaxDialogsFactory
         } else {
             legacyDaxDialogsFactory

--- a/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
+++ b/macOS/DuckDuckGo/Onboarding/OnboardingActionsManager.swift
@@ -132,7 +132,6 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
 
     var configuration: OnboardingConfiguration {
         let systemSettings: SystemSettings
-        let order = featureFlagger.isFeatureOn(.onboardingRebranding) ? "v4" : "v3"
         let platform = OnboardingPlatform(name: "macos")
         if dockCustomization.supportsAddingToDock {
             systemSettings = SystemSettings(rows: [
@@ -166,7 +165,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
 
         return OnboardingConfiguration(stepDefinitions: stepDefinitions,
                                        exclude: excludedSteps,
-                                       order: order,
+                                       order: "v4",
                                        env: env,
                                        locale: preferredLocale,
                                        platform: platform)
@@ -189,8 +188,7 @@ final class OnboardingActionsManager: OnboardingActionsManaging {
     // MARK: Chrome extension install
 
     private var isEligibleForChromeExtensionInstall: Bool {
-        featureFlagger.isFeatureOn(.onboardingRebranding)
-            && chromeExtensionInstaller.canInstallDDGExtension
+        chromeExtensionInstaller.canInstallDDGExtension
     }
 
     private var shouldShowChromeInstallOption: Bool {

--- a/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
+++ b/macOS/DuckDuckGo/Tab/View/BrowserTabViewController.swift
@@ -164,7 +164,7 @@ final class BrowserTabViewController: NSViewController {
          bookmarkDragDropManager: BookmarkDragDropManager = NSApp.delegateTyped.bookmarkDragDropManager,
          onboardingPixelReporter: OnboardingPixelReporting = OnboardingPixelReporter(),
          onboardingDialogTypeProvider: ContextualOnboardingDialogTypeProviding & ContextualOnboardingStateUpdater = Application.appDelegate.onboardingContextualDialogsManager,
-         onboardingDialogFactory: ContextualDaxDialogsFactory = ContextualDaxDialogsProvider(featureFlagger: NSApp.delegateTyped.featureFlagger, fireCoordinator: NSApp.delegateTyped.fireCoordinator),
+         onboardingDialogFactory: ContextualDaxDialogsFactory = ContextualDaxDialogsProvider(fireCoordinator: NSApp.delegateTyped.fireCoordinator),
          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
          newTabPageActionsManager: @autoclosure @escaping @MainActor () -> NewTabPageActionsManager = NSApp.delegateTyped.newTabPageCoordinator.actionsManager,
          activeRemoteMessageModel: ActiveRemoteMessageModel = NSApp.delegateTyped.activeRemoteMessageModel,

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -32,9 +32,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866470686549
     case contextualOnboarding
 
-    /// Onboarding rebranding feature flag
-    case onboardingRebranding
-
     /// https://app.asana.com/1/137249556945/project/1211150618152277/task/1216081727196784
     case appRebranding
 
@@ -531,8 +528,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(DBPSubfeature.freemium), supportsLocalOverriding: false)
         case .contextualOnboarding:
             Config(defaultValue: .enabled, source: .remoteReleasable(ContextualOnboardingSubfeature.featureEnabled), supportsLocalOverriding: false)
-        case .onboardingRebranding:
-            Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.onboardingRebranding))
         case .appRebranding:
             Config(defaultValue: .disabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.appRebranding))
         case .newTabPageRebranding:

--- a/macOS/UITests/OnboardingUITests.swift
+++ b/macOS/UITests/OnboardingUITests.swift
@@ -28,20 +28,15 @@ final class OnboardingUITests: UITestCase {
         continueAfterFailure = false
         try resetApplicationData()
 
-        // Default to the legacy "v3" onboarding. Tests that exercise the rebranded
-        // "v4" flow relaunch via `launchOnboarding(rebranded: true)`.
-        launchOnboarding(rebranded: false)
+        launchOnboarding()
     }
 
     /// Launches the app into the onboarding flow.
-    /// - Parameter rebranded: when `true`, enables the `onboardingRebranding` feature flag to
-    ///   exercise the rebranded "v4" onboarding; when `false`, pins the legacy "v3" flow.
-    private func launchOnboarding(rebranded: Bool) {
+    private func launchOnboarding() {
         app = XCUIApplication.setUp(
             environment: [
                 "UITEST_MODE_ONBOARDING": "1"
-            ],
-            featureFlags: ["onboardingRebranding": rebranded]
+            ]
         )
         app.enforceSingleWindow()
         welcomeWindow = app.windows["Welcome"]
@@ -52,85 +47,7 @@ final class OnboardingUITests: UITestCase {
         try super.tearDownWithError()
     }
 
-    func testLegacyOnboardingToBrowsing() throws {
-        // Options button initially disabled on welcome
-        let optionsButton = welcomeWindow.buttons["NavigationBarViewController.optionsButton"]
-        XCTAssertTrue(optionsButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        XCTAssertFalse(optionsButton.isEnabled)
-
-        // Get Started
-        XCTAssertTrue(welcomeWindow.webViews["Welcome"].staticTexts["Ready for a faster browser that keeps you protected?"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
-
-        let getStartedButton = welcomeWindow.webViews["Welcome"].buttons
-            .matching(NSPredicate(format: "label ==[c] %@", "Let’s do it!"))
-            .firstMatch
-        XCTAssertTrue(getStartedButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        // Use coordinate tap to avoid overlay/hittability quirks
-        let centerCoordinate = getStartedButton.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1))
-        centerCoordinate.click()
-
-        // Protections activated
-        XCTAssertTrue(welcomeWindow.webViews["Welcome"].staticTexts["Protections activated!"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
-
-        let skipButton = welcomeWindow.webViews["Welcome"].buttons["Skip"]
-        XCTAssertTrue(skipButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        skipButton.click()
-
-        // Let’s get you set up
-        XCTAssertTrue(welcomeWindow.webViews["Welcome"].staticTexts["Let’s get you set up!"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
-
-        XCTAssertTrue(skipButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        skipButton.click()
-
-        let importNowButton = welcomeWindow.webViews["Welcome"].buttons["Import Now"]
-        XCTAssertTrue(importNowButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        importNowButton.click()
-
-        let cancelButton = welcomeWindow.sheets.buttons["Cancel"]
-        XCTAssertTrue(cancelButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        cancelButton.click()
-
-        let nextButtonSetUp = welcomeWindow.webViews["Welcome"].buttons["Next"]
-        XCTAssertTrue(nextButtonSetUp.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        nextButtonSetUp.click()
-
-        // Customize Experience
-        XCTAssertTrue(welcomeWindow.webViews["Welcome"].staticTexts["Let’s customize a few things…"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
-
-        // Session Restore
-        XCTAssertTrue(skipButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        skipButton.click()
-
-        let enableSessionRestoreButton = welcomeWindow.webViews["Welcome"].buttons["Enable Session Restore"]
-        XCTAssertTrue(enableSessionRestoreButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        enableSessionRestoreButton.click()
-
-        let showHomeButton = welcomeWindow.webViews["Welcome"].buttons["Show Home Button"]
-        XCTAssertTrue(showHomeButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        showHomeButton.click()
-
-        let nextButtonCustomize = welcomeWindow.webViews["Welcome"].buttons["Next"]
-        XCTAssertTrue(nextButtonCustomize.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        nextButtonCustomize.click()
-
-        // AI Chat
-        XCTAssertTrue(welcomeWindow.webViews["Welcome"].staticTexts["Want easy access to private AI Chat?"].waitForExistence(timeout: UITests.Timeouts.elementExistence))
-
-        // Start Browsing
-        let startBrowsingButton = welcomeWindow.webViews["Welcome"].buttons["Start Browsing"]
-        XCTAssertTrue(startBrowsingButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-        startBrowsingButton.click()
-
-        // AfterOnboarding
-        let ddgLogo = app.windows.webViews.groups.containing(.image, identifier: "DuckDuckGo Logo").element
-        let tooltip = app.windows.webViews.groups.containing(.staticText, identifier: "Toggle between search and AI chat").element
-        XCTAssertTrue(ddgLogo.waitForExistence(timeout: UITests.Timeouts.elementExistence) || tooltip.waitForExistence(timeout: UITests.Timeouts.elementExistence))
-    }
-
-    func testRebrandedOnboardingToBrowsing() throws {
-        // Relaunch into the rebranded "v4" onboarding.
-        launchOnboarding(rebranded: true)
-
+    func testOnboardingToBrowsing() throws {
         // Options button initially disabled on welcome
         let optionsButton = welcomeWindow.buttons["NavigationBarViewController.optionsButton"]
         XCTAssertTrue(optionsButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
@@ -139,7 +56,7 @@ final class OnboardingUITests: UITestCase {
         // Get Started
         XCTAssertTrue(welcomeWindow.webViews["Welcome"].staticTexts["Hi there."].waitForExistence(timeout: UITests.Timeouts.elementExistence))
 
-        // The rebranded buttons have no aria-label/identifier, so WebKit exposes their text via `title` rather than `label`.
+        // The onboarding buttons have no aria-label/identifier, so WebKit exposes their text via `title` rather than `label`.
         let getStartedButton = welcomeWindow.webViews["Welcome"].buttons
             .matching(NSPredicate(format: "title ==[c] %@", "Let’s get started!"))
             .firstMatch

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -99,7 +99,7 @@ class OnboardingManagerTests: XCTestCase {
         chromeExtensionInstaller = nil
     }
 
-    func testReturnsExpectedOnboardingConfig_WhenBothFlagsAreOff_ExcludesAddressBarMode() {
+    func testReturnsExpectedOnboardingConfig_WhenNoFlagsAreOn_ExcludesAddressBarMode() {
         // Given
         let systemSettings = SystemSettings(rows: ["dock", "import"])
         let stepDefinitions = StepDefinitions(
@@ -109,7 +109,7 @@ class OnboardingManagerTests: XCTestCase {
         let expectedConfig = OnboardingConfiguration(
             stepDefinitions: stepDefinitions,
             exclude: [OnboardingExcludedStep.duckPlayerSingle.rawValue, OnboardingExcludedStep.addressBarMode.rawValue],
-            order: "v3",
+            order: "v4",
             env: "development",
             locale: "en",
             platform: .init(name: "macos")
@@ -166,7 +166,7 @@ class OnboardingManagerTests: XCTestCase {
         let expectedConfig = OnboardingConfiguration(
             stepDefinitions: stepDefinitions,
             exclude: [OnboardingExcludedStep.duckPlayerSingle.rawValue, OnboardingExcludedStep.addressBarMode.rawValue],
-            order: "v3",
+            order: "v4",
             env: "development",
             locale: "en",
             platform: .init(name: "macos")
@@ -200,7 +200,7 @@ class OnboardingManagerTests: XCTestCase {
         let expectedConfig = OnboardingConfiguration(
             stepDefinitions: stepDefinitions,
             exclude: [OnboardingExcludedStep.duckPlayerSingle.rawValue, OnboardingExcludedStep.addressBarMode.rawValue],
-            order: "v3",
+            order: "v4",
             env: "development",
             locale: "en",
             platform: .init(name: "macos")
@@ -234,7 +234,7 @@ class OnboardingManagerTests: XCTestCase {
         let expectedConfig = OnboardingConfiguration(
             stepDefinitions: stepDefinitions,
             exclude: [OnboardingExcludedStep.duckPlayerSingle.rawValue],
-            order: "v3",
+            order: "v4",
             env: "development",
             locale: "en",
             platform: .init(name: "macos")
@@ -486,20 +486,6 @@ class OnboardingManagerTests: XCTestCase {
         // Then
         XCTAssertTrue(managerWithControl.configuration.stepDefinitions.getStarted.options.isEmpty)
         XCTAssertTrue(featureFlagger.didCallResolveCohort)
-    }
-
-    func testWhenNotV4ThenDoesNotResolveCohortOrIncludeChromeExtensionInstallOption() {
-        // Given
-        let featureFlagger = makeFeatureFlagger(cohort: .treatment, isOnboardingRebrandingEnabled: false)
-        chromeExtensionInstaller.canInstallDDGExtension = true
-        let managerWithTreatment = makeExperimentManager(featureFlagger: featureFlagger)
-
-        // When
-        managerWithTreatment.onboardingStarted()
-
-        // Then
-        XCTAssertTrue(managerWithTreatment.configuration.stepDefinitions.getStarted.options.isEmpty)
-        XCTAssertFalse(featureFlagger.didCallResolveCohort)
     }
 
     func testWhenChromeCannotBeInstalledThenDoesNotResolveCohortOrIncludeOption() {
@@ -851,14 +837,7 @@ private extension OnboardingManagerTests {
         )
     }
 
-    func makeFeatureFlagger(
-        cohort: FeatureFlag.OnboardingChromeExtensionCohort?,
-        isOnboardingRebrandingEnabled: Bool = true
-    ) -> MockFeatureFlagger {
-        let featureFlagger = MockFeatureFlagger(resolveCohortStub: cohort)
-        if isOnboardingRebrandingEnabled {
-            featureFlagger.enabledFeatureFlags = [.onboardingRebranding]
-        }
-        return featureFlagger
+    func makeFeatureFlagger(cohort: FeatureFlag.OnboardingChromeExtensionCohort?) -> MockFeatureFlagger {
+        MockFeatureFlagger(resolveCohortStub: cohort)
     }
 }

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -176,40 +176,6 @@ class OnboardingManagerTests: XCTestCase {
         XCTAssertEqual(appStoreManager.configuration, expectedConfig)
     }
 
-    func testReturnsExpectedOnboardingConfig_WhenOmnibarOnboardingIsOff_ExcludesAddressBarMode() {
-        // Given
-        let featureFlagger = MockFeatureFlagger()
-        featureFlagger.enabledFeatureFlags = []
-        let managerWithFlagOn = OnboardingActionsManager(
-            navigationDelegate: navigationDelegate,
-            dockCustomization: dockCustomization,
-            defaultBrowserProvider: defaultBrowserProvider,
-            appearancePreferences: appearancePreferences,
-            startupPreferences: startupPreferences,
-            dataImportProvider: importProvider,
-            featureFlagger: featureFlagger,
-            onboardingSharedPixelHandler: onboardingSharedPixelHandler,
-            chromeExtensionInstaller: chromeExtensionInstaller
-        )
-
-        let systemSettings = SystemSettings(rows: ["dock", "import"])
-        let stepDefinitions = StepDefinitions(
-            systemSettings: systemSettings,
-            getStarted: GetStarted(options: [])
-        )
-        let expectedConfig = OnboardingConfiguration(
-            stepDefinitions: stepDefinitions,
-            exclude: [OnboardingExcludedStep.duckPlayerSingle.rawValue, OnboardingExcludedStep.addressBarMode.rawValue],
-            order: "v4",
-            env: "development",
-            locale: "en",
-            platform: .init(name: "macos")
-        )
-
-        // Then
-        XCTAssertEqual(managerWithFlagOn.configuration, expectedConfig)
-    }
-
     func testReturnsExpectedOnboardingConfig_WhenOmnibarOnboardingIsOn_DoesNotExcludeAddressBarMode() {
         // Given
         let featureFlagger = MockFeatureFlagger()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217018051146861
CC:

Related: https://github.com/duckduckgo/content-scope-scripts/pull/2924

### Description

The onboarding special page could run one of two flows, "v3" or "v4", chosen by the `order` value we pass in its config. The v4 flow has been released for a while now so it's safe to now remove the v3 flow and the `onboardingRebranding` feature flag. This lets us drop v3 from C-S-S and shed a lot of code – see the linked PR.

### Testing Steps

1. Debug → Reset Data → Reset Onboarding, then launch the app → the rebranded ("v4") onboarding appears, starting on "Hi there."
2. Step through the whole flow to "Start Browsing" → onboarding completes and you land on the new tab page.
3. Confirm there is no longer an `onboardingRebranding` entry under Debug → Feature Flags.

### Impact

Medium – new-user onboarding is the only affected flow. Existing users are unaffected apart from the contextual dax dialogs, which were already defaulting to the rebranded variant.

#### What could go wrong?

Removing the flag removes the remote kill switch for the rebranded onboarding and dax dialogs – mitigated by v4 having been the default-enabled path in production for some time, so the switch was already effectively unused.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New-user onboarding and contextual Dax dialogs lose the remote kill switch for v3; mitigated by v4 having been the production default for some time.
> 
> **Overview**
> Removes the legacy **v3** onboarding path and the **`onboardingRebranding`** feature flag so macOS always uses the rebranded **v4** flow and related UI.
> 
> **Onboarding config** always passes `order: "v4"` in `OnboardingActionsManager`. Chrome extension install eligibility no longer depends on the rebranding flag—only on whether the DDG extension can be installed.
> 
> **Contextual Dax dialogs** in `ContextualDaxDialogsProvider` always pick the rebranded factory on macOS 13+ (legacy only on older OS), without `FeatureFlagger` or flag checks.
> 
> The flag is dropped from **`PrivacyFeature`**, **`FeatureFlag`**, and debug feature-flag surfaces. **UITests** consolidate to a single v4 onboarding test; **unit tests** expect `v4` and remove legacy-flag scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee6fdea0103b6a4199f4e335cfa11c3933d3ffcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->