### PR TITLE
[iOS] Measure interactions with the inactivity notification

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1461,6 +1461,7 @@
 		9D41D8DF2DC5213500BA0B63 /* DBPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D41D8DE2DC5213500BA0B63 /* DBPService.swift */; };
 		9D6891E72DAD2DF800819662 /* DataBrokerProtection-iOS in Frameworks */ = {isa = PBXBuildFile; productRef = 9D6891E62DAD2DF800819662 /* DataBrokerProtection-iOS */; };
 		9DB4A2C72DCA609400DBE00C /* DataBrokerProtectionDebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB4A2C62DCA609400DBE00C /* DataBrokerProtectionDebugViewController.swift */; };
+		9DFED3A23D9B49CAACA9987C /* InactivityNotificationStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBE7DD1430C4B6891A0EA51 /* InactivityNotificationStateStore.swift */; };
 		9F012C632DF7BD9D00AE0F43 /* AudioSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F012C622DF7BD9100AE0F43 /* AudioSession.swift */; };
 		9F012C652DF7BE1F00AE0F43 /* PictureInPictureController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F012C642DF7BE1800AE0F43 /* PictureInPictureController.swift */; };
 		9F03113A2DF7C6B700AC4DB5 /* Logger+VideoPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0311392DF7C6AC00AC4DB5 /* Logger+VideoPlayer.swift */; };
@@ -1899,6 +1900,7 @@
 		BB343F392EBE1EFD00F206F5 /* SERPSettingsEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB343F382EBE1EF600F206F5 /* SERPSettingsEventHandler.swift */; };
 		BB3F734D2F321F4000461429 /* FreeTrialPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3F734C2F321F4000461429 /* FreeTrialPixelHandler.swift */; };
 		BB490ECF2EBDF36B00649B5B /* WinBackOfferFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB490ECE2EBDF36B00649B5B /* WinBackOfferFactory.swift */; };
+		BB4A68EB6CC94473ABB68EB4 /* InactivityNotificationStateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC32EC2491F40BF921F07B4 /* InactivityNotificationStateStoreTests.swift */; };
 		BB631D162DE0D9020099977D /* DesignResourcesKitIcons in Frameworks */ = {isa = PBXBuildFile; productRef = BB631D152DE0D9020099977D /* DesignResourcesKitIcons */; };
 		BB64A3602F6AEBA4006897A2 /* SubscriptionPromoCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB64A35E2F6AEBA4006897A2 /* SubscriptionPromoCoordinatorTests.swift */; };
 		BB6696372E9E6613003CB6AD /* WinBackOffer.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BB6696362E9E6613003CB6AD /* WinBackOffer.xcassets */; };
@@ -4359,6 +4361,7 @@
 		98F78B8D22419093007CACF4 /* ThemableNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemableNavigationController.swift; sourceTree = "<group>"; };
 		9A3E2B5140E5464B0AA21D09 /* RebrandedAddToDockTutorialView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RebrandedAddToDockTutorialView.swift; sourceTree = "<group>"; };
 		9AD3EE389CF6162AB1F6B023 /* UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift; sourceTree = "<group>"; };
+		9BC32EC2491F40BF921F07B4 /* InactivityNotificationStateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactivityNotificationStateStoreTests.swift; sourceTree = "<group>"; };
 		9CE6E4AC0A04CDAE37EE5D76 /* TabsBarLayoutTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TabsBarLayoutTests.swift; sourceTree = "<group>"; };
 		9D41D8DC2DC5153D00BA0B63 /* DataBrokerProtectionSettings+Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataBrokerProtectionSettings+Environment.swift"; sourceTree = "<group>"; };
 		9D41D8DE2DC5213500BA0B63 /* DBPService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBPService.swift; sourceTree = "<group>"; };
@@ -5375,6 +5378,7 @@
 		DD503EBD506182525F5E8107 /* OnboardingView+Landing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "OnboardingView+Landing.swift"; sourceTree = "<group>"; };
 		DE747E6BBE21B3AFA2A1A263 /* SubscriptionOnboardingPrefetcherTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingPrefetcherTests.swift; sourceTree = "<group>"; };
 		DDCC0FF100000000A0A0A001 /* SettingsNextStepsDismissalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsNextStepsDismissalTests.swift; sourceTree = "<group>"; };
+		DEBE7DD1430C4B6891A0EA51 /* InactivityNotificationStateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactivityNotificationStateStore.swift; sourceTree = "<group>"; };
 		E0742FD8DD5F46AB8243103F /* NTPAfterIdleInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPAfterIdleInstrumentation.swift; sourceTree = "<group>"; };
 		E0742FD8DD5F46AB8243A001 /* IdleReturnTabCountInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnTabCountInstrumentation.swift; sourceTree = "<group>"; };
 		E1A4A4D42F2A111100AA11BB /* TabViewController+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabViewController+UI.swift"; sourceTree = "<group>"; };
@@ -6962,6 +6966,7 @@
 			isa = PBXGroup;
 			children = (
 				369E692C2E5F6EB500F98A8F /* InactivityNotificationSchedulerServiceTests.swift */,
