### PR TITLE
[macOS] Add Reorder by Name to bookmarks bar menu

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Model/BookmarkManager.swift
@@ -86,6 +86,26 @@ extension BookmarkManager {
     func move(objectUUIDs: [String], toIndex index: Int?, withinParentFolder parent: ParentFolderType) {
         move(objectUUIDs: objectUUIDs, toIndex: index, withinParentFolder: parent) { _ in }
     }
+
+    func reorderByName(_ children: [BaseBookmarkEntity], withinParentFolder parentFolder: ParentFolderType) {
+        let sortedChildIDs = children
+            .sorted(by: .nameAscending)
+            .map(\.id)
+
+        guard sortedChildIDs != children.map(\.id) else {
+            sortMode = .manual
+            return
+        }
+
+        move(objectUUIDs: sortedChildIDs, toIndex: 0, withinParentFolder: parentFolder) { [weak self] error in
+            guard let error else {
+                self?.sortMode = .manual
+                return
+            }
+
+            Logger.bookmarks.error("Failed to reorder bookmarks by name: \(error.localizedDescription, privacy: .public)")
+        }
+    }
 }
 final class LocalBookmarkManager: BookmarkManager {
 

--- a/macOS/DuckDuckGo/Bookmarks/Services/BookmarksContextMenu.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Services/BookmarksContextMenu.swift
@@ -21,7 +21,6 @@ import Bookmarks
 import DesignResourcesKitIcons
 import FeatureFlags
 import PrivacyConfig
-import os.log
 
 protocol BookmarksContextMenuDelegate: NSMenuDelegate, BookmarkSearchMenuItemSelectors {
     var isSearching: Bool { get }
@@ -469,24 +468,7 @@ extension BookmarksContextMenu: FolderMenuItemSelectors {
             return
         }
 
-        let sortedChildIDs = folder.children
-            .sorted(by: .nameAscending)
-            .map(\.id)
-
-        guard sortedChildIDs != folder.children.map(\.id) else {
-            bookmarkManager.sortMode = .manual
-            return
-        }
-
-        let bookmarkManager = bookmarkManager
-        bookmarkManager.move(objectUUIDs: sortedChildIDs, toIndex: 0, withinParentFolder: .parent(uuid: folder.id)) { error in
-            guard let error else {
-                bookmarkManager.sortMode = .manual
-                return
-            }
-
-            Logger.bookmarks.error("Failed to reorder bookmark folder by name: \(error.localizedDescription, privacy: .public)")
-        }
+        bookmarkManager.reorderByName(folder.children, withinParentFolder: .parent(uuid: folder.id))
     }
 
     @MainActor

--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarMenuFactory.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarMenuFactory.swift
@@ -36,10 +36,25 @@ struct BookmarksBarMenuFactory {
         menu.addItem(makeMenuItem(prefs))
     }
 
-    static func addToMenuWithManageBookmarksSection(_ menu: NSMenu, target: AnyObject, addFolderSelector: Selector, manageBookmarksSelector: Selector, prefs: AppearancePreferences) {
+    static func addToMenuWithManageBookmarksSection(
+        _ menu: NSMenu,
+        target: AnyObject,
+        addFolderSelector: Selector,
+        reorderByNameSelector: Selector?,
+        manageBookmarksSelector: Selector,
+        prefs: AppearancePreferences
+    ) {
         addToMenu(menu, prefs: prefs)
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: UserText.addFolder, action: addFolderSelector, target: target).withImage(DesignSystemImages.Glyphs.Size12.folderAdd))
+        if let reorderByNameSelector {
+            let reorderByNameItem = NSMenuItem(
+                title: UserText.bookmarksBarContextMenuReorderByName,
+                action: reorderByNameSelector,
+                target: target
+            ).withImage(DesignSystemImages.Glyphs.Size12.arrowUpDown)
+            menu.addItem(reorderByNameItem)
+        }
         menu.addItem(NSMenuItem(title: UserText.bookmarksManageBookmarks, action: manageBookmarksSelector, target: target).withImage(DesignSystemImages.Glyphs.Size12.bookmarks))
     }
 

