### PR TITLE
Add Duck.ai subscribe/upgrade modal funnel pixels (macOS)

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatMetricName.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatMetricName.swift
@@ -55,6 +55,15 @@ public enum AIChatMetricName: String, Codable {
     case userDidClickProUpgradeDisclaimerBannerButton
     case userDidClickVoiceChatLimitModalSubscribeButton
     case userDidClickVoiceChatDurationLimitModalSubscribeButton
+
+    // MARK: - Subscription funnel modal metrics
+    // The subscribe / upgrade-to-Pro modal the funnel entry points above open. These carry `source`,
+    // naming the entry point the modal was opened from.
+    case userDidOpenSubscribeModal
+    case userDidClickSubscribeOnSubscribeModal
+    case userDidClickActivateOnSubscribeModal
+    case userDidOpenUpgradeToProModal
+    case userDidClickUpgradeOnUpgradeToProModal
 }
 
 // Model tier for AI Chat metrics
@@ -75,13 +84,17 @@ public struct AIChatMetric: Codable {
     public let pageType: String?
     /// Whether the shown suggestions were smart (page-tailored) rather than generic. Carried by `userDidViewSuggestions`.
     public let isSmart: Bool?
+    /// Funnel entry point a modal was opened from (e.g. `freelimit`). Decoded as a plain string so a new FE
+    /// slug never breaks decoding. Carried by the subscription funnel modal metrics.
+    public let source: String?
 
-     public init(metricName: AIChatMetricName, modelTier: AIChatModelTier? = nil, suggestionId: String? = nil, pageType: String? = nil, isSmart: Bool? = nil) {
+     public init(metricName: AIChatMetricName, modelTier: AIChatModelTier? = nil, suggestionId: String? = nil, pageType: String? = nil, isSmart: Bool? = nil, source: String? = nil) {
          self.metricName = metricName
          self.modelTier = modelTier
          self.suggestionId = suggestionId
          self.pageType = pageType
          self.isSmart = isSmart
+         self.source = source
      }
 }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -1969,6 +1969,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         dialog.onHaveSubscription = { [weak self] in
             self?.omnibarController.presentSubscriptionActivationFlow()
         }
+        omnibarController.pixelHandler.fire(.subscriptionUpsellShown(origin: origin.rawValue))
         dialog.show()
     }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -1925,7 +1925,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     @objc private func reasoningEffortBadgeSelected(_ sender: NSMenuItem) {
         guard let effort = sender.representedObject as? AIChatReasoningEffort,
               let requiredTier = omnibarController.requiredTier(for: effort) else { return }
-        presentSubscriptionUpsellDialog(requiredTier: requiredTier, origin: .addressBarReasoningPicker)
+        presentSubscriptionUpsellDialog(requiredTier: requiredTier, origin: .addressBarReasoningDropdown)
     }
 
     @objc private func reasoningEffortSelected(_ sender: NSMenuItem) {
@@ -1937,7 +1937,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         case .gated(let requiredTier):
             // Explains the upsell via a sheet rather than navigating immediately, and leaves the
             // current selection unchanged.
-            presentSubscriptionUpsellDialog(requiredTier: requiredTier, origin: .addressBarReasoningPicker)
+            presentSubscriptionUpsellDialog(requiredTier: requiredTier, origin: .addressBarReasoningDropdown)
         }
     }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -1768,6 +1768,11 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     }
 
     @objc private func modelPickerButtonClicked() {
+        let items = omnibarController.modelPickerItems(selectedModelId: selectedModelId)
+        // Only a picker that actually shows a gated row is a subscription-funnel impression.
+        if items.contains(where: { if case .gatedModel = $0 { return true } else { return false } }) {
+            omnibarController.pixelHandler.fire(.modelPickerShown)
+        }
         let menu = buildModelPickerMenu()
         // Align menu's trailing edge with button's trailing edge, with a small gap below
         let x = modelPickerButton.bounds.width - menu.size.width
@@ -1889,7 +1894,11 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         menu.minimumWidth = Self.reasoningPickerMinimumWidth
 
         // The controller decides what the menu shows; this only maps each item to an NSMenuItem.
-        for item in omnibarController.reasoningPickerItems() {
+        let items = omnibarController.reasoningPickerItems()
+        if items.contains(where: \.isGated) {
+            omnibarController.pixelHandler.fire(.reasoningPickerShown)
+        }
+        for item in items {
             menu.addItem(reasoningEffortRow(for: item, in: menu))
         }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -1768,12 +1768,14 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     }
 
     @objc private func modelPickerButtonClicked() {
+        // Resolved once and passed on: `modelPickerItems` records a free-trial badge impression, so
+        // asking for it twice per open would burn through the badge's view cap at double speed.
         let items = omnibarController.modelPickerItems(selectedModelId: selectedModelId)
         // Only a picker that actually shows a gated row is a subscription-funnel impression.
         if items.contains(where: { if case .gatedModel = $0 { return true } else { return false } }) {
             omnibarController.pixelHandler.fire(.modelPickerShown)
         }
-        let menu = buildModelPickerMenu()
+        let menu = buildModelPickerMenu(items: items)
         // Align menu's trailing edge with button's trailing edge, with a small gap below
         let x = modelPickerButton.bounds.width - menu.size.width
         popUp(menu, at: NSPoint(x: x, y: -5), in: modelPickerButton)
@@ -1809,12 +1811,12 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             }
     }
 
