### PR TITLE
Declare channel param on passwords status bar setting pixels

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/passwords_status_bar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/passwords_status_bar_pixels.json5
@@ -5,14 +5,14 @@
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_autofill_passwords_status-bar_setting_disabled": {
         "description": "Fired when the user disables the 'Show Passwords in Menu Bar' setting, either from preferences or from the status bar right-click menu",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_autofill_passwords_status-bar_icon_clicked": {
         "description": "Fired when the user clicks the passwords icon in the macOS menu bar to open the passwords popover",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1216888146691495?focus=true
Tech Design URL:
CC:

### Description
Live pixel validation flagged `m_mac_autofill_passwords_status-bar_setting_enabled` and `..._disabled` for an undeclared `channel` parameter. PixelKit attaches `channel` to every pixel on canary and dev builds, so both definitions need to document it. The bulk `channel` rollout in #4648 only covered the sibling `icon_clicked` pixel in this file.

### Testing Steps
1. From `macOS/`, run `npm install` then `npm run validate-pixel-defs` → schema and Prettier checks pass.
2. Write a log line to a file: `PIXEL: m_mac_autofill_passwords_status-bar_setting_enabled_count?appVersion=<latest released version>&pixelSource=browser-dmg&channel=canary`
3. Run `../node_modules/.bin/validate-ddg-pixel-logs ./PixelDefinitions <that file> "PIXEL: "` → reports Valid; on `main` the same line fails with "must NOT have additional properties. Found extra property 'channel'".

### Impact
None — definitions-only change, no Swift is modified and nothing changes on the wire.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSON5 pixel definition updates only; no Swift or wire-format changes.
> 
> **Overview**
> Adds the **`channel`** parameter to **`m_mac_autofill_passwords_status-bar_setting_enabled`** and **`..._setting_disabled`** in `passwords_status_bar_pixels.json5`, matching **`icon_clicked`** in the same file and the broader `channel` rollout elsewhere.
> 
> This fixes live pixel validation when PixelKit sends `channel` on canary/dev builds; definitions-only, no runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7514a4163e8f7a631252351facbc130dfc0dcdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->