### PR TITLE
[iOS] Translate inactivity notification copy

### DIFF
--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -995,8 +995,8 @@ public struct UserText {
 
     public static let macWaitlistAvailableNotificationTitle = NSLocalizedString("mac-waitlist.available.notification.title", value: "DuckDuckGo for Mac is ready!", comment: "Title for the macOS waitlist notification")
     /// https://app.asana.com/1/137249556945/project/38424471409662/task/1211224788080468
-    public static let inactivityNotificationTitle = NotLocalizedString("inactivity.notification.title", value: "Control your online experience", comment: "Title for inactivity notification. Used on for en_US locale only.")
-    public static let inactivityNotificationBody = NotLocalizedString("inactivity.notification.body", value: "Use DuckDuckGo to avoid the ads that track you around the web and reduce your online footprint.", comment: "Body for inactivity notification. Used on for en_US locale only.")
+    public static let inactivityNotificationTitle = NSLocalizedString("inactivity.notification.title", value: "Control your online experience", comment: "Title for the notification sent after a period of inactivity.")
+    public static let inactivityNotificationBody = NSLocalizedString("inactivity.notification.body", value: "Use DuckDuckGo to avoid the ads that track you around the web and reduce your online footprint.", comment: "Body for the notification sent after a period of inactivity.")
     public static func subscriptionExpirationReminderNotificationTitle(daysUntilTrialEnds: Int) -> String {
         let unit = daysUntilTrialEnds == 1 ? "day" : "days"
         return "Your trial ends in \(daysUntilTrialEnds) \(unit)"

--- a/iOS/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/bg.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Импортиране на пароли в DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Използвайте DuckDuckGo, за да избегнете рекламите, които Ви следят в мрежата, и да намалите своя онлайн отпечатък.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Контролирайте онлайн изживяването";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Задайте въпрос поверително";
 

--- a/iOS/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/cs.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Importuj svá hesla do DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Používej DuckDuckGo – vyhneš se reklamám, které tě sledují po celém internetu, a zmenšíš svou digitální stopu.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Tvůj pohyb online, pod kontrolou";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Zeptej se soukromě na cokoli";
 

--- a/iOS/DuckDuckGo/da.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/da.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Importér dine adgangskoder til DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Brug DuckDuckGo til at undgå de annoncer, der følger dig rundt på nettet, og reducere dit online fodaftryk.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Kontroller din onlineoplevelse";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Spørg om hvad som helst privat";
 

--- a/iOS/DuckDuckGo/de.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/de.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Importiere deine Passwörter zu DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Verwende DuckDuckGo, um Werbung zu vermeiden, die dich im Internet trackt, und um deinen digitalen Fußabdruck zu verringern.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Kontrolliere dein Online-Erlebnis";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Alles privat fragen";
 

--- a/iOS/DuckDuckGo/el.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/el.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Εισαγάγετε τους κωδικούς πρόσβασής σας στο DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Χρησιμοποίησε το DuckDuckGo για να αποφύγεις τις διαφημίσεις που σε ακολουθούν στο διαδίκτυο και να μειώσεις το διαδικτυακό σου αποτύπωμα.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Πάρε τον έλεγχο της διαδικτυακής σου εμπειρίας";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Ρώτα οτιδήποτε ιδιωτικά";
 

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -2833,6 +2833,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Import your passwords to DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Use DuckDuckGo to avoid the ads that track you around the web and reduce your online footprint.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Control your online experience";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Ask anything privately";
 

--- a/iOS/DuckDuckGo/es.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/es.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Importa tus contraseñas a DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Usa DuckDuckGo para evitar los anuncios que te rastrean por la web y reducir tu huella digital.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Controla tu experiencia en línea";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Pregunta cualquier cosa en privado";
 

--- a/iOS/DuckDuckGo/et.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/et.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Impordi paroolid DuckDuckGosse";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Kasuta DuckDuckGo-d, et vältida reklaame, mis sind veebis jälgivad, ja vähendada oma digitaalset jalajälge.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Kontrolli oma veebikogemust";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Küsi ükskõik mida privaatselt";
 

--- a/iOS/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fi.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Tuo salasanasi DuckDuckGohon";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Käytä DuckDuckGo välttääksesi sinua verkossa seuraavat mainokset ja pienentääksesi digitaalista jalanjälkeäsi.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Hallinnoi verkkokokemustasi";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Kysy mitä tahansa yksityisesti";
 

--- a/iOS/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fr.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Importez vos mots de passe sur DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Utilisez DuckDuckGo pour éviter les publicités qui vous suivent sur le Web et réduire votre empreinte en ligne.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Contrôlez votre expérience en ligne";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Posez toutes vos questions en privé";
 

--- a/iOS/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hr.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Uvezi svoje lozinke u DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Koristi DuckDuckGo da izbjegneš oglase koji te prate po cijelom webu i smanjiš svoj digitalni trag.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Kontroliraj svoje online iskustvo";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Privatno pitaj bilo što";
 

--- a/iOS/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hu.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Jelszavak importálása a DuckDuckGóba";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Használd a DuckDuckGót, hogy elkerüld a weben követő hirdetéseket, és csökkentsd az online lábnyomodat.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Irányítsd az online élményedet";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Kérdezz bármit privátban";
 

--- a/iOS/DuckDuckGo/it.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/it.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Importa le tue password in DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Usa DuckDuckGo per evitare gli annunci che ti tracciano sul web e ridurre la tua impronta digitale.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Controlla la tua esperienza online";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Chiedi qualsiasi cosa in privato";
 

--- a/iOS/DuckDuckGo/ja.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ja.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "パスワードをDuckDuckGoにインポート";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "DuckDuckGoを使用すると、広告によってウェブでの活動を追跡されることがなくなり、オンラインでの痕跡を減らすことができます。";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "オンライン体験を管理する";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "非公開でなんでも聞いてください";
 

--- a/iOS/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lt.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Importuok slaptažodžius į „DuckDuckGo“";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Naudok „DuckDuckGo“, kad išvengtum internete tave sekančių reklamų ir sumažintum savo skaitmeninį pėdsaką.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Valdyk savo patirtį internete";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Klausk bet ko privačiai";
 

--- a/iOS/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lv.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Importēt savas paroles DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Izmanto DuckDuckGo, lai izvairītos no reklāmām, kas tevi izseko tīmeklī, un samazinātu savus tiešsaistes pēdu nospiedumus.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Pārvaldi savu tiešsaistes pieredzi";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Jautā jebko privāti";
 

--- a/iOS/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nb.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Importer passordene dine til DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Bruk DuckDuckGo for å unngå annonsene som sporer deg rundt om på nettet, og reduser det digitale fotavtrykket ditt.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Kontroller opplevelsen din på nettet";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Spør om hva som helst, privat";
 

--- a/iOS/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nl.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Je wachtwoorden importeren in DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Gebruik DuckDuckGo om advertenties die je overal op het web volgen te vermijden en je online voetafdruk te verkleinen.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Beheer je online ervaring";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Vraag iets privé";
 

--- a/iOS/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pl.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Importuj hasła do DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Używaj DuckDuckGo, aby unikać reklam śledzących Cię w Internecie i zmniejszyć swój ślad cyfrowy.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Przejmij kontrolę nad swoim środowiskiem online";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Zapytaj o cokolwiek prywatnie";
 

--- a/iOS/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pt.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Importa as tuas palavras-passe para o DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Usa o DuckDuckGo para evitar os anúncios que te seguem por toda a Internet e reduzir a tua pegada online.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Controla a tua experiência online";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Pergunta o que quiseres em privado";
 

--- a/iOS/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ro.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Importă-ți parolele în DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Folosește DuckDuckGo ca să eviți reclamele care te urmăresc pe web și să-ți reduci amprenta online.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Controlează-ți experiența online";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Întreabă orice în mod privat";
 

--- a/iOS/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ru.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Импорт паролей в DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Используйте DuckDuckGo, чтобы избежать рекламы, которая отслеживает вас в Интернете, и уменьшить ваш цифровой след.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Управляйте своим опытом в сети";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Задавайте любые вопросы, сохраняя конфиденциальность";
 

--- a/iOS/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sk.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Importuj si svoje heslá do DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Používaj DuckDuckGo a vyhni sa reklamám, ktoré ťa sledujú na webe, a zmenši tak svoju online stopu.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Ovládni svoj online zážitok";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Spýtaj sa na čokoľvek súkromne";
 

--- a/iOS/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sl.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Uvozite gesla v DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Z DuckDuckGo se izognite oglasom, ki vas spremljajo po spletu, in zmanjšajte svoj spletni odtis.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Nadzorujte svojo spletno izkušnjo";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Vprašajte kar koli zasebno";
 

--- a/iOS/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sv.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Importera dina lösenord till DuckDuckGo";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Använd DuckDuckGo för att undvika annonser som spårar dig på webben och minska ditt digitala fotavtryck.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Ta kontroll över din onlineupplevelse";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Fråga vad som helst privat";
 

--- a/iOS/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/tr.lproj/Localizable.strings
@@ -2956,6 +2956,12 @@
 /* Title for the Import Passwords Promotion banner */
 "import.passwords.promo.title" = "Şifrelerinizi DuckDuckGo'ya aktarın";
 
+/* Body for the notification sent after a period of inactivity. */
+"inactivity.notification.body" = "Sizi internette takip eden reklamlardan kaçınmak ve çevrimiçi ayak izinizi azaltmak için DuckDuckGo kullanın.";
+
+/* Title for the notification sent after a period of inactivity. */
+"inactivity.notification.title" = "Çevrimiçi deneyiminizin kontrolünü elinize alın";
+
 /* Placeholder text for the duck.ai input field */
 "input.field.placeholder.duckai" = "Gizli bir şekilde her şeyi sorabilirsiniz";
 

--- a/iOS/scripts/loc_update.sh
+++ b/iOS/scripts/loc_update.sh
@@ -34,7 +34,20 @@ update_localizable_strings() {
 		return 1
 	fi
 
-	if ! iconv -f UTF-16 -t UTF8 "${generated_strings}" > "${tmp_utf8_strings}"; then
+	# `extractLocStrings` writes UTF-16LE with a leading byte-order mark. Decode it
+	# with an explicit little-endian encoding instead of `iconv -f UTF-16`: the latter
+	# infers endianness from the BOM, but macOS iconv can lose that inferred byte order
+	# at an internal buffer boundary and byte-swap the rest of the file, corrupting
+	# non-BMP characters (e.g. emoji like U+1F525, encoded as a surrogate pair) and
+	# every entry after them. Strip the 2-byte BOM so the result matches the committed
+	# (BOM-less) Localizable.strings and the `cmp` check below stays meaningful.
+	bom=$(od -An -tx1 -N2 "${generated_strings}" | tr -d ' \n')
+	if [ "${bom}" != "fffe" ]; then
+		echo "error: expected UTF-16LE BOM (fffe) at the start of ${generated_strings}, found '${bom}'" >&2
+		return 1
+	fi
+
+	if ! tail -c +3 "${generated_strings}" | iconv -f UTF-16LE -t UTF8 > "${tmp_utf8_strings}"; then
 		rm -f "${tmp_utf8_strings}"
 		echo "error: Failed to convert ${generated_strings} to UTF-8" >&2
 		return 1


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1217161599700460
Tech Design URL:
CC:

### Description

Makes inactivity notification copy translatable and adds translated strings (in progress).

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Confirm checks pass

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low: Improvement to existing feature (adds translations)

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-visible change is localized notification copy only; the script fix reduces risk of corrupting generated strings during loc updates.
> 
> **Overview**
> **Inactivity notifications** now use the normal localization pipeline: `inactivityNotificationTitle` and `inactivityNotificationBody` in `UserText.swift` are switched from `NotLocalizedString` to `NSLocalizedString`, with updated comments. Matching entries are added in each supported `Localizable.strings` locale (same English copy in `en.lproj` plus translated title/body elsewhere).
> 
> **Localization tooling:** `loc_update.sh` no longer uses generic `iconv -f UTF-16` on `extractLocStrings` output. It verifies the UTF-16LE BOM, strips it, and decodes with `UTF-16LE` so surrogate pairs (e.g. emoji) and later string entries are not corrupted during UTF-8 conversion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd49ce744977f13dc14a8a99172d9bac684dc6ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->