### PR TITLE
[iOS] Limit the inactivity notification after 4 interactions

### DIFF
--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -369,7 +369,8 @@ struct Launching: LaunchingHandling {
         let inactivityNotificationSchedulerService = InactivityNotificationSchedulerService(
             featureFlagger: featureFlagger,
             notificationServiceManager: notificationServiceManager,
-            privacyConfigurationManager: contentBlockingService.common.privacyConfigurationManager
+            privacyConfigurationManager: contentBlockingService.common.privacyConfigurationManager,
+            stateStore: inactivityStateStore
         )
 
         winBackOfferService.setURLHandler(mainCoordinator)

--- a/iOS/DuckDuckGo/AppServices/InactivityNotificationSchedulerService.swift
+++ b/iOS/DuckDuckGo/AppServices/InactivityNotificationSchedulerService.swift
@@ -48,6 +48,13 @@ final class InactivityNotificationSchedulerService {
             case .maxInteractions: return 4 // default to 4 interactions
             }
         }
+
+        func value(from settings: [String: Any]?) -> Int {
+            guard let value = settings?[rawValue] as? Int, value >= 1 else {
+                return defaultValue
+            }
+            return value
+        }
     }
 
     // MARK: - Dependencies
@@ -130,17 +137,11 @@ final class InactivityNotificationSchedulerService {
     }
 
     var daysInactive: Int {
-        guard let daysInactive = subfeatureSettings?[Settings.daysInactive.rawValue] as? Int, daysInactive >= 1 else {
-            return Settings.daysInactive.defaultValue
-        }
-        return daysInactive
+        Settings.daysInactive.value(from: subfeatureSettings)
     }
 
     var maxInteractions: Int {
-        guard let maxInteractions = subfeatureSettings?[Settings.maxInteractions.rawValue] as? Int, maxInteractions >= 1 else {
-            return Settings.maxInteractions.defaultValue
-        }
-        return maxInteractions
+        Settings.maxInteractions.value(from: subfeatureSettings)
     }
 
     // MARK: - Private

--- a/iOS/DuckDuckGo/AppServices/InactivityNotificationSchedulerService.swift
+++ b/iOS/DuckDuckGo/AppServices/InactivityNotificationSchedulerService.swift
@@ -120,7 +120,7 @@ final class InactivityNotificationSchedulerService {
         }
     }
     
