### PR TITLE
iOS: Add sync scan-QR screen pixel and move barcode screen pixel to code sheet

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1127,6 +1127,7 @@ extension Pixel {
         case syncAutoRestorePreservedAccountClearFailed
 
         case syncSetupBarcodeScreenShown
+        case syncSetupScanQRScreenShown
         case syncSetupBarcodeScannerSuccess
         case syncSetupBarcodeScannerFailed
         case syncSetupBarcodeCodeCopied
@@ -3210,6 +3211,7 @@ extension Pixel.Event {
         case .syncAutoRestorePreservedAccountClearFailed: return "sync-auto-restore_preserved_account_clear_failed"
 
         case .syncSetupBarcodeScreenShown: return "sync_setup_barcode_screen_shown"
+        case .syncSetupScanQRScreenShown: return "sync_setup_scan_qr_screen_shown"
         case .syncSetupBarcodeScannerSuccess: return "sync_setup_barcode_scanner_success"
         case .syncSetupBarcodeScannerFailed: return "sync_setup_barcode_scanner_failed"
         case .syncSetupBarcodeCodeCopied: return "sync_setup_barcode_code_copied"

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2182,6 +2182,7 @@
 		C1FA13652ECFA067001392FA /* AutofillExtensionEnableCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FA13642ECFA067001392FA /* AutofillExtensionEnableCoordinator.swift */; };
 		C1FA13762ECFDB72001392FA /* AutofillExtensionEnableCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FA13752ECFDB72001392FA /* AutofillExtensionEnableCoordinatorTests.swift */; };
 		C1FFBD462C761BE20073622B /* SyncPromoManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FFBD452C761BE20073622B /* SyncPromoManagerTests.swift */; };
+		75FA22045AC409B996F2A204 /* SyncSettingsViewControllerPixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E979526F6A54D9214F20EA13 /* SyncSettingsViewControllerPixelTests.swift */; };
 		C1FFBD482C7749A90073622B /* SyncSettingsViewController+PlatformLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FFBD472C7749A90073622B /* SyncSettingsViewController+PlatformLinks.swift */; };
 		C256781EC700D62BEDE36B94 /* LaunchTimeMetricsSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FD41799FD12C35CD0E1600 /* LaunchTimeMetricsSubscriberTests.swift */; };
 		C2920E700F7D448614155BC5 /* FileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16393FE1ECCB9CC00DDD653 /* FileLoader.swift */; };
@@ -4974,6 +4975,7 @@
 		C1FEDCEA2D08633100BFBF3F /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		C1FEDCEB2D08633100BFBF3F /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C1FFBD452C761BE20073622B /* SyncPromoManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncPromoManagerTests.swift; sourceTree = "<group>"; };
+		E979526F6A54D9214F20EA13 /* SyncSettingsViewControllerPixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncSettingsViewControllerPixelTests.swift; sourceTree = "<group>"; };
 		C1FFBD472C7749A90073622B /* SyncSettingsViewController+PlatformLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SyncSettingsViewController+PlatformLinks.swift"; sourceTree = "<group>"; };
 		C66CF1E0260F3B8AF9E7DC03 /* LaunchTimeMetricsSubscriber.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LaunchTimeMetricsSubscriber.swift; sourceTree = "<group>"; };
 		CB1143DD2AF6D4B600C1CCD3 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -7084,6 +7086,7 @@
 				569437322BE4E3DD00C0881B /* SyncErrorHandlerSyncErrorsAlertsTests.swift */,
 				569437352BE5160600C0881B /* SyncSettingsViewControllerErrorTests.swift */,
 				C1FFBD452C761BE20073622B /* SyncPromoManagerTests.swift */,
+				E979526F6A54D9214F20EA13 /* SyncSettingsViewControllerPixelTests.swift */,
 				C1431C792E7CB7BE005253C8 /* SyncRecoveryPromptPresenterTests.swift */,
 				C1431C7A2E7CB7BE005253C8 /* SyncRecoveryPromptServiceTests.swift */,
 				C1A79A552F8B4C4000A1B2C3 /* SyncAutoRestoreDecisionManagerTests.swift */,
@@ -14871,6 +14874,7 @@
 				C1A79A582F8B4C4000A1B2C3 /* SyncAutoRestoreHandlerTests.swift in Sources */,
 				C1A79A5A2F8B4C4000A1B2C3 /* SyncAutoRestoreDecisionStoreTests.swift in Sources */,
 				C1FFBD462C761BE20073622B /* SyncPromoManagerTests.swift in Sources */,
