### PR TITLE
iOS: Capture tab previews with takeSnapshot instead of blocking drawHierarchy

### DIFF
--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -59,6 +59,17 @@ enum WebViewPreviewSnapshotGeometry {
         guard webViewBounds.width > 0, webViewBounds.height > 0 else { return nil }
         return webViewBounds
     }
+
+    /// The web content rect with the top and bottom content insets removed, matching the framing the
+    /// synchronous `drawHierarchy` capture produced.
+    static func visibleRect(webViewBounds: CGRect, contentInset: UIEdgeInsets) -> CGRect? {
+        let rect = webViewBounds.inset(by: UIEdgeInsets(top: contentInset.top,
+                                                       left: 0,
+                                                       bottom: contentInset.bottom,
+                                                       right: 0))
+        guard rect.width > 0, rect.height > 0 else { return nil }
+        return rect
+    }
 }
 
 class TabViewController: UIViewController {
@@ -2260,26 +2271,34 @@ extension TabViewController: WKNavigationDelegate {
         }
     }
 
+    /// Captures a preview of the current web content via WebKit's asynchronous `takeSnapshot`, which
+    /// renders out of process rather than blocking the main thread. Falls back to `preparePreviewSync`
+    /// only while a JS alert is on screen, since `takeSnapshot` captures web content but not native overlays.
     func preparePreview(completion: @escaping (UIImage?) -> Void) {
-        guard FloatingUIManager(featureFlagger: featureFlagger).isFloatingUIEnabled else {
-            DispatchQueue.main.async { [weak self] in
-                completion(self?.preparePreviewSync(afterScreenUpdates: true))
-            }
-            return
-        }
+        let capturesFullBounds = FloatingUIManager(featureFlagger: featureFlagger).isFloatingUIEnabled
 
         DispatchQueue.main.async { [weak self] in
-            guard let self,
-                  let webView,
-                  let rect = WebViewPreviewSnapshotGeometry.visibleRect(
-                    webViewBounds: webView.bounds
-                  ) else {
+            guard let self, let webView else {
+                completion(nil)
+                return
+            }
+
+            if jsAlertView?.isShown == true {
+                completion(preparePreviewSync(afterScreenUpdates: true))
+                return
+            }
+
+            let visibleRect = capturesFullBounds
+                ? WebViewPreviewSnapshotGeometry.visibleRect(webViewBounds: webView.bounds)
+                : WebViewPreviewSnapshotGeometry.visibleRect(webViewBounds: webView.bounds,
+                                                            contentInset: webView.scrollView.contentInset)
+            guard let visibleRect else {
                 completion(nil)
                 return
             }
 
             let configuration = WKSnapshotConfiguration()
-            configuration.rect = rect
+            configuration.rect = visibleRect
             configuration.afterScreenUpdates = true
             webView.takeSnapshot(with: configuration) { image, _ in
                 completion(image)
@@ -2314,6 +2333,9 @@ extension TabViewController: WKNavigationDelegate {
         }
     }
 
+    /// Renders the web view on the calling thread. `drawHierarchy` blocks until the render server
+    /// commits, so this stalls the main thread — prefer `preparePreview`. Retained only to capture
+    /// native overlays that `takeSnapshot` cannot see.
     private func preparePreviewSync(afterScreenUpdates: Bool = false) -> UIImage? {
         guard let webView, webView.bounds.height > 0, webView.bounds.width > 0 else { return nil }
 

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -61,14 +61,15 @@ enum WebViewPreviewSnapshotGeometry {
     }
 
     /// The web content rect with the top and bottom content insets removed, matching the framing the
-    /// synchronous `drawHierarchy` capture produced.
+    /// synchronous `drawHierarchy` capture produced. Nil when the insets leave no visible height.
     static func visibleRect(webViewBounds: CGRect, contentInset: UIEdgeInsets) -> CGRect? {
-        let rect = webViewBounds.inset(by: UIEdgeInsets(top: contentInset.top,
-                                                       left: 0,
-                                                       bottom: contentInset.bottom,
-                                                       right: 0))
-        guard rect.width > 0, rect.height > 0 else { return nil }
-        return rect
+        let remainingHeight = webViewBounds.height - contentInset.top - contentInset.bottom
+        guard webViewBounds.width > 0, remainingHeight > 0 else { return nil }
+
+        return webViewBounds.inset(by: UIEdgeInsets(top: contentInset.top,
+                                                    left: 0,
+                                                    bottom: contentInset.bottom,
+                                                    right: 0))
     }
 }
 

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -317,6 +317,29 @@ final class WebViewPreviewSnapshotGeometryTests: XCTestCase {
     func testWhenViewportIsEmptyThenVisibleRectIsNil() {
         XCTAssertNil(WebViewPreviewSnapshotGeometry.visibleRect(webViewBounds: .zero))
     }
+
+    func testWhenContentInsetIsGivenThenVisibleRectExcludesTopAndBottomInsets() {
+        let bounds = CGRect(x: 0, y: 0, width: 320, height: 640)
+        let contentInset = UIEdgeInsets(top: 50, left: 0, bottom: 30, right: 0)
+
+        XCTAssertEqual(WebViewPreviewSnapshotGeometry.visibleRect(webViewBounds: bounds, contentInset: contentInset),
+                       CGRect(x: 0, y: 50, width: 320, height: 560))
+    }
+
+    func testWhenContentInsetHasHorizontalValuesThenVisibleRectKeepsFullWidth() {
+        let bounds = CGRect(x: 0, y: 0, width: 320, height: 640)
+        let contentInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+
+        XCTAssertEqual(WebViewPreviewSnapshotGeometry.visibleRect(webViewBounds: bounds, contentInset: contentInset),
+                       bounds)
+    }
+
+    func testWhenContentInsetsExceedHeightThenVisibleRectIsNil() {
+        let bounds = CGRect(x: 0, y: 0, width: 320, height: 100)
+        let contentInset = UIEdgeInsets(top: 60, left: 0, bottom: 60, right: 0)
+
+        XCTAssertNil(WebViewPreviewSnapshotGeometry.visibleRect(webViewBounds: bounds, contentInset: contentInset))
+    }
 }
 
 final class FloatingSwipePreviewGeometryTests: XCTestCase {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1217093719249437
Tech Design URL:
CC:

### Description

Tab thumbnails were captured by rendering the web view synchronously on the main thread, which blocks until the render server responds — and since web content lives in a separate process, that wait is cross-process. It ran on every completed page load.

Capture now uses WebKit's asynchronous snapshot API, which this same file already uses for its other two preview paths, so the work no longer occupies our main thread. The old synchronous renderer is kept for the one case the snapshot API cannot cover: a JavaScript alert on screen.

Apple's hang diagnostics list this call site as a hang point in every release since 7.227.0, growing to roughly 2 reports/day in 7.230.0. The same API caused the 7.226.0/7.227.0 hang spike, fixed then by #5683.

### Testing Steps

Regression testing only. The hang is a 95th-percentile field effect whose cost varies with page complexity and memory pressure, so it will not reproduce reliably on a development device and a clean local run would not demonstrate the fix — that will be confirmed from Organizer hang data after release. What matters here is that tab thumbnails are unchanged.

Throughout: load a content-heavy page (e.g. a news site), open the tab switcher, and check the thumbnail shows the right page correctly framed — no toolbar chrome captured, no black bands, no vertical offset, no stretching, not blank.

1. Address bar at the top.
2. Address bar at the bottom (Settings → Appearance → Address Bar).
3. Scrolled down far enough that the toolbars have auto-hidden.
4. Open 4–5 tabs on different sites → each thumbnail shows its own tab and none are blank.
5. On a page that shows a JavaScript alert, with the alert on screen → the thumbnail is still captured and includes the alert. This is the one case that deliberately still uses the old synchronous renderer.

Steps 1–3 matter most: thumbnails are cropped using the web view's content insets, and those differ in each of those states.

### Impact

Medium. Tab thumbnails are user-visible, so a capture regression would show up as blank or badly framed thumbnails. No privacy or data-loss risk.

#### What could go wrong?

- The snapshot API returns nil where the old renderer returned an image → the thumbnail is simply not updated; `updatePreview()` already skips nil images, so the previous thumbnail stays.
- Framing shifts, because the old path cropped top and bottom content insets while the existing geometry helper returned full bounds → a new inset-aware overload reproduces the original framing, covered by unit tests and by steps 1–3.

### Quality Considerations

Only the inset-cropping path is live in production. The `floatingUI` flag selecting the full-bounds path is absent from the live privacy config and its flag default is `.disabled`, so every user takes the cropped path — which is also why the synchronous renderer was universal rather than a rare fallback.

This is a partial fix. The call site accounts for roughly 8% of hang reports in 7.230.0. Apple's diagnostics carry no duration field, so its share of hang *seconds* is unknown and plausibly larger, since a render-server round trip is a long stall. Unrelated subsystems also roughly doubled in that release, which points to broader main-thread contention; that is tracked separately on the linked task.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible tab thumbnails depend on snapshot success and inset math; failures keep the previous image, but framing regressions would show in the tab switcher.
> 
> **Overview**
> Tab switcher thumbnails are now captured with WebKit’s asynchronous **`takeSnapshot`** instead of synchronously **`drawHierarchy`** on the main thread, reducing main-thread stalls tied to cross-process render-server waits on page load.
> 
> When **floating UI** is off (the live default), snapshot framing matches the old cropped thumbnails via a new **`WebViewPreviewSnapshotGeometry.visibleRect`** overload that subtracts top/bottom scroll **content insets**; horizontal insets are ignored. With floating UI enabled, full web view bounds are still used.
> 
> **`preparePreviewSync`** remains only when a JavaScript alert overlay is visible, because **`takeSnapshot`** does not include native overlays. Unit tests cover inset edge cases (empty height, horizontal-only insets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434e1120d54779fb4531a4cb6a26fa6715c78bd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->