### PR TITLE
[macOS] Load pinned tabs before extracting Duck.ai page content

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -856,13 +856,15 @@ final class AIChatOmnibarController {
         persistTabAttachmentsToActiveTab(current)
     }
 
-    /// Wakes a just-attached tab if it's suspended so its content is loaded by the time the user
-    /// submits, avoiding a submit-time wait. Fire-and-forget — `extractPageContextsForOmnibarSubmit`
-    /// re-resolves and wakes regardless, so this is purely a latency optimization.
+    /// Wakes a just-attached tab whose page isn't loaded yet — a suspended tab, or a pinned tab
+    /// restored at launch and not yet selected — so its content is ready by the time the user submits.
+    /// Fire-and-forget: `extractPageContextsForOmnibarSubmit` re-resolves and waits regardless, so this
+    /// is purely a latency optimization. Without it a pinned-tab attach pays the full navigation +
+    /// collect budget on the submit critical path.
     private func prewarmAttachedTab(id: String) {
         guard let originTabCollection = origin?.originTabCollectionViewModel,
               let resolved = AIChatTabPickerSource.materializeAttachableTab(withId: id, forOrigin: originTabCollection, in: Application.appDelegate.windowControllersManager),
-              resolved.wasMaterialized else {
+              resolved.needsLoad else {
             return
         }
         resolved.tab.reload()

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -856,11 +856,8 @@ final class AIChatOmnibarController {
         persistTabAttachmentsToActiveTab(current)
     }
 
-    /// Wakes a just-attached tab whose page isn't loaded yet — a suspended tab, or a pinned tab
-    /// restored at launch and not yet selected — so its content is ready by the time the user submits.
-    /// Fire-and-forget: `extractPageContextsForOmnibarSubmit` re-resolves and waits regardless, so this
-    /// is purely a latency optimization. Without it a pinned-tab attach pays the full navigation +
-    /// collect budget on the submit critical path.
+    /// Starts loading a just-attached tab whose page isn't loaded yet, so it's ready by submit time.
+    /// Fire-and-forget: the submit path waits regardless, this just keeps it off the critical path.
     private func prewarmAttachedTab(id: String) {
         guard let originTabCollection = origin?.originTabCollectionViewModel,
               let resolved = AIChatTabPickerSource.materializeAttachableTab(withId: id, forOrigin: originTabCollection, in: Application.appDelegate.windowControllersManager),

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatTabPickerSource.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatTabPickerSource.swift
@@ -76,9 +76,24 @@ enum AIChatTabPickerSource {
     /// The result of resolving a picked tab id to a live `Tab`.
     struct ResolvedTab {
         let tab: Tab
-        /// True when the tab was `.unloaded` (suspended or never-loaded) and we just materialized it —
-        /// the caller should trigger a load and wait for navigation before extracting content.
+        /// True when the tab was `.unloaded` (suspended or never-loaded) and we just materialized it.
         let wasMaterialized: Bool
+
+        /// True when the tab has no page in its web view at all, so a load must be kicked before its
+        /// content can be collected.
+        ///
+        /// `wasMaterialized` alone isn't enough: a pinned tab restored at launch is eagerly
+        /// materialized to `.loaded` by `PinnedTabsManager.setUp(movingTabsFrom:)`, yet it holds its
+        /// page in `interactionStateData` and doesn't load until first selection or lazy loading. Such
+        /// a tab resolves with `wasMaterialized == false` while still having an empty web view.
+        ///
+        /// `webView.url == nil` is the same condition `Tab.reload()` uses to route to
+        /// `reloadIfNeeded(source: .lazyLoad)`. Note it goes false as soon as a provisional navigation
+        /// starts, so it means "nothing loaded and nothing in flight" — use `tab.isLoading` to detect a
+        /// load that's already running.
+        var needsLoad: Bool {
+            wasMaterialized || tab.webView.url == nil
+        }
     }
 
     /// Locates the attachable tab with `id` across the origin-scoped collections — **including

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatTabPickerSource.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatTabPickerSource.swift
@@ -79,18 +79,8 @@ enum AIChatTabPickerSource {
         /// True when the tab was `.unloaded` (suspended or never-loaded) and we just materialized it.
         let wasMaterialized: Bool
 
-        /// True when the tab has no page in its web view at all, so a load must be kicked before its
-        /// content can be collected.
-        ///
-        /// `wasMaterialized` alone isn't enough: a pinned tab restored at launch is eagerly
-        /// materialized to `.loaded` by `PinnedTabsManager.setUp(movingTabsFrom:)`, yet it holds its
-        /// page in `interactionStateData` and doesn't load until first selection or lazy loading. Such
-        /// a tab resolves with `wasMaterialized == false` while still having an empty web view.
-        ///
-        /// `webView.url == nil` is the same condition `Tab.reload()` uses to route to
-        /// `reloadIfNeeded(source: .lazyLoad)`. Note it goes false as soon as a provisional navigation
-        /// starts, so it means "nothing loaded and nothing in flight" — use `tab.isLoading` to detect a
-        /// load that's already running.
+        /// True when the web view has no page yet. A pinned tab restored at launch is already `.loaded`
+        /// but unloaded until first selection, so `wasMaterialized` alone misses it.
         var needsLoad: Bool {
             wasMaterialized || tab.webView.url == nil
         }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -565,11 +565,13 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         }
     }
 
-    /// Resolves `tabId` to a live `Tab` within the origin scope — **waking a suspended/unloaded tab
-    /// if needed** — then extracts its page context. A freshly-woken tab's page isn't loaded yet, so
-    /// we trigger a load and wait (bounded) for navigation to finish before collecting; an
-    /// already-loaded tab (e.g. the current page) extracts immediately with no wait. Returns `nil`
-    /// if the tab can't be found, the wake fails, or the page doesn't load within the budget.
+    /// Resolves `tabId` to a live `Tab` within the origin scope — **waking a tab whose page isn't
+    /// loaded yet** — then extracts its page context. A tab with an empty web view (just materialized
+    /// from `.unloaded`, or a pinned tab restored at launch and not yet selected) has its load kicked
+    /// here; a tab whose load is already in flight is waited on. Either way we wait (bounded) for
+    /// loading to finish before collecting, otherwise an early empty JS response could win the
+    /// `collectAndWait` race. An already-loaded tab (e.g. the current page) extracts immediately with
+    /// no wait. Returns `nil` if the tab can't be found or the page doesn't load within the budget.
     /// Never selects or focuses the tab.
     @MainActor
     static func extractPageContext(forTabId tabId: String,
@@ -581,34 +583,48 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             return nil
         }
 
-        if resolved.wasMaterialized {
-            // Mirror `resumeTab(at:)`: a just-materialized tab won't auto-load, so kick a reload and
-            // wait for navigation to finish before collecting — otherwise an early empty JS response
-            // could win the `collectAndWait` race.
-            let didNavigate = await waitForNavigationFinish(tab: resolved.tab, timeout: navigationTimeout) {
+        // `isLoading` is checked first: the attach-time prewarm (or the lazy loader) may already have a
+        // load running, and `needsLoad` goes false the moment that navigation starts. Kicking another
+        // `reload()` over it would restart the load we're about to wait for.
+        if resolved.tab.isLoading {
+            let didLoad = await waitForLoadingFinish(tab: resolved.tab, timeout: navigationTimeout) {}
+            guard didLoad else { return nil }
+        } else if resolved.needsLoad {
+            // Mirror `resumeTab(at:)`: a tab with an empty web view won't auto-load, so kick it.
+            let didLoad = await waitForLoadingFinish(tab: resolved.tab, timeout: navigationTimeout) {
                 resolved.tab.reload()
             }
-            guard didNavigate else { return nil }
+            guard didLoad else { return nil }
         }
 
         return await extractPageContext(from: resolved.tab, timeout: collectTimeout)
     }
 
-    /// Subscribes to the tab's first finished navigation, runs `start()` (e.g. `reload()`), and
-    /// awaits the navigation bounded by `timeout`. Subscribing before `start()` avoids missing a
-    /// fast-finishing navigation. Returns `true` if navigation finished, `false` on timeout.
+    /// Subscribes to the tab's first completed load, runs `start()` (e.g. `reload()`), and awaits the
+    /// load bounded by `timeout`. Subscribing before `start()` avoids missing a fast-finishing load.
+    /// Pass an empty `start` to wait on a load that's already in flight. Returns `true` if loading
+    /// completed, `false` on timeout.
     ///
-    /// The navigation signal is bridged through an `AsyncStream` (not `withCheckedContinuation`) so
-    /// that cancelling the task group on timeout actually tears the waiter down — a bare
-    /// continuation isn't cancellation-aware, so the timeout loser would otherwise hang the group
-    /// forever and leak the continuation. Mirrors `PageContextUserScript.collectAndWait`.
+    /// Waits on `loadingFinishedPublisher` rather than `webViewDidFinishNavigationPublisher`: the
+    /// latter also requires `navigationDelegate.currentNavigation` to be non-nil and filters
+    /// same-document navigations, neither of which is guaranteed when the wake is served by
+    /// `Tab.restoreInteractionState(with:)` (a `reloadIfNeeded` that returns no `ExpectedNavigation`).
+    /// `TabLazyLoader` loads restored pinned tabs with the same plain `reload()` and waits on
+    /// `loadingFinishedPublisher`, so it's proven for that state. It also completes on failure
+    /// (`NavigationState.isCompleted`), so an unreachable page resolves at once instead of burning the
+    /// whole timeout.
+    ///
+    /// The signal is bridged through an `AsyncStream` (not `withCheckedContinuation`) so that
+    /// cancelling the task group on timeout actually tears the waiter down — a bare continuation isn't
+    /// cancellation-aware, so the timeout loser would otherwise hang the group forever and leak the
+    /// continuation. Mirrors `PageContextUserScript.collectAndWait`.
     @MainActor
-    private static func waitForNavigationFinish(tab: Tab,
-                                                timeout: TimeInterval,
-                                                start: @escaping @MainActor () -> Void) async -> Bool {
-        let navigationFinished = AsyncStream<Void> { continuation in
+    private static func waitForLoadingFinish(tab: Tab,
+                                             timeout: TimeInterval,
+                                             start: @escaping @MainActor () -> Void) async -> Bool {
+        let loadingFinished = AsyncStream<Void> { continuation in
             var cancellable: AnyCancellable?
-            cancellable = tab.webViewDidFinishNavigationPublisher
+            cancellable = tab.loadingFinishedPublisher
                 .first()
                 .sink { _ in
                     continuation.yield(())
@@ -620,7 +636,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
 
         return await withTaskGroup(of: Bool.self) { group in
             group.addTask {
-                for await _ in navigationFinished { return true }
+                for await _ in loadingFinished { return true }
                 return false
             }
             group.addTask {

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -565,14 +565,8 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         }
     }
 
-    /// Resolves `tabId` to a live `Tab` within the origin scope — **waking a tab whose page isn't
-    /// loaded yet** — then extracts its page context. A tab with an empty web view (just materialized
-    /// from `.unloaded`, or a pinned tab restored at launch and not yet selected) has its load kicked
-    /// here; a tab whose load is already in flight is waited on. Either way we wait (bounded) for
-    /// loading to finish before collecting, otherwise an early empty JS response could win the
-    /// `collectAndWait` race. An already-loaded tab (e.g. the current page) extracts immediately with
-    /// no wait. Returns `nil` if the tab can't be found or the page doesn't load within the budget.
-    /// Never selects or focuses the tab.
+    /// Resolves `tabId` to a live `Tab` in the origin scope and extracts its page context, loading the
+    /// tab first (or waiting out a load in flight) so content isn't collected from a blank page.
     @MainActor
     static func extractPageContext(forTabId tabId: String,
                                    origin: TabCollectionViewModel,
@@ -583,14 +577,12 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             return nil
         }
 
-        // `isLoading` is checked first: the attach-time prewarm (or the lazy loader) may already have a
-        // load running, and `needsLoad` goes false the moment that navigation starts. Kicking another
-        // `reload()` over it would restart the load we're about to wait for.
+        // `needsLoad` goes false as soon as a navigation starts, so check for a load in flight first —
+        // otherwise the load started at attach time gets restarted here.
         if resolved.tab.isLoading {
             let didLoad = await waitForLoadingFinish(tab: resolved.tab, timeout: navigationTimeout) {}
             guard didLoad else { return nil }
         } else if resolved.needsLoad {
-            // Mirror `resumeTab(at:)`: a tab with an empty web view won't auto-load, so kick it.
             let didLoad = await waitForLoadingFinish(tab: resolved.tab, timeout: navigationTimeout) {
                 resolved.tab.reload()
             }
@@ -600,28 +592,13 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         return await extractPageContext(from: resolved.tab, timeout: collectTimeout)
     }
 
-    /// Subscribes to the tab's first completed load, runs `start()` (e.g. `reload()`), and awaits the
-    /// load bounded by `timeout`. Subscribing before `start()` avoids missing a fast-finishing load.
-    /// Pass an empty `start` to wait on a load that's already in flight. Returns `true` if loading
-    /// completed, `false` on timeout.
-    ///
-    /// Waits on `loadingFinishedPublisher` rather than `webViewDidFinishNavigationPublisher`: the
-    /// latter also requires `navigationDelegate.currentNavigation` to be non-nil and filters
-    /// same-document navigations, neither of which is guaranteed when the wake is served by
-    /// `Tab.restoreInteractionState(with:)` (a `reloadIfNeeded` that returns no `ExpectedNavigation`).
-    /// `TabLazyLoader` loads restored pinned tabs with the same plain `reload()` and waits on
-    /// `loadingFinishedPublisher`, so it's proven for that state. It also completes on failure
-    /// (`NavigationState.isCompleted`), so an unreachable page resolves at once instead of burning the
-    /// whole timeout.
-    ///
-    /// The signal is bridged through an `AsyncStream` (not `withCheckedContinuation`) so that
-    /// cancelling the task group on timeout actually tears the waiter down — a bare continuation isn't
-    /// cancellation-aware, so the timeout loser would otherwise hang the group forever and leak the
-    /// continuation. Mirrors `PageContextUserScript.collectAndWait`.
+    /// Runs `start()` and waits (bounded) for the tab's first completed load; pass an empty `start` to
+    /// wait on a load already in flight. Same signal `TabLazyLoader` uses for restored pinned tabs.
     @MainActor
     private static func waitForLoadingFinish(tab: Tab,
                                              timeout: TimeInterval,
                                              start: @escaping @MainActor () -> Void) async -> Bool {
+        // `AsyncStream` rather than a continuation so cancelling on timeout tears the waiter down.
         let loadingFinished = AsyncStream<Void> { continuation in
             var cancellable: AnyCancellable?
             cancellable = tab.loadingFinishedPublisher

--- a/macOS/UnitTests/AIChat/AIChatTabPickerSourceTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatTabPickerSourceTests.swift
@@ -86,6 +86,39 @@ final class AIChatTabPickerSourceTests: XCTestCase {
         XCTAssertTrue(resolved?.wasMaterialized == true)
     }
 
+    // MARK: - needsLoad (page not in the web view yet)
+
+    func testNeedsLoadIsTrueForJustMaterializedSuspendedTab() {
+        let collection = collectionWithSuspendedTab(id: "suspended-4", url: "https://apple.com")
+        let wcm = WindowControllersManagerMock()
+        wcm.customAllTabCollectionViewModels = [collection]
+
+        let resolved = AIChatTabPickerSource.materializeAttachableTab(withId: "suspended-4", forOrigin: collection, in: wcm)
+
+        XCTAssertTrue(resolved?.wasMaterialized == true)
+        XCTAssertTrue(resolved?.needsLoad == true)
+    }
+
+    /// The pinned-tab-at-launch shape: `PinnedTabsManager.setUp(movingTabsFrom:)` eagerly materializes
+    /// restored pinned tabs into `.loaded` (see `PinnedTabsManagerTests.testSetUpMaterializesUnloadedTabs`),
+    /// but `materialize()` performs no navigation — the page stays in `interactionStateData` until first
+    /// selection or lazy loading. So the tab resolves as *not* materialized while its web view is still
+    /// empty, which is exactly the case the old `wasMaterialized`-only gate skipped: extraction then ran
+    /// against a blank page and the attachment was silently dropped from the payload.
+    func testNeedsLoadIsTrueForRestoredTabThatWasAlreadyLoadedButNeverNavigated() {
+        let restored = Tab(content: .url(URL(string: "https://pinned.example")!, credential: nil, source: .pendingStateRestoration),
+                           interactionStateData: Data())
+        let collection = TabCollectionViewModel(tabCollection: TabCollection(tabs: [restored]))
+        let wcm = WindowControllersManagerMock()
+        wcm.customAllTabCollectionViewModels = [collection]
+
+        let resolved = AIChatTabPickerSource.materializeAttachableTab(withId: restored.uuid, forOrigin: collection, in: wcm)
+
+        XCTAssertNotNil(resolved)
+        XCTAssertFalse(resolved?.wasMaterialized ?? true, "Nothing to materialize — the tab is already .loaded")
+        XCTAssertTrue(resolved?.needsLoad == true, "…but its web view has no page, so a load must still be kicked")
+    }
+
     func testMaterializeDoesNotResolveRegularTabFromFireWindowOrigin() {
         let regular = collectionWithSuspendedTab(id: "suspended-3", url: "https://apple.com")
         let burner = burnerCollection()

--- a/macOS/UnitTests/AIChat/AIChatTabPickerSourceTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatTabPickerSourceTests.swift
@@ -99,12 +99,8 @@ final class AIChatTabPickerSourceTests: XCTestCase {
         XCTAssertTrue(resolved?.needsLoad == true)
     }
 
-    /// The pinned-tab-at-launch shape: `PinnedTabsManager.setUp(movingTabsFrom:)` eagerly materializes
-    /// restored pinned tabs into `.loaded` (see `PinnedTabsManagerTests.testSetUpMaterializesUnloadedTabs`),
-    /// but `materialize()` performs no navigation — the page stays in `interactionStateData` until first
-    /// selection or lazy loading. So the tab resolves as *not* materialized while its web view is still
-    /// empty, which is exactly the case the old `wasMaterialized`-only gate skipped: extraction then ran
-    /// against a blank page and the attachment was silently dropped from the payload.
+    /// The pinned-tab-at-launch shape: already `.loaded` so there's nothing to materialize, but the web
+    /// view is still empty. This is the case a `wasMaterialized`-only check skips.
     func testNeedsLoadIsTrueForRestoredTabThatWasAlreadyLoadedButNeverNavigated() {
         let restored = Tab(content: .url(URL(string: "https://pinned.example")!, credential: nil, source: .pendingStateRestoration),
                            interactionStateData: Data())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217124903028827?focus=true
CC:

### Description

Attaching a pinned tab that hadn't been selected since browser start sent no page content to the conversation. The attachment card showed up as normal, so it looked like it had worked.

The check for "does this tab need loading before I read its content?" missed two cases:

- **A pinned tab restored at launch.** It's already a full tab, but its page isn't loaded until you first click it — so content got read from an empty web view.
- **A tab that's still loading.** The page URL is set the moment a load starts, which made the tab look ready, so content got read half-way through the load. This one affects suspended tabs on `main` too; it's hidden by the second or two people take to type a prompt.

Both now load (or wait for the in-flight load) before reading. Also waits on "loading finished" instead of "navigation finished", because restoring a saved page doesn't produce the navigation the old signal needed.

Covers both attach paths — the omnibar and the sidebar `@`-mention picker share the same extraction code.

### Testing Steps

1. Pin a content-heavy page. Quit the browser, relaunch, and **do not** click the pinned tab.
2. Switch the address bar to Duck.ai mode and attach that pinned tab.
3. Ask something answerable only from that page → the answer uses the page content. On `main` the same steps answer with no page context.
4. Repeat steps 1–2, then submit immediately instead of pausing → content still arrives (covers the in-flight-load case).
5. Repeat step 4 with a *suspended, unpinned* tab → content still arrives. This case is also broken on `main`.
6. Attach a normal already-loaded tab, and the current tab → both attach with no reload flicker and no added delay.
7. Attach a pinned tab pointing at an unreachable host → resolves promptly rather than hanging for ~5s.
8. Repeat step 3 through the sidebar's `@`-mention picker → content arrives there too.

### Impact

Low. Limited to attaching a tab in Duck.ai; already-loaded tabs take the same no-wait path as before.

#### What could go wrong?

- A load that never reports finishing would leave the attachment dropped, as it is today → bounded by the existing timeout, and the signal now used is the one the lazy loader already relies on for these tabs.
- Attaching a tab now triggers a load for pinned tabs that hadn't loaded → only when the web view has no page at all, so no visible page is reloaded under the user.

### Quality Considerations

Unit tests cover the new check for both shapes that need a load, including the restored-pinned-tab shape paired with an assertion that the old check reads false for it. The negative case and the in-flight-load branch aren't unit-testable — tabs never navigate under unit tests, so every tab has a nil web view URL. Those rely on the manual steps above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Duck.ai tab attachment and page-context extraction; already-loaded tabs keep the no-wait path. Bounded timeouts limit hang risk if a load never finishes.
> 
> **Overview**
> Fixes **empty or partial page content** when attaching tabs in Duck.ai (omnibar and sidebar `@` picker) by treating “needs a real page in the web view” more broadly than “was just materialized from suspended.”
> 
> **`ResolvedTab.needsLoad`** is true when the tab was materialized **or** `webView.url` is still nil — covering **pinned tabs restored at launch** that are already `.loaded` but never navigated until first click.
> 
> **Submit-time extraction** now waits on an **in-flight load** before starting another (`isLoading` first), then reloads only when `needsLoad` is still true. Prewarm on attach uses the same `needsLoad` gate.
> 
> The wait path switches from **navigation finished** to **`loadingFinishedPublisher`** (same signal as `TabLazyLoader`), so restored interaction state without a navigation event still completes correctly.
> 
> Unit tests cover `needsLoad` for materialized suspended tabs and restored-but-never-navigated tabs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c8d5ad0207708097c7097b9a8f9a72f68e8bc1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->