+				75FA22045AC409B996F2A204 /* SyncSettingsViewControllerPixelTests.swift in Sources */,
 				317DD5552E0D5DD300CCC28C /* SwitchBarHandlerTests.swift in Sources */,
 				286810A915227B119AC60831 /* DefaultTogglePositionTests.swift in Sources */,
 				9F60CBB42E989EA4004D2367 /* MockRemoteMessagingPresenter.swift in Sources */,

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -648,6 +648,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                                             stringForQRCode: String,
                                             source: SyncSetupSource,
                                             onPresentPixelInfo: SyncSetupPixelInfo?) {
+        scanSetupSource = source
         let model = ScanOrPasteCodeViewModel(
             codeForDisplayOrPasting: codeForDisplayOrPasting,
             qrCodeString: stringForQRCode,
@@ -677,19 +678,18 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
             navController.modalPresentationStyle = .fullScreen
         }
         navigationController?.present(navController, animated: true) {
-            if !self.useSimplifiedLayoutV2 {
-                self.checkCameraPermission(model: model)
-            }
-            if let onPresentPixelInfo {
-                let pixelSource = self.source ?? onPresentPixelInfo.source.rawValue
-                var parameters = [
-                    PixelParameters.source: pixelSource,
-                    SyncSetupPixelInfo.Parameter.myKind: SyncSetupPixelInfo.Value.ddg,
-                    PixelParameters.uiVersion: self.syncUIVersion
-                ]
-                parameters[SyncSetupPixelInfo.Parameter.flowVersion] = onPresentPixelInfo.flowVersion
-                Pixel.fire(pixel: onPresentPixelInfo.pixel, withAdditionalParameters: parameters, includedParameters: [.appVersion])
-            }
+            guard !self.useSimplifiedLayoutV2 else { return }
+            self.checkCameraPermission(model: model)
+
+            guard let onPresentPixelInfo else { return }
+            let pixelSource = self.source ?? onPresentPixelInfo.source.rawValue
+            var parameters = [
+                PixelParameters.source: pixelSource,
+                SyncSetupPixelInfo.Parameter.myKind: SyncSetupPixelInfo.Value.ddg,
+                PixelParameters.uiVersion: self.syncUIVersion
+            ]
+            parameters[SyncSetupPixelInfo.Parameter.flowVersion] = onPresentPixelInfo.flowVersion
+            Pixel.fire(pixel: onPresentPixelInfo.pixel, withAdditionalParameters: parameters, includedParameters: [.appVersion])
         }
     }
 
@@ -876,6 +876,24 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
                     PixelParameters.uiVersion: syncUIVersion
                    ],
                    includedParameters: [.appVersion])
+    }
+
+    func barcodeScreenShown() {
+        fireScanFlowScreenShownPixel(.syncSetupBarcodeScreenShown)
+    }
+
+    func scanQRCodeScreenShown() {
+        fireScanFlowScreenShownPixel(.syncSetupScanQRScreenShown)
+    }
+
+    private func fireScanFlowScreenShownPixel(_ pixel: Pixel.Event) {
+        var parameters = [
+            SyncSetupPixelInfo.Parameter.myKind: SyncSetupPixelInfo.Value.ddg,
+            SyncSetupPixelInfo.Parameter.flowVersion: syncSetupPixelFlowVersion,
+            PixelParameters.uiVersion: syncUIVersion
+        ]
+        parameters[PixelParameters.source] = source ?? scanSetupSource?.rawValue
+        Pixel.fire(pixel: pixel, withAdditionalParameters: parameters, includedParameters: [.appVersion])
     }
 
     func codeCopied(_ code: String, source: CodeCollectionSource) {

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -893,7 +893,7 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
             PixelParameters.uiVersion: syncUIVersion
         ]
         parameters[PixelParameters.source] = source ?? scanSetupSource?.rawValue
