### PR TITLE
macOS: Fix visited links never being recorded

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/WKWebViewExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/WKWebViewExtension.swift
@@ -329,11 +329,17 @@ extension WKWebView {
             return self.value(forKey: NSStringFromSelector(Selector.addsVisitedLinks)) as? Bool ?? false
         }
         set {
-            guard self.responds(to: Selector.addsVisitedLinks) else {
+            // `perform(_:with:)` would pass the boxed value as a pointer where WebKit expects a BOOL,
+            // leaving the flag set to the low byte of that pointer instead of `true`.
+            guard self.responds(to: Selector.setAddsVisitedLinks),
+                  let method = class_getInstanceMethod(object_getClass(self), Selector.setAddsVisitedLinks) else {
                 assertionFailure("WKWebView doesn‘t respond to _setAddsVisitedLinks:")
                 return
             }
-            self.perform(Selector.setAddsVisitedLinks, with: newValue ? true : nil)
+            let imp = method_getImplementation(method)
+            typealias SetAddsVisitedLinksType = @convention(c) (WKWebView, ObjectiveC.Selector, ObjCBool) -> Void
+            let setAddsVisitedLinks = unsafeBitCast(imp, to: SetAddsVisitedLinksType.self)
+            setAddsVisitedLinks(self, Selector.setAddsVisitedLinks, ObjCBool(newValue))
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1213203224545286?focus=true
Tech Design URL:
CC:

### Description

Fixes search result links never turning the visited colour. The private `_setAddsVisitedLinks:` flag was set with `perform(_:with:)`, which passes a boxed value where WebKit expects a primitive BOOL — WebKit read the low byte of the `NSNumber` pointer (0xf8) rather than 1, so it never recorded visits. The getter read back truthy, which hid this since the flag landed in [#3261](https://github.com/duckduckgo/macos-browser/pull/3261/changes).

### Testing Steps
1. Search on DuckDuckGo, click a result, then go back → the title renders in the visited colour.
2. Repeat in a Fire Window → visited colour applies; a second Fire Window shows unvisited.
3. Burn with the Fire button → titles return to the unvisited colour.

### Impact
Low. Restores intended behaviour of an existing feature; nothing new is stored.

### Quality Considerations
`:visited` becomes observable to pages again — a known cross-site history side channel that WebKit mitigates by blocking style readback, and this only brings us to Safari's behaviour. Two follow-ups not addressed here: deleting a single entry from autocomplete (⇧⌫) doesn't clear its visited link, and the store is in-memory so visited state resets on relaunch.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single setter fix in existing WebKit SPI glue; restores intended behavior with no new persistence or auth changes.
> 
> **Overview**
> **Fixes visited link styling** (e.g. DuckDuckGo search result titles after click-and-back) by correcting how the private `_setAddsVisitedLinks:` flag is written on `WKWebView`.
> 
> The setter no longer uses `perform(_:with:)`, which boxed the boolean and left WebKit reading the wrong byte so visits were not recorded. It now invokes the WebKit IMP directly with `ObjCBool`, matching the pattern already used in this file for other private APIs. Tabs still set `addsVisitedLinks = true` at creation; only the write path changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85225088259c73ee9f760f1397a52020278ebf35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->