### PR TITLE
macOS: Video Autoplay Discoverability Pixels

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -2374,6 +2374,8 @@
 		7BD504A12E5FA45A008A0646 /* WebExtensionInternalSiteNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3A2B622D2D225B00F06679 /* WebExtensionInternalSiteNavigationDelegate.swift */; };
 		7BD55D012E8F06010094A2B8 /* PermissionPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD55D002E8F06000094A2B8 /* PermissionPixel.swift */; };
 		7BD55D022E8F06020094A2B8 /* PermissionPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD55D002E8F06000094A2B8 /* PermissionPixel.swift */; };
+		CD41A0010000000000100011 /* AutoplayPromoPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD41A0010000000000100010 /* AutoplayPromoPixel.swift */; };
+		CD41A0010000000000100012 /* AutoplayPromoPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD41A0010000000000100010 /* AutoplayPromoPixel.swift */; };
 		7BD7B0012C19D3830039D20A /* VPNIPCResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD7B0002C19D3830039D20A /* VPNIPCResources.swift */; };
 		7BD7B0022C19D3830039D20A /* VPNIPCResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD7B0002C19D3830039D20A /* VPNIPCResources.swift */; };
 		7BD7B0032C19D3830039D20A /* VPNIPCResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD7B0002C19D3830039D20A /* VPNIPCResources.swift */; };
@@ -5961,6 +5963,7 @@
 		7BD1688D2AD4A4C400D24876 /* NetworkExtensionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkExtensionController.swift; sourceTree = "<group>"; };
 		7BD3AF5C2A8E7AF1006F9F56 /* KeychainType+ClientDefault.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeychainType+ClientDefault.swift"; sourceTree = "<group>"; };
 		7BD55D002E8F06000094A2B8 /* PermissionPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionPixel.swift; sourceTree = "<group>"; };
+		CD41A0010000000000100010 /* AutoplayPromoPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoplayPromoPixel.swift; sourceTree = "<group>"; };
 		7BD7B0002C19D3830039D20A /* VPNIPCResources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNIPCResources.swift; sourceTree = "<group>"; };
 		7BD807BC2E8BCD7600D7C9A0 /* TabCrashAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabCrashAggregator.swift; sourceTree = "<group>"; };
 		7BD8679A2A9E9E000063B9F7 /* VPNFeatureGatekeeper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VPNFeatureGatekeeper.swift; sourceTree = "<group>"; };
@@ -12482,6 +12485,7 @@
 				37598EF32D5A18FB00720EAF /* HistoryViewPixel.swift */,
 				1D99CDDA2D929EBE00656A84 /* PinnedTabsPixel.swift */,
 				7BD55D002E8F06000094A2B8 /* PermissionPixel.swift */,
+				CD41A0010000000000100010 /* AutoplayPromoPixel.swift */,
 				A5A7430C39C716A6A3A1F654 /* WebNotificationPixel.swift */,
 				56DB9FE82CD24B47001BEC23 /* ContextualOnboardingPixel.swift */,
 				CC9B678B2E607AD1003353C3 /* SessionRestorePromptPixel.swift */,
@@ -16243,6 +16247,7 @@
 				3706FBFA293F65D500E42796 /* FileDownloadError.swift in Sources */,
 				1D99CDDC2D929EC900656A84 /* PinnedTabsPixel.swift in Sources */,
 				7BD55D022E8F06020094A2B8 /* PermissionPixel.swift in Sources */,
+				CD41A0010000000000100011 /* AutoplayPromoPixel.swift in Sources */,
 				0F2D07CBC5636188DAF0BD3E /* WebNotificationPixel.swift in Sources */,
 				379E877729E98729001C8BB0 /* BookmarksCleanupErrorHandling.swift in Sources */,
 				EE28685F2EAFC3E000AB597F /* LegacyDataImportSummaryViewModel.swift in Sources */,
@@ -17693,6 +17698,7 @@
 				D1D1D1D100000000000000F1 /* WindowDimmingBlockingView.swift in Sources */,
 				1D99CDDB2D929EC900656A84 /* PinnedTabsPixel.swift in Sources */,
 				7BD55D012E8F06010094A2B8 /* PermissionPixel.swift in Sources */,
+				CD41A0010000000000100012 /* AutoplayPromoPixel.swift in Sources */,
 				63AC47CDA9BC3FA42B5B335A /* WebNotificationPixel.swift in Sources */,
 				1D3A2B672D2D230800F06679 /* WebExtensionInternalSiteHandler.swift in Sources */,
 				3158B1532B0BF75700AF130C /* LoginItem+DataBrokerProtection.swift in Sources */,

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -2947,12 +2947,15 @@ extension AddressBarButtonsViewController {
     }
 
     /// Closes the Permission Center, as long as it still allows autodismissal. This is no longer true once the user interacted with the popover.
-    func autodismissPermissionCenterIfPossible() {
+    /// - Returns: Whether the popover was closed. `false` means there was nothing to close, or the user already engaged with it.
+    @discardableResult
+    func autodismissPermissionCenterIfPossible() -> Bool {
         guard let permissionCenterPopover, permissionCenterPopover.viewController.allowsAutodismiss else {
-            return
+            return false
         }
 
         permissionCenterPopover.close()
+        return true
     }
 }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarButtonsViewController.swift
