### PR TITLE
macOS: Disable smart dashes and quotes in web content

### DIFF
--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1391,6 +1391,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // https://app.asana.com/0/1177771139624306/1207024603216659/f
         LottieConfiguration.shared.renderingEngine = .mainThread
 
+        // Must run before the first web view is created, as WebKit caches its text
+        // checking state – updating later would only take effect on next launch
+        grammarFeaturesManager.manage()
+
         configurationManager.start()
 
         let isFirstLaunch = LocalStatisticsStore().atb == nil
@@ -1460,8 +1464,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 WindowsManager.openNewWindow(isOpenedAutomatically: true, lazyLoadTabs: true)
             }
         }
-
-        grammarFeaturesManager.manage()
 
         applyPreferredTheme()
 

--- a/macOS/DuckDuckGo/Application/GrammarFeaturesManager.swift
+++ b/macOS/DuckDuckGo/Application/GrammarFeaturesManager.swift
@@ -25,12 +25,16 @@ final class GrammarFeaturesManager {
         case continuousSpellChecking
         case grammarChecking
         case autocorrection
+        case dashSubstitution
+        case quoteSubstitution
 
         var webKitPreferenceKey: WebKitPreferenceKey {
             switch self {
             case .continuousSpellChecking: return .WebContinuousSpellCheckingEnabled
             case .grammarChecking: return .WebGrammarCheckingEnabled
             case .autocorrection: return .WebAutomaticSpellingCorrectionEnabled
+            case .dashSubstitution: return .WebAutomaticDashSubstitutionEnabled
+            case .quoteSubstitution: return .WebAutomaticQuoteSubstitutionEnabled
             }
         }
     }
@@ -46,6 +50,10 @@ final class GrammarFeaturesManager {
 
         // Autocorrection
         case WebAutomaticSpellingCorrectionEnabled
+
+        // Text substitutions
+        case WebAutomaticDashSubstitutionEnabled
+        case WebAutomaticQuoteSubstitutionEnabled
     }
     // swiftlint:enable identifier_name
 
@@ -71,9 +79,21 @@ final class GrammarFeaturesManager {
             UserDefaults.standard.setValue(false, forKey: feature.webKitPreferenceKey.rawValue)
         }
 
+        func disableFeatureUnlessChosenByUser(_ feature: Feature) {
+            let key = feature.webKitPreferenceKey.rawValue
+            guard UserDefaults.standard.object(forKey: key) == nil else { return }
+
+            UserDefaults.standard.setValue(false, forKey: key)
+        }
+
         enableFeatureOnce(.continuousSpellChecking, alreadyEnabledOnce: &spellingCheckEnabledOnce)
         enableFeatureOnce(.grammarChecking, alreadyEnabledOnce: &grammarCheckEnabledOnce)
         disableFeature(.autocorrection)
+
+        // Dash and quote substitution can cause formatting issues which break features on sites like Github.
+        // If the user hasn't set an explicit value for these, we'll disable them.
+        disableFeatureUnlessChosenByUser(.dashSubstitution)
+        disableFeatureUnlessChosenByUser(.quoteSubstitution)
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1217205957234554?focus=true
Tech Design URL:
CC:

### Description

MacOS text substitutions for smart dashes and smart quotes were active in text fields, rewriting double hyphens as em-dashes and straight quotes as curly ones.

On GitHub this silently broke attaching images to a pull request review. GitHub inserts a placeholder line while an upload runs (e.g. `<!-- image_name -->`), then swaps it for the image markdown once it finishes. Smart dashes rewrote the closing characters of that placeholder to use an em-dash, so GitHub could no longer find the text it needed to replace and the image would never appear.

The same substitution corrupted the separator row of markdown tables inserted with `/table`, breaking the formatting and requiring manual cleanup.

In this PR I've turned off these substitutions by default in web content, matching both the address bar and Safari and Chrome's behaviour (as far as I can tell). Users who prefer them can still enable them from Edit > Substitutions, and we'll respect that choice.

### Testing Steps

Quit the app and clear any stored preferences:

```
defaults delete com.duckduckgo.macos.browser.debug WebAutomaticDashSubstitutionEnabled
defaults delete com.duckduckgo.macos.browser.debug WebAutomaticQuoteSubstitutionEnabled
```

1. Launch the app and open any pull request on GitHub, then go to the "Files changed" tab.
2. Start a review comment and attach an image by either dragging-and-dropping it into the comment box, or clicking to upload. The placeholder text should appear and then be replaced by the image (previously, the text would never be replaced).
3. Open a new issue and type `/table` in the text area. Choose a number of columns and rows and ensure it's inserted correctly. Previously, the formatting would be broken.
5. Type `--` and `"some text"` into any web page text field and check they stay as typed, rather than becoming `—` and curly quotes.
6. Open the Edit > Substitutions menu, and check that Smart Dashes and Smart Quotes are both unchecked.
7. Enable Smart Dashes, quit, relaunch, and check in the Edit > Substitutions menu that the option is still enabled.

### Impact

Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?

- A user who deliberately enabled substitutions could have that choice overwritten on every launch - but we check in the new code whether there's already a preference.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
