### PR TITLE
Remove feature flag: aiChatRemoveSuggestion

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -544,9 +544,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Enables voice chat shortcut in the focused address bar
     case voiceShortcut
 
-    /// Enables removing individual AI chat suggestions
-    case removeSuggestion
-
     /// Enables the Duck.ai top-level main menu shortcut (macOS only)
     case mainMenuShortcut
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -951,28 +951,25 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             )
         }
 
-        // Handle suggestion deletions (gated by feature flag)
-        let canRemoveSuggestions = NSApp.delegateTyped.featureFlagger.isFeatureOn(.aiChatRemoveSuggestion)
-        suggestionsView.canDeleteSuggestions = canRemoveSuggestions
-        if canRemoveSuggestions {
-            suggestionsView.onSuggestionDeleted = { [weak self] suggestion in
-                guard let self, let window = self.view.window else { return }
+        // Handle suggestion deletions
+        suggestionsView.canDeleteSuggestions = true
+        suggestionsView.onSuggestionDeleted = { [weak self] suggestion in
+            guard let self, let window = self.view.window else { return }
 
-                PixelKit.fire(AIChatPixel.aiChatRecentChatDeleteButtonClicked, frequency: .dailyAndCount, includeAppVersionParameter: true)
+            PixelKit.fire(AIChatPixel.aiChatRecentChatDeleteButtonClicked, frequency: .dailyAndCount, includeAppVersionParameter: true)
 
-                let alert = NSAlert.recentChatDeleteConfirmation(title: suggestion.title)
-                alert.beginSheetModal(for: window) { [weak self] response in
-                    guard let self else { return }
-                    guard response == .OK else {
-                        PixelKit.fire(AIChatPixel.aiChatRecentChatDeleteCancelled, frequency: .dailyAndCount, includeAppVersionParameter: true)
-                        return
-                    }
-                    PixelKit.fire(AIChatPixel.aiChatRecentChatDeleteConfirmed, frequency: .dailyAndCount, includeAppVersionParameter: true)
-                    self.omnibarController.suggestionsViewModel.removeSuggestion(suggestion)
-                    // Refresh after deletion: with native storage unavailable, only the JS clear removes the chat.
-                    self.aiChatDeleter.deleteChat(chatID: suggestion.chatId) { [weak self] in
-                        self?.omnibarController.refreshSuggestions()
-                    }
+            let alert = NSAlert.recentChatDeleteConfirmation(title: suggestion.title)
+            alert.beginSheetModal(for: window) { [weak self] response in
+                guard let self else { return }
+                guard response == .OK else {
+                    PixelKit.fire(AIChatPixel.aiChatRecentChatDeleteCancelled, frequency: .dailyAndCount, includeAppVersionParameter: true)
+                    return
+                }
+                PixelKit.fire(AIChatPixel.aiChatRecentChatDeleteConfirmed, frequency: .dailyAndCount, includeAppVersionParameter: true)
+                self.omnibarController.suggestionsViewModel.removeSuggestion(suggestion)
+                // Refresh after deletion: with native storage unavailable, only the JS clear removes the chat.
+                self.aiChatDeleter.deleteChat(chatID: suggestion.chatId) { [weak self] in
+                    self?.omnibarController.refreshSuggestions()
                 }
             }
         }

--- a/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags/Sources/FeatureFlags/FeatureFlag.swift
@@ -399,10 +399,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Defers menu population to NSMenuDelegate.menuNeedsUpdate(_:) to avoid expensive eager rebuilds
     case lazyMenuRebuild
 
-    /// Enables removing individual AI chat suggestions from the omnibar
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213761882751264?focus=true
-    case aiChatRemoveSuggestion
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213813585476250?focus=true
     case screenTimeCleaning
 
@@ -739,8 +735,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.websitesHistoryFirstTimeQuitSurvey))
         case .lazyMenuRebuild:
             Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.lazyMenuRebuild))
-        case .aiChatRemoveSuggestion:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.removeSuggestion), category: .duckAI)
         case .screenTimeCleaning:
             Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.screenTimeCleaning))
         case .tabSuspension:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1213761882751264
Tech Design URL:
CC:

### Description
Feature flag `aiChatRemoveSuggestion` approved, removing conditional code. Deleting individual AI chat suggestions from the macOS omnibar is now always available; the feature flag and its `removeSuggestion` subfeature entry are removed.

### Testing Steps
1. Open the Duck.ai omnibar so recent chat suggestions are shown.
2. Hover over a suggestion and use the delete affordance — verify the removal confirmation alert appears.
3. Confirm deletion and verify the chat is removed from suggestions and history.

### Impact
Low — this flag was already fully rolled out (Approved); this only removes the now-redundant remote gate. No user-facing behavior change.

### Quality Considerations
Did not touch the bundled `macos-config.json`, which is managed server-side.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MywB56zaJxLNd3KYMRGFQs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag cleanup only; deletion behavior was already shipped behind an approved remote flag, with no new logic paths.
> 
> **Overview**
> Removes the **`aiChatRemoveSuggestion`** rollout gate now that individual AI chat deletion from the macOS Duck.ai omnibar is fully approved. The **`removeSuggestion`** privacy subfeature and matching **`FeatureFlag.aiChatRemoveSuggestion`** entry (and its config mapping) are deleted.
> 
> In **`AIChatOmnibarContainerViewController`**, recent-chat delete is no longer wrapped in a feature check: **`canDeleteSuggestions`** is always **`true`** and the **`onSuggestionDeleted`** handler (confirmation sheet, pixels, **`removeSuggestion`**, **`deleteChat`**, refresh) runs unconditionally.
> 
> No intended user-facing change for users who already had the flag on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b6c5ec84f53ab278f0e243561a33323c25e2afc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->