### PR TITLE
iOS Promo Queue: Add lifecycle-safe scheduling and NTP render gating

### DIFF
--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
@@ -227,6 +227,7 @@ extension Foreground {
     /// Use this method only to pause specific tasks, like video playback, when the app displays a system alert.
     func willLeave() {
         Logger.lifecycle.info("\(type(of: self)): \(#function)")
+        appDependencies.mainCoordinator.prepareModalPromptCoordinationForInactivity()
     }
 
     /// Called when the app resumes activity after being **paused** or when transitioning from launching or background.
@@ -235,6 +236,7 @@ extension Foreground {
     /// Use this method to revert any actions performed in `willLeave()` (if applicable).
     func didReturn() {
         Logger.lifecycle.info("\(type(of: self)): \(#function)")
+        appDependencies.mainCoordinator.prepareModalPromptCoordinationForForeground()
     }
 
 }

--- a/iOS/DuckDuckGo/AppServices/PromoCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/PromoCoordinationService.swift
@@ -29,11 +29,15 @@ import FeatureFlags_iOS
 @MainActor
 protocol ModalPromptPresenter: AnyObject {
     var presentedViewController: UIViewController? { get }
+    /// UIKit host whose attachment is validated before presenting; test presenters may return `nil`.
+    var modalPromptPresentationViewController: UIViewController? { get }
 
     func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?)
 }
 
-extension MainViewController: ModalPromptPresenter {}
+extension MainViewController: ModalPromptPresenter {
+    var modalPromptPresentationViewController: UIViewController? { self }
+}
 
 // MARK: - Service
 