+				9BC32EC2491F40BF921F07B4 /* InactivityNotificationStateStoreTests.swift */,
 				CB3B4D552D649DC8006DAD63 /* AutoClearServiceTests.swift */,
 				CB3B4D532D648C44006DAD63 /* AuthenticationServiceTests.swift */,
 				9F387DF42EA8BED0006861F8 /* PromoCoordinationServiceTests.swift */,
@@ -10748,6 +10753,7 @@
 				BB77957E2E9D4B4D00CF58F4 /* WinBackOfferService.swift */,
 				85E803722E786B95008E87CA /* AIChatService.swift */,
 				369E69272E5F4B8500F98A8F /* InactivityNotificationSchedulerService.swift */,
+				DEBE7DD1430C4B6891A0EA51 /* InactivityNotificationStateStore.swift */,
 				9F2E797D2E0B9F6500E2BEF3 /* DefaultBrowserPromptService.swift */,
 				9858189F2D8C296D00993B04 /* AppKeyValueFileStoreService.swift */,
 				CBF259572D3AA85600AC63E4 /* VPNService.swift */,
@@ -14348,6 +14354,7 @@
 				56D060282C380D83003BAEB5 /* OnboardingSuggestedSearchesProvider.swift in Sources */,
 				F44D279C27F331BB0037F371 /* AutofillLoginPromptView.swift in Sources */,
 				369E69282E5F4B9600F98A8F /* InactivityNotificationSchedulerService.swift in Sources */,
+				9DFED3A23D9B49CAACA9987C /* InactivityNotificationStateStore.swift in Sources */,
 				C1EA86622C74CB8B00E8604D /* SyncPromoViewModel.swift in Sources */,
 				F1FDC9302BF4E0B3006B1435 /* SubscriptionEnvironment+Default.swift in Sources */,
 				7BBE25A32D71EE72003131FA /* MainViewController+Automation.swift in Sources */,
@@ -14822,6 +14829,7 @@
 				98AAF8E4292EB46000DBDF06 /* BookmarksMigrationTests.swift in Sources */,
 				98E5649E2DE8ED1400E6E75F /* SyncMocks.swift in Sources */,
 				369E692D2E5F6EC200F98A8F /* InactivityNotificationSchedulerServiceTests.swift in Sources */,
+				BB4A68EB6CC94473ABB68EB4 /* InactivityNotificationStateStoreTests.swift in Sources */,
 				85D2187224BF24F2004373D2 /* NotFoundCachingDownloaderTests.swift in Sources */,
 				C1935A242C89CC6D001AD72D /* AutofillHeaderViewFactoryTests.swift in Sources */,
 				9FB19C892E94CF4100B651B1 /* RemoteMessagingSurfacesProviderTests.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1456,6 +1456,7 @@
 		9AE3828826E7799156260FC4 /* SubscriptionOnboardingVPNInfoCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B9BA7199137531335CBA79 /* SubscriptionOnboardingVPNInfoCard.swift */; };
 		9C120EFD1C1879698FCE275F /* RemoteMessagingUIPreviewsDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136D952152194AD431654F8D /* RemoteMessagingUIPreviewsDebugView.swift */; };
 		9C9CD1DC620E3580AB799BDB /* SubscriptionOnboardingVPNActivationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F51104EAB9108C45BEA81D /* SubscriptionOnboardingVPNActivationViewModel.swift */; };
