### PR TITLE
iOS and macOS: Report page-context script errors instead of timeouts

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextCollectionResult.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextCollectionResult.swift
@@ -1,0 +1,38 @@
+//
+//  PageContextCollectionResult.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// What a `collectionResult` message from the page-context user script carried. Failures are
+/// distinguished so a collection that answered with an error isn't measured as one that never answered.
+public enum PageContextCollectionResult: Equatable {
+
+    case collected(AIChatPageContextData)
+
+    /// The script replied with its error envelope, which carries no serialized page data.
+    case scriptError
+
+    /// Serialized page data arrived but could not be decoded.
+    case decodeFailed
+
+    /// The collected context, or `nil` for either failure.
+    public var pageContext: AIChatPageContextData? {
+        guard case .collected(let pageContext) = self else { return nil }
+        return pageContext
+    }
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextCollectionResult.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextCollectionResult.swift
@@ -18,19 +18,12 @@
 
 import Foundation
 
-/// What a `collectionResult` message from the page-context user script carried. Failures are
-/// distinguished so a collection that answered with an error isn't measured as one that never answered.
 public enum PageContextCollectionResult: Equatable {
 
     case collected(AIChatPageContextData)
-
-    /// The script replied with its error envelope, which carries no serialized page data.
     case scriptError
-
-    /// Serialized page data arrived but could not be decoded.
     case decodeFailed
 
-    /// The collected context, or `nil` for either failure.
     public var pageContext: AIChatPageContextData? {
         guard case .collected(let pageContext) = self else { return nil }
         return pageContext

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionOutcome.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionOutcome.swift
@@ -23,7 +23,6 @@ public enum PageContextExtractionOutcome: Equatable {
     public enum FailureReason: String, Equatable {
         case emptyContent = "empty_content"
         case deserializeFailed = "deserialize_failed"
-        /// The user script reported that collection threw; distinct from a hang, which is `timeout`.
         case scriptError = "script_error"
         case timeout
         case noWebView = "no_webview"

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionOutcome.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionOutcome.swift
@@ -23,6 +23,8 @@ public enum PageContextExtractionOutcome: Equatable {
     public enum FailureReason: String, Equatable {
         case emptyContent = "empty_content"
         case deserializeFailed = "deserialize_failed"
+        /// The user script reported that collection threw; distinct from a hang, which is `timeout`.
+        case scriptError = "script_error"
         case timeout
         case noWebView = "no_webview"
         case postFailed = "post_failed"

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionResolver.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/PageContextExtractionResolver.swift
@@ -52,14 +52,17 @@ public struct PageContextExtractionResolver {
     }
 
     /// Returns `nil` when no request is outstanding (a duplicate or a collection we didn't initiate).
-    public mutating func resolve(pageContext: AIChatPageContextData?, now: DispatchTime = .now()) -> Resolution? {
+    public mutating func resolve(_ result: PageContextCollectionResult, now: DispatchTime = .now()) -> Resolution? {
         guard !pending.isEmpty else { return nil }
         let request = pending.removeFirst()
 
         let outcome: PageContextExtractionOutcome
-        if let pageContext {
+        switch result {
+        case .collected(let pageContext):
             outcome = pageContext.content.isEmpty ? .failure(.emptyContent) : .success
-        } else {
+        case .scriptError:
+            outcome = .failure(.scriptError)
+        case .decodeFailed:
             outcome = .failure(.deserializeFailed)
         }
 

--- a/SharedPackages/AIChat/Tests/AIChatTests/PageContextExtractionResolverTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/PageContextExtractionResolverTests.swift
@@ -41,15 +41,15 @@ final class PageContextExtractionResolverTests: XCTestCase {
 
     func testWhenResolveWithNoRequestThenReturnsNil() {
         var resolver = PageContextExtractionResolver()
-        XCTAssertNil(resolver.resolve(pageContext: nonEmptyContext()))
+        XCTAssertNil(resolver.resolve(.collected(nonEmptyContext())))
     }
 
     func testWhenExtraResultArrivesAfterDrainingThenReturnsNil() {
         var resolver = PageContextExtractionResolver()
         resolver.requested(trigger: .navigation)
-        XCTAssertNotNil(resolver.resolve(pageContext: nonEmptyContext()))
+        XCTAssertNotNil(resolver.resolve(.collected(nonEmptyContext())))
         // A second (duplicate) result with nothing pending is skipped — the over-count fix.
-        XCTAssertNil(resolver.resolve(pageContext: nonEmptyContext()))
+        XCTAssertNil(resolver.resolve(.collected(nonEmptyContext())))
     }
 
     // MARK: - Reset on navigation
@@ -65,7 +65,7 @@ final class PageContextExtractionResolverTests: XCTestCase {
         XCTAssertFalse(resolver.hasPendingCollections)
         // A previous page's result arriving after reset has nothing to pair with, so it can't
         // mis-attribute the next page's telemetry.
-        XCTAssertNil(resolver.resolve(pageContext: nonEmptyContext()))
+        XCTAssertNil(resolver.resolve(.collected(nonEmptyContext())))
     }
 
     // MARK: - Outcome derivation
@@ -73,13 +73,13 @@ final class PageContextExtractionResolverTests: XCTestCase {
     func testWhenNonEmptyContextThenSuccess() {
         var resolver = PageContextExtractionResolver()
         resolver.requested(trigger: .navigation)
-        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext())?.outcome, .success)
+        XCTAssertEqual(resolver.resolve(.collected(nonEmptyContext()))?.outcome, .success)
     }
 
     func testWhenEmptyContextThenEmptyContentFailure() {
         var resolver = PageContextExtractionResolver()
         resolver.requested(trigger: .auto)
-        XCTAssertEqual(resolver.resolve(pageContext: emptyContext())?.outcome, .failure(.emptyContent))
+        XCTAssertEqual(resolver.resolve(.collected(emptyContext()))?.outcome, .failure(.emptyContent))
     }
 
     /// A page title alone (e.g. a page whose content extraction found nothing) is not a
@@ -87,13 +87,34 @@ final class PageContextExtractionResolverTests: XCTestCase {
     func testWhenTitledContextHasEmptyContentThenEmptyContentFailure() {
         var resolver = PageContextExtractionResolver()
         resolver.requested(trigger: .userRequest)
-        XCTAssertEqual(resolver.resolve(pageContext: titleOnlyContext())?.outcome, .failure(.emptyContent))
+        XCTAssertEqual(resolver.resolve(.collected(titleOnlyContext()))?.outcome, .failure(.emptyContent))
     }
 
-    func testWhenNilContextThenDeserializeFailedFailure() {
+    func testWhenDecodeFailedThenDeserializeFailedFailure() {
         var resolver = PageContextExtractionResolver()
         resolver.requested(trigger: .auto)
-        XCTAssertEqual(resolver.resolve(pageContext: nil)?.outcome, .failure(.deserializeFailed))
+        XCTAssertEqual(resolver.resolve(.decodeFailed)?.outcome, .failure(.deserializeFailed))
+    }
+
+    /// A collection that threw in the page must be reported as such, not as a timeout — the script
+    /// did answer, so the pending entry is resolved immediately with its own reason and latency.
+    func testWhenScriptErrorThenScriptErrorFailureWithLatency() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .userRequest, at: time(10))
+
+        let resolution = resolver.resolve(.scriptError, now: time(10.2))
+
+        XCTAssertEqual(resolution?.outcome, .failure(.scriptError))
+        XCTAssertEqual(resolution?.trigger, .userRequest)
+        XCTAssertEqual(resolution?.latency, .under1s)
+        XCTAssertFalse(resolver.hasPendingCollections)
+    }
+
+    func testWhenScriptErrorResolvesRequestThenItCannotAlsoExpireAsTimeout() {
+        var resolver = PageContextExtractionResolver()
+        resolver.requested(trigger: .auto, at: time(0))
+        _ = resolver.resolve(.scriptError, now: time(1))
+        XCTAssertTrue(resolver.expireCollections(olderThan: 30, now: time(40)).isEmpty)
     }
 
     // MARK: - FIFO trigger attribution
@@ -103,9 +124,9 @@ final class PageContextExtractionResolverTests: XCTestCase {
         resolver.requested(trigger: .navigation)
         resolver.requested(trigger: .userRequest)
 
-        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext())?.trigger, .navigation)
-        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext())?.trigger, .userRequest)
-        XCTAssertNil(resolver.resolve(pageContext: nonEmptyContext()))
+        XCTAssertEqual(resolver.resolve(.collected(nonEmptyContext()))?.trigger, .navigation)
+        XCTAssertEqual(resolver.resolve(.collected(nonEmptyContext()))?.trigger, .userRequest)
+        XCTAssertNil(resolver.resolve(.collected(nonEmptyContext())))
     }
 
     /// The review scenario: the eager pre-markup collect returns empty and the post-markup collect
@@ -115,11 +136,11 @@ final class PageContextExtractionResolverTests: XCTestCase {
         resolver.requested(trigger: .navigation)
         resolver.requested(trigger: .navigation)
 
-        let eager = resolver.resolve(pageContext: emptyContext())
+        let eager = resolver.resolve(.collected(emptyContext()))
         XCTAssertEqual(eager?.outcome, .failure(.emptyContent))
         XCTAssertEqual(eager?.trigger, .navigation)
 
-        let real = resolver.resolve(pageContext: nonEmptyContext())
+        let real = resolver.resolve(.collected(nonEmptyContext()))
         XCTAssertEqual(real?.outcome, .success)
         XCTAssertEqual(real?.trigger, .navigation)
     }
@@ -129,25 +150,25 @@ final class PageContextExtractionResolverTests: XCTestCase {
     func testWhenUnderOneSecondThenUnder1sBucket() {
         var resolver = PageContextExtractionResolver()
         resolver.requested(trigger: .navigation, at: time(10))
-        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext(), now: time(10.5))?.latency, .under1s)
+        XCTAssertEqual(resolver.resolve(.collected(nonEmptyContext()), now: time(10.5))?.latency, .under1s)
     }
 
     func testWhenExactlyOneSecondThenOneToFiveBucket() {
         var resolver = PageContextExtractionResolver()
         resolver.requested(trigger: .navigation, at: time(10))
-        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext(), now: time(11))?.latency, .oneToFiveSeconds)
+        XCTAssertEqual(resolver.resolve(.collected(nonEmptyContext()), now: time(11))?.latency, .oneToFiveSeconds)
     }
 
     func testWhenExactlyFiveSecondsThenOneToFiveBucket() {
         var resolver = PageContextExtractionResolver()
         resolver.requested(trigger: .navigation, at: time(10))
-        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext(), now: time(15))?.latency, .oneToFiveSeconds)
+        XCTAssertEqual(resolver.resolve(.collected(nonEmptyContext()), now: time(15))?.latency, .oneToFiveSeconds)
     }
 
     func testWhenOverFiveSecondsThenOver5sBucket() {
         var resolver = PageContextExtractionResolver()
         resolver.requested(trigger: .navigation, at: time(10))
-        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext(), now: time(16))?.latency, .over5s)
+        XCTAssertEqual(resolver.resolve(.collected(nonEmptyContext()), now: time(16))?.latency, .over5s)
     }
 
     func testWhenTwoRequestsThenEachGetsItsOwnLatency() {
@@ -156,9 +177,9 @@ final class PageContextExtractionResolverTests: XCTestCase {
         resolver.requested(trigger: .userRequest, at: time(14))
 
         // First request started at 10; resolved at 10.4 → under 1s.
-        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext(), now: time(10.4))?.latency, .under1s)
+        XCTAssertEqual(resolver.resolve(.collected(nonEmptyContext()), now: time(10.4))?.latency, .under1s)
         // Second request started at 14; resolved at 20 → over 5s (not measured from the first start).
