### PR TITLE
Add feature flag for sync UI on macOS

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -601,9 +601,6 @@ public enum SyncSubfeature: String, PrivacySubfeature {
     case scopedAccessCredentials
     case canUseV2ConnectFlow
     case canShowV2ConnectCode
-
-    /// Gates the Simplified Sync Setup follow-up screens (deactivation + multi-device path).
-    /// https://app.asana.com/1/137249556945/project/1214200115953388/task/1215960387490701
     case simplifiedSyncSetupV2
 }
 

--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -462,6 +462,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215597855114765?focus=true
     case syncCanShowV2ConnectCode
 
+    /// Gates the Simplified Sync Setup follow-up screens.
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217243916693082?focus=true
+    case simplifiedSyncSetupV2
+
     /// Gates the macOS Prompt Bar: a system-wide Duck.ai entry point opened via a global
     /// keyboard shortcut or a menu bar icon, plus its rows on the AI Features settings screen.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216850216210288?focus=true
@@ -780,6 +784,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(SyncSubfeature.canUseV2ConnectFlow), category: .sync)
         case .syncCanShowV2ConnectCode:
             Config(source: .remoteReleasable(SyncSubfeature.canShowV2ConnectCode), category: .sync)
+        case .simplifiedSyncSetupV2:
+            Config(source: .remoteReleasable(SyncSubfeature.simplifiedSyncSetupV2), category: .sync)
         case .promptBar:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.promptBar), category: .duckAI)
         case .bookmarksReorderByName:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216261329370883?focus=true

### Description
Adds the `simplifiedSyncSetupV2` feature flag on macOS, wired to the existing `SyncSubfeature.simplifiedSyncSetupV2` privacy config subfeature as remote-releasable. This gates the Simplified Sync Setup follow-up screens.

### Testing Steps
1. Build the macOS app.
2. Confirm it compiles and the flag appears under the Sync category in the internal feature flags UI.

### Impact
None — flag defaults to off (remote-releasable) and gates no shipping behavior yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag registration and privacy-config wiring only; remote-releasable default keeps new sync UI off until explicitly enabled.
> 
> **Overview**
> Adds the macOS **`simplifiedSyncSetupV2`** feature flag and wires it to **`SyncSubfeature.simplifiedSyncSetupV2`** as a remote-releasable flag in the **Sync** category, matching other sync rollout flags like `syncCanShowV2ConnectCode`.
> 
> This prepares macOS to gate the **Simplified Sync Setup** follow-up screens (deactivation and multi-device path) the same way iOS already does via the shared privacy subfeature. The flag defaults off until privacy config enables it; no sync UI behavior is switched in this PR.
> 
> Also trims the inline comment above `simplifiedSyncSetupV2` in shared `PrivacyFeature.swift` (the enum case is unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e947b4cc609a5d69612de43b50c07b05205f802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->