### PR TITLE
[iOS] Apply Apple fix to floating UI obscured content insets

### DIFF
--- a/iOS/DuckDuckGo/FloatingUI/FloatingUILayoutPolicy.swift
+++ b/iOS/DuckDuckGo/FloatingUI/FloatingUILayoutPolicy.swift
@@ -28,26 +28,6 @@ enum FloatingUILayoutPolicy {
         isFloatingUIEnabled && addressBarPosition == .top && !isUnifiedToggleInputAffectingLayout
     }
 
-    /// Additional safe-area insets applied to the web view's controller in floating UI mode so WebKit
-    /// treats the region covered by the top glass chrome as obscured, laying out page `position: fixed`
-    /// top elements below the omnibar and offsetting scrollable content to match.
-    ///
-    /// Only the top is applied here: the bottom obscured region is handled by physically resizing the
-    /// web view (see `webViewBottomObscuredHeight`), which pins bottom `position: fixed` elements
-    /// reliably on load without depending on a WebKit inset relayout. Returns `.zero` while the unified
-    /// toggle input owns the layout, since the content is anchored to the chrome there.
-    static func webViewAdditionalSafeAreaInsets(addressBarPosition: AddressBarPosition,
-                                                isUnifiedToggleInputAffectingLayout: Bool,
-                                                omniBarHeight: CGFloat) -> UIEdgeInsets {
-        guard !isUnifiedToggleInputAffectingLayout else { return .zero }
-        switch addressBarPosition {
-        case .top:
-            return UIEdgeInsets(top: omniBarHeight, left: 0, bottom: 0, right: 0)
-        case .bottom:
-            return .zero
-        }
-    }
-
     /// Height obscured by the visible bottom chrome, measured from the web view container's bottom edge
     /// (the screen bottom). The floating web view is resized up by this amount so a page `position: fixed`
     /// footer pins to the top of whatever is on screen at the bottom:

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1280,7 +1280,9 @@ class MainViewController: UIViewController {
         viewCoordinator.updateMinimalChromeBottomAnchor(pinnedToScreenBottom: pinToBottom)
         if pinToBottom {
             // Bar dropped to the screen bottom: clear the keyboard-driven layout left from omnibar editing.
-            currentTab?.webView.scrollView.contentInset.bottom = 0
+            if !isFloatingUIEnabled {
+                currentTab?.webView.scrollView.contentInset.bottom = 0
+            }
             currentTab?.borderView.bottomOffset = 0
             if appSettings.currentAddressBarPosition.isBottom,
                let ntp = newTabPageViewController,
@@ -1693,7 +1695,9 @@ class MainViewController: UIViewController {
             // Web keyboard. Leave bar at rest so keyboard hides it.
             viewCoordinator.constraints.navigationBarContainerHeight.constant = omniBarHeight
             if let currentTab {
-                currentTab.webView.scrollView.contentInset.bottom = 0
+                if !isFloatingUIEnabled {
+                    currentTab.webView.scrollView.contentInset.bottom = 0
+                }
                 currentTab.borderView.bottomOffset = 0
             }
             UIView.animate(withDuration: duration, delay: 0, options: animationCurve) {
@@ -1712,12 +1716,16 @@ class MainViewController: UIViewController {
         if isAnyAITabUTIState, let currentTab {
             // The web view is anchored to the input bar's top (.unifiedToggleInput mode),
             // so it never extends behind the input — no bottom inset is needed.
-            if currentTab.webView.scrollView.contentInset.bottom != 0 {
+            if isFloatingUIEnabled {
+                currentTab.updateWebViewBottomAnchor(for: currentBarsVisibility)
+            } else if currentTab.webView.scrollView.contentInset.bottom != 0 {
                 currentTab.webView.scrollView.contentInset = .init(top: 0, left: 0, bottom: 0, right: 0)
             }
         } else if appSettings.currentAddressBarPosition.isBottom, let currentTab {
             let inset = intersection.height > 0 ? omniBarHeight : 0
-            currentTab.webView.scrollView.contentInset = .init(top: 0, left: 0, bottom: inset, right: 0)
+            if !isFloatingUIEnabled {
+                currentTab.webView.scrollView.contentInset = .init(top: 0, left: 0, bottom: inset, right: 0)
+            }
 
             let bottomOffset = intersection.height > 0 ? containerHeight - omniBarHeight : 0
             currentTab.borderView.bottomOffset = -bottomOffset

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -72,6 +72,28 @@ enum WebViewPreviewSnapshotGeometry {
                                                     bottom: contentInset.bottom,
                                                     right: 0))
     }
+
+    static func visibleRect(webViewBounds: CGRect, contentInset: UIEdgeInsets, capturesFullBounds: Bool) -> CGRect? {
+        capturesFullBounds
+            ? visibleRect(webViewBounds: webViewBounds)
+            : visibleRect(webViewBounds: webViewBounds, contentInset: contentInset)
+    }
+}
+
+enum WebViewScrollViewInsetUpdater {
+
+    static func update(_ scrollView: UIScrollView, insets: UIEdgeInsets) {
+        if scrollView.contentInset != insets {
+            let isPinnedToTop = scrollView.contentOffset.y <= -scrollView.adjustedContentInset.top
+            scrollView.contentInset = insets
+            if isPinnedToTop {
+                scrollView.contentOffset.y = -insets.top
+            }
+        }
+
+        scrollView.verticalScrollIndicatorInsets = insets
+        scrollView.horizontalScrollIndicatorInsets = insets
+    }
 }
 
 class TabViewController: UIViewController {
@@ -201,6 +223,7 @@ class TabViewController: UIViewController {
     let progressWorker = WebProgressWorker()
 
     private(set) var webView: WKWebView!
+    private var hasAppliedFloatingUIScrollViewInsets = false
     private lazy var appRatingPrompt: AppRatingPrompt = AppRatingPrompt(featureFlagger: self.featureFlagger)
     let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
     public weak var privacyDashboard: PrivacyDashboardViewController?
@@ -963,17 +986,11 @@ class TabViewController: UIViewController {
                 // `obscuredContentInsets`, which positions page fixed/sticky elements and the layout
                 // viewport reliably (including on load) and lets content scroll behind the glass.
                 webViewBottomAnchorConstraint?.constant = 0
-                // `obscuredContentInsets` does not adjust the scroll view's content/indicator insets in
-                // UIKit, so scrollable content would rest behind the bars. Feed the chrome region
-                // (beyond the device safe area, which the scroll view already accounts for) into
-                // `additionalSafeAreaInsets` so at-rest content and scroll indicators clear the bars too.
-                let deviceSafeArea = view.window?.safeAreaInsets ?? .zero
-                additionalSafeAreaInsets = UIEdgeInsets(
-                    top: max(0, obscuredInsets.top - deviceSafeArea.top),
-                    left: 0,
-                    bottom: max(0, obscuredInsets.bottom - deviceSafeArea.bottom),
-                    right: 0
-                )
+                if additionalSafeAreaInsets != .zero {
+                    additionalSafeAreaInsets = .zero
+                }
+                WebViewScrollViewInsetUpdater.update(webView.scrollView, insets: obscuredInsets)
+                hasAppliedFloatingUIScrollViewInsets = true
             } else {
                 // iOS 18 fallback: physically resize the web view so its bottom edge sits at the top of
                 // the visible bottom chrome (toolbar -> capsule -> safe area), and inset the top via
@@ -982,6 +999,10 @@ class TabViewController: UIViewController {
                     ? 0
                     : (chromeDelegate?.floatingWebViewBottomObscuredHeight(for: barsVisibilityPercent) ?? 0)
                 webViewBottomAnchorConstraint?.constant = -bottomObscuredHeight
+                if hasAppliedFloatingUIScrollViewInsets {
+                    WebViewScrollViewInsetUpdater.update(webView.scrollView, insets: .zero)
+                    hasAppliedFloatingUIScrollViewInsets = false
+                }
                 updateFloatingUISafeAreaInsets()
             }
         } else {
@@ -989,6 +1010,13 @@ class TabViewController: UIViewController {
             borderView.bottomAlpha = AppWidthObserver.shared.isLargeWidth ? 0 : barsVisibilityPercent
             // Defensive: clear any obscured insets left over if floating UI was toggled off at runtime.
             setWebViewObscuredContentInsetsIfSupported(.zero)
+            if hasAppliedFloatingUIScrollViewInsets {
+                WebViewScrollViewInsetUpdater.update(webView.scrollView, insets: .zero)
+                hasAppliedFloatingUIScrollViewInsets = false
+            }
+            if additionalSafeAreaInsets != .zero {
+                additionalSafeAreaInsets = .zero
+            }
         }
     }
 
@@ -2295,10 +2323,11 @@ extension TabViewController: WKNavigationDelegate {
                 return
             }
 
-            let visibleRect = capturesFullBounds
-                ? WebViewPreviewSnapshotGeometry.visibleRect(webViewBounds: webView.bounds)
-                : WebViewPreviewSnapshotGeometry.visibleRect(webViewBounds: webView.bounds,
-                                                            contentInset: webView.scrollView.contentInset)
+            let visibleRect = WebViewPreviewSnapshotGeometry.visibleRect(
+                webViewBounds: webView.bounds,
+                contentInset: webView.scrollView.contentInset,
+                capturesFullBounds: capturesFullBounds
+            )
             guard let visibleRect else {
                 completion(nil)
                 return
@@ -2320,12 +2349,12 @@ extension TabViewController: WKNavigationDelegate {
             return
         }
 
-        let contentInset = webView.scrollView.contentInset
-        let rect = webView.bounds.inset(by: UIEdgeInsets(top: contentInset.top,
-                                                        left: 0,
-                                                        bottom: contentInset.bottom,
-                                                        right: 0))
-        guard rect.width > 0, rect.height > 0 else {
+        let capturesFullBounds = FloatingUIManager(featureFlagger: featureFlagger).isFloatingUIEnabled
+        guard let rect = WebViewPreviewSnapshotGeometry.visibleRect(
+            webViewBounds: webView.bounds,
+            contentInset: webView.scrollView.contentInset,
+            capturesFullBounds: capturesFullBounds
+        ) else {
             completion(nil)
             return
         }
@@ -2346,13 +2375,15 @@ extension TabViewController: WKNavigationDelegate {
     private func preparePreviewSync(afterScreenUpdates: Bool = false) -> UIImage? {
         guard let webView, webView.bounds.height > 0, webView.bounds.width > 0 else { return nil }
 
+        let capturesFullBounds = FloatingUIManager(featureFlagger: featureFlagger).isFloatingUIEnabled
+        let contentInset = capturesFullBounds ? UIEdgeInsets.zero : webView.scrollView.contentInset
         let size = CGSize(width: webView.frame.size.width,
-                          height: webView.frame.size.height - webView.scrollView.contentInset.top - webView.scrollView.contentInset.bottom)
+                          height: webView.frame.size.height - contentInset.top - contentInset.bottom)
         guard size.width > 0, size.height > 0 else { return nil }
 
         let renderer = UIGraphicsImageRenderer(size: size)
         return renderer.image { context in
-            context.cgContext.translateBy(x: 0, y: -webView.scrollView.contentInset.top)
+            context.cgContext.translateBy(x: 0, y: -contentInset.top)
             webView.drawHierarchy(in: webView.bounds, afterScreenUpdates: afterScreenUpdates)
             if let jsAlertView {
                 jsAlertView.drawHierarchy(in: jsAlertView.bounds, afterScreenUpdates: false)

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -82,6 +82,26 @@ enum WebViewPreviewSnapshotGeometry {
 
 enum WebViewScrollViewInsetUpdater {
 
+    struct AdjustmentBehavior {
+        let contentInsetAdjustmentBehavior: UIScrollView.ContentInsetAdjustmentBehavior
+        let automaticallyAdjustsScrollIndicatorInsets: Bool
+    }
+
+    static func beginManaging(_ scrollView: UIScrollView) -> AdjustmentBehavior {
+        let behavior = AdjustmentBehavior(
+            contentInsetAdjustmentBehavior: scrollView.contentInsetAdjustmentBehavior,
+            automaticallyAdjustsScrollIndicatorInsets: scrollView.automaticallyAdjustsScrollIndicatorInsets
+        )
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.automaticallyAdjustsScrollIndicatorInsets = false
+        return behavior
+    }
+
+    static func endManaging(_ scrollView: UIScrollView, restoring behavior: AdjustmentBehavior) {
+        scrollView.contentInsetAdjustmentBehavior = behavior.contentInsetAdjustmentBehavior
+        scrollView.automaticallyAdjustsScrollIndicatorInsets = behavior.automaticallyAdjustsScrollIndicatorInsets
+    }
+
     static func update(_ scrollView: UIScrollView, insets: UIEdgeInsets) {
         if scrollView.contentInset != insets {
             let isPinnedToTop = scrollView.contentOffset.y <= -scrollView.adjustedContentInset.top
@@ -224,6 +244,7 @@ class TabViewController: UIViewController {
 
     private(set) var webView: WKWebView!
     private var hasAppliedFloatingUIScrollViewInsets = false
+    private var scrollViewAdjustmentBehaviorBeforeFloatingUI: WebViewScrollViewInsetUpdater.AdjustmentBehavior?
     private lazy var appRatingPrompt: AppRatingPrompt = AppRatingPrompt(featureFlagger: self.featureFlagger)
     let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
     public weak var privacyDashboard: PrivacyDashboardViewController?
@@ -981,6 +1002,9 @@ class TabViewController: UIViewController {
             let obscuredInsets: UIEdgeInsets = isUnifiedToggleInputAffectingLayout
                 ? .zero
                 : (chromeDelegate?.floatingWebViewObscuredInsets(for: barsVisibilityPercent) ?? .zero)
+            if scrollViewAdjustmentBehaviorBeforeFloatingUI == nil {
+                scrollViewAdjustmentBehaviorBeforeFloatingUI = WebViewScrollViewInsetUpdater.beginManaging(webView.scrollView)
+            }
             if setWebViewObscuredContentInsetsIfSupported(obscuredInsets) {
                 // Keep the web view full-bleed and reserve the chrome region via WebKit's public
                 // `obscuredContentInsets`, which positions page fixed/sticky elements and the layout
@@ -1003,6 +1027,7 @@ class TabViewController: UIViewController {
                     WebViewScrollViewInsetUpdater.update(webView.scrollView, insets: .zero)
                     hasAppliedFloatingUIScrollViewInsets = false
                 }
+                restoreScrollViewAdjustmentBehaviorAfterFloatingUI()
                 updateFloatingUISafeAreaInsets()
             }
         } else {
@@ -1014,10 +1039,17 @@ class TabViewController: UIViewController {
                 WebViewScrollViewInsetUpdater.update(webView.scrollView, insets: .zero)
                 hasAppliedFloatingUIScrollViewInsets = false
             }
+            restoreScrollViewAdjustmentBehaviorAfterFloatingUI()
             if additionalSafeAreaInsets != .zero {
                 additionalSafeAreaInsets = .zero
             }
         }
+    }
+
+    private func restoreScrollViewAdjustmentBehaviorAfterFloatingUI() {
+        guard let behavior = scrollViewAdjustmentBehaviorBeforeFloatingUI else { return }
+        WebViewScrollViewInsetUpdater.endManaging(webView.scrollView, restoring: behavior)
+        scrollViewAdjustmentBehaviorBeforeFloatingUI = nil
     }
 
     /// In floating UI mode the web view underflows the top glass chrome, so communicate the top

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -950,17 +950,6 @@ class TabViewController: UIViewController {
         updateWebViewBottomAnchor(for: 1.0)
     }
 
-    @discardableResult
-    private func setWebViewObscuredContentInsetsIfSupported(_ insets: UIEdgeInsets) -> Bool {
-        guard #available(iOS 26, *),
-              let webView,
-              webView.responds(to: #selector(setter: WKWebView.obscuredContentInsets)) else {
-            return false
-        }
-        webView.obscuredContentInsets = insets
-        return true
-    }
-
     func updateWebViewBottomAnchor(for barsVisibilityPercent: CGFloat) {
         let isUnifiedToggleInputAffectingBottomLayout = isAITab && unifiedToggleInputFeature.isAvailable
         if appSettings.currentAddressBarPosition == .bottom && !isUnifiedToggleInputAffectingBottomLayout {
@@ -991,6 +980,10 @@ class TabViewController: UIViewController {
             webViewBottomAnchorConstraint?.constant = 0
         }
         if FloatingUIManager(featureFlagger: featureFlagger).isFloatingUIEnabled {
+            guard #available(iOS 26, *) else {
+                assertionFailure("Floating UI requires iOS 26")
+                return
+            }
             borderView.bottomAlpha = 0
             borderView.isHidden = true
             borderView.isTopVisible = false
@@ -1005,36 +998,19 @@ class TabViewController: UIViewController {
             if scrollViewAdjustmentBehaviorBeforeFloatingUI == nil {
                 scrollViewAdjustmentBehaviorBeforeFloatingUI = WebViewScrollViewInsetUpdater.beginManaging(webView.scrollView)
             }
-            if setWebViewObscuredContentInsetsIfSupported(obscuredInsets) {
-                // Keep the web view full-bleed and reserve the chrome region via WebKit's public
-                // `obscuredContentInsets`, which positions page fixed/sticky elements and the layout
-                // viewport reliably (including on load) and lets content scroll behind the glass.
-                webViewBottomAnchorConstraint?.constant = 0
-                if additionalSafeAreaInsets != .zero {
-                    additionalSafeAreaInsets = .zero
-                }
-                WebViewScrollViewInsetUpdater.update(webView.scrollView, insets: obscuredInsets)
-                hasAppliedFloatingUIScrollViewInsets = true
-            } else {
-                // iOS 18 fallback: physically resize the web view so its bottom edge sits at the top of
-                // the visible bottom chrome (toolbar -> capsule -> safe area), and inset the top via
-                // `additionalSafeAreaInsets`.
-                let bottomObscuredHeight = isUnifiedToggleInputAffectingLayout
-                    ? 0
-                    : (chromeDelegate?.floatingWebViewBottomObscuredHeight(for: barsVisibilityPercent) ?? 0)
-                webViewBottomAnchorConstraint?.constant = -bottomObscuredHeight
-                if hasAppliedFloatingUIScrollViewInsets {
-                    WebViewScrollViewInsetUpdater.update(webView.scrollView, insets: .zero)
-                    hasAppliedFloatingUIScrollViewInsets = false
-                }
-                restoreScrollViewAdjustmentBehaviorAfterFloatingUI()
-                updateFloatingUISafeAreaInsets()
+            webView.obscuredContentInsets = obscuredInsets
+            webViewBottomAnchorConstraint?.constant = 0
+            if additionalSafeAreaInsets != .zero {
+                additionalSafeAreaInsets = .zero
             }
+            WebViewScrollViewInsetUpdater.update(webView.scrollView, insets: obscuredInsets)
+            hasAppliedFloatingUIScrollViewInsets = true
         } else {
             borderView.isHidden = false
             borderView.bottomAlpha = AppWidthObserver.shared.isLargeWidth ? 0 : barsVisibilityPercent
-            // Defensive: clear any obscured insets left over if floating UI was toggled off at runtime.
-            setWebViewObscuredContentInsetsIfSupported(.zero)
+            if #available(iOS 26, *) {
+                webView.obscuredContentInsets = .zero
+            }
             if hasAppliedFloatingUIScrollViewInsets {
                 WebViewScrollViewInsetUpdater.update(webView.scrollView, insets: .zero)
                 hasAppliedFloatingUIScrollViewInsets = false
@@ -1050,23 +1026,6 @@ class TabViewController: UIViewController {
         guard let behavior = scrollViewAdjustmentBehaviorBeforeFloatingUI else { return }
         WebViewScrollViewInsetUpdater.endManaging(webView.scrollView, restoring: behavior)
         scrollViewAdjustmentBehaviorBeforeFloatingUI = nil
-    }
-
-    /// In floating UI mode the web view underflows the top glass chrome, so communicate the top
-    /// omnibar-obscured region to WebKit via `additionalSafeAreaInsets` (top only). The bottom obscured
-    /// region is handled by resizing the web view instead (see `updateWebViewBottomAnchor`), which pins
-    /// bottom `position: fixed` elements reliably on load.
-    private func updateFloatingUISafeAreaInsets() {
-        // AI tabs with the unified toggle input manage their own top/bottom layout (the content
-        // container stays anchored to the chrome), so adding insets there would double-offset.
-        let isUnifiedToggleInputAffectingLayout = isAITab && unifiedToggleInputFeature.isAvailable
-        let insets = FloatingUILayoutPolicy.webViewAdditionalSafeAreaInsets(
-            addressBarPosition: appSettings.currentAddressBarPosition,
-            isUnifiedToggleInputAffectingLayout: isUnifiedToggleInputAffectingLayout,
-            omniBarHeight: chromeDelegate?.omniBar.barView.expectedHeight ?? 0
-        )
-        guard additionalSafeAreaInsets != insets else { return }
-        additionalSafeAreaInsets = insets
     }
 
     private func observeNetPConnectionStatusChanges() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -731,7 +731,11 @@ private extension MainViewController {
             return false
         }
         ensureStandardChromeVisibleForAITabRefresh()
-        tab.webView.scrollView.contentInset = .zero
+        if isFloatingUIEnabled {
+            tab.updateWebViewBottomAnchor(for: currentBarsVisibility)
+        } else {
+            tab.webView.scrollView.contentInset = .zero
+        }
         // We're swapping into AI-tab layout, not dismissing the omnibar in place.
         // Skip the dismiss animation — otherwise it runs concurrently with the AI-tab show
         // and the user perceives a top-to-bottom slide.

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -354,6 +354,22 @@ final class WebViewPreviewSnapshotGeometryTests: XCTestCase {
 
 final class WebViewScrollViewInsetUpdaterTests: XCTestCase {
 
+    func testWhenManagingInsetsThenAutomaticAdjustmentIsDisabledAndCanBeRestored() {
+        let scrollView = UIScrollView()
+        scrollView.contentInsetAdjustmentBehavior = .automatic
+        scrollView.automaticallyAdjustsScrollIndicatorInsets = true
+
+        let behavior = WebViewScrollViewInsetUpdater.beginManaging(scrollView)
+
+        XCTAssertEqual(scrollView.contentInsetAdjustmentBehavior, .never)
+        XCTAssertFalse(scrollView.automaticallyAdjustsScrollIndicatorInsets)
+
+        WebViewScrollViewInsetUpdater.endManaging(scrollView, restoring: behavior)
+
+        XCTAssertEqual(scrollView.contentInsetAdjustmentBehavior, .automatic)
+        XCTAssertTrue(scrollView.automaticallyAdjustsScrollIndicatorInsets)
+    }
+
     func testWhenContentInsetsAreUnchangedThenContentOffsetIsUnchanged() {
         let scrollView = UIScrollView()
         let insets = UIEdgeInsets(top: 20, left: 0, bottom: 30, right: 0)

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -340,6 +340,78 @@ final class WebViewPreviewSnapshotGeometryTests: XCTestCase {
 
         XCTAssertNil(WebViewPreviewSnapshotGeometry.visibleRect(webViewBounds: bounds, contentInset: contentInset))
     }
+
+    func testWhenCapturingFullBoundsThenContentInsetsDoNotCropTheViewport() {
+        let bounds = CGRect(x: 0, y: 0, width: 320, height: 640)
+        let contentInset = UIEdgeInsets(top: 50, left: 0, bottom: 30, right: 0)
+
+        XCTAssertEqual(WebViewPreviewSnapshotGeometry.visibleRect(webViewBounds: bounds,
+                                                                  contentInset: contentInset,
+                                                                  capturesFullBounds: true),
+                       bounds)
+    }
+}
+
+final class WebViewScrollViewInsetUpdaterTests: XCTestCase {
+
+    func testWhenContentInsetsAreUnchangedThenContentOffsetIsUnchanged() {
+        let scrollView = UIScrollView()
+        let insets = UIEdgeInsets(top: 20, left: 0, bottom: 30, right: 0)
+        scrollView.contentInset = insets
+        scrollView.contentOffset = CGPoint(x: 0, y: 40)
+
+        WebViewScrollViewInsetUpdater.update(scrollView, insets: insets)
+
+        XCTAssertEqual(scrollView.contentOffset, CGPoint(x: 0, y: 40))
+    }
+
+    func testWhenPinnedToTopThenUpdatingInsetsPreservesPinnedPosition() {
+        let scrollView = UIScrollView()
+        scrollView.contentInset = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
+        scrollView.contentOffset = CGPoint(x: 0, y: -20)
+
+        WebViewScrollViewInsetUpdater.update(scrollView,
+                                             insets: UIEdgeInsets(top: 50, left: 0, bottom: 30, right: 0))
+
+        XCTAssertEqual(scrollView.contentOffset.y, -50)
+    }
+
+    func testWhenNotPinnedToTopThenUpdatingInsetsPreservesContentOffset() {
+        let scrollView = UIScrollView(frame: CGRect(x: 0, y: 0, width: 320, height: 640))
+        scrollView.contentSize = CGSize(width: 320, height: 2_000)
+        scrollView.contentInset = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
+        scrollView.contentOffset = CGPoint(x: 0, y: 40)
+
+        WebViewScrollViewInsetUpdater.update(scrollView,
+                                             insets: UIEdgeInsets(top: 50, left: 0, bottom: 30, right: 0))
+
+        XCTAssertEqual(scrollView.contentOffset.y, 40)
+    }
+
+    func testWhenUpdatingInsetsThenBothScrollIndicatorInsetsAreUpdated() {
+        let scrollView = UIScrollView()
+        let insets = UIEdgeInsets(top: 50, left: 2, bottom: 30, right: 4)
+
+        WebViewScrollViewInsetUpdater.update(scrollView, insets: insets)
+
+        XCTAssertEqual(scrollView.verticalScrollIndicatorInsets, insets)
+        XCTAssertEqual(scrollView.horizontalScrollIndicatorInsets, insets)
+    }
+
+    func testWhenClearingInsetsThenContentAndIndicatorInsetsAreZero() {
+        let scrollView = UIScrollView()
+        let insets = UIEdgeInsets(top: 50, left: 2, bottom: 30, right: 4)
+        scrollView.contentInset = insets
+        scrollView.verticalScrollIndicatorInsets = insets
+        scrollView.horizontalScrollIndicatorInsets = insets
+        scrollView.contentOffset = CGPoint(x: 0, y: 40)
+
+        WebViewScrollViewInsetUpdater.update(scrollView, insets: .zero)
+
+        XCTAssertEqual(scrollView.contentInset, .zero)
+        XCTAssertEqual(scrollView.verticalScrollIndicatorInsets, .zero)
+        XCTAssertEqual(scrollView.horizontalScrollIndicatorInsets, .zero)
+    }
 }
 
 final class FloatingSwipePreviewGeometryTests: XCTestCase {

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -83,42 +83,6 @@ final class FloatingUIManagerTests: XCTestCase {
 
 final class FloatingUILayoutPolicyTests: XCTestCase {
 
-    func testWhenTopAddressBarThenAdditionalSafeAreaInsetsApplyOmniBarHeightToTopOnly() {
-        let insets = FloatingUILayoutPolicy.webViewAdditionalSafeAreaInsets(
-            addressBarPosition: .top,
-            isUnifiedToggleInputAffectingLayout: false,
-            omniBarHeight: 52
-        )
-
-        XCTAssertEqual(insets, UIEdgeInsets(top: 52, left: 0, bottom: 0, right: 0))
-    }
-
-    func testWhenBottomAddressBarThenAdditionalSafeAreaInsetsAreZero() {
-        let insets = FloatingUILayoutPolicy.webViewAdditionalSafeAreaInsets(
-            addressBarPosition: .bottom,
-            isUnifiedToggleInputAffectingLayout: false,
-            omniBarHeight: 52
-        )
-
-        XCTAssertEqual(insets, .zero)
-    }
-
-    func testWhenUnifiedToggleInputAffectsLayoutThenInsetsAreZero() {
-        let topInsets = FloatingUILayoutPolicy.webViewAdditionalSafeAreaInsets(
-            addressBarPosition: .top,
-            isUnifiedToggleInputAffectingLayout: true,
-            omniBarHeight: 52
-        )
-        XCTAssertEqual(topInsets, .zero)
-
-        let bottomInsets = FloatingUILayoutPolicy.webViewAdditionalSafeAreaInsets(
-            addressBarPosition: .bottom,
-            isUnifiedToggleInputAffectingLayout: true,
-            omniBarHeight: 52
-        )
-        XCTAssertEqual(bottomInsets, .zero)
-    }
-
     func testWhenBarsVisibleThenBottomObscuredHeightIsToolbarSlot() {
         let height = FloatingUILayoutPolicy.webViewBottomObscuredHeight(
             barsVisibilityPercent: 1,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217194806473685?focus=true
Tech Design URL:
CC:

### Description
Uses content insets to correctly adjust scroll view in conjunction with obscured content insets.

### Testing Steps

1. `floatingUI` feature flag on and restart app -> Floating UI shows
2. Visit YouTube.com in a clean tab -> renders and behaves correctly
3. Visit privacy-test-pages.site/viewport/ -> renders and behaves correctly
4. General web smoke testing -> View port should appear to be specified correctly
5. Feature flag off -> ensure no feature flag leakage

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Could breaking floating UI further -> gated behind feature flag

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core web viewport, keyboard, and minimal-chrome inset behavior behind the floating UI flag; regressions could affect scroll position, fixed elements, and tab previews on iOS 26.
> 
> **Overview**
> Floating UI on iOS 26 now drives **both** `WKWebView.obscuredContentInsets` and the web scroll view’s content/indicator insets from the same chrome obscured region, instead of mixing obscured insets with `additionalSafeAreaInsets` and bottom-anchor resizing.
> 
> `WebViewScrollViewInsetUpdater` disables automatic scroll inset adjustment while floating UI is active, applies the obscured insets (keeping scroll position pinned when at the top), and restores prior behavior when floating UI is turned off. `MainViewController` and unified-toggle-input paths skip legacy `contentInset` tweaks when floating UI owns layout, and tab preview snapshots use full web bounds when floating UI is enabled so previews aren’t cropped by inset math.
> 
> `FloatingUILayoutPolicy.webViewAdditionalSafeAreaInsets` and its tests are removed as part of dropping the old top safe-area offset approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28abb972acabe27ea81b85d9c185fd7911b8070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->