-        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext(), now: time(20))?.latency, .over5s)
+        XCTAssertEqual(resolver.resolve(.collected(nonEmptyContext()), now: time(20))?.latency, .over5s)
     }
 
     // MARK: - hasPendingCollections
@@ -168,7 +189,7 @@ final class PageContextExtractionResolverTests: XCTestCase {
         XCTAssertFalse(resolver.hasPendingCollections)
         resolver.requested(trigger: .navigation)
         XCTAssertTrue(resolver.hasPendingCollections)
-        _ = resolver.resolve(pageContext: nonEmptyContext())
+        _ = resolver.resolve(.collected(nonEmptyContext()))
         XCTAssertFalse(resolver.hasPendingCollections)
     }
 
@@ -208,13 +229,13 @@ final class PageContextExtractionResolverTests: XCTestCase {
         // At t=6 only the first (age 6) is past the 5s timeout; the second (age 2) stays pending.
         XCTAssertEqual(resolver.expireCollections(olderThan: 5, now: time(6)).map(\.trigger), [.navigation])
         XCTAssertTrue(resolver.hasPendingCollections)
-        XCTAssertEqual(resolver.resolve(pageContext: nonEmptyContext(), now: time(6))?.trigger, .userRequest)
+        XCTAssertEqual(resolver.resolve(.collected(nonEmptyContext()), now: time(6))?.trigger, .userRequest)
     }
 
     func testWhenResolvedBeforeTimeoutThenExpiryIsNoOp() {
         var resolver = PageContextExtractionResolver()
         resolver.requested(trigger: .navigation, at: time(0))
-        _ = resolver.resolve(pageContext: nonEmptyContext(), now: time(1))
+        _ = resolver.resolve(.collected(nonEmptyContext()), now: time(1))
         XCTAssertTrue(resolver.expireCollections(olderThan: 5, now: time(10)).isEmpty)
     }
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatPageContextHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatPageContextHandler.swift
@@ -60,7 +60,7 @@ typealias PageContextMIMETypeProvider = (URL) -> String?
 
 /// Protocol for page context collection, enabling dependency injection and testing.
 protocol PageContextCollecting: AnyObject {
-    var collectionResultPublisher: AnyPublisher<AIChatPageContextData?, Never> { get }
+    var collectionResultPublisher: AnyPublisher<PageContextCollectionResult, Never> { get }
     var webView: WKWebView? { get set }
     func collect()
 }