+		9C82EB251AB64AC1B5CD29E5 /* NotificationServiceManagerInactivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F505ACF205934E868F011C16 /* NotificationServiceManagerInactivityTests.swift */; };
 		9CF2A679A5C82A51D01D49C0 /* SubscriptionOnboardingSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3901A00979D78E26EF811EEA /* SubscriptionOnboardingSectionTests.swift */; };
 		9D41D8DD2DC5153D00BA0B63 /* DataBrokerProtectionSettings+Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D41D8DC2DC5153D00BA0B63 /* DataBrokerProtectionSettings+Environment.swift */; };
 		9D41D8DF2DC5213500BA0B63 /* DBPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D41D8DE2DC5213500BA0B63 /* DBPService.swift */; };
@@ -5610,6 +5611,7 @@
 		F4F7F10725813FE200045D62 /* 01_Fire_really_small.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 01_Fire_really_small.json; sourceTree = "<group>"; };
 		F4F7F10825813FE200045D62 /* 02_Water_swirl_really_small.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 02_Water_swirl_really_small.json; sourceTree = "<group>"; };
 		F4F7F10925813FE200045D62 /* 03_Airstream_divided_by_four.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 03_Airstream_divided_by_four.json; sourceTree = "<group>"; };
+		F505ACF205934E868F011C16 /* NotificationServiceManagerInactivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceManagerInactivityTests.swift; sourceTree = "<group>"; };
 		F5B8A4C2A6FBE678C5A92ABF /* SearchTokenFetcherTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchTokenFetcherTests.swift; sourceTree = "<group>"; };
 		F7594859CB2334A38D629EF5 /* SafariRedirectHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariRedirectHandlerTests.swift; sourceTree = "<group>"; };
 		F773BFAFFD82A0D714B8F35D /* SubscriptionOnboardingConnectionInfoService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingConnectionInfoService.swift; sourceTree = "<group>"; };
@@ -11706,6 +11708,7 @@
 				CB3B4D512D63CDA0006DAD63 /* AppStateMachineTests.swift */,
 				CB18A3652E2790C700BE9D8D /* UserAgentConfigurationTests.swift */,
 				4B2DF8A52E64C67000FBF11E /* WideEventServiceTests.swift */,
+				F505ACF205934E868F011C16 /* NotificationServiceManagerInactivityTests.swift */,
 			);
 			name = Application;
 			sourceTree = "<group>";
@@ -14703,6 +14706,7 @@
 				56A625252ED62AEF00803E31 /* SubscriptionPageFeatureFlagAdapterTests.swift in Sources */,
 				5B4F88C42F465B76003999E2 /* TabExternalLaunchTests.swift in Sources */,
 				366A93062FCE0E3700211BA8 /* SubscriptionExpirationReminderSchedulerTests.swift in Sources */,