@@ -2950,7 +2950,7 @@ extension AddressBarButtonsViewController {
     /// - Returns: Whether the popover was closed. `false` means there was nothing to close, or the user already engaged with it.
     @discardableResult
     func autodismissPermissionCenterIfPossible() -> Bool {
-        guard let permissionCenterPopover, permissionCenterPopover.viewController.allowsAutodismiss else {
+        guard let permissionCenterPopover, permissionCenterPopover.isShown, permissionCenterPopover.viewController.allowsAutodismiss else {
             return false
         }
 

--- a/macOS/DuckDuckGo/Permissions/Promo/AutoplayDiscoverabilityPromoDelegate.swift
+++ b/macOS/DuckDuckGo/Permissions/Promo/AutoplayDiscoverabilityPromoDelegate.swift
@@ -37,15 +37,15 @@ final class AutoplayDiscoverabilityPromoDelegate: InternalPromoDelegate {
 
     private let featureFlagger: FeatureFlagger
     private let windowControllersManager: WindowControllersManagerProtocol
-    private let firePixel: (PixelKitEvent) -> Void
+    private let pixelFiring: PixelFiring?
     private var showContinuation: CheckedContinuation<PromoResult, Never>?
 
     init(featureFlagger: FeatureFlagger,
          windowControllersManager: WindowControllersManagerProtocol,
-         firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0) }) {
+         pixelFiring: PixelFiring? = PixelKit.shared) {
         self.featureFlagger = featureFlagger
         self.windowControllersManager = windowControllersManager
-        self.firePixel = firePixel
+        self.pixelFiring = pixelFiring
     }
 
     var isEligible: Bool {
@@ -78,7 +78,7 @@ final class AutoplayDiscoverabilityPromoDelegate: InternalPromoDelegate {
             return .noChange
         }
 
-        firePixel(AutoplayPromoPixel.shown)
+        pixelFiring?.fire(AutoplayPromoPixel.shown)
 
         return await withCheckedContinuation { continuation in
             showContinuation = continuation
@@ -90,7 +90,7 @@ final class AutoplayDiscoverabilityPromoDelegate: InternalPromoDelegate {
         let didAutodismiss = addressBarButtonsViewController?.autodismissPermissionCenterIfPossible() ?? false
 
         if didAutodismiss {
-            firePixel(AutoplayPromoPixel.autoDismissed)
+            pixelFiring?.fire(AutoplayPromoPixel.autoDismissed)
         }
 
         resume(with: .noChange)

--- a/macOS/DuckDuckGo/Permissions/Promo/AutoplayDiscoverabilityPromoDelegate.swift
+++ b/macOS/DuckDuckGo/Permissions/Promo/AutoplayDiscoverabilityPromoDelegate.swift
@@ -19,6 +19,7 @@
 import Combine
 import Foundation
 import FeatureFlags
+import PixelKit
 import PrivacyConfig
 
 /// Opens the Permission Center by itself the first time a page displays the autoplay policy, so users discover the autoplay controls and the disclaimer UI.
@@ -36,11 +37,15 @@ final class AutoplayDiscoverabilityPromoDelegate: InternalPromoDelegate {
 
     private let featureFlagger: FeatureFlagger
     private let windowControllersManager: WindowControllersManagerProtocol
+    private let firePixel: (PixelKitEvent) -> Void
     private var showContinuation: CheckedContinuation<PromoResult, Never>?
 
-    init(featureFlagger: FeatureFlagger, windowControllersManager: WindowControllersManagerProtocol) {
+    init(featureFlagger: FeatureFlagger,
+         windowControllersManager: WindowControllersManagerProtocol,
+         firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0) }) {
         self.featureFlagger = featureFlagger
         self.windowControllersManager = windowControllersManager
+        self.firePixel = firePixel
     }
 
     var isEligible: Bool {
@@ -73,6 +78,8 @@ final class AutoplayDiscoverabilityPromoDelegate: InternalPromoDelegate {
             return .noChange
         }
 
+        firePixel(AutoplayPromoPixel.shown)
+
         return await withCheckedContinuation { continuation in
             showContinuation = continuation
         }
@@ -80,7 +87,12 @@ final class AutoplayDiscoverabilityPromoDelegate: InternalPromoDelegate {
 
     @MainActor
     func hide() {
-        addressBarButtonsViewController?.autodismissPermissionCenterIfPossible()
+        let didAutodismiss = addressBarButtonsViewController?.autodismissPermissionCenterIfPossible() ?? false
+
+        if didAutodismiss {
+            firePixel(AutoplayPromoPixel.autoDismissed)
+        }
+
         resume(with: .noChange)
     }
 }

--- a/macOS/DuckDuckGo/Permissions/ViewModel/PermissionCenterViewModel.swift
+++ b/macOS/DuckDuckGo/Permissions/ViewModel/PermissionCenterViewModel.swift
@@ -192,6 +192,7 @@ final class PermissionCenterViewModel: ObservableObject {
     private let reloadPage: (() -> Void)?
     private let setPermissionsNeedReload: (() -> Void)?
     private let openSettingsPane: ((PreferencePaneIdentifier) -> Void)?
+    private let firePixel: (PixelKitEvent) -> Void
     private var cancellables = Set<AnyCancellable>()
     private var removedPermissions = Set<PermissionType>()
     private(set) var hasTemporaryPopupAllowance: Bool
@@ -239,6 +240,7 @@ final class PermissionCenterViewModel: ObservableObject {
         displaysAutoplayPolicy: Bool = false,
         permissionsNeedReload: Bool = false,
         displaysAutoplayDiscovery: Bool = false,
+        firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0) },
         systemPermissionManager: SystemPermissionManagerProtocol = SystemPermissionManager()
     ) {
         self.domain = domain
@@ -265,6 +267,7 @@ final class PermissionCenterViewModel: ObservableObject {
         self.showReloadBanner = permissionsNeedReload
         self.displaysAutoplayDiscovery = displaysAutoplayDiscovery
         self.allowsAutodismiss = displaysAutoplayDiscovery
+        self.firePixel = firePixel
 
         loadPermissions()
         subscribeToPermissionChanges()
@@ -275,7 +278,12 @@ final class PermissionCenterViewModel: ObservableObject {
     /// Opts out of automatic dismissal, permanently. Called as soon as the user reaches the UI with the pointer, so that
     /// the Autoplay Policy Discoverability Promo doesn't close the popover from under them.
     func disableAutodismiss() {
+        guard allowsAutodismiss else {
+            return
+        }
+
         allowsAutodismiss = false
+        firePixel(AutoplayPromoPixel.engaged)
     }
 
     /// Updates the decision for a permission type
@@ -290,7 +298,7 @@ final class PermissionCenterViewModel: ObservableObject {
 
         // Fire pixel for decision change
         if previousDecision != decision {
-            PixelKit.fire(PermissionPixel.permissionCenterChanged(permissionType: permissionType, from: previousDecision, to: decision))
+            firePixel(PermissionPixel.permissionCenterChanged(permissionType: permissionType, from: previousDecision, to: decision))
             markReloadNeeded()
         }
 
@@ -326,7 +334,7 @@ final class PermissionCenterViewModel: ObservableObject {
 
         // Fire pixel for decision change
         if previousDecision != decision {
-            PixelKit.fire(PermissionPixel.permissionCenterChanged(permissionType: permissionType, from: previousDecision, to: decision))
+            firePixel(PermissionPixel.permissionCenterChanged(permissionType: permissionType, from: previousDecision, to: decision))
             markReloadNeeded()
         }
     }
@@ -338,7 +346,7 @@ final class PermissionCenterViewModel: ObservableObject {
         removePermissionFromTab(permissionType)
 
         // Fire pixel for permission reset
-        PixelKit.fire(PermissionPixel.permissionCenterReset(permissionType: permissionType))
+        firePixel(PermissionPixel.permissionCenterReset(permissionType: permissionType))
 
         // Show reload banner
         markReloadNeeded()
@@ -445,6 +453,10 @@ final class PermissionCenterViewModel: ObservableObject {
 
     /// Opens the General settings pane, where the all-sites autoplay preference lives
     func openAutoplaySettings() {
+        if displaysAutoplayDiscovery {
+            firePixel(AutoplayPromoPixel.settingsLinkClicked)
+        }
+
         openSettingsPane?(.general)
         dismissPopover()
     }
@@ -461,7 +473,7 @@ final class PermissionCenterViewModel: ObservableObject {
         removePermissionFromTab(permissionType)
 
         // Fire pixel for permission reset
-        PixelKit.fire(PermissionPixel.permissionCenterReset(permissionType: permissionType))
+        firePixel(PermissionPixel.permissionCenterReset(permissionType: permissionType))
 
         // Show reload banner
         markReloadNeeded()

--- a/macOS/DuckDuckGo/Permissions/ViewModel/PermissionCenterViewModel.swift
+++ b/macOS/DuckDuckGo/Permissions/ViewModel/PermissionCenterViewModel.swift
@@ -192,7 +192,7 @@ final class PermissionCenterViewModel: ObservableObject {
     private let reloadPage: (() -> Void)?
     private let setPermissionsNeedReload: (() -> Void)?
     private let openSettingsPane: ((PreferencePaneIdentifier) -> Void)?
-    private let firePixel: (PixelKitEvent) -> Void
+    private let pixelFiring: PixelFiring?
     private var cancellables = Set<AnyCancellable>()
     private var removedPermissions = Set<PermissionType>()
     private(set) var hasTemporaryPopupAllowance: Bool
@@ -240,7 +240,7 @@ final class PermissionCenterViewModel: ObservableObject {
         displaysAutoplayPolicy: Bool = false,
         permissionsNeedReload: Bool = false,
         displaysAutoplayDiscovery: Bool = false,
-        firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0) },
+        pixelFiring: PixelFiring? = PixelKit.shared,
         systemPermissionManager: SystemPermissionManagerProtocol = SystemPermissionManager()
     ) {
         self.domain = domain
@@ -267,7 +267,7 @@ final class PermissionCenterViewModel: ObservableObject {
         self.showReloadBanner = permissionsNeedReload
         self.displaysAutoplayDiscovery = displaysAutoplayDiscovery
         self.allowsAutodismiss = displaysAutoplayDiscovery
-        self.firePixel = firePixel
+        self.pixelFiring = pixelFiring
 
         loadPermissions()
         subscribeToPermissionChanges()
@@ -283,7 +283,7 @@ final class PermissionCenterViewModel: ObservableObject {
         }
 
         allowsAutodismiss = false
-        firePixel(AutoplayPromoPixel.engaged)
+        pixelFiring?.fire(AutoplayPromoPixel.engaged)
     }
 
     /// Updates the decision for a permission type
@@ -298,7 +298,7 @@ final class PermissionCenterViewModel: ObservableObject {
 
         // Fire pixel for decision change
         if previousDecision != decision {
-            firePixel(PermissionPixel.permissionCenterChanged(permissionType: permissionType, from: previousDecision, to: decision))
+            pixelFiring?.fire(PermissionPixel.permissionCenterChanged(permissionType: permissionType, from: previousDecision, to: decision))
             markReloadNeeded()
         }
 
@@ -334,7 +334,7 @@ final class PermissionCenterViewModel: ObservableObject {
 
         // Fire pixel for decision change
         if previousDecision != decision {
-            firePixel(PermissionPixel.permissionCenterChanged(permissionType: permissionType, from: previousDecision, to: decision))
+            pixelFiring?.fire(PermissionPixel.permissionCenterChanged(permissionType: permissionType, from: previousDecision, to: decision))
             markReloadNeeded()
         }
     }
@@ -346,7 +346,7 @@ final class PermissionCenterViewModel: ObservableObject {
         removePermissionFromTab(permissionType)
 
         // Fire pixel for permission reset
-        firePixel(PermissionPixel.permissionCenterReset(permissionType: permissionType))
+        pixelFiring?.fire(PermissionPixel.permissionCenterReset(permissionType: permissionType))
 
         // Show reload banner
         markReloadNeeded()
@@ -454,7 +454,7 @@ final class PermissionCenterViewModel: ObservableObject {
     /// Opens the General settings pane, where the all-sites autoplay preference lives
     func openAutoplaySettings() {
         if displaysAutoplayDiscovery {
-            firePixel(AutoplayPromoPixel.settingsLinkClicked)
+            pixelFiring?.fire(AutoplayPromoPixel.settingsLinkClicked)
         }
 
         openSettingsPane?(.general)
@@ -473,7 +473,7 @@ final class PermissionCenterViewModel: ObservableObject {
         removePermissionFromTab(permissionType)
 
         // Fire pixel for permission reset
-        firePixel(PermissionPixel.permissionCenterReset(permissionType: permissionType))
+        pixelFiring?.fire(PermissionPixel.permissionCenterReset(permissionType: permissionType))
 
         // Show reload banner
         markReloadNeeded()

--- a/macOS/DuckDuckGo/Statistics/AutoplayPromoPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/AutoplayPromoPixel.swift
@@ -1,0 +1,52 @@
+//
+//  AutoplayPromoPixel.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import PixelKit
+
+/// Pixels for the Autoplay Discoverability Promo, which auto-opens the Permission Center the first time a page displays the autoplay policy.
+/// - Note: The promo runs at most once per install, so plain standard pixels are enough to bound their volume.
+enum AutoplayPromoPixel: PixelKitEvent, Equatable {
+
+    case shown
+    case engaged
+    case autoDismissed
+    case settingsLinkClicked
+
+    // MARK: - PixelKitEvent
+
+    var name: String {
+        switch self {
+        case .shown:
+            return "m_mac_autoplay-promo_shown"
+        case .engaged:
+            return "m_mac_autoplay-promo_engaged"
+        case .autoDismissed:
+            return "m_mac_autoplay-promo_auto-dismissed"
+        case .settingsLinkClicked:
+            return "m_mac_autoplay-promo_settings-click"
+        }
+    }
+
+    var parameters: [String: String]? {
+        nil
+    }
+
+    var standardParameters: [PixelKitStandardParameter]? {
+        [.pixelSource]
+    }
+}

--- a/macOS/DuckDuckGo/Statistics/AutoplayPromoPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/AutoplayPromoPixel.swift
@@ -32,13 +32,13 @@ enum AutoplayPromoPixel: PixelKitEvent, Equatable {
     var name: String {
         switch self {
         case .shown:
-            return "m_mac_autoplay-promo_shown"
+            return "autoplay-promo_shown"
         case .engaged:
-            return "m_mac_autoplay-promo_engaged"
+            return "autoplay-promo_engaged"
         case .autoDismissed:
-            return "m_mac_autoplay-promo_auto-dismissed"
+            return "autoplay-promo_auto-dismissed"
         case .settingsLinkClicked:
-            return "m_mac_autoplay-promo_settings-click"
+            return "autoplay-promo_settings-click"
         }
     }
 

--- a/macOS/PixelDefinitions/pixels/definitions/autoplay_promo_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/autoplay_promo_pixels.json5
@@ -1,0 +1,32 @@
+// Autoplay Discoverability Promo pixels
+// The promo auto-opens the Permission Center the first time a page displays the autoplay policy
+{
+    "m_mac_autoplay-promo_shown": {
+        "description": "Fired when the Autoplay Discoverability Promo auto-opens the Permission Center. Not fired for the internal debug force-show path.",
+        "owners": ["jleandroperez"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_autoplay-promo_engaged": {
+        "description": "Fired when the user reaches the Autoplay Discoverability Promo's popover with the pointer before it auto-dismisses, which cancels the pending dismissal. Fires at most once per presentation.",
+        "owners": ["jleandroperez"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_autoplay-promo_auto-dismissed": {
+        "description": "Fired when the Autoplay Discoverability Promo's display window elapses without engagement and the popover closes itself. Mutually exclusive with m_mac_autoplay-promo_engaged.",
+        "owners": ["jleandroperez"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_autoplay-promo_settings-click": {
+        "description": "Fired when the user clicks the settings link in the autoplay disclaimer shown by the Autoplay Discoverability Promo, which opens General > Permissions.",
+        "owners": ["jleandroperez"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    }
+}

--- a/macOS/UnitTests/Permissions/PermissionCenterViewModelTests.swift
+++ b/macOS/UnitTests/Permissions/PermissionCenterViewModelTests.swift
@@ -19,6 +19,7 @@
 import Combine
 import FeatureFlags
 import PixelKit
+import PixelKitTestingUtilities
 import PrivacyConfig
 import XCTest
 
@@ -332,7 +333,7 @@ final class PermissionCenterViewModelTests: XCTestCase {
 
     // Hover events can arrive repeatedly; the promo must only report engagement once.
     func testWhenDisableAutodismissIsCalledRepeatedlyThenEngagedPixelFiresOnce() {
-        var firedPixels: [PixelKitEvent] = []
+        var pixelFiring = PixelKitMock()
 
         let viewModel = PermissionCenterViewModel(
             domain: "example.com",
@@ -344,20 +345,20 @@ final class PermissionCenterViewModelTests: XCTestCase {
             dismissPopover: { },
             displaysAutoplayPolicy: true,
             displaysAutoplayDiscovery: true,
-            firePixel: { firedPixels.append($0) },
+            pixelFiring: pixelFiring,
             systemPermissionManager: mockSystemPermissionManager
         )
 
         viewModel.disableAutodismiss()
         viewModel.disableAutodismiss()
 
-        XCTAssertEqual(firedPixels.map(\.name), [AutoplayPromoPixel.engaged.name])
+        XCTAssertEqual(pixelFiring.actualFireCalls.map(\.pixel.name), [AutoplayPromoPixel.engaged.name])
         XCTAssertFalse(viewModel.allowsAutodismiss)
     }
 
     /// Outside the promo there is nothing to autodismiss, so there is no engagement to report.
     func testWhenDisableAutodismissIsCalledOutsideThePromoThenNoPixelIsFired() {
-        var firedPixels: [PixelKitEvent] = []
+        var pixelFiring = PixelKitMock()
 
         let viewModel = PermissionCenterViewModel(
             domain: "example.com",
@@ -369,18 +370,18 @@ final class PermissionCenterViewModelTests: XCTestCase {
             dismissPopover: { },
             displaysAutoplayPolicy: true,
             displaysAutoplayDiscovery: false,
-            firePixel: { firedPixels.append($0) },
+            pixelFiring: pixelFiring,
             systemPermissionManager: mockSystemPermissionManager
         )
 
         viewModel.disableAutodismiss()
 
-        XCTAssertTrue(firedPixels.isEmpty)
+        XCTAssertTrue(pixelFiring.actualFireCalls.isEmpty)
         XCTAssertFalse(viewModel.allowsAutodismiss)
     }
 
     func testWhenOpenAutoplaySettingsWithinThePromoThenSettingsLinkClickedPixelIsFired() {
-        var firedPixels: [PixelKitEvent] = []
+        var pixelFiring = PixelKitMock()
         var openedPanes: [PreferencePaneIdentifier] = []
 
         let viewModel = PermissionCenterViewModel(
@@ -394,19 +395,19 @@ final class PermissionCenterViewModelTests: XCTestCase {
             openSettingsPane: { openedPanes.append($0) },
             displaysAutoplayPolicy: true,
             displaysAutoplayDiscovery: true,
-            firePixel: { firedPixels.append($0) },
+            pixelFiring: pixelFiring,
             systemPermissionManager: mockSystemPermissionManager
         )
 
         viewModel.openAutoplaySettings()
 
-        XCTAssertEqual(firedPixels.map(\.name), [AutoplayPromoPixel.settingsLinkClicked.name])
+        XCTAssertEqual(pixelFiring.actualFireCalls.map(\.pixel.name), [AutoplayPromoPixel.settingsLinkClicked.name])
         XCTAssertEqual(openedPanes, [.general])
     }
 
     /// The disclaimer link only exists within the promo: a settings jump from anywhere else isn't promo attribution.
     func testWhenOpenAutoplaySettingsOutsideThePromoThenNoPixelIsFired() {
-        var firedPixels: [PixelKitEvent] = []
+        var pixelFiring = PixelKitMock()
         var openedPanes: [PreferencePaneIdentifier] = []
 
         let viewModel = PermissionCenterViewModel(
@@ -420,13 +421,13 @@ final class PermissionCenterViewModelTests: XCTestCase {
             openSettingsPane: { openedPanes.append($0) },
             displaysAutoplayPolicy: true,
             displaysAutoplayDiscovery: false,
-            firePixel: { firedPixels.append($0) },
+            pixelFiring: pixelFiring,
             systemPermissionManager: mockSystemPermissionManager
         )
 
         viewModel.openAutoplaySettings()
 
-        XCTAssertTrue(firedPixels.isEmpty)
+        XCTAssertTrue(pixelFiring.actualFireCalls.isEmpty)
         XCTAssertEqual(openedPanes, [.general])
     }
 

--- a/macOS/UnitTests/Permissions/PermissionCenterViewModelTests.swift
+++ b/macOS/UnitTests/Permissions/PermissionCenterViewModelTests.swift
@@ -330,7 +330,7 @@ final class PermissionCenterViewModelTests: XCTestCase {
 
     // MARK: - Autoplay Promo Pixel Tests
 
-    /// Hover events can arrive repeatedly; the promo must only report engagement once.
+    // Hover events can arrive repeatedly; the promo must only report engagement once.
     func testWhenDisableAutodismissIsCalledRepeatedlyThenEngagedPixelFiresOnce() {
         var firedPixels: [PixelKitEvent] = []
 

--- a/macOS/UnitTests/Permissions/PermissionCenterViewModelTests.swift
+++ b/macOS/UnitTests/Permissions/PermissionCenterViewModelTests.swift
@@ -18,6 +18,7 @@
 
 import Combine
 import FeatureFlags
+import PixelKit
 import PrivacyConfig
 import XCTest
 
@@ -325,6 +326,108 @@ final class PermissionCenterViewModelTests: XCTestCase {
         viewModel.disableAutodismiss()
 
         XCTAssertFalse(viewModel.allowsAutodismiss)
+    }
+
+    // MARK: - Autoplay Promo Pixel Tests
+
+    /// Hover events can arrive repeatedly; the promo must only report engagement once.
+    func testWhenDisableAutodismissIsCalledRepeatedlyThenEngagedPixelFiresOnce() {
+        var firedPixels: [PixelKitEvent] = []
+
+        let viewModel = PermissionCenterViewModel(
+            domain: "example.com",
+            usedPermissions: Permissions(),
+            permissionManager: mockPermissionManager,
+            autoplayPreferences: autoplayPreferences,
+            featureFlagger: mockFeatureFlagger,
+            removePermission: { _ in },
+            dismissPopover: { },
+            displaysAutoplayPolicy: true,
+            displaysAutoplayDiscovery: true,
+            firePixel: { firedPixels.append($0) },
+            systemPermissionManager: mockSystemPermissionManager
+        )
+
+        viewModel.disableAutodismiss()
+        viewModel.disableAutodismiss()
+
+        XCTAssertEqual(firedPixels.map(\.name), [AutoplayPromoPixel.engaged.name])
+        XCTAssertFalse(viewModel.allowsAutodismiss)
+    }
+
+    /// Outside the promo there is nothing to autodismiss, so there is no engagement to report.
+    func testWhenDisableAutodismissIsCalledOutsideThePromoThenNoPixelIsFired() {
+        var firedPixels: [PixelKitEvent] = []
+
+        let viewModel = PermissionCenterViewModel(
+            domain: "example.com",
+            usedPermissions: Permissions(),
+            permissionManager: mockPermissionManager,
+            autoplayPreferences: autoplayPreferences,
+            featureFlagger: mockFeatureFlagger,
+            removePermission: { _ in },
+            dismissPopover: { },
+            displaysAutoplayPolicy: true,
+            displaysAutoplayDiscovery: false,
+            firePixel: { firedPixels.append($0) },
+            systemPermissionManager: mockSystemPermissionManager
+        )
+
+        viewModel.disableAutodismiss()
+
+        XCTAssertTrue(firedPixels.isEmpty)
+        XCTAssertFalse(viewModel.allowsAutodismiss)
+    }
+
+    func testWhenOpenAutoplaySettingsWithinThePromoThenSettingsLinkClickedPixelIsFired() {
+        var firedPixels: [PixelKitEvent] = []
+        var openedPanes: [PreferencePaneIdentifier] = []
+
+        let viewModel = PermissionCenterViewModel(
+            domain: "example.com",
+            usedPermissions: Permissions(),
+            permissionManager: mockPermissionManager,
+            autoplayPreferences: autoplayPreferences,
+            featureFlagger: mockFeatureFlagger,
+            removePermission: { _ in },
+            dismissPopover: { },
+            openSettingsPane: { openedPanes.append($0) },
+            displaysAutoplayPolicy: true,
+            displaysAutoplayDiscovery: true,
+            firePixel: { firedPixels.append($0) },
+            systemPermissionManager: mockSystemPermissionManager
+        )
+
+        viewModel.openAutoplaySettings()
+
+        XCTAssertEqual(firedPixels.map(\.name), [AutoplayPromoPixel.settingsLinkClicked.name])
+        XCTAssertEqual(openedPanes, [.general])
+    }
+
+    /// The disclaimer link only exists within the promo: a settings jump from anywhere else isn't promo attribution.
+    func testWhenOpenAutoplaySettingsOutsideThePromoThenNoPixelIsFired() {
+        var firedPixels: [PixelKitEvent] = []
+        var openedPanes: [PreferencePaneIdentifier] = []
+
+        let viewModel = PermissionCenterViewModel(
+            domain: "example.com",
+            usedPermissions: Permissions(),
+            permissionManager: mockPermissionManager,
+            autoplayPreferences: autoplayPreferences,
+            featureFlagger: mockFeatureFlagger,
+            removePermission: { _ in },
+            dismissPopover: { },
+            openSettingsPane: { openedPanes.append($0) },
+            displaysAutoplayPolicy: true,
+            displaysAutoplayDiscovery: false,
+            firePixel: { firedPixels.append($0) },
+            systemPermissionManager: mockSystemPermissionManager
+        )
+
+        viewModel.openAutoplaySettings()
+
+        XCTAssertTrue(firedPixels.isEmpty)
+        XCTAssertEqual(openedPanes, [.general])
     }
 
     // MARK: - currentAutoplayDecision Tests

--- a/macOS/UnitTests/Promotions/AutoplayDiscoverabilityPromoDelegateTests.swift
+++ b/macOS/UnitTests/Promotions/AutoplayDiscoverabilityPromoDelegateTests.swift
@@ -19,6 +19,7 @@
 import Combine
 import FeatureFlags
 import PixelKit
+import PixelKitTestingUtilities
 import PrivacyConfig
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
@@ -28,22 +29,24 @@ final class AutoplayDiscoverabilityPromoDelegateTests: XCTestCase {
 
     private var featureFlagger: MockFeatureFlagger!
     private var windowControllersManager: WindowControllersManagerMock!
-    private var firedPixels: [PixelKitEvent]!
+    private var pixelFiring: PixelKitMock!
     private var sut: AutoplayDiscoverabilityPromoDelegate!
+
+    private var firedPixels: [ExpectedFireCall] { pixelFiring.actualFireCalls }
 
     override func setUp() {
         super.setUp()
         featureFlagger = MockFeatureFlagger(featuresStub: [FeatureFlag.autoplayPolicy.rawValue: true])
         windowControllersManager = WindowControllersManagerMock()
-        firedPixels = []
+        pixelFiring = PixelKitMock()
         sut = AutoplayDiscoverabilityPromoDelegate(featureFlagger: featureFlagger,
                                                    windowControllersManager: windowControllersManager,
-                                                   firePixel: { [weak self] pixel in self?.firedPixels.append(pixel) })
+                                                   pixelFiring: pixelFiring)
     }
 
     override func tearDown() {
         sut = nil
-        firedPixels = nil
+        pixelFiring = nil
         windowControllersManager = nil
         featureFlagger = nil
         super.tearDown()
@@ -96,11 +99,11 @@ final class AutoplayDiscoverabilityPromoDelegateTests: XCTestCase {
         XCTAssertTrue(firedPixels.isEmpty)
     }
 
-    /// The names must match `autoplay_promo_pixels.json5` verbatim.
+    /// The names must match `autoplay_promo_pixels.json5` minus the `m_mac_` prefix, which PixelKit prepends when firing.
     func testPixelNames() {
-        XCTAssertEqual(AutoplayPromoPixel.shown.name, "m_mac_autoplay-promo_shown")
-        XCTAssertEqual(AutoplayPromoPixel.engaged.name, "m_mac_autoplay-promo_engaged")
-        XCTAssertEqual(AutoplayPromoPixel.autoDismissed.name, "m_mac_autoplay-promo_auto-dismissed")
-        XCTAssertEqual(AutoplayPromoPixel.settingsLinkClicked.name, "m_mac_autoplay-promo_settings-click")
+        XCTAssertEqual(AutoplayPromoPixel.shown.name, "autoplay-promo_shown")
+        XCTAssertEqual(AutoplayPromoPixel.engaged.name, "autoplay-promo_engaged")
+        XCTAssertEqual(AutoplayPromoPixel.autoDismissed.name, "autoplay-promo_auto-dismissed")
+        XCTAssertEqual(AutoplayPromoPixel.settingsLinkClicked.name, "autoplay-promo_settings-click")
     }
 }

--- a/macOS/UnitTests/Promotions/AutoplayDiscoverabilityPromoDelegateTests.swift
+++ b/macOS/UnitTests/Promotions/AutoplayDiscoverabilityPromoDelegateTests.swift
@@ -18,6 +18,7 @@
 
 import Combine
 import FeatureFlags
+import PixelKit
 import PrivacyConfig
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
@@ -27,18 +28,22 @@ final class AutoplayDiscoverabilityPromoDelegateTests: XCTestCase {
 
     private var featureFlagger: MockFeatureFlagger!
     private var windowControllersManager: WindowControllersManagerMock!
+    private var firedPixels: [PixelKitEvent]!
     private var sut: AutoplayDiscoverabilityPromoDelegate!
 
     override func setUp() {
         super.setUp()
         featureFlagger = MockFeatureFlagger(featuresStub: [FeatureFlag.autoplayPolicy.rawValue: true])
         windowControllersManager = WindowControllersManagerMock()
+        firedPixels = []
         sut = AutoplayDiscoverabilityPromoDelegate(featureFlagger: featureFlagger,
-                                                   windowControllersManager: windowControllersManager)
+                                                   windowControllersManager: windowControllersManager,
+                                                   firePixel: { [weak self] pixel in self?.firedPixels.append(pixel) })
     }
 
     override func tearDown() {
         sut = nil
+        firedPixels = nil
         windowControllersManager = nil
         featureFlagger = nil
         super.tearDown()
@@ -75,8 +80,27 @@ final class AutoplayDiscoverabilityPromoDelegateTests: XCTestCase {
         XCTAssertEqual(result, .noChange)
     }
 
-    /// `PromoService` calls `hide()` on any promo it cleans up, including ones that never showed.
-    func testWhenHiddenWithoutShowingThenNothingHappens() {
+    /// `PromoService` calls `hide()` on any promo it cleans up, including ones that never showed: no dismissal to report.
+    func testWhenHiddenWithoutShowingThenNoPixelIsFired() {
         sut.hide()
+
+        XCTAssertTrue(firedPixels.isEmpty)
+    }
+
+    // MARK: - Pixels
+
+    /// Nothing was presented, so there is no impression to report.
+    func testWhenShowCannotPresentThenNoPixelIsFired() async {
+        _ = await sut.show(history: PromoHistoryRecord(id: "autoplay-discoverability"), force: false)
+
+        XCTAssertTrue(firedPixels.isEmpty)
+    }
+
+    /// The names must match `autoplay_promo_pixels.json5` verbatim.
+    func testPixelNames() {
+        XCTAssertEqual(AutoplayPromoPixel.shown.name, "m_mac_autoplay-promo_shown")
+        XCTAssertEqual(AutoplayPromoPixel.engaged.name, "m_mac_autoplay-promo_engaged")
+        XCTAssertEqual(AutoplayPromoPixel.autoDismissed.name, "m_mac_autoplay-promo_auto-dismissed")
+        XCTAssertEqual(AutoplayPromoPixel.settingsLinkClicked.name, "m_mac_autoplay-promo_settings-click")
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1217041230489686?focus=true
Tech Design URL:
CC:

### Description
This PR adds new Pixels for the Autoplay Discoverability flow.

### Testing Steps
1. Open `Debug > Promo Queue > Autoplay Discoverability`
2. Click on `Undismiss and Clear History`
3. Open: https://videojs.github.io/autoplay-tests/videojs/play/autoplay.html

- [ ] Verify the pixel `m_mac_autoplay-promo_shown` is logged
- [ ] Verify that if you move the mouse over the Popup, the pixel `m_mac_autoplay-promo_engaged` is tracked
- [ ] Verify that if you click on the **Settings Link**, `m_mac_autoplay-promo_settings-click` is tracked
- [ ] Verify that if, instead, you don't place the mouse over, the Popup gets dismissed and we track `m_mac_autoplay-promo_auto-dismissed`
- [ ] Verify that if you, afterwards, open the Permissions Center Popup, the `autoplay-promo` pixels don't get tracked

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Worst case scenario, we over-report the `autoplay-promo` pixels

### Quality Considerations
Nothing in particular

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes with guarded firing scoped to the promo flow; worst case is over-reporting pixels, not user-facing behavior.
> 
> **Overview**
> Adds **analytics pixels** for the Autoplay Discoverability Promo (auto-opened Permission Center on first autoplay-policy page), with JSON5 definitions and unit tests.
> 
> **New events** (`AutoplayPromoPixel`): `autoplay-promo_shown` when the promo presents (not debug force-show), `autoplay-promo_engaged` once when the user hovers and autodismiss is disabled, `autoplay-promo_auto-dismissed` when the timed hide actually closes a shown popover, and `autoplay-promo_settings-click` when the disclaimer settings link is used during the promo.
> 
> **Wiring:** `AutoplayDiscoverabilityPromoDelegate` accepts injectable `PixelFiring` and fires shown/auto-dismissed; `PermissionCenterViewModel` uses the same abstraction for promo engagement and settings clicks (and routes existing permission-center pixels through `pixelFiring` instead of `PixelKit.fire` directly). `autodismissPermissionCenterIfPossible()` now returns whether it closed the popover and requires `isShown` before autodismiss.
> 
> **Tests** assert promo-scoped firing (no pixels outside discoverability mode, engaged fires once on repeated hover).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 259c87f48b49147bbe552671aa2bbecd4437ede9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->