### PR TITLE
Rename macosPromptBar feature flag to promptBar

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -626,7 +626,7 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     case nativeSidebar
 
     /// macOS only. System-wide Duck.ai entry point: global keyboard shortcut and menu bar icon.
-    case macosPromptBar
+    case promptBar
 
     /// Supports Duck.ai edit prompt from the native input field.
     case nativePromptEditing

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1634,7 +1634,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// The settings toggles only cover users who touch a setting; this sizes the enabled base.
     @MainActor
     private func fireDailyPromptBarStatePixel() {
-        guard featureFlagger.isFeatureOn(.macosPromptBar) else { return }
+        guard featureFlagger.isFeatureOn(.promptBar) else { return }
 
         PixelKit.fire(PromptBarPixel.state(shortcutEnabled: promptBarPreferences.isKeyboardShortcutEnabled,
                                            menuBarIconEnabled: promptBarPreferences.isMenuBarIconVisible),
@@ -2445,7 +2445,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Must run before `setUpPromptBarMenuBarVisibility()`, which hands the icon's click to the coordinator.
     @MainActor
     private func setUpPromptBar() {
-        guard featureFlagger.isFeatureOn(.macosPromptBar) else {
+        guard featureFlagger.isFeatureOn(.promptBar) else {
             promptBarCoordinator = nil
             return
         }
@@ -2469,7 +2469,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     private func setUpPromptBarMenuBarVisibility() {
-        guard featureFlagger.isFeatureOn(.macosPromptBar) else {
+        guard featureFlagger.isFeatureOn(.promptBar) else {
             promptBarMenuBarController?.hide()
             promptBarMenuBarController = nil
             promptBarMenuBarCancellable = nil

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -169,7 +169,7 @@ final class AIChatPreferences: ObservableObject {
     }
 
     var shouldShowPromptBarPreferences: Bool {
-        featureFlagger.isFeatureOn(.macosPromptBar)
+        featureFlagger.isFeatureOn(.promptBar)
     }
 
     // Native SERP AI settings (Search Assist / Hide AI Images), backed by the shared SERP settings store.

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarCoordinator.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarCoordinator.swift
@@ -43,7 +43,7 @@ final class PromptBarCoordinator {
     }
 
     func start() {
-        guard featureFlagger.isFeatureOn(.macosPromptBar) else { return }
+        guard featureFlagger.isFeatureOn(.promptBar) else { return }
 
         shortcutCancellable = preferences.effectiveKeyboardShortcutPublisher
             .sink { [weak self] shortcut in
@@ -53,7 +53,7 @@ final class PromptBarCoordinator {
 
     /// - Parameter source: The entry point that asked, which is what the visibility pixels report.
     func togglePromptBar(source: PromptBarPresentationSource) {
-        guard featureFlagger.isFeatureOn(.macosPromptBar) else { return }
+        guard featureFlagger.isFeatureOn(.promptBar) else { return }
         presenter.toggle(source: source)
     }
 

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -471,7 +471,7 @@ public enum FeatureFlag: String, CaseIterable {
     /// Gates the macOS Prompt Bar: a system-wide Duck.ai entry point opened via a global
     /// keyboard shortcut or a menu bar icon, plus its rows on the AI Features settings screen.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216850216210288?focus=true
-    case macosPromptBar
+    case promptBar
 
     /// Gates the bookmarks "Reorder by name" action, which permanently reorders the target
     /// folder's direct children alphabetically and persists the new order.
@@ -790,8 +790,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(SyncSubfeature.canUseV2ConnectFlow), category: .sync)
         case .syncCanShowV2ConnectCode:
             Config(source: .remoteReleasable(SyncSubfeature.canShowV2ConnectCode), category: .sync)
-        case .macosPromptBar:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.macosPromptBar), category: .duckAI)
+        case .promptBar:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.promptBar), category: .duckAI)
         case .bookmarksReorderByName:
             Config(defaultValue: .disabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.bookmarksReorderByName))
         }

--- a/macOS/UnitTests/PromptBar/PromptBarCoordinatorTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarCoordinatorTests.swift
@@ -90,7 +90,7 @@ final class PromptBarCoordinatorTests: XCTestCase {
     ) -> (PromptBarCoordinator, PromptBarPreferences, MockGlobalShortcutRegistrar, MockPromptBarPresenter) {
         let registrar = MockGlobalShortcutRegistrar()
         let presenter = MockPromptBarPresenter()
-        let featureFlagger = MockFeatureFlagger(featuresStub: [FeatureFlag.macosPromptBar.rawValue: isFeatureOn])
+        let featureFlagger = MockFeatureFlagger(featuresStub: [FeatureFlag.promptBar.rawValue: isFeatureOn])
 
         let configuration = MockAIChatConfig()
         configuration.shouldDisplayAnyAIChatFeature = isDuckAIAvailable


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217149067901421?focus=true
Tech Design URL:
CC:

### Description
Renames the matching FeatureFlag case and its call sites. Behaviour is unchanged

### Testing Steps
1. Enable the promptBar feature flag, check the prompt bar feature is working as expected

### Impact
Low

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure rename of enum cases and call sites; flag semantics and remote subfeature mapping stay the same aside from the new name.
> 
> **Overview**
> Renames the macOS Duck.ai **Prompt Bar** feature flag from `macosPromptBar` to `promptBar` across privacy config (`AIChatSubfeature`), macOS `FeatureFlag`, and every gate (AppDelegate setup/pixels, `AIChatPreferences`, `PromptBarCoordinator`, unit tests). **Remote config wiring** now points at `AIChatSubfeature.promptBar` with the same internal-only default and Duck.ai category—**no behavior change**, only identifier alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b25b6a4640dd5905a39f9b05d293754f4b615355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->