@@ -269,8 +269,8 @@ private extension AIChatPageContextHandler {
     }
 
     /// No pending request => a duplicate or a collect we didn't initiate; skip.
-    func fireExtractionOutcome(for pageContext: AIChatPageContextData?) {
-        guard let resolution = extractionResolver.resolve(pageContext: pageContext) else { return }
+    func fireExtractionOutcome(for result: PageContextCollectionResult) {
+        guard let resolution = extractionResolver.resolve(result) else { return }
         fireExtractionPixel(resolution.outcome, trigger: resolution.trigger, latency: resolution.latency)
     }
 
@@ -310,13 +310,13 @@ private extension AIChatPageContextHandler {
         Logger.aiChat.debug("[PageContext] startObservingUpdates - subscribing to new script instance")
         updatesCancellable = script.collectionResultPublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] pageContext in
+            .sink { [weak self] result in
                 guard let self else { return }
 
-                self.fireExtractionOutcome(for: pageContext)
+                self.fireExtractionOutcome(for: result)
 
-                guard let pageContext else {
-                    Logger.aiChat.debug("[PageContext] Context collection returned nil - decode failure, publishing nil to subscribers")
+                guard let pageContext = result.pageContext else {
+                    Logger.aiChat.debug("[PageContext] Context collection failed (\(String(describing: result))) - publishing nil to subscribers")
                     self.contextSubject.send(nil)
                     return
                 }

--- a/iOS/DuckDuckGo/AIChat/UserScript/PageContextUserScript.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/PageContextUserScript.swift
@@ -28,11 +28,13 @@ import WebKit
 
 private struct PageContextCollectionPayload: Codable {
     let serializedPageData: String?
+    /// Set (with no `serializedPageData`) when collection threw in the page.
+    let error: String?
 }
 
 final class PageContextUserScript: NSObject, Subfeature {
 
-    let collectionResultPublisher: AnyPublisher<AIChatPageContextData?, Never>
+    let collectionResultPublisher: AnyPublisher<PageContextCollectionResult, Never>
 
     static let featureName: String = "pageContext"
     var featureName: String { Self.featureName }
@@ -41,7 +43,7 @@ final class PageContextUserScript: NSObject, Subfeature {
     weak var webView: WKWebView?
     let messageOriginPolicy: MessageOriginPolicy = .all
 
-    private let collectionResultSubject = PassthroughSubject<AIChatPageContextData?, Never>()
+    private let collectionResultSubject = PassthroughSubject<PageContextCollectionResult, Never>()
 
     private enum MessageName: String {
         case collect
@@ -79,19 +81,31 @@ final class PageContextUserScript: NSObject, Subfeature {
         }
     }
 
-    /// Receives collected page context
+    /// Receives collected page context. Every reply must publish a result, including failures —
+    /// otherwise the caller's pending collection is only cleared by its timeout.
     private func collectionResult(params: Any, message: UserScriptMessage) async -> Encodable? {
         Logger.aiChat.debug("[PageContextUserScript] collectionResult received")
-        guard let payload: PageContextCollectionPayload = DecodableHelper.decode(from: params),
-              let jsonString = payload.serializedPageData,
-              let jsonData = jsonString.data(using: .utf8) else {
+        guard let payload: PageContextCollectionPayload = DecodableHelper.decode(from: params) else {
             Logger.aiChat.debug("[PageContextUserScript] collectionResult - failed to decode payload")
+            collectionResultSubject.send(.decodeFailed)
             return nil
         }
 
-        let pageContextData: AIChatPageContextData? = DecodableHelper.decode(jsonData: jsonData)
-        Logger.aiChat.debug("[PageContextUserScript] collectionResult - decoded context: \(pageContextData != nil ? "success" : "nil")")
-        collectionResultSubject.send(pageContextData)
+        guard let jsonString = payload.serializedPageData,
+              let jsonData = jsonString.data(using: .utf8) else {
+            Logger.aiChat.debug("[PageContextUserScript] collectionResult - script error: \(payload.error ?? "unknown")")
+            collectionResultSubject.send(.scriptError)
+            return nil
+        }
+
+        guard let pageContextData: AIChatPageContextData = DecodableHelper.decode(jsonData: jsonData) else {
+            Logger.aiChat.debug("[PageContextUserScript] collectionResult - failed to decode context")
+            collectionResultSubject.send(.decodeFailed)
+            return nil
+        }
+
+        Logger.aiChat.debug("[PageContextUserScript] collectionResult - decoded context: success")
+        collectionResultSubject.send(.collected(pageContextData))
 
         return nil
     }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatPageContextHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatPageContextHandlerTests.swift
@@ -466,6 +466,34 @@ final class AIChatPageContextHandlerTests: XCTestCase {
         XCTAssertEqual(extractionPixels.calls.first?.outcome, .failure(.deserializeFailed))
     }
 
+    /// A script error used to be dropped without resolving the request, so it surfaced 30s later as
+    /// a timeout. It must now report its own reason, with a latency, as soon as the reply arrives.
+    func testWhenScriptErrorThenReportsScriptErrorOutcomeNotTimeout() {
+        let mockScript = MockPageContextCollecting()
+        let extractionPixels = MockPageContextExtractionPixelFiring()
+        let policy = makeBlocklistPolicy()
+        let handler = makeHandler(
+            webViewProvider: { WKWebView() },
+            userScriptProvider: { mockScript },
+            attachabilityPolicyProvider: { policy },
+            currentURLProvider: { URL(string: "https://example.com/article") },
+            mimeTypeProvider: { _ in "text/html" },
+            extractionPixelHandler: extractionPixels
+        )
+
+        let expectation = XCTestExpectation(description: "Context published")
+        handler.contextPublisher.dropFirst().first().sink { _ in expectation.fulfill() }.store(in: &cancellables)
+
+        handler.triggerContextCollection(trigger: .userRequest)
+        mockScript.simulateScriptError()
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(extractionPixels.calls.count, 1)
+        XCTAssertEqual(extractionPixels.calls.first?.outcome, .failure(.scriptError))
+        XCTAssertEqual(extractionPixels.calls.first?.trigger, .userRequest)
+        XCTAssertNotNil(extractionPixels.calls.first?.latency)
+    }
+
     func testWhenNoAttachabilityConfigThenCollectsButFiresNoExtractionPixels() {
         let mockScript = MockPageContextCollecting()
         let extractionPixels = MockPageContextExtractionPixelFiring()
@@ -699,9 +727,9 @@ private final class MockContextualModePixelHandler: AIChatContextualModePixelFir
 // MARK: - Mock Page Context Collecting
 
 private final class MockPageContextCollecting: PageContextCollecting {
-    private let mockSubject = PassthroughSubject<AIChatPageContextData?, Never>()
+    private let mockSubject = PassthroughSubject<PageContextCollectionResult, Never>()
 
-    var collectionResultPublisher: AnyPublisher<AIChatPageContextData?, Never> {
+    var collectionResultPublisher: AnyPublisher<PageContextCollectionResult, Never> {
         mockSubject.eraseToAnyPublisher()
     }
 
@@ -714,7 +742,11 @@ private final class MockPageContextCollecting: PageContextCollecting {
     }
 
     func simulateNilContext() {
-        mockSubject.send(nil)
+        mockSubject.send(.decodeFailed)
+    }
+
+    func simulateScriptError() {
+        mockSubject.send(.scriptError)
     }
 
     func simulateEmptyContext() {
@@ -726,7 +758,7 @@ private final class MockPageContextCollecting: PageContextCollecting {
             truncated: false,
             fullContentLength: 0
         )
-        mockSubject.send(emptyContext)
+        mockSubject.send(.collected(emptyContext))
     }
 
     func simulateValidContext() {
@@ -738,11 +770,11 @@ private final class MockPageContextCollecting: PageContextCollecting {
             truncated: false,
             fullContentLength: 39
         )
-        mockSubject.send(validContext)
+        mockSubject.send(.collected(validContext))
     }
 
     func simulate(context: AIChatPageContextData) {
-        mockSubject.send(context)
+        mockSubject.send(.collected(context))
     }
 }
 

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_page_context_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_page_context_pixels.json5
@@ -17,7 +17,7 @@
                 "key": "reason",
                 "description": "Why extraction produced no usable content.",
                 "type": "string",
-                "enum": ["empty_content", "deserialize_failed", "timeout", "no_webview", "post_failed", "tab_evicted"]
+                "enum": ["empty_content", "deserialize_failed", "script_error", "timeout", "no_webview", "post_failed", "tab_evicted"]
             },
             {
                 "key": "trigger",

--- a/macOS/DuckDuckGo/AIChat/UserScript/PageContextUserScript.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/PageContextUserScript.swift
@@ -28,6 +28,8 @@ import WebKit
 
 struct PageContextCollectionPayload: Codable {
     let serializedPageData: String?
+    /// Set (with no `serializedPageData`) when collection threw in the page.
+    let error: String?
 }
 
 struct PageContextResponse: Codable {
@@ -39,7 +41,7 @@ struct SelectionContextResponse: Codable {
 }
 
 final class PageContextUserScript: NSObject, Subfeature {
-    public let collectionResultPublisher: AnyPublisher<AIChatPageContextData?, Never>
+    public let collectionResultPublisher: AnyPublisher<PageContextCollectionResult, Never>
     static public let featureName: String = "pageContext"
     public var featureName: String {
         Self.featureName
@@ -48,7 +50,7 @@ final class PageContextUserScript: NSObject, Subfeature {
     weak var webView: WKWebView?
     let messageOriginPolicy: MessageOriginPolicy = .all
 
-    private let collectionResultSubject = PassthroughSubject<AIChatPageContextData?, Never>()
+    private let collectionResultSubject = PassthroughSubject<PageContextCollectionResult, Never>()
     private var cancellables: Set<AnyCancellable> = []
 
     public func with(broker: UserScriptMessageBroker) {
@@ -98,7 +100,8 @@ final class PageContextUserScript: NSObject, Subfeature {
             cancellable = collectionResultSubject
                 .first()
                 .sink { result in
-                    continuation.yield(result)
+                    // A failed collection yields nil, same as the timeout branch below.
+                    continuation.yield(result.pageContext)
                     continuation.finish()
                     cancellable?.cancel()
                 }
@@ -133,16 +136,27 @@ final class PageContextUserScript: NSObject, Subfeature {
         }
     }
 
-    /// Receives collected page context
+    /// Receives collected page context. Every reply must publish a result, including failures —
+    /// otherwise the caller's pending collection is only cleared by its timeout.
     private func collectionResult(params: Any, message: UserScriptMessage) async -> Encodable? {
-        guard let payload: PageContextCollectionPayload = DecodableHelper.decode(from: params),
-              let jsonString = payload.serializedPageData,
-              let jsonData = jsonString.data(using: .utf8) else {
+        guard let payload: PageContextCollectionPayload = DecodableHelper.decode(from: params) else {
+            collectionResultSubject.send(.decodeFailed)
             return nil
         }
 
-        let pageContextData: AIChatPageContextData? = DecodableHelper.decode(jsonData: jsonData)
-        collectionResultSubject.send(pageContextData)
+        guard let jsonString = payload.serializedPageData,
+              let jsonData = jsonString.data(using: .utf8) else {
+            Logger.aiChat.debug("[PageContextUserScript] collectionResult - script error: \(payload.error ?? "unknown")")
+            collectionResultSubject.send(.scriptError)
+            return nil
+        }
+
+        guard let pageContextData: AIChatPageContextData = DecodableHelper.decode(jsonData: jsonData) else {
+            collectionResultSubject.send(.decodeFailed)
+            return nil
+        }
+
+        collectionResultSubject.send(.collected(pageContextData))
 
         return nil
     }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -231,10 +231,11 @@ final class PageContextTabExtension {
 
         pageContextUserScript.collectionResultPublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] pageContext in
+            .sink { [weak self] result in
                 guard let self else {
                     return
                 }
+                let pageContext = result.pageContext
                 /// Process full collection when auto-collect is enabled (or the user explicitly
                 /// requested context). When auto-collect is OFF but we requested a signals-only
                 /// collection, deliver just the page-type signals (content stripped). Otherwise
@@ -243,7 +244,7 @@ final class PageContextTabExtension {
                     self.pendingSignalsOnlyCollection = false
                     let wasForced = self.shouldForceContextCollection
                     self.shouldForceContextCollection = false
-                    self.fireExtractionOutcome(for: pageContext)
+                    self.fireExtractionOutcome(for: result)
                     if Self.shouldDeliverCollectionResult(pageContext, wasForced: wasForced, cached: self.cachedPageContext) {
                         Task {
                             await self.handle(pageContext)
@@ -431,9 +432,9 @@ final class PageContextTabExtension {
         fireExtractionPixel(.prevented(reason), trigger: trigger, latency: nil)
     }
 
-    private func fireExtractionOutcome(for pageContext: AIChatPageContextData?) {
+    private func fireExtractionOutcome(for result: PageContextCollectionResult) {
         // No pending request → duplicate or a collect we didn't initiate; skip the pixel.
-        guard let resolution = extractionResolver.resolve(pageContext: pageContext) else {
+        guard let resolution = extractionResolver.resolve(result) else {
             return
         }
         fire(resolution)

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_page_context_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_page_context_pixels.json5
@@ -52,7 +52,7 @@
                 "key": "reason",
                 "description": "Why extraction produced no usable content.",
                 "type": "string",
-                "enum": ["empty_content", "deserialize_failed", "timeout", "no_webview", "post_failed", "tab_evicted"]
+                "enum": ["empty_content", "deserialize_failed", "script_error", "timeout", "no_webview", "post_failed", "tab_evicted"]
             },
             {
                 "key": "trigger",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1217188480589111?focus=true
Tech Design URL:
CC:

### Description
Correctly send pixel with script_error instead of timeout when the collection fails

### Testing Steps

1. Serve a page whose extraction throws — e.g. one that runs `document.head.remove()`, which throws in the unguarded `document.head.querySelectorAll` inside `getFaviconList()`. You can find some [here](https://app.asana.com/1/137249556945/project/1201011656765697/task/1217189675296167?focus=true), no-head.html
2. Open Duck.ai on that page and attach it (or leave auto-attach on). The failure pixel should fire immediately with `reason=script_error` and a `latency` param, instead of `reason=timeout` after 30s.
3. Attach an ordinary page and confirm `extraction_success` still fires and the context chip attaches as before.

### Impact and Risks

Low — measurement-only change; the UI path still treats a failed collection as nil context exactly as before.

#### What could go wrong?

The `reason` enum gains a value, so any dashboard that enumerates reasons will omit `script_error` until its query is updated.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only change with no auth or data-handling impact; dashboards that enumerate failure reasons need to include `script_error`.
> 
> **Overview**
> When in-page extraction **throws**, Duck.ai now records **`reason=script_error`** with a **latency** bucket as soon as the script replies, instead of leaving the collect pending until the **30s** safety timeout mislabels it as **`timeout`**.
> 
> The collection pipeline moves from optional **`AIChatPageContextData?`** to **`PageContextCollectionResult`** (**`collected`**, **`scriptError`**, **`decodeFailed`**). **`PageContextUserScript`** on iOS and macOS always publishes one of those outcomes (including decode/script failures from the payload’s optional **`error`** field). **`PageContextExtractionResolver`** pairs those results with pending requests FIFO. **Pixel definitions** add **`script_error`** to the failed-extraction **`reason`** enum.
> 
> **UI behavior is unchanged**: failed collections still surface as nil context to subscribers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28162947ee814054efe8595865e291a84e0ae8d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->