### PR TITLE
iOS: Unified Input - Centre the collapsed UTI stop button in the flanked pill

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -216,6 +216,7 @@ class SwitchBarTextEntryView: UIView {
 
     private var heightConstraint: NSLayoutConstraint?
     private var buttonsTrailingConstraint: NSLayoutConstraint?
+    private var buttonsCenterYConstraint: NSLayoutConstraint?
     private var placeholderTopConstraint: NSLayoutConstraint?
     private var placeholderCenterYConstraint: NSLayoutConstraint?
 
@@ -265,6 +266,13 @@ class SwitchBarTextEntryView: UIView {
     var isUsingIncreasedButtonPadding: Bool = false {
         didSet {
             updateButtonsPadding()
+        }
+    }
+
+    var trailingButtonsRowHeight: CGFloat = Constants.minHeight {
+        didSet {
+            guard trailingButtonsRowHeight != oldValue else { return }
+            updateButtonsVerticalAlignment()
         }
     }
 
@@ -448,10 +456,16 @@ class SwitchBarTextEntryView: UIView {
         buttonsTrailingConstraint?.constant = isUsingIncreasedButtonPadding ? -Constants.additionalVerticalButtonsPadding : 0
     }
 
+    private func updateButtonsVerticalAlignment() {
+        buttonsCenterYConstraint?.constant = trailingButtonsRowHeight / 2
+    }
+
     private func setupConstraints() {
 
         buttonsTrailingConstraint = buttonsView.trailingAnchor.constraint(equalTo: trailingAnchor)
         buttonsTrailingConstraint?.isActive = true
+        let buttonsCenterY = buttonsView.centerYAnchor.constraint(equalTo: topAnchor, constant: trailingButtonsRowHeight / 2)
+        buttonsCenterYConstraint = buttonsCenterY
         let placeholderTopConstraint = placeholderLabel.topAnchor.constraint(equalTo: textView.topAnchor, constant: Constants.placeholderTopOffset)
         let placeholderCenterYConstraint = placeholderLabel.centerYAnchor.constraint(equalTo: textView.centerYAnchor)
         self.placeholderTopConstraint = placeholderTopConstraint
@@ -476,7 +490,7 @@ class SwitchBarTextEntryView: UIView {
             placeholderLabel.trailingAnchor.constraint(equalTo: buttonsView.leadingAnchor),
 
             // Pin to the top row so the button stays top-right when the field grows multi-line.
-            buttonsView.centerYAnchor.constraint(equalTo: topAnchor, constant: Constants.minHeight / 2)
+            buttonsCenterY
         ])
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -889,6 +889,7 @@ final class UnifiedToggleInputView: UIView {
         } else {
             cardPinnedHeightConstraint.isActive = false
         }
+        textEntryView.trailingButtonsRowHeight = dimensions.pinnedHeight ?? Constants.collapsedCardHeight
 
         cardView.layer.maskedCorners = Constants.allCorners
         cardView.clipsToBounds = expanded && (usesOmnibarMargins || !isToggleEnabled)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -54,6 +54,22 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertFalse(sut.isToolbarSubmitEnabled)
     }
 
+    func test_flankedPillCentresTrailingButtonsOnItsTallerCard() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+        sut.frame = CGRect(x: 0, y: 0, width: 402, height: 120)
+
+        let buttons = try XCTUnwrap(firstDescendant(of: SwitchBarButtonsView.self, in: sut))
+
+        sut.applyCardLayout(.collapsed, animated: false)
+        sut.layoutIfNeeded()
+        XCTAssertEqual(buttons.center.y, 22, accuracy: 0.5)
+
+        sut.applyCardLayout(.flanked, animated: false)
+        sut.layoutIfNeeded()
+        XCTAssertEqual(buttons.center.y, 24, accuracy: 0.5)
+    }
+
     func test_dismissPoseFadesAttachmentsStripOutSoItAnimatesWithTheCollapse() throws {
         let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
         let sut = UnifiedToggleInputView(handler: handler)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1217124317632955
Tech Design URL:
CC:

### Description
The stop button shown while a Duck.ai answer is generating looked off-centre in the collapsed omnibar on an AI tab. That pill is 48pt tall, but the omnibar's trailing buttons were vertically centred on a hardcoded 44pt row, leaving the stop button 2pt high — a 2pt gap above the circle and 6pt below. They now centre on the card's actual height, so the 44pt collapsed bar is unchanged and the 48pt pill is correct.

### Testing Steps
1. On an AI tab, submit a prompt that takes a few seconds to answer → while the answer streams, the stop button in the collapsed omnibar pill is vertically centred (equal gap above and below the circle).

### Impact
Low — vertical alignment of one button in the collapsed omnibar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only constraint alignment for trailing omnibar buttons; no auth, data, or submission logic changes.
> 
> **Overview**
> Fixes **off-centre trailing controls** (notably the stop button while Duck.ai is generating) in the collapsed AI-tab omnibar, where the **48pt flanked pill** was taller than the row used to vertically centre trailing buttons.
> 
> `SwitchBarTextEntryView` no longer pins `buttonsView` to a fixed **44pt** row (`minHeight / 2`). It exposes **`trailingButtonsRowHeight`** and drives a stored **`buttonsCenterYConstraint`** at `trailingButtonsRowHeight / 2` from the top, updating when the height changes.
> 
> `UnifiedToggleInputView` sets that height from the active card layout’s **pinned card height** (44pt collapsed, 48pt flanked), so the **44pt collapsed bar stays the same** while the taller flanked capsule centres correctly.
> 
> Adds **`test_flankedPillCentresTrailingButtonsOnItsTallerCard`** asserting button centre Y at 22 vs 24 for collapsed vs flanked layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18dada2d537863ecb6cff68beae479b8e75c1816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->