@@ -73,6 +77,7 @@ final class PromoCoordinationService {
     private var pendingPromoQueueFeatureTargetState: PromoQueueFeatureTargetState?
     private var promoRetryRegistrations = [WeakPromoRetryRegistration]()
     private var isRetryingVisiblePromoRegistrations = false
+    private let promoQueueFeatureStateSubject: CurrentValueSubject<PromoQueueFeatureState, Never>
 
     private(set) var promoQueueFeatureState: PromoQueueFeatureState
 
@@ -138,8 +143,28 @@ final class PromoCoordinationService {
         self.promoQueueLeaseArbiter = promoQueueLeaseArbiter
 
         let initialTargetState = PromoQueueFeatureTargetState(isEnabled: featureFlagger.isFeatureOn(.promoPresentationCoordination))
-        promoQueueFeatureState = PromoQueueFeatureState(targetState: initialTargetState)
+        let initialFeatureState = PromoQueueFeatureState(targetState: initialTargetState)
+        promoQueueFeatureState = initialFeatureState
+        promoQueueFeatureStateSubject = CurrentValueSubject(initialFeatureState)
+        modalPromptCoordinationManager.setCoordinatedAttemptReleaseHandler { [weak self] in
+            guard self?.promoQueueFeatureState == .enabled else {
+                return
+            }
+            self?.retryActiveVisiblePromoRegistrations()
+        }
         subscribeToPromoQueueFeatureState(initialTargetState: initialTargetState)
+    }
+
+    func applicationWillResignActive() {
+        modalPromptCoordinationManager.applicationWillResignActive()
+    }
+
+    func applicationDidBecomeActive() {
+        modalPromptCoordinationManager.applicationDidBecomeActive()
+    }
+
+    func applicationDidEnterBackground() {
+        modalPromptCoordinationManager.applicationDidEnterBackground()
     }
 
     func presentModalPromptIfNeeded(from viewController: ModalPromptPresenter) {
@@ -196,14 +221,6 @@ final class PromoCoordinationService {
         }
     }
 
-    private func admitVisiblePromoDuringEnablingTransition(_ identity: VisiblePromoIdentity) -> VisiblePromoAdmissionResult {
-        guard promoQueueFeatureState == .transitioning(to: .enabled) else {
-            return .unavailableDuringTransition
-        }
-
-        return admitCoordinatedVisiblePromo(identity)
-    }
-
     private func admitCoordinatedVisiblePromo(_ identity: VisiblePromoIdentity) -> VisiblePromoAdmissionResult {
         let didReleaseModalLease = modalPromptCoordinationManager.reconcilePresentedModal()
         let result: VisiblePromoAdmissionResult
@@ -253,12 +270,13 @@ final class PromoCoordinationService {
             return
         }
 
-        promoQueueFeatureState = .transitioning(to: targetState)
+        updatePromoQueueFeatureState(.transitioning(to: targetState))
         defer {
-            // Keep the public barrier up through manager callbacks and the synchronous NTP retry pass. Publish the
-            // completed state before draining a reentrant flag update so the pending transition starts from a stable
-            // source state and its result cannot be overwritten by this transition.
+            // Keep the public barrier up through manager and NTP callbacks. Publish the completed state before draining
+            // a reentrant flag update so the pending transition starts from a stable source state and its result cannot
+            // be overwritten by this transition.
             promoQueueFeatureState = PromoQueueFeatureState(targetState: targetState)
+            promoQueueFeatureStateSubject.send(promoQueueFeatureState)
             if let pendingTargetState = pendingPromoQueueFeatureTargetState {
                 pendingPromoQueueFeatureTargetState = nil
                 transitionPromoQueueFeature(to: pendingTargetState)
@@ -266,17 +284,22 @@ final class PromoCoordinationService {
         }
 
         modalPromptCoordinationManager.promoQueueWillTransition(to: targetState)
+        let registrationsSnapshot = promoRetryRegistrations
+        for registration in registrationsSnapshot {
+            registration.target?.promoQueueWillTransition(to: targetState)
+        }
 
         promoQueueLeaseArbiter.invalidateAllLeases()
 
         modalPromptCoordinationManager.promoQueueDidTransition(to: targetState)
-
-        if targetState == .enabled {
-            retryActiveVisiblePromoRegistrations(
-                excluding: nil,
-                using: admitVisiblePromoDuringEnablingTransition
-            )
+        for registration in registrationsSnapshot {
+            registration.target?.promoQueueDidTransition(to: targetState)
         }
+    }
+
+    private func updatePromoQueueFeatureState(_ state: PromoQueueFeatureState) {
+        promoQueueFeatureState = state
+        promoQueueFeatureStateSubject.send(state)
     }
 
     private func deregisterVisiblePromoRetry(for surfaceID: UUID, registrationID: UUID) {
@@ -321,6 +344,10 @@ final class PromoCoordinationService {
 }
 
 extension PromoCoordinationService: NewTabPagePromoCoordinating {
+    var promoQueueFeatureStatePublisher: AnyPublisher<PromoQueueFeatureState, Never> {
+        promoQueueFeatureStateSubject.eraseToAnyPublisher()
+    }
+
     func admitVisiblePromo(_ identity: VisiblePromoIdentity) -> VisiblePromoAdmissionResult {
         switch promoQueueFeatureState {
         case .disabled:

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2036,10 +2036,12 @@ class MainViewController: UIViewController {
         // presentChatPathOnboardingCompletionIfNeeded. Restored by NewTabPageViewController
         // on every dismissal path.
         if daxDialogsManager.chatPathPhase == .trackerToEOJ && aiChatSettings.isAIChatEnabled {
+            controller.setPromoSurfaceVisible(false)
             controller.view.alpha = 0
         }
 
         addToContentContainer(controller: controller)
+        controller.setPromoSurfaceActive(true)
         viewCoordinator.logoContainer.isHidden = true
         adjustNewTabPageSafeAreaInsets(for: appSettings.currentAddressBarPosition)
 
@@ -2107,6 +2109,7 @@ class MainViewController: UIViewController {
     }
 
     fileprivate func removeHomeScreen() {
+        newTabPageViewController?.setPromoSurfaceActive(false)
         newTabPageViewController?.willMove(toParent: nil)
         newTabPageViewController?.dismiss()
         newTabPageViewController = nil
@@ -3089,6 +3092,7 @@ class MainViewController: UIViewController {
     }
     
     private func showSuggestionTray(_ type: SuggestionTrayViewController.SuggestionType) {
+        newTabPageViewController?.setPromoSurfaceActive(false)
         suggestionTrayController?.show(for: type)
         applyWidthToTrayController()
         if !isUsingSingleBar {
@@ -3108,6 +3112,8 @@ class MainViewController: UIViewController {
         viewCoordinator.suggestionTrayContainer.isHidden = true
         currentTab?.webView.accessibilityElementsHidden = false
         suggestionTrayController?.didHide(animated: false)
+        let isCoveredByUnifiedInput = unifiedToggleInputCoordinator?.computeRenderState().isContentVisible == true
+        newTabPageViewController?.setPromoSurfaceActive(!isCoveredByUnifiedInput)
     }
     
     func launchAutofillLogins(with currentTabUrl: URL? = nil, currentTabUid: String? = nil, openSearch: Bool = false, source: AutofillSettingsSource, selectedAccount: SecureVaultModels.WebsiteAccount? = nil, extensionPromotionManager: AutofillExtensionPromotionManaging? = nil) {
@@ -6166,6 +6172,7 @@ extension MainViewController: TabDelegate {
         // Hide the NTP synchronously, before any frame is rendered, so its empty-state Dax can't
         // flash before the editing-state transition begins. Restored by NewTabPageViewController
         // on every dismissal path.
+        newTabPageViewController?.setPromoSurfaceVisible(false)
         newTabPageViewController?.view.alpha = 0
         DispatchQueue.main.async { [weak self] in
             self?.newTabPageViewController?.showDuckAIOnboardingCompletionWithActiveAddressBar(message: message)
@@ -6542,18 +6549,26 @@ extension MainViewController: TabSwitcherDelegate {
     }
 
     private func animateLogoAppearance() {
-        newTabPageViewController?.view.transform = CGAffineTransform().scaledBy(x: 0.5, y: 0.5)
-        newTabPageViewController?.view.alpha = 0.0
+        guard let newTabPageViewController else { return }
+        newTabPageViewController.setPromoSurfaceVisible(false)
+        newTabPageViewController.view.transform = CGAffineTransform().scaledBy(x: 0.5, y: 0.5)
+        newTabPageViewController.view.alpha = 0.0
         UIView.animate(withDuration: 0.2, delay: 0.1, options: [.curveEaseInOut, .beginFromCurrentState]) {
-            self.newTabPageViewController?.view.transform = .identity
-            self.newTabPageViewController?.view.alpha = 1.0
+            newTabPageViewController.view.transform = .identity
+            newTabPageViewController.view.alpha = 1.0
+        } completion: { _ in
+            newTabPageViewController.setPromoSurfaceVisible(true)
         }
     }
 
     private func deferNTPAppearance() {
-        newTabPageViewController?.view.alpha = 0.0
+        guard let newTabPageViewController else { return }
+        newTabPageViewController.setPromoSurfaceVisible(false)
+        newTabPageViewController.view.alpha = 0.0
         UIView.animate(withDuration: 0.2, delay: 0.2, options: [.curveEaseInOut, .beginFromCurrentState]) {
-            self.newTabPageViewController?.view.alpha = 1.0
+            newTabPageViewController.view.alpha = 1.0
+        } completion: { _ in
+            newTabPageViewController.setPromoSurfaceVisible(true)
         }
     }
 

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Helpers/ModalPromptScheduling.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Helpers/ModalPromptScheduling.swift
@@ -19,13 +19,49 @@
 
 import Foundation
 
-// Used to present modal prompt with a small delay. Used to easily write test by replacing it with an ImmediateScheduler.
-protocol ModalPromptScheduling {
-    func schedule(after delay: TimeInterval, execute: @escaping @MainActor () -> Void)
+/// An idempotently cancellable handle for scheduled modal-prompt work.
+@MainActor
+final class ModalPromptScheduledTask {
+    private var cancellationHandler: (() -> Void)?
+
+    init(cancellationHandler: @escaping () -> Void = {}) {
+        self.cancellationHandler = cancellationHandler
+    }
+
+    func cancel() {
+        let cancellationHandler = cancellationHandler
+        self.cancellationHandler = nil
+        cancellationHandler?()
+    }
 }
 
+/// Schedules modal-prompt work while allowing tests to substitute deterministic timing.
+@MainActor
+protocol ModalPromptScheduling {
+    @discardableResult
+    func schedule(after delay: TimeInterval, execute: @escaping @MainActor () -> Void) -> ModalPromptScheduledTask
+
+    @discardableResult
+    func scheduleOnNextMainTurn(execute: @escaping @MainActor () -> Void) -> ModalPromptScheduledTask
+}
+
+@MainActor
 final class ModalPromptScheduler: ModalPromptScheduling {
-    func schedule(after delay: TimeInterval, execute: @escaping @MainActor () -> Void) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: execute)
+    @discardableResult
+    func schedule(after delay: TimeInterval, execute: @escaping @MainActor () -> Void) -> ModalPromptScheduledTask {
+        let workItem = DispatchWorkItem(block: execute)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+        return ModalPromptScheduledTask {
+            workItem.cancel()
+        }
+    }
+
+    @discardableResult
+    func scheduleOnNextMainTurn(execute: @escaping @MainActor () -> Void) -> ModalPromptScheduledTask {
+        let workItem = DispatchWorkItem(block: execute)
+        DispatchQueue.main.async(execute: workItem)
+        return ModalPromptScheduledTask {
+            workItem.cancel()
+        }
     }
 }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
@@ -23,6 +23,7 @@ import UIKit
 protocol ModalPromptCoordinationManaging {
     var didPresentModalPromptThisSession: Bool { get }
 
+    func setCoordinatedAttemptReleaseHandler(_ handler: (@MainActor () -> Void)?)
     func presentModalPromptIfNeeded(from presenter: ModalPromptPresenter)
     func presentModalPromptIfNeeded(
         from presenter: ModalPromptPresenter,
@@ -31,23 +32,26 @@ protocol ModalPromptCoordinationManaging {
     func reconcilePresentedModal() -> Bool
     func promoQueueWillTransition(to targetState: PromoQueueFeatureTargetState)
     func promoQueueDidTransition(to targetState: PromoQueueFeatureTargetState)
+    func applicationWillResignActive()
+    func applicationDidBecomeActive()
+    func applicationDidEnterBackground()
 }
 
 enum ModalPromptLeaseDisposition: Equatable {
-    /// The manager kept the lease for a selected or presented modal.
+    /// The manager retained the lease for pending or active modal work.
     case retained
-    /// The manager released the lease because no modal will be presented.
+    /// The manager released the lease because no coordinated modal work remains.
     case released
 }
 
 enum ModalPromptAttemptPhase: Equatable {
-    /// No coordinated modal owns a lease.
+    /// No coordinated modal attempt owns a lease.
     case idle
-    /// A modal is being selected; carries this lease acquisition's identity.
+    /// Providers are being evaluated for the identified lease acquisition.
     case evaluating(PromoQueueModalAttemptIdentity)
-    /// A modal was selected and scheduled; carries this lease acquisition's identity.
+    /// A prepared modal is waiting for its scheduled presentation attempt.
     case committed(PromoQueueModalAttemptIdentity)
-    /// The modal root was handed to UIKit; carries this lease acquisition's identity.
+    /// UIKit handoff is being verified or the presented root has been accepted.
     case presentationActive(PromoQueueModalAttemptIdentity)
 }
 
@@ -61,39 +65,109 @@ enum ModalPromptAttemptPhase: Equatable {
 /// App-lifecycle concerns, such as launch source checks, belong to `PromoCoordinationService`.
 @MainActor
 final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
-    private struct SelectedPrompt {
+    // MARK: - Attempt Model
+
+    /// A prepared prompt paired with its provider and idempotent presentation accounting.
+    private final class PreparedItem {
         let configuration: ModalPromptConfiguration
         let provider: any ModalPromptProvider
+        var didRecordPresentation = false
+
+        init(configuration: ModalPromptConfiguration, provider: any ModalPromptProvider) {
+            self.configuration = configuration
+            self.provider = provider
+        }
     }
 
-    private struct CommittedAttempt {
-        let lease: PromoQueueModalLease
-        let selectedPrompt: SelectedPrompt
+    /// Retains the exact root during UIKit handoff and weakly tracks the presenter and intended host.
+    private final class VerifyingPresentation {
+        let preparedItem: PreparedItem
+        let exactRoot: UIViewController
+        weak var presenter: ModalPromptPresenter?
+        weak var intendedHost: UIViewController?
+
+        init(
+            preparedItem: PreparedItem,
+            exactRoot: UIViewController,
+            presenter: ModalPromptPresenter,
+            intendedHost: UIViewController?
+        ) {
+            self.preparedItem = preparedItem
+            self.exactRoot = exactRoot
+            self.presenter = presenter
+            self.intendedHost = intendedHost
+        }
     }
 
-    /// Weak holder for a presented modal root, since an enum payload cannot itself be `weak`.
-    ///
-    /// Checkpoints are sparse (foreground and NTP promo admission), so a strong payload would leave the manager the
-    /// sole owner of a dismissed modal's whole view hierarchy for as long as the user keeps browsing. The providers that
-    /// keep the presented controller keep it weakly for the same reason.
-    private final class PresentedModalRoot {
-        weak var viewController: UIViewController?
+    /// Weakly tracks an accepted root so sparse reconciliation does not retain dismissed UI.
+    private final class WeakPresentedRoot {
+        private(set) weak var viewController: UIViewController?
 
         init(_ viewController: UIViewController) {
             self.viewController = viewController
         }
     }
 
+    /// The UIKit host path selected immediately before coordinated presentation.
+    private enum PresentationRoute {
+        /// Present through the supplied presenter, optionally exposing its UIKit host for attachment validation.
+        case presenter(UIViewController?)
+        /// Present directly over the currently attached OmniBar editing controller.
+        case omniBar(UIViewController)
+
+        var intendedHost: UIViewController? {
+            switch self {
+            case .presenter(let host):
+                return host
+            case .omniBar(let host):
+                return host
+            }
+        }
+    }
+
+    private struct CoordinatedAttempt {
+        let lease: PromoQueueModalLease
+    }
+
+    private struct CommittedAttempt {
+        let attempt: CoordinatedAttempt
+        let preparedItem: PreparedItem
+        let presenter: ModalPromptPresenter
+    }
+
+    private struct PresentationActiveAttempt {
+        enum State {
+            /// UIKit received the root, but physical attachment or completion has not yet confirmed presentation.
+            case verifying(VerifyingPresentation)
+            /// The exact root was observed attached and is now tracked weakly until dismissal.
+            case accepted(WeakPresentedRoot)
+        }
+
+        let attempt: CoordinatedAttempt
+        let state: State
+
+        var exactRoot: UIViewController? {
+            switch state {
+            case .verifying(let presentation):
+                return presentation.exactRoot
+            case .accepted(let root):
+                return root.viewController
+            }
+        }
+    }
+
     private enum AttemptState {
-        /// No coordinated modal owns a lease.
+        /// No coordinated attempt owns a lease.
         case idle
         /// Holds the lease while providers are evaluated.
-        case evaluating(PromoQueueModalLease)
-        /// Holds the lease and selected prompt until scheduled presentation begins.
+        case evaluating(CoordinatedAttempt)
+        /// Holds the prepared prompt and lease until scheduled presentation begins.
         case committed(CommittedAttempt)
-        /// Holds the lease and exact presented root until reconciliation observes its dismissal.
-        case presentationActive(PromoQueueModalLease, exactRoot: PresentedModalRoot)
+        /// Holds the lease while UIKit handoff is verified or the accepted root remains attached.
+        case presentationActive(PresentationActiveAttempt)
     }
+
+    // MARK: - Dependencies
 
     private let providers: [any ModalPromptProvider]
     private let cooldownManager: PromptCooldownManaging
@@ -102,78 +176,125 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
     private let promoQueueLeaseArbiter: PromoQueueLeaseArbitrating
     private let rootAttachmentChecker: ModalPromptRootAttachmentChecking
 
-    private var attemptState = AttemptState.idle
-    private var legacyActiveAttemptIDs = Set<UUID>()
+    // MARK: - State
 
-    /// The exact root of the most recent modal the manager actually handed to UIKit, on either path.
-    ///
-    /// Recorded at presentation time rather than selection time: its only reader re-adopts a modal that is genuinely on
-    /// screen when the feature turns on, and a root that was merely selected has nothing on screen to re-adopt.
+    private var attemptState = AttemptState.idle
+    private var pendingPreparedItem: PreparedItem?
+    private var scheduledPresentationTask: ModalPromptScheduledTask?
+    private var attachmentVerificationTask: ModalPromptScheduledTask?
+    private var attachmentVerificationRequestID: UUID?
+    private var legacyActiveAttemptIDs = Set<UUID>()
+    /// The latest exact root handed to UIKit, used to adopt an attached presentation when coordination enables.
     private weak var lastPresentedExactRoot: UIViewController?
+    private var isPromoQueueEnabled = false
+    private var isApplicationActive = true
 
     private(set) var didActuallyPresentModalPromptThisSession = false
+    var coordinatedAttemptReleaseHandler: (@MainActor () -> Void)?
 
     var didPresentModalPromptThisSession: Bool {
         didActuallyPresentModalPromptThisSession || hasActiveOrPendingModalAttempt
     }
 
     var hasActiveOrPendingModalAttempt: Bool {
-        !legacyActiveAttemptIDs.isEmpty || modalAttemptPhase != .idle
+        !legacyActiveAttemptIDs.isEmpty || modalAttemptPhase != .idle || pendingPreparedItem != nil
     }
 
     var modalAttemptPhase: ModalPromptAttemptPhase {
         switch attemptState {
         case .idle:
             return .idle
-        case .evaluating(let lease):
-            return .evaluating(lease.attemptIdentity)
+        case .evaluating(let attempt):
+            return .evaluating(attempt.lease.attemptIdentity)
         case .committed(let committedAttempt):
-            return .committed(committedAttempt.lease.attemptIdentity)
-        case .presentationActive(let lease, _):
-            return .presentationActive(lease.attemptIdentity)
+            return .committed(committedAttempt.attempt.lease.attemptIdentity)
+        case .presentationActive(let activeAttempt):
+            return .presentationActive(activeAttempt.attempt.lease.attemptIdentity)
         }
     }
+
+    // MARK: - Initialization
 
     init(
         providers: [any ModalPromptProvider],
         cooldownManager: PromptCooldownManaging,
         onboardingStatusProvider: ContextualDaxDialogStatusProvider,
         promoQueueLeaseArbiter: PromoQueueLeaseArbitrating,
-        modalPromptScheduling: ModalPromptScheduling = ModalPromptScheduler(),
+        modalPromptScheduling: ModalPromptScheduling? = nil,
         rootAttachmentChecker: ModalPromptRootAttachmentChecking? = nil
     ) {
         self.providers = providers
         self.cooldownManager = cooldownManager
         self.onboardingStatusProvider = onboardingStatusProvider
         self.promoQueueLeaseArbiter = promoQueueLeaseArbiter
-        self.scheduler = modalPromptScheduling
+        self.scheduler = modalPromptScheduling ?? ModalPromptScheduler()
         self.rootAttachmentChecker = rootAttachmentChecker ?? ModalPromptRootAttachmentChecker()
     }
 
-    /// Clears legacy and coordinated modal bookkeeping before the feature state flips.
-    ///
-    /// The cleanup is intentionally direction-independent, so `targetState` is not consulted here: both directions
-    /// must drop the other path's in-flight bookkeeping. The parameter is kept because transition callbacks carry
-    /// the target state by design.
+    // MARK: - Lifecycle
+
+    /// Clears legacy and coordinated bookkeeping before either feature-state transition direction.
     func promoQueueWillTransition(to targetState: PromoQueueFeatureTargetState) {
-        legacyActiveAttemptIDs.removeAll()
+        isPromoQueueEnabled = false
         latchActualPresentationHistoryIfModalIsAttached()
+        pendingPreparedItem = nil
+        legacyActiveAttemptIDs.removeAll()
         releaseCoordinationAttempt()
     }
 
     func promoQueueDidTransition(to targetState: PromoQueueFeatureTargetState) {
+        isPromoQueueEnabled = targetState == .enabled
         guard targetState == .enabled,
               let lastPresentedExactRoot,
-              rootAttachmentChecker.isAttached(lastPresentedExactRoot) else {
+              isExactRootAttached(lastPresentedExactRoot),
+              case .acquired(let lease) = promoQueueLeaseArbiter.acquireModalLease() else {
             return
         }
 
-        guard case .acquired(let lease) = promoQueueLeaseArbiter.acquireModalLease() else {
-            return
-        }
-
-        attemptState = .presentationActive(lease, exactRoot: PresentedModalRoot(lastPresentedExactRoot))
+        attemptState = .presentationActive(
+            PresentationActiveAttempt(
+                attempt: CoordinatedAttempt(lease: lease),
+                state: .accepted(WeakPresentedRoot(lastPresentedExactRoot))
+            )
+        )
     }
+
+    func applicationWillResignActive() {
+        isApplicationActive = false
+    }
+
+    func applicationDidBecomeActive() {
+        isApplicationActive = true
+
+        guard case .presentationActive(let activeAttempt) = attemptState,
+              case .verifying(let presentation) = activeAttempt.state else {
+            return
+        }
+
+        scheduleAttachmentVerification(
+            attemptIdentity: activeAttempt.attempt.lease.attemptIdentity,
+            exactRoot: presentation.exactRoot
+        )
+    }
+
+    func applicationDidEnterBackground() {
+        isApplicationActive = false
+
+        guard case .committed(let committedAttempt) = attemptState else {
+            return
+        }
+
+        pendingPreparedItem = committedAttempt.preparedItem
+        cancelScheduledPresentation()
+        attemptState = .idle
+        committedAttempt.attempt.lease.release()
+    }
+
+    func setCoordinatedAttemptReleaseHandler(_ handler: (@MainActor () -> Void)?) {
+        coordinatedAttemptReleaseHandler = handler
+    }
+
+    // MARK: - Presentation
 
     /// Attempts to present a modal prompt if one is eligible.
     ///
@@ -186,20 +307,20 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
     ///
     /// - Parameter presenter: The view controller to present from.
     func presentModalPromptIfNeeded(from presenter: ModalPromptPresenter) {
-        guard let selectedPrompt = selectModalPrompt() else { return }
+        guard let preparedItem = selectModalPrompt() else { return }
 
         let scheduledAttemptID = UUID()
         legacyActiveAttemptIDs.insert(scheduledAttemptID)
-        Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal from \(type(of: selectedPrompt.provider))")
+        Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal from \(type(of: preparedItem.provider))")
         presentLegacyModalPrompt(
-            modalPromptConfiguration: selectedPrompt.configuration,
+            modalPromptConfiguration: preparedItem.configuration,
             from: presenter,
             scheduledAttemptID: scheduledAttemptID
         ) { [weak self] in
             self?.legacyActiveAttemptIDs.remove(scheduledAttemptID)
             self?.didActuallyPresentModalPromptThisSession = true
             self?.saveModalPromptLastPresentationDate()
-            selectedPrompt.provider.didPresentModal()
+            preparedItem.provider.didPresentModal()
         }
     }
 
@@ -213,47 +334,88 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
             return .released
         }
 
-        attemptState = .evaluating(lease)
+        isPromoQueueEnabled = true
+        let attempt = CoordinatedAttempt(lease: lease)
+        attemptState = .evaluating(attempt)
 
-        guard let selectedPrompt = selectModalPrompt() else {
+        if let pendingPreparedItem {
+            self.pendingPreparedItem = nil
+            guard let preparedItem = selectModalPrompt(pendingPreparedItem: pendingPreparedItem) else {
+                releaseCoordinationAttempt()
+                return .released
+            }
+
+            let committedAttempt = CommittedAttempt(
+                attempt: attempt,
+                preparedItem: preparedItem,
+                presenter: presenter
+            )
+            attemptState = .committed(committedAttempt)
+            Logger.modalPrompt.debug("[Modal Prompt Coordination] - Retrying modal presentation after pending work.")
+            presentCoordinatedModal(committedAttempt)
+            return .retained
+        }
+
+        guard let preparedItem = selectModalPrompt() else {
             releaseCoordinationAttempt()
             return .released
         }
 
         let committedAttempt = CommittedAttempt(
-            lease: lease,
-            selectedPrompt: selectedPrompt
+            attempt: attempt,
+            preparedItem: preparedItem,
+            presenter: presenter
         )
         attemptState = .committed(committedAttempt)
-        Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal from \(type(of: selectedPrompt.provider))")
-        presentCoordinatedModal(committedAttempt, from: presenter)
+        Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal from \(type(of: preparedItem.provider))")
+        presentCoordinatedModal(committedAttempt)
         return .retained
     }
 
     /// Releases a coordinated modal only after the exact selected root is no longer attached.
     ///
     /// A child presented by that root does not affect this check because attachment is evaluated
-    /// against the observed root itself rather than the topmost view controller. A root that has already been
-    /// deallocated counts as not attached, so a lease can never outlive the modal it was taken for.
+    /// against the retained root itself rather than the topmost view controller.
     func reconcilePresentedModal() -> Bool {
-        guard case .presentationActive(let lease, let exactRoot) = attemptState else { return false }
-
-        if let root = exactRoot.viewController, rootAttachmentChecker.isAttached(root) {
+        guard case .presentationActive(let activeAttempt) = attemptState else {
             return false
         }
 
-        attemptState = .idle
-        lease.release()
-        return true
+        switch activeAttempt.state {
+        case .verifying:
+            return reconcileVerifyingPresentation(activeAttempt)
+        case .accepted:
+            if let exactRoot = activeAttempt.exactRoot,
+               isExactRootAttached(exactRoot) {
+                return false
+            }
+
+            cancelAttachmentVerification()
+            attemptState = .idle
+            activeAttempt.attempt.lease.release()
+            return true
+        }
     }
 }
 
 // MARK: - Private
 
 private extension ModalPromptCoordinationManager {
+    // MARK: - Selection and Preflight
 
-    private func selectModalPrompt() -> SelectedPrompt? {
-        guard !cooldownManager.isInCooldownPeriod else {
+    private enum PrePresentationValidationResult {
+        /// Presentation can proceed through the resolved UIKit route.
+        case ready(PresentationRoute)
+        /// The prepared root is already attached and can be adopted without another presentation call.
+        case alreadyAttached
+        /// Current conditions prevent presentation but allow the prepared prompt to be retried.
+        case recoverableFailure
+        /// The prepared prompt must be discarded rather than retried.
+        case terminalFailure
+    }
+
+    private func selectModalPrompt(pendingPreparedItem: PreparedItem? = nil) -> PreparedItem? {
+        guard pendingPreparedItem != nil || !cooldownManager.isInCooldownPeriod else {
             let cooldownInfo = cooldownManager.cooldownInfo
             let lastPresentationDate = cooldownInfo.lastPresentationDate.flatMap(String.init) ?? "-"
             Logger.modalPrompt.debug(
@@ -263,6 +425,16 @@ private extension ModalPromptCoordinationManager {
                 """
             )
             return nil
+        }
+
+        let invalidPendingPreparedItem: PreparedItem?
+        if let pendingPreparedItem {
+            if isRetainedPreparedItemStillValid(pendingPreparedItem) {
+                return pendingPreparedItem
+            }
+            invalidPendingPreparedItem = pendingPreparedItem
+        } else {
+            invalidPendingPreparedItem = nil
         }
 
         let isOnboardingComplete = onboardingStatusProvider.hasSeenOnboarding
@@ -276,39 +448,55 @@ private extension ModalPromptCoordinationManager {
                 )
                 continue
             }
-            guard let configuration = provider.provideModalPrompt() else { continue }
+            let configuration: ModalPromptConfiguration?
+            if let invalidPendingPreparedItem,
+               provider === invalidPendingPreparedItem.provider {
+                configuration = provider.provideReplacementModalPrompt(for: invalidPendingPreparedItem.configuration)
+            } else {
+                configuration = provider.provideModalPrompt()
+            }
+            guard let configuration else { continue }
 
-            return SelectedPrompt(configuration: configuration, provider: provider)
+            return PreparedItem(configuration: configuration, provider: provider)
         }
 
         Logger.modalPrompt.debug("[Modal Prompt Coordination] - No provider is eligible to present a modal.")
         return nil
     }
 
-    private func presentCoordinatedModal(_ committedAttempt: CommittedAttempt, from presenter: ModalPromptPresenter) {
-        scheduler.schedule(after: 0.1) { [weak self] in
+    // MARK: - Presentation Scheduling
+
+    private func presentCoordinatedModal(_ committedAttempt: CommittedAttempt) {
+        scheduledPresentationTask = scheduler.schedule(after: 0.1) { [weak self] in
             guard let self,
                   case .committed(let currentAttempt) = self.attemptState,
-                  currentAttempt.lease.attemptIdentity == committedAttempt.lease.attemptIdentity else {
+                  currentAttempt.attempt.lease.attemptIdentity == committedAttempt.attempt.lease.attemptIdentity else {
                 return
             }
 
-            self.attemptState = .presentationActive(
-                committedAttempt.lease,
-                exactRoot: PresentedModalRoot(committedAttempt.selectedPrompt.configuration.viewController)
-            )
-            self.performPresentation(
-                modalPromptConfiguration: committedAttempt.selectedPrompt.configuration,
-                from: presenter
-            ) { [weak self] in
-                self?.didActuallyPresentModalPromptThisSession = true
-                self?.saveModalPromptLastPresentationDate()
-                committedAttempt.selectedPrompt.provider.didPresentModal()
+            self.scheduledPresentationTask = nil
+            switch self.validatePrePresentation(committedAttempt) {
+            case .ready(let route):
+                self.beginPresentation(committedAttempt, using: route)
+            case .alreadyAttached:
+                self.adoptAttachedRoot(committedAttempt)
+            case .recoverableFailure:
+                self.finishPreVisibleAttempt(
+                    committedAttempt,
+                    retainAsPending: true,
+                    notifyRelease: true
+                )
+            case .terminalFailure:
+                self.finishPreVisibleAttempt(
+                    committedAttempt,
+                    retainAsPending: false,
+                    notifyRelease: true
+                )
             }
         }
     }
 
-    func presentLegacyModalPrompt(
+    private func presentLegacyModalPrompt(
         modalPromptConfiguration: ModalPromptConfiguration,
         from presenter: ModalPromptPresenter,
         scheduledAttemptID: UUID,
@@ -328,48 +516,357 @@ private extension ModalPromptCoordinationManager {
         }
     }
 
-    /// Hands the selected root to UIKit, and records it as the last root the manager presented.
-    func performPresentation(
+    private func presentationRoute(from presenter: ModalPromptPresenter) -> PresentationRoute? {
+        if let presented = presenter.presentedViewController,
+           presented is OmniBarEditingStateViewController,
+           !presented.isBeingDismissed {
+            return .omniBar(presented)
+        }
+
+        guard presenter.presentedViewController == nil
+                || presenter.presentedViewController?.isBeingDismissed == true else {
+            return nil
+        }
+
+        return .presenter(presenter.modalPromptPresentationViewController)
+    }
+
+    private func validatePrePresentation(_ committedAttempt: CommittedAttempt) -> PrePresentationValidationResult {
+        guard isPromoQueueEnabled else {
+            return .terminalFailure
+        }
+
+        guard isApplicationActive else {
+            return .recoverableFailure
+        }
+
+        let exactRoot = committedAttempt.preparedItem.configuration.viewController
+        if isExactRootAttached(exactRoot) {
+            return .alreadyAttached
+        }
+
+        guard isPreparedItemStillValid(committedAttempt.preparedItem) else {
+            return .terminalFailure
+        }
+
+        guard !exactRoot.isBeingDismissed else {
+            return .terminalFailure
+        }
+
+        guard let route = presentationRoute(from: committedAttempt.presenter),
+              isIntendedHostAttached(route.intendedHost) else {
+            return .recoverableFailure
+        }
+
+        return .ready(route)
+    }
+
+    private func isPreparedItemStillValid(_ preparedItem: PreparedItem) -> Bool {
+        let isOnboardingComplete = onboardingStatusProvider.hasSeenOnboarding
+        return preparedItem.provider.isEligibleToPresent(isOnboardingComplete: isOnboardingComplete)
+            && preparedItem.provider.isPreparedModalPromptStillValid(preparedItem.configuration)
+    }
+
+    private func isRetainedPreparedItemStillValid(_ preparedItem: PreparedItem) -> Bool {
+        let isOnboardingComplete = onboardingStatusProvider.hasSeenOnboarding
+        return preparedItem.provider.isEligibleToPresent(isOnboardingComplete: isOnboardingComplete)
+            && preparedItem.provider.isRetainedPreparedModalPromptStillValid(preparedItem.configuration)
+    }
+
+    private func isIntendedHostAttached(_ intendedHost: UIViewController?) -> Bool {
+        guard let intendedHost else {
+            // Protocol-only presenters used by tests do not necessarily expose their UIKit host.
+            return true
+        }
+
+        return rootAttachmentChecker.isAttached(intendedHost)
+    }
+
+    // MARK: - UIKit Handoff and Verification
+
+    private func beginPresentation(_ committedAttempt: CommittedAttempt, using route: PresentationRoute) {
+        let exactRoot = committedAttempt.preparedItem.configuration.viewController
+        let presentation = VerifyingPresentation(
+            preparedItem: committedAttempt.preparedItem,
+            exactRoot: exactRoot,
+            presenter: committedAttempt.presenter,
+            intendedHost: route.intendedHost
+        )
+        let activeAttempt = PresentationActiveAttempt(
+            attempt: committedAttempt.attempt,
+            state: .verifying(presentation)
+        )
+        attemptState = .presentationActive(activeAttempt)
+        rememberPresentedRoot(exactRoot)
+        let attemptIdentity = committedAttempt.attempt.lease.attemptIdentity
+
+        performPresentation(
+            committedAttempt.preparedItem.configuration,
+            using: route,
+            presenter: committedAttempt.presenter
+        ) { [weak self, attemptIdentity, preparedItem = committedAttempt.preparedItem, exactRoot] in
+            self?.recordPresentationCompletion(
+                attemptIdentity: attemptIdentity,
+                preparedItem: preparedItem,
+                exactRoot: exactRoot
+            )
+        }
+
+        guard case .presentationActive(let currentAttempt) = attemptState,
+              currentAttempt.attempt.lease.attemptIdentity == attemptIdentity,
+              case .verifying = currentAttempt.state else {
+            return
+        }
+
+        scheduleAttachmentVerification(attemptIdentity: attemptIdentity, exactRoot: exactRoot)
+    }
+
+    private func adoptAttachedRoot(_ committedAttempt: CommittedAttempt) {
+        let exactRoot = committedAttempt.preparedItem.configuration.viewController
+        attemptState = .presentationActive(
+            PresentationActiveAttempt(
+                attempt: committedAttempt.attempt,
+                state: .accepted(WeakPresentedRoot(exactRoot))
+            )
+        )
+        rememberPresentedRoot(exactRoot)
+        recordPresentation(for: committedAttempt.preparedItem)
+    }
+
+    private func verifyPresentationAttachment(
+        attemptIdentity: PromoQueueModalAttemptIdentity,
+        exactRoot: UIViewController
+    ) {
+        guard case .presentationActive(let activeAttempt) = attemptState,
+              activeAttempt.attempt.lease.attemptIdentity == attemptIdentity,
+              case .verifying(let presentation) = activeAttempt.state,
+              presentation.exactRoot === exactRoot else {
+            return
+        }
+
+        if reconcileVerifyingPresentation(activeAttempt) {
+            coordinatedAttemptReleaseHandler?()
+        }
+    }
+
+    private func scheduleAttachmentVerification(
+        attemptIdentity: PromoQueueModalAttemptIdentity,
+        exactRoot: UIViewController
+    ) {
+        guard attachmentVerificationRequestID == nil else {
+            return
+        }
+
+        let requestID = UUID()
+        attachmentVerificationRequestID = requestID
+        let task = scheduler.scheduleOnNextMainTurn { [weak self] in
+            guard let self,
+                  self.attachmentVerificationRequestID == requestID else {
+                return
+            }
+
+            self.attachmentVerificationRequestID = nil
+            self.attachmentVerificationTask = nil
+            self.verifyPresentationAttachment(attemptIdentity: attemptIdentity, exactRoot: exactRoot)
+        }
+
+        if attachmentVerificationRequestID == requestID {
+            attachmentVerificationTask = task
+        } else {
+            task.cancel()
+        }
+    }
+
+    private func recordPresentationCompletion(
+        attemptIdentity: PromoQueueModalAttemptIdentity,
+        preparedItem: PreparedItem,
+        exactRoot: UIViewController
+    ) {
+        let isCurrentAttempt: Bool
+        if case .presentationActive(let activeAttempt) = attemptState {
+            isCurrentAttempt = activeAttempt.attempt.lease.attemptIdentity == attemptIdentity
+                && activeAttempt.exactRoot === exactRoot
+        } else {
+            isCurrentAttempt = false
+        }
+
+        guard isCurrentAttempt || isExactRootAttached(exactRoot) else {
+            return
+        }
+
+        if isCurrentAttempt,
+           case .presentationActive(let activeAttempt) = attemptState,
+           case .verifying = activeAttempt.state {
+            acceptPresentation(activeAttempt, exactRoot: exactRoot)
+        }
+
+        recordPresentation(for: preparedItem)
+    }
+
+    private func finishPreVisibleAttempt(
+        _ committedAttempt: CommittedAttempt,
+        retainAsPending: Bool,
+        notifyRelease: Bool
+    ) {
+        pendingPreparedItem = retainAsPending ? committedAttempt.preparedItem : nil
+        attemptState = .idle
+        committedAttempt.attempt.lease.release()
+        if notifyRelease {
+            coordinatedAttemptReleaseHandler?()
+        }
+    }
+
+    // MARK: - Presentation Execution
+
+    private func performPresentation(
+        _ modalPromptConfiguration: ModalPromptConfiguration,
+        using route: PresentationRoute,
+        presenter: ModalPromptPresenter,
+        completion: @escaping (() -> Void)
+    ) {
+        switch route {
+        case .omniBar(let host):
+            Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal on top of OmniBarEditingStateViewController")
+            host.present(
+                modalPromptConfiguration.viewController,
+                animated: modalPromptConfiguration.animated,
+                completion: completion
+            )
+        case .presenter:
+            presenter.present(
+                modalPromptConfiguration.viewController,
+                animated: modalPromptConfiguration.animated,
+                completion: completion
+            )
+        }
+    }
+
+    private func performPresentation(
         modalPromptConfiguration: ModalPromptConfiguration,
         from presenter: ModalPromptPresenter,
         completion: @escaping (() -> Void)
     ) {
-        lastPresentedExactRoot = modalPromptConfiguration.viewController
-
         if let presented = presenter.presentedViewController, presented is OmniBarEditingStateViewController, !presented.isBeingDismissed {
             Logger.modalPrompt.debug("[Modal Prompt Coordination] - Presenting modal on top of OmniBarEditingStateViewController")
+            rememberPresentedRoot(modalPromptConfiguration.viewController)
             presented.present(modalPromptConfiguration.viewController, animated: modalPromptConfiguration.animated, completion: completion)
         } else {
+            rememberPresentedRoot(modalPromptConfiguration.viewController)
             presenter.present(modalPromptConfiguration.viewController, animated: modalPromptConfiguration.animated, completion: completion)
         }
     }
 
-    /// Records an attempt whose modal is genuinely on screen as actual session history before a feature transition tears
-    /// it down.
-    func latchActualPresentationHistoryIfModalIsAttached() {
-        guard case .presentationActive(_, let exactRoot) = attemptState,
-              let root = exactRoot.viewController,
-              rootAttachmentChecker.isAttached(root) else {
+    // MARK: - Reconciliation and Accounting
+
+    private func rememberPresentedRoot(_ exactRoot: UIViewController) {
+        lastPresentedExactRoot = exactRoot
+    }
+
+    private func reconcileVerifyingPresentation(_ activeAttempt: PresentationActiveAttempt) -> Bool {
+        guard isApplicationActive,
+              case .verifying(let presentation) = activeAttempt.state else {
+            return false
+        }
+
+        if isExactRootAttached(presentation.exactRoot) {
+            acceptPresentation(activeAttempt, exactRoot: presentation.exactRoot)
+            return false
+        }
+
+        // UIKit establishes the presentation relationship before the transition finishes attaching the root.
+        // Keep the lease while that relationship exists so a checkpoint during the animation cannot admit RMF.
+        guard !isPresentationInProgress(presentation) else {
+            return false
+        }
+
+        cancelAttachmentVerification()
+        // If UIKit attaches after this relationship-free rejection, the next pending retry will adopt the root.
+        pendingPreparedItem = presentation.preparedItem.didRecordPresentation ? nil : presentation.preparedItem
+        attemptState = .idle
+        activeAttempt.attempt.lease.release()
+        return true
+    }
+
+    private func recordPresentation(for preparedItem: PreparedItem) {
+        guard !preparedItem.didRecordPresentation else {
+            return
+        }
+
+        preparedItem.didRecordPresentation = true
+        didActuallyPresentModalPromptThisSession = true
+        saveModalPromptLastPresentationDate()
+        preparedItem.provider.didPresentModal()
+    }
+
+    private func acceptPresentation(_ activeAttempt: PresentationActiveAttempt, exactRoot: UIViewController) {
+        cancelAttachmentVerification()
+        attemptState = .presentationActive(
+            PresentationActiveAttempt(
+                attempt: activeAttempt.attempt,
+                state: .accepted(WeakPresentedRoot(exactRoot))
+            )
+        )
+    }
+
+    private func isExactRootAttached(_ exactRoot: UIViewController) -> Bool {
+        rootAttachmentChecker.isAttached(exactRoot)
+    }
+
+    private func isPresentationInProgress(_ presentation: VerifyingPresentation) -> Bool {
+        if presentation.presenter?.presentedViewController === presentation.exactRoot {
+            return true
+        }
+
+        guard let intendedHost = presentation.intendedHost else {
+            return false
+        }
+
+        return intendedHost.presentedViewController === presentation.exactRoot
+            || presentation.exactRoot.presentingViewController === intendedHost
+    }
+
+    // MARK: - Cleanup
+
+    private func releaseCoordinationAttempt() {
+        switch attemptState {
+        case .idle:
+            return
+        case .evaluating(let attempt):
+            attemptState = .idle
+            attempt.lease.release()
+        case .committed(let committedAttempt):
+            cancelScheduledPresentation()
+            attemptState = .idle
+            committedAttempt.attempt.lease.release()
+        case .presentationActive(let activeAttempt):
+            cancelAttachmentVerification()
+            attemptState = .idle
+            activeAttempt.attempt.lease.release()
+        }
+    }
+
+    /// Preserves session history before a feature transition forgets an exact root that UIKit attached.
+    private func latchActualPresentationHistoryIfModalIsAttached() {
+        guard let lastPresentedExactRoot,
+              isExactRootAttached(lastPresentedExactRoot) else {
             return
         }
 
         didActuallyPresentModalPromptThisSession = true
     }
 
-    func releaseCoordinationAttempt() {
-        switch attemptState {
-        case .idle:
-            return
-        case .evaluating(let lease), .presentationActive(let lease, _):
-            attemptState = .idle
-            lease.release()
-        case .committed(let committedAttempt):
-            attemptState = .idle
-            committedAttempt.lease.release()
-        }
+    private func cancelScheduledPresentation() {
+        scheduledPresentationTask?.cancel()
+        scheduledPresentationTask = nil
     }
 
-    func saveModalPromptLastPresentationDate() {
+    private func cancelAttachmentVerification() {
+        attachmentVerificationRequestID = nil
+        attachmentVerificationTask?.cancel()
+        attachmentVerificationTask = nil
+    }
+
+    private func saveModalPromptLastPresentationDate() {
         cooldownManager.recordLastPromptPresentationTimestamp()
     }
 

--- a/iOS/DuckDuckGo/ModalPromptCoordination/NewTabPagePromoCoordination.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/NewTabPagePromoCoordination.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+import Combine
 import Foundation
 
 enum VisiblePromoAdmissionResult {
@@ -34,17 +35,25 @@ enum VisiblePromoAdmissionResult {
 
 typealias VisiblePromoAdmissionHandler = @MainActor (VisiblePromoIdentity) -> VisiblePromoAdmissionResult
 
+/// A mounted NTP surface that can refresh and retry its retained visible-promo candidate.
 @MainActor
 protocol NewTabPagePromoRetrying: AnyObject {
     var isActiveForPromoRetry: Bool { get }
 
     /// Refreshes the retained candidate and retries it through the admission route supplied by the coordination owner.
     ///
-    /// The handler is synchronous and nonescaping so a feature transition can grant admission only to its own retry
-    /// pass while the public admission barrier remains active.
+    /// The handler is synchronous and nonescaping so the coordination owner controls admission for the entire retry.
     func retryVisiblePromoAdmission(using admissionHandler: VisiblePromoAdmissionHandler)
+    func promoQueueWillTransition(to targetState: PromoQueueFeatureTargetState)
+    func promoQueueDidTransition(to targetState: PromoQueueFeatureTargetState)
 }
 
+extension NewTabPagePromoRetrying {
+    func promoQueueWillTransition(to targetState: PromoQueueFeatureTargetState) {}
+    func promoQueueDidTransition(to targetState: PromoQueueFeatureTargetState) {}
+}
+
+/// An idempotently removable registration for NTP visible-promo retries.
 @MainActor
 final class NewTabPagePromoRetryRegistration {
     private var deregistrationHandler: (@MainActor () -> Void)?
@@ -60,9 +69,13 @@ final class NewTabPagePromoRetryRegistration {
     }
 }
 
+/// Coordinates NTP visible-promo admission, lease release, and retry registration.
 @MainActor
 protocol NewTabPagePromoCoordinating: AnyObject {
     var promoQueueFeatureState: PromoQueueFeatureState { get }
+    /// Emits the current state on subscription, followed by serialized transition states. Stable states are emitted
+    /// only after their transition barrier has been lowered.
+    var promoQueueFeatureStatePublisher: AnyPublisher<PromoQueueFeatureState, Never> { get }
 
     func admitVisiblePromo(_ identity: VisiblePromoIdentity) -> VisiblePromoAdmissionResult
     func releaseVisiblePromoLease(_ lease: PromoQueueVisiblePromoLease)
@@ -70,4 +83,10 @@ protocol NewTabPagePromoCoordinating: AnyObject {
         for surfaceID: UUID,
         target: NewTabPagePromoRetrying
     ) -> NewTabPagePromoRetryRegistration
+}
+
+extension NewTabPagePromoCoordinating {
+    var promoQueueFeatureStatePublisher: AnyPublisher<PromoQueueFeatureState, Never> {
+        Just(promoQueueFeatureState).eraseToAnyPublisher()
+    }
 }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Providers/CookiePopupProtectionOptInModalPromptProvider.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Providers/CookiePopupProtectionOptInModalPromptProvider.swift
@@ -137,6 +137,10 @@ final class CookiePopupProtectionOptInModalPromptProvider: ModalPromptProvider {
         }))
     }
 
+    func isPreparedModalPromptStillValid(_ configuration: ModalPromptConfiguration) -> Bool {
+        isEligibleToShow
+    }
+
     func didPresentModal() {
         let parameters = [PixelParameters.autoconsentEnabled: AppUserDefaults().autoconsentEnabled ? "true" : "false"]
         if store.shownCount == 0 {

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Providers/DefaultBrowserModalPromptProvider.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Providers/DefaultBrowserModalPromptProvider.swift
@@ -35,4 +35,12 @@ final class DefaultBrowserModalPromptProvider: ModalPromptProvider {
             animated: true
         )
     }
+
+    func isPreparedModalPromptStillValid(_ configuration: ModalPromptConfiguration) -> Bool {
+        presenter.isPreparedDefaultModalPromptStillValid()
+    }
+
+    func isRetainedPreparedModalPromptStillValid(_ configuration: ModalPromptConfiguration) -> Bool {
+        presenter.isRetainedPreparedDefaultModalPromptStillValid()
+    }
 }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Providers/ModalPromptProvider.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Providers/ModalPromptProvider.swift
@@ -40,7 +40,7 @@ struct ModalPromptConfiguration {
 /// A type that can provide a prompt to be presented to the centralised modal prompts coordination system.
 /// Providers act as lightweight adapters between feature-specific modal prompt logic and the centralised `ModalPromptCoordinationManager`.
 @MainActor
-protocol ModalPromptProvider {
+protocol ModalPromptProvider: AnyObject {
     /// Per-provider onboarding gate. The manager calls this before evaluating `provideModalPrompt()`.
     ///
     /// Default: returns `isOnboardingComplete` — providers that need standard gating get it for free.
@@ -50,6 +50,20 @@ protocol ModalPromptProvider {
     /// Provides a `ModalPromptConfiguration` if the provider has a prompt that is eligible to present.
     /// - Returns: A configured `ModalPromptConfiguration` ready for presentation if it is eligible to present the modal. `nil` otherwise.
     func provideModalPrompt() -> ModalPromptConfiguration?
+
+    /// Revalidates an already prepared prompt without preparing another controller or consuming selection state.
+    ///
+    /// The manager calls this before presenting coordinated work that may have been delayed or retained as pending.
+    /// Providers whose eligibility can change after preparation should override this with a read-only check.
+    func isPreparedModalPromptStillValid(_ configuration: ModalPromptConfiguration) -> Bool
+
+    /// Revalidates a prepared prompt that was retained across a recoverable presentation failure.
+    func isRetainedPreparedModalPromptStillValid(_ configuration: ModalPromptConfiguration) -> Bool
+
+    /// Provides a replacement for an invalid prepared prompt when repeating preparation is safe.
+    ///
+    /// The default implementation returns `nil` so providers whose preparation has side effects are not evaluated twice.
+    func provideReplacementModalPrompt(for invalidConfiguration: ModalPromptConfiguration) -> ModalPromptConfiguration?
 
     /// Called after the modal has been successfully presented.
     /// Use this to update any feature-specific tracking or state.
@@ -62,6 +76,18 @@ extension ModalPromptProvider {
     /// Override to apply a softer or stricter check.
     func isEligibleToPresent(isOnboardingComplete: Bool) -> Bool {
         isOnboardingComplete
+    }
+
+    func isPreparedModalPromptStillValid(_ configuration: ModalPromptConfiguration) -> Bool {
+        true
+    }
+
+    func isRetainedPreparedModalPromptStillValid(_ configuration: ModalPromptConfiguration) -> Bool {
+        isPreparedModalPromptStillValid(configuration)
+    }
+
+    func provideReplacementModalPrompt(for invalidConfiguration: ModalPromptConfiguration) -> ModalPromptConfiguration? {
+        nil
     }
 
     func didPresentModal() {}

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Providers/NewAddressBarPickerModalPromptProvider.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Providers/NewAddressBarPickerModalPromptProvider.swift
@@ -67,6 +67,10 @@ final class NewAddressBarPickerModalPromptProvider: ModalPromptProvider {
             animated: true
         )
     }
+
+    func isPreparedModalPromptStillValid(_ configuration: ModalPromptConfiguration) -> Bool {
+        validator.shouldDisplayNewAddressBarPicker()
+    }
     
     func didPresentModal() {
         Logger.modalPrompt.info("[Modal Prompt Coordination] - New Address Bar Picker Did Present Prompt")

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Providers/SubscriptionPromoModalPromptProvider.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Providers/SubscriptionPromoModalPromptProvider.swift
@@ -38,6 +38,10 @@ final class SubscriptionPromoModalPromptProvider: ModalPromptProvider {
         return ModalPromptConfiguration(viewController: prompt, animated: true)
     }
 
+    func isPreparedModalPromptStillValid(_ configuration: ModalPromptConfiguration) -> Bool {
+        coordinator.shouldPresentLaunchPrompt()
+    }
+
     func didPresentModal() {
         coordinator.markLaunchPromptPresented()
     }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Providers/WhatsNewModalPromptProvider.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Providers/WhatsNewModalPromptProvider.swift
@@ -99,6 +99,19 @@ final class WhatsNewCoordinator: NSObject, ModalPromptProvider {
         )
     }
 
+    func isPreparedModalPromptStillValid(_ configuration: ModalPromptConfiguration) -> Bool {
+        guard displayContext == .scheduled,
+              let preparedMessageID = remoteMessage?.id else {
+            return true
+        }
+
+        return repository.fetchScheduledMessage()?.id == preparedMessageID
+    }
+
+    func provideReplacementModalPrompt(for invalidConfiguration: ModalPromptConfiguration) -> ModalPromptConfiguration? {
+        provideModalPrompt()
+    }
+
     func didPresentModal() {
         // Only mark as shown for modal prompt context
         guard displayContext == .scheduled else { return }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Providers/WinBackOfferModalPromptProvider.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Providers/WinBackOfferModalPromptProvider.swift
@@ -38,6 +38,10 @@ final class WinBackOfferModalPromptProvider: ModalPromptProvider {
             animated: true
         )
     }
+
+    func isPreparedModalPromptStillValid(_ configuration: ModalPromptConfiguration) -> Bool {
+        coordinator.shouldPresentLaunchPrompt()
+    }
     
     func didPresentModal() {
         coordinator.markLaunchPromptPresented()

--- a/iOS/DuckDuckGo/NewTabPageMessagesModel.swift
+++ b/iOS/DuckDuckGo/NewTabPageMessagesModel.swift
@@ -21,11 +21,89 @@ import Core
 import Foundation
 import RemoteMessaging
 
-final class NewTabPageMessagesModel: ObservableObject {
+// MARK: - Render Models
 
-    @Published private(set) var homeMessageViewModels: [HomeMessageViewModel] = []
+/// A stable SwiftUI render slot for either a direct home message or a coordinated remote-message gate.
+struct NewTabPageHomeMessageRenderItem: Identifiable {
+    enum Content {
+        /// A home message rendered directly without coordinated admission.
+        case message(HomeMessageViewModel)
+        /// A stable mount point whose optional session reflects visible-promo admission.
+        case remoteMessageGate(NewTabPageRemoteMessageGate)
+    }
+
+    /// Stable identity used to preserve the appropriate SwiftUI mount across model refreshes.
+    let id: String
+    let content: Content
+}
+
+/// Keeps a remote-message mount in the render tree while admission controls whether it has content.
+struct NewTabPageRemoteMessageGate {
+    /// Identity of the gate for the current remote-message candidate.
+    let id: UUID
+    let messageID: String
+    /// Present only while this gate owns an admitted visible-promo render session.
+    let renderSession: NewTabPageRemoteMessageRenderSession?
+}
+
+/// Identity and view model for one admitted rendering of a remote message.
+struct NewTabPageRemoteMessageRenderSession {
+    /// Changes when SwiftUI should replace the mounted card with a newly admitted session.
+    let id: UUID
+    let viewModel: HomeMessageViewModel
+}
+
+@MainActor
+final class NewTabPageMessagesModel: ObservableObject {
+    // MARK: - Published State
+
+    @Published private(set) var homeMessageRenderItems: [NewTabPageHomeMessageRenderItem] = []
+
+    var homeMessageViewModels: [HomeMessageViewModel] {
+        homeMessageRenderItems.compactMap { item in
+            switch item.content {
+            case .message(let viewModel):
+                return viewModel
+            case .remoteMessageGate(let gate):
+                return gate.renderSession?.viewModel
+            }
+        }
+    }
+
+    let surfaceID: UUID
+
+    // MARK: - Coordination State
+
+    private struct AdmittedRemoteMessageSession {
+        let id: UUID
+        let gateID: UUID
+        let identity: VisiblePromoIdentity
+        let lease: PromoQueueVisiblePromoLease
+        var message: HomeMessage
+        var viewModel: HomeMessageViewModel
+        var appearanceRecorded: Bool
+    }
+
+    private struct RemoteMessageGateIdentity {
+        let id: UUID
+        let messageID: String
+    }
 
     private var observable: NSObjectProtocol?
+    private var retryRegistration: NewTabPagePromoRetryRegistration?
+    private var isLoaded = false
+    private var isTornDown = false
+    private var isSurfaceRenderable = false
+    private var attachedToWindowProvider: () -> Bool = { false }
+    private var messagesSnapshot = [HomeMessage]()
+    private var remoteMessageCandidate: HomeMessage?
+    private var remoteMessageGateIdentity: RemoteMessageGateIdentity?
+    private var visibleRemoteMessageGateID: UUID?
+    private var visibleRemoteMessageGateMountIDs = Set<UUID>()
+    private var admittedRemoteMessageSession: AdmittedRemoteMessageSession?
+    private var featureTransitionTarget: PromoQueueFeatureTargetState?
+
+    // MARK: - Dependencies
 
     private let homePageMessagesConfiguration: HomePageMessagesConfiguration
     private let notificationCenter: NotificationCenter
@@ -37,7 +115,10 @@ final class NewTabPageMessagesModel: ObservableObject {
     private let promoCoordinator: NewTabPagePromoCoordinating
     private let isOpenedAfterIdle: () -> Bool
 
+    // MARK: - Initialization
+
     init(homePageMessagesConfiguration: HomePageMessagesConfiguration,
+         surfaceID: UUID = UUID(),
          notificationCenter: NotificationCenter = .default,
          pixelFiring: PixelFiring.Type = Pixel.self,
          subscriptionDataReporter: SubscriptionDataReporting? = nil,
@@ -47,6 +128,7 @@ final class NewTabPageMessagesModel: ObservableObject {
          promoCoordinator: NewTabPagePromoCoordinating,
          isOpenedAfterIdle: @escaping () -> Bool = { false }) {
         self.homePageMessagesConfiguration = homePageMessagesConfiguration
+        self.surfaceID = surfaceID
         self.notificationCenter = notificationCenter
         self.pixelFiring = pixelFiring
         self.subscriptionDataReporter = subscriptionDataReporter
@@ -57,16 +139,132 @@ final class NewTabPageMessagesModel: ObservableObject {
         self.isOpenedAfterIdle = isOpenedAfterIdle
     }
 
+    deinit {
+        if let observable {
+            notificationCenter.removeObserver(observable)
+        }
+    }
+
+    // MARK: - Lifecycle
+
     func load() {
+        guard !isLoaded, !isTornDown else {
+            return
+        }
+
+        isLoaded = true
+        retryRegistration = promoCoordinator.registerVisiblePromoRetry(
+            for: surfaceID,
+            target: self
+        )
         observable = notificationCenter.addObserver(
             forName: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
             object: nil,
             queue: .main) { [weak self] _ in
-                self?.refresh()
+                MainActor.assumeIsolated {
+                    self?.refresh()
+                }
         }
 
         refresh()
     }
+
+    func tearDown() {
+        guard !isTornDown else {
+            return
+        }
+
+        isTornDown = true
+        isSurfaceRenderable = false
+        visibleRemoteMessageGateID = nil
+        visibleRemoteMessageGateMountIDs.removeAll()
+        remoteMessageGateIdentity = nil
+
+        if let observable {
+            notificationCenter.removeObserver(observable)
+            self.observable = nil
+        }
+        retryRegistration?.deregister()
+        retryRegistration = nil
+
+        withdrawAdmittedRemoteMessage()
+        messagesSnapshot = []
+        remoteMessageCandidate = nil
+        publishRenderItems()
+    }
+
+    // MARK: - Surface Exposure
+
+    func setSurfaceAttachmentProvider(_ provider: @escaping () -> Bool) {
+        attachedToWindowProvider = provider
+        attemptRemoteMessageAdmission()
+    }
+
+    func setSurfaceRenderable(_ isRenderable: Bool) {
+        guard isSurfaceRenderable != isRenderable else {
+            if isRenderable {
+                attemptRemoteMessageAdmission()
+            }
+            return
+        }
+
+        isSurfaceRenderable = isRenderable
+        if isRenderable {
+            attemptRemoteMessageAdmission()
+        } else {
+            withdrawAdmittedRemoteMessage()
+        }
+    }
+
+    // MARK: - Gate Mount Lifecycle
+
+    func remoteMessageGateDidAppear(gateID: UUID, messageID: String, mountID: UUID) {
+        guard remoteMessageCandidate?.remoteMessageID == messageID,
+              remoteMessageGateIdentity?.id == gateID,
+              remoteMessageGateIdentity?.messageID == messageID else {
+            return
+        }
+
+        visibleRemoteMessageGateID = gateID
+        visibleRemoteMessageGateMountIDs.insert(mountID)
+        attemptRemoteMessageAdmission()
+    }
+
+    func remoteMessageGateDidDisappear(gateID: UUID, messageID: String, mountID: UUID) {
+        guard remoteMessageGateIdentity?.id == gateID,
+              remoteMessageGateIdentity?.messageID == messageID,
+              visibleRemoteMessageGateID == gateID else {
+            return
+        }
+        guard visibleRemoteMessageGateMountIDs.remove(mountID) != nil else {
+            return
+        }
+        guard visibleRemoteMessageGateMountIDs.isEmpty else {
+            return
+        }
+
+        visibleRemoteMessageGateID = nil
+        withdrawAdmittedRemoteMessage()
+    }
+
+    func remoteMessageDidDisappear(renderSessionID: UUID, mountID: UUID) {
+        if admittedRemoteMessageSession?.id == renderSessionID {
+            guard visibleRemoteMessageGateMountIDs.count == 1,
+                  visibleRemoteMessageGateMountIDs.contains(mountID) else {
+                return
+            }
+
+            guard let session = admittedRemoteMessageSession else {
+                return
+            }
+            admittedRemoteMessageSession = nil
+            publishRenderItems()
+            promoCoordinator.releaseVisiblePromoLease(session.lease)
+            scheduleAdmissionAfterPhysicalRemoval()
+        }
+    }
+
+    // MARK: - Message Actions
 
     @MainActor
     func dismissHomeMessage(_ homeMessage: HomeMessage) async {
@@ -78,95 +276,441 @@ final class NewTabPageMessagesModel: ObservableObject {
         homePageMessagesConfiguration.didAppear(homeMessage)
     }
 
-    // MARK: - Private
-
     func refresh() {
+        refresh(shouldAttemptAdmission: true)
+    }
+
+    private func refresh(shouldAttemptAdmission: Bool) {
+        guard !isTornDown else {
+            return
+        }
+
         homePageMessagesConfiguration.refresh(openedAfterIdle: isOpenedAfterIdle())
-        updateHomeMessageViewModel()
+        updateHomeMessageViewModel(shouldAttemptAdmission: shouldAttemptAdmission)
     }
 
-    private func updateHomeMessageViewModel() {
-        let messages = homePageMessagesConfiguration.homeMessages
-        homeMessageViewModels = messages.compactMap(homeMessageViewModel(for:))
-    }
+    // MARK: - Render Model Updates
 
-    // MARK: - HomeMessageViewModel Mapping
+    private func updateHomeMessageViewModel(shouldAttemptAdmission: Bool = true) {
+        let newMessages = homePageMessagesConfiguration.homeMessages
+        let newRemoteMessageCandidate = newMessages.first(where: \.isRemoteMessage)
+        let previousMessageID = remoteMessageCandidate?.remoteMessageID
+        let newMessageID = newRemoteMessageCandidate?.remoteMessageID
 
-    private func homeMessageViewModel(for message: HomeMessage) -> HomeMessageViewModel? {
-        switch message {
-        case .placeholder:
-            return HomeMessageViewModel(messageId: "",
-                                        modelType: .small(titleText: "", descriptionText: ""),
-                                        messageActionHandler: messageActionHandler,
-                                        preloadedImage: nil,
-                                        loadRemoteImage: nil) { [weak self] _ in
-                await self?.dismissHomeMessage(message)
-            } onDidAppear: {
-                // no-op
-            } onAttachAdditionalParameters: { _, params in
-                params
-            }
+        messagesSnapshot = newMessages
 
-        case .remoteMessage(let remoteMessage):
+        if previousMessageID != newMessageID {
+            withdrawAdmittedRemoteMessage()
+            visibleRemoteMessageGateID = nil
+            visibleRemoteMessageGateMountIDs.removeAll()
+            remoteMessageGateIdentity = nil
+        }
 
-            // call didAppear here to support marking messages as shown when they appear on the new tab page
-            // as a result of refreshing a config while the user was on a new tab page already.
-            didAppear(message)
+        remoteMessageCandidate = newRemoteMessageCandidate
 
-            return HomeMessageViewModelBuilder.build(for: remoteMessage,
-                                                     with: subscriptionDataReporter,
-                                                     messageActionHandler: messageActionHandler,
-                                                     imageLoader: imageLoader,
-                                                     pixelReporter: pixelReporter) { @MainActor [weak self] action in
-                guard let action,
-                      let self else { return }
+        if let admittedRemoteMessageSession,
+           admittedRemoteMessageSession.identity.promoID == newMessageID,
+           let newRemoteMessageCandidate {
+            updateAdmittedRemoteMessageSession(
+                admittedRemoteMessageSession,
+                with: newRemoteMessageCandidate
+            )
+        }
 
-                switch action {
+        publishRenderItems()
 
-                case .action(let isSharing):
-                    if !isSharing {
-                        await self.dismissHomeMessage(message)
-                    }
-                    if remoteMessage.isMetricsEnabled {
-                        pixelFiring.fire(.remoteMessageActionClicked,
-                                         withAdditionalParameters: self.additionalParameters(for: remoteMessage.id))
-                    }
-
-                case .primaryAction(let isSharing):
-                    if !isSharing {
-                        await self.dismissHomeMessage(message)
-                    }
-                    if remoteMessage.isMetricsEnabled {
-                        pixelFiring.fire(.remoteMessagePrimaryActionClicked,
-                                         withAdditionalParameters: self.additionalParameters(for: remoteMessage.id))
-                    }
-
-                case .secondaryAction(let isSharing):
-                    if !isSharing {
-                        await self.dismissHomeMessage(message)
-                    }
-                    if remoteMessage.isMetricsEnabled {
-                        pixelFiring.fire(.remoteMessageSecondaryActionClicked,
-                                         withAdditionalParameters: self.additionalParameters(for: remoteMessage.id))
-                    }
-
-                case .close:
-                    await self.dismissHomeMessage(message)
-                    if remoteMessage.isMetricsEnabled {
-                        pixelFiring.fire(.remoteMessageDismissed,
-                                         withAdditionalParameters: self.additionalParameters(for: remoteMessage.id))
-                    }
-
-                }
-            } onDidAppear: { [weak self] in
-                self?.didAppear(message)
-            }
+        if previousMessageID != newMessageID {
+            scheduleAdmissionAfterPhysicalRemoval()
+        } else if shouldAttemptAdmission {
+            attemptRemoteMessageAdmission()
         }
     }
 
+    private func updateAdmittedRemoteMessageSession(
+        _ session: AdmittedRemoteMessageSession,
+        with message: HomeMessage
+    ) {
+        guard case .remoteMessage(let remoteMessage) = message else {
+            return
+        }
+
+        var updatedSession = session
+        updatedSession.message = message
+        guard let viewModel = makeRemoteMessageViewModel(
+            for: remoteMessage,
+            message: message,
+            renderSessionID: session.id
+        ) else {
+            withdrawAdmittedRemoteMessage()
+            return
+        }
+        updatedSession.viewModel = viewModel
+        admittedRemoteMessageSession = updatedSession
+    }
+
+    private func publishRenderItems(useCoordinatedGate coordinatedGateOverride: Bool? = nil) {
+        let shouldUseCoordinatedGate = coordinatedGateOverride
+            ?? (featureTransitionTarget != nil || promoCoordinator.promoQueueFeatureState != .disabled)
+        var renderItems = [NewTabPageHomeMessageRenderItem]()
+
+        for (index, message) in messagesSnapshot.enumerated() {
+            switch message {
+            case .placeholder:
+                let viewModel = makePlaceholderViewModel(for: message)
+                renderItems.append(NewTabPageHomeMessageRenderItem(
+                    id: "local-message-\(index)",
+                    content: .message(viewModel)
+                ))
+
+            case .remoteMessage(let remoteMessage):
+                if shouldUseCoordinatedGate {
+                    guard remoteMessage.id == remoteMessageCandidate?.remoteMessageID else {
+                        assertionFailure("Expected at most one remote message candidate")
+                        continue
+                    }
+                    let gateIdentity = remoteMessageGateIdentity(for: remoteMessage.id)
+                    let renderSession: NewTabPageRemoteMessageRenderSession?
+                    if let session = admittedRemoteMessageSession,
+                       session.identity.promoID == remoteMessage.id,
+                       session.gateID == gateIdentity.id {
+                        renderSession = NewTabPageRemoteMessageRenderSession(
+                            id: session.id,
+                            viewModel: session.viewModel
+                        )
+                    } else {
+                        renderSession = nil
+                    }
+
+                    renderItems.append(NewTabPageHomeMessageRenderItem(
+                        id: "remote-message-gate-\(gateIdentity.id.uuidString)",
+                        content: .remoteMessageGate(NewTabPageRemoteMessageGate(
+                            id: gateIdentity.id,
+                            messageID: remoteMessage.id,
+                            renderSession: renderSession
+                        ))
+                    ))
+                } else {
+                    remoteMessageGateIdentity = nil
+                    visibleRemoteMessageGateID = nil
+                    visibleRemoteMessageGateMountIDs.removeAll()
+                    guard let viewModel = makeLegacyRemoteMessageViewModel(
+                        for: remoteMessage,
+                        message: message
+                    ) else {
+                        continue
+                    }
+                    renderItems.append(NewTabPageHomeMessageRenderItem(
+                        id: "remote-message-\(remoteMessage.id)",
+                        content: .message(viewModel)
+                    ))
+                }
+            }
+        }
+
+        homeMessageRenderItems = renderItems
+    }
+
+    // MARK: - View Model Construction
+
+    private func makePlaceholderViewModel(for message: HomeMessage) -> HomeMessageViewModel {
+        HomeMessageViewModel(
+            messageId: "",
+            modelType: .small(titleText: "", descriptionText: ""),
+            messageActionHandler: messageActionHandler,
+            preloadedImage: nil,
+            loadRemoteImage: nil
+        ) { [weak self] _ in
+            await self?.dismissHomeMessage(message)
+        } onDidAppear: {
+            // no-op
+        } onAttachAdditionalParameters: { _, params in
+            params
+        }
+    }
+
+    private func makeLegacyRemoteMessageViewModel(
+        for remoteMessage: RemoteMessageModel,
+        message: HomeMessage
+    ) -> HomeMessageViewModel? {
+        // Preserve the feature-off path exactly: refreshing an already-visible NTP records
+        // appearance eagerly, and the SwiftUI view records its normal onAppear separately.
+        didAppear(message)
+
+        return buildRemoteMessageViewModel(
+            for: remoteMessage,
+            message: message
+        ) { [weak self] in
+            self?.didAppear(message)
+        }
+    }
+
+    private func makeRemoteMessageViewModel(
+        for remoteMessage: RemoteMessageModel,
+        message: HomeMessage,
+        renderSessionID: UUID
+    ) -> HomeMessageViewModel? {
+        buildRemoteMessageViewModel(
+            for: remoteMessage,
+            message: message
+        ) { [weak self] in
+            self?.recordAppearance(
+                for: message,
+                renderSessionID: renderSessionID
+            )
+        }
+    }
+
+    private func buildRemoteMessageViewModel(
+        for remoteMessage: RemoteMessageModel,
+        message: HomeMessage,
+        onDidAppear: @escaping () -> Void
+    ) -> HomeMessageViewModel? {
+        HomeMessageViewModelBuilder.build(
+            for: remoteMessage,
+            with: subscriptionDataReporter,
+            messageActionHandler: messageActionHandler,
+            imageLoader: imageLoader,
+            pixelReporter: pixelReporter
+        ) { @MainActor [weak self] action in
+            guard let action,
+                  let self else {
+                return
+            }
+
+            switch action {
+            case .action(let isSharing):
+                if !isSharing {
+                    await dismissHomeMessage(message)
+                }
+                if remoteMessage.isMetricsEnabled {
+                    pixelFiring.fire(
+                        .remoteMessageActionClicked,
+                        withAdditionalParameters: additionalParameters(for: remoteMessage.id)
+                    )
+                }
+
+            case .primaryAction(let isSharing):
+                if !isSharing {
+                    await dismissHomeMessage(message)
+                }
+                if remoteMessage.isMetricsEnabled {
+                    pixelFiring.fire(
+                        .remoteMessagePrimaryActionClicked,
+                        withAdditionalParameters: additionalParameters(for: remoteMessage.id)
+                    )
+                }
+
+            case .secondaryAction(let isSharing):
+                if !isSharing {
+                    await dismissHomeMessage(message)
+                }
+                if remoteMessage.isMetricsEnabled {
+                    pixelFiring.fire(
+                        .remoteMessageSecondaryActionClicked,
+                        withAdditionalParameters: additionalParameters(for: remoteMessage.id)
+                    )
+                }
+
+            case .close:
+                await dismissHomeMessage(message)
+                if remoteMessage.isMetricsEnabled {
+                    pixelFiring.fire(
+                        .remoteMessageDismissed,
+                        withAdditionalParameters: additionalParameters(for: remoteMessage.id)
+                    )
+                }
+            }
+        } onDidAppear: {
+            onDidAppear()
+        }
+    }
+
+    // MARK: - Appearance Accounting
+
+    private func recordAppearance(
+        for message: HomeMessage,
+        renderSessionID: UUID
+    ) {
+        guard var session = admittedRemoteMessageSession,
+              session.id == renderSessionID,
+              !session.appearanceRecorded else {
+            return
+        }
+
+        session.appearanceRecorded = true
+        admittedRemoteMessageSession = session
+        didAppear(message)
+    }
+
+    // MARK: - Admission
+
+    private func attemptRemoteMessageAdmission() {
+        guard promoCoordinator.promoQueueFeatureState == .enabled else {
+            return
+        }
+
+        attemptRemoteMessageAdmission(using: promoCoordinator.admitVisiblePromo)
+    }
+
+    private func attemptRemoteMessageAdmission(
+        using admissionHandler: VisiblePromoAdmissionHandler
+    ) {
+        guard isLoaded,
+              !isTornDown,
+              featureTransitionTarget == nil,
+              isSurfaceRenderable,
+              attachedToWindowProvider(),
+              let message = remoteMessageCandidate,
+              let messageID = message.remoteMessageID,
+              let gateIdentity = remoteMessageGateIdentity,
+              gateIdentity.messageID == messageID,
+              visibleRemoteMessageGateID == gateIdentity.id,
+              !visibleRemoteMessageGateMountIDs.isEmpty else {
+            return
+        }
+
+        if admittedRemoteMessageSession?.identity.promoID == messageID,
+           admittedRemoteMessageSession?.gateID == gateIdentity.id {
+            return
+        }
+
+        let identity = VisiblePromoIdentity(
+            surfaceID: surfaceID,
+            promoType: .remoteMessage,
+            promoID: messageID
+        )
+
+        let admissionResult = admissionHandler(identity)
+        switch admissionResult {
+        case .acquired(let lease):
+            guard case .remoteMessage(let remoteMessage) = message else {
+                promoCoordinator.releaseVisiblePromoLease(lease)
+                return
+            }
+            let renderSessionID = UUID()
+            guard let viewModel = makeRemoteMessageViewModel(
+                for: remoteMessage,
+                message: message,
+                renderSessionID: renderSessionID
+            ) else {
+                promoCoordinator.releaseVisiblePromoLease(lease)
+                return
+            }
+            admittedRemoteMessageSession = AdmittedRemoteMessageSession(
+                id: renderSessionID,
+                gateID: gateIdentity.id,
+                identity: identity,
+                lease: lease,
+                message: message,
+                viewModel: viewModel,
+                appearanceRecorded: false
+            )
+            publishRenderItems()
+
+        case .blockedByModal, .occupiedSurfaceSlot, .featureDisabled, .unavailableDuringTransition:
+            break
+        }
+    }
+
+    private func withdrawAdmittedRemoteMessage() {
+        guard let session = admittedRemoteMessageSession else {
+            return
+        }
+
+        admittedRemoteMessageSession = nil
+        publishRenderItems()
+        // SwiftUI removes the card in the transaction triggered above. The next-turn release
+        // bounds any physical-removal overlap to that single animation.
+        let promoCoordinator = promoCoordinator
+        DispatchQueue.main.async { [weak self, promoCoordinator, session] in
+            promoCoordinator.releaseVisiblePromoLease(session.lease)
+            self?.attemptRemoteMessageAdmission()
+        }
+    }
+
+    private func scheduleAdmissionAfterPhysicalRemoval() {
+        DispatchQueue.main.async { [weak self] in
+            self?.attemptRemoteMessageAdmission()
+        }
+    }
+
+    // MARK: - Utilities
+
     private func additionalParameters(for messageID: String) -> [String: String] {
         let defaultParameters = [PixelParameters.message: "\(messageID)"]
-        return subscriptionDataReporter?.mergeRandomizedParameters(for: .messageID(messageID),
-                                                                 with: defaultParameters) ?? defaultParameters
+        return subscriptionDataReporter?.mergeRandomizedParameters(
+            for: .messageID(messageID),
+            with: defaultParameters
+        ) ?? defaultParameters
+    }
+
+    private func remoteMessageGateIdentity(for messageID: String) -> RemoteMessageGateIdentity {
+        if let remoteMessageGateIdentity,
+           remoteMessageGateIdentity.messageID == messageID {
+            return remoteMessageGateIdentity
+        }
+
+        let identity = RemoteMessageGateIdentity(
+            id: UUID(),
+            messageID: messageID
+        )
+        remoteMessageGateIdentity = identity
+        return identity
+    }
+
+}
+
+// MARK: - NewTabPagePromoRetrying
+
+extension NewTabPageMessagesModel: NewTabPagePromoRetrying {
+    var isActiveForPromoRetry: Bool {
+        isLoaded
+            && !isTornDown
+            && isSurfaceRenderable
+            && attachedToWindowProvider()
+    }
+
+    func retryVisiblePromoAdmission(using admissionHandler: VisiblePromoAdmissionHandler) {
+        refresh(shouldAttemptAdmission: false)
+        attemptRemoteMessageAdmission(using: admissionHandler)
+    }
+
+    func promoQueueWillTransition(to targetState: PromoQueueFeatureTargetState) {
+        featureTransitionTarget = targetState
+        withdrawAdmittedRemoteMessage()
+        visibleRemoteMessageGateID = nil
+        visibleRemoteMessageGateMountIDs.removeAll()
+        publishRenderItems()
+    }
+
+    func promoQueueDidTransition(to targetState: PromoQueueFeatureTargetState) {
+        guard featureTransitionTarget == targetState else {
+            return
+        }
+
+        featureTransitionTarget = nil
+        if targetState == .disabled {
+            publishRenderItems(useCoordinatedGate: false)
+        } else {
+            publishRenderItems(useCoordinatedGate: true)
+        }
+    }
+}
+
+// MARK: - HomeMessage Helpers
+
+private extension HomeMessage {
+    var isRemoteMessage: Bool {
+        if case .remoteMessage = self {
+            return true
+        }
+        return false
+    }
+
+    var remoteMessageID: String? {
+        guard case .remoteMessage(let remoteMessage) = self else {
+            return nil
+        }
+        return remoteMessage.id
     }
 }

--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -49,8 +49,6 @@ struct NewTabPageView: View {
         self.narrowLayoutInLandscape = narrowLayoutInLandscape
         self.dismissKeyboardOnScroll = dismissKeyboardOnScroll
         self.layoutConfiguration = layoutConfiguration
-
-        self.messagesModel.load()
     }
 
     private var isShowingSections: Bool {
@@ -228,10 +226,39 @@ private extension NewTabPageView {
     }
 
     private var messagesSectionView: some View {
-        ForEach(messagesModel.homeMessageViewModels, id: \.messageId) { messageModel in
-            HomeMessageView(viewModel: messageModel)
-                .frame(maxWidth: horizontalSizeClass == .regular ? Metrics.messageMaximumWidthPad : Metrics.messageMaximumWidth)
-                .transition(.scale.combined(with: .opacity))
+        ForEach(messagesModel.homeMessageRenderItems) { item in
+            switch item.content {
+            case .message(let messageModel):
+                homeMessageView(messageModel)
+
+            case .remoteMessageGate(let gate):
+                remoteMessageGate(gate)
+            }
+        }
+    }
+
+    private func homeMessageView(_ viewModel: HomeMessageViewModel) -> some View {
+        HomeMessageView(viewModel: viewModel)
+            .frame(maxWidth: horizontalSizeClass == .regular ? Metrics.messageMaximumWidthPad : Metrics.messageMaximumWidth)
+            .transition(.scale.combined(with: .opacity))
+    }
+
+    @ViewBuilder
+    private func remoteMessageGate(_ gate: NewTabPageRemoteMessageGate) -> some View {
+        RemoteMessageGateMountView(gate: gate, messagesModel: messagesModel) { mountID in
+            if let renderSession = gate.renderSession {
+                homeMessageView(renderSession.viewModel)
+                    .id(renderSession.id)
+                    .onDisappear {
+                        messagesModel.remoteMessageDidDisappear(
+                            renderSessionID: renderSession.id,
+                            mountID: mountID
+                        )
+                    }
+            } else {
+                Color.clear
+                    .frame(height: 0)
+            }
         }
     }
 
@@ -261,6 +288,43 @@ private extension NewTabPageView {
         }
         let folded = layoutConfiguration.favoritesShareHatchTopInset ? Metrics.nonGridSectionTopPadding : 0
         return sectionsViewPadding(in: geometry) + folded
+    }
+}
+
+/// Gives each physical SwiftUI gate mount an identity for balanced appearance and disappearance callbacks.
+private struct RemoteMessageGateMountView<Content: View>: View {
+    @State private var mountID = UUID()
+
+    let gate: NewTabPageRemoteMessageGate
+    let messagesModel: NewTabPageMessagesModel
+    let content: (UUID) -> Content
+
+    init(
+        gate: NewTabPageRemoteMessageGate,
+        messagesModel: NewTabPageMessagesModel,
+        @ViewBuilder content: @escaping (UUID) -> Content
+    ) {
+        self.gate = gate
+        self.messagesModel = messagesModel
+        self.content = content
+    }
+
+    var body: some View {
+        content(mountID)
+            .onAppear {
+                messagesModel.remoteMessageGateDidAppear(
+                    gateID: gate.id,
+                    messageID: gate.messageID,
+                    mountID: mountID
+                )
+            }
+            .onDisappear {
+                messagesModel.remoteMessageGateDidDisappear(
+                    gateID: gate.id,
+                    messageID: gate.messageID,
+                    mountID: mountID
+                )
+            }
     }
 }
 
@@ -300,14 +364,7 @@ private struct Metrics {
 #Preview("Regular") {
     NewTabPageView(
         viewModel: NewTabPageViewModel(fireTab: false),
-        messagesModel: NewTabPageMessagesModel(
-            homePageMessagesConfiguration: PreviewMessagesConfiguration(
-                homeMessages: []
-            ),
-            messageActionHandler: RemoteMessagingActionHandler(),
-            imageLoader: PreviewImageLoader(),
-            promoCoordinator: PreviewNewTabPagePromoCoordinator()
-        ),
+        messagesModel: makePreviewMessagesModel(homeMessages: []),
         favoritesViewModel: FavoritesPreviewModel()
     )
 }
@@ -315,25 +372,18 @@ private struct Metrics {
 #Preview("With message") {
     NewTabPageView(
         viewModel: NewTabPageViewModel(fireTab: false),
-        messagesModel: NewTabPageMessagesModel(
-            homePageMessagesConfiguration: PreviewMessagesConfiguration(
-                homeMessages: [
-                    HomeMessage.remoteMessage(
-                        remoteMessage: RemoteMessageModel(
-                            id: "0",
-                            surfaces: .newTabPage,
-                            content: .small(titleText: "Title", descriptionText: "Description"),
-                            matchingRules: [],
-                            exclusionRules: [],
-                            isMetricsEnabled: false
-                        )
-                    )
-                ]
-            ),
-            messageActionHandler: RemoteMessagingActionHandler(),
-            imageLoader: PreviewImageLoader(),
-            promoCoordinator: PreviewNewTabPagePromoCoordinator()
-        ),
+        messagesModel: makePreviewMessagesModel(homeMessages: [
+            HomeMessage.remoteMessage(
+                remoteMessage: RemoteMessageModel(
+                    id: "0",
+                    surfaces: .newTabPage,
+                    content: .small(titleText: "Title", descriptionText: "Description"),
+                    matchingRules: [],
+                    exclusionRules: [],
+                    isMetricsEnabled: false
+                )
+            )
+        ]),
         favoritesViewModel: FavoritesPreviewModel()
     )
 }
@@ -341,14 +391,7 @@ private struct Metrics {
 #Preview("No favorites") {
     NewTabPageView(
         viewModel: NewTabPageViewModel(fireTab: false),
-        messagesModel: NewTabPageMessagesModel(
-            homePageMessagesConfiguration: PreviewMessagesConfiguration(
-                homeMessages: []
-            ),
-            messageActionHandler: RemoteMessagingActionHandler(),
-            imageLoader: PreviewImageLoader(),
-            promoCoordinator: PreviewNewTabPagePromoCoordinator()
-        ),
+        messagesModel: makePreviewMessagesModel(homeMessages: []),
         favoritesViewModel: FavoritesPreviewModel(favorites: [])
     )
 }
@@ -356,19 +399,26 @@ private struct Metrics {
 #Preview("Empty") {
     NewTabPageView(
         viewModel: NewTabPageViewModel(fireTab: false),
-        messagesModel: NewTabPageMessagesModel(
-            homePageMessagesConfiguration: PreviewMessagesConfiguration(
-                homeMessages: []
-            ),
-            messageActionHandler: RemoteMessagingActionHandler(),
-            imageLoader: PreviewImageLoader(),
-            promoCoordinator: PreviewNewTabPagePromoCoordinator()
-        ),
+        messagesModel: makePreviewMessagesModel(homeMessages: []),
         favoritesViewModel: FavoritesPreviewModel()
     )
 }
 
 /// An inert, always-disabled promo coordinator for SwiftUI previews.
+@MainActor
+private func makePreviewMessagesModel(homeMessages: [HomeMessage]) -> NewTabPageMessagesModel {
+    let model = NewTabPageMessagesModel(
+        homePageMessagesConfiguration: PreviewMessagesConfiguration(
+            homeMessages: homeMessages
+        ),
+        messageActionHandler: RemoteMessagingActionHandler(),
+        imageLoader: PreviewImageLoader(),
+        promoCoordinator: PreviewNewTabPagePromoCoordinator()
+    )
+    model.load()
+    return model
+}
+
 @MainActor
 private final class PreviewNewTabPagePromoCoordinator: NewTabPagePromoCoordinating {
     let promoQueueFeatureState = PromoQueueFeatureState.disabled

--- a/iOS/DuckDuckGo/NewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPageViewController.swift
@@ -76,6 +76,10 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
     private(set) var isShowingDuckAICompletionDialog = false
     private var isBorderSuppressedForChromeLayout = false
     private var didHideBarsForChatPathVisitSiteDialog = false
+    private var isPromoSurfaceOwnerActive = false
+    private var isPromoRenderLocationReady = false
+    private var isPromoSurfaceVisible = true
+    private var isPromoSurfaceCovered = false
     private let appSettings: AppSettings
     private let appWidthObserver: AppWidthObserver
     private let floatingUIManager: FloatingUIManaging
@@ -127,7 +131,9 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
                                             faviconLoader: faviconLoader,
                                             faviconsCache: faviconsCache)
         let viewModel = newTabPageViewModel
+        let promoSurfaceID = UUID()
         messagesModel = NewTabPageMessagesModel(homePageMessagesConfiguration: homePageMessagesConfiguration,
+                                                surfaceID: promoSurfaceID,
                                                 subscriptionDataReporter: subscriptionDataReporting,
                                                 messageActionHandler: remoteMessagingActionHandler,
                                                 imageLoader: remoteMessagingImageLoader,
@@ -143,7 +149,18 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
                                             messagesModel: self.messagesModel,
                                             favoritesViewModel: self.favoritesModel))
 
+        messagesModel.setSurfaceAttachmentProvider { [weak self] in
+            self?.viewIfLoaded?.window != nil
+        }
+        messagesModel.load()
         assignFavoriteModelActions()
+    }
+
+    deinit {
+        // UIKit view controllers are expected to deallocate on the main thread.
+        MainActor.assumeIsolated {
+            messagesModel.tearDown()
+        }
     }
 
     func setEscapeHatch(_ model: EscapeHatchModel?) {
@@ -166,7 +183,21 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        let windowAttachmentProbe = WindowAttachmentProbeView()
+        windowAttachmentProbe.isHidden = true
+        windowAttachmentProbe.isUserInteractionEnabled = false
+        windowAttachmentProbe.onWindowChanged = { [weak self] in
+            self?.updatePromoSurfaceExposure()
+        }
+        view.addSubview(windowAttachmentProbe)
+
         registerForNotifications()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        isPromoRenderLocationReady = true
+        updatePromoSurfaceExposure()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -178,6 +209,12 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
         if let hc = hostingController, hc.parent !== self {
             dismissHostingController(didFinishNTPOnboarding: false)
         }
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        isPromoRenderLocationReady = false
+        updatePromoSurfaceExposure()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -202,6 +239,40 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
             borderView.insertSelf(into: view)
             updateBorderView()
         }
+    }
+
+    func setPromoSurfaceActive(_ isActive: Bool) {
+        isPromoSurfaceOwnerActive = isActive
+        updatePromoSurfaceExposure()
+    }
+
+    func setPromoSurfaceRenderable(_ isRenderable: Bool) {
+        isPromoSurfaceOwnerActive = isRenderable
+        isPromoRenderLocationReady = isRenderable
+        updatePromoSurfaceExposure()
+    }
+
+    func setPromoSurfaceVisible(_ isVisible: Bool) {
+        isPromoSurfaceVisible = isVisible
+        updatePromoSurfaceExposure()
+    }
+
+    func tearDownPromoSurface() {
+        messagesModel.tearDown()
+    }
+
+    private func setPromoSurfaceCovered(_ isCovered: Bool) {
+        isPromoSurfaceCovered = isCovered
+        updatePromoSurfaceExposure()
+    }
+
+    private func updatePromoSurfaceExposure() {
+        messagesModel.setSurfaceRenderable(
+            isPromoSurfaceOwnerActive
+                && isPromoRenderLocationReady
+                && isPromoSurfaceVisible
+                && !isPromoSurfaceCovered
+        )
     }
 
     func setSectionTitle(_ title: String?) {
@@ -321,6 +392,8 @@ final class NewTabPageViewController: UIHostingController<NewTabPageView>, NewTa
     }
 
     func dismiss() {
+        messagesModel.setSurfaceRenderable(false)
+        messagesModel.tearDown()
         notifyDuckAICompletionDismissedIfNeeded()
         chromeDelegate?.setUnifiedInputContentOverlaySuppressed(false)
         if didHideBarsForChatPathVisitSiteDialog {
@@ -424,10 +497,20 @@ extension NewTabPageViewController: HomeScreenTransitionSource {
     }
 }
 
+/// Reports physical window attachment changes that hosting-controller lifecycle callbacks can miss.
+private final class WindowAttachmentProbeView: UIView {
+    var onWindowChanged: (() -> Void)?
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        onWindowChanged?()
+    }
+}
+
 extension NewTabPageViewController {
 
     func showDuckAIOnboardingCompletionDialog(message: String) {
-        dismissHostingController(didFinishNTPOnboarding: false)
+        dismissHostingController(didFinishNTPOnboarding: false, updatePromoSurfaceCoverage: false)
         // Completion dialog should not hide NTP background state.
         newTabPageViewModel.finishOnboarding()
 
@@ -445,9 +528,12 @@ extension NewTabPageViewController {
             isShowingDuckAICompletionDialog = false
             setLogoHidden(false)
             view.alpha = 1
+            setPromoSurfaceVisible(true)
+            setPromoSurfaceCovered(false)
             return
         }
 
+        setPromoSurfaceCovered(true)
         isShowingDuckAICompletionDialog = true
         editingController.setLogoHidden(true)
 
@@ -467,7 +553,7 @@ extension NewTabPageViewController {
                     // Editing state is about to be dismissed for the subscription promo —
                     // keep the suppressed Dax non-installed so the dismiss animation can't
                     // slide it in along with the editing state's logo Y-offset animation.
-                    self.dismissHostingController(didFinishNTPOnboarding: true)
+                    self.dismissHostingController(didFinishNTPOnboarding: true, updatePromoSurfaceCoverage: false)
                     self.chromeDelegate?.omniBar.endEditing()
                     self.showNextDaxDialog()
                 } else {
@@ -532,6 +618,7 @@ extension NewTabPageViewController {
         coordinator: UnifiedToggleInputCoordinator,
         message: String
     ) {
+        setPromoSurfaceCovered(true)
         isShowingDuckAICompletionDialog = true
         // The NTP view is about to become visible (view.alpha = 1 below) but
         // finishOnboarding() has already set isOnboarding = false, so SwiftUI
@@ -540,6 +627,7 @@ extension NewTabPageViewController {
         // below (it lives inside the unifiedInputContentContainer).
         setLogoHidden(true)
         view.alpha = 1
+        setPromoSurfaceVisible(true)
         // Mirror showNextDaxDialogNew: suppress the UTI content overlay so the NTP
         // (contentContainer) remains visible while the address bar is active.
         // dismissHostingController re-enables the overlay when the dialog is torn down.
@@ -573,7 +661,8 @@ extension NewTabPageViewController {
                     }
                     collapseUTI { [weak self] in
                         self?.dismissHostingController(didFinishNTPOnboarding: false,
-                                                       updateUnifiedInputContentOverlaySuppression: false)
+                                                       updateUnifiedInputContentOverlaySuppression: false,
+                                                       updatePromoSurfaceCoverage: false)
                         self?.showNextDaxDialog()
                         self?.hostingController?.view.backgroundColor = UIColor(singleUseColor: .rebranding(.backdrop))
                     }
@@ -624,7 +713,9 @@ extension NewTabPageViewController {
     }
 
     func showNextDaxDialogNew(dialogProvider: NewTabDialogSpecProvider, factory: any NewTabDaxDialogProviding) {
-        dismissHostingController(didFinishNTPOnboarding: false, updateUnifiedInputContentOverlaySuppression: false)
+        dismissHostingController(didFinishNTPOnboarding: false,
+                                 updateUnifiedInputContentOverlaySuppression: false,
+                                 updatePromoSurfaceCoverage: false)
 
         guard let spec = dialogProvider.nextHomeScreenMessageNew() else {
             // When the chat-path completion dialog (presentChatPathOnboardingCompletionIfNeeded)
@@ -637,8 +728,10 @@ extension NewTabPageViewController {
             if !chatPathCompletionPending {
                 chromeDelegate?.setUnifiedInputContentOverlaySuppressed(false)
             }
+            setPromoSurfaceCovered(false)
             return
         }
+        setPromoSurfaceCovered(true)
         chromeDelegate?.setUnifiedInputContentOverlaySuppressed(true)
 
         // The EoJ ("High five!") dialog surfaces with an active address bar in UTI mode so the user
@@ -682,25 +775,28 @@ extension NewTabPageViewController {
         }
 
         let onManualDismiss: () -> Void = { [weak self] in
-            self?.dismissHostingController(didFinishNTPOnboarding: true)
+            guard let self else { return }
+            self.dismissHostingController(didFinishNTPOnboarding: true,
+                                          updatePromoSurfaceCoverage: spec != .final)
 
             if spec == .final {
                 let nextSpec = dialogProvider.nextHomeScreenMessageNew()
                 if nextSpec == .subscriptionPromotion {
                     // Hide the NTP logo before the promo fades in — mirrors the onDismiss path.
-                    self?.setLogoHidden(true)
-                    self?.dismissAddressBarEditingForSubscriptionPromo(completion: { [weak self] in
+                    self.setLogoHidden(true)
+                    self.dismissAddressBarEditingForSubscriptionPromo(completion: { [weak self] in
                         self?.showNextDaxDialog()
                         // Set the background color to the rebranding backdrop color to prevent the NTP logo from flashing through the completion dialog.
                         self?.hostingController?.view.backgroundColor = UIColor(singleUseColor: .rebranding(.backdrop))
                     })
                     return
                 }
+                self.setPromoSurfaceCovered(false)
                 dialogProvider.dismiss()
             }
 
             // Show keyboard when manually dismiss the Dax tips.
-            self?.chromeDelegate?.omniBar.beginEditing(animated: true)
+            self.chromeDelegate?.omniBar.beginEditing(animated: true)
         }
 
         let daxDialogView = AnyView(factory.createDaxDialog(for: spec, onCompletion: onDismiss, onManualDismiss: onManualDismiss))
@@ -753,7 +849,9 @@ extension NewTabPageViewController {
         }
     }
 
-    private func dismissHostingController(didFinishNTPOnboarding: Bool, updateUnifiedInputContentOverlaySuppression: Bool = true) {
+    private func dismissHostingController(didFinishNTPOnboarding: Bool,
+                                          updateUnifiedInputContentOverlaySuppression: Bool = true,
+                                          updatePromoSurfaceCoverage: Bool = true) {
         let didDismissDuckAICompletionDialog = isShowingDuckAICompletionDialog
         hostingController?.willMove(toParent: nil)
         hostingController?.view.removeFromSuperview()
@@ -771,11 +869,15 @@ extension NewTabPageViewController {
             // Restore NTP visibility that was muted during the chat-path handoff so the
             // empty-state Dax doesn't flash through the editing-state transition.
             view.alpha = 1
+            setPromoSurfaceVisible(true)
             delegate?.newTabPageDidDismissDuckAIFireOnboardingCompletion(self)
         }
         if didFinishNTPOnboarding {
             self.newTabPageViewModel.finishOnboarding()
             self.setLogoHidden(false)
+        }
+        if updatePromoSurfaceCoverage {
+            setPromoSurfaceCovered(false)
         }
     }
 
@@ -805,6 +907,7 @@ extension NewTabPageViewController {
             daxDialogsManager.dismiss()
         }
         view.alpha = 1
+        setPromoSurfaceVisible(true)
         delegate?.newTabPageDidDismissDuckAIFireOnboardingCompletion(self)
     }
 }

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -127,6 +127,7 @@ class SuggestionTrayViewController: UIViewController {
     private var popoverContentHeights: [PopoverSuggestionsMode: CGFloat] = [:]
     private var newTabPage: NewTabPageViewController?
     private var willRemoveAutocomplete = false
+    private var contentPresentationGeneration = 0
 
     /// Allows to defer autocomplete presentation to avoid short UI glitch (blink) when presenting
     /// autocomplete suggestions when unifiedToggleInput flag is on.
@@ -312,23 +313,49 @@ class SuggestionTrayViewController: UIViewController {
     }
 
     func show(for type: SuggestionType, animated: Bool = true) {
+        contentPresentationGeneration += 1
+        let presentationGeneration = contentPresentationGeneration
         self.fullHeightSafeAreaConstraint.constant = appSettings.currentAddressBarPosition == .bottom ? 50 : 0
 
         switch type {
         case .autocomplete(let query):
+            newTabPage?.setPromoSurfaceRenderable(false)
             displayAutocompleteSuggestions(forQuery: query, animated: animated)
         case .duckAISuggestions:
+            newTabPage?.setPromoSurfaceRenderable(false)
             removeNewTabPage(animated: false)
             setPopoverMode(.duckAI)
         case .favorites:
             if isPad {
-                removeAutocomplete(animated: animated)
-                displayFavoritesIfNeeded(animated: animated)
+                let physicalTransitions = DispatchGroup()
+                physicalTransitions.enter()
+                removeAutocomplete(animated: animated) {
+                    physicalTransitions.leave()
+                }
+                physicalTransitions.enter()
+                displayFavoritesIfNeeded(animated: animated) { _ in
+                    physicalTransitions.leave()
+                }
+                physicalTransitions.notify(queue: .main) { [weak self] in
+                    guard let self,
+                          contentPresentationGeneration == presentationGeneration,
+                          let newTabPage else { return }
+                    newTabPage.setPromoSurfaceRenderable(true)
+                }
             } else {
                 willRemoveAutocomplete = true
-                displayFavoritesIfNeeded(animated: animated) { [weak self] in
-                    self?.removeAutocomplete(animated: animated)
-                    self?.willRemoveAutocomplete = false
+                displayFavoritesIfNeeded(animated: animated) { [weak self] controller in
+                    guard let self else { return }
+                    removeAutocomplete(animated: animated) { [weak self, weak controller] in
+                        guard let self else { return }
+                        guard let controller,
+                              contentPresentationGeneration == presentationGeneration,
+                              newTabPage === controller else { return }
+                        // The cached favorites controller sits below autocomplete during its removal animation.
+                        // Wait for physical removal before allowing it to own the promo slot.
+                        controller.setPromoSurfaceRenderable(true)
+                    }
+                    willRemoveAutocomplete = false
                 }
             }
         }
@@ -343,6 +370,8 @@ class SuggestionTrayViewController: UIViewController {
     }
 
     func didHide(animated: Bool) {
+        contentPresentationGeneration += 1
+        newTabPage?.setPromoSurfaceRenderable(false)
         removeAutocomplete(animated: animated)
         removeNewTabPage(animated: animated)
         teardownPopoverDuckAIController()
@@ -464,15 +493,16 @@ class SuggestionTrayViewController: UIViewController {
         newTabPage?.setSectionTitle(title)
     }
 
-    private func displayFavoritesIfNeeded(animated: Bool, onInstall: @escaping () -> Void = {}) {
-        if newTabPage == nil {
-            installNewTabPage(animated: animated, onInstall: onInstall)
+    private func displayFavoritesIfNeeded(animated: Bool,
+                                          onInstall: @escaping (NewTabPageViewController) -> Void) {
+        if let newTabPage {
+            onInstall(newTabPage)
         } else {
-            onInstall()
+            installNewTabPage(animated: animated, onInstall: onInstall)
         }
     }
 
-    private func installNewTabPage(animated: Bool, onInstall: @escaping () -> Void = {}) {
+    private func installNewTabPage(animated: Bool, onInstall: @escaping (NewTabPageViewController) -> Void = { _ in }) {
         let dependencies = newTabPageDependencies
         let controller = NewTabPageViewController(
             isFocussedState: true,
@@ -504,10 +534,10 @@ class SuggestionTrayViewController: UIViewController {
             controller.setSectionTitle(pendingFavoritesSectionTitle)
         }
 
+        newTabPage = controller
         install(controller: controller,
                 animated: animated,
-                completion: onInstall)
-        newTabPage = controller
+                completion: { onInstall(controller) })
     }
     
     private func canDisplayAutocompleteSuggestions(forQuery query: String, animated: Bool) -> Bool {
@@ -730,31 +760,54 @@ class SuggestionTrayViewController: UIViewController {
         }
     }
 
-    private func removeAutocomplete(animated: Bool) {
+    private func removeAutocomplete(animated: Bool, completion: @escaping () -> Void = {}) {
+        var removals = [(controller: UIViewController, animated: Bool)]()
         if let popoverController = popoverSearchController {
             popoverController.tearDown()
-            removeController(popoverController, animated: animated)
+            removals.append((popoverController, animated))
             popoverSearchController = nil
             popoverSearchSource = nil
         }
-        guard let controller = autocompleteController else { return }
-        removeController(controller, animated: deferAutocompleteReveal ? false : animated)
-        autocompleteController = nil
-        pendingDeferredAutocompleteReveal = false
+        if let autocompleteController {
+            removals.append((autocompleteController, deferAutocompleteReveal ? false : animated))
+            self.autocompleteController = nil
+            pendingDeferredAutocompleteReveal = false
+        }
+
+        guard !removals.isEmpty else {
+            completion()
+            return
+        }
+
+        var remainingRemovalCount = removals.count
+        for removal in removals {
+            removeController(removal.controller, animated: removal.animated) {
+                remainingRemovalCount -= 1
+                if remainingRemovalCount == 0 {
+                    completion()
+                }
+            }
+        }
     }
 
     private func removeNewTabPage(animated: Bool) {
         guard let controller = newTabPage else { return }
-        removeController(controller, animated: animated)
+        removeController(controller, animated: animated) {
+            controller.setPromoSurfaceRenderable(false)
+            controller.tearDownPromoSurface()
+        }
         newTabPage = nil
     }
 
-    private func removeController(_ controller: UIViewController, animated: Bool) {
+    private func removeController(_ controller: UIViewController,
+                                  animated: Bool,
+                                  completion: @escaping () -> Void = {}) {
         controller.willMove(toParent: nil)
 
         let finalize = {
             controller.view.removeFromSuperview()
             controller.removeFromParent()
+            completion()
         }
 
         if animated {

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -660,6 +660,14 @@ final class MainCoordinator {
         promoCoordinationService.presentModalPromptIfNeeded(from: controller)
     }
 
+    func prepareModalPromptCoordinationForForeground() {
+        promoCoordinationService.applicationDidBecomeActive()
+    }
+
+    func prepareModalPromptCoordinationForInactivity() {
+        promoCoordinationService.applicationWillResignActive()
+    }
+
     // MARK: App Lifecycle handling
 
     func onForeground(isFirstForeground: Bool) {
@@ -684,6 +692,7 @@ final class MainCoordinator {
     }
 
     func onBackground() {
+        promoCoordinationService.applicationDidEnterBackground()
         resetAppStartTime()
         Task {
             await privacyStats.handleAppTermination()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -877,6 +877,7 @@ extension MainViewController {
         )
 
         if renderState.isContentVisible {
+            newTabPageViewController?.setPromoSurfaceActive(false)
             coordinator.contentViewController.setActive(true)
             coordinator.syncContentInputMode(renderState.contentInputMode, animated: false)
             coordinator.pushContentInsets()
@@ -885,6 +886,7 @@ extension MainViewController {
         } else {
             coordinator.contentViewController.setActive(false)
             viewCoordinator.hideUnifiedInputContent()
+            newTabPageViewController?.setPromoSurfaceActive(viewCoordinator.suggestionTrayContainer.isHidden)
         }
 
         if isOnAITab {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/UnifiedSuggestionsHost.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/UnifiedSuggestionsHost.swift
@@ -41,6 +41,8 @@ final class UnifiedSuggestionsHost {
     private var cancellables = Set<AnyCancellable>()
     /// Built once on first `.favorites` render; NTP has a heavy init, so don't rebuild per body pass.
     private var cachedFavoritesController: NewTabPageViewController?
+    private var isSurfaceHostActive = false
+    private var isFavoritesContentResolved = false
 
     /// Single-host path only: the duck.ai surface's source/VM, attached lazily and detached on
     /// disappear (mirrors the legacy per-host lifecycle). Nil on the old single-surface path.
@@ -49,6 +51,7 @@ final class UnifiedSuggestionsHost {
     private func memoizedFavoritesController() -> NewTabPageViewController? {
         if let cachedFavoritesController { return cachedFavoritesController }
         cachedFavoritesController = config.favoritesProvider()
+        updateFavoritesPromoSurfaceActivity()
         return cachedFavoritesController
     }
 
@@ -82,7 +85,16 @@ final class UnifiedSuggestionsHost {
         viewModel.$content
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in self?.onContentChanged?() }
+            .sink { [weak self] content in
+                guard let self else { return }
+                if case .favorites = content {
+                    isFavoritesContentResolved = true
+                } else {
+                    isFavoritesContentResolved = false
+                }
+                updateFavoritesPromoSurfaceActivity()
+                onContentChanged?()
+            }
             .store(in: &cancellables)
 
         let view = UnifiedSuggestionsView(
@@ -113,6 +125,7 @@ final class UnifiedSuggestionsHost {
     /// Fire tabs render the fire empty state instead of the Dax logo for the empty (`.logo`) state.
     func setIsFireTab(_ value: Bool) {
         viewModel.setFireTab(value)
+        updateFavoritesPromoSurfaceActivity()
     }
 
     /// iPhone landscape suppresses the empty state (no room) — matches the unfocused NTP.
@@ -134,6 +147,11 @@ final class UnifiedSuggestionsHost {
     /// Resets the dismiss/morph state on each focus.
     func prepareForActivation() {
         viewModel.prepareForActivation()
+    }
+
+    func setPromoSurfaceHostActive(_ isActive: Bool) {
+        isSurfaceHostActive = isActive
+        updateFavoritesPromoSurfaceActivity()
     }
 
     func setAdditionalTopInset(_ inset: CGFloat) {
@@ -199,6 +217,11 @@ final class UnifiedSuggestionsHost {
     }
 
     func tearDown() {
+        isSurfaceHostActive = false
+        updateFavoritesPromoSurfaceActivity()
+        let favoritesController = cachedFavoritesController
+        favoritesController?.tearDownPromoSurface()
+        cachedFavoritesController = nil
         cancellables.removeAll()
         onContentChanged = nil
         config.source.tearDown()
@@ -218,5 +241,13 @@ final class UnifiedSuggestionsHost {
             viewModel: viewModel,
             isAddressBarAtBottom: isAddressBarAtBottom,
             favoritesProvider: { [weak self] in self?.memoizedFavoritesController() })
+    }
+
+    private func updateFavoritesPromoSurfaceActivity() {
+        let isActive = isSurfaceHostActive
+            && isFavoritesContentResolved
+            && !viewModel.isFireTab
+
+        cachedFavoritesController?.setPromoSurfaceRenderable(isActive)
     }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -148,6 +148,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
     private var isSyncPromoCardVisible = false
 
     private var notificationCancellable: AnyCancellable?
+    private var promoQueueFeatureStateCancellable: AnyCancellable?
 
     private weak var contentAnimator: UIViewPropertyAnimator?
 
@@ -190,6 +191,10 @@ final class UnifiedInputContentContainerViewController: UIViewController {
 
     deinit {
         searchDeleteTask?.cancel()
+        // UIKit view controllers are expected to deallocate on the main thread.
+        MainActor.assumeIsolated {
+            unifiedSuggestionsHost?.tearDown()
+        }
     }
 
     // MARK: - Lifecycle
@@ -201,6 +206,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         installComponents()
         setupSubscriptions()
         observeRemoteMessagesChanges()
+        observePromoQueueFeatureStateChanges()
         observeAddressBarPositionChanges()
 
         refreshSyncPromoIfActive()
@@ -209,6 +215,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
+        unifiedSuggestionsHost?.setPromoSurfaceHostActive(isContentActive)
         attachDuckAISurfaceIfNeeded()
     }
 
@@ -225,6 +232,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+        unifiedSuggestionsHost?.setPromoSurfaceHostActive(false)
         detachDuckAISurfaceFromSingleHost()
     }
 
@@ -265,10 +273,12 @@ final class UnifiedInputContentContainerViewController: UIViewController {
             // Re-resolve now (synchronously, before the host is shown) so the prior session's stale
             // content isn't flashed. Runs after `prepareForActivation` clears the dismiss freeze.
             activationResolveTrigger.send(())
+            unifiedSuggestionsHost?.setPromoSurfaceHostActive(true)
             syncDuckAISurfaceWithSettings()
             duckAISurface?.refreshRecents()
         } else {
             fireSearchSuggestionsDisplayPixels()
+            unifiedSuggestionsHost?.setPromoSurfaceHostActive(false)
         }
     }
 
@@ -826,9 +836,28 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         notificationCancellable = NotificationCenter.default.publisher(for: RemoteMessagingStore.Notifications.remoteMessagesDidChange)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                guard let self else { return }
-                self.refreshVisibleContent(animateContentUpdates: false)
+                self?.refreshVisibleContent(animateContentUpdates: false)
             }
+    }
+
+    private func observePromoQueueFeatureStateChanges() {
+        guard let promoCoordinator = suggestionTrayDependencies?.newTabPageDependencies.promoCoordinator else {
+            return
+        }
+
+        promoQueueFeatureStateCancellable = promoQueueEnablementPublisher(promoCoordinator.promoQueueFeatureStatePublisher)
+            .sink { [weak self] in
+                guard let self else { return }
+                refreshRemoteMessagesForPromoQueue()
+                refreshVisibleContent(animateContentUpdates: false)
+            }
+    }
+
+    private func refreshRemoteMessagesForPromoQueue() {
+        suggestionTrayDependencies?.newTabPageDependencies.homePageMessagesConfiguration.refresh(
+            openedAfterIdle: sessionOpenedAfterIdle
+        )
+        activationResolveTrigger.send(())
     }
 
     private func markNeedsVisibleRefresh() {
@@ -985,6 +1014,18 @@ private extension UnifiedInputContentContainerViewController {
             applyContentUpdates()
         }
     }
+}
+
+/// Emits when promo coordination reaches enabled after the initial feature-state value.
+func promoQueueEnablementPublisher(
+    _ featureStatePublisher: AnyPublisher<PromoQueueFeatureState, Never>
+) -> AnyPublisher<Void, Never> {
+    featureStatePublisher
+        .removeDuplicates()
+        .dropFirst()
+        .filter { $0 == .enabled }
+        .map { _ in () }
+        .eraseToAnyPublisher()
 }
 
 // MARK: - DuckAISuggestionsSurfaceProviderDelegate

--- a/iOS/DuckDuckGoTests/AppServices/PromoCoordinationServicePromoQueueTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/PromoCoordinationServicePromoQueueTests.swift
@@ -272,6 +272,79 @@ final class PromoCoordinationServicePromoQueueTests {
         #expect(replacementTarget.retryCount == 1)
     }
 
+    @available(iOS 16, *)
+    @Test("Failed Pre-Visible Attempt Synchronously Retries Active Registrations", .timeLimit(.minutes(1)))
+    func whenManagerNotifiesPreVisibleReleaseThenActiveRegistrationsRetry() {
+        featureFlaggerMock.enabledFeatureFlags = [.promoPresentationCoordination]
+        sut = PromoCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+        let target = MockNewTabPagePromoRetryTarget()
+        let registration = sut.registerVisiblePromoRetry(for: UUID(), target: target)
+
+        managerMock.coordinatedAttemptReleaseHandler?()
+
+        #expect(target.retryCount == 1)
+        _ = registration
+    }
+
+    @available(iOS 16, *)
+    @Test("Inactive Visible Promo Registrations Are Skipped Until Active", .timeLimit(.minutes(1)))
+    func whenManagerNotifiesPreVisibleReleaseThenOnlyActiveRegistrationsRetry() {
+        featureFlaggerMock.enabledFeatureFlags = [.promoPresentationCoordination]
+        sut = PromoCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+        let target = MockNewTabPagePromoRetryTarget()
+        target.isActiveForPromoRetry = false
+        let registration = sut.registerVisiblePromoRetry(for: UUID(), target: target)
+
+        managerMock.coordinatedAttemptReleaseHandler?()
+        #expect(target.retryCount == 0)
+
+        target.isActiveForPromoRetry = true
+        managerMock.coordinatedAttemptReleaseHandler?()
+        #expect(target.retryCount == 1)
+        _ = registration
+    }
+
+    @available(iOS 16, *)
+    @Test("Lifecycle Events Are Forwarded Without Invalidating Arbiter Leases", .timeLimit(.minutes(1)))
+    func whenServiceMovesBetweenActiveInactiveAndBackgroundThenManagerOwnsModalMigration() {
+        featureFlaggerMock.enabledFeatureFlags = [.promoPresentationCoordination]
+        sut = PromoCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+        let identity = VisiblePromoIdentity(
+            surfaceID: UUID(),
+            promoType: .remoteMessage,
+            promoID: "rmf"
+        )
+        guard case .acquired(let visibleLease) = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: identity) else {
+            Issue.record("Expected visible promo lease acquisition")
+            return
+        }
+        sut.applicationWillResignActive()
+        sut.applicationDidBecomeActive()
+        sut.applicationWillResignActive()
+        sut.applicationDidEnterBackground()
+
+        #expect(managerMock.applicationWillResignActiveCallCount == 2)
+        #expect(managerMock.applicationDidEnterBackgroundCallCount == 1)
+        #expect(managerMock.applicationDidBecomeActiveCallCount == 1)
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities == [identity])
+        _ = visibleLease
+    }
+
     // MARK: - Visible Promo Admission Results
 
     @available(iOS 16, *)
@@ -392,6 +465,56 @@ final class PromoCoordinationServicePromoQueueTests {
         }
         #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities == [identity])
         _ = reacquiredLease
+    }
+
+    @available(iOS 16, *)
+    @Test("NTP Transition Snapshot Callbacks Bracket Lease Invalidation", .timeLimit(.minutes(1)))
+    func whenPromoQueueTransitionsThenSnapshotCallbacksBracketInvalidation() async {
+        sut = PromoCoordinationService(
+            launchSourceManager: launchSourceManagerMock,
+            modalPromptCoordinationManager: managerMock,
+            featureFlagger: featureFlaggerMock,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+        )
+        let target = MockNewTabPagePromoRetryTarget()
+        let registration = sut.registerVisiblePromoRetry(for: UUID(), target: target)
+        var callbackStates = [PromoQueueFeatureState]()
+        var callbackVisibleLeaseCounts = [Int]()
+        target.onWillTransition = { [weak self] _ in
+            guard let self else { return }
+            callbackStates.append(sut.promoQueueFeatureState)
+            callbackVisibleLeaseCounts.append(promoQueueLeaseArbiter.snapshot.visiblePromoCount)
+        }
+        target.onDidTransition = { [weak self] _ in
+            guard let self else { return }
+            callbackStates.append(sut.promoQueueFeatureState)
+            callbackVisibleLeaseCounts.append(promoQueueLeaseArbiter.snapshot.visiblePromoCount)
+        }
+
+        featureFlaggerMock.enabledFeatureFlags = [.promoPresentationCoordination]
+        featureFlaggerMock.triggerUpdate()
+        await waitForFeatureFlagUpdateDelivery()
+
+        #expect(target.events == ["will-enable", "did-enable"])
+        #expect(callbackStates == [.transitioning(to: .enabled), .transitioning(to: .enabled)])
+
+        target.events.removeAll()
+        callbackStates.removeAll()
+        callbackVisibleLeaseCounts.removeAll()
+        let identity = VisiblePromoIdentity(surfaceID: UUID(), promoType: .remoteMessage, promoID: "rmf")
+        guard case .acquired(let lease) = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: identity) else {
+            Issue.record("Expected visible promo lease acquisition")
+            return
+        }
+
+        featureFlaggerMock.enabledFeatureFlags = []
+        featureFlaggerMock.triggerUpdate()
+        await waitForFeatureFlagUpdateDelivery()
+
+        #expect(target.events == ["will-disable", "did-disable"])
+        #expect(callbackStates == [.transitioning(to: .disabled), .transitioning(to: .disabled)])
+        #expect(callbackVisibleLeaseCounts == [1, 0])
+        _ = (registration, lease)
     }
 
     // MARK: - Promo Queue Feature State
@@ -579,7 +702,7 @@ final class PromoCoordinationServicePromoQueueTests {
         await waitForFeatureFlagUpdateDelivery()
 
         // Both callbacks of both transitions re-enter admission, and every one of the four must be refused: only the
-        // transition routine's own re-adoption and retry steps may mutate arbiter state while the barrier is up.
+        // transition routine's own manager re-adoption may mutate arbiter state while the barrier is up.
         #expect(admissionAttemptsDuringCallbacks == 4)
         #expect(refusalsDuringCallbacks == 4)
         #expect(managerMock.reconcilePresentedModalCallCount == 0)
@@ -588,56 +711,32 @@ final class PromoCoordinationServicePromoQueueTests {
     }
 
     @available(iOS 16, *)
-    @Test("Enable Retry Keeps Public Barrier Up And Uses Transition Admission", .timeLimit(.minutes(1)))
-    func whenEnablingRetriesActiveVisiblePromoThenOnlyTransitionAdmissionCanAcquire() async {
+    @Test("Feature State Publisher Emits Enabled Only After Transition Barrier Is Lowered", .timeLimit(.minutes(1)))
+    func whenLiveEnableCompletesThenPublishedEnabledStateCanUsePublicAdmission() async {
         sut = PromoCoordinationService(
             launchSourceManager: launchSourceManagerMock,
             modalPromptCoordinationManager: managerMock,
             featureFlagger: featureFlaggerMock,
             promoQueueLeaseArbiter: promoQueueLeaseArbiter
         )
-        launchSourceManagerMock.source = .standard
-        presenterMock.presentedViewController = nil
-
-        let surfaceID = UUID()
-        let publicIdentity = VisiblePromoIdentity(
-            surfaceID: UUID(),
-            promoType: .remoteMessage,
-            promoID: "public-reentrant"
-        )
-        let transitionIdentity = VisiblePromoIdentity(
-            surfaceID: surfaceID,
-            promoType: .remoteMessage,
-            promoID: "transition-retry"
-        )
-        let retryTarget = MockNewTabPagePromoRetryTarget()
-        var stateObservedDuringRetry: PromoQueueFeatureState?
-        var publicAdmissionResult = VisiblePromoAdmissionResult.featureDisabled
-        retryTarget.identityToAdmitOnRetry = transitionIdentity
-        retryTarget.onRetry = { [weak self] in
+        let identity = VisiblePromoIdentity(surfaceID: UUID(), promoType: .remoteMessage, promoID: "rmf")
+        var publishedStates = [PromoQueueFeatureState]()
+        var retainedLease: PromoQueueVisiblePromoLease?
+        let cancellable = sut.promoQueueFeatureStatePublisher.sink { [weak self] state in
             guard let self else { return }
-            stateObservedDuringRetry = sut.promoQueueFeatureState
-            publicAdmissionResult = sut.admitVisiblePromo(publicIdentity)
-            sut.presentModalPromptIfNeeded(from: presenterMock)
+            publishedStates.append(state)
+            if state == .enabled, case .acquired(let lease) = sut.admitVisiblePromo(identity) {
+                retainedLease = lease
+            }
         }
-        let registration = sut.registerVisiblePromoRetry(for: surfaceID, target: retryTarget)
 
         featureFlaggerMock.enabledFeatureFlags = [.promoPresentationCoordination]
         featureFlaggerMock.triggerUpdate()
         await waitForFeatureFlagUpdateDelivery()
 
-        #expect(retryTarget.retryCount == 1)
-        #expect(stateObservedDuringRetry == .transitioning(to: .enabled))
-        guard case .unavailableDuringTransition = publicAdmissionResult else {
-            Issue.record("Expected public visible-promo admission to remain blocked during the retry callback")
-            return
-        }
-        #expect(managerMock.callCount == 0)
-        #expect(managerMock.reconcilePresentedModalCallCount == 1)
-        #expect(retryTarget.retainedLease != nil)
-        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities == [transitionIdentity])
-        #expect(sut.promoQueueFeatureState == .enabled)
-        _ = registration
+        #expect(publishedStates == [.disabled, .transitioning(to: .enabled), .enabled])
+        #expect(retainedLease != nil)
+        withExtendedLifetime((cancellable, retainedLease)) {}
     }
 
     private func waitForFeatureFlagUpdateDelivery() async {
@@ -706,19 +805,40 @@ private final class ModalPromptCoordinationSubscriptionHookFeatureFlagger: Featu
 private final class MockNewTabPagePromoRetryTarget: NewTabPagePromoRetrying {
     var isActiveForPromoRetry = true
     var identityToAdmitOnRetry: VisiblePromoIdentity?
-    var onRetry: (@MainActor () -> Void)?
+    var onWillTransition: (@MainActor (PromoQueueFeatureTargetState) -> Void)?
+    var onDidTransition: (@MainActor (PromoQueueFeatureTargetState) -> Void)?
+    var events = [String]()
     private(set) var retryCount = 0
     private(set) var retainedLease: PromoQueueVisiblePromoLease?
 
     func retryVisiblePromoAdmission(using admissionHandler: VisiblePromoAdmissionHandler) {
         retryCount += 1
-        onRetry?()
+        events.append("retry")
         guard let identityToAdmitOnRetry else {
             return
         }
 
         if case .acquired(let lease) = admissionHandler(identityToAdmitOnRetry) {
             retainedLease = lease
+        }
+    }
+
+    func promoQueueWillTransition(to targetState: PromoQueueFeatureTargetState) {
+        events.append("will-\(targetState.eventName)")
+        onWillTransition?(targetState)
+    }
+
+    func promoQueueDidTransition(to targetState: PromoQueueFeatureTargetState) {
+        events.append("did-\(targetState.eventName)")
+        onDidTransition?(targetState)
+    }
+}
+
+private extension PromoQueueFeatureTargetState {
+    var eventName: String {
+        switch self {
+        case .disabled: return "disable"
+        case .enabled: return "enable"
         }
     }
 }

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerPromoQueueTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerPromoQueueTests.swift
@@ -181,8 +181,8 @@ final class ModalPromptCoordinationManagerPromoQueueTests {
     }
 
     @available(iOS 16, *)
-    @Test("Deallocated Presented Root Releases The Modal Lease", .timeLimit(.minutes(1)))
-    func whenPresentedRootIsDeallocatedThenReconciliationReleasesLease() throws {
+    @Test("Detached Presented Root Releases The Modal Lease", .timeLimit(.minutes(1)))
+    func whenPresentedRootIsDetachedThenReconciliationReleasesLease() throws {
         // GIVEN
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider()
@@ -197,29 +197,125 @@ final class ModalPromptCoordinationManagerPromoQueueTests {
             rootAttachmentChecker: attachmentChecker
         )
         let lease = try acquireModalLease()
-        weak var weakExactRoot: UIViewController?
+        let exactRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
+        attachmentChecker.markAttached(exactRoot)
 
-        autoreleasepool {
-            var exactRoot: UIViewController! = UIViewController()
-            weakExactRoot = exactRoot
-            provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
-            attachmentChecker.markAttached(exactRoot)
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+        scheduler.executeAndReleaseScheduledBlock()
 
-            _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
-            scheduler.executeAndReleaseScheduledBlock()
+        #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+        #expect(!sut.reconcilePresentedModal())
+        #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
 
-            #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
-            #expect(!sut.reconcilePresentedModal())
-            #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
+        // WHEN UIKit detaches the exact root.
+        attachmentChecker.attachedRoots.remove(ObjectIdentifier(exactRoot))
 
-            // WHEN every fixture reference is dropped, the manager is the only thing that could keep the root alive.
-            provider.modalConfigurationToReturn = nil
-            presenterMock.reset()
-            exactRoot = nil
-        }
+        // THEN the lease is released rather than pinned until the next foreground.
+        #expect(sut.reconcilePresentedModal())
+        #expect(sut.modalAttemptPhase == .idle)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+    }
 
-        // THEN — the presented modal is gone, so its lease must be released rather than pinned until the next
-        // foreground, and the manager must not be the last owner of the whole view-controller hierarchy.
+    @available(iOS 16, *)
+    @Test("Attached Root Is Adopted Without Re-Presentation", .timeLimit(.minutes(1)))
+    func whenSelectedRootIsAlreadyAttachedThenPreflightAdoptsIt() throws {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let exactRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
+        let intendedHost = UIViewController()
+        presenterMock.modalPromptPresentationViewController = intendedHost
+        let attachmentChecker = MockModalPromptRootAttachmentChecker()
+        attachmentChecker.markAttached(intendedHost)
+        attachmentChecker.markAttached(exactRoot)
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock,
+            rootAttachmentChecker: attachmentChecker
+        )
+        let lease = try acquireModalLease()
+
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+        schedulerMock.executeScheduledBlock()
+
+        #expect(!presenterMock.didCallPresent)
+        #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+        #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(sut.didActuallyPresentModalPromptThisSession)
+        #expect(provider.didPresentModalCallCount == 1)
+        #expect(cooldownManagerMock.recordLastPromptPresentationTimestampCallCount == 1)
+    }
+
+    @available(iOS 16, *)
+    @Test("Attachment Verification Retains Lease For Attached Root", .timeLimit(.minutes(1)))
+    func whenPresentedRootAttachesThenVerificationRetainsLease() throws {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let exactRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
+        let intendedHost = UIViewController()
+        presenterMock.modalPromptPresentationViewController = intendedHost
+        presenterMock.shouldCompletePresentation = false
+        let attachmentChecker = MockModalPromptRootAttachmentChecker()
+        attachmentChecker.markAttached(intendedHost)
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock,
+            rootAttachmentChecker: attachmentChecker
+        )
+        let lease = try acquireModalLease()
+
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+        schedulerMock.executeScheduledBlock()
+        attachmentChecker.markAttached(exactRoot)
+        schedulerMock.executeNextMainTurnBlock()
+
+        #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+        #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(!sut.reconcilePresentedModal())
+    }
+
+    @available(iOS 16, *)
+    @Test("Accepted Presentation Does Not Retain Detached Root", .timeLimit(.minutes(1)))
+    func whenAcceptedRootDeallocatesThenReconciliationReleasesLease() throws {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        var exactRoot: UIViewController? = UIViewController()
+        weak var weakExactRoot = exactRoot
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: try #require(exactRoot))
+        let scheduler = BlockReleasingModalPromptScheduler()
+        let attachmentChecker = MockModalPromptRootAttachmentChecker()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: scheduler,
+            rootAttachmentChecker: attachmentChecker
+        )
+        let lease = try acquireModalLease()
+
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+        scheduler.executeAndReleaseScheduledBlock()
+        let presentedRootIdentifier = ObjectIdentifier(try #require(exactRoot))
+        attachmentChecker.markAttached(try #require(exactRoot))
+        scheduler.executeAndReleaseScheduledBlock()
+
+        #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+        #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
+
+        attachmentChecker.attachedRoots.remove(presentedRootIdentifier)
+        provider.modalConfigurationToReturn = nil
+        presenterMock.reset()
+        exactRoot = nil
+
         #expect(weakExactRoot == nil)
         #expect(sut.reconcilePresentedModal())
         #expect(sut.modalAttemptPhase == .idle)
@@ -264,7 +360,9 @@ final class ModalPromptCoordinationManagerPromoQueueTests {
         // reproduce that on its own — it never hands the root to UIKit — so the checker states the premise explicitly
         // instead of leaving it to whatever the real attachment predicate happens to answer for a detached controller.
         let attachmentChecker = MockModalPromptRootAttachmentChecker()
-        attachmentChecker.markAttached(exactRoot)
+        deferredPresenter.onPresent = {
+            attachmentChecker.markAttached(exactRoot)
+        }
         sut = ModalPromptCoordinationManager(
             providers: [provider],
             cooldownManager: cooldownManagerMock,
@@ -352,7 +450,9 @@ final class ModalPromptCoordinationManagerPromoQueueTests {
         let exactRoot = UIViewController()
         provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
         let attachmentChecker = MockModalPromptRootAttachmentChecker()
-        attachmentChecker.attachedRoots.insert(ObjectIdentifier(exactRoot))
+        let intendedHost = UIViewController()
+        presenterMock.modalPromptPresentationViewController = intendedHost
+        attachmentChecker.markAttached(exactRoot)
         sut = ModalPromptCoordinationManager(
             providers: [provider],
             cooldownManager: cooldownManagerMock,
@@ -375,18 +475,310 @@ final class ModalPromptCoordinationManagerPromoQueueTests {
         }
     }
 
+    // MARK: - Safe Scheduling And Lifecycle
+
     @available(iOS 16, *)
-    @Test("Enabling Does Not Re-Adopt A Root That Was Only Selected", .timeLimit(.minutes(1)))
-    func whenSelectedRootWasNeverPresentedThenEnablingDoesNotReAdoptModalLease() throws {
-        // GIVEN
+    @Test("Temporary Inactivity Moves Delayed Presentation To Pending", .timeLimit(.minutes(1)))
+    func whenAppTemporarilyResignsActiveDuringDelayThenPreparedItemIsRetriedWithoutReevaluation() throws {
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider()
-        let exactRoot = UIViewController()
-        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
-        // The root would satisfy the attachment predicate, so only the absence of an actual presentation can stop the
-        // manager re-adopting it.
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        var releaseNotificationCount = 0
+        sut.coordinatedAttemptReleaseHandler = {
+            releaseNotificationCount += 1
+        }
+        let lease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+
+        sut.applicationWillResignActive()
+        schedulerMock.executeScheduledBlock()
+
+        #expect(!presenterMock.didCallPresent)
+        #expect(sut.modalAttemptPhase == .idle)
+        #expect(sut.hasActiveOrPendingModalAttempt)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(releaseNotificationCount == 1)
+
+        sut.applicationDidBecomeActive()
+        let retryLease = try acquireModalLease()
+        let retryDisposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: retryLease)
+
+        #expect(retryDisposition == .retained)
+        #expect(provider.provideModalPromptCallCount == 1)
+        #expect(sut.modalAttemptPhase == .committed(retryLease.attemptIdentity))
+
+        schedulerMock.executeScheduledBlock()
+
+        #expect(presenterMock.didCallPresent)
+        #expect(sut.modalAttemptPhase == .presentationActive(retryLease.attemptIdentity))
+    }
+
+    @available(iOS 16, *)
+    @Test("Background Moves Committed Work To Pending And Cancelled Delay Cannot Present", .timeLimit(.minutes(1)))
+    func whenAppBackgroundsDuringDelayThenPreparedItemIsRetriedBeforeProviders() throws {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        let firstLease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: firstLease)
+
+        sut.applicationWillResignActive()
+
+        #expect(sut.modalAttemptPhase == .committed(firstLease.attemptIdentity))
+        #expect(promoQueueLeaseArbiter.snapshot.modalAttemptIdentity == firstLease.attemptIdentity)
+
+        sut.applicationDidEnterBackground()
+
+        #expect(sut.modalAttemptPhase == .idle)
+        #expect(sut.hasActiveOrPendingModalAttempt)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(!provider.didCallDidPresentModal)
+
+        schedulerMock.executeScheduledBlock(includingCancelled: true)
+        #expect(!presenterMock.didCallPresent)
+
+        sut.applicationDidBecomeActive()
+        let retryLease = try acquireModalLease()
+        let retryDisposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: retryLease)
+
+        #expect(retryDisposition == .retained)
+        #expect(provider.provideModalPromptCallCount == 1)
+        #expect(sut.modalAttemptPhase == .committed(retryLease.attemptIdentity))
+    }
+
+    @available(iOS 16, *)
+    @Test("Disabling Clears Pending Work And Restores Fresh Legacy Evaluation", .timeLimit(.minutes(1)))
+    func whenPreparedPromptIsPendingThenDisablingClearsItBeforeLegacyEvaluation() throws {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        let lease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+        sut.applicationDidEnterBackground()
+
+        sut.promoQueueWillTransition(to: .disabled)
+        promoQueueLeaseArbiter.invalidateAllLeases()
+        sut.promoQueueDidTransition(to: .disabled)
+        schedulerMock.executeScheduledBlock(includingCancelled: true)
+
+        #expect(!sut.hasActiveOrPendingModalAttempt)
+        #expect(!sut.didPresentModalPromptThisSession)
+        #expect(!presenterMock.didCallPresent)
+        #expect(provider.provideModalPromptCallCount == 1)
+
+        cooldownManagerMock.cooldownInfoToReturn = .inCoolDown
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+
+        #expect(provider.provideModalPromptCallCount == 1)
+        #expect(!presenterMock.didCallPresent)
+
+        let freshRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: freshRoot)
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        sut.presentModalPromptIfNeeded(from: presenterMock)
+        schedulerMock.executeScheduledBlock()
+
+        #expect(presenterMock.didCallPresent)
+        #expect(presenterMock.capturedViewController === freshRoot)
+        #expect(provider.provideModalPromptCallCount == 2)
+    }
+
+    @available(iOS 16, *)
+    @Test("Invalid Pending Prompt Is Replaced By Its Provider In Priority Order", .timeLimit(.minutes(1)))
+    func whenPendingPromptBecomesInvalidThenRetrySelectsReplacementFromSameProvider() throws {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let replacementRoot = UIViewController()
+        provider.replacementModalConfigurationToReturn = ModalPromptConfiguration(viewController: replacementRoot)
+        let lowerPriorityProvider = MockModalPromptProvider()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider, lowerPriorityProvider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        let firstLease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: firstLease)
+        sut.applicationDidEnterBackground()
+        provider.isPreparedModalPromptStillValidResult = false
+        sut.applicationDidBecomeActive()
+
+        let retryLease = try acquireModalLease()
+        let disposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: retryLease)
+
+        #expect(disposition == .retained)
+        #expect(provider.provideModalPromptCallCount == 1)
+        #expect(provider.isPreparedModalPromptStillValidCallCount == 1)
+        #expect(provider.provideReplacementModalPromptCallCount == 1)
+        #expect(lowerPriorityProvider.provideModalPromptCallCount == 0)
+        #expect(!presenterMock.didCallPresent)
+        #expect(sut.modalAttemptPhase == .committed(retryLease.attemptIdentity))
+        #expect(promoQueueLeaseArbiter.snapshot.modalAttemptIdentity == retryLease.attemptIdentity)
+        #expect(!cooldownManagerMock.didCallRecordLastPromptPresentationTimestamp)
+
+        schedulerMock.executeScheduledBlock(includingCancelled: true)
+        schedulerMock.executeScheduledBlock()
+
+        #expect(presenterMock.capturedViewController === replacementRoot)
+    }
+
+    @available(iOS 16, *)
+    @Test("Invalid Pending Prompt Releases When No Other Provider Is Eligible", .timeLimit(.minutes(1)))
+    func whenPendingPromptBecomesInvalidThenRetryDoesNotAskItForAnotherController() throws {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        provider.isPreparedModalPromptStillValidResult = true
+        provider.isRetainedPreparedModalPromptStillValidResult = false
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        let firstLease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: firstLease)
+        sut.applicationDidEnterBackground()
+        sut.applicationDidBecomeActive()
+
+        let retryLease = try acquireModalLease()
+        let disposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: retryLease)
+
+        #expect(disposition == .released)
+        #expect(provider.provideModalPromptCallCount == 1)
+        #expect(provider.isPreparedModalPromptStillValidCallCount == 0)
+        #expect(provider.isRetainedPreparedModalPromptStillValidCallCount == 1)
+        #expect(provider.provideReplacementModalPromptCallCount == 1)
+        #expect(!presenterMock.didCallPresent)
+        #expect(!sut.hasActiveOrPendingModalAttempt)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+    }
+
+    @available(iOS 16, *)
+    @Test("Valid Pending Prompt Is Retried Before Newly Eligible Providers", .timeLimit(.minutes(1)))
+    func whenHigherPriorityProviderBecomesEligibleThenValidPendingPromptIsRetriedFirst() throws {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let higherPriorityProvider = MockModalPromptProvider(shouldReturnPrompt: false)
+        let pendingProvider = MockModalPromptProvider()
+        let pendingRoot = UIViewController()
+        pendingProvider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: pendingRoot)
+        sut = ModalPromptCoordinationManager(
+            providers: [higherPriorityProvider, pendingProvider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        let firstLease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: firstLease)
+        sut.applicationDidEnterBackground()
+        higherPriorityProvider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: UIViewController())
+        sut.applicationDidBecomeActive()
+
+        let retryLease = try acquireModalLease()
+        let disposition = sut.presentModalPromptIfNeeded(from: presenterMock, with: retryLease)
+
+        #expect(disposition == .retained)
+        #expect(higherPriorityProvider.provideModalPromptCallCount == 1)
+        #expect(pendingProvider.provideModalPromptCallCount == 1)
+        #expect(pendingProvider.isPreparedModalPromptStillValidCallCount == 1)
+        #expect(sut.modalAttemptPhase == .committed(retryLease.attemptIdentity))
+
+        schedulerMock.executeScheduledBlock(includingCancelled: true)
+        schedulerMock.executeScheduledBlock()
+
+        #expect(presenterMock.capturedViewController === pendingRoot)
+    }
+
+    @available(iOS 16, *)
+    @Test("Invalid Prepared Prompt Is Discarded Immediately Before Presentation", .timeLimit(.minutes(1)))
+    func whenPreparedPromptBecomesInvalidDuringDelayThenItIsNotPresentedOrRetained() throws {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        var releaseNotificationCount = 0
+        sut.coordinatedAttemptReleaseHandler = {
+            releaseNotificationCount += 1
+        }
+        let lease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+        provider.isPreparedModalPromptStillValidResult = false
+
+        schedulerMock.executeScheduledBlock()
+
+        #expect(provider.provideModalPromptCallCount == 1)
+        #expect(provider.isPreparedModalPromptStillValidCallCount == 1)
+        #expect(!presenterMock.didCallPresent)
+        #expect(!provider.didCallDidPresentModal)
+        #expect(!cooldownManagerMock.didCallRecordLastPromptPresentationTimestamp)
+        #expect(!sut.hasActiveOrPendingModalAttempt)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(releaseNotificationCount == 1)
+    }
+
+    @available(iOS 16, *)
+    @Test("Changed Provider Eligibility Invalidates Prepared Prompt", .timeLimit(.minutes(1)))
+    func whenOnboardingEligibilityChangesDuringDelayThenPreparedPromptIsDiscarded() throws {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let onboardingStatusProvider = MockContextualOnboardingStatusProvider(hasSeenOnboarding: true)
+        let provider = MockModalPromptProvider()
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: onboardingStatusProvider,
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock
+        )
+        let lease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+        onboardingStatusProvider.hasSeenOnboarding = false
+
+        schedulerMock.executeScheduledBlock()
+
+        #expect(provider.provideModalPromptCallCount == 1)
+        #expect(provider.capturedIsOnboardingComplete == false)
+        #expect(provider.isPreparedModalPromptStillValidCallCount == 0)
+        #expect(!presenterMock.didCallPresent)
+        #expect(!sut.hasActiveOrPendingModalAttempt)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+    }
+
+    @available(iOS 16, *)
+    @Test("Presentation Route Is Resolved At Fire Time", .timeLimit(.minutes(1)))
+    func whenPresentationHostChangesDuringDelayThenCurrentRouteIsUsed() throws {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let originalHost = UIViewController()
+        let currentHost = UIViewController()
+        presenterMock.modalPromptPresentationViewController = originalHost
         let attachmentChecker = MockModalPromptRootAttachmentChecker()
-        attachmentChecker.markAttached(exactRoot)
+        attachmentChecker.markAttached(originalHost)
+        attachmentChecker.markAttached(currentHost)
         sut = ModalPromptCoordinationManager(
             providers: [provider],
             cooldownManager: cooldownManagerMock,
@@ -397,29 +789,155 @@ final class ModalPromptCoordinationManagerPromoQueueTests {
         )
         let lease = try acquireModalLease()
         _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+        presenterMock.modalPromptPresentationViewController = currentHost
 
-        // The prompt is selected and committed, but its scheduled presentation never runs.
-        #expect(sut.modalAttemptPhase == .committed(lease.attemptIdentity))
-        #expect(!presenterMock.didCallPresent)
+        schedulerMock.executeScheduledBlock()
 
-        // WHEN
-        sut.promoQueueWillTransition(to: .enabled)
-        promoQueueLeaseArbiter.invalidateAllLeases()
-        sut.promoQueueDidTransition(to: .enabled)
-
-        // THEN — nothing ever reached the screen, so there is nothing to re-adopt: the manager must not park itself in
-        // `.presentationActive` holding the modal lease, and must not even consider the merely selected root.
-        #expect(sut.modalAttemptPhase == .idle)
-        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
-        #expect(!sut.hasActiveOrPendingModalAttempt)
-        #expect(!attachmentChecker.didQuery(exactRoot))
+        #expect(presenterMock.didCallPresent)
+        #expect(attachmentChecker.didQuery(currentHost))
+        #expect(!attachmentChecker.didQuery(originalHost))
+        #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+        #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(provider.provideModalPromptCallCount == 1)
     }
 
     @available(iOS 16, *)
-    @Test("Enabling Invalidates Legacy Delayed Presentation", .timeLimit(.minutes(1)))
-    func whenFeatureEnablesDuringLegacyDelayThenStaleClosureCannotPresent() {
+    @Test("In-Flight Presentation Retains Lease Until Late Root Attachment", .timeLimit(.minutes(1)))
+    func whenPresentationRelationshipExistsThenLeaseIsRetainedUntilRootAttaches() throws {
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let provider = MockModalPromptProvider()
+        let exactRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
+        let attachmentChecker = MockModalPromptRootAttachmentChecker()
+        let intendedHost = UIViewController()
+        presenterMock.modalPromptPresentationViewController = intendedHost
+        attachmentChecker.markAttached(intendedHost)
+        presenterMock.shouldCompletePresentation = false
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock,
+            rootAttachmentChecker: attachmentChecker
+        )
+        let lease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+        schedulerMock.executeScheduledBlock()
+
+        // UIKit publishes this relationship synchronously when it accepts `present`, before the transition finishes
+        // attaching the destination root to a window.
+        presenterMock.presentedViewController = exactRoot
+        schedulerMock.executeNextMainTurnBlock()
+
+        #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+        #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(!sut.didActuallyPresentModalPromptThisSession)
+        #expect(!sut.reconcilePresentedModal())
+        guard case .blockedByModal = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: makeVisiblePromoIdentity()) else {
+            Issue.record("Expected the in-flight modal presentation to keep blocking visible promo admission")
+            return
+        }
+
+        attachmentChecker.markAttached(exactRoot)
+        presenterMock.capturedCompletion?()
+
+        #expect(!sut.reconcilePresentedModal())
+        #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+        #expect(promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(sut.didActuallyPresentModalPromptThisSession)
+        #expect(provider.didPresentModalCallCount == 1)
+        #expect(cooldownManagerMock.recordLastPromptPresentationTimestampCallCount == 1)
+        guard case .blockedByModal = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: makeVisiblePromoIdentity()) else {
+            Issue.record("Expected reconciliation to block visible promo admission with the restored modal lease")
+            return
+        }
+    }
+
+    @available(iOS 16, *)
+    @Test("Refused Presentation Releases Lease Without A UIKit Presentation Relationship", .timeLimit(.minutes(1)))
+    func whenPresentationHasNoAttachmentOrPresentationRelationshipThenLeaseIsReleased() throws {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let exactRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
+        let attachmentChecker = MockModalPromptRootAttachmentChecker()
+        let intendedHost = UIViewController()
+        presenterMock.modalPromptPresentationViewController = intendedHost
+        attachmentChecker.markAttached(intendedHost)
+        presenterMock.shouldCompletePresentation = false
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock,
+            rootAttachmentChecker: attachmentChecker
+        )
+        let modalLease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: modalLease)
+        schedulerMock.executeScheduledBlock()
+        schedulerMock.executeNextMainTurnBlock()
+        let visibleIdentity = makeVisiblePromoIdentity()
+        guard case .acquired(let visibleLease) = promoQueueLeaseArbiter.acquireVisiblePromoLease(for: visibleIdentity) else {
+            Issue.record("Expected visible promo admission after UIKit refused the modal presentation")
+            return
+        }
+
+        #expect(sut.modalAttemptPhase == .idle)
+        #expect(sut.hasActiveOrPendingModalAttempt)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(promoQueueLeaseArbiter.snapshot.visiblePromoIdentities == [visibleIdentity])
+        #expect(!sut.didActuallyPresentModalPromptThisSession)
+        #expect(provider.didPresentModalCallCount == 0)
+        #expect(cooldownManagerMock.recordLastPromptPresentationTimestampCallCount == 0)
+        _ = visibleLease
+    }
+
+    @available(iOS 16, *)
+    @Test("Accepted Deferred Completion Accounts After Feature Disable", .timeLimit(.minutes(1)))
+    func whenFeatureDisablesAfterUIKitAcceptsThenDeferredCompletionStillRecordsExactlyOnce() throws {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        let exactRoot = UIViewController()
+        provider.modalConfigurationToReturn = ModalPromptConfiguration(viewController: exactRoot)
+        let attachmentChecker = MockModalPromptRootAttachmentChecker()
+        let intendedHost = UIViewController()
+        presenterMock.modalPromptPresentationViewController = intendedHost
+        attachmentChecker.markAttached(intendedHost)
+        presenterMock.shouldCompletePresentation = false
+        sut = ModalPromptCoordinationManager(
+            providers: [provider],
+            cooldownManager: cooldownManagerMock,
+            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            modalPromptScheduling: schedulerMock,
+            rootAttachmentChecker: attachmentChecker
+        )
+        let lease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
+        schedulerMock.executeScheduledBlock()
+        attachmentChecker.markAttached(exactRoot)
+        let acceptedCompletion = presenterMock.capturedCompletion
+
+        sut.promoQueueWillTransition(to: .disabled)
+        promoQueueLeaseArbiter.invalidateAllLeases()
+        sut.promoQueueDidTransition(to: .disabled)
+        acceptedCompletion?()
+        acceptedCompletion?()
+
+        #expect(sut.didActuallyPresentModalPromptThisSession)
+        #expect(provider.didPresentModalCallCount == 1)
+        #expect(cooldownManagerMock.didCallRecordLastPromptPresentationTimestamp)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+    }
+
+    @available(iOS 16, *)
+    @Test("Inactive Next-Turn Verification Is Retried After Becoming Active", .timeLimit(.minutes(1)))
+    func whenAppBackgroundsAfterUIKitCallThenUnverifiedLeaseIsRecheckedAfterBecomingActive() throws {
+        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
+        let provider = MockModalPromptProvider()
+        presenterMock.shouldCompletePresentation = false
         sut = ModalPromptCoordinationManager(
             providers: [provider],
             cooldownManager: cooldownManagerMock,
@@ -427,16 +945,28 @@ final class ModalPromptCoordinationManagerPromoQueueTests {
             promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             modalPromptScheduling: schedulerMock
         )
-        sut.presentModalPromptIfNeeded(from: presenterMock)
-
-        sut.promoQueueWillTransition(to: .enabled)
-        promoQueueLeaseArbiter.invalidateAllLeases()
-        sut.promoQueueDidTransition(to: .enabled)
+        var releaseNotificationCount = 0
+        sut.coordinatedAttemptReleaseHandler = {
+            releaseNotificationCount += 1
+        }
+        let lease = try acquireModalLease()
+        _ = sut.presentModalPromptIfNeeded(from: presenterMock, with: lease)
         schedulerMock.executeScheduledBlock()
 
-        #expect(!presenterMock.didCallPresent)
-        #expect(!sut.hasActiveOrPendingModalAttempt)
-        #expect(!sut.didActuallyPresentModalPromptThisSession)
+        sut.applicationDidEnterBackground()
+        schedulerMock.executeNextMainTurnBlock()
+
+        #expect(sut.modalAttemptPhase == .presentationActive(lease.attemptIdentity))
+        #expect(promoQueueLeaseArbiter.snapshot.modalAttemptIdentity == lease.attemptIdentity)
+        #expect(releaseNotificationCount == 0)
+
+        sut.applicationDidBecomeActive()
+        schedulerMock.executeNextMainTurnBlock()
+
+        #expect(sut.modalAttemptPhase == .idle)
+        #expect(sut.hasActiveOrPendingModalAttempt)
+        #expect(!promoQueueLeaseArbiter.snapshot.hasModalLease)
+        #expect(releaseNotificationCount == 1)
     }
 
     private func acquireModalLease() throws -> PromoQueueModalLease {
@@ -444,6 +974,14 @@ final class ModalPromptCoordinationManagerPromoQueueTests {
             throw TestError.expectedAcquiredLease
         }
         return lease
+    }
+
+    private func makeVisiblePromoIdentity() -> VisiblePromoIdentity {
+        VisiblePromoIdentity(
+            surfaceID: UUID(),
+            promoType: .remoteMessage,
+            promoID: "message"
+        )
     }
 }
 
@@ -459,8 +997,20 @@ private enum TestError: Error {
 private final class BlockReleasingModalPromptScheduler: ModalPromptScheduling {
     private var scheduledBlock: (@MainActor () -> Void)?
 
-    func schedule(after delay: TimeInterval, execute: @escaping @MainActor () -> Void) {
+    @discardableResult
+    func schedule(after delay: TimeInterval, execute: @escaping @MainActor () -> Void) -> ModalPromptScheduledTask {
         scheduledBlock = execute
+        return ModalPromptScheduledTask { [weak self] in
+            self?.scheduledBlock = nil
+        }
+    }
+
+    @discardableResult
+    func scheduleOnNextMainTurn(execute: @escaping @MainActor () -> Void) -> ModalPromptScheduledTask {
+        scheduledBlock = execute
+        return ModalPromptScheduledTask { [weak self] in
+            self?.scheduledBlock = nil
+        }
     }
 
     @MainActor
@@ -475,6 +1025,8 @@ private final class BlockReleasingModalPromptScheduler: ModalPromptScheduling {
 @MainActor
 private final class DeferredCompletionModalPromptPresenter: ModalPromptPresenter {
     var presentedViewController: UIViewController?
+    var modalPromptPresentationViewController: UIViewController?
+    var onPresent: (() -> Void)?
 
     private(set) var didCallPresent = false
     private(set) var capturedViewController: UIViewController?
@@ -484,6 +1036,7 @@ private final class DeferredCompletionModalPromptPresenter: ModalPromptPresenter
         didCallPresent = true
         capturedViewController = viewControllerToPresent
         pendingCompletion = completion
+        onPresent?()
     }
 
     func completePendingPresentation() {

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationRealUIKitTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationRealUIKitTests.swift
@@ -316,6 +316,8 @@ private enum RealUIKitTestError: Error {
 /// A real UIKit presentation host, so a test can observe genuine presentation and dismissal transitions.
 @MainActor
 private final class UIKitModalPromptPresenter: UIViewController, ModalPromptPresenter {
+    var modalPromptPresentationViewController: UIViewController? { self }
+
     /// Called once, after UIKit reports that the presentation transition has finished.
     ///
     /// A test that goes on to observe a dismissal must wait on this first: UIKit coalesces a dismissal requested

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/Providers/DefaultBrowserModalPromptProviderTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/Providers/DefaultBrowserModalPromptProviderTests.swift
@@ -146,14 +146,61 @@ final class DefaultBrowserModalPromptProviderTests {
         // THEN
         #expect(configuration?.animated == true)
     }
+
+    @Test("Prepared Prompt Is Invalid After Browser Becomes Default")
+    func whenBrowserBecomesDefaultThenPreparedPromptIsInvalid() throws {
+        let mockViewController = UIViewController()
+        let presenter = MockDefaultBrowserPromptPresenter(viewControllerToReturn: mockViewController)
+        let sut = DefaultBrowserModalPromptProvider(presenter: presenter)
+        let configuration = try #require(sut.provideModalPrompt())
+        presenter.isPreparedPromptStillValidResult = false
+
+        let isStillValid = sut.isPreparedModalPromptStillValid(configuration)
+
+        #expect(!isStillValid)
+        #expect(presenter.makeCallCount == 1)
+        #expect(presenter.isPreparedPromptStillValidCallCount == 1)
+    }
+
+    @Test("Prepared Prompt Remains Valid When Presenter Revalidation Succeeds")
+    func whenPresenterRevalidationSucceedsThenPreparedPromptRemainsValid() throws {
+        let mockViewController = UIViewController()
+        let presenter = MockDefaultBrowserPromptPresenter(viewControllerToReturn: mockViewController)
+        let sut = DefaultBrowserModalPromptProvider(presenter: presenter)
+        let configuration = try #require(sut.provideModalPrompt())
+
+        let isStillValid = sut.isPreparedModalPromptStillValid(configuration)
+
+        #expect(isStillValid)
+        #expect(presenter.makeCallCount == 1)
+        #expect(presenter.isPreparedPromptStillValidCallCount == 1)
+    }
+
+    @Test("Retained Prepared Prompt Uses Current Browser Revalidation")
+    func whenPreparedPromptWasRetainedThenProviderUsesCurrentBrowserRevalidation() throws {
+        let presenter = MockDefaultBrowserPromptPresenter(viewControllerToReturn: UIViewController())
+        let sut = DefaultBrowserModalPromptProvider(presenter: presenter)
+        let configuration = try #require(sut.provideModalPrompt())
+        presenter.isRetainedPreparedPromptStillValidResult = false
+
+        let isStillValid = sut.isRetainedPreparedModalPromptStillValid(configuration)
+
+        #expect(!isStillValid)
+        #expect(presenter.isPreparedPromptStillValidCallCount == 0)
+        #expect(presenter.isRetainedPreparedPromptStillValidCallCount == 1)
+    }
 }
 
 // This should belong to SetAsDefaultBrowserTestSupport. Had linking issue as UI depends on DesignResourceKitIcons. Possibly TestSupport needs to depend on that too. Will investigate in a follow up task
 @MainActor
 public final class MockDefaultBrowserPromptPresenter: DefaultBrowserPromptPresenting {
     private let viewControllerToReturn: UIViewController?
+    public var isPreparedPromptStillValidResult = true
+    public var isRetainedPreparedPromptStillValidResult = true
     public private(set) var didCallMakePresentDefaultModalPrompt = false
     public private(set) var makeCallCount = 0
+    public private(set) var isPreparedPromptStillValidCallCount = 0
+    public private(set) var isRetainedPreparedPromptStillValidCallCount = 0
 
     public init(viewControllerToReturn: UIViewController?) {
         self.viewControllerToReturn = viewControllerToReturn
@@ -163,5 +210,15 @@ public final class MockDefaultBrowserPromptPresenter: DefaultBrowserPromptPresen
         didCallMakePresentDefaultModalPrompt = true
         makeCallCount += 1
         return viewControllerToReturn
+    }
+
+    public func isPreparedDefaultModalPromptStillValid() -> Bool {
+        isPreparedPromptStillValidCallCount += 1
+        return isPreparedPromptStillValidResult
+    }
+
+    public func isRetainedPreparedDefaultModalPromptStillValid() -> Bool {
+        isRetainedPreparedPromptStillValidCallCount += 1
+        return isRetainedPreparedPromptStillValidResult
     }
 }

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/Providers/WhatsNewModalPromptProviderTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/Providers/WhatsNewModalPromptProviderTests.swift
@@ -54,6 +54,32 @@ final class WhatsNewCoordinatorTests {
         #expect(!mockRepository.didCallFetchLastShownMessage)
     }
 
+    @Test("Check Invalid Scheduled Message Can Be Replaced By Current Message")
+    func whenScheduledMessageChangesThenReplacementUsesCurrentMessage() throws {
+        let firstMessage = RemoteMessageModel.makeCardsListMessage(id: "first-message")
+        let replacementMessage = RemoteMessageModel.makeCardsListMessage(id: "replacement-message")
+        let mockRepository = MockWhatsNewMessageRepository(scheduledRemoteMessage: firstMessage)
+        let coordinator = WhatsNewCoordinator(
+            displayContext: .scheduled,
+            repository: mockRepository,
+            remoteMessageActionHandler: MockRemoteMessagingActionHandler(),
+            isIPad: false,
+            pixelReporter: MockRemoteMessagingPixelReporter(),
+            userScriptsDependencies: DefaultScriptSourceProvider.Dependencies.makeMock(),
+            imageLoader: MockRemoteMessagingImageLoader(),
+            featureFlagger: MockFeatureFlagger()
+        )
+        let firstConfiguration = try #require(coordinator.provideModalPrompt())
+        mockRepository.setScheduledRemoteMessage(replacementMessage)
+
+        #expect(!coordinator.isPreparedModalPromptStillValid(firstConfiguration))
+
+        let replacementConfiguration = try #require(coordinator.provideReplacementModalPrompt(for: firstConfiguration))
+
+        #expect(replacementConfiguration.viewController !== firstConfiguration.viewController)
+        #expect(coordinator.isPreparedModalPromptStillValid(replacementConfiguration))
+    }
+
     @Test(
         "Check View Controller Sets Page Sheet Presentation Style On iPhone",
         arguments: [.scheduled, .onDemand] as [WhatsNewCoordinator.DisplayContext]

--- a/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -69,6 +69,424 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         XCTAssertEqual(sut.homeMessageViewModels.count, 1)
     }
 
+    func testLoadIsIdempotentAndTearDownRemovesObserverAndRetryRegistration() {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock()
+        let sut = createSUT(promoCoordinator: promoCoordinator)
+
+        sut.load()
+        sut.load()
+
+        XCTAssertEqual(messagesConfiguration.refreshCallCount, 1)
+        XCTAssertEqual(promoCoordinator.registrationCount, 1)
+
+        notificationCenter.post(
+            name: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
+            object: nil
+        )
+        XCTAssertEqual(messagesConfiguration.refreshCallCount, 2)
+
+        sut.tearDown()
+        notificationCenter.post(
+            name: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
+            object: nil
+        )
+
+        XCTAssertEqual(messagesConfiguration.refreshCallCount, 2)
+        XCTAssertEqual(promoCoordinator.deregistrationCount, 1)
+        XCTAssertNil(promoCoordinator.retryTarget)
+    }
+
+    func testFeatureOffRecordsLegacyAppearanceEagerlyThenAgainWhenVisible() throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .disabled)
+        let message = HomeMessage.mockRemote(id: "message-a", withType: .small(titleText: "Title", descriptionText: "Body"))
+        messagesConfiguration.homeMessages = [message]
+        let sut = createSUT(promoCoordinator: promoCoordinator)
+
+        sut.load()
+
+        let viewModel = try XCTUnwrap(sut.homeMessageViewModels.first)
+        XCTAssertEqual(messagesConfiguration.appearanceCallCount, 1)
+        XCTAssertEqual(messagesConfiguration.lastAppearedHomeMessage, message)
+        XCTAssertEqual(promoCoordinator.publicAdmissionCallCount, 0)
+
+        viewModel.onDidAppear()
+
+        XCTAssertEqual(messagesConfiguration.appearanceCallCount, 2)
+        XCTAssertEqual(messagesConfiguration.lastAppearedHomeMessage, message)
+        XCTAssertEqual(promoCoordinator.publicAdmissionCallCount, 0)
+    }
+
+    func testFeatureOnRetainsBlockedCandidateWithoutPublishingOrRecordingRemoteCard() throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .enabled)
+        promoCoordinator.acquireModalLease()
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "Title", descriptionText: "Body"))]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+
+        try appearRemoteMessageGate(in: sut, expectedMessageID: "message-a")
+
+        XCTAssertTrue(sut.homeMessageViewModels.isEmpty)
+        XCTAssertNil(try remoteRenderSession(in: sut))
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 0)
+        XCTAssertNil(messagesConfiguration.lastAppearedHomeMessage)
+    }
+
+    func testFeatureOnConstructsAndPublishesRemoteCardOnlyAfterLeaseAdmission() throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .enabled)
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "Title", descriptionText: "Body"))]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+
+        XCTAssertTrue(sut.homeMessageViewModels.isEmpty)
+        XCTAssertNil(try remoteRenderSession(in: sut))
+
+        try appearRemoteMessageGate(in: sut, expectedMessageID: "message-a")
+
+        XCTAssertEqual(sut.homeMessageViewModels.map(\.messageId), ["message-a"])
+        XCTAssertNotNil(try remoteRenderSession(in: sut))
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 1)
+        XCTAssertNil(messagesConfiguration.lastAppearedHomeMessage)
+    }
+
+    func testAdmittedAppearanceIsRecordedOncePerRenderSession() throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .enabled)
+        let message = HomeMessage.mockRemote(id: "message-a", withType: .small(titleText: "Title", descriptionText: "Body"))
+        messagesConfiguration.homeMessages = [message]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+        try appearRemoteMessageGate(in: sut, expectedMessageID: "message-a")
+        let session = try XCTUnwrap(try remoteRenderSession(in: sut))
+
+        session.viewModel.onDidAppear()
+        session.viewModel.onDidAppear()
+
+        XCTAssertEqual(messagesConfiguration.appearanceCallCount, 1)
+        XCTAssertEqual(messagesConfiguration.lastAppearedHomeMessage, message)
+    }
+
+    func testSameIDRefreshKeepsLeaseRenderSessionAndAppearanceReservation() throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .enabled)
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "First", descriptionText: "Body"))]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+        let originalGate = try XCTUnwrap(try remoteMessageGate(in: sut))
+        let mountID = UUID()
+        sut.remoteMessageGateDidAppear(
+            gateID: originalGate.id,
+            messageID: originalGate.messageID,
+            mountID: mountID
+        )
+        let originalSession = try XCTUnwrap(try remoteRenderSession(in: sut))
+        originalSession.viewModel.onDidAppear()
+
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "Updated", descriptionText: "Body"))]
+        sut.refresh()
+        let refreshedGate = try XCTUnwrap(try remoteMessageGate(in: sut))
+        let refreshedSession = try XCTUnwrap(try remoteRenderSession(in: sut))
+        refreshedSession.viewModel.onDidAppear()
+
+        XCTAssertEqual(refreshedGate.id, originalGate.id)
+        XCTAssertEqual(refreshedSession.id, originalSession.id)
+        XCTAssertEqual(refreshedSession.viewModel.title, "Updated")
+        XCTAssertEqual(messagesConfiguration.appearanceCallCount, 1)
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 1)
+    }
+
+    func testReplacementMountAppearingBeforeStaleMountDisappearsKeepsCurrentSessionAndLease() throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .enabled)
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "Title", descriptionText: "Body"))]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+        let gate = try XCTUnwrap(try remoteMessageGate(in: sut))
+        let originalMountID = UUID()
+        let replacementMountID = UUID()
+
+        sut.remoteMessageGateDidAppear(
+            gateID: gate.id,
+            messageID: gate.messageID,
+            mountID: originalMountID
+        )
+        let session = try XCTUnwrap(try remoteRenderSession(in: sut))
+
+        sut.remoteMessageGateDidAppear(
+            gateID: gate.id,
+            messageID: gate.messageID,
+            mountID: replacementMountID
+        )
+        sut.remoteMessageGateDidDisappear(
+            gateID: gate.id,
+            messageID: gate.messageID,
+            mountID: originalMountID
+        )
+        sut.remoteMessageDidDisappear(
+            renderSessionID: session.id,
+            mountID: originalMountID
+        )
+
+        XCTAssertEqual(try remoteRenderSession(in: sut)?.id, session.id)
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 1)
+    }
+
+    func testReplacementMountDisappearingBeforeItsGateKeepsOriginalSessionAndLease() throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .enabled)
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "Title", descriptionText: "Body"))]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+        let gate = try XCTUnwrap(try remoteMessageGate(in: sut))
+        let originalMountID = UUID()
+        let replacementMountID = UUID()
+
+        sut.remoteMessageGateDidAppear(
+            gateID: gate.id,
+            messageID: gate.messageID,
+            mountID: originalMountID
+        )
+        let session = try XCTUnwrap(try remoteRenderSession(in: sut))
+
+        sut.remoteMessageGateDidAppear(
+            gateID: gate.id,
+            messageID: gate.messageID,
+            mountID: replacementMountID
+        )
+        sut.remoteMessageDidDisappear(
+            renderSessionID: session.id,
+            mountID: replacementMountID
+        )
+        sut.remoteMessageGateDidDisappear(
+            gateID: gate.id,
+            messageID: gate.messageID,
+            mountID: replacementMountID
+        )
+
+        XCTAssertEqual(try remoteRenderSession(in: sut)?.id, session.id)
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 1)
+    }
+
+    func testWhenRemoteMessageIDChangesThenReplacementAdmitsAfterDeferredRelease() async throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .enabled)
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "First", descriptionText: "Body"))]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+        try appearRemoteMessageGate(in: sut, expectedMessageID: "message-a")
+        let originalSession = try XCTUnwrap(try remoteRenderSession(in: sut))
+
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-b", withType: .small(titleText: "Second", descriptionText: "Body"))]
+        sut.refresh()
+        try appearRemoteMessageGate(in: sut, expectedMessageID: "message-b")
+
+        XCTAssertNil(try remoteRenderSession(in: sut))
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoIdentities.map(\.promoID), ["message-a"])
+
+        await waitForNextMainQueueTurn()
+        let replacementSession = try XCTUnwrap(try remoteRenderSession(in: sut))
+
+        XCTAssertNotEqual(replacementSession.id, originalSession.id)
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoIdentities.map(\.promoID), ["message-b"])
+    }
+
+    func testRenderableWithdrawalReleasesLeaseOnNextTurnAndReadmitsWhenRenderableAgain() async throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .enabled)
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "Title", descriptionText: "Body"))]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+        try appearRemoteMessageGate(in: sut, expectedMessageID: "message-a")
+
+        sut.setSurfaceRenderable(false)
+
+        XCTAssertTrue(sut.homeMessageViewModels.isEmpty)
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 1)
+
+        await waitForNextMainQueueTurn()
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 0)
+
+        sut.setSurfaceRenderable(true)
+
+        XCTAssertNotNil(try remoteRenderSession(in: sut))
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 1)
+    }
+
+    func testOwnerTeardownReleasesLeaseOnNextTurn() async throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .enabled)
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "Title", descriptionText: "Body"))]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+        try appearRemoteMessageGate(in: sut, expectedMessageID: "message-a")
+
+        sut.tearDown()
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 1)
+
+        await waitForNextMainQueueTurn()
+
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 0)
+    }
+
+    func testConfigurationRemovalClearsBlockedCandidateWithoutAppearanceAccounting() throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .enabled)
+        promoCoordinator.acquireModalLease()
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "Title", descriptionText: "Body"))]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+        try appearRemoteMessageGate(in: sut, expectedMessageID: "message-a")
+
+        messagesConfiguration.homeMessages = []
+        sut.refresh()
+
+        XCTAssertTrue(sut.homeMessageRenderItems.isEmpty)
+        XCTAssertTrue(sut.homeMessageViewModels.isEmpty)
+        XCTAssertNil(messagesConfiguration.lastAppearedHomeMessage)
+        XCTAssertNil(try remoteRenderSession(in: sut))
+    }
+
+    func testWhenRetryRefreshesBlockedCandidateThenSuppliedAdmissionHandlerIsCalledOnce() throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .enabled)
+        promoCoordinator.acquireModalLease()
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "Title", descriptionText: "Body"))]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+        try appearRemoteMessageGate(in: sut, expectedMessageID: "message-a")
+        let admissionCallCountBeforeRetry = promoCoordinator.publicAdmissionCallCount
+
+        sut.retryVisiblePromoAdmission(using: promoCoordinator.admitVisiblePromo)
+
+        XCTAssertEqual(promoCoordinator.publicAdmissionCallCount - admissionCallCountBeforeRetry, 1)
+        XCTAssertNil(try remoteRenderSession(in: sut))
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 0)
+    }
+
+    func testWhenLegacyCandidateChangesDuringLiveEnableThenReplacementWaitsForGateAppearance() throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock()
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "First", descriptionText: "Body"))]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+
+        promoCoordinator.promoQueueFeatureState = .transitioning(to: .enabled)
+        sut.promoQueueWillTransition(to: .enabled)
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-b", withType: .small(titleText: "Second", descriptionText: "Body"))]
+        sut.promoQueueDidTransition(to: .enabled)
+        sut.retryVisiblePromoAdmission(using: promoCoordinator.admitVisiblePromo)
+
+        XCTAssertNil(try remoteRenderSession(in: sut))
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 0)
+
+        promoCoordinator.promoQueueFeatureState = .enabled
+        try appearRemoteMessageGate(in: sut, expectedMessageID: "message-b")
+
+        XCTAssertNotNil(try remoteRenderSession(in: sut))
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoIdentities.map(\.promoID), ["message-b"])
+    }
+
+    func testLiveDisableReleasesCoordinatedLeaseOnNextTurnBeforeLegacyRepublish() async throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .enabled)
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "Title", descriptionText: "Body"))]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+        try appearRemoteMessageGate(in: sut, expectedMessageID: "message-a")
+        let coordinatedSession = try XCTUnwrap(try remoteRenderSession(in: sut))
+        coordinatedSession.viewModel.onDidAppear()
+
+        promoCoordinator.promoQueueFeatureState = .transitioning(to: .disabled)
+        sut.promoQueueWillTransition(to: .disabled)
+
+        XCTAssertTrue(sut.homeMessageViewModels.isEmpty)
+        XCTAssertNil(try remoteRenderSession(in: sut))
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 1)
+
+        await waitForNextMainQueueTurn()
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 0)
+
+        sut.promoQueueDidTransition(to: .disabled)
+
+        XCTAssertEqual(sut.homeMessageViewModels.map(\.messageId), ["message-a"])
+        XCTAssertEqual(messagesConfiguration.appearanceCallCount, 2)
+        sut.homeMessageViewModels.first?.onDidAppear()
+        XCTAssertEqual(messagesConfiguration.appearanceCallCount, 3)
+    }
+
+    func testRemovedAndReinsertedSameIDGetsNewGateAndIgnoresStaleGateCallbacks() async throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .enabled)
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "First", descriptionText: "Body"))]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+        let originalGate = try XCTUnwrap(try remoteMessageGate(in: sut))
+        let originalMountID = UUID()
+        sut.remoteMessageGateDidAppear(
+            gateID: originalGate.id,
+            messageID: originalGate.messageID,
+            mountID: originalMountID
+        )
+        XCTAssertNotNil(try remoteRenderSession(in: sut))
+
+        messagesConfiguration.homeMessages = []
+        sut.refresh()
+        await waitForNextMainQueueTurn()
+
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "Second", descriptionText: "Body"))]
+        sut.refresh()
+        let replacementGate = try XCTUnwrap(try remoteMessageGate(in: sut))
+
+        XCTAssertNotEqual(replacementGate.id, originalGate.id)
+
+        sut.remoteMessageGateDidAppear(
+            gateID: originalGate.id,
+            messageID: originalGate.messageID,
+            mountID: originalMountID
+        )
+        XCTAssertNil(try remoteRenderSession(in: sut))
+
+        let replacementMountID = UUID()
+        sut.remoteMessageGateDidAppear(
+            gateID: replacementGate.id,
+            messageID: replacementGate.messageID,
+            mountID: replacementMountID
+        )
+        let replacementSession = try XCTUnwrap(try remoteRenderSession(in: sut))
+
+        sut.remoteMessageGateDidDisappear(
+            gateID: originalGate.id,
+            messageID: originalGate.messageID,
+            mountID: originalMountID
+        )
+
+        XCTAssertEqual(try remoteRenderSession(in: sut)?.id, replacementSession.id)
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 1)
+    }
+
+    func testRapidDisableEnableUsesNewGateAndIgnoresPriorGenerationCallbacks() throws {
+        let promoCoordinator = ArbitratingNewTabPagePromoCoordinatorMock(featureState: .enabled)
+        messagesConfiguration.homeMessages = [.mockRemote(id: "message-a", withType: .small(titleText: "Title", descriptionText: "Body"))]
+        let sut = createRenderableSUT(promoCoordinator: promoCoordinator)
+        let originalGate = try XCTUnwrap(try remoteMessageGate(in: sut))
+        let originalMountID = UUID()
+        sut.remoteMessageGateDidAppear(
+            gateID: originalGate.id,
+            messageID: originalGate.messageID,
+            mountID: originalMountID
+        )
+        let originalSession = try XCTUnwrap(try remoteRenderSession(in: sut))
+
+        promoCoordinator.promoQueueFeatureState = .transitioning(to: .disabled)
+        sut.promoQueueWillTransition(to: .disabled)
+        sut.remoteMessageDidDisappear(renderSessionID: originalSession.id, mountID: originalMountID)
+        promoCoordinator.arbiter.invalidateAllLeases()
+        sut.promoQueueDidTransition(to: .disabled)
+
+        promoCoordinator.promoQueueFeatureState = .transitioning(to: .enabled)
+        sut.promoQueueWillTransition(to: .enabled)
+        sut.promoQueueDidTransition(to: .enabled)
+        promoCoordinator.promoQueueFeatureState = .enabled
+        let replacementGate = try XCTUnwrap(try remoteMessageGate(in: sut))
+
+        XCTAssertNotEqual(replacementGate.id, originalGate.id)
+
+        sut.remoteMessageGateDidAppear(
+            gateID: originalGate.id,
+            messageID: originalGate.messageID,
+            mountID: originalMountID
+        )
+        sut.remoteMessageGateDidDisappear(
+            gateID: originalGate.id,
+            messageID: originalGate.messageID,
+            mountID: originalMountID
+        )
+        XCTAssertNil(try remoteRenderSession(in: sut))
+
+        let replacementMountID = UUID()
+        sut.remoteMessageGateDidAppear(
+            gateID: replacementGate.id,
+            messageID: replacementGate.messageID,
+            mountID: replacementMountID
+        )
+
+        XCTAssertNotNil(try remoteRenderSession(in: sut))
+        XCTAssertEqual(promoCoordinator.arbiter.snapshot.visiblePromoCount, 1)
+    }
+
     // MARK: Callbacks
 
     func testCallsDismissOnClose() async throws {
@@ -328,7 +746,13 @@ final class NewTabPageMessagesModelTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func createSUT(isOpenedAfterIdle: Bool = false) -> NewTabPageMessagesModel {
+    private func createSUT(
+        isOpenedAfterIdle: Bool = false,
+        promoCoordinator: ArbitratingNewTabPagePromoCoordinatorMock? = nil
+    ) -> NewTabPageMessagesModel {
+        // Built here rather than as a default argument: the mock is `@MainActor`, and default
+        // argument expressions are evaluated in a nonisolated context.
+        let promoCoordinator = promoCoordinator ?? ArbitratingNewTabPagePromoCoordinatorMock()
         let remoteMessageActionHandler = RemoteMessagingActionHandler(lastSearchStateRefresher: RemoteMessagingSurveyLastSearchStateRefresher())
         remoteMessageActionHandler.messageNavigator = DefaultMessageNavigator(delegate: self)
 
@@ -337,11 +761,125 @@ final class NewTabPageMessagesModelTests: XCTestCase {
                                 pixelFiring: PixelFiringMock.self,
                                 messageActionHandler: remoteMessageActionHandler,
                                 imageLoader: MockRemoteMessagingImageLoader(),
-                                promoCoordinator: MockNewTabPagePromoCoordinator(),
+                                promoCoordinator: promoCoordinator,
                                 isOpenedAfterIdle: { isOpenedAfterIdle })
+    }
+
+    private func createRenderableSUT(
+        promoCoordinator: ArbitratingNewTabPagePromoCoordinatorMock
+    ) -> NewTabPageMessagesModel {
+        let sut = createSUT(promoCoordinator: promoCoordinator)
+        sut.setSurfaceAttachmentProvider { true }
+        sut.load()
+        sut.setSurfaceRenderable(true)
+        return sut
+    }
+
+    private func remoteRenderSession(
+        in sut: NewTabPageMessagesModel
+    ) throws -> NewTabPageRemoteMessageRenderSession? {
+        try remoteMessageGate(in: sut)?.renderSession
+    }
+
+    private func remoteMessageGate(
+        in sut: NewTabPageMessagesModel
+    ) throws -> NewTabPageRemoteMessageGate? {
+        guard let item = sut.homeMessageRenderItems.first else {
+            return nil
+        }
+        guard case .remoteMessageGate(let gate) = item.content else {
+            return nil
+        }
+        return gate
+    }
+
+    @discardableResult
+    private func appearRemoteMessageGate(
+        in sut: NewTabPageMessagesModel,
+        expectedMessageID: String
+    ) throws -> UUID {
+        let gate = try XCTUnwrap(try remoteMessageGate(in: sut))
+        XCTAssertEqual(gate.messageID, expectedMessageID)
+        let mountID = UUID()
+        sut.remoteMessageGateDidAppear(
+            gateID: gate.id,
+            messageID: gate.messageID,
+            mountID: mountID
+        )
+        return mountID
+    }
+
+    private func waitForNextMainQueueTurn() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
     }
 }
 
+@MainActor
+private final class ArbitratingNewTabPagePromoCoordinatorMock: NewTabPagePromoCoordinating {
+    var promoQueueFeatureState: PromoQueueFeatureState
+    let arbiter = PromoQueueLeaseArbiter()
+    private(set) weak var retryTarget: NewTabPagePromoRetrying?
+    private(set) var registrationCount = 0
+    private(set) var deregistrationCount = 0
+    private(set) var publicAdmissionCallCount = 0
+    private var modalLease: PromoQueueModalLease?
+
+    init(featureState: PromoQueueFeatureState = .disabled) {
+        promoQueueFeatureState = featureState
+    }
+
+    func acquireModalLease() {
+        guard case .acquired(let lease) = arbiter.acquireModalLease() else {
+            XCTFail("Expected the mock modal lease to be acquired.")
+            return
+        }
+        modalLease = lease
+    }
+
+    func admitVisiblePromo(_ identity: VisiblePromoIdentity) -> VisiblePromoAdmissionResult {
+        publicAdmissionCallCount += 1
+        switch promoQueueFeatureState {
+        case .disabled:
+            return .featureDisabled
+        case .transitioning:
+            return .unavailableDuringTransition
+        case .enabled:
+            break
+        }
+
+        switch arbiter.acquireVisiblePromoLease(for: identity) {
+        case .acquired(let lease):
+            return .acquired(lease)
+        case .blockedByModal:
+            return .blockedByModal
+        case .occupiedSurfaceSlot(let identity):
+            return .occupiedSurfaceSlot(identity)
+        }
+    }
+
+    func releaseVisiblePromoLease(_ lease: PromoQueueVisiblePromoLease) {
+        lease.release()
+    }
+
+    func registerVisiblePromoRetry(
+        for surfaceID: UUID,
+        target: NewTabPagePromoRetrying
+    ) -> NewTabPagePromoRetryRegistration {
+        registrationCount += 1
+        retryTarget = target
+        return NewTabPagePromoRetryRegistration { [weak self, weak target] in
+            guard let self, retryTarget === target else {
+                return
+            }
+            deregistrationCount += 1
+            retryTarget = nil
+        }
+    }
+}
 extension NewTabPageMessagesModelTests: MessageNavigationDelegate {
 
     func segueToSettingsAIChat(openedFromSERPSettingsButton: Bool, presentationStyle: PresentationContext.Style) {
@@ -379,10 +917,14 @@ extension NewTabPageMessagesModelTests: MessageNavigationDelegate {
 }
 
 private extension HomeMessage {
-    static func mockRemote(withType type: RemoteMessageModelType, isMetricsEnabled: Bool = true) -> Self {
+    static func mockRemote(
+        id: String = "foo",
+        withType type: RemoteMessageModelType,
+        isMetricsEnabled: Bool = true
+    ) -> Self {
         HomeMessage.remoteMessage(
             remoteMessage: .init(
-                id: "foo",
+                id: id,
                 surfaces: .newTabPage,
                 content: type,
                 matchingRules: [],

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedInputContentContainerViewControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedInputContentContainerViewControllerTests.swift
@@ -39,6 +39,20 @@ final class UnifiedInputContentContainerViewControllerTests: XCTestCase {
 
         XCTAssertEqual(delegate.syncSetupRequestCount, 1)
     }
+
+    func testPromoQueueEnablementPublisher_WhenAlreadyFocused_RefreshesAfterCompletedLiveEnable() {
+        let featureState = CurrentValueSubject<PromoQueueFeatureState, Never>(.disabled)
+        var refreshCount = 0
+        let cancellable = promoQueueEnablementPublisher(featureState.eraseToAnyPublisher())
+            .sink { refreshCount += 1 }
+
+        featureState.send(.transitioning(to: .enabled))
+        XCTAssertEqual(refreshCount, 0)
+
+        featureState.send(.enabled)
+        XCTAssertEqual(refreshCount, 1)
+        withExtendedLifetime(cancellable) {}
+    }
 }
 
 private final class MockUnifiedInputContentContainerDelegate: UnifiedInputContentContainerViewControllerDelegate {

--- a/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
+++ b/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
@@ -407,10 +407,17 @@ final class ModalPromptCoordinationManagerIntegrationTests {
 
 // MARK: - Helpers
 
+@MainActor
 private final class ImmediateScheduler: ModalPromptScheduling {
-    func schedule(after delay: TimeInterval, execute: @escaping @MainActor () -> Void) {
-        MainActor.assumeIsolated {
-            execute()
-        }
+    @discardableResult
+    func schedule(after delay: TimeInterval, execute: @escaping @MainActor () -> Void) -> ModalPromptScheduledTask {
+        execute()
+        return ModalPromptScheduledTask()
+    }
+
+    @discardableResult
+    func scheduleOnNextMainTurn(execute: @escaping @MainActor () -> Void) -> ModalPromptScheduledTask {
+        execute()
+        return ModalPromptScheduledTask()
     }
 }

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/CheckDefaultBrowserService/CheckDefaultBrowserManager.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/CheckDefaultBrowserService/CheckDefaultBrowserManager.swift
@@ -22,6 +22,8 @@ import class UIKit.UIApplication
 
 public protocol DefaultBrowserManaging: AnyObject {
     func defaultBrowserInfo() -> DefaultBrowserInfoResult
+    /// Returns the cached browser-status context without performing a new system check.
+    func storedDefaultBrowserInfo() -> DefaultBrowserContext?
 }
 
 // MARK: - DefaultBrowserManager
@@ -74,6 +76,10 @@ public final class DefaultBrowserManager: DefaultBrowserManaging {
         case .failure(.notSupportedOnThisOSVersion):
             return .failure(.notSupportedOnCurrentOSVersion)
         }
+    }
+
+    public func storedDefaultBrowserInfo() -> DefaultBrowserContext? {
+        defaultBrowserInfoStore.defaultBrowserContext
     }
 
     private func makeDefaultBrowserInfo(isDefaultBrowser: Bool, lastSuccessfulCheckDate: TimeInterval? = nil, nextRetryAvailableDate: Date? = nil) -> DefaultBrowserContext {

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/Coordinator/DefaultBrowserPromptCoordinator.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/Coordinator/DefaultBrowserPromptCoordinator.swift
@@ -38,10 +38,20 @@ package enum DefaultBrowserPromptPresentationType {
 @MainActor
 package protocol DefaultBrowserPromptCoordinating: AnyObject {
     func getPrompt() -> DefaultBrowserPromptPresentationType?
+    /// Revalidates prepared work without consuming prompt-selection state or performing a new status check.
+    func isPreparedPromptStillValid() -> Bool
+    /// Revalidates retained work using current browser status before a presentation retry.
+    func isRetainedPreparedPromptStillValid() -> Bool
 
     func setDefaultBrowserAction(forPrompt prompt: DefaultBrowserPromptPresentationType)
     func dismissAction(forPrompt prompt: DefaultBrowserPromptPresentationType, shouldDismissPromptPermanently: Bool)
     func moreProtectionsAction()
+}
+
+package extension DefaultBrowserPromptCoordinating {
+    func isRetainedPreparedPromptStillValid() -> Bool {
+        isPreparedPromptStillValid()
+    }
 }
 
 @MainActor
@@ -82,6 +92,14 @@ extension DefaultBrowserPromptCoordinator: DefaultBrowserPromptCoordinating {
         resetUserActivity()
 
         return DefaultBrowserPromptPresentationType(prompt)
+    }
+
+    package func isPreparedPromptStillValid() -> Bool {
+        promptTypeDecider.isPreparedPromptStillValid()
+    }
+
+    package func isRetainedPreparedPromptStillValid() -> Bool {
+        promptTypeDecider.isRetainedPreparedPromptStillValid()
     }
 
     package func setDefaultBrowserAction(forPrompt prompt: DefaultBrowserPromptPresentationType) {

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/PromptDecider/DefaultBrowserPromptTypeDecider.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserCore/PromptDecider/DefaultBrowserPromptTypeDecider.swift
@@ -58,6 +58,21 @@ package extension DefaultBrowserPromptType {
 @MainActor
 package protocol DefaultBrowserPromptTypeDeciding {
     func promptType() -> DefaultBrowserPromptType?
+    /// Revalidates prepared work from cached browser status without consuming selection state.
+    func isPreparedPromptStillValid() -> Bool
+    /// Revalidates retained work using a fresh browser-status check before retrying presentation.
+    /// A failed check falls back to the stored status rather than invalidating the retained work.
+    func isRetainedPreparedPromptStillValid() -> Bool
+}
+
+package extension DefaultBrowserPromptTypeDeciding {
+    func isPreparedPromptStillValid() -> Bool {
+        true
+    }
+
+    func isRetainedPreparedPromptStillValid() -> Bool {
+        isPreparedPromptStillValid()
+    }
 }
 
 @MainActor
@@ -154,6 +169,25 @@ package final class DefaultBrowserPromptTypeDecider: DefaultBrowserPromptTypeDec
         return defaultBrowserManager.defaultBrowserInfo().isEligibleToShowDefaultBrowserPrompt() ? promptToShow : nil
     }
 
+    package func isPreparedPromptStillValid() -> Bool {
+        guard let storedInfo = defaultBrowserManager.storedDefaultBrowserInfo() else {
+            return true
+        }
+        return storedInfo.isEligibleToShowDefaultBrowserPrompt()
+    }
+
+    package func isRetainedPreparedPromptStillValid() -> Bool {
+        switch defaultBrowserManager.defaultBrowserInfo() {
+        case let .success(newInfo):
+            return newInfo.isEligibleToShowDefaultBrowserPrompt()
+        case .failure:
+            // The OS status check is rate limited, and the retained prompt already consumed its
+            // selection state, so a failed check must not discard it. Fall back to the stored
+            // status, which a rate-limited check refreshes before failing.
+            return isPreparedPromptStillValid()
+        }
+    }
+
 }
 
 // MARK: - Private
@@ -181,7 +215,15 @@ private extension DefaultBrowserInfoResult {
 
     func isEligibleToShowDefaultBrowserPrompt() -> Bool {
         guard case let .success(newInfo) = self else { return false }
-        return !newInfo.isDefaultBrowser
+        return newInfo.isEligibleToShowDefaultBrowserPrompt()
+    }
+
+}
+
+private extension DefaultBrowserContext {
+
+    func isEligibleToShowDefaultBrowserPrompt() -> Bool {
+        !isDefaultBrowser
     }
 
 }

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserTestSupport/CheckDefaultBrowser/MockCheckDefaultBrowserService.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserTestSupport/CheckDefaultBrowser/MockCheckDefaultBrowserService.swift
@@ -24,8 +24,10 @@ public final class MockCheckDefaultBrowserService: CheckDefaultBrowserService {
     public init() {}
 
     public var resultToReturn: Result<Bool, CheckDefaultBrowserServiceError> = .success(true)
+    public private(set) var isDefaultWebBrowserCallCount = 0
 
     public func isDefaultWebBrowser() -> Result<Bool, CheckDefaultBrowserServiceError> {
-        resultToReturn
+        isDefaultWebBrowserCallCount += 1
+        return resultToReturn
     }
 }

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserTestSupport/CheckDefaultBrowser/MockDefaultBrowserManager.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserTestSupport/CheckDefaultBrowser/MockDefaultBrowserManager.swift
@@ -24,11 +24,18 @@ public final class MockDefaultBrowserManager: DefaultBrowserManaging {
     public init() {}
 
     public private(set) var didCallDefaultBrowserInfo: Bool = false
+    public private(set) var didCallStoredDefaultBrowserInfo: Bool = false
     public var resultToReturn: DefaultBrowserInfoResult = .successful(isDefaultBrowser: true)
+    public var storedInfoToReturn: DefaultBrowserContext?
 
     public func defaultBrowserInfo() -> DefaultBrowserInfoResult {
         didCallDefaultBrowserInfo = true
         return resultToReturn
+    }
+
+    public func storedDefaultBrowserInfo() -> DefaultBrowserContext? {
+        didCallStoredDefaultBrowserInfo = true
+        return storedInfoToReturn
     }
 
 }

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserTestSupport/MockDefaultBrowserPromptTypeDecider.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserTestSupport/MockDefaultBrowserPromptTypeDecider.swift
@@ -21,13 +21,27 @@ import SetDefaultBrowserCore
 
 package final class MockDefaultBrowserPromptTypeDecider: DefaultBrowserPromptTypeDeciding {
     package var promptToReturn: DefaultBrowserPromptType?
+    package var isPreparedPromptStillValidResult = true
+    package var isRetainedPreparedPromptStillValidResult = true
     package private(set) var didCallPromptType: Bool = false
+    package private(set) var didCallIsPreparedPromptStillValid = false
+    package private(set) var didCallIsRetainedPreparedPromptStillValid = false
 
     package init() {}
 
     package func promptType() -> DefaultBrowserPromptType? {
         didCallPromptType = true
         return promptToReturn
+    }
+
+    package func isPreparedPromptStillValid() -> Bool {
+        didCallIsPreparedPromptStillValid = true
+        return isPreparedPromptStillValidResult
+    }
+
+    package func isRetainedPreparedPromptStillValid() -> Bool {
+        didCallIsRetainedPreparedPromptStillValid = true
+        return isRetainedPreparedPromptStillValidResult
     }
 
 }

--- a/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/DefaultBrowserPromptPresenter.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Sources/SetDefaultBrowserUI/DefaultBrowserPromptPresenter.swift
@@ -26,6 +26,16 @@ import SetDefaultBrowserCore
 public protocol DefaultBrowserPromptPresenting: AnyObject {
     /// Returns a view controller if the prompt is eligible to show to the user. Nil, otherwise.
     func makePresentDefaultModalPrompt() -> UIViewController?
+    /// Revalidates an already prepared prompt without consuming prompt-selection state.
+    func isPreparedDefaultModalPromptStillValid() -> Bool
+    /// Revalidates a prompt retained across a recoverable presentation failure using current browser status.
+    func isRetainedPreparedDefaultModalPromptStillValid() -> Bool
+}
+
+public extension DefaultBrowserPromptPresenting {
+    func isRetainedPreparedDefaultModalPromptStillValid() -> Bool {
+        isPreparedDefaultModalPromptStillValid()
+    }
 }
 
 @MainActor
@@ -49,6 +59,14 @@ final class DefaultBrowserModalPresenter: NSObject, DefaultBrowserPromptPresenti
         case .inactiveUserModal:
             return makeDefaultBrowserPromptForInactiveUser()
         }
+    }
+
+    func isPreparedDefaultModalPromptStillValid() -> Bool {
+        coordinator.isPreparedPromptStillValid()
+    }
+
+    func isRetainedPreparedDefaultModalPromptStillValid() -> Bool {
+        coordinator.isRetainedPreparedPromptStillValid()
     }
 
 }

--- a/iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserTests/CheckDefaultBrowserManagerTests.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserTests/CheckDefaultBrowserManagerTests.swift
@@ -44,6 +44,24 @@ final class DefaultBrowserManagerTests {
         )
     }
 
+    @Test("Stored Browser Info Is Read Without Checking The OS")
+    func storedDefaultBrowserInfoDoesNotCheckTheOS() {
+        let storedInfo = DefaultBrowserContext(
+            isDefaultBrowser: false,
+            lastSuccessfulCheckDate: 1741586108000,
+            lastAttemptedCheckDate: 1741586108000,
+            numberOfTimesChecked: 1,
+            nextRetryAvailableDate: nil
+        )
+        store.defaultBrowserContext = storedInfo
+
+        let result = sut.storedDefaultBrowserInfo()
+
+        #expect(result == storedInfo)
+        #expect(defaultBrowserService.isDefaultWebBrowserCallCount == 0)
+        #expect(!eventMapperMock.didCallFireEvent)
+    }
+
     @Test("Check Browser Succeeds store and returns expected info",
         arguments: [
             true,

--- a/iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserTests/DefaultBrowserPromptCoordinatorTests.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserTests/DefaultBrowserPromptCoordinatorTests.swift
@@ -73,6 +73,29 @@ final class DefaultBrowserPromptCoordinatorTests {
         #expect(result == .activeUserModal)
     }
 
+    @Test("Prepared Prompt Validity Is Delegated Without Selecting Another Prompt")
+    func preparedPromptValidityDelegatesToDecider() {
+        promptTypeDeciderMock.isPreparedPromptStillValidResult = false
+
+        let isStillValid = sut.isPreparedPromptStillValid()
+
+        #expect(!isStillValid)
+        #expect(promptTypeDeciderMock.didCallIsPreparedPromptStillValid)
+        #expect(!promptTypeDeciderMock.didCallPromptType)
+    }
+
+    @Test("Retained Prepared Prompt Validity Uses Current-Status Validation")
+    func retainedPreparedPromptValidityDelegatesToDecider() {
+        promptTypeDeciderMock.isRetainedPreparedPromptStillValidResult = false
+
+        let isStillValid = sut.isRetainedPreparedPromptStillValid()
+
+        #expect(!isStillValid)
+        #expect(promptTypeDeciderMock.didCallIsRetainedPreparedPromptStillValid)
+        #expect(!promptTypeDeciderMock.didCallIsPreparedPromptStillValid)
+        #expect(!promptTypeDeciderMock.didCallPromptType)
+    }
+
     @Test(
         "Check Prompt Occurrency Is Incremented for Active Modal When Prompt Is Not Nil",
         arguments: [

--- a/iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserTests/DefaultBrowserPromptDeciderTests.swift
+++ b/iOS/LocalPackages/SetDefaultBrowser/Tests/SetDefaultBrowserTests/DefaultBrowserPromptDeciderTests.swift
@@ -45,6 +45,16 @@ final class DefaultBrowserPromptDeciderTests {
         )
     }
 
+    private func makeDefaultBrowserContext(isDefaultBrowser: Bool) -> DefaultBrowserContext {
+        DefaultBrowserContext(
+            isDefaultBrowser: isDefaultBrowser,
+            lastSuccessfulCheckDate: 1741586108000,
+            lastAttemptedCheckDate: 1741586108000,
+            numberOfTimesChecked: 1,
+            nextRetryAvailableDate: nil
+        )
+    }
+
     @Test("Check No Modal Is Presented When Prompt Is Permanently Dismissed")
     func checkPromptIsNilWhenPromptIsPermanentlyDismissed() {
         // GIVEN
@@ -58,6 +68,103 @@ final class DefaultBrowserPromptDeciderTests {
         // THEN
         #expect(result == nil)
         #expect(!userTypeProviderMock.didCallCurrentUserType)
+    }
+
+    @Test("Prepared Prompt Remains Valid When Stored Status Says Browser Is Not Default")
+    func preparedPromptIsValidWhenBrowserIsNotDefault() {
+        defaultBrowserManagerMock.storedInfoToReturn = makeDefaultBrowserContext(isDefaultBrowser: false)
+        makeSUT()
+
+        let isStillValid = sut.isPreparedPromptStillValid()
+
+        #expect(isStillValid)
+        #expect(defaultBrowserManagerMock.didCallStoredDefaultBrowserInfo)
+        #expect(!defaultBrowserManagerMock.didCallDefaultBrowserInfo)
+    }
+
+    @Test("Prepared Prompt Is Invalid When Stored Status Says Browser Is Default")
+    func preparedPromptIsInvalidWhenBrowserIsDefault() {
+        defaultBrowserManagerMock.storedInfoToReturn = makeDefaultBrowserContext(isDefaultBrowser: true)
+        makeSUT()
+
+        let isStillValid = sut.isPreparedPromptStillValid()
+
+        #expect(!isStillValid)
+        #expect(defaultBrowserManagerMock.didCallStoredDefaultBrowserInfo)
+        #expect(!defaultBrowserManagerMock.didCallDefaultBrowserInfo)
+    }
+
+    @Test("Prepared Prompt Remains Valid When No Status Is Stored")
+    func preparedPromptIsValidWhenNoStatusIsStored() {
+        defaultBrowserManagerMock.storedInfoToReturn = nil
+        makeSUT()
+
+        let isStillValid = sut.isPreparedPromptStillValid()
+
+        #expect(isStillValid)
+        #expect(defaultBrowserManagerMock.didCallStoredDefaultBrowserInfo)
+        #expect(!defaultBrowserManagerMock.didCallDefaultBrowserInfo)
+    }
+
+    @Test("Retained Prepared Prompt Is Invalid When Browser Became Default")
+    func retainedPreparedPromptIsInvalidWhenCurrentBrowserStatusIsDefault() {
+        defaultBrowserManagerMock.storedInfoToReturn = makeDefaultBrowserContext(isDefaultBrowser: false)
+        defaultBrowserManagerMock.resultToReturn = .successful(isDefaultBrowser: true)
+        makeSUT()
+
+        let isStillValid = sut.isRetainedPreparedPromptStillValid()
+
+        #expect(!isStillValid)
+        #expect(defaultBrowserManagerMock.didCallDefaultBrowserInfo)
+        #expect(!defaultBrowserManagerMock.didCallStoredDefaultBrowserInfo)
+    }
+
+    @Test("Retained Prepared Prompt Remains Valid When Browser Is Currently Not Default")
+    func retainedPreparedPromptIsValidWhenCurrentBrowserStatusIsNotDefault() {
+        defaultBrowserManagerMock.storedInfoToReturn = makeDefaultBrowserContext(isDefaultBrowser: true)
+        defaultBrowserManagerMock.resultToReturn = .successful(isDefaultBrowser: false)
+        makeSUT()
+
+        let isStillValid = sut.isRetainedPreparedPromptStillValid()
+
+        #expect(isStillValid)
+        #expect(defaultBrowserManagerMock.didCallDefaultBrowserInfo)
+        #expect(!defaultBrowserManagerMock.didCallStoredDefaultBrowserInfo)
+    }
+
+    @Test("Retained Prepared Prompt Falls Back To Stored Status When The Fresh Check Fails")
+    func retainedPreparedPromptRemainsValidWhenCheckFailsAndStoredStatusIsNotDefault() {
+        defaultBrowserManagerMock.resultToReturn = .failure(.rateLimitReached(updatedStoredInfo: makeDefaultBrowserContext(isDefaultBrowser: false)))
+        defaultBrowserManagerMock.storedInfoToReturn = makeDefaultBrowserContext(isDefaultBrowser: false)
+        makeSUT()
+
+        let isStillValid = sut.isRetainedPreparedPromptStillValid()
+
+        #expect(isStillValid)
+        #expect(defaultBrowserManagerMock.didCallDefaultBrowserInfo)
+        #expect(defaultBrowserManagerMock.didCallStoredDefaultBrowserInfo)
+    }
+
+    @Test("Retained Prepared Prompt Is Invalid When Failed Check Falls Back To A Default-Browser Status")
+    func retainedPreparedPromptIsInvalidWhenCheckFailsAndStoredStatusIsDefault() {
+        defaultBrowserManagerMock.resultToReturn = .failure(.rateLimitReached(updatedStoredInfo: makeDefaultBrowserContext(isDefaultBrowser: true)))
+        defaultBrowserManagerMock.storedInfoToReturn = makeDefaultBrowserContext(isDefaultBrowser: true)
+        makeSUT()
+
+        let isStillValid = sut.isRetainedPreparedPromptStillValid()
+
+        #expect(!isStillValid)
+    }
+
+    @Test("Retained Prepared Prompt Remains Valid When The Fresh Check Fails With No Stored Status")
+    func retainedPreparedPromptRemainsValidWhenCheckFailsWithNoStoredStatus() {
+        defaultBrowserManagerMock.resultToReturn = .failure(.rateLimitReached(updatedStoredInfo: nil))
+        defaultBrowserManagerMock.storedInfoToReturn = nil
+        makeSUT()
+
+        let isStillValid = sut.isRetainedPreparedPromptStillValid()
+
+        #expect(isStillValid)
     }
 
     @Test("Check Inactive User Modal Has Priority Over Active User Modal")

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptCoordinationManager.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptCoordinationManager.swift
@@ -30,8 +30,12 @@ final class MockModalPromptCoordinationManager: ModalPromptCoordinationManaging 
     var didPresentModalPromptThisSession = false
     var coordinatedPresentationDisposition = ModalPromptLeaseDisposition.retained
     var reconcilePresentedModalResult = false
+    var coordinatedAttemptReleaseHandler: (@MainActor () -> Void)?
     private(set) var capturedModalLease: PromoQueueModalLease?
     private(set) var reconcilePresentedModalCallCount = 0
+    private(set) var applicationWillResignActiveCallCount = 0
+    private(set) var applicationDidBecomeActiveCallCount = 0
+    private(set) var applicationDidEnterBackgroundCallCount = 0
     var onPresentCoordinated: (@MainActor () -> Void)?
     var onReconcilePresentedModal: (@MainActor () -> Void)?
     var onPromoQueueWillTransition: (@MainActor (PromoQueueFeatureTargetState) -> Void)?
@@ -41,6 +45,10 @@ final class MockModalPromptCoordinationManager: ModalPromptCoordinationManaging 
         didCallPresentModalPromptIfNeeded = true
         capturedPresenter = presenter
         callCount += 1
+    }
+
+    func setCoordinatedAttemptReleaseHandler(_ handler: (@MainActor () -> Void)?) {
+        coordinatedAttemptReleaseHandler = handler
     }
 
     func presentModalPromptIfNeeded(
@@ -72,5 +80,17 @@ final class MockModalPromptCoordinationManager: ModalPromptCoordinationManaging 
     func promoQueueDidTransition(to targetState: PromoQueueFeatureTargetState) {
         promoQueueDidTransitionTargets.append(targetState)
         onPromoQueueDidTransition?(targetState)
+    }
+
+    func applicationWillResignActive() {
+        applicationWillResignActiveCallCount += 1
+    }
+
+    func applicationDidBecomeActive() {
+        applicationDidBecomeActiveCallCount += 1
+    }
+
+    func applicationDidEnterBackground() {
+        applicationDidEnterBackgroundCallCount += 1
     }
 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptPresenter.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptPresenter.swift
@@ -20,21 +20,27 @@
 import UIKit
 @testable import DuckDuckGo
 
+/// Completes presentation synchronously without establishing `presentedViewController`, unlike real UIKit.
+/// Ordering-sensitive tests must use `DeferredCompletionModalPromptPresenter` or establish the presentation relationship manually.
 @MainActor
 final class MockModalPromptPresenter: ModalPromptPresenter {
     var presentedViewController: UIViewController?
+    var modalPromptPresentationViewController: UIViewController?
 
     private(set) var didCallPresent = false
     private(set) var capturedViewController: UIViewController?
     private(set) var capturedAnimated: Bool?
     private(set) var capturedCompletion: (() -> Void)?
+    var shouldCompletePresentation = true
 
     func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?) {
         didCallPresent = true
         capturedViewController = viewControllerToPresent
         capturedAnimated = flag
         capturedCompletion = completion
-        completion?()
+        if shouldCompletePresentation {
+            completion?()
+        }
     }
 
     func reset() {
@@ -48,6 +54,7 @@ final class MockModalPromptPresenter: ModalPromptPresenter {
 @MainActor
 final class MockDismissibleViewController: UIViewController {
     private(set) var didCallDismiss = false
+    private(set) var dismissCallCount = 0
     private(set) var capturedDismissAnimated: Bool?
     var dismissCompletion: (() -> Void)?
 
@@ -56,6 +63,7 @@ final class MockDismissibleViewController: UIViewController {
 
     override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
         didCallDismiss = true
+        dismissCallCount += 1
         capturedDismissAnimated = flag
         dismissCompletion = completion
         completion?()
@@ -68,19 +76,65 @@ final class MockDismissibleViewController: UIViewController {
     }
 }
 
+@MainActor
 final class MockModalPromptScheduler: ModalPromptScheduling {
+    private final class ScheduledBlock {
+        let execute: @MainActor () -> Void
+        var isCancelled = false
+
+        init(execute: @escaping @MainActor () -> Void) {
+            self.execute = execute
+        }
+    }
+
     private(set) var didCallSchedule = false
     private(set) var capturedScheduledDelay: TimeInterval?
-    private var scheduledBlock: (@MainActor () -> Void)?
+    private var delayedBlocks = [ScheduledBlock]()
+    private var nextMainTurnBlocks = [ScheduledBlock]()
 
-    func schedule(after delay: TimeInterval, execute: @escaping @MainActor () -> Void) {
+    @discardableResult
+    func schedule(after delay: TimeInterval, execute: @escaping @MainActor () -> Void) -> ModalPromptScheduledTask {
         didCallSchedule = true
         capturedScheduledDelay = delay
-        scheduledBlock = execute
+        let scheduledBlock = ScheduledBlock(execute: execute)
+        delayedBlocks.append(scheduledBlock)
+        return ModalPromptScheduledTask {
+            scheduledBlock.isCancelled = true
+        }
+    }
+
+    @discardableResult
+    func scheduleOnNextMainTurn(execute: @escaping @MainActor () -> Void) -> ModalPromptScheduledTask {
+        let scheduledBlock = ScheduledBlock(execute: execute)
+        nextMainTurnBlocks.append(scheduledBlock)
+        return ModalPromptScheduledTask {
+            scheduledBlock.isCancelled = true
+        }
     }
 
     @MainActor
-    func executeScheduledBlock() {
-        scheduledBlock?()
+    func executeScheduledBlock(includingCancelled: Bool = false) {
+        guard !delayedBlocks.isEmpty else {
+            return
+        }
+
+        let scheduledBlock = delayedBlocks.removeFirst()
+        guard includingCancelled || !scheduledBlock.isCancelled else {
+            return
+        }
+        scheduledBlock.execute()
+    }
+
+    @MainActor
+    func executeNextMainTurnBlock(includingCancelled: Bool = false) {
+        guard !nextMainTurnBlocks.isEmpty else {
+            return
+        }
+
+        let scheduledBlock = nextMainTurnBlocks.removeFirst()
+        guard includingCancelled || !scheduledBlock.isCancelled else {
+            return
+        }
+        scheduledBlock.execute()
     }
 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptProvider.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptProvider.swift
@@ -23,10 +23,18 @@ import UIKit
 @MainActor
 final class MockModalPromptProvider: ModalPromptProvider {
     var modalConfigurationToReturn: ModalPromptConfiguration?
+    var replacementModalConfigurationToReturn: ModalPromptConfiguration?
     var isEligibleToPresentResult: Bool?
+    var isPreparedModalPromptStillValidResult = true
+    var isRetainedPreparedModalPromptStillValidResult: Bool?
 
     private(set) var didCallProvideModalPrompt = false
     private(set) var didCallDidPresentModal = false
+    private(set) var provideModalPromptCallCount = 0
+    private(set) var didPresentModalCallCount = 0
+    private(set) var isPreparedModalPromptStillValidCallCount = 0
+    private(set) var isRetainedPreparedModalPromptStillValidCallCount = 0
+    private(set) var provideReplacementModalPromptCallCount = 0
     private(set) var capturedIsOnboardingComplete: Bool?
 
     init(shouldReturnPrompt: Bool = true) {
@@ -40,6 +48,7 @@ final class MockModalPromptProvider: ModalPromptProvider {
 
     func provideModalPrompt() -> ModalPromptConfiguration? {
         didCallProvideModalPrompt = true
+        provideModalPromptCallCount += 1
         return modalConfigurationToReturn
     }
 
@@ -48,14 +57,38 @@ final class MockModalPromptProvider: ModalPromptProvider {
         return isEligibleToPresentResult ?? isOnboardingComplete
     }
 
+    func isPreparedModalPromptStillValid(_ configuration: ModalPromptConfiguration) -> Bool {
+        isPreparedModalPromptStillValidCallCount += 1
+        return isPreparedModalPromptStillValidResult
+    }
+
+    func isRetainedPreparedModalPromptStillValid(_ configuration: ModalPromptConfiguration) -> Bool {
+        isRetainedPreparedModalPromptStillValidCallCount += 1
+        return isRetainedPreparedModalPromptStillValidResult ?? isPreparedModalPromptStillValid(configuration)
+    }
+
+    func provideReplacementModalPrompt(for invalidConfiguration: ModalPromptConfiguration) -> ModalPromptConfiguration? {
+        provideReplacementModalPromptCallCount += 1
+        return replacementModalConfigurationToReturn
+    }
+
     func didPresentModal() {
         didCallDidPresentModal = true
+        didPresentModalCallCount += 1
     }
 
     func reset() {
         didCallProvideModalPrompt = false
         didCallDidPresentModal = false
+        provideModalPromptCallCount = 0
+        didPresentModalCallCount = 0
+        isPreparedModalPromptStillValidCallCount = 0
+        isRetainedPreparedModalPromptStillValidCallCount = 0
+        provideReplacementModalPromptCallCount = 0
         capturedIsOnboardingComplete = nil
         isEligibleToPresentResult = nil
+        isPreparedModalPromptStillValidResult = true
+        isRetainedPreparedModalPromptStillValidResult = nil
+        replacementModalConfigurationToReturn = nil
     }
 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/PromptCooldownMocks.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/PromptCooldownMocks.swift
@@ -32,6 +32,7 @@ final class MockPromptCooldownManager: PromptCooldownManaging {
     var cooldownInfoToReturn: PromptCooldownInfo = .notInCoolDown
 
     private(set) var didCallRecordLastPromptPresentationTimestamp = false
+    private(set) var recordLastPromptPresentationTimestampCallCount = 0
 
     var cooldownInfo: PromptCooldownInfo {
         cooldownInfoToReturn
@@ -39,6 +40,7 @@ final class MockPromptCooldownManager: PromptCooldownManaging {
 
     func recordLastPromptPresentationTimestamp() {
         didCallRecordLastPromptPresentationTimestamp = true
+        recordLastPromptPresentationTimestampCallCount += 1
     }
 }
 

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/NewTabPage/HomePageMessagesConfigurationMock.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/NewTabPage/HomePageMessagesConfigurationMock.swift
@@ -31,7 +31,9 @@ class HomePageMessagesConfigurationMock: HomePageMessagesConfiguration {
     }
 
     private(set) var lastAppearedHomeMessage: HomeMessage?
+    private(set) var appearanceCallCount = 0
     func didAppear(_ homeMessage: HomeMessage) {
+        appearanceCallCount += 1
         lastAppearedHomeMessage = homeMessage
     }
 
@@ -41,9 +43,11 @@ class HomePageMessagesConfigurationMock: HomePageMessagesConfiguration {
     }
 
     private(set) var didRefresh: Bool = false
+    private(set) var refreshCallCount = 0
     private(set) var lastRefreshOpenedAfterIdle: Bool?
     func refresh(openedAfterIdle: Bool) {
         didRefresh = true
+        refreshCallCount += 1
         lastRefreshOpenedAfterIdle = openedAfterIdle
     }
 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/WhatsNew/MockWhatsNewMessageRepository.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/WhatsNew/MockWhatsNewMessageRepository.swift
@@ -30,12 +30,16 @@ final class MockWhatsNewMessageRepository: WhatsNewMessageRepository {
     private(set) var capturedMessageId: String?
 
 
-    private let remoteMessageModel: RemoteMessageModel?
+    private var remoteMessageModel: RemoteMessageModel?
     var hasShownMessage: Bool
 
     init(scheduledRemoteMessage: RemoteMessageModel?, hasShownMessage: Bool = false) {
         self.remoteMessageModel = scheduledRemoteMessage
         self.hasShownMessage = hasShownMessage
+    }
+
+    func setScheduledRemoteMessage(_ message: RemoteMessageModel?) {
+        remoteMessageModel = message
     }
 
     func fetchScheduledMessage() -> RemoteMessageModel? {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1217045769951384?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1216624996708289?focus=true
CC:

### Description

PR 2 of 3. Makes delayed modal promo scheduling lifecycle-safe and gates NTP remote messages so visible and modal promos cannot overlap. The feature remains behind a default-disabled flag (`promoPresentationCoordination`). Flag-off behavior remains identical to `main`.

### Testing Steps

- Check for regressions to current behavior (`main`) with the `promoPresentationCoordination` flag off.

### Impact

Low—the feature flag defaults to disabled.

#### What could go wrong?

When enabled, a promo could remain blocked or overlap another promo → covered by lifecycle, admission, retry, and integration tests.

### Quality Considerations

Existing behavior remains unchanged while the feature flag is disabled.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk when the flag is enabled: modal and visible promo arbitration touches foreground lifecycle, NTP/SwiftUI mount timing, and UIKit presentation—regressions could block or overlap promos; flag defaults off limits production exposure.
> 
> **Overview**
> When **`promoPresentationCoordination`** is on, coordinated modal promos get **lifecycle-aware scheduling** (cancellable delayed work, pre-present validation, UIKit attachment checks, pending retry on recoverable failure) and **app lifecycle hooks** so inactivity/background do not race presentation.
> 
> **NTP remote messages** move behind a stable **gate + lease** model: admission only when the surface is attached, visible, and not covered by omnibar editing, suggestion tray, UTI content, or Dax overlays. **`PromoCoordinationService`** publishes feature-state transitions to NTP surfaces, forwards lifecycle to the modal manager, and retries visible promos when a modal slot frees.
> 
> Modal providers gain **revalidation** hooks for delayed/retained prompts. Flag-off behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28517eca42feffc6e7e62c26aeaa4a3a235180ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



