### PR TITLE
[macOS] Stop asserting on expected too-long-filename download errors

### DIFF
--- a/macOS/DuckDuckGo/FileDownload/Model/FileDownloadManager.swift
+++ b/macOS/DuckDuckGo/FileDownload/Model/FileDownloadManager.swift
@@ -256,6 +256,7 @@ extension FileDownloadManager: WebKitDownloadTaskDelegate {
                 NSFileWriteVolumeReadOnlyError,   // EROFS   — read-only filesystem
                 NSFileWriteNoPermissionError,     // EACCES/EPERM — no write permission
                 NSFileNoSuchFileError,            // ENOENT  — parent dir removed / volume unmounted
+                NSFileWriteInvalidFileNameError,  // ENAMETOOLONG — suggested filename too long for the filesystem
                 NSFileWriteUnknownError,          // catch-all for unexpected write failures
             ]
             Logger.fileDownload.error("Failed to create file in the Downloads folder: \(error)")

--- a/macOS/UnitTests/FileDownload/FileDownloadManagerTests.swift
+++ b/macOS/UnitTests/FileDownload/FileDownloadManagerTests.swift
@@ -326,6 +326,42 @@ final class FileDownloadManagerTests: XCTestCase {
         }
     }
 
+    // A too-long suggested filename makes the OS return NSFileWriteInvalidFileNameError (ENAMETOOLONG).
+    // This is an expected, non-actionable condition: the download should fail with the real error and
+    // must NOT trip the pixel assertion reserved for genuinely unexpected write failures.
+    @MainActor
+    func testWhenFileCreationFailsWithInvalidFileNameThenDownloadIsMarkedFailed() {
+        let downloadsURL = fm.temporaryDirectory
+        preferences.selectedDownloadLocation = downloadsURL
+
+        // Inject the error the OS raises when the suggested filename exceeds the filesystem limit.
+        let writeError = CocoaError(.fileWriteInvalidFileName)
+        dm.reservePlaceholderFile = { _ in throw writeError }
+
+        let download = WKDownloadMock(url: .duckDuckGo)
+        let task = dm.add(download, fireWindowSession: nil, delegate: self, destination: .auto)
+
+        self.chooseDestination = { _, _, _ in
+            XCTFail("Unexpected chooseDestination call — download should have failed, not prompted")
+        }
+
+        let e = expectation(description: "WKDownload callback called")
+        download.delegate?.download(download.asWKDownload(), decideDestinationUsing: response, suggestedFilename: "file.pdf") { url in
+            XCTAssertNil(url, "Download should be cancelled when the filename is invalid")
+            e.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+
+        if case .failed(_, _, _, let error) = task.state {
+            let nsError = error.underlyingError as NSError?
+            XCTAssertEqual(nsError?.domain, NSCocoaErrorDomain)
+            XCTAssertEqual(nsError?.code, NSFileWriteInvalidFileNameError)
+        } else {
+            XCTFail("Expected task state .failed, got \(task.state)")
+        }
+    }
+
     // When the preferred filename is already taken on disk (TOCTOU race: another process claimed it),
     // the download manager should retry with the next available filename rather than aborting.
     @MainActor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202406491309510/task/1213975525679527
CC: @mallexxx

### Description
Downloads whose server-suggested filename is too long for the filesystem fail with `NSFileWriteInvalidFileNameError` (underlying POSIX `ENAMETOOLONG`). This is an expected, non-actionable condition, but it was missing from the write-error allow-list added in #4483, so it tripped the "unexpected error" pixel assertion.

This surfaced as the `m.mac.debug.assertion.failure` anomaly on 2026-08-03 (+420%), which tracked the 1.200.1 rollout rather than any real download regression. Adding the code to the allow-list stops the false assertion; the download still fails with the real underlying error as before.

### Testing Steps
1. Trigger a download whose suggested filename exceeds the filesystem limit (or rely on the added unit test).
2. Confirm the download is marked failed with the real error and no debug assertion pixel fires.

### Impact
Low — removes a false-positive debug assertion; no user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts which Cocoa write errors skip a debug assertion; download failure handling and user flows are unchanged.
> 
> **Overview**
> Stops false **`m.mac.debug.assertion.failure`** pixels when a download’s server-suggested name exceeds the filesystem limit (`NSFileWriteInvalidFileNameError` / `ENAMETOOLONG`). That case was missing from the legitimate write-error allow-list in `FileDownloadManager.defaultDownloadLocation`, so placeholder creation failures were treated as “unexpected” even though the download already fails with the real Cocoa error.
> 
> **`NSFileWriteInvalidFileNameError`** is now included alongside disk-full, permission, and similar codes so the assertion is skipped while the task still ends in **`.failed`** with the underlying error—same user-visible outcome, no save dialog fallback.
> 
> Adds **`testWhenFileCreationFailsWithInvalidFileNameThenDownloadIsMarkedFailed`** to lock in: no `chooseDestination`, nil destination to WebKit, and failed state with the invalid-filename code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f3e2541e03bea7827ee84a8a4e56c823c6b337d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->