### PR TITLE
Add resting outline to the Duck.ai model picker pill

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
@@ -32,6 +32,7 @@ final class AIChatModelPickerButton: NSView {
         static let chevronSize: CGFloat = 16
         static let fontSize: CGFloat = 12
         static let cornerRadius: CGFloat = 14
+        static let borderWidth: CGFloat = 1
     }
 
     private let themeManager: ThemeManaging = NSApp.delegateTyped.themeManager
@@ -62,6 +63,16 @@ final class AIChatModelPickerButton: NSView {
     }()
 
     private let backgroundLayer = CALayer()
+
+    /// Resting outline. Kept on its own layer because `backgroundLayer` is faded in and out
+    /// for hover/press, and the outline has to stay visible in every state.
+    private let borderLayer: CALayer = {
+        let layer = CALayer()
+        layer.cornerRadius = Constants.cornerRadius
+        layer.borderWidth = Constants.borderWidth
+        return layer
+    }()
+
     private let focusRingLayer: CAShapeLayer = {
         let layer = CAShapeLayer()
         layer.fillColor = nil
@@ -93,6 +104,17 @@ final class AIChatModelPickerButton: NSView {
     /// via `applyTheme(theme:)` so the ring follows in-app theme switches (Pink, Blue, etc.).
     var focusRingColor: NSColor = NSColor(designSystemColor: .accentPrimary) {
         didSet { updateFocusRingStrokeColor() }
+    }
+
+    /// `borderColor` is a `CGColor`, so the dynamic `lines` colour has to be resolved against the
+    /// view's own appearance — `NSApp`'s would be wrong in a burner window's dark override.
+    private func updateBorderColor() {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            borderLayer.borderColor = NSColor(designSystemColor: .lines).cgColor
+        }
+        CATransaction.commit()
     }
 
     private func updateFocusRingStrokeColor() {
@@ -197,6 +219,11 @@ final class AIChatModelPickerButton: NSView {
         backgroundLayer.opacity = 0
         layer?.insertSublayer(backgroundLayer, at: 0)
 
+        // Outline above the background fill, below the focus ring, so a focused pill still
+        // reads as focused rather than double-stroked.
+        layer?.addSublayer(borderLayer)
+        updateBorderColor()
+
         // Focus ring sublayer sits above the background so it stays visible while hovered.
         // Stroke colour follows `focusRingColor` and re-resolves against the view's effective
         // appearance — see `updateFocusRingStrokeColor()`.
@@ -224,6 +251,7 @@ final class AIChatModelPickerButton: NSView {
     override func layout() {
         super.layout()
         backgroundLayer.frame = bounds
+        borderLayer.frame = bounds
 
         // Focus ring sits 1pt outside the pill. Rendered as a sublayer rather than
         // in `draw(_:)` so the 1pt overflow is not clipped by the view's backing layer
@@ -341,6 +369,7 @@ final class AIChatModelPickerButton: NSView {
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
         updateAppearance()
+        updateBorderColor()
         updateFocusRingStrokeColor()
     }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
@@ -314,6 +314,10 @@ final class AIChatModelPickerButton: NSView {
         )
         addTrackingArea(newTrackingArea)
         trackingArea = newTrackingArea
+
+        // Picking a model resizes the pill and lands here. A freshly added tracking area reports
+        // nothing about a pointer that is already outside it, so re-sync explicitly.
+        refreshHoverState()
     }
 
     override func mouseEntered(with event: NSEvent) {
@@ -327,6 +331,21 @@ final class AIChatModelPickerButton: NSView {
 
     override func mouseExited(with event: NSEvent) {
         isHovered = false
+    }
+
+    /// Re-derives hover from the pointer's real position, for the cases where the tracking area
+    /// can't be trusted — see `sendMenuOpeningAction` and `updateTrackingAreas`.
+    private func refreshHoverState() {
+        guard let window else {
+            isHovered = false
+            return
+        }
+        isHovered = bounds.contains(convert(window.mouseLocationOutsideOfEventStream, from: nil))
+    }
+
+    func resetTransientFillState() {
+        isMouseDown = false
+        refreshHoverState()
     }
 
     override func mouseDown(with event: NSEvent) {
@@ -343,7 +362,10 @@ final class AIChatModelPickerButton: NSView {
         let locationInView = convert(event.locationInWindow, from: nil)
         if bounds.contains(locationInView) && isMouseDown {
             if let action, let target {
-                NSApp.sendAction(action, to: target, from: self)
+                sendMenuOpeningAction {
+                    NSApp.sendAction(action, to: target, from: self)
+                }
+                return
             }
         }
         isMouseDown = false

--- a/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
@@ -64,8 +64,8 @@ final class AIChatModelPickerButton: NSView {
 
     private let backgroundLayer = CALayer()
 
-    /// Resting outline. Kept on its own layer because `backgroundLayer` is faded in and out
-    /// for hover/press, and the outline has to stay visible in every state.
+    /// Own layer because `backgroundLayer` fades in and out for hover/press, and the outline has
+    /// to stay visible in every state.
     private let borderLayer: CALayer = {
         let layer = CALayer()
         layer.cornerRadius = Constants.cornerRadius
@@ -106,8 +106,8 @@ final class AIChatModelPickerButton: NSView {
         didSet { updateFocusRingStrokeColor() }
     }
 
-    /// `borderColor` is a `CGColor`, so the dynamic `lines` colour has to be resolved against the
-    /// view's own appearance — `NSApp`'s would be wrong in a burner window's dark override.
+    /// A `CGColor` freezes the appearance it's resolved in, and `NSApp`'s would be wrong in a
+    /// burner window's dark override.
     private func updateBorderColor() {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
@@ -219,8 +219,7 @@ final class AIChatModelPickerButton: NSView {
         backgroundLayer.opacity = 0
         layer?.insertSublayer(backgroundLayer, at: 0)
 
-        // Outline above the background fill, below the focus ring, so a focused pill still
-        // reads as focused rather than double-stroked.
+        // Below the focus ring, so a focused pill doesn't read as double-stroked.
         layer?.addSublayer(borderLayer)
         updateBorderColor()
 
@@ -315,8 +314,7 @@ final class AIChatModelPickerButton: NSView {
         addTrackingArea(newTrackingArea)
         trackingArea = newTrackingArea
 
-        // Picking a model resizes the pill and lands here. A freshly added tracking area reports
-        // nothing about a pointer that is already outside it, so re-sync explicitly.
+        // A new tracking area reports nothing about a pointer already outside it.
         refreshHoverState()
     }
 
@@ -333,8 +331,7 @@ final class AIChatModelPickerButton: NSView {
         isHovered = false
     }
 
-    /// Re-derives hover from the pointer's real position, for the cases where the tracking area
-    /// can't be trusted — see `sendMenuOpeningAction` and `updateTrackingAreas`.
+    /// For the cases where the tracking area can't be trusted — see `sendMenuOpeningAction`.
     private func refreshHoverState() {
         guard let window else {
             isHovered = false

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
@@ -34,6 +34,42 @@ protocol FocusRingControlling: AnyObject {
     func takeKeyboardFocus()
 
     var isFocusRingSuppressed: Bool { get set }
+
+    /// Drops the press fill and re-derives hover from where the pointer actually is.
+    func resetTransientFillState()
+}
+
+extension FocusRingControlling {
+
+    /// Sends a button action that pops a menu, clearing the button's transient fill in step with
+    /// the menu disappearing.
+    ///
+    /// Two problems make the naive "reset after `sendAction` returns" wrong. Menu tracking is
+    /// modal, so no `mouseExited` reaches the button's tracking area while the menu is up and its
+    /// hover state is stale by the time it closes. And `popUp` only returns once AppKit has
+    /// flashed the selected item and animated the menu away, so resetting on its return trails
+    /// the menu's disappearance by a visible beat. `didEndTrackingNotification` lands when the
+    /// user commits to an item, ahead of both animations.
+    func sendMenuOpeningAction(_ sendAction: () -> Void) {
+        let observer = NotificationCenter.default.addObserver(
+            forName: NSMenu.didEndTrackingNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] notification in
+            // Submenus post this too as they close under a still-open parent. Only the root menu
+            // going away means the button is done being "active" — a submenu has a `supermenu`.
+            guard (notification.object as? NSMenu)?.supermenu == nil else { return }
+            // `queue: nil` posts synchronously on the posting thread, and menu tracking runs on
+            // the main thread, so this is already main-actor in practice.
+            MainActor.assumeIsolated {
+                self?.resetTransientFillState()
+            }
+        }
+        sendAction()
+        NotificationCenter.default.removeObserver(observer)
+        // Belt and braces: covers an action that popped no menu at all, so posted no notification.
+        resetTransientFillState()
+    }
 }
 
 /// A reusable toolbar button for the AI Chat omnibar with circular hover background effect.
@@ -451,6 +487,25 @@ final class AIChatOmnibarToolButton: NSView {
         )
         addTrackingArea(newTrackingArea)
         trackingArea = newTrackingArea
+
+        // A label or toggle change resizes the button and lands here. A freshly added tracking
+        // area reports nothing about a pointer that is already outside it, so re-sync explicitly.
+        refreshHoverState()
+    }
+
+    /// Re-derives hover from the pointer's real position, for the cases where the tracking area
+    /// can't be trusted — see `sendMenuOpeningAction` and `updateTrackingAreas`.
+    private func refreshHoverState() {
+        guard let window else {
+            isHovered = false
+            return
+        }
+        isHovered = bounds.contains(convert(window.mouseLocationOutsideOfEventStream, from: nil))
+    }
+
+    func resetTransientFillState() {
+        isMouseDown = false
+        refreshHoverState()
     }
 
     override func mouseEntered(with event: NSEvent) {
@@ -483,7 +538,10 @@ final class AIChatOmnibarToolButton: NSView {
                 isToggled.toggle()
             }
             if let action, let target {
-                NSApp.sendAction(action, to: target, from: self)
+                sendMenuOpeningAction {
+                    NSApp.sendAction(action, to: target, from: self)
+                }
+                return
             }
         }
         isMouseDown = false

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
@@ -17,6 +17,7 @@
 //
 
 import AppKit
+import ConcurrencyExtensions
 import DesignResourcesKit
 
 /// An image view that doesn't intercept mouse events, allowing its superview to handle them.
@@ -61,7 +62,7 @@ extension FocusRingControlling {
             guard (notification.object as? NSMenu)?.supermenu == nil else { return }
             // `queue: nil` posts synchronously on the posting thread, and menu tracking runs on
             // the main thread, so this is already main-actor in practice.
-            MainActor.assumeIsolated {
+            MainActor.assumeMainThread {
                 self?.resetTransientFillState()
             }
         }

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
@@ -36,39 +36,30 @@ protocol FocusRingControlling: AnyObject {
 
     var isFocusRingSuppressed: Bool { get set }
 
-    /// Drops the press fill and re-derives hover from where the pointer actually is.
+    /// Drops the press fill and re-derives hover from the pointer's real position.
     func resetTransientFillState()
 }
 
 extension FocusRingControlling {
 
-    /// Sends a button action that pops a menu, clearing the button's transient fill in step with
-    /// the menu disappearing.
-    ///
-    /// Two problems make the naive "reset after `sendAction` returns" wrong. Menu tracking is
-    /// modal, so no `mouseExited` reaches the button's tracking area while the menu is up and its
-    /// hover state is stale by the time it closes. And `popUp` only returns once AppKit has
-    /// flashed the selected item and animated the menu away, so resetting on its return trails
-    /// the menu's disappearance by a visible beat. `didEndTrackingNotification` lands when the
-    /// user commits to an item, ahead of both animations.
+    /// Modal menu tracking swallows `mouseExited`, and `popUp` returns only after AppKit's flash
+    /// and dismissal animations — so reset on this notification, which lands at the user's click.
     func sendMenuOpeningAction(_ sendAction: () -> Void) {
         let observer = NotificationCenter.default.addObserver(
             forName: NSMenu.didEndTrackingNotification,
             object: nil,
             queue: nil
         ) { [weak self] notification in
-            // Submenus post this too as they close under a still-open parent. Only the root menu
-            // going away means the button is done being "active" — a submenu has a `supermenu`.
+            // Submenus post this too, under a still-open parent; only the root menu means done.
             guard (notification.object as? NSMenu)?.supermenu == nil else { return }
-            // `queue: nil` posts synchronously on the posting thread, and menu tracking runs on
-            // the main thread, so this is already main-actor in practice.
+            // `queue: nil` posts synchronously, and menu tracking runs on the main thread.
             MainActor.assumeMainThread {
                 self?.resetTransientFillState()
             }
         }
         sendAction()
         NotificationCenter.default.removeObserver(observer)
-        // Belt and braces: covers an action that popped no menu at all, so posted no notification.
+        // Covers an action that popped no menu, so posted no notification.
         resetTransientFillState()
     }
 }
@@ -489,13 +480,11 @@ final class AIChatOmnibarToolButton: NSView {
         addTrackingArea(newTrackingArea)
         trackingArea = newTrackingArea
 
-        // A label or toggle change resizes the button and lands here. A freshly added tracking
-        // area reports nothing about a pointer that is already outside it, so re-sync explicitly.
+        // A new tracking area reports nothing about a pointer already outside it.
         refreshHoverState()
     }
 
-    /// Re-derives hover from the pointer's real position, for the cases where the tracking area
-    /// can't be trusted — see `sendMenuOpeningAction` and `updateTrackingAreas`.
+    /// For the cases where the tracking area can't be trusted — see `sendMenuOpeningAction`.
     private func refreshHoverState() {
         guard let window else {
             isHovered = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217146848886708

### Description

This PR matches model picker in the address bar's Duck.ai input with other platforms by adding a border in its resting state

### Testing Steps
1. Focus the address bar and switch it to Duck.ai mode → the model pill has a visible outline at rest, matching the same pill on the New Tab Page input below it.
2. Hover the pill, then press and hold → the fill tints as before, outline stays visible in both states.
4. Switch the app to dark mode, then open a Fire Window → the outline follows the appearance in both.
5. Click the pill and pick a different model → the fill clears as the menu disappears, with no lag and nothing left
7. Click the image-generation and web-search buttons → no stuck fill, and their active-pill styling is unchanged.

### Impact

Low — visual only. No behaviour change beyond the fill no longer sticking.

#### What could go wrong?

The fill reset hooks `NSMenu.didEndTrackingNotification`, which every menu in the app posts → filtered to the button's own root menu (a submenu has a `supermenu`), and the pre-existing reset on the action's return is kept as a fallback for actions that pop no menu at all.

### Quality Considerations

The outline colour is written to a `CGColor`, which freezes whichever appearance is current when it's assigned. It's resolved against the view's own `effectiveAppearance` rather than the app's, so a Fire Window's forced dark override gets the right colour — the pre-existing fill colours on this button resolve against the app appearance and have that latent bug, left alone as out of scope here.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and local AppKit interaction only in AI Chat omnibar controls; menu notification handling is scoped to root menus with a synchronous fallback reset.
> 
> **Overview**
> Adds a **persistent resting outline** on the address-bar Duck.ai **model picker pill** via a dedicated `borderLayer` (design-system `.lines`), resolved against the view’s `effectiveAppearance` so Fire Window dark overrides stay correct.
> 
> **Interaction fix:** model picker and omnibar tool buttons that open menus now route clicks through `sendMenuOpeningAction`, which clears pressed/hover fill when root menu tracking ends (`NSMenu.didEndTrackingNotification`) and re-syncs hover from the pointer. That stops the press fill sticking after model/menu dismissal; `refreshHoverState` also runs when tracking areas are recreated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28d8fbe112d094ccc37a6603834b9fee91bfeb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->