### PR TITLE
EventHub for Apple #1b: Add diagnostics — logging at every fail-safe boundary, plus two error events

### DIFF
--- a/SharedPackages/EventHub/Package.swift
+++ b/SharedPackages/EventHub/Package.swift
@@ -40,6 +40,7 @@ let package = Package(
         .target(
             name: "EventHub",
             dependencies: [
+                .product(name: "Common", package: "BrowserServicesKit"),
                 .product(name: "Persistence", package: "BrowserServicesKit"),
                 .product(name: "UserScript", package: "BrowserServicesKit"),
             ]),

--- a/SharedPackages/EventHub/Sources/EventHub/Config/BucketCounter.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Config/BucketCounter.swift
@@ -29,9 +29,10 @@ public struct BucketConfig: Equatable, Sendable {
     }
 }
 
-/// A single (name, config) pair. JSON object key order determines bucket evaluation order
-/// (first-match-wins), so buckets are carried as an ordered list rather than `[String: BucketConfig]`
-/// (Swift's `Dictionary` does not preserve insertion order).
+/// A single (name, config) pair. Evaluation order matters (`BucketCounter` is first-match-wins), so
+/// buckets are carried as an ordered list rather than `[String: BucketConfig]` (Swift's `Dictionary` does
+/// not preserve insertion order). The order is established once, by the parser, sorted by range — never
+/// taken from JSON object key order, which is arbitrary by the time config reaches us.
 public struct OrderedBucket: Equatable, Sendable {
     public let name: String
     public let config: BucketConfig

--- a/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfigParser.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfigParser.swift
@@ -194,11 +194,9 @@ public final class EventHubConfigParser: EventHubConfigParsing {
     }
 
     /// Decodes/encodes the `buckets` JSON object as an ordered list, because `BucketCounter` is
-    /// first-match-wins and Swift's `Dictionary` would not preserve order. Decoding relies on
-    /// `KeyedDecodingContainer.allKeys` returning keys in document order, which holds for the persisted
-    /// snapshot but NOT for live remote config: that arrives as an unordered `[String: Any]`, so the
-    /// initial order is arbitrary. Harmless while bucket ranges are disjoint (exactly one match, and
-    /// `shouldStopCounting` scans all of them); overlapping ranges would resolve unpredictably.
+    /// first-match-wins and Swift's `Dictionary` would not preserve order. The order is *not* taken from
+    /// the JSON — live remote config reaches us as an unordered dictionary, so document order is
+    /// arbitrary there — it is established explicitly by `sortedByRange`.
     /// A bucket without a lower bound (`gte`) is invalid and disqualifies the whole counter.
     private struct BucketsDTO: Codable {
         let ordered: BucketList
@@ -226,7 +224,21 @@ public final class EventHubConfigParser: EventHubConfigParsing {
                 }
                 result.append(OrderedBucket(name: key.stringValue, config: BucketConfig(gte: gte, lt: dto.lt)))
             }
-            ordered = result
+            ordered = Self.sortedByRange(result)
+        }
+
+        /// Ascending by lower bound, then by upper bound with open-ended last, so a bounded bucket wins
+        /// over an open-ended one sharing its lower bound. Buckets left in identical ranges are
+        /// interchangeable, so their relative order cannot affect the outcome.
+        private static func sortedByRange(_ buckets: BucketList) -> BucketList {
+            buckets.sorted { lhs, rhs in
+                guard lhs.config.gte == rhs.config.gte else { return lhs.config.gte < rhs.config.gte }
+                switch (lhs.config.lt, rhs.config.lt) {
+                case let (lhsLt?, rhsLt?): return lhsLt < rhsLt
+                case (_?, nil): return true
+                case (nil, _): return false
+                }
+            }
         }
 
         func encode(to encoder: Encoder) throws {

--- a/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfigParser.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfigParser.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import os.log
 
 /// Parses the remote `eventHub` feature settings JSON into validated telemetry pixel configs, and
 /// serialises a single config back to JSON for persistence as a period's config snapshot.
@@ -42,10 +43,15 @@ public final class EventHubConfigParser: EventHubConfigParsing {
     public init() {}
 
     public func parseTelemetry(_ settingsJSON: Data) -> [TelemetryPixelConfig] {
-        guard let settings = try? JSONDecoder().decode(SettingsDTO.self, from: settingsJSON) else {
+        let settings: SettingsDTO
+        do {
+            settings = try JSONDecoder().decode(SettingsDTO.self, from: settingsJSON)
+        } catch {
+            Logger.eventHub.error("config: settings JSON could not be decoded, no telemetry configured: \(error.localizedDescription, privacy: .public)")
             return []
         }
-        return settings.telemetry.compactMap { name, pixel in Self.toPixelConfig(name: name, pixel: pixel) }
+        guard let telemetry = settings.telemetry else { return [] }
+        return telemetry.compactMap { name, pixel in Self.toPixelConfig(name: name, pixel: pixel) }
     }
 
     public func parseSinglePixelConfig(name: String, json: String) -> TelemetryPixelConfig? {
@@ -62,53 +68,68 @@ public final class EventHubConfigParser: EventHubConfigParsing {
     }
 
     private static func toPixelConfig(name: String, pixel: PixelDTO) -> TelemetryPixelConfig? {
-        guard let state = pixel.state, let triggerDTO = pixel.trigger, let trigger = toTrigger(triggerDTO) else {
+        guard let state = pixel.state, let triggerDTO = pixel.trigger else {
+            Logger.eventHub.error("config: pixel \(name, privacy: .public) skipped, missing state and/or trigger")
             return nil
         }
-        let parameters = toParameters(pixel.parameters ?? [:])
+        guard let trigger = toTrigger(triggerDTO, pixelName: name) else { return nil }
+        let parameters = toParameters(pixel.parameters ?? [:], pixelName: name)
         // A period pixel with no parameters has nothing to report; immediate pixels may legitimately
         // carry none (they fire on the event alone).
         if trigger.isPeriod && parameters.isEmpty {
+            Logger.eventHub.error("config: period pixel \(name, privacy: .public) skipped, no valid parameters")
             return nil
         }
         return TelemetryPixelConfig(name: name, state: state, trigger: trigger, parameters: parameters)
     }
 
-    private static func toTrigger(_ dto: TriggerDTO) -> TelemetryTriggerConfig? {
+    private static func toTrigger(_ dto: TriggerDTO, pixelName: String) -> TelemetryTriggerConfig? {
         let type = dto.type ?? periodType
         if type == immediateType {
-            guard let source = dto.source, !source.isEmpty else { return nil }
+            guard let source = dto.source, !source.isEmpty else {
+                Logger.eventHub.error("config: pixel \(pixelName, privacy: .public) skipped, immediate trigger with no source")
+                return nil
+            }
             return TelemetryTriggerConfig(type: immediateType, source: source)
         }
         if type == periodType {
-            guard let period = dto.period, period.seconds > 0 else { return nil }
+            guard let period = dto.period, period.seconds > 0 else {
+                Logger.eventHub.error("config: pixel \(pixelName, privacy: .public) skipped, period seconds missing or not positive")
+                return nil
+            }
             return TelemetryTriggerConfig(type: periodType, period: TelemetryPeriodConfig(seconds: period.seconds))
         }
+        Logger.eventHub.error("config: pixel \(pixelName, privacy: .public) skipped, unknown trigger type \(type, privacy: .public)")
         return nil
     }
 
-    private static func toParameters(_ parameters: [String: ParameterDTO]) -> [String: TelemetryParameterConfig] {
+    private static func toParameters(_ parameters: [String: ParameterDTO], pixelName: String) -> [String: TelemetryParameterConfig] {
         var result: [String: TelemetryParameterConfig] = [:]
         for (name, parameter) in parameters {
-            if let mapped = toParameter(parameter) {
+            if let mapped = toParameter(parameter, pixelName: pixelName, parameterName: name) {
                 result[name] = mapped
             }
         }
         return result
     }
 
-    private static func toParameter(_ parameter: ParameterDTO) -> TelemetryParameterConfig? {
+    private static func toParameter(_ parameter: ParameterDTO, pixelName: String, parameterName: String) -> TelemetryParameterConfig? {
         if parameter.template == counterTemplate {
             guard let source = parameter.source, !source.isEmpty,
                   let buckets = parameter.buckets, !buckets.ordered.isEmpty else {
+                Logger.eventHub.error("config: counter parameter \(pixelName, privacy: .public)/\(parameterName, privacy: .public) dropped, missing source and/or usable buckets")
                 return nil
             }
             return TelemetryParameterConfig(template: counterTemplate, source: source, buckets: buckets.ordered)
         }
         if parameter.template == dataTemplate {
-            guard let dataKey = parameter.dataKey, !dataKey.isEmpty else { return nil }
+            guard let dataKey = parameter.dataKey, !dataKey.isEmpty else {
+                Logger.eventHub.error("config: data parameter \(pixelName, privacy: .public)/\(parameterName, privacy: .public) dropped, missing dataKey")
+                return nil
+            }
             return TelemetryParameterConfig(template: dataTemplate, source: parameter.source, dataKey: dataKey)
         }
+        Logger.eventHub.error("config: parameter \(pixelName, privacy: .public)/\(parameterName, privacy: .public) dropped, unknown template \(parameter.template ?? "<none>", privacy: .public)")
         return nil
     }
 
@@ -131,7 +152,8 @@ public final class EventHubConfigParser: EventHubConfigParsing {
     // MARK: DTOs
 
     private struct SettingsDTO: Decodable {
-        let telemetry: [String: PixelDTO]
+        /// Optional: a missing `telemetry` key means "nothing configured yet", not malformed settings.
+        let telemetry: [String: PixelDTO]?
     }
 
     private struct PixelDTO: Codable {
@@ -185,6 +207,7 @@ public final class EventHubConfigParser: EventHubConfigParsing {
             for key in container.allKeys {
                 let dto = try container.decode(BucketDTO.self, forKey: key)
                 guard let gte = dto.gte else {
+                    Logger.eventHub.error("config: bucket \(key.stringValue, privacy: .public) has no `gte` lower bound, counter discarded")
                     ordered = []
                     return
                 }

--- a/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfigParser.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfigParser.swift
@@ -22,9 +22,11 @@ import os.log
 /// Parses the remote `eventHub` feature settings JSON into validated telemetry pixel configs, and
 /// serialises a single config back to JSON for persistence as a period's config snapshot.
 public protocol EventHubConfigParsing {
-    /// Parses the `telemetry` map from the feature settings JSON, returning only valid, fully-formed
-    /// pixel configs. Malformed or invalid input yields an empty list (never throws).
-    func parseTelemetry(_ settingsJSON: Data) -> [TelemetryPixelConfig]
+    /// Parses the `telemetry` map from the feature settings, returning only valid, fully-formed pixel
+    /// configs. Malformed or invalid input yields an empty list (never throws). Takes the settings in the
+    /// `[String: Any]` shape remote config already holds them in (BSK's `settings(for:)`), so no JSON
+    /// round trip is needed to reach the parser.
+    func parseTelemetry(_ settings: [String: Any]) -> [TelemetryPixelConfig]
 
     /// Parses a single serialised pixel config (as produced by `serializePixelConfig`), returning `nil`
     /// if it is malformed or invalid.
@@ -35,6 +37,10 @@ public protocol EventHubConfigParsing {
 }
 
 public final class EventHubConfigParser: EventHubConfigParsing {
+    /// The feature-settings key holding the per-pixel telemetry map. Also read by `EventHubSettings`,
+    /// which strips consent-gated entries out of it.
+    static let telemetryKey = "telemetry"
+
     private static let periodType = "period"
     private static let immediateType = "immediate"
     private static let counterTemplate = "counter"
@@ -42,16 +48,24 @@ public final class EventHubConfigParser: EventHubConfigParsing {
 
     public init() {}
 
-    public func parseTelemetry(_ settingsJSON: Data) -> [TelemetryPixelConfig] {
-        let settings: SettingsDTO
-        do {
-            settings = try JSONDecoder().decode(SettingsDTO.self, from: settingsJSON)
-        } catch {
-            Logger.eventHub.error("config: settings JSON could not be decoded, no telemetry configured: \(error.localizedDescription, privacy: .public)")
+    public func parseTelemetry(_ settings: [String: Any]) -> [TelemetryPixelConfig] {
+        // An absent `telemetry` key is the normal pre-rollout state ("eventHub enabled, nothing configured
+        // yet"), not malformed settings, so it must stay distinguishable from the failures below.
+        guard let telemetry = settings[Self.telemetryKey] else { return [] }
+        // `isValidJSONObject` first: `data(withJSONObject:)` raises an ObjC exception Swift cannot catch
+        // for values JSON can't represent, and this is a public entry point taking untyped input.
+        guard JSONSerialization.isValidJSONObject(telemetry) else {
+            Logger.eventHub.error("config: `\(Self.telemetryKey, privacy: .public)` is not a valid JSON object, no telemetry configured")
             return []
         }
-        guard let telemetry = settings.telemetry else { return [] }
-        return telemetry.compactMap { name, pixel in Self.toPixelConfig(name: name, pixel: pixel) }
+        do {
+            let data = try JSONSerialization.data(withJSONObject: telemetry)
+            return try JSONDecoder().decode([String: PixelDTO].self, from: data)
+                .compactMap { name, pixel in Self.toPixelConfig(name: name, pixel: pixel) }
+        } catch {
+            Logger.eventHub.error("config: `\(Self.telemetryKey, privacy: .public)` could not be decoded, no telemetry configured: \(error.localizedDescription, privacy: .public)")
+            return []
+        }
     }
 
     public func parseSinglePixelConfig(name: String, json: String) -> TelemetryPixelConfig? {
@@ -151,11 +165,6 @@ public final class EventHubConfigParser: EventHubConfigParsing {
 
     // MARK: DTOs
 
-    private struct SettingsDTO: Decodable {
-        /// Optional: a missing `telemetry` key means "nothing configured yet", not malformed settings.
-        let telemetry: [String: PixelDTO]?
-    }
-
     private struct PixelDTO: Codable {
         let state: String?
         let trigger: TriggerDTO?
@@ -184,8 +193,12 @@ public final class EventHubConfigParser: EventHubConfigParsing {
         let lt: Int?
     }
 
-    /// Decodes/encodes the `buckets` JSON object preserving key order (`BucketCounter` is
-    /// first-match-wins), relying on `KeyedDecodingContainer.allKeys` returning keys in document order.
+    /// Decodes/encodes the `buckets` JSON object as an ordered list, because `BucketCounter` is
+    /// first-match-wins and Swift's `Dictionary` would not preserve order. Decoding relies on
+    /// `KeyedDecodingContainer.allKeys` returning keys in document order, which holds for the persisted
+    /// snapshot but NOT for live remote config: that arrives as an unordered `[String: Any]`, so the
+    /// initial order is arbitrary. Harmless while bucket ranges are disjoint (exactly one match, and
+    /// `shouldStopCounting` scans all of them); overlapping ranges would resolve unpredictably.
     /// A bucket without a lower bound (`gte`) is invalid and disqualifies the whole counter.
     private struct BucketsDTO: Codable {
         let ordered: BucketList

--- a/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
@@ -72,10 +72,10 @@ public final class EventHub: EventHubManaging {
     /// How often pending (dirty) pixel state is persisted, absent a period boundary sooner than that.
     private static let flushInterval: Int64 = 10_000 // milliseconds
 
-    /// Debug-only marker for the same-queue misconfiguration described on `init`'s and
+    /// Marker for the same-queue misconfiguration described on `init`'s and
     /// `DispatchQueueEventHubScheduler`'s doc comments. Dispatch doesn't expose a clean way to compare
     /// two `DispatchQueue` instances for identity from inside a closure running on one of them, so
-    /// `init` associates this key with `queue` via `setSpecific`, and `assertSchedulerFiredOnADifferentQueue`
+    /// `init` associates this key with `queue` via `setSpecific`, and `requireSchedulerFiredOnADifferentQueue`
     /// checks whether that same value is visible on whichever queue the scheduler's callback is
     /// currently executing on.
     private static let ownQueueIdentityKey = DispatchSpecificKey<ObjectIdentifier>()
@@ -107,8 +107,9 @@ public final class EventHub: EventHubManaging {
     ///   with a **different** `DispatchQueue` instance than `queue`. The scheduler's timer fires on its
     ///   own queue; `EventHub`'s scheduler-fire handler then calls `queue.sync { ... }` from inside that
     ///   callback. If both queues were the same instance, the timer would fire on `queue` and then
-    ///   `.sync` onto itself — a silent deadlock. See `DispatchQueueEventHubScheduler`'s doc comment for
-    ///   the same constraint from the scheduler's side.
+    ///   `.sync` onto itself, which deadlocks — so `requireSchedulerFiredOnADifferentQueue` traps on the
+    ///   first timer fire instead, in release builds too. See `DispatchQueueEventHubScheduler`'s doc
+    ///   comment for the same constraint from the scheduler's side.
     public init(
         store: EventHubStore,
         parser: EventHubConfigParsing,
@@ -321,19 +322,26 @@ public final class EventHub: EventHubManaging {
         let nextFlush = dirtyNames.isEmpty ? nil : scheduler.nowMillis() + Self.flushInterval
         let candidates = [earliestPeriodEnd, nextFlush].compactMap { $0 }
         scheduler.arm(atMillis: candidates.min()) { [weak self] in
-            self?.assertSchedulerFiredOnADifferentQueue()
+            self?.requireSchedulerFiredOnADifferentQueue()
             self?.queue.sync { self?.onSchedulerFiredLocked() }
         }
     }
 
-    /// Debug-only guard for the same-queue misconfiguration described on `init`'s doc comment: if the
-    /// scheduler's timer fires directly on `queue` (i.e. the integrator passed the same `DispatchQueue`
-    /// instance to both `EventHub.init(queue:)` and `DispatchQueueEventHubScheduler.init(queue:)`), the
-    /// `.sync` immediately below would deadlock. Compiled out entirely in release builds (the `assert`
-    /// condition is an autoclosure that's never evaluated with `-O`), so this costs nothing there; the
-    /// one-time `setSpecific` call in `init` is the only cost paid in release.
-    private func assertSchedulerFiredOnADifferentQueue() {
-        assert(DispatchQueue.getSpecific(key: Self.ownQueueIdentityKey) != ObjectIdentifier(queue),
+    /// Guards the same-queue misconfiguration described on `init`'s doc comment: if the scheduler's timer
+    /// fires directly on `queue` (i.e. the integrator passed the same `DispatchQueue` instance to both
+    /// `EventHub.init(queue:)` and `DispatchQueueEventHubScheduler.init(queue:)`), the `.sync` immediately
+    /// below would deadlock.
+    ///
+    /// Deliberately a `precondition`, not an `assert`: `assert` is compiled out under `-O`, so in release
+    /// the deadlock would happen instead. And it would not stay contained — every public entry point goes
+    /// through `queue.sync`, so once that queue is wedged the next caller blocks too, including the main
+    /// thread via `handleWebEvent`. A hang attributed to an unrelated thread is far harder to diagnose
+    /// than a trap naming the exact wiring mistake. The condition depends only on how the two objects were
+    /// constructed, so it is constant for a build: it trips on the first timer fire for everyone or for
+    /// nobody, which is what makes it safe to ship. Cost in release is one `getSpecific` TLS read per
+    /// scheduler fire, plus the one-time `setSpecific` in `init`.
+    private func requireSchedulerFiredOnADifferentQueue() {
+        precondition(DispatchQueue.getSpecific(key: Self.ownQueueIdentityKey) != ObjectIdentifier(queue),
                "EventHub's scheduler must fire on a different DispatchQueue than EventHub's own `queue` — " +
                "passing the same DispatchQueue instance to both EventHub.init(queue:) and " +
                "DispatchQueueEventHubScheduler.init(queue:) causes the timer to fire on `queue` and then " +

--- a/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
@@ -283,11 +283,17 @@ public final class EventHub: EventHubManaging {
         store.deletePixelState(named: name)
 
         if var params = telemetry.buildPixelParameters() {
-            let attributionPeriod = EventHubAttribution.startOfIntervalSeconds(
-                periodStartMillis: telemetry.periodStartMillis,
-                periodSeconds: telemetry.config.trigger.period?.periodSeconds ?? 0)
-            params["attributionPeriod"] = String(attributionPeriod)
-            pixelFiring.enqueueFirePixel(named: name, parameters: params)
+            // `periodSeconds` is the divisor in the attribution calculation, so a missing period would
+            // trap. `EventHubConfigParser` rejects a period trigger without a positive `seconds`, on both
+            // the live-config and restored-snapshot paths, so this only guards that invariant — if it ever
+            // breaks, skip the fire rather than crash.
+            if let periodSeconds = telemetry.config.trigger.period?.periodSeconds {
+                params["attributionPeriod"] = String(EventHubAttribution.startOfIntervalSeconds(
+                    periodStartMillis: telemetry.periodStartMillis, periodSeconds: periodSeconds))
+                pixelFiring.enqueueFirePixel(named: name, parameters: params)
+            } else {
+                Logger.eventHub.error("pixel \(name, privacy: .public) not fired, its period trigger has no period to attribute to")
+            }
         }
 
         if let latest = latestConfigs.first(where: { $0.name == name }) {

--- a/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import Combine
+import os.log
 
 /// The EventHub runtime. Receives web events and browser-native signals, routes them to the configured
 /// telemetry, maintains aggregation state and period windows, and fires telemetry pixels. Lifecycle and
@@ -364,10 +365,16 @@ public final class EventHub: EventHubManaging {
 
     private static func encode(_ data: Encodable?) -> [String: Any]? {
         guard let data else { return nil }
-        guard let encoded = try? JSONEncoder().encode(data),
-              let object = try? JSONSerialization.jsonObject(with: encoded) as? [String: Any] else {
+        do {
+            let encoded = try JSONEncoder().encode(data)
+            guard let object = try JSONSerialization.jsonObject(with: encoded) as? [String: Any] else {
+                Logger.eventHub.error("native event payload is not a JSON object, payload dropped")
+                return nil
+            }
+            return object
+        } catch {
+            Logger.eventHub.error("native event payload could not be serialised, payload dropped: \(error.localizedDescription, privacy: .public)")
             return nil
         }
-        return object
     }
 }

--- a/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
@@ -129,9 +129,9 @@ public final class EventHub: EventHubManaging {
             .sink { [weak self] enabled in self?.queue.sync { self?.latestEnabled = enabled } }
             .store(in: &subscriptions)
         settings.settingsPublisher
-            .sink { [weak self] data in
+            .sink { [weak self] settings in
                 self?.queue.sync {
-                    self?.latestConfigs = data.map { self?.parser.parseTelemetry($0) ?? [] } ?? []
+                    self?.latestConfigs = settings.map { self?.parser.parseTelemetry($0) ?? [] } ?? []
                 }
             }
             .store(in: &subscriptions)

--- a/SharedPackages/EventHub/Sources/EventHub/Core/Parameter.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/Parameter.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import os.log
 
 /// A single pixel parameter's runtime behavior. `CounterParameter` owns its counter value and the
 /// stop-at-max-bucket logic, and makes the per-tab dedup decision against the hub-owned `DedupStore`
@@ -115,7 +116,10 @@ final class DataParameter: Parameter {
     func handle(data: [String: Any]?, tabID: EventHubTabID) -> Bool {
         guard let dataKey, let data, let raw = data[dataKey] else { return false }
         guard let encoded = try? JSONSerialization.data(withJSONObject: raw, options: [.fragmentsAllowed]),
-              let compact = String(data: encoded, encoding: .utf8) else { return false }
+              let compact = String(data: encoded, encoding: .utf8) else {
+            Logger.eventHub.error("data parameter for key \(dataKey, privacy: .public) is not JSON-serialisable, value dropped")
+            return false
+        }
         lastValue = compact.addingPercentEncoding(withAllowedCharacters: Self.unreservedCharacters)
         return true
     }

--- a/SharedPackages/EventHub/Sources/EventHub/EventHubDebugEvent.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/EventHubDebugEvent.swift
@@ -1,0 +1,50 @@
+//
+//  EventHubDebugEvent.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// The EventHub failures worth fleet-wide visibility, rather than only a local log entry. Delivered
+/// through an injected `EventMapping`, so this package stays free of any pixel dependency and tests can
+/// assert on events instead of on side effects.
+///
+/// Deliberately narrow: every fail-safe boundary in EventHub logs to `Logger.eventHub`, but only failures
+/// that are both *actionable* and *invisible from the outside* earn an event here. Excluded on purpose are
+/// the paths that encode our own structs (no failure mode reachable from remote input) and the ones that
+/// degrade gracefully and self-heal on the next period.
+public enum EventHubDebugEvent: Equatable {
+    /// EventHub could not read or write its own persisted state, so counting silently restarts or a
+    /// finished period is lost. `operation` says which step failed; the fired pixel carries it as a
+    /// parameter rather than splitting into one pixel name per operation.
+    case pixelStatePersistenceFailed(operation: PersistenceOperation)
+
+    /// A consent-gated telemetry entry could not be removed from the settings, so EventHub failed closed
+    /// and is now running no telemetry at all. Does not fire for the normal "nothing configured yet"
+    /// state, only when telemetry exists in a shape we cannot process.
+    case consentStripFailed
+
+    public enum PersistenceOperation: String {
+        /// The key-value store threw while reading.
+        case read
+        /// Something was stored, but it is not state we can decode.
+        case decode
+        /// The key-value store threw while persisting.
+        case write
+        /// The key-value store threw while deleting.
+        case delete
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHub/Logger+EventHub.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Logger+EventHub.swift
@@ -1,0 +1,30 @@
+//
+//  Logger+EventHub.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import os.log
+
+extension Logger {
+    /// Replaces the Windows implementation's `Diagnostic.cs` ETW source: every fail-safe boundary in
+    /// EventHub logs here rather than swallowing silently. Local only — never PII, never a URL.
+    ///
+    /// Only config-governed identifiers (pixel names, parameter names, bucket names, data keys) and
+    /// error descriptions are interpolated as `.public`; web-page-derived event payloads are never
+    /// logged at all, at any privacy level.
+    static let eventHub = Logger(subsystem: "EventHub", category: "")
+}

--- a/SharedPackages/EventHub/Sources/EventHub/Persistence/EventHubStore.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Persistence/EventHubStore.swift
@@ -76,11 +76,9 @@ public final class EventHubKeyValueStore: EventHubStore {
             Logger.eventHub.error("store: could not serialise the config snapshot for pixel \(state.pixelName, privacy: .public), state not saved")
             return
         }
-        let paramsJSON: String
-        do {
-            paramsJSON = String(decoding: try JSONEncoder().encode(state.params), as: UTF8.self)
-        } catch {
-            Logger.eventHub.error("store: could not serialise params for pixel \(state.pixelName, privacy: .public), state not saved: \(error.localizedDescription, privacy: .public)")
+        guard let paramsData = try? JSONEncoder().encode(state.params),
+              let paramsJSON = String(bytes: paramsData, encoding: .utf8) else {
+            Logger.eventHub.error("store: could not serialise params for pixel \(state.pixelName, privacy: .public), state not saved")
             return
         }
         var map = readMap()

--- a/SharedPackages/EventHub/Sources/EventHub/Persistence/EventHubStore.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Persistence/EventHubStore.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import Persistence
+import os.log
 
 /// Persists per-pixel EventHub runtime state across app restarts. State survives the fire button and
 /// is only cleared by EventHub itself (period fire, config disable). Backed by the key-value store.
@@ -41,7 +42,7 @@ public protocol EventHubStore {
 /// Backs `EventHubStore` with a `ThrowingKeyValueStoring`. All persisted pixel states live under a
 /// single composite key (`storageKey`) as a `[String: EventHubStoredPixelState]` map, JSON-encoded to
 /// `Data`. Read/write/parse failures are treated as absence rather than propagated: a corrupt entry is
-/// skipped, not thrown.
+/// skipped, not thrown — but every such boundary is logged to `Logger.eventHub`.
 public final class EventHubKeyValueStore: EventHubStore {
     /// The single key under which the map of pixel-name to `EventHubStoredPixelState` is stored.
     public static let storageKey = "eventhub_pixel_states"
@@ -63,8 +64,15 @@ public final class EventHubKeyValueStore: EventHubStore {
     }
 
     public func savePixelState(_ state: PixelState) {
-        guard let configJSON = parser.serializePixelConfig(state.config),
-              let paramsJSON = try? String(data: JSONEncoder().encode(state.params), encoding: .utf8) else {
+        guard let configJSON = parser.serializePixelConfig(state.config) else {
+            Logger.eventHub.error("store: could not serialise the config snapshot for pixel \(state.pixelName, privacy: .public), state not saved")
+            return
+        }
+        let paramsJSON: String
+        do {
+            paramsJSON = String(decoding: try JSONEncoder().encode(state.params), as: UTF8.self)
+        } catch {
+            Logger.eventHub.error("store: could not serialise params for pixel \(state.pixelName, privacy: .public), state not saved: \(error.localizedDescription, privacy: .public)")
             return
         }
         var map = readMap()
@@ -81,25 +89,59 @@ public final class EventHubKeyValueStore: EventHubStore {
     }
 
     public func deleteAllPixelStates() {
-        try? store.removeObject(forKey: Self.storageKey)
+        do {
+            try store.removeObject(forKey: Self.storageKey)
+        } catch {
+            Logger.eventHub.error("store: could not delete all pixel state: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     private func readMap() -> [String: EventHubStoredPixelState] {
-        guard let data = try? store.object(forKey: Self.storageKey) as? Data,
-              let map = try? JSONDecoder().decode([String: EventHubStoredPixelState].self, from: data) else {
+        let stored: Any?
+        do {
+            stored = try store.object(forKey: Self.storageKey)
+        } catch {
+            Logger.eventHub.error("store: could not read pixel state: \(error.localizedDescription, privacy: .public)")
             return [:]
         }
-        return map
+        // Nothing stored yet is the normal cold-start state, not a failure.
+        guard let stored else { return [:] }
+        guard let data = stored as? Data else {
+            Logger.eventHub.error("store: stored pixel state is not Data, treating as absent")
+            return [:]
+        }
+        do {
+            return try JSONDecoder().decode([String: EventHubStoredPixelState].self, from: data)
+        } catch {
+            Logger.eventHub.error("store: stored pixel state could not be decoded, treating as absent: \(error.localizedDescription, privacy: .public)")
+            return [:]
+        }
     }
 
     private func writeMap(_ map: [String: EventHubStoredPixelState]) {
-        guard let data = try? JSONEncoder().encode(map) else { return }
-        try? store.set(data, forKey: Self.storageKey)
+        guard let data = try? JSONEncoder().encode(map) else {
+            Logger.eventHub.error("store: could not encode the pixel state map, nothing persisted")
+            return
+        }
+        do {
+            try store.set(data, forKey: Self.storageKey)
+        } catch {
+            Logger.eventHub.error("store: could not persist pixel state: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     private func toPixelState(name: String, entry: EventHubStoredPixelState) -> PixelState? {
-        guard let config = parser.parseSinglePixelConfig(name: name, json: entry.configJSON) else { return nil }
-        let params = (try? JSONDecoder().decode([String: ParamState].self, from: Data(entry.paramsJSON.utf8))) ?? [:]
+        guard let config = parser.parseSinglePixelConfig(name: name, json: entry.configJSON) else {
+            Logger.eventHub.error("store: stored config snapshot for pixel \(name, privacy: .public) is unusable, state discarded")
+            return nil
+        }
+        let params: [String: ParamState]
+        do {
+            params = try JSONDecoder().decode([String: ParamState].self, from: Data(entry.paramsJSON.utf8))
+        } catch {
+            Logger.eventHub.error("store: stored params for pixel \(name, privacy: .public) are unusable, counters restart from zero: \(error.localizedDescription, privacy: .public)")
+            params = [:]
+        }
         return PixelState(pixelName: name, periodStartMillis: entry.periodStartMillis,
                            periodEndMillis: entry.periodEndMillis, config: config, params: params)
     }

--- a/SharedPackages/EventHub/Sources/EventHub/Persistence/EventHubStore.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Persistence/EventHubStore.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import Common
 import Persistence
 import os.log
 
@@ -42,17 +43,24 @@ public protocol EventHubStore {
 /// Backs `EventHubStore` with a `ThrowingKeyValueStoring`. All persisted pixel states live under a
 /// single composite key (`storageKey`) as a `[String: EventHubStoredPixelState]` map, JSON-encoded to
 /// `Data`. Read/write/parse failures are treated as absence rather than propagated: a corrupt entry is
-/// skipped, not thrown — but every such boundary is logged to `Logger.eventHub`.
+/// skipped, not thrown — but every such boundary is logged to `Logger.eventHub`, and the ones that lose
+/// state also fire `EventHubDebugEvent.pixelStatePersistenceFailed` through `eventMapping`.
 public final class EventHubKeyValueStore: EventHubStore {
     /// The single key under which the map of pixel-name to `EventHubStoredPixelState` is stored.
     public static let storageKey = "eventhub_pixel_states"
 
     private let store: ThrowingKeyValueStoring
     private let parser: EventHubConfigParsing
+    private let eventMapping: EventMapping<EventHubDebugEvent>?
 
-    public init(store: ThrowingKeyValueStoring, parser: EventHubConfigParsing) {
+    public init(
+        store: ThrowingKeyValueStoring,
+        parser: EventHubConfigParsing,
+        eventMapping: EventMapping<EventHubDebugEvent>? = nil
+    ) {
         self.store = store
         self.parser = parser
+        self.eventMapping = eventMapping
     }
 
     public func pixelState(named name: String) -> PixelState? {
@@ -93,6 +101,7 @@ public final class EventHubKeyValueStore: EventHubStore {
             try store.removeObject(forKey: Self.storageKey)
         } catch {
             Logger.eventHub.error("store: could not delete all pixel state: \(error.localizedDescription, privacy: .public)")
+            eventMapping?.fire(.pixelStatePersistenceFailed(operation: .delete), error: error)
         }
     }
 
@@ -102,18 +111,21 @@ public final class EventHubKeyValueStore: EventHubStore {
             stored = try store.object(forKey: Self.storageKey)
         } catch {
             Logger.eventHub.error("store: could not read pixel state: \(error.localizedDescription, privacy: .public)")
+            eventMapping?.fire(.pixelStatePersistenceFailed(operation: .read), error: error)
             return [:]
         }
-        // Nothing stored yet is the normal cold-start state, not a failure.
+        // Nothing stored yet is the normal cold-start state, not a failure: no event, no error log.
         guard let stored else { return [:] }
         guard let data = stored as? Data else {
             Logger.eventHub.error("store: stored pixel state is not Data, treating as absent")
+            eventMapping?.fire(.pixelStatePersistenceFailed(operation: .decode))
             return [:]
         }
         do {
             return try JSONDecoder().decode([String: EventHubStoredPixelState].self, from: data)
         } catch {
             Logger.eventHub.error("store: stored pixel state could not be decoded, treating as absent: \(error.localizedDescription, privacy: .public)")
+            eventMapping?.fire(.pixelStatePersistenceFailed(operation: .decode), error: error)
             return [:]
         }
     }
@@ -127,6 +139,7 @@ public final class EventHubKeyValueStore: EventHubStore {
             try store.set(data, forKey: Self.storageKey)
         } catch {
             Logger.eventHub.error("store: could not persist pixel state: \(error.localizedDescription, privacy: .public)")
+            eventMapping?.fire(.pixelStatePersistenceFailed(operation: .write), error: error)
         }
     }
 

--- a/SharedPackages/EventHub/Sources/EventHub/Scheduling/EventHubScheduler.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Scheduling/EventHubScheduler.swift
@@ -39,8 +39,9 @@ public protocol EventHubScheduler: EventHubClock {
 ///   `EventHub.init(queue:)`. This queue is where the timer fires; `EventHub`'s scheduler-fire handler
 ///   then calls `.sync` onto its own queue to serialize the fire with all its other state mutations. If
 ///   the two queues are the same instance, the timer fires ON that queue and the `.sync` call is then
-///   dispatched onto the queue it's already executing on — a silent deadlock (the block waiting on
-///   `.sync` can never run until the currently-executing block — itself — returns).
+///   dispatched onto the queue it's already executing on — a deadlock (the block waiting on `.sync` can
+///   never run until the currently-executing block — itself — returns). `EventHub` traps on this before
+///   the `.sync` rather than hanging; see `requireSchedulerFiredOnADifferentQueue`.
 public final class DispatchQueueEventHubScheduler: EventHubScheduler {
     private let queue: DispatchQueue
     private var timer: DispatchSourceTimer?

--- a/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubSettings.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubSettings.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import Combine
+import os.log
 
 /// The EventHub view of remote config: feature enablement plus the telemetry settings JSON with any
 /// consent-gated entries already removed. EventHub consumes this instead of talking to remote config or
@@ -66,8 +67,12 @@ public final class EventHubSettings: EventHubSettingsProviding {
         do {
             // Fail closed: if we cannot verify the settings JSON shape when suppressed is non-empty,
             // expose no telemetry at all rather than risk collecting without consent.
-            guard var object = try JSONSerialization.jsonObject(with: settings) as? [String: Any],
-                  var telemetry = object[telemetryKey] as? [String: Any] else {
+            guard var object = try JSONSerialization.jsonObject(with: settings) as? [String: Any] else {
+                Logger.eventHub.error("settings: consent stripping could not read the settings JSON as an object, failing closed")
+                return nil
+            }
+            guard var telemetry = object[telemetryKey] as? [String: Any] else {
+                Logger.eventHub.error("settings: consent stripping found no usable `\(telemetryKey, privacy: .public)` object, failing closed")
                 return nil
             }
             for name in suppressed { telemetry.removeValue(forKey: name) }
@@ -76,6 +81,7 @@ public final class EventHubSettings: EventHubSettingsProviding {
         } catch {
             // Fail closed: if we cannot reliably strip a gated entry, expose no telemetry at all
             // rather than risk collecting without consent.
+            Logger.eventHub.error("settings: consent stripping failed, failing closed: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }

--- a/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubSettings.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubSettings.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import Combine
+import Common
 import os.log
 
 /// The EventHub view of remote config: feature enablement plus the telemetry settings JSON with any
@@ -40,11 +41,12 @@ public final class EventHubSettings: EventHubSettingsProviding {
     public init(
         featureEnabledPublisher: AnyPublisher<Bool, Never>,
         featureSettingsPublisher: AnyPublisher<[String: Any]?, Never>,
-        consentRequirements: [EventHubConsentRequirement]
+        consentRequirements: [EventHubConsentRequirement],
+        eventMapping: EventMapping<EventHubDebugEvent>? = nil
     ) {
         self.enabledPublisher = featureEnabledPublisher
         self.settingsPublisher = Publishers.CombineLatest(featureSettingsPublisher, Self.suppressedNames(consentRequirements))
-            .map(Self.strip)
+            .map { settings, suppressed in Self.strip(settings, suppressed: suppressed, eventMapping: eventMapping) }
             .eraseToAnyPublisher()
     }
 
@@ -63,13 +65,22 @@ public final class EventHubSettings: EventHubSettingsProviding {
             .eraseToAnyPublisher()
     }
 
-    private static func strip(_ settings: [String: Any]?, suppressed: Set<String>) -> [String: Any]? {
+    private static func strip(
+        _ settings: [String: Any]?,
+        suppressed: Set<String>,
+        eventMapping: EventMapping<EventHubDebugEvent>?
+    ) -> [String: Any]? {
         guard !suppressed.isEmpty, var settings else { return settings }
         let key = EventHubConfigParser.telemetryKey
-        // Fail closed: if we cannot reach the telemetry map to remove a gated entry from it, expose no
+        // No telemetry configured is the normal pre-rollout state: there is nothing to strip, and nothing
+        // that could be collected without consent, so pass the settings through untouched. Blacking them
+        // out here would fail closed against a config that holds no gated data in the first place.
+        guard settings[key] != nil else { return settings }
+        // Fail closed: telemetry exists but we cannot reach into it to remove a gated entry, so expose no
         // telemetry at all rather than risk collecting without consent.
         guard var telemetry = settings[key] as? [String: Any] else {
             Logger.eventHub.error("settings: consent stripping found no usable `\(key, privacy: .public)` object, failing closed")
+            eventMapping?.fire(.consentStripFailed)
             return nil
         }
         for name in suppressed { telemetry.removeValue(forKey: name) }

--- a/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubSettings.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubSettings.swift
@@ -25,20 +25,21 @@ import os.log
 /// consent directly, keeping the manager consent-agnostic.
 public protocol EventHubSettingsProviding {
     var enabledPublisher: AnyPublisher<Bool, Never> { get }
-    var settingsPublisher: AnyPublisher<Data?, Never> { get }
+    /// The feature settings in the `[String: Any]` shape remote config already holds them in (BSK's
+    /// `settings(for:)` returns `FeatureSettings = [String: Any]`), so no JSON round trip is needed to
+    /// hand them over. `nil` means no settings are available and no telemetry may run.
+    var settingsPublisher: AnyPublisher<[String: Any]?, Never> { get }
 }
 
 /// Combines the raw feature settings with the live consent state of every `EventHubConsentRequirement`,
 /// removing the `telemetry` entries for any consent group that is not currently granted.
 public final class EventHubSettings: EventHubSettingsProviding {
-    private static let telemetryKey = "telemetry"
-
     public let enabledPublisher: AnyPublisher<Bool, Never>
-    public let settingsPublisher: AnyPublisher<Data?, Never>
+    public let settingsPublisher: AnyPublisher<[String: Any]?, Never>
 
     public init(
         featureEnabledPublisher: AnyPublisher<Bool, Never>,
-        featureSettingsPublisher: AnyPublisher<Data?, Never>,
+        featureSettingsPublisher: AnyPublisher<[String: Any]?, Never>,
         consentRequirements: [EventHubConsentRequirement]
     ) {
         self.enabledPublisher = featureEnabledPublisher
@@ -62,27 +63,17 @@ public final class EventHubSettings: EventHubSettingsProviding {
             .eraseToAnyPublisher()
     }
 
-    private static func strip(_ settings: Data?, suppressed: Set<String>) -> Data? {
-        guard !suppressed.isEmpty, let settings else { return settings }
-        do {
-            // Fail closed: if we cannot verify the settings JSON shape when suppressed is non-empty,
-            // expose no telemetry at all rather than risk collecting without consent.
-            guard var object = try JSONSerialization.jsonObject(with: settings) as? [String: Any] else {
-                Logger.eventHub.error("settings: consent stripping could not read the settings JSON as an object, failing closed")
-                return nil
-            }
-            guard var telemetry = object[telemetryKey] as? [String: Any] else {
-                Logger.eventHub.error("settings: consent stripping found no usable `\(telemetryKey, privacy: .public)` object, failing closed")
-                return nil
-            }
-            for name in suppressed { telemetry.removeValue(forKey: name) }
-            object[telemetryKey] = telemetry
-            return try JSONSerialization.data(withJSONObject: object)
-        } catch {
-            // Fail closed: if we cannot reliably strip a gated entry, expose no telemetry at all
-            // rather than risk collecting without consent.
-            Logger.eventHub.error("settings: consent stripping failed, failing closed: \(error.localizedDescription, privacy: .public)")
+    private static func strip(_ settings: [String: Any]?, suppressed: Set<String>) -> [String: Any]? {
+        guard !suppressed.isEmpty, var settings else { return settings }
+        let key = EventHubConfigParser.telemetryKey
+        // Fail closed: if we cannot reach the telemetry map to remove a gated entry from it, expose no
+        // telemetry at all rather than risk collecting without consent.
+        guard var telemetry = settings[key] as? [String: Any] else {
+            Logger.eventHub.error("settings: consent stripping found no usable `\(key, privacy: .public)` object, failing closed")
             return nil
         }
+        for name in suppressed { telemetry.removeValue(forKey: name) }
+        settings[key] = telemetry
+        return settings
     }
 }

--- a/SharedPackages/EventHub/Sources/EventHub/Wiring/WebEventsHandler.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Wiring/WebEventsHandler.swift
@@ -19,6 +19,7 @@
 import Foundation
 import WebKit
 import UserScript
+import os.log
 
 /// Routes inbound content-scope-scripts `webEvent` messages to `EventHubManaging`: extracts the
 /// event payload (`{ type, data }`) and forwards only events whose `type` is present and non-empty.
@@ -40,9 +41,13 @@ public final class WebEventsHandler: Subfeature {
     public func handler(forMethodNamed methodName: String) -> Handler? {
         guard methodName == "webEvent" else { return nil }
         return { [weak self] params, original in
-            guard let self,
-                  let dict = params as? [String: Any],
-                  let type = dict["type"] as? String, !type.isEmpty else {
+            guard let self else { return nil }
+            guard let dict = params as? [String: Any] else {
+                Logger.eventHub.error("webEvent message ignored, params were not an object")
+                return nil
+            }
+            guard let type = dict["type"] as? String, !type.isEmpty else {
+                Logger.eventHub.error("webEvent message ignored, `type` was missing, not a string, or empty")
                 return nil
             }
             self.manager.handleWebEvent(dict, tabID: self.tabIDProvider(original))

--- a/SharedPackages/EventHub/Sources/EventHubTests/Functional/EventHubFunctionalTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Functional/EventHubFunctionalTests.swift
@@ -120,9 +120,9 @@ struct EventHubFunctionalTests {
     /// `FakeEventHubSettingsProviding`.
     private struct StaticSettingsProviding: EventHubSettingsProviding {
         let enabledPublisher: AnyPublisher<Bool, Never>
-        let settingsPublisher: AnyPublisher<Data?, Never>
+        let settingsPublisher: AnyPublisher<[String: Any]?, Never>
         init(json: String, enabled: AnyPublisher<Bool, Never> = Just(true).eraseToAnyPublisher()) {
-            settingsPublisher = Just(json.data(using: .utf8)).eraseToAnyPublisher()
+            settingsPublisher = Just(settingsDictionary(json)).eraseToAnyPublisher()
             enabledPublisher = enabled
         }
     }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Functional/EventHubFunctionalTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Functional/EventHubFunctionalTests.swift
@@ -22,7 +22,7 @@ import Combine
 import WebKit
 @testable import EventHub
 
-@Suite("EventHub functional (message handler through manager to fired pixel)")
+@Suite("EventHub functional (message handler through manager to fired pixel)", .timeLimit(.minutes(1)))
 struct EventHubFunctionalTests {
     static let periodSeconds: TimeInterval = 60
 

--- a/SharedPackages/EventHub/Sources/EventHubTests/Integration/EventHubPersistenceIntegrationTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Integration/EventHubPersistenceIntegrationTests.swift
@@ -20,7 +20,7 @@ import Testing
 import Foundation
 @testable import EventHub
 
-@Suite("EventHub persistence (real UserDefaults round trip)")
+@Suite("EventHub persistence (real UserDefaults round trip)", .timeLimit(.minutes(1)))
 struct EventHubPersistenceIntegrationTests {
     @Test("pixel state survives a real Codable + UserDefaults round trip across repository instances")
     func pixelStateSurvivesRealRoundTripAcrossRepositoryInstances() throws {

--- a/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/CapturingEventMapping.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/CapturingEventMapping.swift
@@ -1,0 +1,35 @@
+//
+//  CapturingEventMapping.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Common
+@testable import EventHub
+
+/// Captures the debug events a component fires, so tests can assert on the event itself rather than on
+/// whatever a real pixel implementation would do with it.
+final class CapturingEventMapping {
+    private(set) var fired: [EventHubDebugEvent] = []
+    private(set) var errors: [Error?] = []
+
+    /// The mapping to inject. Holds this capture weakly, so a test can keep reading `fired` for as long
+    /// as it holds the capture, regardless of what owns the mapping.
+    lazy var eventMapping: EventMapping<EventHubDebugEvent> = EventMapping { [weak self] event, error, _, _ in
+        self?.fired.append(event)
+        self?.errors.append(error)
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/EventHubFixture.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/EventHubFixture.swift
@@ -40,7 +40,7 @@ final class EventHubFixture {
     var fired: [FiredPixel] { spyPixelFiring.fired }
 
     private let enabledSubject: CurrentValueSubject<Bool, Never>
-    private let settingsSubject: CurrentValueSubject<Data?, Never>
+    private let settingsSubject: CurrentValueSubject<[String: Any]?, Never>
     private let settingsJSON: String
 
     private init(store: InMemoryKeyValueStore, settingsJSON: String, enabled: Bool, hasSettings: Bool) {
@@ -51,7 +51,7 @@ final class EventHubFixture {
         let parser = EventHubConfigParser()
         self.repository = EventHubKeyValueStore(store: store, parser: parser)
         self.enabledSubject = CurrentValueSubject(enabled)
-        self.settingsSubject = CurrentValueSubject(hasSettings ? settingsJSON.data(using: .utf8) : nil)
+        self.settingsSubject = CurrentValueSubject(hasSettings ? settingsDictionary(settingsJSON) : nil)
 
         let settingsProvider = FakeEventHubSettingsProviding(enabled: enabledSubject.eraseToAnyPublisher(), settings: settingsSubject.eraseToAnyPublisher())
 
@@ -100,7 +100,7 @@ final class EventHubFixture {
 
     func setEnabled(_ value: Bool) { enabledSubject.send(value) }
 
-    func setSettings(_ json: String) { settingsSubject.send(json.data(using: .utf8)) }
+    func setSettings(_ json: String) { settingsSubject.send(settingsDictionary(json)) }
 
     func advance(by interval: TimeInterval) { scheduler.advance(by: interval) }
 
@@ -131,8 +131,8 @@ final class EventHubFixture {
 
     private struct FakeEventHubSettingsProviding: EventHubSettingsProviding {
         let enabledPublisher: AnyPublisher<Bool, Never>
-        let settingsPublisher: AnyPublisher<Data?, Never>
-        init(enabled: AnyPublisher<Bool, Never>, settings: AnyPublisher<Data?, Never>) {
+        let settingsPublisher: AnyPublisher<[String: Any]?, Never>
+        init(enabled: AnyPublisher<Bool, Never>, settings: AnyPublisher<[String: Any]?, Never>) {
             self.enabledPublisher = enabled
             self.settingsPublisher = settings
         }

--- a/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SettingsDictionary.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SettingsDictionary.swift
@@ -1,0 +1,30 @@
+//
+//  SettingsDictionary.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Turns a JSON literal into the `[String: Any]` shape remote config hands EventHub, so tests can keep
+/// expressing settings as readable JSON. Traps on invalid JSON: that is a broken test fixture, not a
+/// scenario under test — malformed config bytes can no longer reach EventHub, since BSK parses them.
+func settingsDictionary(_ json: String) -> [String: Any] {
+    guard let object = try? JSONSerialization.jsonObject(with: Data(json.utf8)),
+          let dictionary = object as? [String: Any] else {
+        fatalError("invalid settings JSON in test fixture: \(json)")
+    }
+    return dictionary
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/ThrowingKeyValueStore.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/ThrowingKeyValueStore.swift
@@ -1,0 +1,52 @@
+//
+//  ThrowingKeyValueStore.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Persistence
+
+/// A `ThrowingKeyValueStoring` whose individual operations can be made to throw, so the store's
+/// fail-safe boundaries can be exercised. `InMemoryKeyValueStore` cannot: it conforms to the
+/// non-throwing `KeyValueStoring`, so its operations never fail.
+final class ThrowingKeyValueStore: ThrowingKeyValueStoring {
+    struct StoreError: Error {}
+
+    private var storage: [String: Any] = [:]
+
+    var throwOnRead = false
+    var throwOnWrite = false
+    var throwOnRemove = false
+
+    init(storage: [String: Any] = [:]) {
+        self.storage = storage
+    }
+
+    func object(forKey defaultName: String) throws -> Any? {
+        if throwOnRead { throw StoreError() }
+        return storage[defaultName]
+    }
+
+    func set(_ value: Any?, forKey defaultName: String) throws {
+        if throwOnWrite { throw StoreError() }
+        storage[defaultName] = value
+    }
+
+    func removeObject(forKey defaultName: String) throws {
+        if throwOnRemove { throw StoreError() }
+        storage.removeValue(forKey: defaultName)
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/BucketCounterTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/BucketCounterTests.swift
@@ -19,7 +19,7 @@
 import Testing
 @testable import EventHub
 
-@Suite("BucketCounter")
+@Suite("BucketCounter", .timeLimit(.minutes(1)))
 struct BucketCounterTests {
     static let buckets: BucketList = [
         OrderedBucket(name: "0", config: BucketConfig(gte: 0, lt: 1)),

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/EventHubConfigParserTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/EventHubConfigParserTests.swift
@@ -22,7 +22,7 @@ import Foundation
 
 @Suite("EventHubConfigParser")
 struct EventHubConfigParserTests {
-    static let settingsJSON = """
+    static let settings = settingsDictionary("""
     {
         "telemetry": {
             "webTelemetry_testPixel1": {
@@ -48,13 +48,13 @@ struct EventHubConfigParserTests {
             }
         }
     }
-    """.data(using: .utf8)!
+    """)
 
     let parser: EventHubConfigParsing = EventHubConfigParser()
 
     @Test("settings JSON parses the pixel correctly")
     func settingsJSONParsesPixelCorrectly() {
-        let telemetry = parser.parseTelemetry(Self.settingsJSON)
+        let telemetry = parser.parseTelemetry(Self.settings)
 
         #expect(telemetry.count == 1)
         let pixel = telemetry[0]
@@ -64,7 +64,7 @@ struct EventHubConfigParserTests {
 
     @Test("counter parameter with map buckets is parsed correctly")
     func counterParameterWithMapBucketsParsedCorrectly() throws {
-        let telemetry = parser.parseTelemetry(Self.settingsJSON)
+        let telemetry = parser.parseTelemetry(Self.settings)
         let param = try #require(telemetry.first?.parameters["count"])
 
         #expect(param.isCounter)
@@ -76,92 +76,98 @@ struct EventHubConfigParserTests {
 
     @Test("seconds period parses correctly")
     func secondsPeriodParsesCorrectly() {
-        let json = """
+        let json = settingsDictionary("""
         { "telemetry": { "test": {
             "state": "enabled",
             "trigger": { "period": { "seconds": 30 } },
             "parameters": { "c": { "template": "counter", "source": "e", "buckets": {"0+": {"gte": 0}} } }
         } } }
-        """.data(using: .utf8)!
+        """)
 
         #expect(parser.parseTelemetry(json).first?.trigger.period?.periodSeconds == 30)
     }
 
     @Test("empty JSON returns empty telemetry")
     func emptyJSONReturnsEmptyTelemetry() {
-        #expect(parser.parseTelemetry("{}".data(using: .utf8)!).isEmpty)
+        #expect(parser.parseTelemetry(settingsDictionary("{}")).isEmpty)
     }
 
     @Test("pixel missing state is skipped")
     func pixelMissingStateIsSkipped() {
-        let json = """
+        let json = settingsDictionary("""
         { "telemetry": { "test": {
             "trigger": { "period": { "seconds": 86400 } },
             "parameters": { "c": { "template": "counter", "source": "e", "buckets": {"0+": {"gte": 0}} } }
         } } }
-        """.data(using: .utf8)!
+        """)
 
         #expect(parser.parseTelemetry(json).isEmpty)
     }
 
     @Test("bucket missing gte is skipped")
     func bucketMissingGteIsSkipped() {
-        let json = """
+        let json = settingsDictionary("""
         { "telemetry": { "test": {
             "state": "enabled",
             "trigger": { "period": { "seconds": 86400 } },
             "parameters": { "c": { "template": "counter", "source": "e", "buckets": {"bad": {"lt": 5}} } }
         } } }
-        """.data(using: .utf8)!
+        """)
 
         #expect(parser.parseTelemetry(json).isEmpty)
     }
 
-    @Test("malformed JSON returns empty")
-    func malformedJSONReturnsEmpty() {
-        #expect(parser.parseTelemetry("not valid json".data(using: .utf8)!).isEmpty)
+    @Test("telemetry that is not an object returns empty")
+    func telemetryThatIsNotAnObjectReturnsEmpty() {
+        #expect(parser.parseTelemetry([EventHubConfigParser.telemetryKey: "not an object"]).isEmpty)
+    }
+
+    @Test("telemetry holding a value JSON cannot represent returns empty")
+    func telemetryHoldingUnrepresentableValueReturnsEmpty() {
+        // Guards the `isValidJSONObject` check: serialising this would raise an ObjC exception, not throw.
+        #expect(parser.parseTelemetry([EventHubConfigParser.telemetryKey: ["pixel": Date()]]).isEmpty)
     }
 
     @Test("missing telemetry key returns empty telemetry")
     func missingTelemetryKeyReturnsEmptyTelemetry() {
-        #expect(parser.parseTelemetry(#"{"other": {}}"#.data(using: .utf8)!).isEmpty)
+        #expect(parser.parseTelemetry(settingsDictionary(#"{"other": {}}"#)).isEmpty)
     }
 
     @Test("zero period returns no telemetry")
     func zeroPeriodReturnsNoTelemetry() {
-        let json = """
+        let json = settingsDictionary("""
         { "telemetry": { "test": {
             "state": "enabled",
             "trigger": { "period": { "seconds": 0 } },
             "parameters": { "c": { "template": "counter", "source": "e", "buckets": {"0+": {"gte": 0}} } }
         } } }
-        """.data(using: .utf8)!
+        """)
 
         #expect(parser.parseTelemetry(json).isEmpty)
     }
 
     @Test("negative period returns no telemetry")
     func negativePeriodReturnsNoTelemetry() {
-        let json = """
+        let json = settingsDictionary("""
         { "telemetry": { "test": {
             "state": "enabled",
             "trigger": { "period": { "seconds": -10 } },
             "parameters": { "c": { "template": "counter", "source": "e", "buckets": {"0+": {"gte": 0}} } }
         } } }
-        """.data(using: .utf8)!
+        """)
 
         #expect(parser.parseTelemetry(json).isEmpty)
     }
 
     @Test("unknown template is skipped")
     func unknownTemplateIsSkipped() {
-        let json = """
+        let json = settingsDictionary("""
         { "telemetry": { "test": {
             "state": "enabled",
             "trigger": { "period": { "seconds": 86400 } },
             "parameters": { "c": { "template": "unknown_template", "source": "e" } }
         } } }
-        """.data(using: .utf8)!
+        """)
 
         #expect(parser.parseTelemetry(json).isEmpty)
     }
@@ -178,7 +184,7 @@ struct EventHubConfigParserTests {
 
     @Test("serializePixelConfig produces valid JSON that round trips")
     func serializePixelConfigProducesValidJSONThatRoundTrips() throws {
-        let original = try #require(parser.parseTelemetry(Self.settingsJSON).first)
+        let original = try #require(parser.parseTelemetry(Self.settings).first)
 
         let json = try #require(parser.serializePixelConfig(original))
         let restored = try #require(parser.parseSinglePixelConfig(name: original.name, json: json))

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/EventHubConfigParserTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/EventHubConfigParserTests.swift
@@ -20,7 +20,7 @@ import Testing
 import Foundation
 @testable import EventHub
 
-@Suite("EventHubConfigParser")
+@Suite("EventHubConfigParser", .timeLimit(.minutes(1)))
 struct EventHubConfigParserTests {
     static let settings = settingsDictionary("""
     {

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/EventHubConfigParserTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/EventHubConfigParserTests.swift
@@ -117,6 +117,43 @@ struct EventHubConfigParserTests {
         #expect(parser.parseTelemetry(json).isEmpty)
     }
 
+    @Test("buckets are ordered by range, not by JSON key order")
+    func bucketsAreOrderedByRangeNotByJSONKeyOrder() throws {
+        let json = settingsDictionary("""
+        { "telemetry": { "test": {
+            "state": "enabled",
+            "trigger": { "period": { "seconds": 86400 } },
+            "parameters": { "c": { "template": "counter", "source": "e", "buckets": {
+                "40+":   {"gte": 40},
+                "0":     {"gte": 0,  "lt": 1},
+                "3-5":   {"gte": 3,  "lt": 6},
+                "1-2":   {"gte": 1,  "lt": 3}
+            } } }
+        } } }
+        """)
+
+        let buckets = try #require(parser.parseTelemetry(json).first?.parameters["c"]?.buckets)
+        #expect(buckets.map(\.name) == ["0", "1-2", "3-5", "40+"])
+    }
+
+    @Test("an open-ended bucket is evaluated after a bounded bucket sharing its lower bound")
+    func openEndedBucketIsEvaluatedAfterBoundedBucketSharingItsLowerBound() throws {
+        let json = settingsDictionary("""
+        { "telemetry": { "test": {
+            "state": "enabled",
+            "trigger": { "period": { "seconds": 86400 } },
+            "parameters": { "c": { "template": "counter", "source": "e", "buckets": {
+                "40+":   {"gte": 40},
+                "40-49": {"gte": 40, "lt": 50}
+            } } }
+        } } }
+        """)
+
+        let buckets = try #require(parser.parseTelemetry(json).first?.parameters["c"]?.buckets)
+        #expect(buckets.map(\.name) == ["40-49", "40+"])
+        #expect(BucketCounter.bucketCount(45, buckets: buckets) == "40-49")
+    }
+
     @Test("telemetry that is not an object returns empty")
     func telemetryThatIsNotAnObjectReturnsEmpty() {
         #expect(parser.parseTelemetry([EventHubConfigParser.telemetryKey: "not an object"]).isEmpty)

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubDataParameterTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubDataParameterTests.swift
@@ -19,7 +19,7 @@
 import Testing
 @testable import EventHub
 
-@Suite("EventHub data parameters")
+@Suite("EventHub data parameters", .timeLimit(.minutes(1)))
 struct EventHubDataParameterTests {
     static let immediateDataConfig = """
     { "telemetry": { "webEvent_login": {

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubImmediatePixelTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubImmediatePixelTests.swift
@@ -19,7 +19,7 @@
 import Testing
 @testable import EventHub
 
-@Suite("EventHub immediate pixels")
+@Suite("EventHub immediate pixels", .timeLimit(.minutes(1)))
 struct EventHubImmediatePixelTests {
     static let immediateConfig = """
     { "telemetry": { "webEvent_impression": {

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubNativeIngressTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubNativeIngressTests.swift
@@ -20,7 +20,7 @@ import Foundation
 import Testing
 @testable import EventHub
 
-@Suite("EventHub native ingress")
+@Suite("EventHub native ingress", .timeLimit(.minutes(1)))
 struct EventHubNativeIngressTests {
     static let pixel1 = "webTelemetry_testPixel1"
 

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubPersistenceThrottlingTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubPersistenceThrottlingTests.swift
@@ -19,7 +19,7 @@
 import Testing
 @testable import EventHub
 
-@Suite("EventHub persistence throttling")
+@Suite("EventHub persistence throttling", .timeLimit(.minutes(1)))
 struct EventHubPersistenceThrottlingTests {
     static let burstSize = 5000
 

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubTests.swift
@@ -20,7 +20,7 @@ import Testing
 import Foundation
 @testable import EventHub
 
-@Suite("EventHub")
+@Suite("EventHub", .timeLimit(.minutes(1)))
 struct EventHubTests {
     static let pixel1 = "webTelemetry_testPixel1"
 

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/ParameterTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/ParameterTests.swift
@@ -20,7 +20,7 @@ import Testing
 import Foundation
 @testable import EventHub
 
-@Suite("CounterParameter")
+@Suite("CounterParameter", .timeLimit(.minutes(1)))
 struct CounterParameterTests {
     static let buckets: BucketList = [
         OrderedBucket(name: "0", config: BucketConfig(gte: 0, lt: 1)),
@@ -115,7 +115,7 @@ struct CounterParameterTests {
     }
 }
 
-@Suite("DataParameter")
+@Suite("DataParameter", .timeLimit(.minutes(1)))
 struct DataParameterTests {
     @Test("captures and percent-encodes a matching data key")
     func capturesAndEncodesMatchingKey() {

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/TelemetryTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/TelemetryTests.swift
@@ -20,7 +20,7 @@ import Testing
 import Foundation
 @testable import EventHub
 
-@Suite("Telemetry")
+@Suite("Telemetry", .timeLimit(.minutes(1)))
 struct TelemetryTests {
     static let config = TelemetryPixelConfig(
         name: "webTelemetry_test",

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Persistence/EventHubStoreDebugEventTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Persistence/EventHubStoreDebugEventTests.swift
@@ -20,7 +20,7 @@ import Testing
 import Foundation
 @testable import EventHub
 
-@Suite("EventHubStore debug events")
+@Suite("EventHubStore debug events", .timeLimit(.minutes(1)))
 struct EventHubStoreDebugEventTests {
     private static let sampleConfig = TelemetryPixelConfig(
         name: "testPixel",
@@ -94,8 +94,8 @@ struct EventHubStoreDebugEventTests {
         #expect(capture.errors.first is ThrowingKeyValueStore.StoreError)
     }
 
-    /// Regression guard: "nothing stored yet" is the normal cold-start state on every first launch. Were
-    /// it treated as a read failure, this pixel would fire for the entire install base.
+    // Regression guard: "nothing stored yet" is the normal cold-start state on every first launch. Were
+    // it treated as a read failure, this pixel would fire for the entire install base.
     @Test("an absent value fires nothing")
     func absentValueFiresNothing() {
         _ = repository.allPixelStates()
@@ -104,7 +104,7 @@ struct EventHubStoreDebugEventTests {
         #expect(capture.fired.isEmpty)
     }
 
-    /// The successful path must stay silent even though it reads, writes and deletes.
+    // The successful path must stay silent even though it reads, writes and deletes.
     @Test("a successful round trip fires nothing")
     func successfulRoundTripFiresNothing() {
         repository.savePixelState(Self.sampleState)

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Persistence/EventHubStoreDebugEventTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Persistence/EventHubStoreDebugEventTests.swift
@@ -1,0 +1,117 @@
+//
+//  EventHubStoreDebugEventTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Testing
+import Foundation
+@testable import EventHub
+
+@Suite("EventHubStore debug events")
+struct EventHubStoreDebugEventTests {
+    private static let sampleConfig = TelemetryPixelConfig(
+        name: "testPixel",
+        state: "enabled",
+        trigger: TelemetryTriggerConfig(type: "period", period: TelemetryPeriodConfig(seconds: 86400)),
+        parameters: [
+            "count": TelemetryParameterConfig(
+                template: "counter",
+                source: "adwall.detected",
+                buckets: [OrderedBucket(name: "0+", config: BucketConfig(gte: 0))]),
+        ])
+
+    private static var sampleState: PixelState {
+        PixelState(pixelName: "testPixel", periodStartMillis: 1000, periodEndMillis: 87_401_000,
+                   config: sampleConfig, params: ["count": ParamState(value: 3)])
+    }
+
+    private let capture = CapturingEventMapping()
+    private let store = ThrowingKeyValueStore()
+    private let repository: EventHubStore
+
+    init() {
+        repository = EventHubKeyValueStore(store: store, parser: EventHubConfigParser(), eventMapping: capture.eventMapping)
+    }
+
+    @Test("a throwing read reports the read operation")
+    func throwingReadReportsReadOperation() {
+        store.throwOnRead = true
+
+        _ = repository.allPixelStates()
+
+        #expect(capture.fired == [.pixelStatePersistenceFailed(operation: .read)])
+        #expect(capture.errors.first is ThrowingKeyValueStore.StoreError)
+    }
+
+    @Test("an undecodable stored blob reports the decode operation")
+    func undecodableStoredBlobReportsDecodeOperation() throws {
+        try store.set(Data("not encoded state".utf8), forKey: EventHubKeyValueStore.storageKey)
+
+        _ = repository.allPixelStates()
+
+        #expect(capture.fired == [.pixelStatePersistenceFailed(operation: .decode)])
+    }
+
+    @Test("a stored value that is not Data reports the decode operation")
+    func storedValueThatIsNotDataReportsDecodeOperation() throws {
+        try store.set("not Data at all", forKey: EventHubKeyValueStore.storageKey)
+
+        _ = repository.allPixelStates()
+
+        #expect(capture.fired == [.pixelStatePersistenceFailed(operation: .decode)])
+    }
+
+    @Test("a throwing write reports the write operation")
+    func throwingWriteReportsWriteOperation() {
+        store.throwOnWrite = true
+
+        repository.savePixelState(Self.sampleState)
+
+        #expect(capture.fired == [.pixelStatePersistenceFailed(operation: .write)])
+        #expect(capture.errors.first is ThrowingKeyValueStore.StoreError)
+    }
+
+    @Test("a throwing delete reports the delete operation")
+    func throwingDeleteReportsDeleteOperation() {
+        store.throwOnRemove = true
+
+        repository.deleteAllPixelStates()
+
+        #expect(capture.fired == [.pixelStatePersistenceFailed(operation: .delete)])
+        #expect(capture.errors.first is ThrowingKeyValueStore.StoreError)
+    }
+
+    /// Regression guard: "nothing stored yet" is the normal cold-start state on every first launch. Were
+    /// it treated as a read failure, this pixel would fire for the entire install base.
+    @Test("an absent value fires nothing")
+    func absentValueFiresNothing() {
+        _ = repository.allPixelStates()
+        #expect(repository.pixelState(named: "testPixel") == nil)
+
+        #expect(capture.fired.isEmpty)
+    }
+
+    /// The successful path must stay silent even though it reads, writes and deletes.
+    @Test("a successful round trip fires nothing")
+    func successfulRoundTripFiresNothing() {
+        repository.savePixelState(Self.sampleState)
+        #expect(repository.pixelState(named: "testPixel") != nil)
+        repository.deletePixelState(named: "testPixel")
+        repository.deleteAllPixelStates()
+
+        #expect(capture.fired.isEmpty)
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Persistence/EventHubStoreTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Persistence/EventHubStoreTests.swift
@@ -20,7 +20,7 @@ import Testing
 import Foundation
 @testable import EventHub
 
-@Suite("EventHubStore")
+@Suite("EventHubStore", .timeLimit(.minutes(1)))
 struct EventHubStoreTests {
     static let sampleConfig = TelemetryPixelConfig(
         name: "testPixel",

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Persistence/EventHubStoredPixelStateTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Persistence/EventHubStoredPixelStateTests.swift
@@ -20,7 +20,7 @@ import Testing
 import Foundation
 @testable import EventHub
 
-@Suite("EventHubStoredPixelState")
+@Suite("EventHubStoredPixelState", .timeLimit(.minutes(1)))
 struct EventHubStoredPixelStateTests {
     @Test("round trips all fields")
     func roundTripsAllFields() throws {

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Scheduling/DispatchQueueEventHubSchedulerTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Scheduling/DispatchQueueEventHubSchedulerTests.swift
@@ -42,7 +42,7 @@ private final class FireRecorder: @unchecked Sendable {
     }
 }
 
-@Suite("DispatchQueueEventHubScheduler")
+@Suite("DispatchQueueEventHubScheduler", .timeLimit(.minutes(1)))
 struct DispatchQueueEventHubSchedulerTests {
     @Test("fires the armed action once the real deadline elapses")
     func firesArmedActionOnceRealDeadlineElapses() async throws {

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Scheduling/EventHubSchedulerTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Scheduling/EventHubSchedulerTests.swift
@@ -19,7 +19,7 @@
 import Testing
 @testable import EventHub
 
-@Suite("ManualEventHubScheduler")
+@Suite("ManualEventHubScheduler", .timeLimit(.minutes(1)))
 struct EventHubSchedulerTests {
     @Test("fires the armed action once the deadline is reached")
     func firesArmedActionOnceDeadlineReached() {

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/EventHubSettingsTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/EventHubSettingsTests.swift
@@ -21,7 +21,7 @@ import Foundation
 import Combine
 @testable import EventHub
 
-@Suite("EventHubSettings")
+@Suite("EventHubSettings", .timeLimit(.minutes(1)))
 struct EventHubSettingsTests {
     static let settings = settingsDictionary("""
     { "telemetry": {
@@ -60,9 +60,9 @@ struct EventHubSettingsTests {
         #expect(Self.telemetryKeys(latest) == ["gated_pixel", "ungated_pixel"])
     }
 
-    /// Regression guard: "eventHub enabled, nothing configured yet" is the normal pre-rollout state. It
-    /// holds no gated data, so failing closed on it would black out all telemetry — and fire the debug
-    /// event — for every install running a config that has not reached the rollout yet.
+    // Regression guard: "eventHub enabled, nothing configured yet" is the normal pre-rollout state. It
+    // holds no gated data, so failing closed on it would black out all telemetry — and fire the debug
+    // event — for every install running a config that has not reached the rollout yet.
     @Test("settings without a telemetry key pass through untouched and fire nothing")
     func settingsWithoutTelemetryKeyPassThroughUntouchedAndFireNothing() {
         let capture = CapturingEventMapping()

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/EventHubSettingsTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/EventHubSettingsTests.swift
@@ -59,4 +59,43 @@ struct EventHubSettingsTests {
         requirement.granted.send(true)
         #expect(Self.telemetryKeys(latest) == ["gated_pixel", "ungated_pixel"])
     }
+
+    /// Regression guard: "eventHub enabled, nothing configured yet" is the normal pre-rollout state. It
+    /// holds no gated data, so failing closed on it would black out all telemetry — and fire the debug
+    /// event — for every install running a config that has not reached the rollout yet.
+    @Test("settings without a telemetry key pass through untouched and fire nothing")
+    func settingsWithoutTelemetryKeyPassThroughUntouchedAndFireNothing() {
+        let capture = CapturingEventMapping()
+        let subject = EventHubSettings(
+            featureEnabledPublisher: Just(true).eraseToAnyPublisher(),
+            featureSettingsPublisher: Just(["other": "value"] as [String: Any]?).eraseToAnyPublisher(),
+            consentRequirements: [FakeConsentRequirement()],
+            eventMapping: capture.eventMapping)
+
+        var latest: [String: Any]?
+        let cancellable = subject.settingsPublisher.sink { latest = $0 }
+        defer { cancellable.cancel() }
+
+        #expect(latest?["other"] as? String == "value")
+        #expect(capture.fired.isEmpty)
+    }
+
+    @Test("telemetry in a shape that cannot be stripped fails closed and reports it")
+    func telemetryInUnstrippableShapeFailsClosedAndReportsIt() {
+        let capture = CapturingEventMapping()
+        let subject = EventHubSettings(
+            featureEnabledPublisher: Just(true).eraseToAnyPublisher(),
+            featureSettingsPublisher: Just([EventHubConfigParser.telemetryKey: "not an object"] as [String: Any]?).eraseToAnyPublisher(),
+            consentRequirements: [FakeConsentRequirement()],
+            eventMapping: capture.eventMapping)
+
+        var latest: [String: Any]?
+        var received = false
+        let cancellable = subject.settingsPublisher.sink { latest = $0; received = true }
+        defer { cancellable.cancel() }
+
+        #expect(received)
+        #expect(latest == nil)
+        #expect(capture.fired == [.consentStripFailed])
+    }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/EventHubSettingsTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/EventHubSettingsTests.swift
@@ -23,16 +23,15 @@ import Combine
 
 @Suite("EventHubSettings")
 struct EventHubSettingsTests {
-    static let json = """
+    static let settings = settingsDictionary("""
     { "telemetry": {
         "gated_pixel":   { "state": "enabled", "trigger": { "type": "period", "period": { "seconds": 60 } } },
         "ungated_pixel": { "state": "enabled", "trigger": { "type": "period", "period": { "seconds": 60 } } }
     } }
-    """.data(using: .utf8)!
+    """)
 
-    private static func telemetryKeys(_ settings: Data?) throws -> [String] {
-        let object = try JSONSerialization.jsonObject(with: settings ?? Data()) as? [String: Any]
-        let telemetry = object?["telemetry"] as? [String: Any] ?? [:]
+    private static func telemetryKeys(_ settings: [String: Any]?) -> [String] {
+        let telemetry = settings?[EventHubConfigParser.telemetryKey] as? [String: Any] ?? [:]
         return telemetry.keys.sorted()
     }
 
@@ -44,20 +43,20 @@ struct EventHubSettingsTests {
     }
 
     @Test("removes the gated config while consent is withheld")
-    func removesGatedConfigWhileConsentIsWithheld() throws {
+    func removesGatedConfigWhileConsentIsWithheld() {
         let requirement = FakeConsentRequirement()
         let subject = EventHubSettings(
             featureEnabledPublisher: Just(true).eraseToAnyPublisher(),
-            featureSettingsPublisher: Just(Self.json as Data?).eraseToAnyPublisher(),
+            featureSettingsPublisher: Just(Self.settings as [String: Any]?).eraseToAnyPublisher(),
             consentRequirements: [requirement])
 
-        var latest: Data?
+        var latest: [String: Any]?
         let cancellable = subject.settingsPublisher.sink { latest = $0 }
         defer { cancellable.cancel() }
 
-        #expect(try Self.telemetryKeys(latest) == ["ungated_pixel"])
+        #expect(Self.telemetryKeys(latest) == ["ungated_pixel"])
 
         requirement.granted.send(true)
-        #expect(try Self.telemetryKeys(latest) == ["gated_pixel", "ungated_pixel"])
+        #expect(Self.telemetryKeys(latest) == ["gated_pixel", "ungated_pixel"])
     }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/WebEventsHandlerTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/WebEventsHandlerTests.swift
@@ -21,7 +21,7 @@ import Foundation
 import WebKit
 @testable import EventHub
 
-@Suite("WebEventsHandler")
+@Suite("WebEventsHandler", .timeLimit(.minutes(1)))
 struct WebEventsHandlerTests {
     private final class SpyManager: EventHubManaging {
         var handledWebEvents: [(data: [String: Any], tabID: EventHubTabID)] = []


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216794817159920
Tech Design URL: https://app.asana.com/1/137249556945/project/1203936086921904/task/1216592765148783?focus=true
CC: @bwaresiak

### Description
Stacked on `michal/event-hub-1` (#5959) — that one first; this PR's diff is only the diagnostics work layered on top.

Answers the review comment on #5959: *"There's quite a bit of `try?` calls here — shouldn't we add error pixels (daily/count)?"* The root cause was a port omission. Windows has `Diagnostic.cs`, an ETW source logging every fail-safe boundary; it was deliberately not ported (no ETW on Apple) and never replaced, so around fifteen failure paths were swallowing errors in silence.

Windows added no error or debug pixels for these — its `eventhub_pixels.json` holds only the nine governed telemetry pixels — so the cross-platform precedent is local tracing, not pixels. This PR follows it: **everything logs, two things also pixel.**

- **Logging at every fail-safe boundary**, via a new `Logger.eventHub` — the Apple stand-in for `Diagnostic.cs`. Config rejections, persistence read/write/decode failures, consent-strip failures, unserialisable payloads and dropped web events all say so now.
- **Two debug events**, delivered through an injected `EventMapping` so the package stays free of any pixel dependency and tests can assert on the event rather than a side effect. One covers losing persisted state, carrying which operation failed as a parameter rather than splitting into four pixel names; the other covers failing closed on consent stripping. Injection defaults to nil, so a target that wants logging only gets exactly that. The pixel definitions themselves are deferred — see Quality Considerations.

Auditing those paths turned up four things worth fixing, each with covering tests:

- **A cold start was indistinguishable from a broken store.** "Nothing persisted yet" and "the read threw" landed in the same branch. Left alone, the new pixel would have fired for every install on first launch.
- **"Nothing configured yet" was treated as broken config.** Two paths did this. In the parser it merely logged a spurious error, but in consent stripping it *failed closed* — so a consent-gated build running a pre-rollout config would have blacked out all telemetry and fired the new pixel, over settings holding nothing gated in the first place.
- **A latent divide-by-zero on the fire path.** The period length was defaulted to zero before being used as a divisor, so a period trigger that somehow arrived without a period would trap — in the one code path that is the whole point of an aggregation period. Unreachable today because the parser rejects those configs; the default was the enabling line, and it is now a guard that skips the fire and logs.
- **A misconfiguration guard that only worked in debug.** Passing the same queue to the hub and its scheduler deadlocks the hub. That was caught by an `assert`, which is compiled out under `-O` — so in release the guard vanished and the deadlock happened instead, and it does not stay contained: every entry point serialises on that queue, so the main thread blocks next and the symptom is an app-wide hang attributed to an unrelated thread. Now a `precondition`, i.e. a loud trap naming the exact wiring mistake. See What could go wrong.

Two API-shaping changes came out of the same pass:

- **Feature settings cross the package boundary as `[String: Any]`, not `Data`.** Remote config already holds them that way, so the old signature forced the app to re-serialise, then this package parsed twice — four conversions to reach a model one would do. Beyond the waste, it manufactured failures: the consent-strip pixel would partly have measured our own round trip. Taking the dictionary directly deletes one whole fail-closed branch as unreachable. Worth landing before the integration PR writes both apps' wiring against the old shape.
- **Bucket evaluation order is now set explicitly by the parser**, sorted by range, instead of inherited from JSON object key order. See Quality Considerations — this is a pre-existing issue the change above made visible rather than one it introduced.

### Testing Steps
1. `cd SharedPackages/EventHub && swift test` → 143/143 passing (131 before this PR, 12 new).
2. To see the tracing, filter Console.app or `log stream` on subsystem `EventHub` — nothing in this package emits yet without a host app, so this is only useful once the integration PR lands.

No app to manually test: this package still isn't referenced by any app target.

### Impact
None for users — the package isn't imported anywhere yet, and no pixel is defined or fired by this PR.

#### What could go wrong?
- A same-queue misconfiguration now crashes release builds instead of hanging → the condition depends only on how the two objects were constructed, so it is constant for a build: it trips on the first timer fire for everyone or for nobody. The only code that can wire it wrongly is the integration PR, where it would surface immediately in dogfood.
- The persistence event is spike-prone, since a read happens on every save and delete → intended to be fired daily-and-count so one wedged install can't dominate the daily figure, and two tests assert the healthy paths (cold start, successful round trip) fire nothing at all.
- Consent stripping now passes settings through where it previously blacked them out → only when there is no `telemetry` key whatsoever, i.e. nothing gated to leak. Covered by a test; the fail-closed behaviour is unchanged whenever telemetry actually exists.

### Quality Considerations
- **Pixel definitions are deliberately not in this PR.** Names, `owners`, `triggers`, `expires`, the json5 entries and the privacy triage belong with the integration PR, where firing is actually wired and the Tech Design already schedules triage. The package side is just the typed events and the injection points. Suggested names when that lands, per the current no-`m_` snake_case convention: `event_hub_persistence_failed` / `event_hub_consent_strip_failed` on iOS, with `_macos` appended on macOS. Note these are ordinary app error pixels and follow the normal convention — unlike the *telemetry* pixels EventHub itself fires, which take a governed base name from config per TD note [5].
- **Bucket ordering was never deterministic for live config, and still isn't guaranteed by the JSON.** `BucketCounter` is first-match-wins, and the decoder relied on JSON keys arriving in document order. That holds for the persisted snapshot but not for remote config, which reaches us as an unordered dictionary — so the order was arbitrary before this PR too, just hidden behind a `Data` round trip. It has been harmless because real bucket sets are disjoint (exactly one match, and the stop-counting check scans all of them), but overlapping ranges would have resolved differently per device. The parser now sorts by lower bound, then upper bound with open-ended last, so a bounded bucket wins over an open-ended one sharing its lower bound. Flagging rather than burying it, since it means the ordered-list machinery was carrying a guarantee it couldn't keep.
- **Still not covered by CI**, carried over from #5959: this package isn't in any Xcode scheme's test plan, so `ios_pr_checks.yml`/`macos_pr_checks.yml` don't run its suite. Only local `swift test` does. That mattered less at 131 tests than it does at 143 — worth the scheme/test-plan wiring or a dedicated workflow alongside the integration PR.
- Nothing logged is user-identifiable: only config-governed identifiers (pixel, parameter, bucket and data-key names) and error descriptions are interpolated, all as `.public`. Web-page-derived event payloads and URLs are never logged at any privacy level — the two paths handling caller data say so at the call site.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes telemetry config ingestion, consent fail-closed behavior, and bucket ordering (could alter bucket labels if ranges overlapped); release precondition on scheduler wiring is intentional but will crash misconfigured integrators on first timer fire.
> 
> **Overview**
> Adds **Apple-side diagnostics** for EventHub: a `Logger.eventHub` (`os.log`) at every fail-safe boundary (config parsing, persistence, consent stripping, web ingress, native payload encoding), plus two optional **`EventHubDebugEvent`** types delivered through injected `EventMapping`—persistence failures (with operation) and consent-strip failures—so the package stays pixel-free until integration wires real pixels.
> 
> **Settings and parsing** now use **`[String: Any]`** end-to-end (`EventHubSettingsProviding`, `parseTelemetry`) instead of `Data`, matching BSK remote config and dropping redundant serialize/parse round trips. **`EventHubConfigParser`** logs skipped pixels/parameters, validates telemetry with `isValidJSONObject`, and **sorts counter buckets by range** (not JSON key order) so first-match-wins behavior is deterministic for live config.
> 
> **Correctness / safety fixes:** distinguish absent store vs read/decode failures (cold start does not fire debug events); consent stripping passes through settings with no `telemetry` key; period pixel fire skips instead of dividing when period seconds are missing; same-queue scheduler/hub wiring is a **release `precondition`** instead of debug-only `assert`. **`EventHubKeyValueStore`** logs all store boundaries and fires debug events on state-losing failures. Tests add coverage for debug events, bucket order, consent strip, and throwing KV store; package adds **Common** dependency for `EventMapping`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b553d9d8f716090166358b992a0a323259eadcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->