-        Pixel.fire(pixel: pixel, withAdditionalParameters: parameters, includedParameters: [.appVersion])
+        pixelFiring.fire(pixel, withAdditionalParameters: parameters, includedParameters: [.appVersion], onComplete: { _ in })
     }
 
     func codeCopied(_ code: String, source: CodeCollectionSource) {

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -65,6 +65,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
     let featureFlagger: FeatureFlagger
     let syncAutoRestoreHandler: SyncAutoRestoreHandling
     let syncSettingsStore: KeyValueStoring
+    let pixelFiring: PixelFiring.Type
 
     var isSyncEnabled: Bool {
         syncService.account != nil
@@ -132,7 +133,8 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
         pairingInfo: PairingInfo? = nil,
         featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
         syncAutoRestoreHandler: SyncAutoRestoreHandling,
-        syncSettingsStore: KeyValueStoring = UserDefaults.standard
+        syncSettingsStore: KeyValueStoring = UserDefaults.standard,
+        pixelFiring: PixelFiring.Type = Pixel.self
     ) {
         self.syncService = syncService
         self.syncBookmarksAdapter = syncBookmarksAdapter
@@ -144,6 +146,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
         self.featureFlagger = featureFlagger
         self.syncAutoRestoreHandler = syncAutoRestoreHandler
         self.syncSettingsStore = syncSettingsStore
+        self.pixelFiring = pixelFiring
 
         let viewModel = SyncSettingsViewModel(
             isOnDevEnvironment: { syncService.serverEnvironment == .development },

--- a/iOS/DuckDuckGo/SyncSettingsViewController.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController.swift
@@ -95,6 +95,7 @@ class SyncSettingsViewController: UIHostingController<SyncSettingsRootView> {
     let viewModel: SyncSettingsViewModel
 
     var source: String?
+    var scanSetupSource: SyncSetupSource?
     var pairingInfo: PairingInfo?
     var pairingV2PeerKind: PairingV2DeviceKind?
     var pairingV2JoinerCodeSource: SyncCodeSource?

--- a/iOS/DuckDuckGoTests/SyncSettingsViewControllerPixelTests.swift
+++ b/iOS/DuckDuckGoTests/SyncSettingsViewControllerPixelTests.swift
@@ -1,0 +1,121 @@
+//
+//  SyncSettingsViewControllerPixelTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Testing
+import Foundation
+import Core
+@testable import DuckDuckGo
+@testable import DDGSync
+import Persistence
+import Common
+import FoundationExtensions
+import SyncUI_iOS
+import SecureStorage
+
+@Suite("Sync Settings scan-flow pixels", .serialized)
+@MainActor
+final class SyncSettingsViewControllerPixelTests {
+
+    private let ddgSyncing: MockDDGSyncing
+    private let syncBookmarksAdapter: SyncBookmarksAdapter
+    private let syncCredentialsAdapter: SyncCredentialsAdapter
+    private let syncCreditCardsAdapter: SyncCreditCardsAdapter
+    private let syncPausedStateManager: CapturingSyncPausedStateManager
+    private let syncAutoRestoreHandler: MockSyncAutoRestoreHandler
+
+    init() throws {
+        let bundle = DDGSync.bundle
+        let model = try #require(CoreDataDatabase.loadModel(from: bundle, named: "SyncMetadata"))
+        let database = CoreDataDatabase(name: "",
+                                        containerLocation: FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString),
+                                        model: model,
+                                        readOnly: true,
+                                        options: [:])
+        ddgSyncing = MockDDGSyncing(authState: .active, isSyncInProgress: false)
+        syncBookmarksAdapter = SyncBookmarksAdapter(
+            database: database,
+            favoritesDisplayModeStorage: MockFavoritesDisplayModeStoring(),
+            syncErrorHandler: CapturingAdapterErrorHandler(),
+            faviconStoring: MockFaviconStore())
+        syncCredentialsAdapter = SyncCredentialsAdapter(
+            secureVaultErrorReporter: MockSecureVaultReporting(),
+            syncErrorHandler: CapturingAdapterErrorHandler(),
+            tld: TLD())
+        syncCreditCardsAdapter = SyncCreditCardsAdapter(
+            secureVaultErrorReporter: MockSecureVaultReporting(),
+            syncErrorHandler: CapturingAdapterErrorHandler())
+        syncPausedStateManager = CapturingSyncPausedStateManager()
+        syncAutoRestoreHandler = MockSyncAutoRestoreHandler()
+        syncAutoRestoreHandler.isAutoRestoreFeatureEnabled = true
+    }
+
+    deinit {
+        PixelFiringMock.tearDown()
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("scanQRCodeScreenShown fires the scan-QR screen pixel", .timeLimit(.minutes(1)))
+    func scanQRCodeScreenShownFiresScanQRScreenPixel() {
+        let vc = makeViewController(source: "test_source", enabledFeatureFlags: [.simplifiedSyncSetupV2])
+
+        vc.scanQRCodeScreenShown()
+
+        #expect(PixelFiringMock.allPixelsFired.contains {
+            $0.pixelName == Pixel.Event.syncSetupScanQRScreenShown.name &&
+            $0.params == [
+                "source": "test_source",
+                "my_kind": "ddg",
+                "flow_version": "v1",
+                "ui_version": "v2"
+            ]
+        })
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("barcodeScreenShown fires the barcode screen pixel", .timeLimit(.minutes(1)))
+    func barcodeScreenShownFiresBarcodeScreenPixel() {
+        let vc = makeViewController(source: "test_source", enabledFeatureFlags: [.simplifiedSyncSetupV2])
+
+        vc.barcodeScreenShown()
+
+        #expect(PixelFiringMock.allPixelsFired.contains {
+            $0.pixelName == Pixel.Event.syncSetupBarcodeScreenShown.name &&
+            $0.params == [
+                "source": "test_source",
+                "my_kind": "ddg",
+                "flow_version": "v1",
+                "ui_version": "v2"
+            ]
+        })
+    }
+
+    private func makeViewController(source: String?, enabledFeatureFlags: [FeatureFlag]) -> SyncSettingsViewController {
+        SyncSettingsViewController(
+            syncService: ddgSyncing,
+            syncBookmarksAdapter: syncBookmarksAdapter,
+            syncCredentialsAdapter: syncCredentialsAdapter,
+            syncCreditCardsAdapter: syncCreditCardsAdapter,
+            syncPausedStateManager: syncPausedStateManager,
+            source: source,
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: enabledFeatureFlags),
+            syncAutoRestoreHandler: syncAutoRestoreHandler,
+            pixelFiring: PixelFiringMock.self
+        )
+    }
+}

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/ScanOrPasteCodeViewModel.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/ScanOrPasteCodeViewModel.swift
@@ -47,6 +47,8 @@ public protocol ScanOrPasteCodeViewModelDelegate: AnyObject {
     func shareCode(_ code: String, source: CodeCollectionSource)
 
     func codeEntryScreenShown()
+    func barcodeScreenShown()
+    func scanQRCodeScreenShown()
     func codeCopied(_ code: String, source: CodeCollectionSource)
 }
 

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/ScanTabView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/ScanTabView.swift
@@ -56,6 +56,7 @@ struct ScanTabView: View {
         .onAppear {
             model.resetScanningGate()
             model.prepareCameraForIntroIfAuthorized()
+            model.delegate?.scanQRCodeScreenShown()
         }
     }
 

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncCodeSheetView.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncCodeSheetView.swift
@@ -38,6 +38,9 @@ struct SyncCodeSheetView: View {
             }
             .padding(Metrics.contentPadding)
             .background(SimplifiedSyncStyle.screenBackground)
