### PR TITLE
[macOS] Show file names on Duck.ai attachment cards, harmonize with cross-platform spec

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatFileAttachmentCardView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatFileAttachmentCardView.swift
@@ -29,13 +29,13 @@ import DesignResourcesKitIcons
 final class AIChatFileAttachmentCardView: NSView {
 
     private enum Constants {
-        static let cardWidth: CGFloat = 224
+        static let cardWidth: CGFloat = 180
         static let cardHeight: CGFloat = 56
-        static let cornerRadius: CGFloat = 12
+        static let cornerRadius: CGFloat = 8
         static let leadingPadding: CGFloat = 10
         static let trailingPadding: CGFloat = 14
         static let thumbnailSize: CGFloat = 36
-        static let spacingAfterThumbnail: CGFloat = 12
+        static let spacingAfterThumbnail: CGFloat = 10
         static let removeButtonSize: CGFloat = 20
         static let removeButtonOverflow: CGFloat = 6
         static let removeButtonInset: CGFloat = 4
@@ -260,10 +260,10 @@ private final class AIChatFilePagePreviewView: NSView {
     private enum Layout {
         static let size: CGFloat = 36
         static let cornerRadius: CGFloat = 6
-        static let bar1Rect = NSRect(x: 6, y: 7, width: 18, height: 2)
-        static let bar2Rect = NSRect(x: 6, y: 12, width: 12, height: 2)
-        static let badgeRect = NSRect(x: 4, y: 18, width: 28, height: 13)
-        static let badgeCornerRadius: CGFloat = 3.5
+        static let bar1Rect = NSRect(x: 5, y: 6, width: 16, height: 2)
+        static let bar2Rect = NSRect(x: 5, y: 11, width: 10, height: 2)
+        static let badgeRect = NSRect(x: 5, y: 18, width: 26, height: 13)
+        static let badgeCornerRadius: CGFloat = 4
         static let barCornerRadius: CGFloat = 1
     }
 
@@ -313,12 +313,12 @@ private final class AIChatFilePagePreviewView: NSView {
         super.draw(dirtyRect)
 
         NSAppearance.withAppAppearance {
-            NSColor(designSystemColor: .lines).setFill()
+            NSColor(designSystemColor: .surfaceDecorationSecondary).setFill()
             NSBezierPath(roundedRect: Layout.bar1Rect, xRadius: Layout.barCornerRadius, yRadius: Layout.barCornerRadius).fill()
             NSBezierPath(roundedRect: Layout.bar2Rect, xRadius: Layout.barCornerRadius, yRadius: Layout.barCornerRadius).fill()
 
-            // Brand-red kind badge (the duck.ai web app uses the same hue).
-            NSColor.systemRed.setFill()
+            // Fixed brand red — the badge doesn't tint with the theme accent (same on Windows).
+            NSColor(baseColor: .red50).setFill()
             NSBezierPath(roundedRect: Layout.badgeRect, xRadius: Layout.badgeCornerRadius, yRadius: Layout.badgeCornerRadius).fill()
         }
     }

--- a/macOS/DuckDuckGo/AIChat/AIChatFileAttachmentCardView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatFileAttachmentCardView.swift
@@ -21,16 +21,21 @@ import AppKit
 import DesignResourcesKit
 import DesignResourcesKitIcons
 
-/// A square card representing a file attachment (PDF etc.) in the duck.ai omnibar carousel.
-/// Matches the duck.ai web app's attachment style: a 56×56 surface-secondary tile with two
-/// short "text" lines at the top and a red filled "PDF" pill below — no inline filename
-/// (the filename surfaces via tooltip and accessibility label so the visual stays compact and
-/// reads as a kind-of-thing, not a labelled item).
+/// A horizontal card representing a file attachment (PDF etc.) in the duck.ai omnibar carousel.
+/// Deliberately shares `AIChatTabAttachmentCardView`'s geometry — same card size, same 36×36
+/// thumbnail slot, same bold title beside it — so a mixed carousel of tabs and files reads as one
+/// row of like elements. Only the thumbnail's contents differ: a stylised page with a red file-kind
+/// badge instead of a favicon.
 final class AIChatFileAttachmentCardView: NSView {
 
     private enum Constants {
-        static let cardSize: CGFloat = 56
+        static let cardWidth: CGFloat = 224
+        static let cardHeight: CGFloat = 56
         static let cornerRadius: CGFloat = 12
+        static let leadingPadding: CGFloat = 10
+        static let trailingPadding: CGFloat = 14
+        static let thumbnailSize: CGFloat = 36
+        static let spacingAfterThumbnail: CGFloat = 12
         static let removeButtonSize: CGFloat = 20
         static let removeButtonOverflow: CGFloat = 6
         static let removeButtonInset: CGFloat = 4
@@ -45,7 +50,7 @@ final class AIChatFileAttachmentCardView: NSView {
     /// Total height of the view including the remove button's vertical overflow — kept identical
     /// to `AIChatTabAttachmentCardView.totalHeight` so files / images / tabs share the same row
     /// baseline in the carousel.
-    static let totalHeight: CGFloat = Constants.cardSize + Constants.removeButtonOverflow
+    static let totalHeight: CGFloat = Constants.cardHeight + Constants.removeButtonOverflow
 
     let attachmentId: UUID
     var onRemove: ((UUID) -> Void)?
@@ -73,7 +78,17 @@ final class AIChatFileAttachmentCardView: NSView {
         return view
     }()
 
-    private let pagePreviewView = AIChatFilePagePreviewView()
+    private let filePreviewView = AIChatFilePagePreviewView()
+
+    private let titleLabel: NSTextField = {
+        let label = NSTextField(labelWithString: "")
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.lineBreakMode = .byTruncatingTail
+        label.maximumNumberOfLines = 1
+        label.usesSingleLineMode = true
+        label.font = .systemFont(ofSize: 14, weight: .semibold)
+        return label
+    }()
 
     private let removeButton: PointingHandButton = {
         let button = PointingHandButton()
@@ -94,16 +109,16 @@ final class AIChatFileAttachmentCardView: NSView {
         translatesAutoresizingMaskIntoConstraints = false
         addSubview(shadowBackingView)
         addSubview(cardView)
-        cardView.addSubview(pagePreviewView)
+        cardView.addSubview(filePreviewView)
+        cardView.addSubview(titleLabel)
         addSubview(removeButton) // outside the card so its overflow can clip past the corner.
 
-        // Filename only surfaces via tooltip + accessibility — the visual is filename-agnostic
-        // to match the duck.ai web app's compact tile style.
+        titleLabel.stringValue = attachment.fileName
+        // The label truncates on narrow cards; the tooltip carries the full filename.
         toolTip = attachment.fileName
         setAccessibilityLabel(String(format: UserText.aiChatFileAttachmentAccessibilityFormat, attachment.fileName))
 
-        pagePreviewView.translatesAutoresizingMaskIntoConstraints = false
-        pagePreviewView.kindLabel = Self.kindLabel(for: attachment.mimeType)
+        filePreviewView.kindLabel = Self.kindLabel(for: attachment.mimeType)
 
         removeButton.image = DesignSystemImages.Glyphs.Size16.clearSolid
         removeButton.imageScaling = .scaleNone
@@ -119,18 +134,22 @@ final class AIChatFileAttachmentCardView: NSView {
             cardView.leadingAnchor.constraint(equalTo: leadingAnchor),
             cardView.bottomAnchor.constraint(equalTo: bottomAnchor),
             cardView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.removeButtonOverflow),
-            cardView.widthAnchor.constraint(equalToConstant: Constants.cardSize),
-            cardView.heightAnchor.constraint(equalToConstant: Constants.cardSize),
+            cardView.widthAnchor.constraint(equalToConstant: Constants.cardWidth),
+            cardView.heightAnchor.constraint(equalToConstant: Constants.cardHeight),
 
             shadowBackingView.leadingAnchor.constraint(equalTo: cardView.leadingAnchor),
             shadowBackingView.trailingAnchor.constraint(equalTo: cardView.trailingAnchor),
             shadowBackingView.topAnchor.constraint(equalTo: cardView.topAnchor),
             shadowBackingView.bottomAnchor.constraint(equalTo: cardView.bottomAnchor),
 
-            pagePreviewView.leadingAnchor.constraint(equalTo: cardView.leadingAnchor),
-            pagePreviewView.trailingAnchor.constraint(equalTo: cardView.trailingAnchor),
-            pagePreviewView.topAnchor.constraint(equalTo: cardView.topAnchor),
-            pagePreviewView.bottomAnchor.constraint(equalTo: cardView.bottomAnchor),
+            filePreviewView.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: Constants.leadingPadding),
+            filePreviewView.centerYAnchor.constraint(equalTo: cardView.centerYAnchor),
+            filePreviewView.widthAnchor.constraint(equalToConstant: Constants.thumbnailSize),
+            filePreviewView.heightAnchor.constraint(equalToConstant: Constants.thumbnailSize),
+
+            titleLabel.leadingAnchor.constraint(equalTo: filePreviewView.trailingAnchor, constant: Constants.spacingAfterThumbnail),
+            titleLabel.centerYAnchor.constraint(equalTo: cardView.centerYAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -Constants.trailingPadding),
 
             removeButton.centerXAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -Constants.removeButtonInset),
             removeButton.centerYAnchor.constraint(equalTo: cardView.topAnchor, constant: Constants.removeButtonInset),
@@ -200,22 +219,11 @@ final class AIChatFileAttachmentCardView: NSView {
         addCursorRect(removeButton.frame, cursor: .pointingHand)
     }
 
-    /// Short uppercased label shown on the file pill — derived from the mime type.
+    /// Badge text for the thumbnail. Only PDFs are called out by name; every other accepted type
+    /// gets the generic label (mime subtypes like `vnd.openxmlformats-…` are unreadable at badge
+    /// size, and the filename in the title already carries the extension).
     private static func kindLabel(for mimeType: String) -> String {
-        let lower = mimeType.lowercased()
-        if lower.contains("pdf") {
-            return "PDF"
-        }
-        // Trim "application/" or similar prefixes and uppercase whatever remains. Falls back to
-        // a generic "FILE" label so the pill always reads as something.
-        if let slashIndex = lower.firstIndex(of: "/") {
-            let suffix = lower[lower.index(after: slashIndex)...]
-            let trimmed = suffix.split(separator: "+").first.map(String.init) ?? String(suffix)
-            if !trimmed.isEmpty {
-                return trimmed.uppercased()
-            }
-        }
-        return "FILE"
+        mimeType.lowercased().contains("pdf") ? "PDF" : "FILE"
     }
 
     // MARK: - Appearance
@@ -232,7 +240,7 @@ final class AIChatFileAttachmentCardView: NSView {
             removeButton.layer?.borderColor = removeButtonBackgroundColor.cgColor
             removeButton.contentTintColor = removeButtonIconColor
         }
-        pagePreviewView.refreshAppearance()
+        filePreviewView.refreshAppearance()
     }
 
     override func viewDidChangeEffectiveAppearance() {
@@ -241,34 +249,35 @@ final class AIChatFileAttachmentCardView: NSView {
     }
 }
 
-// MARK: - File preview
+// MARK: - File preview thumbnail
 
-/// Draws the inside of the file card: two short "text" lines at the top and a filled red pill
-/// with the file kind label centred below. Geometry is in flipped (top-left origin) coordinates
-/// so it matches how a designer would describe the layout.
+/// A 36×36 stylised "document" thumbnail matching `AIChatTabAttachmentCardView`'s page preview in
+/// size, corner radius and background: two short "text" lines at the top, and a filled red badge
+/// with the file kind below. Geometry is in flipped (top-left origin) coordinates so it reads the
+/// way a designer would describe it.
 private final class AIChatFilePagePreviewView: NSView {
 
     private enum Layout {
-        // All in flipped-Y coordinates (origin at top-left of the 56×56 card).
-        static let bar1Rect = NSRect(x: 10, y: 10, width: 22, height: 3)
-        static let bar2Rect = NSRect(x: 10, y: 16, width: 14, height: 3)
-        static let pillRect = NSRect(x: 8, y: 24, width: 40, height: 22)
-        static let pillCornerRadius: CGFloat = 5
-        static let barCornerRadius: CGFloat = 1.5
+        static let size: CGFloat = 36
+        static let cornerRadius: CGFloat = 6
+        static let bar1Rect = NSRect(x: 6, y: 7, width: 18, height: 2)
+        static let bar2Rect = NSRect(x: 6, y: 12, width: 12, height: 2)
+        static let badgeRect = NSRect(x: 4, y: 18, width: 28, height: 13)
+        static let badgeCornerRadius: CGFloat = 3.5
+        static let barCornerRadius: CGFloat = 1
     }
 
     var kindLabel: String = "PDF" {
         didSet {
             guard kindLabel != oldValue else { return }
             label.stringValue = kindLabel
-            needsDisplay = true
         }
     }
 
     private let label: NSTextField = {
         let label = NSTextField(labelWithString: "PDF")
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .systemFont(ofSize: 10, weight: .bold)
+        label.font = .systemFont(ofSize: 8, weight: .bold)
         label.textColor = .white
         label.alignment = .center
         return label
@@ -276,15 +285,24 @@ private final class AIChatFilePagePreviewView: NSView {
 
     override var isFlipped: Bool { true }
 
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
+    init() {
+        super.init(frame: NSRect(x: 0, y: 0, width: Layout.size, height: Layout.size))
+
+        // The card positions us with Auto Layout (centerY + width/height), so opt out of the
+        // autoresizing-mask constraints AppKit would otherwise synthesise from this frame.
+        translatesAutoresizingMaskIntoConstraints = false
+
+        wantsLayer = true
+        layer?.cornerRadius = Layout.cornerRadius
+        layer?.masksToBounds = true
+
         addSubview(label)
-        // Centre the label inside the pill area; using AppKit constraints keeps the text
-        // pixel-aligned regardless of the parent's frame.
         NSLayoutConstraint.activate([
-            label.centerXAnchor.constraint(equalTo: leadingAnchor, constant: Layout.pillRect.midX),
-            label.centerYAnchor.constraint(equalTo: topAnchor, constant: Layout.pillRect.midY),
+            label.centerXAnchor.constraint(equalTo: leadingAnchor, constant: Layout.badgeRect.midX),
+            label.centerYAnchor.constraint(equalTo: topAnchor, constant: Layout.badgeRect.midY),
         ])
+
+        refreshAppearance()
     }
 
     required init?(coder: NSCoder) {
@@ -295,18 +313,22 @@ private final class AIChatFilePagePreviewView: NSView {
         super.draw(dirtyRect)
 
         NSAppearance.withAppAppearance {
-            let barColor = NSColor(designSystemColor: .lines)
-            barColor.setFill()
+            NSColor(designSystemColor: .lines).setFill()
             NSBezierPath(roundedRect: Layout.bar1Rect, xRadius: Layout.barCornerRadius, yRadius: Layout.barCornerRadius).fill()
             NSBezierPath(roundedRect: Layout.bar2Rect, xRadius: Layout.barCornerRadius, yRadius: Layout.barCornerRadius).fill()
 
-            // Brand-red PDF pill (the duck.ai web app uses the same hue).
+            // Brand-red kind badge (the duck.ai web app uses the same hue).
             NSColor.systemRed.setFill()
-            NSBezierPath(roundedRect: Layout.pillRect, xRadius: Layout.pillCornerRadius, yRadius: Layout.pillCornerRadius).fill()
+            NSBezierPath(roundedRect: Layout.badgeRect, xRadius: Layout.badgeCornerRadius, yRadius: Layout.badgeCornerRadius).fill()
         }
     }
 
     func refreshAppearance() {
+        NSAppearance.withAppAppearance {
+            // Subtler tint than the card surface so the thumbnail reads as a nested page preview
+            // rather than a flat block — same treatment as the tab card's page preview.
+            layer?.backgroundColor = NSColor(designSystemColor: .surfaceTertiary).cgColor
+        }
         needsDisplay = true
     }
 }

--- a/macOS/DuckDuckGo/AIChat/AIChatFileAttachmentCardView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatFileAttachmentCardView.swift
@@ -21,11 +21,7 @@ import AppKit
 import DesignResourcesKit
 import DesignResourcesKitIcons
 
-/// A horizontal card representing a file attachment (PDF etc.) in the duck.ai omnibar carousel.
-/// Deliberately shares `AIChatTabAttachmentCardView`'s geometry — same card size, same 36×36
-/// thumbnail slot, same bold title beside it — so a mixed carousel of tabs and files reads as one
-/// row of like elements. Only the thumbnail's contents differ: a stylised page with a red file-kind
-/// badge instead of a favicon.
+/// A file (PDF etc.) card for the duck.ai omnibar carousel, sharing `AIChatTabAttachmentCardView`'s geometry so mixed rows line up.
 final class AIChatFileAttachmentCardView: NSView {
 
     private enum Constants {
@@ -114,8 +110,7 @@ final class AIChatFileAttachmentCardView: NSView {
         addSubview(removeButton) // outside the card so its overflow can clip past the corner.
 
         titleLabel.stringValue = attachment.fileName
-        // The label truncates on narrow cards; the tooltip carries the full filename.
-        toolTip = attachment.fileName
+        toolTip = attachment.fileName // the label truncates; the tooltip carries the full name
         setAccessibilityLabel(String(format: UserText.aiChatFileAttachmentAccessibilityFormat, attachment.fileName))
 
         filePreviewView.kindLabel = Self.kindLabel(for: attachment.mimeType)
@@ -219,9 +214,7 @@ final class AIChatFileAttachmentCardView: NSView {
         addCursorRect(removeButton.frame, cursor: .pointingHand)
     }
 
-    /// Badge text for the thumbnail. Only PDFs are called out by name; every other accepted type
-    /// gets the generic label (mime subtypes like `vnd.openxmlformats-…` are unreadable at badge
-    /// size, and the filename in the title already carries the extension).
+    /// Generic label for non-PDFs — mime subtypes are unreadable at badge size and the title already carries the extension.
     private static func kindLabel(for mimeType: String) -> String {
         mimeType.lowercased().contains("pdf") ? "PDF" : "FILE"
     }
@@ -251,10 +244,7 @@ final class AIChatFileAttachmentCardView: NSView {
 
 // MARK: - File preview thumbnail
 
-/// A 36×36 stylised "document" thumbnail matching `AIChatTabAttachmentCardView`'s page preview in
-/// size, corner radius and background: two short "text" lines at the top, and a filled red badge
-/// with the file kind below. Geometry is in flipped (top-left origin) coordinates so it reads the
-/// way a designer would describe it.
+/// A 36×36 document thumbnail: two text bars and a red file-kind badge, in flipped-Y coordinates.
 private final class AIChatFilePagePreviewView: NSView {
 
     private enum Layout {
@@ -288,9 +278,7 @@ private final class AIChatFilePagePreviewView: NSView {
     init() {
         super.init(frame: NSRect(x: 0, y: 0, width: Layout.size, height: Layout.size))
 
-        // The card positions us with Auto Layout (centerY + width/height), so opt out of the
-        // autoresizing-mask constraints AppKit would otherwise synthesise from this frame.
-        translatesAutoresizingMaskIntoConstraints = false
+        translatesAutoresizingMaskIntoConstraints = false // the card positions us with Auto Layout
 
         wantsLayer = true
         layer?.cornerRadius = Layout.cornerRadius
@@ -325,8 +313,6 @@ private final class AIChatFilePagePreviewView: NSView {
 
     func refreshAppearance() {
         NSAppearance.withAppAppearance {
-            // Subtler tint than the card surface so the thumbnail reads as a nested page preview
-            // rather than a flat block — same treatment as the tab card's page preview.
             layer?.backgroundColor = NSColor(designSystemColor: .surfaceTertiary).cgColor
         }
         needsDisplay = true

--- a/macOS/DuckDuckGo/AIChat/AIChatImageAttachmentThumbnailView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatImageAttachmentThumbnailView.swift
@@ -26,7 +26,7 @@ final class AIChatImageAttachmentThumbnailView: NSView {
 
     private enum Constants {
         static let thumbnailSize: CGFloat = 56
-        static let cornerRadius: CGFloat = 12
+        static let cornerRadius: CGFloat = 8
         static let removeButtonSize: CGFloat = 20
         static let removeButtonInset: CGFloat = 4
         /// How far the remove button extends beyond the thumbnail edge. Calibrated so that

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -1612,6 +1612,11 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             self?.lastAttachmentError = nil
             self?.updateAttachmentsLayout()
         }
+        // Submit-time validation rejection: surface it where pick-time rejections show up.
+        omnibarController.onAttachmentValidationFailed = { [weak self] message in
+            self?.lastAttachmentError = message
+            self?.updateAttachmentsLayout()
+        }
         // Block submit until in-flight resize tasks finish so the prompt carries the resized
         // image, not the placeholder.
         omnibarController.waitForAttachmentsReady = { [weak self] in

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -386,9 +386,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             .sink { [weak self] text in
                 guard let self else { return }
                 self.updateSubmitButtonState(for: text)
-                // A file rejected at pick time never becomes a card, so there's no × to clear its
-                // error with — editing the prompt is the only interaction left, and it means the
-                // user has read the message and moved on. A blocked submit re-shows it.
+                // A file rejected at pick time leaves no card, so editing is the only way to clear its error.
                 if self.lastAttachmentError != nil {
                     self.lastAttachmentError = nil
                     self.updateAttachmentsLayout()

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -384,7 +384,15 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         textChangeCancellable = omnibarController.$currentText
             .receive(on: DispatchQueue.main)
             .sink { [weak self] text in
-                self?.updateSubmitButtonState(for: text)
+                guard let self else { return }
+                self.updateSubmitButtonState(for: text)
+                // A file rejected at pick time never becomes a card, so there's no × to clear its
+                // error with — editing the prompt is the only interaction left, and it means the
+                // user has read the message and moved on. A blocked submit re-shows it.
+                if self.lastAttachmentError != nil {
+                    self.lastAttachmentError = nil
+                    self.updateAttachmentsLayout()
+                }
             }
     }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -128,8 +128,7 @@ final class AIChatOmnibarController {
     /// resize tasks (data is cleared via `persistAttachmentsToActiveTab([])`).
     var onAttachmentsClearRequested: (() -> Void)?
 
-    /// Called when a submit is blocked by attachment validation, so the container VC can surface
-    /// the reason in the attachments error label — the same channel pick-time rejections use.
+    /// Blocked-submit reason, for the container VC's attachments error label.
     var onAttachmentValidationFailed: ((String) -> Void)?
 
     /// Waits for all attachment resizing to complete before proceeding.
@@ -1158,12 +1157,7 @@ final class AIChatOmnibarController {
         return hasExcessTabAttachments
     }
 
-    /// Re-validates the already-attached files against the current limits. Pick-time validation is
-    /// skipped entirely while `attachmentLimits` is still `nil` (models endpoint slow or down), and
-    /// the limits can be refreshed afterwards — on a tier change, say — so a file that was accepted
-    /// then can be over the limit by the time the user submits. Cumulative, and with `enforceCount`
-    /// off, exactly as at pick time: the count limit keeps its one-over cue via
-    /// `hasSubmitBlockingAttachmentExcess`.
+    /// Files accepted while `attachmentLimits` was nil were never validated, and the limits can change after a pick.
     private var fileSubmissionValidationError: AIChatAttachmentValidator.FileValidationError? {
         guard attachmentLimits != nil, selectedModelSupportsFileUpload else { return nil }
 
@@ -1173,6 +1167,7 @@ final class AIChatOmnibarController {
                 pendingImageCount: activeImageAttachments.count,
                 pendingFiles: validated
             )
+            // enforceCount off: the count limit keeps its one-over cue via `hasSubmitBlockingAttachmentExcess`.
             if let error = validator.fileValidationError(for: descriptor, enforceCount: false) {
                 return error
             }

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -128,6 +128,10 @@ final class AIChatOmnibarController {
     /// resize tasks (data is cleared via `persistAttachmentsToActiveTab([])`).
     var onAttachmentsClearRequested: (() -> Void)?
 
+    /// Called when a submit is blocked by attachment validation, so the container VC can surface
+    /// the reason in the attachments error label — the same channel pick-time rejections use.
+    var onAttachmentValidationFailed: ((String) -> Void)?
+
     /// Waits for all attachment resizing to complete before proceeding.
     var waitForAttachmentsReady: (() async -> Void)?
 
@@ -1154,12 +1158,41 @@ final class AIChatOmnibarController {
         return hasExcessTabAttachments
     }
 
+    /// Re-validates the already-attached files against the current limits. Pick-time validation is
+    /// skipped entirely while `attachmentLimits` is still `nil` (models endpoint slow or down), and
+    /// the limits can be refreshed afterwards — on a tier change, say — so a file that was accepted
+    /// then can be over the limit by the time the user submits. Cumulative, and with `enforceCount`
+    /// off, exactly as at pick time: the count limit keeps its one-over cue via
+    /// `hasSubmitBlockingAttachmentExcess`.
+    private var fileSubmissionValidationError: AIChatAttachmentValidator.FileValidationError? {
+        guard attachmentLimits != nil, selectedModelSupportsFileUpload else { return nil }
+
+        var validated: [AIChatAttachmentValidator.FileDescriptor] = []
+        for descriptor in activeFileAttachments.map(AIChatAttachmentValidator.FileDescriptor.init) {
+            let validator = makeAttachmentValidator(
+                pendingImageCount: activeImageAttachments.count,
+                pendingFiles: validated
+            )
+            if let error = validator.fileValidationError(for: descriptor, enforceCount: false) {
+                return error
+            }
+            validated.append(descriptor)
+        }
+        return nil
+    }
+
     func submit() {
         guard !currentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return
         }
 
         guard !hasSubmitBlockingAttachmentExcess else {
+            return
+        }
+
+        if let error = fileSubmissionValidationError {
+            pixelHandler.fire(.fileValidationFailed(reason: error.reason.rawValue))
+            onAttachmentValidationFailed?(error.message)
             return
         }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatTabAttachmentCardView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabAttachmentCardView.swift
@@ -31,13 +31,13 @@ import DesignResourcesKitIcons
 final class AIChatTabAttachmentCardView: NSView {
 
     private enum Constants {
-        static let cardWidth: CGFloat = 224
+        static let cardWidth: CGFloat = 180
         static let cardHeight: CGFloat = 56
-        static let cornerRadius: CGFloat = 12
+        static let cornerRadius: CGFloat = 8
         static let leadingPadding: CGFloat = 10
         static let trailingPadding: CGFloat = 14
         static let thumbnailSize: CGFloat = 36
-        static let spacingAfterThumbnail: CGFloat = 12
+        static let spacingAfterThumbnail: CGFloat = 10
         static let removeButtonSize: CGFloat = 20
         static let removeButtonOverflow: CGFloat = 6
         static let removeButtonInset: CGFloat = 4
@@ -309,7 +309,7 @@ private final class AIChatTabPagePreviewView: NSView {
 
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
-        let barColor = NSColor(designSystemColor: .lines)
+        let barColor = NSColor(designSystemColor: .surfaceDecorationSecondary)
         barColor.setFill()
         for bar in Self.bars {
             NSBezierPath(roundedRect: bar, xRadius: 1, yRadius: 1).fill()

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -817,6 +817,101 @@ final class AIChatOmnibarControllerTests: XCTestCase {
                       "File attachments are cleared from shared state after a successful submit")
     }
 
+    // MARK: - Submit-time file re-validation
+    //
+    // Pick-time validation lives in the container VC and is skipped entirely while
+    // `attachmentLimits` is nil, so `submit()` re-checks the pending files itself. These cover the
+    // gate directly: an accepted-then-invalid file must not reach the prompt handler.
+
+    func testWhenSubmitWithOversizedFile_ThenSubmitIsBlockedAndErrorSurfaces() async {
+        await loadPDFModel(limits: makeAttachmentLimits(maxFileSizeMB: 1))
+        var reportedError: String?
+        controller.onAttachmentValidationFailed = { reportedError = $0 }
+
+        controller.addFileAttachmentToActiveTab(makePDFAttachment(byteCount: 1_048_577, pageCount: 1))
+        controller.updateText("summarise this PDF")
+
+        controller.submit()
+        await Task.yield()
+
+        XCTAssertFalse(mockTabOpener.openAIChatTabCalled, "An over-size file must not reach the backend")
+        XCTAssertNil(AIChatPromptHandler.shared.consumeData(), "No prompt is posted when submit is blocked")
+        XCTAssertEqual(reportedError, UserText.aiChatAttachmentFileTooLarge(maxFileSizeMB: 1))
+        XCTAssertEqual(controller.activeFileAttachments.count, 1, "A blocked submit leaves the attachment in place")
+    }
+
+    func testWhenSubmitWithFilesOverTotalSizeLimit_ThenSubmitIsBlocked() async {
+        // Each file is inside the 1MB per-file limit; together they exceed the 1.5MB total, which
+        // only the cumulative pass catches.
+        await loadPDFModel(limits: makeAttachmentLimits(maxFileSizeMB: 1, maxTotalFileSizeBytes: 1_500_000))
+        var reportedError: String?
+        controller.onAttachmentValidationFailed = { reportedError = $0 }
+
+        controller.addFileAttachmentToActiveTab(makePDFAttachment(byteCount: 800_000, pageCount: 1))
+        controller.addFileAttachmentToActiveTab(makePDFAttachment(byteCount: 800_000, pageCount: 1))
+        controller.updateText("compare these")
+
+        controller.submit()
+        await Task.yield()
+
+        XCTAssertFalse(mockTabOpener.openAIChatTabCalled)
+        // The copy rounds the byte budget up to whole MB (1_500_000 bytes -> "2 MB").
+        XCTAssertEqual(reportedError, UserText.aiChatAttachmentFilesExceedTotalSizeLimit(maxTotalFileSizeMB: 2))
+    }
+
+    func testWhenSubmitWithFileOverPageLimit_ThenSubmitIsBlocked() async {
+        await loadPDFModel(limits: makeAttachmentLimits(maxPagesPerFile: 15))
+        var reportedError: String?
+        controller.onAttachmentValidationFailed = { reportedError = $0 }
+
+        controller.addFileAttachmentToActiveTab(makePDFAttachment(byteCount: 1_000, pageCount: 16))
+        controller.updateText("summarise")
+
+        controller.submit()
+        await Task.yield()
+
+        XCTAssertFalse(mockTabOpener.openAIChatTabCalled)
+        XCTAssertEqual(reportedError, UserText.aiChatAttachmentFileTooManyPages(maxPagesPerFile: 15))
+    }
+
+    func testWhenSubmitWithFileWithinLimits_ThenSubmitProceeds() async {
+        await loadPDFModel(limits: makeAttachmentLimits())
+        var reportedError: String?
+        controller.onAttachmentValidationFailed = { reportedError = $0 }
+
+        controller.addFileAttachmentToActiveTab(makePDFAttachment(byteCount: 100_000, pageCount: 5))
+        controller.updateText("summarise")
+
+        controller.submit()
+        await Task.yield()
+
+        XCTAssertTrue(mockTabOpener.openAIChatTabCalled, "A valid file still submits")
+        XCTAssertNil(reportedError)
+        guard case let .query(query)? = AIChatPromptHandler.shared.consumeData()?.tool else {
+            XCTFail("Expected a `.query` tool in the submitted prompt")
+            return
+        }
+        XCTAssertEqual(query.files?.count, 1)
+    }
+
+    func testWhenLimitsAreUnavailable_ThenOversizedFileStillSubmits() async {
+        // No limits from the endpoint means no client-side enforcement anywhere — the backend
+        // stays the authority. Deliberate: blocking here would make PDFs unsendable whenever the
+        // models endpoint is unreachable.
+        await loadPDFModel(limits: nil)
+        var reportedError: String?
+        controller.onAttachmentValidationFailed = { reportedError = $0 }
+
+        controller.addFileAttachmentToActiveTab(makePDFAttachment(byteCount: 30_000_000, pageCount: nil))
+        controller.updateText("summarise")
+
+        controller.submit()
+        await Task.yield()
+
+        XCTAssertTrue(mockTabOpener.openAIChatTabCalled)
+        XCTAssertNil(reportedError)
+    }
+
     func testWhenSubmitWithoutTabAttachments_ThenPromptOmitsPageContext() async {
         // Given — only text, no attachments
         controller.updateText("just text")
@@ -2286,6 +2381,48 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         )
     }
 
+    /// A PDF attachment with the byte size and page count the validator reads. The size is passed
+    /// explicitly rather than allocated, so a "30MB file" costs nothing. `pageCount: nil` stands in
+    /// for an unreadable PDF (what the inspector returns when it can't parse one).
+    private func makePDFAttachment(byteCount: Int, pageCount: Int?) -> AIChatFileAttachment {
+        AIChatFileAttachment(
+            data: Data("%PDF-1.4 mock".utf8),
+            fileName: "spec.pdf",
+            mimeType: "application/pdf",
+            fileSizeBytes: byteCount,
+            pageCount: pageCount
+        )
+    }
+
+    /// Same limits on every tier, so a test doesn't have to pin the resolved tier to assert on them.
+    private func makeAttachmentLimits(
+        maxPerConversation: Int = 5,
+        maxFileSizeMB: Int = 5,
+        maxTotalFileSizeBytes: Int = 20_000_000,
+        maxPagesPerFile: Int = 15
+    ) -> AIChatAttachmentLimits {
+        let tier = AIChatAttachmentTierLimits(
+            files: AIChatAttachmentFileLimits(
+                maxPerConversation: maxPerConversation,
+                maxFileSizeMB: maxFileSizeMB,
+                maxTotalFileSizeBytes: maxTotalFileSizeBytes,
+                maxPagesPerFile: maxPagesPerFile
+            ),
+            images: AIChatAttachmentImageLimits(maxPerTurn: 3, maxPerConversation: 3, maxInputCharsWithAttachments: 10_000)
+        )
+        return AIChatAttachmentLimits(free: tier, plus: tier, pro: tier)
+    }
+
+    /// Loads a single PDF-capable model plus `limits`, as a real models fetch would.
+    private func loadPDFModel(limits: AIChatAttachmentLimits?) async {
+        mockModelsService.attachmentLimitsToReturn = limits
+        mockPreferences.selectedModelId = "pdf-model"
+        await loadModels(
+            [makeRemoteModel(id: "pdf-model", supportedFileTypes: ["application/pdf"], entityHasAccess: true)],
+            tier: nil
+        )
+    }
+
     /// Loads `models` and resolves the user's tier + trial eligibility, mirroring a real fetch.
     private func loadModels(_ models: [AIChatRemoteModel], tier: TierName?, trialEligible: Bool = false) async {
         setUserTier(tier)
@@ -2475,13 +2612,14 @@ private class MockAIChatPreferencesPersisting: AIChatPreferencesPersisting {
 @MainActor
 private class MockAIChatModelsProviding: AIChatModelsProviding {
     var modelsToReturn: [AIChatRemoteModel] = []
+    var attachmentLimitsToReturn: AIChatAttachmentLimits?
     var errorToThrow: Error?
 
     func fetchModels() async throws -> AIChatModelsResponse {
         if let error = errorToThrow {
             throw error
         }
-        return AIChatModelsResponse(models: modelsToReturn)
+        return AIChatModelsResponse(models: modelsToReturn, attachmentLimits: attachmentLimitsToReturn)
     }
 }
 

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -818,10 +818,6 @@ final class AIChatOmnibarControllerTests: XCTestCase {
     }
 
     // MARK: - Submit-time file re-validation
-    //
-    // Pick-time validation lives in the container VC and is skipped entirely while
-    // `attachmentLimits` is nil, so `submit()` re-checks the pending files itself. These cover the
-    // gate directly: an accepted-then-invalid file must not reach the prompt handler.
 
     func testWhenSubmitWithOversizedFile_ThenSubmitIsBlockedAndErrorSurfaces() async {
         await loadPDFModel(limits: makeAttachmentLimits(maxFileSizeMB: 1))
@@ -841,8 +837,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
     }
 
     func testWhenSubmitWithFilesOverTotalSizeLimit_ThenSubmitIsBlocked() async {
-        // Each file is inside the 1MB per-file limit; together they exceed the 1.5MB total, which
-        // only the cumulative pass catches.
+        // Each file is inside the per-file limit; only the cumulative pass catches the total.
         await loadPDFModel(limits: makeAttachmentLimits(maxFileSizeMB: 1, maxTotalFileSizeBytes: 1_500_000))
         var reportedError: String?
         controller.onAttachmentValidationFailed = { reportedError = $0 }
@@ -895,9 +890,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
     }
 
     func testWhenLimitsAreUnavailable_ThenOversizedFileStillSubmits() async {
-        // No limits from the endpoint means no client-side enforcement anywhere — the backend
-        // stays the authority. Deliberate: blocking here would make PDFs unsendable whenever the
-        // models endpoint is unreachable.
+        // Deliberate: blocking here would make PDFs unsendable whenever the models endpoint is unreachable.
         await loadPDFModel(limits: nil)
         var reportedError: String?
         controller.onAttachmentValidationFailed = { reportedError = $0 }
@@ -2381,9 +2374,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         )
     }
 
-    /// A PDF attachment with the byte size and page count the validator reads. The size is passed
-    /// explicitly rather than allocated, so a "30MB file" costs nothing. `pageCount: nil` stands in
-    /// for an unreadable PDF (what the inspector returns when it can't parse one).
+    /// Size is declared, not allocated, so a "30MB file" is free. `pageCount: nil` = unreadable PDF.
     private func makePDFAttachment(byteCount: Int, pageCount: Int?) -> AIChatFileAttachment {
         AIChatFileAttachment(
             data: Data("%PDF-1.4 mock".utf8),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1216831900874434?focus=true
Tech Design URL:
CC:

### Description

Attached PDFs rendered as anonymous 56x56 tiles, so several of them were indistinguishable. They now use the same card as tab attachments.

| Before | After |
|--------|--------|
| <img width="833" height="178" alt="Screenshot 2026-08-04 at 6 51 24 PM" src="https://github.com/user-attachments/assets/d4bb5ef3-9b4d-459e-9ad2-3b994dad6177" /> | <img width="832" height="177" alt="Screenshot 2026-08-04 at 6 51 40 PM" src="https://github.com/user-attachments/assets/ad7f7b66-775d-4f30-b5aa-1eca850763a9" /> |


### Testing Steps
1. Enable the `aiChatOmnibarAttachMoreTabs` feature flag from Debug.
2. Open the address bar in Duck.ai mode and attach two PDFs with different names — each card shows its own name, the tooltip has the full one; mix in a tab and an image and check the row lines up in Light and Dark.
3. Attach a PDF over the size limit — no card is added, error names the limit; type a character and the error clears.

### Impact

Low. Omnibar attachment UI plus one submit-time guard; no change to what a valid submission sends.

#### What could go wrong?
Submit-time validation could reject a valid file → guarded on `attachmentLimits != nil` so a missing-limits response keeps the previous behaviour, and covered by `AIChatOmnibarControllerTests`.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Omnibar attachment UI and a guarded submit-time validation path; valid submissions are unchanged when limits are nil or files pass checks, with unit tests on the submit gate.
> 
> **Overview**
> **File attachment cards** in the Duck.ai omnibar carousel are no longer anonymous 56×56 tiles. They use the same **180×56** horizontal layout as tab cards: 36×36 document thumbnail plus a **truncated filename** (full name in tooltip/accessibility). Corner radius moves to **8**; thumbnail bars use **`surfaceDecorationSecondary`**, the PDF badge uses brand **`red50`**, and the thumbnail background matches tab page previews (**`surfaceTertiary`**). Tab cards and image thumbnails get the same radius/spacing tweaks for a single mixed row.
> 
> **Submit-time file validation** re-checks attached files against current `attachmentLimits` before send (pick-time validation is skipped while limits are still nil, or limits can change after attach). Failures block submit, fire a pixel, and show the reason via **`onAttachmentValidationFailed`** in the same error label as pick-time rejections. **Editing the prompt** clears a sticky pick-time error when no card exists to dismiss it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b4e7e47a0c7a5f25ca780fa6f3a93b58d5b9854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->