-    private func buildModelPickerMenu() -> NSMenu {
+    private func buildModelPickerMenu(items: [AIChatModelPickerItem]) -> NSMenu {
         let menu = NSMenu()
         menu.autoenablesItems = false
 
         // The controller decides what the menu shows; this only maps each item to an NSMenuItem.
-        for item in omnibarController.modelPickerItems(selectedModelId: selectedModelId) {
+        for item in items {
             switch item {
             case .model(let model, let badge, let isSelected):
                 menu.addItem(modelRow(for: model, trailingText: badge, isSelected: isSelected,

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarSubscriptionUpsellPresenter.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarSubscriptionUpsellPresenter.swift
@@ -50,11 +50,11 @@ struct AIChatOmnibarSubscriptionUpsellPresenter: AIChatOmnibarSubscriptionUpsell
     func routeGatedSelection(requiredTier: AIChatModelPublicAccessTier, userTier: AIChatUserTier, origin: SubscriptionFunnelOrigin) -> Bool {
         switch userTier.upgradeFlow(for: requiredTier) {
         case .purchase:
-            firePixel(currentTier: userTier, requiredTier: requiredTier, flowType: "purchase")
+            firePixel(currentTier: userTier, requiredTier: requiredTier, flowType: "purchase", origin: origin)
             coordinator.navigateToSubscriptionPurchase(origin: origin.rawValue, featurePage: Self.featurePage)
             return true
         case .upgrade:
-            firePixel(currentTier: userTier, requiredTier: requiredTier, flowType: "upgrade")
+            firePixel(currentTier: userTier, requiredTier: requiredTier, flowType: "upgrade", origin: origin)
             coordinator.navigateToSubscriptionPlans(origin: origin.rawValue, featurePage: Self.featurePage)
             return true
         case .none:
@@ -67,12 +67,16 @@ struct AIChatOmnibarSubscriptionUpsellPresenter: AIChatOmnibarSubscriptionUpsell
         coordinator.navigateToSubscriptionActivation()
     }
 
-    private func firePixel(currentTier: AIChatUserTier, requiredTier: AIChatModelPublicAccessTier, flowType: String) {
+    private func firePixel(currentTier: AIChatUserTier,
+                           requiredTier: AIChatModelPublicAccessTier,
+                           flowType: String,
+                           origin: SubscriptionFunnelOrigin) {
         PixelKit.fire(
             AIChatPixel.aiChatAddressBarSubscriptionUpsellTriggered(
                 currentTier: currentTier.rawValue,
                 requiredTier: requiredTier.rawValue,
-                flowType: flowType
+                flowType: flowType,
+                origin: origin.rawValue
             ),
             frequency: .dailyAndCount,
             includeAppVersionParameter: true

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -312,6 +312,21 @@ enum AIChatPixel: PixelKitEvent {
     /// Event Trigger: The CTA on a Duck.ai subscription-funnel entry point is clicked, reported over the `reportMetric` bridge.
     case aiChatSubscriptionFunnelClick(origin: String)
 
+    /// Event Trigger: The Duck.ai subscribe modal is shown. `origin` is the entry point it was opened from.
+    case aiChatSubscriptionFunnelSubscribeModalImpression(origin: String)
+
+    /// Event Trigger: The subscribe CTA in the Duck.ai subscribe modal is clicked.
+    case aiChatSubscriptionFunnelSubscribeModalSubscribeClick(origin: String)
+
+    /// Event Trigger: The "I have a subscription" CTA in the Duck.ai subscribe modal is clicked.
+    case aiChatSubscriptionFunnelSubscribeModalActivateClick(origin: String)
+
+    /// Event Trigger: The Duck.ai upgrade-to-Pro modal is shown. `origin` is the entry point it was opened from.
+    case aiChatSubscriptionFunnelUpgradeToProModalImpression(origin: String)
+
+    /// Event Trigger: The upgrade CTA in the Duck.ai upgrade-to-Pro modal is clicked.
+    case aiChatSubscriptionFunnelUpgradeToProModalUpgradeClick(origin: String)
+
     /// Event Trigger: User opens a new voice Duck.ai chat from the native omnibar
     case aiChatNewVoiceChatOmnibarNative
 
@@ -676,6 +691,16 @@ enum AIChatPixel: PixelKitEvent {
             return "aichat_subscription-funnel_impression"
         case .aiChatSubscriptionFunnelClick:
             return "aichat_subscription-funnel_click"
+        case .aiChatSubscriptionFunnelSubscribeModalImpression:
+            return "aichat_subscription-funnel_subscribe-modal_impression"
+        case .aiChatSubscriptionFunnelSubscribeModalSubscribeClick:
+            return "aichat_subscription-funnel_subscribe-modal_subscribe_click"
+        case .aiChatSubscriptionFunnelSubscribeModalActivateClick:
+            return "aichat_subscription-funnel_subscribe-modal_activate_click"
+        case .aiChatSubscriptionFunnelUpgradeToProModalImpression:
+            return "aichat_subscription-funnel_upgrade-to-pro-modal_impression"
+        case .aiChatSubscriptionFunnelUpgradeToProModalUpgradeClick:
+            return "aichat_subscription-funnel_upgrade-to-pro-modal_upgrade_click"
         case .aiChatNewVoiceChatOmnibarNative:
             return "aichat_new_voice_chat_omnibar_native"
         case .aiChatAddressBarImageGenerationActivated:
@@ -897,7 +922,12 @@ enum AIChatPixel: PixelKitEvent {
         case .aiChatAddressBarSubscriptionUpsellTriggered(let currentTier, let requiredTier, let flowType):
             return ["current_tier": currentTier, "required_tier": requiredTier, "flow_type": flowType]
         case .aiChatSubscriptionFunnelImpression(let origin),
-                .aiChatSubscriptionFunnelClick(let origin):
+                .aiChatSubscriptionFunnelClick(let origin),
+                .aiChatSubscriptionFunnelSubscribeModalImpression(let origin),
+                .aiChatSubscriptionFunnelSubscribeModalSubscribeClick(let origin),
+                .aiChatSubscriptionFunnelSubscribeModalActivateClick(let origin),
+                .aiChatSubscriptionFunnelUpgradeToProModalImpression(let origin),
+                .aiChatSubscriptionFunnelUpgradeToProModalUpgradeClick(let origin):
             return ["origin": origin]
         case .aiChatNtpSubscriptionUpsellTriggered(let flowType, let source):
             return ["flow_type": flowType, "source": source]
@@ -1051,6 +1081,11 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatAddressBarSubscriptionUpsellTriggered,
                 .aiChatSubscriptionFunnelImpression,
                 .aiChatSubscriptionFunnelClick,
+                .aiChatSubscriptionFunnelSubscribeModalImpression,
+                .aiChatSubscriptionFunnelSubscribeModalSubscribeClick,
+                .aiChatSubscriptionFunnelSubscribeModalActivateClick,
+                .aiChatSubscriptionFunnelUpgradeToProModalImpression,
+                .aiChatSubscriptionFunnelUpgradeToProModalUpgradeClick,
                 .aiChatNtpSubmitWithImage,
                 .aiChatNtpModelSelected,
                 .aiChatNtpReasoningEffortSelected,

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -304,6 +304,12 @@ enum AIChatPixel: PixelKitEvent {
     /// routing them to the subscription purchase/upgrade flow.
     case aiChatAddressBarSubscriptionUpsellTriggered(currentTier: String, requiredTier: String, flowType: String)
 
+    /// Event Trigger: The address bar's model picker opened showing at least one gated model.
+    case aiChatAddressBarModelPickerShown(origin: String)
+
+    /// Event Trigger: The address bar's reasoning picker opened showing at least one gated effort.
+    case aiChatAddressBarReasoningPickerShown(origin: String)
+
     // MARK: - Duck.ai Subscription Funnel (frontend-reported)
 
     /// Event Trigger: A Duck.ai subscription-funnel entry point is shown in the web frontend, reported over the `reportMetric` bridge. `origin` is the entry point.
@@ -687,6 +693,10 @@ enum AIChatPixel: PixelKitEvent {
             return "aichat_addressbar_reasoning_effort_selected"
         case .aiChatAddressBarSubscriptionUpsellTriggered:
             return "aichat_addressbar_subscription_upsell_triggered"
+        case .aiChatAddressBarModelPickerShown:
+            return "aichat_addressbar_model_picker_shown"
+        case .aiChatAddressBarReasoningPickerShown:
+            return "aichat_addressbar_reasoning_picker_shown"
         case .aiChatSubscriptionFunnelImpression:
             return "aichat_subscription-funnel_impression"
         case .aiChatSubscriptionFunnelClick:
@@ -921,6 +931,9 @@ enum AIChatPixel: PixelKitEvent {
             return nil
         case .aiChatAddressBarSubscriptionUpsellTriggered(let currentTier, let requiredTier, let flowType):
             return ["current_tier": currentTier, "required_tier": requiredTier, "flow_type": flowType]
+        case .aiChatAddressBarModelPickerShown(let origin),
+                .aiChatAddressBarReasoningPickerShown(let origin):
+            return ["origin": origin]
         case .aiChatSubscriptionFunnelImpression(let origin),
                 .aiChatSubscriptionFunnelClick(let origin),
                 .aiChatSubscriptionFunnelSubscribeModalImpression(let origin),
@@ -1079,6 +1092,8 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatAddressBarModelSelected,
                 .aiChatAddressBarReasoningEffortSelected,
                 .aiChatAddressBarSubscriptionUpsellTriggered,
+                .aiChatAddressBarModelPickerShown,
+                .aiChatAddressBarReasoningPickerShown,
                 .aiChatSubscriptionFunnelImpression,
                 .aiChatSubscriptionFunnelClick,
                 .aiChatSubscriptionFunnelSubscribeModalImpression,

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -304,6 +304,15 @@ enum AIChatPixel: PixelKitEvent {
     /// routing them to the subscription purchase/upgrade flow.
     case aiChatAddressBarSubscriptionUpsellTriggered(currentTier: String, requiredTier: String, flowType: String)
 
+    /// Event Trigger: The New Tab Page omnibar reported a picker impression over `telemetryEvent`.
+    /// The `tryForFree`/`upgrade` variants mean the gated section carried that CTA.
+    case aiChatNtpModelPickerShown(origin: String)
+    case aiChatNtpModelPickerTryForFreeShown(origin: String)
+    case aiChatNtpModelPickerUpgradeShown(origin: String)
+    case aiChatNtpReasoningPickerShown(origin: String)
+    case aiChatNtpReasoningPickerTryForFreeShown(origin: String)
+    case aiChatNtpReasoningPickerUpgradeShown(origin: String)
+
     /// Event Trigger: The address bar's model picker opened showing at least one gated model.
     case aiChatAddressBarModelPickerShown(origin: String)
 
@@ -369,7 +378,7 @@ enum AIChatPixel: PixelKitEvent {
 
     /// Event Trigger: User taps a gated model or reasoning effort in the New Tab Page omnibar,
     /// routing them to the subscription purchase/upgrade flow.
-    case aiChatNtpSubscriptionUpsellTriggered(flowType: String, source: String)
+    case aiChatNtpSubscriptionUpsellTriggered(flowType: String, source: String, origin: String)
 
     /// Event Trigger: User taps "View all chats" from the New Tab Page omnibar
     case aiChatNtpViewAllChatsClicked
@@ -693,6 +702,18 @@ enum AIChatPixel: PixelKitEvent {
             return "aichat_addressbar_reasoning_effort_selected"
         case .aiChatAddressBarSubscriptionUpsellTriggered:
             return "aichat_addressbar_subscription_upsell_triggered"
+        case .aiChatNtpModelPickerShown:
+            return "aichat_ntp_model_picker_shown"
+        case .aiChatNtpModelPickerTryForFreeShown:
+            return "aichat_ntp_model_picker_tryforfree_shown"
+        case .aiChatNtpModelPickerUpgradeShown:
+            return "aichat_ntp_model_picker_upgrade_shown"
+        case .aiChatNtpReasoningPickerShown:
+            return "aichat_ntp_reasoning_picker_shown"
+        case .aiChatNtpReasoningPickerTryForFreeShown:
+            return "aichat_ntp_reasoning_picker_tryforfree_shown"
+        case .aiChatNtpReasoningPickerUpgradeShown:
+            return "aichat_ntp_reasoning_picker_upgrade_shown"
         case .aiChatAddressBarModelPickerShown:
             return "aichat_addressbar_model_picker_shown"
         case .aiChatAddressBarReasoningPickerShown:
@@ -932,7 +953,13 @@ enum AIChatPixel: PixelKitEvent {
         case .aiChatAddressBarSubscriptionUpsellTriggered(let currentTier, let requiredTier, let flowType):
             return ["current_tier": currentTier, "required_tier": requiredTier, "flow_type": flowType]
         case .aiChatAddressBarModelPickerShown(let origin),
-                .aiChatAddressBarReasoningPickerShown(let origin):
+                .aiChatAddressBarReasoningPickerShown(let origin),
+                .aiChatNtpModelPickerShown(let origin),
+                .aiChatNtpModelPickerTryForFreeShown(let origin),
+                .aiChatNtpModelPickerUpgradeShown(let origin),
+                .aiChatNtpReasoningPickerShown(let origin),
+                .aiChatNtpReasoningPickerTryForFreeShown(let origin),
+                .aiChatNtpReasoningPickerUpgradeShown(let origin):
             return ["origin": origin]
         case .aiChatSubscriptionFunnelImpression(let origin),
                 .aiChatSubscriptionFunnelClick(let origin),
@@ -942,8 +969,8 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatSubscriptionFunnelUpgradeToProModalImpression(let origin),
                 .aiChatSubscriptionFunnelUpgradeToProModalUpgradeClick(let origin):
             return ["origin": origin]
-        case .aiChatNtpSubscriptionUpsellTriggered(let flowType, let source):
-            return ["flow_type": flowType, "source": source]
+        case .aiChatNtpSubscriptionUpsellTriggered(let flowType, let source, let origin):
+            return ["flow_type": flowType, "source": source, "origin": origin]
         case .aiChatIsEnabled(let isEnabled):
             return ["is_enabled": isEnabled ? "1" : "0"]
         case .aiFeaturesState(let duckAI, let searchAssist, let hideAIImages, let noAI):
@@ -1094,6 +1121,12 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatAddressBarSubscriptionUpsellTriggered,
                 .aiChatAddressBarModelPickerShown,
                 .aiChatAddressBarReasoningPickerShown,
+                .aiChatNtpModelPickerShown,
+                .aiChatNtpModelPickerTryForFreeShown,
+                .aiChatNtpModelPickerUpgradeShown,
+                .aiChatNtpReasoningPickerShown,
+                .aiChatNtpReasoningPickerTryForFreeShown,
+                .aiChatNtpReasoningPickerUpgradeShown,
                 .aiChatSubscriptionFunnelImpression,
                 .aiChatSubscriptionFunnelClick,
                 .aiChatSubscriptionFunnelSubscribeModalImpression,

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -302,7 +302,15 @@ enum AIChatPixel: PixelKitEvent {
 
     /// Event Trigger: User taps a gated model or reasoning effort in the native omnibar picker,
     /// routing them to the subscription purchase/upgrade flow.
-    case aiChatAddressBarSubscriptionUpsellTriggered(currentTier: String, requiredTier: String, flowType: String)
+    case aiChatAddressBarSubscriptionUpsellTriggered(currentTier: String, requiredTier: String, flowType: String, origin: String)
+
+    /// Event Trigger: The native subscription upsell dialog was shown after a gated pick in the
+    /// address bar. Pairs with `aiChatAddressBarSubscriptionUpsellTriggered` for a view-to-click rate.
+    case aiChatAddressBarSubscriptionUpsellShown(origin: String)
+
+    /// Event Trigger: The native subscription upsell dialog was shown after a gated pick in the
+    /// New Tab Page omnibar.
+    case aiChatNtpSubscriptionUpsellShown(origin: String)
 
     /// Event Trigger: The New Tab Page omnibar reported a picker impression over `telemetryEvent`.
     /// The `tryForFree`/`upgrade` variants mean the gated section carried that CTA.
@@ -702,6 +710,10 @@ enum AIChatPixel: PixelKitEvent {
             return "aichat_addressbar_reasoning_effort_selected"
         case .aiChatAddressBarSubscriptionUpsellTriggered:
             return "aichat_addressbar_subscription_upsell_triggered"
+        case .aiChatAddressBarSubscriptionUpsellShown:
+            return "aichat_addressbar_subscription_upsell_shown"
+        case .aiChatNtpSubscriptionUpsellShown:
+            return "aichat_ntp_subscription_upsell_shown"
         case .aiChatNtpModelPickerShown:
             return "aichat_ntp_model_picker_shown"
         case .aiChatNtpModelPickerTryForFreeShown:
@@ -950,8 +962,11 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatNtpCustomizeResponsesOpened,
                 .serpSettingsUnrecognizedValue:
             return nil
-        case .aiChatAddressBarSubscriptionUpsellTriggered(let currentTier, let requiredTier, let flowType):
-            return ["current_tier": currentTier, "required_tier": requiredTier, "flow_type": flowType]
+        case .aiChatAddressBarSubscriptionUpsellTriggered(let currentTier, let requiredTier, let flowType, let origin):
+            return ["current_tier": currentTier, "required_tier": requiredTier, "flow_type": flowType, "origin": origin]
+        case .aiChatAddressBarSubscriptionUpsellShown(let origin),
+                .aiChatNtpSubscriptionUpsellShown(let origin):
+            return ["origin": origin]
         case .aiChatAddressBarModelPickerShown(let origin),
                 .aiChatAddressBarReasoningPickerShown(let origin),
                 .aiChatNtpModelPickerShown(let origin),
@@ -1119,6 +1134,8 @@ enum AIChatPixel: PixelKitEvent {
                 .aiChatAddressBarModelSelected,
                 .aiChatAddressBarReasoningEffortSelected,
                 .aiChatAddressBarSubscriptionUpsellTriggered,
+                .aiChatAddressBarSubscriptionUpsellShown,
+                .aiChatNtpSubscriptionUpsellShown,
                 .aiChatAddressBarModelPickerShown,
                 .aiChatAddressBarReasoningPickerShown,
                 .aiChatNtpModelPickerShown,

--- a/macOS/DuckDuckGo/AIChat/PromptInput/DuckAIPromptPixelFiring.swift
+++ b/macOS/DuckDuckGo/AIChat/PromptInput/DuckAIPromptPixelFiring.swift
@@ -44,6 +44,10 @@ enum DuckAIPromptPixelEvent: Equatable {
     case tabPickerCanceled
     case modelSelected
     case reasoningEffortSelected
+    /// A picker opened showing at least one gated row — the funnel impression. Each surface attaches
+    /// its own origin, so the event itself carries none.
+    case modelPickerShown
+    case reasoningPickerShown
     case subscriptionUpsellTriggered(currentTier: String, requiredTier: String, flowType: String)
     case voiceChatOpened
 }
@@ -89,6 +93,10 @@ struct AddressBarPromptPixelHandler: DuckAIPromptPixelFiring {
         case .tabPickerCanceled: .aiChatAddressBarAttachPickerCanceled
         case .modelSelected: .aiChatAddressBarModelSelected
         case .reasoningEffortSelected: .aiChatAddressBarReasoningEffortSelected
+        case .modelPickerShown:
+            .aiChatAddressBarModelPickerShown(origin: SubscriptionFunnelOrigin.addressBarModelPicker.rawValue)
+        case .reasoningPickerShown:
+            .aiChatAddressBarReasoningPickerShown(origin: SubscriptionFunnelOrigin.addressBarReasoningDropdown.rawValue)
         case .subscriptionUpsellTriggered(let currentTier, let requiredTier, let flowType):
             .aiChatAddressBarSubscriptionUpsellTriggered(currentTier: currentTier, requiredTier: requiredTier, flowType: flowType)
         case .voiceChatOpened: nil

--- a/macOS/DuckDuckGo/AIChat/PromptInput/DuckAIPromptPixelFiring.swift
+++ b/macOS/DuckDuckGo/AIChat/PromptInput/DuckAIPromptPixelFiring.swift
@@ -48,7 +48,10 @@ enum DuckAIPromptPixelEvent: Equatable {
     /// its own origin, so the event itself carries none.
     case modelPickerShown
     case reasoningPickerShown
-    case subscriptionUpsellTriggered(currentTier: String, requiredTier: String, flowType: String)
+    /// The native upsell dialog was shown after a gated pick. Carries the origin because it varies
+    /// per picker within a surface.
+    case subscriptionUpsellShown(origin: String)
+    case subscriptionUpsellTriggered(currentTier: String, requiredTier: String, flowType: String, origin: String)
     case voiceChatOpened
 }
 
@@ -97,8 +100,13 @@ struct AddressBarPromptPixelHandler: DuckAIPromptPixelFiring {
             .aiChatAddressBarModelPickerShown(origin: SubscriptionFunnelOrigin.addressBarModelPicker.rawValue)
         case .reasoningPickerShown:
             .aiChatAddressBarReasoningPickerShown(origin: SubscriptionFunnelOrigin.addressBarReasoningDropdown.rawValue)
-        case .subscriptionUpsellTriggered(let currentTier, let requiredTier, let flowType):
-            .aiChatAddressBarSubscriptionUpsellTriggered(currentTier: currentTier, requiredTier: requiredTier, flowType: flowType)
+        case .subscriptionUpsellShown(let origin):
+            .aiChatAddressBarSubscriptionUpsellShown(origin: origin)
+        case .subscriptionUpsellTriggered(let currentTier, let requiredTier, let flowType, let origin):
+            .aiChatAddressBarSubscriptionUpsellTriggered(currentTier: currentTier,
+                                                        requiredTier: requiredTier,
+                                                        flowType: flowType,
+                                                        origin: origin)
         case .voiceChatOpened: nil
         }
     }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -988,12 +988,49 @@ extension AIChatUserScriptHandler: AIChatMetricReportingHandling {
         .userDidClickVoiceChatDurationLimitModalSubscribeButton: (.duckAIVoiceChatDurationLimit, true),
     ]
 
+    /// The modal metrics, each building its pixel from the origin the modal was opened from.
+    private static let modalFunnelPixels: [AIChatMetricName: (String) -> AIChatPixel] = [
+        .userDidOpenSubscribeModal: AIChatPixel.aiChatSubscriptionFunnelSubscribeModalImpression,
+        .userDidClickSubscribeOnSubscribeModal: AIChatPixel.aiChatSubscriptionFunnelSubscribeModalSubscribeClick,
+        .userDidClickActivateOnSubscribeModal: AIChatPixel.aiChatSubscriptionFunnelSubscribeModalActivateClick,
+        .userDidOpenUpgradeToProModal: AIChatPixel.aiChatSubscriptionFunnelUpgradeToProModalImpression,
+        .userDidClickUpgradeOnUpgradeToProModal: AIChatPixel.aiChatSubscriptionFunnelUpgradeToProModalUpgradeClick,
+    ]
+
+    /// Entry points a modal can be opened from. Allow-listed rather than interpolated into an origin so
+    /// an unrecognised frontend slug can't reach the pixel's origin parameter.
+    private static let modalFunnelOrigins: [String: SubscriptionFunnelOrigin] = [
+        "activatesubscription": .duckAIActivateSubscription,
+        "aisidebar": .duckAIAiSidebar,
+        "disclaimerbanner": .duckAIDisclaimerBanner,
+        "freelabel": .duckAIFreeLabel,
+        "freelimit": .duckAIFreeLimit,
+        "imagegenerationlimit": .duckAIImageGenerationLimit,
+        "modelpicker": .duckAIModelPicker,
+        "pluslimit": .duckAIPlusLimit,
+        "promotioncard": .duckAIPromotionCard,
+        "reasoningdropdown": .duckAIReasoningDropdown,
+        "switchmodel": .duckAISwitchModel,
+        "voicechatdurationlimit": .duckAIVoiceChatDurationLimit,
+        "voicechatlimit": .duckAIVoiceChatLimit,
+        "unknown": .duckAIUnknown,
+    ]
+
     func didReportMetric(_ metric: AIChatMetric, completion: (() -> Void)? = nil) {
         if let funnel = Self.funnelMetrics[metric.metricName] {
             let pixel: AIChatPixel = funnel.isClick
                 ? .aiChatSubscriptionFunnelClick(origin: funnel.origin.rawValue)
                 : .aiChatSubscriptionFunnelImpression(origin: funnel.origin.rawValue)
             pixelFiring?.fire(pixel, frequency: .dailyAndCount)
+            completion?()
+            return
+        }
+
+        if let makePixel = Self.modalFunnelPixels[metric.metricName] {
+            // Without a recognised entry point the pixel would carry no usable attribution, so skip it.
+            if let source = metric.source, let origin = Self.modalFunnelOrigins[source] {
+                pixelFiring?.fire(makePixel(origin.rawValue), frequency: .dailyAndCount)
+            }
             completion?()
             return
         }

--- a/macOS/DuckDuckGo/NewTabPage/Features/NewTabPageConfigurationEventHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NewTabPageConfigurationEventHandler.swift
@@ -34,11 +34,36 @@ final class NewTabPageConfigurationEventHandler: EventMapping<NewTabPageConfigur
 
             case .newTabPageTelemetry(.customizerClosed):
                 PixelKit.fire(NewTabPagePixel.customizerHidden)
+
+            // Duck.ai omnibar picker impressions. The frontend owns these pickers, so a reported
+            // telemetry event is the only signal native gets that a gated row was on screen.
+            case .newTabPageTelemetry(.omnibarModelPickerShown):
+                Self.fireOmnibarPickerImpression(AIChatPixel.aiChatNtpModelPickerShown, .newTabPageModelPicker)
+
+            case .newTabPageTelemetry(.omnibarModelPickerTryForFreeShown):
+                Self.fireOmnibarPickerImpression(AIChatPixel.aiChatNtpModelPickerTryForFreeShown, .newTabPageModelPicker)
+
+            case .newTabPageTelemetry(.omnibarModelPickerUpgradeShown):
+                Self.fireOmnibarPickerImpression(AIChatPixel.aiChatNtpModelPickerUpgradeShown, .newTabPageModelPicker)
+
+            case .newTabPageTelemetry(.omnibarReasoningPickerShown):
+                Self.fireOmnibarPickerImpression(AIChatPixel.aiChatNtpReasoningPickerShown, .newTabPageReasoningDropdown)
+
+            case .newTabPageTelemetry(.omnibarReasoningPickerTryForFreeShown):
+                Self.fireOmnibarPickerImpression(AIChatPixel.aiChatNtpReasoningPickerTryForFreeShown, .newTabPageReasoningDropdown)
+
+            case .newTabPageTelemetry(.omnibarReasoningPickerUpgradeShown):
+                Self.fireOmnibarPickerImpression(AIChatPixel.aiChatNtpReasoningPickerUpgradeShown, .newTabPageReasoningDropdown)
             }
         }
     }
 
     override init(mapping: @escaping EventMapping<NewTabPageConfigurationEvent>.Mapping) {
         fatalError("Use init()")
+    }
+
+    private static func fireOmnibarPickerImpression(_ makePixel: (String) -> AIChatPixel,
+                                                    _ origin: SubscriptionFunnelOrigin) {
+        PixelKit.fire(makePixel(origin.rawValue), frequency: .dailyAndCount, includeAppVersionParameter: true)
     }
 }

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarSubscriptionDialogPresenter.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarSubscriptionDialogPresenter.swift
@@ -37,10 +37,12 @@ final class NewTabPageOmnibarSubscriptionDialogPresenter: NewTabPageOmnibarSubsc
     }
 
     func showSubscriptionUpsellDialog(source: NewTabPageDataModel.OmnibarSubscriptionUpsellSource) async {
+        Self.fireDialogShown(source: source)
         makeUpsellDialog(userTier: await resolveUserTier(), source: source).show()
     }
 
     func showSubscriptionUpgradeDialog(source: NewTabPageDataModel.OmnibarSubscriptionUpsellSource) {
+        Self.fireDialogShown(source: source)
         makeUpgradeDialog(source: source).show()
     }
 
@@ -96,6 +98,14 @@ final class NewTabPageOmnibarSubscriptionDialogPresenter: NewTabPageOmnibarSubsc
         case .model: .newTabPageModelPicker
         case .reasoning: .newTabPageReasoningDropdown
         }
+    }
+
+    private static func fireDialogShown(source: NewTabPageDataModel.OmnibarSubscriptionUpsellSource) {
+        PixelKit.fire(
+            AIChatPixel.aiChatNtpSubscriptionUpsellShown(origin: origin(for: source).rawValue),
+            frequency: .dailyAndCount,
+            includeAppVersionParameter: true
+        )
     }
 
     private static func firePixel(flowType: String, source: NewTabPageDataModel.OmnibarSubscriptionUpsellSource) {

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarSubscriptionDialogPresenter.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarSubscriptionDialogPresenter.swift
@@ -51,7 +51,7 @@ final class NewTabPageOmnibarSubscriptionDialogPresenter: NewTabPageOmnibarSubsc
             isEligibleForFreeTrial: userTier == .free && subscriptionManager.isUserEligibleForFreeTrial()
         )
         dialog.onSubscribe = { [coordinator] in
-            coordinator.navigateToSubscriptionPurchase(origin: SubscriptionFunnelOrigin.newTabPageOmnibar.rawValue, featurePage: Self.featurePage)
+            coordinator.navigateToSubscriptionPurchase(origin: Self.origin(for: source).rawValue, featurePage: Self.featurePage)
             Self.firePixel(flowType: "purchase", source: source)
         }
         dialog.onHaveSubscription = { [coordinator] in
@@ -64,7 +64,7 @@ final class NewTabPageOmnibarSubscriptionDialogPresenter: NewTabPageOmnibarSubsc
     func makeUpgradeDialog(source: NewTabPageDataModel.OmnibarSubscriptionUpsellSource) -> AIChatSubscriptionUpsellDialog {
         var dialog: AIChatSubscriptionUpsellDialog = .proUpgrade()
         dialog.onSubscribe = { [coordinator] in
-            coordinator.navigateToSubscriptionPlans(origin: SubscriptionFunnelOrigin.newTabPageOmnibar.rawValue, featurePage: Self.featurePage)
+            coordinator.navigateToSubscriptionPlans(origin: Self.origin(for: source).rawValue, featurePage: Self.featurePage)
             Self.firePixel(flowType: "upgrade", source: source)
         }
         dialog.onHaveSubscription = { [coordinator] in
@@ -89,9 +89,20 @@ final class NewTabPageOmnibarSubscriptionDialogPresenter: NewTabPageOmnibarSubsc
         }
     }
 
+    /// Which picker the user was gated in, so the funnel attributes the entry point rather than
+    /// lumping both pickers under one omnibar origin.
+    static func origin(for source: NewTabPageDataModel.OmnibarSubscriptionUpsellSource) -> SubscriptionFunnelOrigin {
+        switch source {
+        case .model: .newTabPageModelPicker
+        case .reasoning: .newTabPageReasoningDropdown
+        }
+    }
+
     private static func firePixel(flowType: String, source: NewTabPageDataModel.OmnibarSubscriptionUpsellSource) {
         PixelKit.fire(
-            AIChatPixel.aiChatNtpSubscriptionUpsellTriggered(flowType: flowType, source: source.rawValue),
+            AIChatPixel.aiChatNtpSubscriptionUpsellTriggered(flowType: flowType,
+                                                             source: source.rawValue,
+                                                             origin: origin(for: source).rawValue),
             frequency: .dailyAndCount,
             includeAppVersionParameter: true
         )

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixel.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixel.swift
@@ -80,6 +80,12 @@ enum PromptBarPixel: PixelKitEvent {
     /// Event Trigger: User selects a reasoning effort from the picker
     case reasoningEffortSelected
 
+    /// Event Trigger: The model picker opened showing at least one gated model
+    case modelPickerShown(origin: String)
+
+    /// Event Trigger: The reasoning picker opened showing at least one gated effort
+    case reasoningPickerShown(origin: String)
+
     /// Event Trigger: User opens a new voice Duck.ai chat from the Prompt Bar
     case newVoiceChat
 
@@ -153,6 +159,10 @@ enum PromptBarPixel: PixelKitEvent {
             return "aichat_promptbar_model_selected"
         case .reasoningEffortSelected:
             return "aichat_promptbar_reasoning_effort_selected"
+        case .modelPickerShown:
+            return "aichat_promptbar_model_picker_shown"
+        case .reasoningPickerShown:
+            return "aichat_promptbar_reasoning_picker_shown"
         case .newVoiceChat:
             return "aichat_promptbar_new_voice_chat"
         case .shownFromShortcut:
@@ -212,6 +222,8 @@ enum PromptBarPixel: PixelKitEvent {
         case .state(let shortcutEnabled, let menuBarIconEnabled):
             return ["shortcut_enabled": String(shortcutEnabled),
                     "menu_bar_icon_enabled": String(menuBarIconEnabled)]
+        case .modelPickerShown(let origin), .reasoningPickerShown(let origin):
+            return ["origin": origin]
         }
     }
 

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixelHandler.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixelHandler.swift
@@ -66,6 +66,7 @@ struct PromptBarPixelHandler: DuckAIPromptPixelFiring {
                 .tabChosen,
                 .tabPickerCanceled,
                 .customizeResponsesOpened,
+                .subscriptionUpsellShown,
                 .subscriptionUpsellTriggered:
             nil
         }

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixelHandler.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixelHandler.swift
@@ -57,6 +57,8 @@ struct PromptBarPixelHandler: DuckAIPromptPixelFiring {
         case .fileValidationFailed(let reason): .fileValidationFailed(reason: reason)
         case .modelSelected: .modelSelected
         case .reasoningEffortSelected: .reasoningEffortSelected
+        case .modelPickerShown: .modelPickerShown(origin: SubscriptionFunnelOrigin.promptBarModelPicker.rawValue)
+        case .reasoningPickerShown: .reasoningPickerShown(origin: SubscriptionFunnelOrigin.promptBarReasoningDropdown.rawValue)
         case .voiceChatOpened: .newVoiceChat
         case .submittedWithTabs,
                 .tabAttachmentRemoved,

--- a/macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
@@ -78,7 +78,7 @@ enum SubscriptionFunnelOrigin: String {
 
     /// User entered the funnel by tapping a gated reasoning effort in the address bar's duck.ai omnibar.
     /// https://app.asana.com/1/137249556945/project/1208671677432066/task/1215275657171787
-    case addressBarReasoningPicker = "funnel_addressbar_macos__reasoningpicker"
+    case addressBarReasoningDropdown = "funnel_addressbar_macos__reasoningdropdown"
 
     /// User entered the funnel by tapping a gated model in duck.ai's own model picker.
     /// https://app.asana.com/1/137249556945/project/1208671677432066/task/1215275657171787
@@ -86,7 +86,7 @@ enum SubscriptionFunnelOrigin: String {
 
     /// User entered the funnel by tapping a gated reasoning effort in duck.ai's own omnibar.
     /// https://app.asana.com/1/137249556945/project/1208671677432066/task/1215275657171787
-    case duckAIReasoningPicker = "funnel_duckai_macos__reasoningpicker"
+    case duckAIReasoningDropdown = "funnel_duckai_macos__reasoningdropdown"
 
     /// User entered the funnel by tapping a gated model or reasoning effort in the New Tab Page's duck.ai omnibar.
     /// https://app.asana.com/1/137249556945/task/1216424447885172
@@ -108,6 +108,13 @@ enum SubscriptionFunnelOrigin: String {
     case duckAIDisclaimerBanner = "funnel_duckai_macos__disclaimerbanner"
     case duckAIVoiceChatLimit = "funnel_duckai_macos__voicechatlimit"
     case duckAIVoiceChatDurationLimit = "funnel_duckai_macos__voicechatdurationlimit"
+
+    /// The model switcher under a chat response. Only ever reported as a modal's `source` — the surface
+    /// itself is frontend-only, so nothing native fires this on its own.
+    case duckAISwitchModel = "funnel_duckai_macos__switchmodel"
+
+    /// The frontend opened a modal without attributing it to an entry point.
+    case duckAIUnknown = "funnel_duckai_macos__unknown"
 }
 
 /// Represents the origin point from which the user enters the subscription restore funnel in the macOS app.

--- a/macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
@@ -92,6 +92,12 @@ enum SubscriptionFunnelOrigin: String {
     /// https://app.asana.com/1/137249556945/task/1216424447885172
     case newTabPageOmnibar = "funnel_newtab_macos__omnibar"
 
+    /// Gated model in the New Tab Page omnibar's model picker.
+    case newTabPageModelPicker = "funnel_newtab_macos__modelpicker"
+
+    /// Gated reasoning effort in the New Tab Page omnibar's reasoning picker.
+    case newTabPageReasoningDropdown = "funnel_newtab_macos__reasoningdropdown"
+
     /// Gated model shown in the Prompt Bar's model picker. Impression only — gated rows aren't
     /// interactive on this surface, so nothing routes into the purchase flow from here.
     case promptBarModelPicker = "funnel_promptbar_macos__modelpicker"

--- a/macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
@@ -92,6 +92,13 @@ enum SubscriptionFunnelOrigin: String {
     /// https://app.asana.com/1/137249556945/task/1216424447885172
     case newTabPageOmnibar = "funnel_newtab_macos__omnibar"
 
+    /// Gated model shown in the Prompt Bar's model picker. Impression only — gated rows aren't
+    /// interactive on this surface, so nothing routes into the purchase flow from here.
+    case promptBarModelPicker = "funnel_promptbar_macos__modelpicker"
+
+    /// Gated reasoning effort shown in the Prompt Bar's reasoning picker. Impression only, as above.
+    case promptBarReasoningDropdown = "funnel_promptbar_macos__reasoningdropdown"
+
     // MARK: - Duck.ai Funnel Origins (frontend-reported)
 
     /// Entry points shown in the duck.ai web frontend; reported over the `reportMetric` bridge because

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Telemetry/NewTabPageDataModel+Telemetry.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Telemetry/NewTabPageDataModel+Telemetry.swift
@@ -23,6 +23,14 @@ public extension NewTabPageDataModel {
     enum TelemetryEvent: Equatable {
         case customizerOpened(themePopoverWasOpen: Bool)
         case customizerClosed
+        /// A duck.ai omnibar picker was shown. `tryForFree`/`upgrade` mean the gated section carried
+        /// that CTA; the plain cases mean the picker was shown without one.
+        case omnibarModelPickerShown
+        case omnibarModelPickerTryForFreeShown
+        case omnibarModelPickerUpgradeShown
+        case omnibarReasoningPickerShown
+        case omnibarReasoningPickerTryForFreeShown
+        case omnibarReasoningPickerUpgradeShown
     }
 }
 
@@ -32,11 +40,19 @@ extension NewTabPageDataModel.TelemetryEvent: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let payload = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .payload)
         let eventName = try payload.decode(EventName.self, forKey: .name)
-        let parameters = try payload.nestedContainer(keyedBy: CodingKeys.self, forKey: .parameters)
 
         switch eventName {
         case .customizer:
+            // Only the customizer event carries a `value`; the omnibar events are name-only, so
+            // decoding that container up front would make every one of them fail to decode.
+            let parameters = try payload.nestedContainer(keyedBy: CodingKeys.self, forKey: .parameters)
             self = try Self.decodeCustomizerEvent(from: parameters)
+        case .omnibarModelPickerShown: self = .omnibarModelPickerShown
+        case .omnibarModelPickerTryForFreeShown: self = .omnibarModelPickerTryForFreeShown
+        case .omnibarModelPickerUpgradeShown: self = .omnibarModelPickerUpgradeShown
+        case .omnibarReasoningPickerShown: self = .omnibarReasoningPickerShown
+        case .omnibarReasoningPickerTryForFreeShown: self = .omnibarReasoningPickerTryForFreeShown
+        case .omnibarReasoningPickerUpgradeShown: self = .omnibarReasoningPickerUpgradeShown
         }
     }
 }
@@ -53,6 +69,12 @@ private extension NewTabPageDataModel.TelemetryEvent {
 
     enum EventName: String, Decodable {
         case customizer = "customizer_drawer"
+        case omnibarModelPickerShown = "omnibar_model_picker_shown"
+        case omnibarModelPickerTryForFreeShown = "omnibar_model_picker_tryforfree_shown"
+        case omnibarModelPickerUpgradeShown = "omnibar_model_picker_upgrade_shown"
+        case omnibarReasoningPickerShown = "omnibar_reasoning_picker_shown"
+        case omnibarReasoningPickerTryForFreeShown = "omnibar_reasoning_picker_tryforfree_shown"
+        case omnibarReasoningPickerUpgradeShown = "omnibar_reasoning_picker_upgrade_shown"
     }
 
     enum CustomizerState: String, Decodable {

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
@@ -262,6 +262,13 @@
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
+    "m_mac_aichat_addressbar_subscription_upsell_shown": {
+        "description": "Fired when the native subscription upsell dialog is shown after the user taps a gated model or reasoning effort in the address bar's Duck.ai picker. Pairs with m_mac_aichat_addressbar_subscription_upsell_triggered for a view-to-click rate. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
     "m_mac_aichat_addressbar_subscription_upsell_triggered": {
         "description": "Fired when user taps a gated model or reasoning effort in the native omnibar picker, routing them to the subscription purchase/upgrade flow",
         "owners": ["tomasstrba"],
@@ -275,7 +282,7 @@
                 "key": "current_tier",
                 "type": "string",
                 "description": "The user's subscription tier at the time of the gated selection",
-                "enum": ["free", "plus", "pro", "internal"]
+                "enum": ["free", "plus", "pro", "internal", "subscriptionFunnelOrigin"]
             },
             {
                 "key": "required_tier",

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
@@ -241,6 +241,20 @@
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
+    "m_mac_aichat_addressbar_model_picker_shown": {
+        "description": "Fired when the address bar's Duck.ai model picker is opened showing at least one subscriber-exclusive model — the subscription-funnel impression for that entry point. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
+    "m_mac_aichat_addressbar_reasoning_picker_shown": {
+        "description": "Fired when the address bar's Duck.ai reasoning-effort picker is opened showing at least one gated effort — the subscription-funnel impression for that entry point. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
     "m_mac_aichat_addressbar_reasoning_effort_selected": {
         "description": "Fired when user selects a reasoning effort from the native omnibar picker",
         "owners": ["jotaemepereira"],

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
@@ -282,7 +282,7 @@
                 "key": "current_tier",
                 "type": "string",
                 "description": "The user's subscription tier at the time of the gated selection",
-                "enum": ["free", "plus", "pro", "internal", "subscriptionFunnelOrigin"]
+                "enum": ["free", "plus", "pro", "internal"]
             },
             {
                 "key": "required_tier",
@@ -295,7 +295,8 @@
                 "type": "string",
                 "description": "Which subscription flow the user was routed to",
                 "enum": ["purchase", "upgrade"]
-            }
+            },
+            "subscriptionFunnelOrigin"
         ]
     },
     "m_mac_aichat_new_voice_chat_omnibar_native": {

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_ntp_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_ntp_pixels.json5
@@ -49,7 +49,8 @@
                 "type": "string",
                 "description": "Which omnibar picker triggered the upsell",
                 "enum": ["model", "reasoning"]
-            }
+            },
+            "subscriptionFunnelOrigin"
         ]
     },
     "m_mac_aichat_ntp_view_all_chats_clicked": {
@@ -86,5 +87,47 @@
         "triggers": ["other"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_ntp_model_picker_shown": {
+        "description": "Fired when the New Tab Page omnibar's model picker is shown with a subscriber-exclusive section. Reported by the Duck.ai frontend over the New Tab Page telemetryEvent message, since the frontend owns this picker. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
+    "m_mac_aichat_ntp_model_picker_tryforfree_shown": {
+        "description": "Fired when the New Tab Page omnibar's model picker is shown with a \"Try for Free\" CTA on its subscriber-exclusive section. Reported by the Duck.ai frontend over the New Tab Page telemetryEvent message, since the frontend owns this picker. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
+    "m_mac_aichat_ntp_model_picker_upgrade_shown": {
+        "description": "Fired when the New Tab Page omnibar's model picker is shown with an \"Upgrade\" CTA on its subscriber-exclusive section. Reported by the Duck.ai frontend over the New Tab Page telemetryEvent message, since the frontend owns this picker. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
+    "m_mac_aichat_ntp_reasoning_picker_shown": {
+        "description": "Fired when the New Tab Page omnibar's reasoning-effort picker is shown with a subscriber-exclusive section. Reported by the Duck.ai frontend over the New Tab Page telemetryEvent message, since the frontend owns this picker. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
+    "m_mac_aichat_ntp_reasoning_picker_tryforfree_shown": {
+        "description": "Fired when the New Tab Page omnibar's reasoning-effort picker is shown with a \"Try for Free\" CTA on its subscriber-exclusive section. Reported by the Duck.ai frontend over the New Tab Page telemetryEvent message, since the frontend owns this picker. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
+    "m_mac_aichat_ntp_reasoning_picker_upgrade_shown": {
+        "description": "Fired when the New Tab Page omnibar's reasoning-effort picker is shown with an \"Upgrade\" CTA on its subscriber-exclusive section. Reported by the Duck.ai frontend over the New Tab Page telemetryEvent message, since the frontend owns this picker. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_ntp_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_ntp_pixels.json5
@@ -29,6 +29,13 @@
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
+    "m_mac_aichat_ntp_subscription_upsell_shown": {
+        "description": "Fired when the native subscription upsell dialog is shown after the user taps a gated model or reasoning effort in the New Tab Page omnibar. Pairs with m_mac_aichat_ntp_subscription_upsell_triggered for a view-to-click rate. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
     "m_mac_aichat_ntp_subscription_upsell_triggered": {
         "description": "Fired when user taps a gated model or reasoning effort in the New Tab Page omnibar, routing them to the subscription purchase/upgrade flow",
         "owners": ["tomasstrba"],

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_pixels.json5
@@ -346,5 +346,40 @@
         "triggers": ["other"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
+    "m_mac_aichat_subscription-funnel_subscribe-modal_impression": {
+        "description": "Fired when the Duck.ai subscribe modal is shown in the web frontend. The frontend reports the modal over the reportMetric bridge and the native layer fires this pixel with the funnel origin of the entry point the modal was opened from. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
+    "m_mac_aichat_subscription-funnel_subscribe-modal_subscribe_click": {
+        "description": "Fired when the user clicks the subscribe CTA in the Duck.ai subscribe modal. The frontend reports the click over the reportMetric bridge and the native layer fires this pixel with the funnel origin of the entry point the modal was opened from. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
+    "m_mac_aichat_subscription-funnel_subscribe-modal_activate_click": {
+        "description": "Fired when the user clicks the \"I have a subscription\" CTA in the Duck.ai subscribe modal. The frontend reports the click over the reportMetric bridge and the native layer fires this pixel with the funnel origin of the entry point the modal was opened from. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
+    "m_mac_aichat_subscription-funnel_upgrade-to-pro-modal_impression": {
+        "description": "Fired when the Duck.ai upgrade-to-Pro modal is shown to an existing Plus subscriber in the web frontend. The frontend reports the modal over the reportMetric bridge and the native layer fires this pixel with the funnel origin of the entry point the modal was opened from. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
+    "m_mac_aichat_subscription-funnel_upgrade-to-pro-modal_upgrade_click": {
+        "description": "Fired when the user clicks the upgrade CTA in the Duck.ai upgrade-to-Pro modal. The frontend reports the click over the reportMetric bridge and the native layer fires this pixel with the funnel origin of the entry point the modal was opened from. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_promptbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_promptbar_pixels.json5
@@ -251,5 +251,19 @@
                 "type": "boolean"
             }
         ]
+    },
+    "m_mac_aichat_promptbar_model_picker_shown": {
+        "description": "Fired when the Prompt Bar's model picker is opened showing at least one subscriber-exclusive model — the subscription-funnel impression for that entry point. Impression only: gated rows aren't interactive on this surface, so there is no matching click pixel. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
+    },
+    "m_mac_aichat_promptbar_reasoning_picker_shown": {
+        "description": "Fired when the Prompt Bar's reasoning-effort picker is opened showing at least one gated effort — the subscription-funnel impression for that entry point. Impression only, as above. See https://app.asana.com/1/137249556945/task/1216395339071571",
+        "owners": ["tomasstrba"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel", "subscriptionFunnelOrigin"]
     }
 }

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -1858,12 +1858,12 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         setUserTier(.plus)
 
         // When
-        controller.presentSubscriptionUpsell(requiredTier: .pro, origin: .addressBarReasoningPicker)
+        controller.presentSubscriptionUpsell(requiredTier: .pro, origin: .addressBarReasoningDropdown)
 
         // Then
         XCTAssertTrue(mockSubscriptionUpsellPresenter.routeGatedSelectionCalled)
         XCTAssertEqual(mockSubscriptionUpsellPresenter.lastRequiredTier, .pro)
-        XCTAssertEqual(mockSubscriptionUpsellPresenter.lastOrigin, .addressBarReasoningPicker)
+        XCTAssertEqual(mockSubscriptionUpsellPresenter.lastOrigin, .addressBarReasoningDropdown)
     }
 
     func testWhenRequiredTierForGatedModel_ThenReturnsModelsLowestPublicAccessTier() async {

--- a/macOS/UnitTests/AIChat/AIChatOmnibarSubscriptionUpsellPresenterTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarSubscriptionUpsellPresenterTests.swift
@@ -64,14 +64,14 @@ struct AIChatOmnibarSubscriptionUpsellPresenterTests {
         let (presenter, mockTabShower, mockSubscriptionManager) = createPresenter()
         mockSubscriptionManager.resultURL = URL(string: "https://duckduckgo.com/pro/purchase")!
 
-        let routed = presenter.routeGatedSelection(requiredTier: .pro, userTier: .free, origin: .addressBarReasoningPicker)
+        let routed = presenter.routeGatedSelection(requiredTier: .pro, userTier: .free, origin: .addressBarReasoningDropdown)
 
         #expect(routed == true)
         guard case let .subscription(url) = mockTabShower.capturedContent else {
             Issue.record("Expected .subscription tab content")
             return
         }
-        #expect(url.absoluteString.contains("origin=funnel_addressbar_macos__reasoningpicker"))
+        #expect(url.absoluteString.contains("origin=funnel_addressbar_macos__reasoningdropdown"))
     }
 
     @available(iOS 16, macOS 13, *)
@@ -108,7 +108,7 @@ struct AIChatOmnibarSubscriptionUpsellPresenterTests {
     func internalUserHasNoGatedFlow() async throws {
         let (presenter, mockTabShower, _) = createPresenter()
 
-        let routed = presenter.routeGatedSelection(requiredTier: .pro, userTier: .internal, origin: .addressBarReasoningPicker)
+        let routed = presenter.routeGatedSelection(requiredTier: .pro, userTier: .internal, origin: .addressBarReasoningDropdown)
 
         #expect(routed == false)
         #expect(mockTabShower.capturedContent == nil)

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -618,6 +618,27 @@ struct AIChatUserScriptHandlerTests {
         #expect(pixelFiring.expectedFireCalls == pixelFiring.actualFireCalls)
     }
 
+    /// Pins the wire-visible names, which must match the keys in aichat_pixels.json5. The firing tests
+    /// build expected and actual from the same enum, so they can't catch a wrong name on their own.
+    @available(iOS 16, macOS 13, *)
+    @Test("Modal funnel pixels use the agreed names and carry the origin parameter", .timeLimit(.minutes(1)), arguments: [
+        (AIChatPixel.aiChatSubscriptionFunnelSubscribeModalImpression(origin: "funnel_duckai_macos__freelimit"),
+         "aichat_subscription-funnel_subscribe-modal_impression"),
+        (.aiChatSubscriptionFunnelSubscribeModalSubscribeClick(origin: "funnel_duckai_macos__freelimit"),
+         "aichat_subscription-funnel_subscribe-modal_subscribe_click"),
+        (.aiChatSubscriptionFunnelSubscribeModalActivateClick(origin: "funnel_duckai_macos__freelimit"),
+         "aichat_subscription-funnel_subscribe-modal_activate_click"),
+        (.aiChatSubscriptionFunnelUpgradeToProModalImpression(origin: "funnel_duckai_macos__freelimit"),
+         "aichat_subscription-funnel_upgrade-to-pro-modal_impression"),
+        (.aiChatSubscriptionFunnelUpgradeToProModalUpgradeClick(origin: "funnel_duckai_macos__freelimit"),
+         "aichat_subscription-funnel_upgrade-to-pro-modal_upgrade_click")
+    ])
+    @MainActor
+    func testModalFunnelPixelNameAndParameters(pixel: AIChatPixel, expectedName: String) {
+        #expect(pixel.name == expectedName)
+        #expect(pixel.parameters == ["origin": "funnel_duckai_macos__freelimit"])
+    }
+
     @available(iOS 16, macOS 13, *)
     @Test("didReportMetric maps every allowed modal source to its funnel origin", .timeLimit(.minutes(1)), arguments: [
         ("activatesubscription", "funnel_duckai_macos__activatesubscription"),

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -618,8 +618,8 @@ struct AIChatUserScriptHandlerTests {
         #expect(pixelFiring.expectedFireCalls == pixelFiring.actualFireCalls)
     }
 
-    /// Pins the wire-visible names, which must match the keys in aichat_pixels.json5. The firing tests
-    /// build expected and actual from the same enum, so they can't catch a wrong name on their own.
+    // Pins the names against the aichat_pixels.json5 keys; the firing tests build both sides from
+    // the same enum, so they can't catch a wrong name.
     @available(iOS 16, macOS 13, *)
     @Test("Modal funnel pixels use the agreed names and carry the origin parameter", .timeLimit(.minutes(1)), arguments: [
         (AIChatPixel.aiChatSubscriptionFunnelSubscribeModalImpression(origin: "funnel_duckai_macos__freelimit"),

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -592,6 +592,97 @@ struct AIChatUserScriptHandlerTests {
         #expect(pixelFiring.expectedFireCalls == pixelFiring.actualFireCalls)
     }
 
+    @available(iOS 16, macOS 13, *)
+    @Test("didReportMetric fires the matching modal pixel for each modal metric", .timeLimit(.minutes(1)), arguments: [
+        (AIChatMetricName.userDidOpenSubscribeModal,
+         AIChatPixel.aiChatSubscriptionFunnelSubscribeModalImpression(origin: "funnel_duckai_macos__freelimit")),
+        (.userDidClickSubscribeOnSubscribeModal,
+         .aiChatSubscriptionFunnelSubscribeModalSubscribeClick(origin: "funnel_duckai_macos__freelimit")),
+        (.userDidClickActivateOnSubscribeModal,
+         .aiChatSubscriptionFunnelSubscribeModalActivateClick(origin: "funnel_duckai_macos__freelimit")),
+        (.userDidOpenUpgradeToProModal,
+         .aiChatSubscriptionFunnelUpgradeToProModalImpression(origin: "funnel_duckai_macos__freelimit")),
+        (.userDidClickUpgradeOnUpgradeToProModal,
+         .aiChatSubscriptionFunnelUpgradeToProModalUpgradeClick(origin: "funnel_duckai_macos__freelimit"))
+    ])
+    @MainActor
+    func testModalMetricFiresMatchingModalPixel(metric: AIChatMetricName, expectedPixel: AIChatPixel) async {
+        pixelFiring.expectedFireCalls = [.init(pixel: expectedPixel, frequency: .dailyAndCount)]
+
+        await withCheckedContinuation { continuation in
+            handler.didReportMetric(.init(metricName: metric, source: "freelimit")) {
+                continuation.resume()
+            }
+        }
+
+        #expect(pixelFiring.expectedFireCalls == pixelFiring.actualFireCalls)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("didReportMetric maps every allowed modal source to its funnel origin", .timeLimit(.minutes(1)), arguments: [
+        ("activatesubscription", "funnel_duckai_macos__activatesubscription"),
+        ("aisidebar", "funnel_duckai_macos__aisidebar"),
+        ("disclaimerbanner", "funnel_duckai_macos__disclaimerbanner"),
+        ("freelabel", "funnel_duckai_macos__freelabel"),
+        ("freelimit", "funnel_duckai_macos__freelimit"),
+        ("imagegenerationlimit", "funnel_duckai_macos__imagegenerationlimit"),
+        ("modelpicker", "funnel_duckai_macos__modelpicker"),
+        ("pluslimit", "funnel_duckai_macos__pluslimit"),
+        ("promotioncard", "funnel_duckai_macos__promotioncard"),
+        ("reasoningdropdown", "funnel_duckai_macos__reasoningdropdown"),
+        ("switchmodel", "funnel_duckai_macos__switchmodel"),
+        ("voicechatdurationlimit", "funnel_duckai_macos__voicechatdurationlimit"),
+        ("voicechatlimit", "funnel_duckai_macos__voicechatlimit"),
+        ("unknown", "funnel_duckai_macos__unknown")
+    ])
+    @MainActor
+    func testModalMetricMapsSourceToOrigin(source: String, origin: String) async {
+        pixelFiring.expectedFireCalls = [
+            .init(pixel: AIChatPixel.aiChatSubscriptionFunnelSubscribeModalImpression(origin: origin), frequency: .dailyAndCount)
+        ]
+
+        await withCheckedContinuation { continuation in
+            handler.didReportMetric(.init(metricName: .userDidOpenSubscribeModal, source: source)) {
+                continuation.resume()
+            }
+        }
+
+        #expect(pixelFiring.expectedFireCalls == pixelFiring.actualFireCalls)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("didReportMetric fires no modal pixel when the source is missing or unrecognised", .timeLimit(.minutes(1)), arguments: [
+        nil, "", "somethingnew", "funnel_duckai_macos__freelimit"
+    ] as [String?])
+    @MainActor
+    func testModalMetricWithoutUsableSourceFiresNothing(source: String?) async {
+        await withCheckedContinuation { continuation in
+            handler.didReportMetric(.init(metricName: .userDidOpenSubscribeModal, source: source)) {
+                continuation.resume()
+            }
+        }
+
+        #expect(pixelFiring.actualFireCalls.isEmpty)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("reportMetric decodes source off the wire and fires the modal pixel", .timeLimit(.minutes(1)))
+    @MainActor
+    func testReportMetricDecodesModalSource() async {
+        pixelFiring.expectedFireCalls = [
+            .init(pixel: AIChatPixel.aiChatSubscriptionFunnelSubscribeModalImpression(origin: "funnel_duckai_macos__pluslimit"),
+                  frequency: .dailyAndCount)
+        ]
+
+        _ = await handler.reportMetric(
+            params: ["metricName": "userDidOpenSubscribeModal", "source": "pluslimit"],
+            message: WKScriptMessage.mock()
+        )
+
+        #expect(pixelFiring.expectedFireCalls == pixelFiring.actualFireCalls)
+        #expect(userScriptErrorEventMapper.events.isEmpty)
+    }
+
     // MARK: - Sync tests
 
     @available(iOS 16, macOS 13, *)

--- a/macOS/UnitTests/AIChat/DuckAIPromptPixelFiringTests.swift
+++ b/macOS/UnitTests/AIChat/DuckAIPromptPixelFiringTests.swift
@@ -50,8 +50,11 @@ final class DuckAIPromptPixelFiringTests: XCTestCase {
         (.reasoningEffortSelected, .aiChatAddressBarReasoningEffortSelected),
         (.modelPickerShown, .aiChatAddressBarModelPickerShown(origin: "funnel_addressbar_macos__modelpicker")),
         (.reasoningPickerShown, .aiChatAddressBarReasoningPickerShown(origin: "funnel_addressbar_macos__reasoningdropdown")),
-        (.subscriptionUpsellTriggered(currentTier: "free", requiredTier: "plus", flowType: "modal"),
-         .aiChatAddressBarSubscriptionUpsellTriggered(currentTier: "free", requiredTier: "plus", flowType: "modal")),
+        (.subscriptionUpsellShown(origin: "funnel_addressbar_macos__modelpicker"),
+         .aiChatAddressBarSubscriptionUpsellShown(origin: "funnel_addressbar_macos__modelpicker")),
+        (.subscriptionUpsellTriggered(currentTier: "free", requiredTier: "plus", flowType: "modal", origin: "funnel_addressbar_macos__modelpicker"),
+         .aiChatAddressBarSubscriptionUpsellTriggered(currentTier: "free", requiredTier: "plus", flowType: "modal",
+                                                      origin: "funnel_addressbar_macos__modelpicker")),
         (.voiceChatOpened, nil)
     ]
 
@@ -83,7 +86,8 @@ final class DuckAIPromptPixelFiringTests: XCTestCase {
         (.reasoningEffortSelected, .reasoningEffortSelected),
         (.modelPickerShown, .modelPickerShown(origin: "funnel_promptbar_macos__modelpicker")),
         (.reasoningPickerShown, .reasoningPickerShown(origin: "funnel_promptbar_macos__reasoningdropdown")),
-        (.subscriptionUpsellTriggered(currentTier: "free", requiredTier: "plus", flowType: "modal"), nil),
+        (.subscriptionUpsellShown(origin: "x"), nil),
+        (.subscriptionUpsellTriggered(currentTier: "free", requiredTier: "plus", flowType: "modal", origin: "x"), nil),
         (.voiceChatOpened, .newVoiceChat)
     ]
 

--- a/macOS/UnitTests/AIChat/DuckAIPromptPixelFiringTests.swift
+++ b/macOS/UnitTests/AIChat/DuckAIPromptPixelFiringTests.swift
@@ -48,6 +48,8 @@ final class DuckAIPromptPixelFiringTests: XCTestCase {
         (.tabPickerCanceled, .aiChatAddressBarAttachPickerCanceled),
         (.modelSelected, .aiChatAddressBarModelSelected),
         (.reasoningEffortSelected, .aiChatAddressBarReasoningEffortSelected),
+        (.modelPickerShown, .aiChatAddressBarModelPickerShown(origin: "funnel_addressbar_macos__modelpicker")),
+        (.reasoningPickerShown, .aiChatAddressBarReasoningPickerShown(origin: "funnel_addressbar_macos__reasoningdropdown")),
         (.subscriptionUpsellTriggered(currentTier: "free", requiredTier: "plus", flowType: "modal"),
          .aiChatAddressBarSubscriptionUpsellTriggered(currentTier: "free", requiredTier: "plus", flowType: "modal")),
         (.voiceChatOpened, nil)
@@ -79,9 +81,27 @@ final class DuckAIPromptPixelFiringTests: XCTestCase {
         (.tabPickerCanceled, nil),
         (.modelSelected, .modelSelected),
         (.reasoningEffortSelected, .reasoningEffortSelected),
+        (.modelPickerShown, .modelPickerShown(origin: "funnel_promptbar_macos__modelpicker")),
+        (.reasoningPickerShown, .reasoningPickerShown(origin: "funnel_promptbar_macos__reasoningdropdown")),
         (.subscriptionUpsellTriggered(currentTier: "free", requiredTier: "plus", flowType: "modal"), nil),
         (.voiceChatOpened, .newVoiceChat)
     ]
+
+    /// Names are asserted as literals because the mapping tables build expected and actual from the
+    /// same enum; they have to stay in step with the keys in the pixel definition files.
+    private static let pickerImpressionNames: [(AIChatPixel, String)] = [
+        (.aiChatAddressBarModelPickerShown(origin: "x"), "aichat_addressbar_model_picker_shown"),
+        (.aiChatAddressBarReasoningPickerShown(origin: "x"), "aichat_addressbar_reasoning_picker_shown")
+    ]
+
+    func testPickerImpressionPixelNames() {
+        for (pixel, expectedName) in Self.pickerImpressionNames {
+            XCTAssertEqual(pixel.name, expectedName)
+        }
+        XCTAssertEqual(PromptBarPixel.modelPickerShown(origin: "x").name, "aichat_promptbar_model_picker_shown")
+        XCTAssertEqual(PromptBarPixel.reasoningPickerShown(origin: "x").name, "aichat_promptbar_reasoning_picker_shown")
+        XCTAssertEqual(PromptBarPixel.modelPickerShown(origin: "x").parameters, ["origin": "x"])
+    }
 
     func testWhenAddressBarHandlerMapsAnEvent_ThenItKeepsThePixelItFiredBefore() {
         for (event, expected) in Self.addressBarMapping {

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarSubscriptionDialogPresenterTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarSubscriptionDialogPresenterTests.swift
@@ -68,7 +68,7 @@ struct NewTabPageOmnibarSubscriptionDialogPresenterTests {
             return
         }
         #expect(url.absoluteString.contains("featurePage=duckai"))
-        #expect(url.absoluteString.contains("origin=funnel_newtab_macos__omnibar"))
+        #expect(url.absoluteString.contains("origin=funnel_newtab_macos__modelpicker"))
     }
 
     @available(iOS 16, macOS 13, *)
@@ -116,7 +116,26 @@ struct NewTabPageOmnibarSubscriptionDialogPresenterTests {
             return
         }
         #expect(url.absoluteString.contains("featurePage=duckai"))
-        #expect(url.absoluteString.contains("origin=funnel_newtab_macos__omnibar"))
+        #expect(url.absoluteString.contains("origin=funnel_newtab_macos__modelpicker"))
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("The gated picker decides the funnel origin", .timeLimit(.minutes(1)))
+    func pickerDecidesOrigin() async throws {
+        // Not parameterized: `OmnibarSubscriptionUpsellSource` isn't Sendable, so passing it as a
+        // test argument warns today and fails under the Swift 6 language mode.
+        for (source, expectedOrigin) in [(NewTabPageDataModel.OmnibarSubscriptionUpsellSource.model, "funnel_newtab_macos__modelpicker"),
+                                         (.reasoning, "funnel_newtab_macos__reasoningdropdown")] {
+            let (presenter, mockTabShower, _) = createPresenter()
+
+            presenter.makeUpsellDialog(userTier: .free, source: source).onSubscribe?()
+
+            guard case let .subscription(url) = mockTabShower.capturedContent else {
+                Issue.record("Expected .subscription tab content for \(source)")
+                return
+            }
+            #expect(url.absoluteString.contains("origin=\(expectedOrigin)"))
+        }
     }
 
     @available(iOS 16, macOS 13, *)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216395339071571
Tech Design URL: N/A
CC:

### Description

Closes the remaining Duck.ai subscription-funnel gaps on macOS, so every entry point that can lead to a subscription is counted and attributed.

**Subscribe / upgrade-to-Pro modal.** The frontend reports five metrics for the modal that the funnel entry points open. macOS didn't know those metric names, so they arrived as decode errors instead of pixels. The modal reports which entry point opened it as `source` — an arbitrary string that can be missing — so it's resolved through an allow-list into a `funnel_duckai_macos__*` origin; anything unrecognised fires nothing. Names reuse what Windows shipped.

| Pixel (`m_mac_` added by PixelKit) | FE metric |
|---|---|
| `aichat_subscription-funnel_subscribe-modal_impression` | `userDidOpenSubscribeModal` |
| `aichat_subscription-funnel_subscribe-modal_subscribe_click` | `userDidClickSubscribeOnSubscribeModal` |
| `aichat_subscription-funnel_subscribe-modal_activate_click` | `userDidClickActivateOnSubscribeModal` |
| `aichat_subscription-funnel_upgrade-to-pro-modal_impression` | `userDidOpenUpgradeToProModal` |
| `aichat_subscription-funnel_upgrade-to-pro-modal_upgrade_click` | `userDidClickUpgradeOnUpgradeToProModal` |

**Picker impressions.** No surface reported the funnel impression — all only fired on selection, so a user seeing subscriber-exclusive rows was invisible until they acted. These fire when a picker opens showing at least one gated row.

| Pixel | Origin |
|---|---|
| `aichat_addressbar_{model,reasoning}_picker_shown` | `funnel_addressbar_macos__{modelpicker,reasoningdropdown}` |
| `aichat_promptbar_{model,reasoning}_picker_shown` | `funnel_promptbar_macos__{modelpicker,reasoningdropdown}` |
| `aichat_ntp_{model,reasoning}_picker_shown` (+ `_tryforfree_shown`, `_upgrade_shown`) | `funnel_newtab_macos__{modelpicker,reasoningdropdown}` |

The NTP pickers are frontend-rendered and report over `telemetryEvent`. macOS had been receiving those events since content-scope-scripts 15.21.0 but dropping all of them — the decoder required a `value` field these name-only events don't send. Fixed here.

**Native dialog attribution.** The upsell dialog itself went uncounted, and its click carried no origin, so address-bar clicks couldn't be told apart from other entry points. Adds `aichat_{addressbar,ntp}_subscription_upsell_shown` and puts `origin` on both `_subscription_upsell_triggered` pixels, giving a view-to-click rate per picker.

Also renames the reasoning origin to `reasoningdropdown`, and splits the NTP's single `funnel_newtab_macos__omnibar` per picker — both matching the frontend and Windows.

### Testing Steps

**Automated** — the mapping, origins and pixel names are fully covered:

1. `AIChatUserScriptHandlerTests` — each modal metric fires its pixel; all 14 `source` values map to the right origin; a missing or unrecognised `source` fires nothing; `source` decodes off the wire; pixel names asserted as literals against the JSON5 keys.
2. `DuckAIPromptPixelFiringTests` — picker and dialog events map to the right pixel and origin per surface, the two surfaces never share a name, names asserted as literals.
3. `NewTabPageOmnibarSubscriptionDialogPresenterTests` — `.model`/`.reasoning` resolve to their distinct origins.
4. `AIChatOmnibarControllerTests` and `AIChatOmnibarSubscriptionUpsellPresenterTests` — the reasoning-origin rename.
5. `npm run validate-pixel-defs` from `macOS/`.

**Manual smoke test** — the native pixels can be exercised today (the modal ones can't: the frontend side, ddg#47241, is merged but not deployed). Watch pixels with:

`log stream --predicate 'subsystem == "PixelKit"' --level debug`

Signed in as a free user, so gated rows are visible:

6. Address bar → Duck.ai mode → open the model picker with a subscriber-exclusive model listed → `aichat_addressbar_model_picker_shown` fires with `origin=funnel_addressbar_macos__modelpicker`.
7. Click that gated model → the upsell dialog appears → `aichat_addressbar_subscription_upsell_shown`, same origin.
8. Click **Try for Free** → `aichat_addressbar_subscription_upsell_triggered` with `flow_type=purchase` and the same origin; the subscription page opens carrying it.
9. Repeat 6–8 with the reasoning-effort picker → the same three pixels with `origin=funnel_addressbar_macos__reasoningdropdown`.
10. New Tab Page omnibar → same two pickers → `aichat_ntp_*_picker_shown`, then `aichat_ntp_subscription_upsell_shown` / `_triggered`, all with `funnel_newtab_macos__{modelpicker,reasoningdropdown}`.
11. Prompt Bar (global shortcut) → open its model picker with a gated row → `aichat_promptbar_model_picker_shown` fires, and the gated row stays non-interactive: no dialog and no `*_subscription_upsell_*` pixel. Same for its reasoning picker.
12. Throughout, `aichat_report_metric_decode_error` should never appear.

### Impact

Low — instrumentation only, no user-facing change. Notes for the data side: `funnel_addressbar_macos__reasoningpicker` becomes `…__reasoningdropdown` and the NTP's `funnel_newtab_macos__omnibar` becomes per-picker (both live in 1.201.0/1.202.0, so those series names change); `origin` is added to the existing `addressbar_subscription_upsell_triggered` mid-series; and the new `funnel_promptbar_macos__*` / `funnel_newtab_macos__*` origins still need the origins proposal.