+            .onAppear {
+                model.delegate?.barcodeScreenShown()
+            }
             .navigationTitle(UserText.simplifiedSyncCodeSheetTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/iOS/LocalPackages/SyncUI-iOS/Tests/SyncUI-iOSTests/MockScanOrPasteCodeViewModelDelegate.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Tests/SyncUI-iOSTests/MockScanOrPasteCodeViewModelDelegate.swift
@@ -32,6 +32,8 @@ final class MockScanOrPasteCodeViewModelDelegate: ScanOrPasteCodeViewModelDelega
     private(set) var requestCameraPermissionModels: [ScanOrPasteCodeViewModel] = []
     private(set) var shareCodeCalls: [(code: String, source: CodeCollectionSource)] = []
     private(set) var didCallCodeEntryScreenShown = false
+    private(set) var didCallBarcodeScreenShown = false
+    private(set) var didCallScanQRCodeScreenShown = false
     private(set) var codeCopiedCalls: [(code: String, source: CodeCollectionSource)] = []
 
     func endConnectMode() {
@@ -61,6 +63,14 @@ final class MockScanOrPasteCodeViewModelDelegate: ScanOrPasteCodeViewModelDelega
 
     func codeEntryScreenShown() {
         didCallCodeEntryScreenShown = true
+    }
+
+    func barcodeScreenShown() {
+        didCallBarcodeScreenShown = true
+    }
+
+    func scanQRCodeScreenShown() {
+        didCallScanQRCodeScreenShown = true
     }
 
     func codeCopied(_ code: String, source: CodeCollectionSource) {

--- a/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -24,8 +24,35 @@
         ]
     },
     "sync_setup_barcode_screen_shown": {
-        "description": "Fired when the Sync setup QR/code screen is shown.",
-        "owners": ["amddg44"],
+        "description": "Fired when the Sync setup screen displaying this device's QR code/text code is shown. In the V2 simplified layout this is the 'Show QR code' sheet; in the legacy layout it is the combined scan/show-code screen.",
+        "owners": ["amddg44", "pballart"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "ui_version",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The setup source or entry surface."
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Whether V2 Sync setup scanning is enabled for this flow.",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "The kind of this client.",
+                "enum": ["ddg"]
+            }
+        ]
+    },
+    "sync_setup_scan_qr_screen_shown": {
+        "description": "Fired when the Sync setup QR code scanner (camera) screen is shown. V2 simplified layout only.",
+        "owners": ["amddg44", "pballart"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor"],
         "parameters": [

--- a/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -34,7 +34,20 @@
             {
                 "key": "source",
                 "type": "string",
-                "description": "The setup source or entry surface."
+                "description": "The setup source or entry surface.",
+                "enum": [
+                    "sync-start",
+                    "sync-backup",
+                    "data_import_summary",
+                    "promotion_data_import_summary",
+                    "promotion_bookmarks",
+                    "promotion_passwords",
+                    "promotion_ai_chat",
+                    "recovery",
+                    "exchange",
+                    "connect",
+                    "unknown"
+                ]
             },
             {
                 "key": "flow_version",
@@ -61,7 +74,20 @@
             {
                 "key": "source",
                 "type": "string",
-                "description": "The setup source or entry surface."
+                "description": "The setup source or entry surface.",
+                "enum": [
+                    "sync-start",
+                    "sync-backup",
+                    "data_import_summary",
+                    "promotion_data_import_summary",
+                    "promotion_bookmarks",
+                    "promotion_passwords",
+                    "promotion_ai_chat",
+                    "recovery",
+                    "exchange",
+                    "connect",
+                    "unknown"
+                ]
             },
             {
                 "key": "flow_version",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1217185337821238?focus=true

### Description
Release fix for the V2 Simplified Sync layout scan-flow pixels.

- `sync_setup_barcode_screen_shown` previously fired when the combined scan screen was presented — which lands on the camera scanner, not on the device's own code. It now fires when the "Show QR code" sheet (the screen that actually displays this device's code) appears, so the pixel name matches what the user sees. 
- A new `sync_setup_scan_qr_screen_shown` fires when the camera scanner tab appears, giving the scanner screen its own signal. The legacy layout is unchanged, and `sync_setup_manual_code_entry_screen_shown` is untouched.

### Testing Steps
1. Enable the Simplified Sync V2 layout (`ff.simplifiedSyncSetupV2`).
2. Settings → Sync & Back Up → start the "Sync With Another Device" flow so the scan screen appears → `sync_setup_scan_qr_screen_shown` fires.
3. Tap the QR button (top-right) to open the Show QR code sheet → `sync_setup_barcode_screen_shown` fires.
4. Switch to the Enter Code tab → `sync_setup_manual_code_entry_screen_shown` fires (unchanged).

### Impact
Low — pixel-only change; no user-facing behaviour change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes to sync setup pixel timing and definitions; no sync pairing, auth, or user-facing flow logic is modified.
> 
> **Overview**
> Fixes **V2 simplified sync setup** analytics so screen-shown pixels match what users actually see.
> 
> **`sync_setup_barcode_screen_shown`** no longer fires when the combined scan flow is presented (which defaulted to the camera). It now fires when the screen that shows **this device’s** QR/text code appears—the V2 “Show QR code” sheet (`SyncCodeSheetView.onAppear` → `barcodeScreenShown()`). The **legacy** layout still fires that pixel on present via the existing `onPresentPixelInfo` path when V2 is off.
> 
> Adds **`sync_setup_scan_qr_screen_shown`** for the camera scanner tab (`ScanTabView.onAppear` → `scanQRCodeScreenShown()`), with a new `Pixel.Event` case and json5 definition.
> 
> `SyncSettingsViewController` centralizes firing through **`fireScanFlowScreenShownPixel`**, stores **`scanSetupSource`**, injects **`pixelFiring`** for tests, and skips the old present-time barcode pixel when **`useSimplifiedLayoutV2`** is enabled. **`sync_setup_manual_code_entry_screen_shown`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fd69ba075552a442e2306d6e19a9ea425748dd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->