### PR TITLE
Add RSA-3072 account_info key generation

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
@@ -269,6 +269,10 @@ public enum SyncCredentialID {
     public static let thirdParty = "3party"
 }
 
+enum ProtectedKeyPurpose {
+    static let accountInfo = "account_info"
+}
+
 // AccessCredential is decoded from API responses using JSONDecoder.snakeCaseKeys. The server key
 // is "encrypted_3party_credential", and .convertFromSnakeCase maps that to encrypted3PartyCredential.
 // Adding a CodingKeys raw value for the literal server key would make decoding return nil.

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyFactory.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyFactory.swift
@@ -1,0 +1,73 @@
+//
+//  AccountInfoKeyFactory.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+struct AccountInfoKeyFactory {
+
+    private static let keySizeInBits = 3072
+
+    private let crypter: CryptingInternal
+    private let jweCompactCodec: JWECompactCodec
+
+    init(crypter: CryptingInternal, jweCompactCodec: JWECompactCodec = JWECompactCodec()) {
+        self.crypter = crypter
+        self.jweCompactCodec = jweCompactCodec
+    }
+
+    /// Creates one RSA key pair and wraps its private key for each available account credential.
+    func makeProtectedKeys(accountSecretKey: Data, thirdPartyMainKey: Data? = nil) throws -> [ProtectedKey] {
+        let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial(keySizeInBits: Self.keySizeInBits)
+        let keyID = UUID().uuidString
+        let defaultCredentialKey = try makeDefaultCredentialKey(keyMaterial: keyMaterial,
+                                                                keyID: keyID,
+                                                                accountSecretKey: accountSecretKey)
+        guard let thirdPartyMainKey else {
+            return [defaultCredentialKey]
+        }
+
+        let thirdPartyCredentialKey = try makeThirdPartyCredentialKey(keyMaterial: keyMaterial,
+                                                                      keyID: keyID,
+                                                                      thirdPartyMainKey: thirdPartyMainKey)
+        return [defaultCredentialKey, thirdPartyCredentialKey]
+    }
+
+    private func makeDefaultCredentialKey(keyMaterial: ScopedAccessKeyFactory.RSAKeyMaterial,
+                                          keyID: String,
+                                          accountSecretKey: Data) throws -> ProtectedKey {
+        let encryptedPrivateKey = try crypter.encrypt(keyMaterial.privateKeyPKCS8, using: accountSecretKey)
+        return ProtectedKey(kid: keyID,
+                            encryptedPrivateKey: Base64URL.encode(encryptedPrivateKey),
+                            publicKey: keyMaterial.publicKeyJWK,
+                            encryptedWith: SyncCredentialID.defaultCredential,
+                            purpose: ProtectedKeyPurpose.accountInfo)
+    }
+
+    private func makeThirdPartyCredentialKey(keyMaterial: ScopedAccessKeyFactory.RSAKeyMaterial,
+                                             keyID: String,
+                                             thirdPartyMainKey: Data) throws -> ProtectedKey {
+        let encryptedPrivateKey = try jweCompactCodec.encryptDirect(payload: keyMaterial.privateKeyPKCS8,
+                                                                    contentEncryptionKey: thirdPartyMainKey,
+                                                                    kid: SyncCredentialID.thirdParty)
+        return ProtectedKey(kid: keyID,
+                            encryptedPrivateKey: encryptedPrivateKey,
+                            publicKey: keyMaterial.publicKeyJWK,
+                            encryptedWith: SyncCredentialID.thirdParty,
+                            purpose: ProtectedKeyPurpose.accountInfo)
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessKeyFactory.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessKeyFactory.swift
@@ -32,7 +32,6 @@ enum ScopedAccessKeyFactoryError: Error {
 enum ScopedAccessKeyFactory {
 
     private static let scopedPasswordLength = 32
-    private static let rsaKeySizeInBits = 2048
 
     struct RSAKeyMaterial {
         let publicKeyJWK: ProtectedKeyPublicKey
@@ -43,8 +42,8 @@ enum ScopedAccessKeyFactory {
         try randomBytes(count: scopedPasswordLength)
     }
 
-    static func makeRSAKeyMaterial() throws -> RSAKeyMaterial {
-        let keyPair = try makeRSAKeyPair()
+    static func makeRSAKeyMaterial(keySizeInBits: Int = 2048) throws -> RSAKeyMaterial {
+        let keyPair = try makeRSAKeyPair(keySizeInBits: keySizeInBits)
         let publicKeyPKCS1 = try copyExternalRepresentation(for: keyPair.publicKey,
                                                             error: .publicKeyExportFailed)
         let privateKeyPKCS1 = try copyExternalRepresentation(for: keyPair.privateKey,
@@ -76,9 +75,9 @@ enum ScopedAccessKeyFactory {
                             purpose: purpose)
     }
 
-    private static func makeRSAKeyPair() throws -> RSAKeyPair {
+    private static func makeRSAKeyPair(keySizeInBits: Int) throws -> RSAKeyPair {
         do {
-            return try RSAKeyPairGenerator.makeKeyPair(keySizeInBits: rsaKeySizeInBits)
+            return try RSAKeyPairGenerator.makeKeyPair(keySizeInBits: keySizeInBits)
         } catch RSAKeyPairGeneratorError.keyGenerationFailed {
             throw ScopedAccessKeyFactoryError.keyGenerationFailed
         } catch RSAKeyPairGeneratorError.publicKeyExtractionFailed {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyFactoryTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyFactoryTests.swift
@@ -1,0 +1,74 @@
+//
+//  AccountInfoKeyFactoryTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+@testable import DDGSync
+
+final class AccountInfoKeyFactoryTests: XCTestCase {
+
+    private let accountSecretKey = Data(repeating: 0x01, count: 32)
+    private let thirdPartyMainKey = Data(repeating: 0x02, count: 32)
+
+    func testWhenThirdPartyMainKeyIsUnavailableThenCreatesRSA3072DefaultCredentialWrapper() throws {
+        let crypter = CryptingMock()
+        let factory = AccountInfoKeyFactory(crypter: crypter)
+
+        let protectedKeys = try factory.makeProtectedKeys(accountSecretKey: accountSecretKey)
+
+        let protectedKey = try XCTUnwrap(protectedKeys.first)
+        XCTAssertEqual(protectedKeys.count, 1)
+        XCTAssertEqual(protectedKey.encryptedWith, SyncCredentialID.defaultCredential)
+        XCTAssertEqual(protectedKey.purpose, ProtectedKeyPurpose.accountInfo)
+        XCTAssertEqual(try modulusByteCount(of: protectedKey), 384)
+        XCTAssertFalse(try unwrapDefaultCredentialPrivateKey(protectedKey, crypter: crypter).isEmpty)
+    }
+
+    func testWhenThirdPartyMainKeyIsAvailableThenWrapsSameRSA3072PrivateKeyForBothCredentials() throws {
+        let crypter = CryptingMock()
+        let factory = AccountInfoKeyFactory(crypter: crypter)
+
+        let protectedKeys = try factory.makeProtectedKeys(accountSecretKey: accountSecretKey,
+                                                          thirdPartyMainKey: thirdPartyMainKey)
+
+        let defaultCredentialKey = try XCTUnwrap(protectedKeys.first { $0.encryptedWith == SyncCredentialID.defaultCredential })
+        let thirdPartyCredentialKey = try XCTUnwrap(protectedKeys.first { $0.encryptedWith == SyncCredentialID.thirdParty })
+        XCTAssertEqual(protectedKeys.count, 2)
+        XCTAssertEqual(defaultCredentialKey.kid, thirdPartyCredentialKey.kid)
+        XCTAssertEqual(defaultCredentialKey.publicKey, thirdPartyCredentialKey.publicKey)
+        XCTAssertEqual(defaultCredentialKey.purpose, ProtectedKeyPurpose.accountInfo)
+        XCTAssertEqual(thirdPartyCredentialKey.purpose, ProtectedKeyPurpose.accountInfo)
+        XCTAssertEqual(try modulusByteCount(of: defaultCredentialKey), 384)
+
+        let defaultCredentialPrivateKey = try unwrapDefaultCredentialPrivateKey(defaultCredentialKey, crypter: crypter)
+        let thirdPartyCredentialPrivateKey = try JWECompactCodec().decryptDirect(token: thirdPartyCredentialKey.encryptedPrivateKey,
+                                                                                contentEncryptionKey: thirdPartyMainKey)
+        XCTAssertEqual(defaultCredentialPrivateKey, thirdPartyCredentialPrivateKey)
+    }
+
+    private func modulusByteCount(of protectedKey: ProtectedKey) throws -> Int {
+        let modulus = try XCTUnwrap(protectedKey.publicKey.n)
+        return try XCTUnwrap(Base64URL.decode(modulus)).count
+    }
+
+    private func unwrapDefaultCredentialPrivateKey(_ protectedKey: ProtectedKey,
+                                                   crypter: CryptingInternal) throws -> Data {
+        let encryptedPrivateKey = try XCTUnwrap(Base64URL.decode(protectedKey.encryptedPrivateKey))
+        return try crypter.decryptData(encryptedPrivateKey, using: accountSecretKey)
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessKeyFactoryTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessKeyFactoryTests.swift
@@ -1,0 +1,41 @@
+//
+//  ScopedAccessKeyFactoryTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+@testable import DDGSync
+
+final class ScopedAccessKeyFactoryTests: XCTestCase {
+
+    func testWhenKeySizeIsNotSpecifiedThenCreatesRSA2048KeyMaterial() throws {
+        let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
+
+        XCTAssertEqual(try modulusByteCount(in: keyMaterial), 256)
+    }
+
+    func testWhenKeySizeIs3072ThenCreatesRSA3072KeyMaterial() throws {
+        let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial(keySizeInBits: 3072)
+
+        XCTAssertEqual(try modulusByteCount(in: keyMaterial), 384)
+    }
+
+    private func modulusByteCount(in keyMaterial: ScopedAccessKeyFactory.RSAKeyMaterial) throws -> Int {
+        let modulus = try XCTUnwrap(keyMaterial.publicKeyJWK.n)
+        return try XCTUnwrap(Base64URL.decode(modulus)).count
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1217213092722097?focus=true
Tech Design URL:
CC:

### Description
- Makes RSA key generation configurable while preserving RSA-2048 as the default for existing callers.
- Adds the account_info key purpose and generates RSA-3072 key material.
- Wraps the same private key for ddg and, when available, 3party credentials while preserving key identity and public JWK.
- Adds focused unit coverage.
- This foundation does not register keys or alter runtime/server behaviour.

### Testing Steps
1. No manual testing required; this code is not yet wired into app flows. CI coverage validates RSA-2048 compatibility, RSA-3072 generation, and single/dual-wrapper key consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync cryptography and key-wrapping paths, but changes are isolated behind new factory code with RSA-2048 defaults preserved and no runtime integration yet.
> 
> **Overview**
> Introduces **RSA-3072 `account_info` protected key generation** as foundational DDG Sync scoped-access work, without wiring it into app or server flows yet.
> 
> Adds `AccountInfoKeyFactory`, which builds one RSA-3072 key pair and emits `ProtectedKey` entries with purpose `account_info`: the private key is encrypted with the account secret for the `ddg` credential, and when a third-party main key is present, the **same** `kid`/public JWK/private material is wrapped again via direct JWE for `3party`. `ScopedAccessKeyFactory.makeRSAKeyMaterial` now accepts an optional key size (default **2048** unchanged for existing callers such as `makeJWEProtectedKey`). Defines `ProtectedKeyPurpose.accountInfo` in sync models. Unit tests cover 2048 vs 3072 key material and single/dual credential wrapping consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b753073aa0b3ddc3b4a79d36a446dba82170aef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->