### PR TITLE
iOS: Fix broken main build after searchTokenExperiment enum rename

### DIFF
--- a/iOS/Core/StatisticsLoader.swift
+++ b/iOS/Core/StatisticsLoader.swift
@@ -86,7 +86,7 @@ public class StatisticsLoader {
     /// started with. Drop each experiment as it is cleaned up, and delete this once none remain.
     static func fireLegacySearchRetentionExperimentPixels() {
         let inProgressExperiments = [
-            iOSBrowserConfigSubfeature.searchTokenExperiment.rawValue,
+            iOSBrowserConfigSubfeature.searchTokenExperimentV2.rawValue,
             iOSBrowserConfigSubfeature.onboardingFlowByDownloadReasonExperiment.rawValue,
             PrivacyProSubfeature.monthlyFreeTrialExperiment.rawValue,
             AutoconsentSubfeature.cookiePopupOptInDialogExperiment.rawValue


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1217155274711074?focus=true
CC:

### Description

`main` currently fails to compile. Two independently-green PRs collided semantically once both landed:

- #6135 renamed the `iOSBrowserConfigSubfeature` experiment case (resetting cohorts).
- #6083 (which merged afterwards) added a legacy search-retention pixel shim that still referenced the pre-rename case, which no longer exists.

This updates that reference to the current case name, restoring the build. `V2` is the correct target: it's the search-token experiment that was in-flight when #6083 shortened the retention window, so it's exactly what the legacy shim is meant to preserve the old window for. The pre-rename experiment was superseded by the rename and has no remaining cohorts.

### Testing Steps
1. Build the `iOS Browser` scheme on `main` with this PR merged → compiles (previously failed with `type 'iOSBrowserConfigSubfeature' has no member 'searchTokenExperiment'`).

### Impact
None — build fix. No behavioural change; one dangling enum reference updated to its renamed case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single compile-time enum rename with no runtime or analytics behavior change beyond using the correct subfeature ID.
> 
> **Overview**
> Restores the **iOS Browser** build after `iOSBrowserConfigSubfeature.searchTokenExperiment` was renamed to **`searchTokenExperimentV2`**.
> 
> In `StatisticsLoader.fireLegacySearchRetentionExperimentPixels()`, the in-flight experiment list now uses **`searchTokenExperimentV2`**, matching the renamed case and the other search-token pixel helpers in the same file. No change to retention windows or pixel firing logic—only the enum reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c3dbbf163d7878b45f04edd7d61b763f1c02fc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->