--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
@@ -61,6 +61,7 @@ final class BookmarksBarViewController: NSViewController {
     private let viewModel: BookmarksBarViewModel
     private let tabCollectionViewModel: TabCollectionViewModel
     private let appereancePreferences: AppearancePreferencesPersistor
+    private let featureFlagger: FeatureFlagger
 
     let themeManager: ThemeManaging
     var themeUpdateCancellable: AnyCancellable?
@@ -81,9 +82,22 @@ final class BookmarksBarViewController: NSViewController {
     @UserDefaultsWrapper(key: .bookmarksBarPromptShown, defaultValue: false)
     var bookmarksBarPromptShown: Bool
 
-    static func create(tabCollectionViewModel: TabCollectionViewModel, bookmarkManager: BookmarkManager, dragDropManager: BookmarkDragDropManager, pinningManager: PinningManager) -> BookmarksBarViewController {
+    static func create(
+        tabCollectionViewModel: TabCollectionViewModel,
+        bookmarkManager: BookmarkManager,
+        dragDropManager: BookmarkDragDropManager,
+        pinningManager: PinningManager,
+        featureFlagger: FeatureFlagger
+    ) -> BookmarksBarViewController {
         NSStoryboard(name: "BookmarksBar", bundle: nil).instantiateInitialController { coder in
-            self.init(coder: coder, tabCollectionViewModel: tabCollectionViewModel, bookmarkManager: bookmarkManager, dragDropManager: dragDropManager, pinningManager: pinningManager)
+            self.init(
+                coder: coder,
+                tabCollectionViewModel: tabCollectionViewModel,
+                bookmarkManager: bookmarkManager,
+                dragDropManager: dragDropManager,
+                pinningManager: pinningManager,
+                featureFlagger: featureFlagger
+            )
         }!
     }
 
@@ -92,6 +106,7 @@ final class BookmarksBarViewController: NSViewController {
           bookmarkManager: BookmarkManager,
           dragDropManager: BookmarkDragDropManager,
           pinningManager: PinningManager,
+          featureFlagger: FeatureFlagger,
           appereancePreferences: AppearancePreferencesPersistor = AppearancePreferencesUserDefaultsPersistor(keyValueStore: NSApp.delegateTyped.keyValueStore),
           themeManager: ThemeManaging = NSApp.delegateTyped.themeManager,
     ) {
@@ -100,6 +115,7 @@ final class BookmarksBarViewController: NSViewController {
         self.pinningManager = pinningManager
         self.appereancePreferences = appereancePreferences
         self.themeManager = themeManager
+        self.featureFlagger = featureFlagger
 
         self.tabCollectionViewModel = tabCollectionViewModel
         self.viewModel = BookmarksBarViewModel(bookmarkManager: bookmarkManager,
@@ -573,7 +589,7 @@ extension BookmarksBarViewController: NSMenuDelegate {
             menu,
             target: self,
             addFolderSelector: #selector(addFolder(sender:)),
-            reorderByNameSelector: NSApp.delegateTyped.featureFlagger.isFeatureOn(.bookmarksReorderByName) ? #selector(reorderBookmarksBarByName(_:)) : nil,
+            reorderByNameSelector: featureFlagger.isFeatureOn(.bookmarksReorderByName) ? #selector(reorderBookmarksBarByName(_:)) : nil,
             manageBookmarksSelector: #selector(manageBookmarks),
             prefs: NSApp.delegateTyped.appearancePreferences
         )

--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
@@ -21,6 +21,7 @@ import Combine
 import Common
 import ConcurrencyExtensions
 import DesignResourcesKitIcons
+import FeatureFlags
 import Foundation
 import FoundationExtensions
 import os.log
@@ -558,6 +559,10 @@ private extension BookmarksBarViewController {
         showDialog(BookmarksDialogViewFactory.makeAddBookmarkFolderView(parentFolder: nil, bookmarkManager: bookmarkManager))
     }
 
+    @objc func reorderBookmarksBarByName(_ sender: NSMenuItem) {
+        bookmarkManager.reorderByName(bookmarkManager.list?.topLevelEntities ?? [], withinParentFolder: .root)
+    }
+
 }
 // MARK: - NSMenuDelegate
 extension BookmarksBarViewController: NSMenuDelegate {
@@ -568,6 +573,7 @@ extension BookmarksBarViewController: NSMenuDelegate {
             menu,
             target: self,
             addFolderSelector: #selector(addFolder(sender:)),
+            reorderByNameSelector: NSApp.delegateTyped.featureFlagger.isFeatureOn(.bookmarksReorderByName) ? #selector(reorderBookmarksBarByName(_:)) : nil,
             manageBookmarksSelector: #selector(manageBookmarks),
             prefs: NSApp.delegateTyped.appearancePreferences
         )

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -1987,7 +1987,7 @@ struct UserText {
     static let showBookmarksBarNewTabOnly = NSLocalizedString("bookmarks.bar.show.new-tab-only", value: "Only show on New Tab", comment: "Preference for only showing the bookmarks bar on new tab")
     static let bookmarksBarFolderEmpty = NSLocalizedString("bookmarks.bar.folder.empty", value: "Empty", comment: "Empty state for a bookmarks bar folder")
     static let bookmarksBarContextMenuDelete = NSLocalizedString("bookmarks.bar.context-menu.delete", value: "Delete", comment: "Delete menu item for the bookmarks bar context menu")
-    static let bookmarksBarContextMenuReorderByName = NotLocalizedString("bookmarks.bar.context-menu.reorder-by-name", value: "Reorder by Name", comment: "Reorder by Name menu item for bookmark folder context menus")
+    static let bookmarksBarContextMenuReorderByName = NotLocalizedString("bookmarks.bar.context-menu.reorder-by-name", value: "Reorder by name", comment: "Reorder by name menu item for bookmark folder context menus")
     static let bookmarksBarContextMenuMoveToEnd = NSLocalizedString("bookmarks.bar.context-menu.move-to-end", value: "Move to End", comment: "Move to End menu item for the bookmarks bar context menu")
 
     static let inviteDialogGetStartedButton = NSLocalizedString("invite.dialog.get.started.button", value: "Get Started", comment: "Get Started button on an invite dialog")

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -309,7 +309,8 @@ final class MainViewController: NSViewController {
             tabCollectionViewModel: tabCollectionViewModel,
             bookmarkManager: bookmarkManager,
             dragDropManager: bookmarkDragDropManager,
-            pinningManager: pinningManager
+            pinningManager: pinningManager,
+            featureFlagger: featureFlagger
         )
 
         // Create the shared AI Chat omnibar controller

--- a/macOS/IntegrationTests/BookmarksBar/BookmarksBarViewControllerTests.swift
+++ b/macOS/IntegrationTests/BookmarksBar/BookmarksBarViewControllerTests.swift
@@ -82,7 +82,13 @@ final class BookmarksBarViewControllerTests: XCTestCase {
     func testWhenThereAreBookmarks_ThenImportBookmarksButtonIsHidden() throws {
         // Given
         let boolmarkList = BookmarkList(topLevelEntities: [Bookmark(id: "test", url: "", title: "Something", isFavorite: false), Bookmark(id: "test", url: "", title: "Impori", isFavorite: false)])
-        let vc = BookmarksBarViewController.create(tabCollectionViewModel: TabCollectionViewModel(isPopup: false), bookmarkManager: bookmarksManager, dragDropManager: .init(bookmarkManager: bookmarksManager), pinningManager: MockPinningManager())
+        let vc = BookmarksBarViewController.create(
+            tabCollectionViewModel: TabCollectionViewModel(isPopup: false),
+            bookmarkManager: bookmarksManager,
+            dragDropManager: .init(bookmarkManager: bookmarksManager),
+            pinningManager: MockPinningManager(),
+            featureFlagger: MockFeatureFlagger()
+        )
         _=vc.view
         vc.viewWillAppear()
         vc.viewDidAppear()
@@ -107,7 +113,13 @@ final class BookmarksBarViewControllerTests: XCTestCase {
     @MainActor
     func testWhenThereAreNoBookmarks_AndbookmarkListEmpty_ThenImportBookmarksButtonIsNotShown() throws {
         // Given
-        let vc = BookmarksBarViewController.create(tabCollectionViewModel: TabCollectionViewModel(isPopup: false), bookmarkManager: bookmarksManager, dragDropManager: .init(bookmarkManager: bookmarksManager), pinningManager: MockPinningManager())
+        let vc = BookmarksBarViewController.create(
+            tabCollectionViewModel: TabCollectionViewModel(isPopup: false),
+            bookmarkManager: bookmarksManager,
+            dragDropManager: .init(bookmarkManager: bookmarksManager),
+            pinningManager: MockPinningManager(),
+            featureFlagger: MockFeatureFlagger()
+        )
         _=vc.view
         vc.viewWillAppear()
         vc.viewDidAppear()
@@ -120,7 +132,13 @@ final class BookmarksBarViewControllerTests: XCTestCase {
     func testWhenThereAreNoBookmarks_ThenImportBookmarksButtonIsShown() throws {
         // Given
         let boolmarkList = BookmarkList(topLevelEntities: [])
-        let vc = BookmarksBarViewController.create(tabCollectionViewModel: TabCollectionViewModel(isPopup: false), bookmarkManager: bookmarksManager, dragDropManager: .init(bookmarkManager: bookmarksManager), pinningManager: MockPinningManager())
+        let vc = BookmarksBarViewController.create(
+            tabCollectionViewModel: TabCollectionViewModel(isPopup: false),
+            bookmarkManager: bookmarksManager,
+            dragDropManager: .init(bookmarkManager: bookmarksManager),
+            pinningManager: MockPinningManager(),
+            featureFlagger: MockFeatureFlagger()
+        )
         _=vc.view
         vc.viewWillAppear()
         vc.viewDidAppear()

--- a/macOS/UnitTests/Bookmarks/Factory/BookmarksBarMenuFactoryTests.swift
+++ b/macOS/UnitTests/Bookmarks/Factory/BookmarksBarMenuFactoryTests.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import DesignResourcesKitIcons
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 
@@ -28,16 +29,62 @@ final class BookmarksBarMenuFactoryTests: XCTestCase {
         XCTAssertTrue(menu.items.isEmpty)
 
         // WHEN
-        BookmarksBarMenuFactory.addToMenuWithManageBookmarksSection(menu, target: targetMock, addFolderSelector: #selector(targetMock.addFolder(_:)), manageBookmarksSelector: #selector(targetMock.manageBookmarks), prefs: NSApp.delegateTyped.appearancePreferences)
+        BookmarksBarMenuFactory.addToMenuWithManageBookmarksSection(
+            menu,
+            target: targetMock,
+            addFolderSelector: #selector(targetMock.addFolder(_:)),
+            reorderByNameSelector: #selector(targetMock.reorderByName(_:)),
+            manageBookmarksSelector: #selector(targetMock.manageBookmarks),
+            prefs: NSApp.delegateTyped.appearancePreferences)
 
         // THEN
-        XCTAssertEqual(menu.items.count, 4)
+        XCTAssertEqual(menu.items.count, 5)
         XCTAssertEqual(menu.items[1].title, "")
         XCTAssertNil(menu.items[1].action)
         XCTAssertEqual(menu.items[2].title, UserText.addFolder)
         XCTAssertEqual(menu.items[2].action, #selector(targetMock.addFolder(_:)))
-        XCTAssertEqual(menu.items[3].title, UserText.bookmarksManageBookmarks)
-        XCTAssertEqual(menu.items[3].action, #selector(targetMock.manageBookmarks))
+        XCTAssertEqual(menu.items[3].title, UserText.bookmarksBarContextMenuReorderByName)
+        XCTAssertEqual(menu.items[3].action, #selector(targetMock.reorderByName(_:)))
+        XCTAssertEqual(menu.items[3].image?.pngData(), DesignSystemImages.Glyphs.Size12.arrowUpDown.pngData())
+        XCTAssertEqual(menu.items[4].title, UserText.bookmarksManageBookmarks)
+        XCTAssertEqual(menu.items[4].action, #selector(targetMock.manageBookmarks))
+    }
+
+    func testReorderByNameIsMissingWhenSelectorIsNil() {
+        // GIVEN
+        let menu = NSMenu(title: "")
+        let targetMock = BookmarksBarTargetMock()
+
+        // WHEN
+        BookmarksBarMenuFactory.addToMenuWithManageBookmarksSection(
+            menu,
+            target: targetMock,
+            addFolderSelector: #selector(targetMock.addFolder(_:)),
+            reorderByNameSelector: nil,
+            manageBookmarksSelector: #selector(targetMock.manageBookmarks),
+            prefs: NSApp.delegateTyped.appearancePreferences)
+
+        // THEN
+        XCTAssertEqual(menu.items.count, 4)
+        XCTAssertFalse(menu.items.contains(where: { $0.title == UserText.bookmarksBarContextMenuReorderByName }))
+    }
+
+    func testReorderByNameMovesTopLevelEntitiesWithinRoot() {
+        // GIVEN
+        let zulu = Bookmark(id: "zulu", url: "https://zulu.example", title: "Zulu", isFavorite: false)
+        let alpha = BookmarkFolder(id: "alpha", title: "Alpha")
+        let bookmarkManager = MockBookmarkManager(
+            list: BookmarkList(entities: [zulu], topLevelEntities: [zulu, alpha]),
+            sortMode: .nameDescending)
+
+        // WHEN
+        bookmarkManager.reorderByName(bookmarkManager.list?.topLevelEntities ?? [], withinParentFolder: .root)
+
+        // THEN
+        XCTAssertEqual(
+            bookmarkManager.moveObjectsCalled,
+            .init(objectUUIDs: [alpha.id, zulu.id], toIndex: 0, withinParentFolder: .root))
+        XCTAssertEqual(bookmarkManager.sortMode, .manual)
     }
 
     func testShouldNotReturnAddFolderAndManageBookmarksWhenAddToMenuIsCalled() {
@@ -55,5 +102,6 @@ final class BookmarksBarMenuFactoryTests: XCTestCase {
 
 private class BookmarksBarTargetMock: NSObject {
     @objc func addFolder(_ sender: NSMenuItem) {}
+    @objc func reorderByName(_ sender: NSMenuItem) {}
     @objc func manageBookmarks() {}
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216562341335231/task/1217121031488191?focus=true

### Description

- Adds a feature-flagged **Reorder by name** action to the bookmarks bar menu. Selecting it permanently sorts top-level bookmarks and folders A–Z and switches Sort View to Manual, matching the folder context-menu behavior introduced in #6146.
- Bring back 3 dots to Bookmark panel that were missing

### Testing Steps

1. Enable the `bookmarksReorderByName` feature flag.
2. Add top-level bookmarks and folders to the bookmarks bar in a non-alphabetical order.
3. Open the bookmarks bar menu → **Reorder by name** appears between **Add Folder** and **Manage Bookmarks**.
4. Select **Reorder by name** → the top-level items are sorted A–Z and Sort View changes to Manual.
5. Restart the app → the new order remains.
6. Disable the feature flag → **Reorder by name** no longer appears in the bookmarks bar menu.

### Impact

Medium — updates synced top-level bookmark ordering, but the action is user-initiated and gated behind a disabled-by-default feature flag.

#### What could go wrong?

Top-level bookmarks could be persisted in the wrong order → the action reuses the folder reorder path covered by persistence tests, with additional bookmarks-bar menu and ordering coverage.

### Quality Considerations

Empty and already-sorted bookmark bars skip the write while still switching Sort View to Manual. The action uses the existing localized, case-insensitive ordering and leaves the current Sort View unchanged if persistence fails.

### Visual Changes

<img width="442" height="292" alt="CleanShot 2026-08-05 at 12 09 46@2x" src="https://github.com/user-attachments/assets/c3afaa93-dbc9-4b6b-a4bf-1e5876a902fb" />

<img width="866" height="1094" alt="CleanShot 2026-08-05 at 11 58 58@2x" src="https://github.com/user-attachments/assets/7195b7b3-cf1c-400e-8c90-be53ff41a454" />

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-initiated reorder persists synced top-level bookmark order, but the change is gated behind a disabled-by-default feature flag and reuses the existing folder move/persistence path.
> 
> **Overview**
> Adds a feature-flagged **Reorder by name** item to the bookmarks bar overflow menu (between **Add Folder** and **Manage Bookmarks**). Choosing it sorts top-level bar items A–Z and sets Sort View to **Manual**, aligned with folder context-menu behavior.
> 
> **Reorder-by-name** logic is moved into `BookmarkManager.reorderByName`, which folder menus and the bar now share instead of duplicating sort/move/sortMode handling in `BookmarksContextMenu`.
> 
> `BookmarksBarMenuFactory.addToMenuWithManageBookmarksSection` accepts an optional `reorderByNameSelector`; when nil (flag off), the item is omitted. `BookmarksBarViewController` receives `FeatureFlagger` and gates the menu on `.bookmarksReorderByName`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee8179f0d0f10703a1b5ff61452eb72cd6f10ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->