-    func makeUNNotificationContent(with daysInactive: Int = Settings.daysInactive.defaultValue) -> UNNotificationContent {
+    static func makeUNNotificationContent(with daysInactive: Int = Settings.daysInactive.defaultValue) -> UNNotificationContent {
         let content = UNMutableNotificationContent()
         content.title = UserText.inactivityNotificationTitle
         content.body = UserText.inactivityNotificationBody
@@ -169,7 +169,7 @@ final class InactivityNotificationSchedulerService {
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: .days(daysInactive), repeats: false)
         return UNNotificationRequest(
             identifier: Constants.notificationIdentifier,
-            content: makeUNNotificationContent(with: daysInactive),
+            content: Self.makeUNNotificationContent(with: daysInactive),
             trigger: trigger
         )
     }

--- a/iOS/DuckDuckGo/AppServices/InactivityNotificationSchedulerService.swift
+++ b/iOS/DuckDuckGo/AppServices/InactivityNotificationSchedulerService.swift
@@ -29,8 +29,6 @@ final class InactivityNotificationSchedulerService {
     // MARK: - Constants
     
     enum Constants {
-        static let daysInactiveSettingKey: String = "daysInactive"
-        static let defaultDaysInactive: Int = 7 // default to 7 days
         static let notificationIdentifier = "com.duckduckgo.inactivity.notification"
         static let subfeature: any PrivacySubfeature = iOSBrowserConfigSubfeature.inactivityNotification
 
@@ -39,24 +37,39 @@ final class InactivityNotificationSchedulerService {
                                                                  intentIdentifiers: [],
                                                                  options: [.customDismissAction])
     }
-    
+
+    enum Settings: String {
+        case daysInactive
+        case maxInteractions
+
+        var defaultValue: Int {
+            switch self {
+            case .daysInactive: return 7 // default to 7 days
+            case .maxInteractions: return 4 // default to 4 interactions
+            }
+        }
+    }
+
     // MARK: - Dependencies
-    
+
     private let featureFlagger: FeatureFlagger
     private let notificationServiceManager: NotificationServiceManaging
     private let privacyConfigurationManager: PrivacyConfigurationManaging
+    private let stateStore: InactivityNotificationStateStoring
     private let userNotificationCenter: UNUserNotificationCenterRepresentable
-    
+
     init(featureFlagger: FeatureFlagger,
          notificationServiceManager: NotificationServiceManaging,
          privacyConfigurationManager: PrivacyConfigurationManaging,
+         stateStore: InactivityNotificationStateStoring,
          userNotificationCenter: UNUserNotificationCenterRepresentable = UNUserNotificationCenter.current(),
     ) {
         self.featureFlagger = featureFlagger
         self.notificationServiceManager = notificationServiceManager
         self.privacyConfigurationManager = privacyConfigurationManager
+        self.stateStore = stateStore
         self.userNotificationCenter = userNotificationCenter
-        
+
         self.userNotificationCenter.delegate = notificationServiceManager
     }
     
@@ -64,7 +77,8 @@ final class InactivityNotificationSchedulerService {
     
     @discardableResult
     func resume() -> Task<Void, Never> {
-        guard isFeatureEnabled() else {
+        guard isFeatureEnabled(),
+              stateStore.interactionCount < maxInteractions else {
             cancelPendingNotifications()
             return Task {} // noop
         }
@@ -72,14 +86,17 @@ final class InactivityNotificationSchedulerService {
             await schedule()
         }
     }
-    
+
     func schedule() async {
         cancelPendingNotifications()
         await requestProvisionalAuthorizationIfNeeded()
-        
+
         let status = await userNotificationCenter.authorizationStatus()
-        guard status == .provisional else { return }
-            
+        guard status == .provisional || status == .authorized,
+              stateStore.interactionCount < maxInteractions else {
+            return
+        }
+
         let request = buildUNNotificationRequest()
         do {
             try await userNotificationCenter.add(request)
@@ -103,34 +120,43 @@ final class InactivityNotificationSchedulerService {
         }
     }
     
-    func makeUNNotificationContent(with daysInactive: Int = Constants.defaultDaysInactive) -> UNNotificationContent {
+    func makeUNNotificationContent(with daysInactive: Int = Settings.daysInactive.defaultValue) -> UNNotificationContent {
         let content = UNMutableNotificationContent()
         content.title = UserText.inactivityNotificationTitle
         content.body = UserText.inactivityNotificationBody
-        content.userInfo = [Constants.daysInactiveSettingKey: daysInactive]
+        content.userInfo = [Settings.daysInactive.rawValue: daysInactive]
         content.categoryIdentifier = Constants.notificationIdentifier
         return content
     }
-    
-    func makeDaysInactive() -> Int {
-        guard let settings = privacyConfigurationManager.privacyConfig.settings(for: Constants.subfeature),
-              let jsonData = settings.data(using: .utf8) else { return Constants.defaultDaysInactive }
-        
-        do {
-            if let settingsDict = try JSONSerialization.jsonObject(with: jsonData) as? [String: String],
-               let daysInactiveStr = settingsDict[Constants.daysInactiveSettingKey],
-               let daysInactive = Int(daysInactiveStr), daysInactive >= 1 {
-                return daysInactive
-            }
-        } catch {
-            Logger.pushNotification.error("Inactivity notification daysInactiveSettingKey parsed failed with \(error.localizedDescription, privacy: .public)")
+
+    var daysInactive: Int {
+        guard let daysInactive = subfeatureSettings?[Settings.daysInactive.rawValue] as? Int, daysInactive >= 1 else {
+            return Settings.daysInactive.defaultValue
         }
-        
-        return Constants.defaultDaysInactive
+        return daysInactive
     }
-    
+
+    var maxInteractions: Int {
+        guard let maxInteractions = subfeatureSettings?[Settings.maxInteractions.rawValue] as? Int, maxInteractions >= 1 else {
+            return Settings.maxInteractions.defaultValue
+        }
+        return maxInteractions
+    }
+
     // MARK: - Private
-    
+
+    private var subfeatureSettings: [String: Any]? {
+        guard let settings = privacyConfigurationManager.privacyConfig.settings(for: Constants.subfeature),
+              let jsonData = settings.data(using: .utf8) else { return nil }
+
+        do {
+            return try JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+        } catch {
+            Logger.pushNotification.error("Inactivity notification subfeature settings parsing failed with \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
     private func isFeatureEnabled() -> Bool {
         return featureFlagger.isFeatureOn(.inactivityNotification)
     }
@@ -140,7 +166,6 @@ final class InactivityNotificationSchedulerService {
     }
     
     private func buildUNNotificationRequest() -> UNNotificationRequest {
-        let daysInactive = makeDaysInactive()
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: .days(daysInactive), repeats: false)
         return UNNotificationRequest(
             identifier: Constants.notificationIdentifier,

--- a/iOS/DuckDuckGo/AppServices/InactivityNotificationStateStore.swift
+++ b/iOS/DuckDuckGo/AppServices/InactivityNotificationStateStore.swift
@@ -24,6 +24,7 @@ import Core
 protocol InactivityNotificationStateStoring: AnyObject {
     var interactionCount: Int { get }
     func recordInteraction()
+    func reset()
 }
 
 final class InactivityNotificationStateStore: InactivityNotificationStateStoring {
@@ -47,6 +48,14 @@ final class InactivityNotificationStateStore: InactivityNotificationStateStoring
             try keyValueStore.set(next, forKey: StorageKey.interactionCount)
         } catch {
             Logger.pushNotification.error("Inactivity notification recordInteraction failed with \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    func reset() {
+        do {
+            try keyValueStore.set(nil, forKey: StorageKey.interactionCount)
+        } catch {
+            Logger.pushNotification.error("Inactivity notification reset failed with \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
@@ -162,8 +162,8 @@ extension DebugScreensViewModel {
             .view(title: "Default Browser Prompt", { d in
                 DefaultBrowserPromptDebugView(model: DefaultBrowserPromptDebugViewModel(keyValueFilesStore: d.keyValueStore))
             }),
-            .view(title: "Notifications Playground", { _ in
-                LocalNotificationsPlaygroundView()
+            .view(title: "Notifications Playground", { d in
+                LocalNotificationsPlaygroundView(keyValueStore: d.keyValueStore)
             }),
             .view(title: "Win-back Offer", { d in
                 WinBackOfferDebugView(keyValueStore: d.keyValueStore)

--- a/iOS/DuckDuckGo/LocalNotificationsPlaygroundView.swift
+++ b/iOS/DuckDuckGo/LocalNotificationsPlaygroundView.swift
@@ -61,26 +61,42 @@ struct LocalNotificationsPlaygroundView: View {
             }
 
             Section {
-                VStack(alignment: .leading, spacing: 0) {
-                    Text(verbatim: "Title")
-                        .font(.caption)
-                    TextField("Title", text: $model.notificationTitle)
-                }
+                Picker(
+                    selection: $model.contentMode,
+                    content: {
+                        ForEach(LocalNotificationsPlaygroundViewModel.ContentMode.allCases, id: \.rawValue) { mode in
+                            Text(verbatim: mode.description).tag(mode)
+                        }
+                    },
+                    label: {
+                        Text(verbatim: "Content:")
+                    }
+                )
 
-                VStack(alignment: .leading, spacing: 0) {
-                    Text(verbatim: "Message")
-                        .font(.caption)
-                    TextField("Message", text: $model.notificationMessage)
+                if model.contentMode == .custom {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(verbatim: "Title")
+                            .font(.caption)
+                        TextField("Title", text: $model.notificationTitle)
+                    }
+
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(verbatim: "Message")
+                            .font(.caption)
+                        TextField("Message", text: $model.notificationMessage)
+                    }
                 }
             } header: {
                 Text(verbatim: "Content:")
             } footer: {
-                HStack {
-                    Button("Clear", action: model.clearAllContent)
+                if model.contentMode == .custom {
+                    HStack {
+                        Button("Clear", action: model.clearAllContent)
 
-                    Spacer()
+                        Spacer()
 
-                    Button("Default", action: model.fillDefaultContent)
+                        Button("Default", action: model.fillDefaultContent)
+                    }
                 }
             }
 
@@ -96,6 +112,7 @@ struct LocalNotificationsPlaygroundView: View {
                         Text(verbatim: "Type:")
                     }
                 )
+                .disabled(model.contentMode == .inactivityNotification)
 
                 Picker(
                     selection: $model.notificationSchedulingTime,
@@ -137,6 +154,14 @@ private final class LocalNotificationsPlaygroundViewModel: ObservableObject {
     private static let defaultBody = "We stopped 5 trackers from following you."
 
     @Published private(set) var isSchedulingNotification = false
+    @Published var contentMode: ContentMode = .custom {
+        didSet {
+            // Inactivity notifications are always provisional; keep the type in sync when selected.
+            if contentMode == .inactivityNotification {
+                notificationType = .provisional
+            }
+        }
+    }
     @Published var notificationTitle: String = defaultTitle
     @Published var notificationMessage: String = defaultBody
     @Published var notificationAuthStatus: NotificationAuthStatus = .notDetermined
@@ -162,7 +187,14 @@ private final class LocalNotificationsPlaygroundViewModel: ObservableObject {
             do {
                 guard try await center.requestAuthorization(options: options) else { return }
                 let trigger = UNTimeIntervalNotificationTrigger(timeInterval: Double(notificationSchedulingTime), repeats: false)
-                try await UNUserNotificationCenter.current().add(.make(identifier: Self.testNotificationIdentifier, title: notificationTitle, body: notificationMessage, trigger: trigger))
+                let request: UNNotificationRequest
+                switch contentMode {
+                case .inactivityNotification:
+                    request = .makeInactivityNotification(trigger: trigger)
+                case .custom:
+                    request = .make(identifier: Self.testNotificationIdentifier, title: notificationTitle, body: notificationMessage, trigger: trigger)
+                }
+                try await center.add(request)
             } catch {
                 print("~~~FAILED TO SEND NOTIFICATION TYPE: \(notificationType.description)")
             }
@@ -214,6 +246,20 @@ private final class LocalNotificationsPlaygroundViewModel: ObservableObject {
 
 extension LocalNotificationsPlaygroundViewModel {
 
+    enum ContentMode: Int, CaseIterable {
+        case inactivityNotification
+        case custom
+
+        var description: String {
+            switch self {
+            case .inactivityNotification:
+                return "Inactivity Notification"
+            case .custom:
+                return "Custom"
+            }
+        }
+    }
+
     enum NotificationType: Int, CaseIterable {
         case provisional
         case alert
@@ -264,6 +310,12 @@ extension UNNotificationRequest {
 
     static func make(identifier: String, title: String, body: String, trigger: UNNotificationTrigger? = nil) -> UNNotificationRequest {
         let content = UNNotificationContent.make(title: title, body: body)
+        return UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+    }
+
+    static func makeInactivityNotification(trigger: UNNotificationTrigger) -> UNNotificationRequest {
+        let identifier = InactivityNotificationSchedulerService.Constants.notificationIdentifier
+        let content = InactivityNotificationSchedulerService.makeUNNotificationContent()
         return UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
     }
 

--- a/iOS/DuckDuckGo/LocalNotificationsPlaygroundView.swift
+++ b/iOS/DuckDuckGo/LocalNotificationsPlaygroundView.swift
@@ -147,7 +147,7 @@ struct LocalNotificationsPlaygroundView: View {
                     }
                 case .inactivityNotification:
                     HStack(alignment: .top) {
-                        Text("The inactivity notification stops being scheduled when interaction count reaches the maxInteractions limit from the privacy config. Reset the count to test scheduling again.")
+                        Text(verbatim: "The inactivity notification stops being scheduled when interaction count reaches the maxInteractions limit from the privacy config. Reset the count to test scheduling again.")
                             .font(.caption)
                         Spacer()
 

--- a/iOS/DuckDuckGo/LocalNotificationsPlaygroundView.swift
+++ b/iOS/DuckDuckGo/LocalNotificationsPlaygroundView.swift
@@ -20,9 +20,14 @@
 import SwiftUI
 import Combine
 import UserNotifications
+import Persistence
 
 struct LocalNotificationsPlaygroundView: View {
-    @StateObject private var model = LocalNotificationsPlaygroundViewModel()
+    @StateObject private var model: LocalNotificationsPlaygroundViewModel
+
+    init(keyValueStore: ThrowingKeyValueStoring) {
+        _model = StateObject(wrappedValue: LocalNotificationsPlaygroundViewModel(keyValueStore: keyValueStore))
+    }
 
     var body: some View {
         List {
@@ -61,6 +66,40 @@ struct LocalNotificationsPlaygroundView: View {
             }
 
             Section {
+                if model.pendingNotifications.isEmpty {
+                    Text(verbatim: "No notifications scheduled")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(model.pendingNotifications) { notification in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(verbatim: notification.title.isEmpty ? notification.id : notification.title)
+                            Text(verbatim: notification.id)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            if let fireDate = notification.fireDate {
+                                Text(verbatim: "Fires: \(fireDate.formatted())")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            } header: {
+                Text(verbatim: "Scheduled Notifications:")
+            } footer: {
+                HStack {
+                    Text(verbatim: "Notifications currently pending in the system.")
+                        .font(.caption)
+
+                    Spacer()
+
+                    Button(action: { Task { await model.refreshPendingNotifications() } }) {
+                        Text(verbatim: "Refresh")
+                    }
+                }
+            }
+
+            Section {
                 Picker(
                     selection: $model.contentMode,
                     content: {
@@ -73,7 +112,8 @@ struct LocalNotificationsPlaygroundView: View {
                     }
                 )
 
-                if model.contentMode == .custom {
+                switch model.contentMode {
+                case .custom:
                     VStack(alignment: .leading, spacing: 0) {
                         Text(verbatim: "Title")
                             .font(.caption)
@@ -85,17 +125,35 @@ struct LocalNotificationsPlaygroundView: View {
                             .font(.caption)
                         TextField("Message", text: $model.notificationMessage)
                     }
+                case .inactivityNotification:
+                    HStack {
+                        Text(verbatim: "Interaction count")
+                        Spacer()
+                        Text(verbatim: "\(model.interactionCount)")
+                            .foregroundStyle(.secondary)
+                    }
                 }
             } header: {
-                Text(verbatim: "Content:")
+                Text(verbatim: "Schedule a notification:")
             } footer: {
-                if model.contentMode == .custom {
+                switch model.contentMode {
+                case .custom:
                     HStack {
                         Button("Clear", action: model.clearAllContent)
 
                         Spacer()
 
                         Button("Default", action: model.fillDefaultContent)
+                    }
+                case .inactivityNotification:
+                    HStack(alignment: .top) {
+                        Text("The inactivity notification stops being scheduled when interaction count reaches the maxInteractions limit from the privacy config. Reset the count to test scheduling again.")
+                            .font(.caption)
+                        Spacer()
+
+                        Button(role: .destructive, action: model.resetInteractionCount) {
+                            Text(verbatim: "Reset")
+                        }
                     }
                 }
             }
@@ -125,8 +183,6 @@ struct LocalNotificationsPlaygroundView: View {
                         Text(verbatim: "Schedule in seconds:")
                     }
                 )
-            } header: {
-                Text(verbatim: "Type:")
             } footer: {
                 if model.notificationType == .provisional {
                     Text(verbatim: "Provisional notifications are not delivered when the app is in foreground. Put the app in background once the notification is scheduled.")
@@ -169,15 +225,50 @@ private final class LocalNotificationsPlaygroundViewModel: ObservableObject {
     @Published var notificationType: NotificationType = .provisional
     @Published var notificationSchedulingTime: Int = 5
 
+    @Published private(set) var interactionCount: Int = 0
+
+    struct PendingNotification: Identifiable {
+        let id: String        // the request identifier (unique per pending request)
+        let title: String
+        let fireDate: Date?
+    }
+
+    @Published private(set) var pendingNotifications: [PendingNotification] = []
+
+    private let inactivityStateStore: InactivityNotificationStateStoring
+
     private var cancellable: AnyCancellable?
 
-    init() {
+    init(keyValueStore: ThrowingKeyValueStoring) {
+        inactivityStateStore = InactivityNotificationStateStore(keyValueStore: keyValueStore)
         bind()
     }
 
     func onAppear() {
+        refreshInteractionCount()
         Task {
             await refreshAuthorizationSettings()
+            await refreshPendingNotifications()
+        }
+    }
+
+    func resetInteractionCount() {
+        inactivityStateStore.reset()
+        refreshInteractionCount()
+    }
+
+    func refreshInteractionCount() {
+        interactionCount = inactivityStateStore.interactionCount
+    }
+
+    func refreshPendingNotifications() async {
+        let requests = await center.pendingNotificationRequests()
+        pendingNotifications = requests.map { request in
+            PendingNotification(
+                id: request.identifier,
+                title: request.content.title,
+                fireDate: (request.trigger as? UNTimeIntervalNotificationTrigger)?.nextTriggerDate()
+            )
         }
     }
 
@@ -195,6 +286,7 @@ private final class LocalNotificationsPlaygroundViewModel: ObservableObject {
                     request = .make(identifier: Self.testNotificationIdentifier, title: notificationTitle, body: notificationMessage, trigger: trigger)
                 }
                 try await center.add(request)
+                await refreshPendingNotifications()
             } catch {
                 print("~~~FAILED TO SEND NOTIFICATION TYPE: \(notificationType.description)")
             }
@@ -213,10 +305,8 @@ private final class LocalNotificationsPlaygroundViewModel: ObservableObject {
 
     private func bind() {
         cancellable = NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
-            .sink { _ in
-                Task { [weak self] in
-                    await self?.refreshAuthorizationSettings()
-                }
+            .sink { [weak self] _ in
+                self?.onAppear()
             }
     }
 
@@ -321,6 +411,12 @@ extension UNNotificationRequest {
 
 }
 
+private final class PreviewThrowingKeyValueStore: ThrowingKeyValueStoring {
+    func object(forKey defaultName: String) throws -> Any? { nil }
+    func set(_ value: Any?, forKey defaultName: String) throws {}
+    func removeObject(forKey defaultName: String) throws {}
+}
+
 #Preview {
-    LocalNotificationsPlaygroundView()
+    LocalNotificationsPlaygroundView(keyValueStore: PreviewThrowingKeyValueStore())
 }

--- a/iOS/DuckDuckGo/NotificationServiceManager.swift
+++ b/iOS/DuckDuckGo/NotificationServiceManager.swift
@@ -99,8 +99,8 @@ extension NotificationServiceManager {
     static func handleInactivityNotification(actionIdentifier: String,
                                              userInfo: [AnyHashable: Any],
                                              stateStore: InactivityNotificationStateStoring) {
-        let daysInactiveKey = InactivityNotificationSchedulerService.Constants.daysInactiveSettingKey
-        let daysInactive = userInfo[daysInactiveKey] as? Int ?? InactivityNotificationSchedulerService.Constants.defaultDaysInactive
+        let daysInactiveKey = InactivityNotificationSchedulerService.Settings.daysInactive.rawValue
+        let daysInactive = userInfo[daysInactiveKey] as? Int ?? InactivityNotificationSchedulerService.Settings.daysInactive.defaultValue
 
         switch actionIdentifier {
         case UNNotificationDefaultActionIdentifier:

--- a/iOS/DuckDuckGoTests/AppServices/InactivityNotificationSchedulerServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/InactivityNotificationSchedulerServiceTests.swift
@@ -19,6 +19,7 @@
 
 import XCTest
 import FoundationExtensions
+import PersistenceTestingUtils
 @testable import DuckDuckGo
 @testable import Core
 @testable import BrowserServicesKit
@@ -26,24 +27,27 @@ import FoundationExtensions
 final class MockNotificationServiceManager: NSObject, NotificationServiceManaging {}
 
 final class InactivityNotificationSchedulerServiceTests: XCTestCase {
-    
+
     var mockFeatureFlagger: MockFeatureFlagger!
     var mockPrivacyConfigManager: PrivacyConfigurationManagerMock!
     var mockNotificationServiceManager: MockNotificationServiceManager!
     var mockUserNotificationCenter: MockUNUserNotificationCenter!
+    var stateStore: InactivityNotificationStateStoring!
     var service: InactivityNotificationSchedulerService!
-    
+
     override func setUp() {
         super.setUp()
         mockPrivacyConfigManager = PrivacyConfigurationManagerMock()
         mockFeatureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.inactivityNotification])
         mockNotificationServiceManager = MockNotificationServiceManager()
         mockUserNotificationCenter = MockUNUserNotificationCenter()
-        
+        stateStore = InactivityNotificationStateStore(keyValueStore: MockKeyValueFileStore())
+
         service = InactivityNotificationSchedulerService(
             featureFlagger: mockFeatureFlagger,
             notificationServiceManager: mockNotificationServiceManager,
             privacyConfigurationManager: mockPrivacyConfigManager,
+            stateStore: stateStore,
             userNotificationCenter: mockUserNotificationCenter
         )
     }
@@ -53,6 +57,7 @@ final class InactivityNotificationSchedulerServiceTests: XCTestCase {
         mockFeatureFlagger = nil
         mockNotificationServiceManager = nil
         mockUserNotificationCenter = nil
+        stateStore = nil
         service = nil
         super.tearDown()
     }
@@ -88,7 +93,7 @@ final class InactivityNotificationSchedulerServiceTests: XCTestCase {
         XCTAssertEqual(notificationRequest.content.body, UserText.inactivityNotificationBody)
         XCTAssertEqual(notificationRequest.trigger, UNTimeIntervalNotificationTrigger(timeInterval: .days(7), repeats: false))
         
-        guard let daysInactive = notificationRequest.content.userInfo[ InactivityNotificationSchedulerService.Constants.daysInactiveSettingKey] as? Int else {
+        guard let daysInactive = notificationRequest.content.userInfo[ InactivityNotificationSchedulerService.Settings.daysInactive.rawValue] as? Int else {
             return XCTFail("Expected Int for daysInactive in userInfo")
         }
         XCTAssertEqual(daysInactive, 7)
@@ -136,20 +141,59 @@ final class InactivityNotificationSchedulerServiceTests: XCTestCase {
         }
     }
     
-    // MARK: - Schedule
-    
-    func test_schedule_statusNotProvisional_doNotSchedule() async {
+    func test_resume_whenInteractionLimitReached_cancelsAndDoesNotSchedule() async throws {
         // Given
-        mockUserNotificationCenter.authorizationStatus = .authorized
-        
+        mockUserNotificationCenter.authorizationStatus = .provisional
+        for _ in 0..<4 { stateStore.recordInteraction() }
+
         // When
-        await service.schedule()
-        
-        
+        await service.resume().value
+
         // Then
         XCTAssertTrue(mockUserNotificationCenter.removedIdentifiers.contains { $0.contains(InactivityNotificationSchedulerService.Constants.notificationIdentifier) })
-        XCTAssertTrue(mockUserNotificationCenter.didCheckAuthorizationStatus)
+        XCTAssertTrue(mockUserNotificationCenter.addedRequests.isEmpty)
+    }
+
+    func test_resume_whenRemoteMaxInteractionsDropsBelowCurrentCount_doesNotSchedule() async {
+        // Given: remote config now caps interactions at 2, and the user has already interacted twice.
+        (mockPrivacyConfigManager.privacyConfig as? PrivacyConfigurationMock)?.subfeatureSettings = [
+            "inactivityNotification": """
+                {"maxInteractions": 2}
+            """
+        ]
+        mockUserNotificationCenter.authorizationStatus = .provisional
+        for _ in 0..<2 { stateStore.recordInteraction() }
+
+        // When
+        await service.resume().value
+
+        // Then
+        XCTAssertTrue(mockUserNotificationCenter.addedRequests.isEmpty)
+    }
+
+    // MARK: - Schedule
+
+    func test_schedule_statusAuthorized_schedules() async {
+        // Given
+        mockUserNotificationCenter.authorizationStatus = .authorized
+
+        // When
+        await service.schedule()
+
+        // Then
+        XCTAssertEqual(mockUserNotificationCenter.addedRequests.count, 1)
         XCTAssertFalse(mockUserNotificationCenter.didRequestAuthorization)
+    }
+
+    func test_schedule_statusDenied_doesNotSchedule() async {
+        // Given
+        mockUserNotificationCenter.authorizationStatus = .denied
+
+        // When
+        await service.schedule()
+
+        // Then
+        XCTAssertTrue(mockUserNotificationCenter.addedRequests.isEmpty)
     }
     
     func test_schedule_statusIsNotDetermined_requestAndSchedule() async {
@@ -196,7 +240,38 @@ final class InactivityNotificationSchedulerServiceTests: XCTestCase {
         XCTAssertFalse(mockUserNotificationCenter.didRequestAuthorization)
         XCTAssertEqual(mockUserNotificationCenter.addedRequests.count, 0)
     }
-    
+
+    func test_schedule_whenInteractionLimitReachedBetweenResumeCheckAndSchedule_doesNotSchedule() async {
+        // Given: simulates the race where `resume()`'s outer gate passed, but interactions were
+        // recorded (e.g. from a concurrent notification response) before `schedule()`'s own
+        // add() call runs. `schedule()` must re-check the cap itself as defense-in-depth.
+        mockUserNotificationCenter.authorizationStatus = .provisional
+        for _ in 0..<InactivityNotificationSchedulerService.Settings.maxInteractions.defaultValue {
+            stateStore.recordInteraction()
+        }
+
+        // When
+        await service.schedule()
+
+        // Then
+        XCTAssertTrue(mockUserNotificationCenter.addedRequests.isEmpty)
+    }
+
+    func test_scheduledContent_hasInactivityIdentifier() async throws {
+        // Given
+        mockUserNotificationCenter.authorizationStatus = .provisional
+
+        // When
+        await service.schedule()
+
+        // Then
+        let request = try XCTUnwrap(mockUserNotificationCenter.addedRequests.first)
+        XCTAssertEqual(
+            request.content.categoryIdentifier,
+            InactivityNotificationSchedulerService.Constants.notificationIdentifier
+        )
+    }
+
     // MARK: - RequestAuthorizationIfNeeded
     
     func test_requestAuthIfNeeded_statusIsNotNotDetermined_doNotRequest() async {
@@ -238,24 +313,24 @@ final class InactivityNotificationSchedulerServiceTests: XCTestCase {
         XCTAssertTrue(mockUserNotificationCenter.requestedAuthorizationOptions.contains(.provisional))
     }
     
-    // MARK: - MakeDaysInactive
-    
-    func test_makeDaysInactive_readsConfiguredValue() {
+    // MARK: - daysInactive
+
+    func test_daysInactive_readsConfiguredValue() {
         // Given
         (mockPrivacyConfigManager.privacyConfig as? PrivacyConfigurationMock)?.subfeatureSettings = [
             "inactivityNotification": """
-                {"daysInactive": "5"}
+                {"daysInactive": 5}
             """
         ]
         
         // When
-        let result = service.makeDaysInactive()
-        
+        let result = service.daysInactive
+
         // Then
         XCTAssertEqual(result, 5)
     }
         
-    func test_makeDaysInactive_invalidValue_usesDefault() {
+    func test_daysInactive_invalidValue_usesDefault() {
         // Given
         (mockPrivacyConfigManager.privacyConfig as? PrivacyConfigurationMock)?.subfeatureSettings = [
             "inactivityNotification": """
@@ -264,38 +339,96 @@ final class InactivityNotificationSchedulerServiceTests: XCTestCase {
         ]
         
         // When
-        let result = service.makeDaysInactive()
-        
+        let result = service.daysInactive
+
         // Then
         XCTAssertEqual(result, 7)
     }
     
-    func test_makeDaysInactive_lessThanOne_usesDefault() {
+    func test_daysInactive_lessThanOne_usesDefault() {
         // Given
         (mockPrivacyConfigManager.privacyConfig as? PrivacyConfigurationMock)?.subfeatureSettings = [
             "inactivityNotification": """
-                {"daysInactive": "0"}
+                {"daysInactive": 0}
             """
         ]
         
         // When
-        let result = service.makeDaysInactive()
-        
+        let result = service.daysInactive
+
         // Then
         XCTAssertEqual(result, 7)
     }
     
-    func test_makeDaysInactive_emptyValue_usesDefault() {
+    func test_daysInactive_emptyValue_usesDefault() {
         // Given
         (mockPrivacyConfigManager.privacyConfig as? PrivacyConfigurationMock)?.subfeatureSettings = [:]
         
         // When
-        let result = service.makeDaysInactive()
-        
+        let result = service.daysInactive
+
         // Then
         XCTAssertEqual(result, 7)
     }
-    
+
+    // MARK: - maxInteractions
+
+    func test_maxInteractions_readsConfiguredValue() {
+        // Given
+        (mockPrivacyConfigManager.privacyConfig as? PrivacyConfigurationMock)?.subfeatureSettings = [
+            "inactivityNotification": """
+                {"maxInteractions": 3}
+            """
+        ]
+
+        // When
+        let result = service.maxInteractions
+
+        // Then
+        XCTAssertEqual(result, 3)
+    }
+
+    func test_maxInteractions_invalidValue_usesDefault() {
+        // Given
+        (mockPrivacyConfigManager.privacyConfig as? PrivacyConfigurationMock)?.subfeatureSettings = [
+            "inactivityNotification": """
+                {"maxInteractions": "x"}
+            """
+        ]
+
+        // When
+        let result = service.maxInteractions
+
+        // Then
+        XCTAssertEqual(result, InactivityNotificationSchedulerService.Settings.maxInteractions.defaultValue)
+    }
+
+    func test_maxInteractions_lessThanOne_usesDefault() {
+        // Given
+        (mockPrivacyConfigManager.privacyConfig as? PrivacyConfigurationMock)?.subfeatureSettings = [
+            "inactivityNotification": """
+                {"maxInteractions": 0}
+            """
+        ]
+
+        // When
+        let result = service.maxInteractions
+
+        // Then
+        XCTAssertEqual(result, InactivityNotificationSchedulerService.Settings.maxInteractions.defaultValue)
+    }
+
+    func test_maxInteractions_emptyValue_usesDefault() {
+        // Given
+        (mockPrivacyConfigManager.privacyConfig as? PrivacyConfigurationMock)?.subfeatureSettings = [:]
+
+        // When
+        let result = service.maxInteractions
+
+        // Then
+        XCTAssertEqual(result, InactivityNotificationSchedulerService.Settings.maxInteractions.defaultValue)
+    }
+
     // MARK: - makeNotficationContent
         
     func test_makeNotificationContent_setsTitleBodyAndUserInfo() {
@@ -306,7 +439,7 @@ final class InactivityNotificationSchedulerServiceTests: XCTestCase {
         XCTAssertEqual(content.title, UserText.inactivityNotificationTitle)
         XCTAssertEqual(content.body, UserText.inactivityNotificationBody)
         
-        if let daysInactive = content.userInfo[InactivityNotificationSchedulerService.Constants.daysInactiveSettingKey] as? Int {
+        if let daysInactive = content.userInfo[InactivityNotificationSchedulerService.Settings.daysInactive.rawValue] as? Int {
             XCTAssertEqual(daysInactive, 5)
         } else {
             XCTFail("Expected daysInactive in userInfo")
@@ -318,8 +451,8 @@ final class InactivityNotificationSchedulerServiceTests: XCTestCase {
         let content = service.makeUNNotificationContent()
         
         // Then
-        if let daysInactive = content.userInfo[InactivityNotificationSchedulerService.Constants.daysInactiveSettingKey] as? Int {
-            XCTAssertEqual(daysInactive, InactivityNotificationSchedulerService.Constants.defaultDaysInactive)
+        if let daysInactive = content.userInfo[InactivityNotificationSchedulerService.Settings.daysInactive.rawValue] as? Int {
+            XCTAssertEqual(daysInactive, InactivityNotificationSchedulerService.Settings.daysInactive.defaultValue)
         } else {
             XCTFail("Expected daysInactive in userInfo")
         }

--- a/iOS/DuckDuckGoTests/AppServices/InactivityNotificationSchedulerServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/InactivityNotificationSchedulerServiceTests.swift
@@ -433,7 +433,7 @@ final class InactivityNotificationSchedulerServiceTests: XCTestCase {
         
     func test_makeNotificationContent_setsTitleBodyAndUserInfo() {
         // When
-        let content = service.makeUNNotificationContent(with: 5)
+        let content = InactivityNotificationSchedulerService.makeUNNotificationContent(with: 5)
         
         // Then
         XCTAssertEqual(content.title, UserText.inactivityNotificationTitle)
@@ -448,7 +448,7 @@ final class InactivityNotificationSchedulerServiceTests: XCTestCase {
     
     func test_makeNotificationContent_setsTitleBodyAndUserInfo_useDefaultValue() {
         // When
-        let content = service.makeUNNotificationContent()
+        let content = InactivityNotificationSchedulerService.makeUNNotificationContent()
         
         // Then
         if let daysInactive = content.userInfo[InactivityNotificationSchedulerService.Settings.daysInactive.rawValue] as? Int {

--- a/iOS/DuckDuckGoTests/NotificationServiceManagerInactivityTests.swift
+++ b/iOS/DuckDuckGoTests/NotificationServiceManagerInactivityTests.swift
@@ -129,10 +129,16 @@ final class NotificationServiceManagerInactivityTests: XCTestCase {
 
 final class MockInactivityNotificationStateStore: InactivityNotificationStateStoring {
     private(set) var recordInteractionCallCount = 0
+    private(set) var resetCallCount = 0
     var interactionCount: Int = 0
 
     func recordInteraction() {
         recordInteractionCallCount += 1
         interactionCount += 1
+    }
+
+    func reset() {
+        resetCallCount += 1
+        interactionCount = 0
     }
 }

--- a/iOS/DuckDuckGoTests/NotificationServiceManagerInactivityTests.swift
+++ b/iOS/DuckDuckGoTests/NotificationServiceManagerInactivityTests.swift
@@ -25,7 +25,7 @@ import UserNotifications
 final class NotificationServiceManagerInactivityTests: XCTestCase {
 
     private var stateStore: MockInactivityNotificationStateStore!
-    private let daysInactiveKey = InactivityNotificationSchedulerService.Constants.daysInactiveSettingKey
+    private let daysInactiveKey = InactivityNotificationSchedulerService.Settings.daysInactive.rawValue
     private let tappedPixelName = Pixel.Event.inactiveUserProvisionalPushNotificationTapped.name
 
     override func setUp() {

--- a/iOS/IntegrationTests/InactivityNotificationSchedulerServiceIntegrationTests.swift
+++ b/iOS/IntegrationTests/InactivityNotificationSchedulerServiceIntegrationTests.swift
@@ -71,7 +71,7 @@ final class InactivityNotificationSchedulerServiceTests: XCTestCase {
 
         // Then
         let status = await userNotificationCenter.authorizationStatus()
-        guard status == .provisional else {
+        guard status == .provisional || status == .authorized else {
             let pending = await UNUserNotificationCenter.current().pendingNotificationRequests()
             XCTAssertEqual(pending.filter { $0.identifier == targetId }.count, 0)
             return
@@ -93,7 +93,7 @@ final class InactivityNotificationSchedulerServiceTests: XCTestCase {
 
         // Then
         let status = await userNotificationCenter.authorizationStatus()
-        guard status == .provisional else {
+        guard status == .provisional || status == .authorized else {
             let pending = await UNUserNotificationCenter.current().pendingNotificationRequests()
             XCTAssertEqual(pending.filter { $0.identifier == targetId }.count, 0)
             return

--- a/iOS/IntegrationTests/InactivityNotificationSchedulerServiceIntegrationTests.swift
+++ b/iOS/IntegrationTests/InactivityNotificationSchedulerServiceIntegrationTests.swift
@@ -18,6 +18,7 @@
 //
 
 import XCTest
+import PersistenceTestingUtils
 @testable import DuckDuckGo
 @testable import Core
 @testable import BrowserServicesKit
@@ -25,33 +26,37 @@ import XCTest
 final class MockNotificationServiceManager: NSObject, NotificationServiceManaging {}
 
 final class InactivityNotificationSchedulerServiceTests: XCTestCase {
-    
+
     var mockFeatureFlagger: MockFeatureFlagger!
     var mockPrivacyConfigManager: PrivacyConfigurationManagerMock!
     var mockNotificationServiceManager: MockNotificationServiceManager!
     var userNotificationCenter: UNUserNotificationCenterRepresentable!
+    var stateStore: InactivityNotificationStateStoring!
     var service: InactivityNotificationSchedulerService!
-    
+
     override func setUp() {
         super.setUp()
         mockPrivacyConfigManager = PrivacyConfigurationManagerMock()
         mockFeatureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.inactivityNotification])
         mockNotificationServiceManager = MockNotificationServiceManager()
         userNotificationCenter = UNUserNotificationCenter.current()
-        
+        stateStore = InactivityNotificationStateStore(keyValueStore: MockKeyValueFileStore())
+
         service = InactivityNotificationSchedulerService(
             featureFlagger: mockFeatureFlagger,
             notificationServiceManager: mockNotificationServiceManager,
             privacyConfigurationManager: mockPrivacyConfigManager,
+            stateStore: stateStore,
             userNotificationCenter: userNotificationCenter
         )
     }
-    
+
     override func tearDown() {
         mockPrivacyConfigManager = nil
         mockFeatureFlagger = nil
         mockNotificationServiceManager = nil
         userNotificationCenter = nil
+        stateStore = nil
         service = nil
         super.tearDown()
     }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1217241593830526?focus=true
Tech Design URL:
CC:

### Description

Limits the inactivity notification so it is no longer scheduled after 4 interactions (tap or dismiss) by default, or the count provided by privacy config setting.

Also adds a debug option to send the inactivity notification with a custom trigger (reduced wait), for testing the notification handling.

Corresponding privacy config change: https://github.com/duckduckgo/privacy-configuration/pull/5727

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
Enable the feature flag:
1. Go to Settings → Debug → Feature Flags → enable Internal User
2. Toggle `inactivityNotification` on

Test settings from privacy config:
1. Set breakpoints in `InactivityNotificationSchedulerService` at lines 136 and 143.
2. Go to Settings → Debug → Configuration URLs →Override privacy config: https://duckduckgo.github.io/privacy-configuration/pr-5727/v4/ios-config.json
3. Background the app.
4. Reopen the app:
   - Confirm the breakpoint at line 143 is hit and `maxInteractions` is 4 (value read from privacy config).
   - Confirm the breakpoint at line 136 is hit and `daysInactive` is 7 (value read from privacy config).

Fire and interact with the notification:
1. Go to Settings → Debug → Notifications Playground
3. Under "Scheduled Notifications" confirm you see an inactivity notification scheduled for 7 days in the future
4. Set Content to "Inactivity Notification"
5. Pick a delay (e.g. 5s) and schedule the notification
6. Background the app (provisional notifications are not delivered in the foreground)
7. Open Notification Center
8. Tap or dismiss the notification. If dismissed, reopen the app.
9. Confirm an inactivity notification is scheduled and the interaction count increased by 1.
10. Repeat steps 4-8 until the interaction count shows 4. Confirm there is no scheduled inactivity notification.

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Medium: Could disrupt the inactivity notification

#### What could go wrong?

A mistake could cause the inactivity notification to be misfired:
- An issue with decoding the privacy config settings could cause it to always fall back to the in-app default settings
- An issue with storing/retrieving the interaction count or checking the limit could cause it to always be scheduled (not setting a limit, this is the current behavior)

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when inactivity notifications are scheduled and how remote privacy config is decoded; mis-parsing or cap logic could over-schedule or stop notifications unexpectedly for some users.
> 
> **Overview**
> Stops scheduling the inactivity provisional push after the user has tapped or dismissed it enough times—**default 4**, overridable via privacy config **`maxInteractions`** (with **`daysInactive`** still defaulting to 7). **`InactivityNotificationSchedulerService`** now depends on **`InactivityNotificationStateStoring`**: **`resume()`** and **`schedule()`** bail out and cancel pending requests when **`interactionCount >= maxInteractions`**, with a second check in **`schedule()`** for races after notification responses.
> 
> Privacy subfeature settings are parsed as a generic JSON dictionary with typed **`Settings`** keys (ints for **`daysInactive`** / **`maxInteractions`**), replacing string-based **`daysInactive`** parsing. Scheduling is allowed when notification authorization is **provisional or authorized** (not only provisional).
> 
> **`InactivityNotificationStateStore`** adds **`reset()`** to clear the persisted interaction count for debug/testing.
> 
> The debug **Notifications Playground** gains pending-notification listing, an **Inactivity Notification** content mode (provisional, real identifier/content), interaction count display, and reset—wired through **`keyValueStore`** from debug dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5f414d0d4f7092fc2c665113356ac4f7e1cad85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->