+				9C82EB251AB64AC1B5CD29E5 /* NotificationServiceManagerInactivityTests.swift in Sources */,
 				5B4F88C72F466017003999E2 /* TabManagerExternalLaunchTests.swift in Sources */,
 				9876DF2D2DEEE21700E30713 /* MockThemeManager.swift in Sources */,
 				84EFBCC92D81796000706739 /* AutocompleteSuggestionsDataSourceTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -357,7 +357,13 @@ struct Launching: LaunchingHandling {
         remoteMessagingService.messageNavigator = DefaultMessageNavigator(delegate: mainCoordinator.controller)
         omniBarFocuser.focuser = mainCoordinator.controller
 
-        let notificationServiceManager = NotificationServiceManager(mainCoordinator: mainCoordinator)
+        let inactivityStateStore = InactivityNotificationStateStore(
+            keyValueStore: appKeyValueFileStoreService.keyValueFilesStore
+        )
+        let notificationServiceManager = NotificationServiceManager(
+            mainCoordinator: mainCoordinator,
+            inactivityStateStore: inactivityStateStore
+        )
 
         let vpnService = VPNService(mainCoordinator: mainCoordinator, notificationServiceManager: notificationServiceManager)
         let inactivityNotificationSchedulerService = InactivityNotificationSchedulerService(

--- a/iOS/DuckDuckGo/AppServices/InactivityNotificationSchedulerService.swift
+++ b/iOS/DuckDuckGo/AppServices/InactivityNotificationSchedulerService.swift
@@ -33,6 +33,11 @@ final class InactivityNotificationSchedulerService {
         static let defaultDaysInactive: Int = 7 // default to 7 days
         static let notificationIdentifier = "com.duckduckgo.inactivity.notification"
         static let subfeature: any PrivacySubfeature = iOSBrowserConfigSubfeature.inactivityNotification
+
+        static let notificationCategory = UNNotificationCategory(identifier: notificationIdentifier,
+                                                                 actions: [],
+                                                                 intentIdentifiers: [],
+                                                                 options: [.customDismissAction])
     }
     
     // MARK: - Dependencies
@@ -103,6 +108,7 @@ final class InactivityNotificationSchedulerService {
         content.title = UserText.inactivityNotificationTitle
         content.body = UserText.inactivityNotificationBody
         content.userInfo = [Constants.daysInactiveSettingKey: daysInactive]
+        content.categoryIdentifier = Constants.notificationIdentifier
         return content
     }
     

--- a/iOS/DuckDuckGo/AppServices/InactivityNotificationStateStore.swift
+++ b/iOS/DuckDuckGo/AppServices/InactivityNotificationStateStore.swift
@@ -38,20 +38,19 @@ final class InactivityNotificationStateStore: InactivityNotificationStateStoring
     }
 
     var interactionCount: Int {
-        do {
-            return try keyValueStore.object(forKey: StorageKey.interactionCount) as? Int ?? 0
-        } catch {
-            Logger.pushNotification.error("Inactivity notification interactionCount read failed with \(error.localizedDescription, privacy: .public)")
-            return 0
-        }
+        (try? readInteractionCount()) ?? 0
     }
 
     func recordInteraction() {
-        let next = interactionCount + 1
         do {
+            let next = try readInteractionCount() + 1
             try keyValueStore.set(next, forKey: StorageKey.interactionCount)
         } catch {
-            Logger.pushNotification.error("Inactivity notification recordInteraction write failed with \(error.localizedDescription, privacy: .public)")
+            Logger.pushNotification.error("Inactivity notification recordInteraction failed with \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    private func readInteractionCount() throws -> Int {
+        try keyValueStore.object(forKey: StorageKey.interactionCount) as? Int ?? 0
     }
 }

--- a/iOS/DuckDuckGo/AppServices/InactivityNotificationStateStore.swift
+++ b/iOS/DuckDuckGo/AppServices/InactivityNotificationStateStore.swift
@@ -1,0 +1,57 @@
+//
+//  InactivityNotificationStateStore.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Persistence
+import Core
+
+protocol InactivityNotificationStateStoring: AnyObject {
+    var interactionCount: Int { get }
+    func recordInteraction()
+}
+
+final class InactivityNotificationStateStore: InactivityNotificationStateStoring {
+    enum StorageKey {
+        static let interactionCount = "inactivity-notification.interaction-count"
+    }
+
+    private let keyValueStore: ThrowingKeyValueStoring
+
+    init(keyValueStore: ThrowingKeyValueStoring) {
+        self.keyValueStore = keyValueStore
+    }
+
+    var interactionCount: Int {
+        do {
+            return try keyValueStore.object(forKey: StorageKey.interactionCount) as? Int ?? 0
+        } catch {
+            Logger.pushNotification.error("Inactivity notification interactionCount read failed with \(error.localizedDescription, privacy: .public)")
+            return 0
+        }
+    }
+
+    func recordInteraction() {
+        let next = interactionCount + 1
+        do {
+            try keyValueStore.set(next, forKey: StorageKey.interactionCount)
+        } catch {
+            Logger.pushNotification.error("Inactivity notification recordInteraction write failed with \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/iOS/DuckDuckGo/NotificationServiceManager.swift
+++ b/iOS/DuckDuckGo/NotificationServiceManager.swift
@@ -29,14 +29,18 @@ protocol NotificationServiceManaging: UNUserNotificationCenterDelegate {}
 final class NotificationServiceManager: NSObject, NotificationServiceManaging {
 
     private let mainCoordinator: MainCoordinator
+    private let inactivityStateStore: InactivityNotificationStateStoring
 
     static let notificationCategories: Set<UNNotificationCategory> = [
-        DefaultSubscriptionExpirationReminderScheduler.notificationCategory
+        DefaultSubscriptionExpirationReminderScheduler.notificationCategory,
+        InactivityNotificationSchedulerService.Constants.notificationCategory
     ]
 
     init(mainCoordinator: MainCoordinator,
+         inactivityStateStore: InactivityNotificationStateStoring,
          notificationCenter: UNUserNotificationCenterRepresentable = UNUserNotificationCenter.current()) {
         self.mainCoordinator = mainCoordinator
+        self.inactivityStateStore = inactivityStateStore
         super.init()
         Self.registerNotificationCategories(on: notificationCenter)
     }
@@ -65,11 +69,14 @@ final class NotificationServiceManager: NSObject, NotificationServiceManaging {
             return
         }
 
+        if id == InactivityNotificationSchedulerService.Constants.notificationIdentifier {
+            handleInactivityNotification(for: response)
+            return
+        }
+
         guard response.actionIdentifier == UNNotificationDefaultActionIdentifier else { return }
 
         switch id {
-        case InactivityNotificationSchedulerService.Constants.notificationIdentifier:
-            handleInactivityNotification(for: response)
         case let raw where NetworkProtectionNotificationIdentifier(rawValue: raw) != nil:
             if let identifier = NetworkProtectionNotificationIdentifier(rawValue: raw) {
                 handleVPNNotification(identifier: identifier)
@@ -85,16 +92,39 @@ final class NotificationServiceManager: NSObject, NotificationServiceManaging {
 }
 
 
+// MARK: - Testability
+
+extension NotificationServiceManager {
+
+    static func handleInactivityNotification(actionIdentifier: String,
+                                             userInfo: [AnyHashable: Any],
+                                             stateStore: InactivityNotificationStateStoring) {
+        let daysInactiveKey = InactivityNotificationSchedulerService.Constants.daysInactiveSettingKey
+        let daysInactive = userInfo[daysInactiveKey] as? Int ?? InactivityNotificationSchedulerService.Constants.defaultDaysInactive
+
+        switch actionIdentifier {
+        case UNNotificationDefaultActionIdentifier:
+            stateStore.recordInteraction()
+            Pixel.fire(pixel: .inactiveUserProvisionalPushNotificationTapped, withAdditionalParameters: [daysInactiveKey: String(daysInactive)])
+            // no special navigation
+        case UNNotificationDismissActionIdentifier:
+            stateStore.recordInteraction()
+        default:
+            break
+        }
+    }
+}
+
 // MARK: - Helpers
 
 private extension NotificationServiceManager {
-    
+
     func handleInactivityNotification(for response: UNNotificationResponse) {
-        let daysInactiveKey = InactivityNotificationSchedulerService.Constants.daysInactiveSettingKey
-        let daysInactive = response.notification.request.content.userInfo[daysInactiveKey] as? Int ?? InactivityNotificationSchedulerService.Constants.defaultDaysInactive
-        Pixel.fire(pixel: .inactiveUserProvisionalPushNotificationTapped, withAdditionalParameters: [daysInactiveKey: String(daysInactive)])
+        Self.handleInactivityNotification(actionIdentifier: response.actionIdentifier,
+                                          userInfo: response.notification.request.content.userInfo,
+                                          stateStore: inactivityStateStore)
     }
-    
+
     @MainActor
     func handleVPNNotification(identifier: NetworkProtectionNotificationIdentifier) {
         let scrollToStrictRouting = identifier == .strictRoutingReminder

--- a/iOS/DuckDuckGoTests/AppServices/InactivityNotificationStateStoreTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/InactivityNotificationStateStoreTests.swift
@@ -1,0 +1,44 @@
+//
+//  InactivityNotificationStateStoreTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import PersistenceTestingUtils
+@testable import DuckDuckGo
+
+final class InactivityNotificationStateStoreTests: XCTestCase {
+    func testWhenNewStoreThenInteractionCountIsZero() throws {
+        let store = InactivityNotificationStateStore(keyValueStore: MockKeyValueFileStore())
+        XCTAssertEqual(store.interactionCount, 0)
+    }
+
+    func testWhenRecordInteractionThenCountIncrements() throws {
+        let store = InactivityNotificationStateStore(keyValueStore: MockKeyValueFileStore())
+        store.recordInteraction()
+        store.recordInteraction()
+        XCTAssertEqual(store.interactionCount, 2)
+    }
+
+    func testWhenPersistedCountThenNewStoreInstanceReadsIt() throws {
+        let kv = MockKeyValueFileStore()
+        let first = InactivityNotificationStateStore(keyValueStore: kv)
+        first.recordInteraction()
+        let second = InactivityNotificationStateStore(keyValueStore: kv)
+        XCTAssertEqual(second.interactionCount, 1)
+    }
+}

--- a/iOS/DuckDuckGoTests/AppServices/InactivityNotificationStateStoreTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/InactivityNotificationStateStoreTests.swift
@@ -41,4 +41,16 @@ final class InactivityNotificationStateStoreTests: XCTestCase {
         let second = InactivityNotificationStateStore(keyValueStore: kv)
         XCTAssertEqual(second.interactionCount, 1)
     }
+
+    func testWhenReadFailsThenRecordInteractionDoesNotResetPersistedCount() throws {
+        let kv = MockKeyValueFileStore(underlyingDict: [InactivityNotificationStateStore.StorageKey.interactionCount: 5])
+        let store = InactivityNotificationStateStore(keyValueStore: kv)
+
+        kv.throwOnRead = MockKeyValueFileStore.MockError.getError
+        store.recordInteraction()
+
+        // The write should have been abandoned rather than resetting the counter to 1.
+        kv.throwOnRead = nil
+        XCTAssertEqual(store.interactionCount, 5)
+    }
 }

--- a/iOS/DuckDuckGoTests/NotificationServiceManagerInactivityTests.swift
+++ b/iOS/DuckDuckGoTests/NotificationServiceManagerInactivityTests.swift
@@ -1,0 +1,138 @@
+//
+//  NotificationServiceManagerInactivityTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import UserNotifications
+@testable import DuckDuckGo
+@testable import Core
+
+final class NotificationServiceManagerInactivityTests: XCTestCase {
+
+    private var stateStore: MockInactivityNotificationStateStore!
+    private let daysInactiveKey = InactivityNotificationSchedulerService.Constants.daysInactiveSettingKey
+    private let tappedPixelName = Pixel.Event.inactiveUserProvisionalPushNotificationTapped.name
+
+    override func setUp() {
+        super.setUp()
+        stateStore = MockInactivityNotificationStateStore()
+        clearPixelStorage()
+    }
+
+    override func tearDown() {
+        stateStore = nil
+        clearPixelStorage()
+        super.tearDown()
+    }
+
+    private func clearPixelStorage() {
+        Pixel.storage.removeObject(forKey: tappedPixelName)
+    }
+
+    // MARK: - Category registration
+
+    func test_notificationCategories_includesInactivityCategoryWithCustomDismissAction() throws {
+        let category = try XCTUnwrap(NotificationServiceManager.notificationCategories.first {
+            $0.identifier == InactivityNotificationSchedulerService.Constants.notificationIdentifier
+        })
+        XCTAssertTrue(category.options.contains(.customDismissAction),
+                      "The inactivity category must register .customDismissAction, otherwise the dismiss callback is never delivered")
+    }
+
+    func test_registerNotificationCategories_registersInactivityCategoryOnCenter() throws {
+        let center = MockUNUserNotificationCenter()
+
+        NotificationServiceManager.registerNotificationCategories(on: center)
+
+        XCTAssertTrue(center.registeredCategories.contains {
+            $0.identifier == InactivityNotificationSchedulerService.Constants.notificationIdentifier
+        })
+    }
+
+    // MARK: - Tap (default action)
+
+    func test_defaultAction_recordsInteractionOnceAndFiresTapPixel() {
+        NotificationServiceManager.handleInactivityNotification(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            userInfo: [daysInactiveKey: 5],
+            stateStore: stateStore
+        )
+
+        XCTAssertEqual(stateStore.recordInteractionCallCount, 1)
+        XCTAssertNotNil(Pixel.storage.object(forKey: tappedPixelName), "Tap pixel should have fired")
+    }
+
+    func test_defaultAction_missingDaysInactiveInUserInfo_stillRecordsAndFiresUsingDefaultDays() {
+        NotificationServiceManager.handleInactivityNotification(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            userInfo: [:],
+            stateStore: stateStore
+        )
+
+        XCTAssertEqual(stateStore.recordInteractionCallCount, 1)
+        XCTAssertNotNil(Pixel.storage.object(forKey: tappedPixelName))
+    }
+
+    // MARK: - Dismiss
+
+    func test_dismissAction_recordsInteractionOnceAndFiresNoPixel() {
+        NotificationServiceManager.handleInactivityNotification(
+            actionIdentifier: UNNotificationDismissActionIdentifier,
+            userInfo: [daysInactiveKey: 5],
+            stateStore: stateStore
+        )
+
+        XCTAssertEqual(stateStore.recordInteractionCallCount, 1)
+        XCTAssertNil(Pixel.storage.object(forKey: tappedPixelName), "Tap pixel should not have fired")
+    }
+
+    func test_dismissAction_missingDaysInactiveInUserInfo_stillRecordsInteraction() {
+        NotificationServiceManager.handleInactivityNotification(
+            actionIdentifier: UNNotificationDismissActionIdentifier,
+            userInfo: [:],
+            stateStore: stateStore
+        )
+
+        XCTAssertEqual(stateStore.recordInteractionCallCount, 1)
+    }
+
+    // MARK: - Other action identifiers unaffected
+
+    func test_otherActionIdentifier_doesNotRecordInteractionOrFireAnyPixel() {
+        NotificationServiceManager.handleInactivityNotification(
+            actionIdentifier: "com.duckduckgo.some.other.action",
+            userInfo: [daysInactiveKey: 5],
+            stateStore: stateStore
+        )
+
+        XCTAssertEqual(stateStore.recordInteractionCallCount, 0)
+        XCTAssertNil(Pixel.storage.object(forKey: tappedPixelName))
+    }
+}
+
+// MARK: - Mocks
+
+final class MockInactivityNotificationStateStore: InactivityNotificationStateStoring {
+    private(set) var recordInteractionCallCount = 0
+    var interactionCount: Int = 0
+
+    func recordInteraction() {
+        recordInteractionCallCount += 1
+        interactionCount += 1
+    }
+}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1217241593830525?focus=true
Tech Design URL:
CC:

### Description

Adds support to locally count how many times a user has interacted with the inactivity notification (tap or dismiss):
* Storage for the interaction count
* Increments the interaction count after receiving a tap or dismiss action

Support for using this interaction count will be added in a followup PR.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Confirm checks pass.

These changes can be manually tested by triggering the notification with the changes and testing steps in https://github.com/duckduckgo/apple-browsers/pull/6208.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
3. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low: Adds non-user-facing changes to existing (currently disabled) feature

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->
Refactors how inactivity notifications are handled. A mistake could disrupt how the notification tap pixel is fired; mitigated with unit tests, and this notification is currently disabled by a remote feature flag.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect only the flag-gated inactivity notification path and local analytics storage; tap pixel behavior is covered by unit tests and the feature remains remotely disabled.
> 
> **Overview**
> Adds **local tracking** of how often users **tap or dismiss** the inactivity push notification, so a follow-up PR can use that count without new plumbing.
> 
> **`InactivityNotificationStateStore`** persists an interaction counter in the app key-value store and increments it on each recorded interaction; read failures during increment are handled so the stored count is not reset.
> 
> **Notification handling** is refactored: the inactivity notification uses a registered category with **`.customDismissAction`** so dismiss actions are delivered. **`NotificationServiceManager`** routes inactivity responses by notification id and, on **tap**, records an interaction and fires the existing tap pixel; on **dismiss**, it records an interaction only. Launch wiring creates the state store and injects it into the notification manager.
> 
> Unit tests cover category registration, tap vs dismiss behavior, pixel firing, and store persistence/error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c74d949971a198592388713b3851d1e551b2f739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217241614991312