### PR TITLE
Add merge snapshots label workflow

### DIFF
--- a/.github/workflows/merge_snapshots.yml
+++ b/.github/workflows/merge_snapshots.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - name: Check out trusted automation
         uses: actions/checkout@v6
@@ -40,5 +41,6 @@ jobs:
         if: success()
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh pr edit "$PR_NUMBER" --remove-label "Merge snapshots"
+        run: gh api -X DELETE "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/Merge%20snapshots" 2>/dev/null || true

--- a/.github/workflows/merge_snapshots.yml
+++ b/.github/workflows/merge_snapshots.yml
@@ -1,30 +1,40 @@
 name: Shared - Merge Snapshots
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 jobs:
   merge-snapshots:
-    if: github.event.label.name == 'Merge snapshots'
+    if: github.event.label.name == 'Merge snapshots' && github.event.pull_request.head.repo.full_name == github.repository
     name: Merge snapshots PR and update pointer
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
+      - name: Check out trusted automation
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted
+          persist-credentials: false
+          sparse-checkout: scripts/merge-snapshots.sh
+
       - name: Check out the PR branch
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pull-request
           token: ${{ secrets.GHA_ELEVATED_PERMISSIONS_TOKEN }}
           persist-credentials: true
 
       - name: Merge snapshots PR and update pointer
         env:
           GH_TOKEN: ${{ secrets.GHA_ELEVATED_PERMISSIONS_TOKEN }}
-          PR_BRANCH: ${{ github.head_ref }}
-        run: ./scripts/merge-snapshots.sh "$PR_BRANCH"
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+        working-directory: pull-request
+        run: ../trusted/scripts/merge-snapshots.sh "$PR_BRANCH"
 
       - name: Remove the label
         if: success()

--- a/.github/workflows/merge_snapshots.yml
+++ b/.github/workflows/merge_snapshots.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check out trusted automation
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.sha }}
           path: trusted
           persist-credentials: false
           sparse-checkout: scripts/merge-snapshots.sh

--- a/.github/workflows/merge_snapshots.yml
+++ b/.github/workflows/merge_snapshots.yml
@@ -1,0 +1,34 @@
+name: Shared - Merge Snapshots
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  merge-snapshots:
+    if: github.event.label.name == 'Merge snapshots'
+    name: Merge snapshots PR and update pointer
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out the PR branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GHA_ELEVATED_PERMISSIONS_TOKEN }}
+          persist-credentials: true
+
+      - name: Merge snapshots PR and update pointer
+        env:
+          GH_TOKEN: ${{ secrets.GHA_ELEVATED_PERMISSIONS_TOKEN }}
+          PR_BRANCH: ${{ github.head_ref }}
+        run: ./scripts/merge-snapshots.sh "$PR_BRANCH"
+
+      - name: Remove the label
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr edit "$PR_NUMBER" --remove-label "Merge snapshots"

--- a/.github/workflows/merge_snapshots.yml
+++ b/.github/workflows/merge_snapshots.yml
@@ -38,7 +38,7 @@ jobs:
         run: ../trusted/scripts/merge-snapshots.sh "$PR_BRANCH"
 
       - name: Remove the label
-        if: success()
+        if: always()
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,7 @@ Detailed rules live in `.cursor/rules/`. Read from the list below when the reque
 | `anti-patterns.mdc` | What NOT to do: singletons, async mistakes, SwiftUI pitfalls, testing mistakes |
 | `user-defaults-storage.mdc` | Storing settings or preferences via `KeyValueStore` |
 | `pixels.mdc` | Defining, naming, or firing pixel events |
+
+## Opening a PR with snapshot changes
+
+Before opening a monorepo PR, if the working tree has changes under the `SnapshotReferences` submodule, run `./scripts/open-snapshot-submodule-pr.sh` first, then add the submodule PR link it prints to the monorepo PR description.

--- a/scripts/merge-snapshots.sh
+++ b/scripts/merge-snapshots.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Merges the companion PR in the apple-browsers-snapshots submodule into its
+# main, then repoints the monorepo PR branch at the resulting main commit so the
+# monorepo can never reference a commit that only lives on a soon-deleted branch.
+#
+# Triggered by the "Merge snapshots" label via
+# .github/workflows/merge_snapshots.yml. Requires a `gh`/git authenticated with
+# write access to both duckduckgo/apple-browsers and
+# duckduckgo/apple-browsers-snapshots.
+#
+# Usage: ./scripts/merge-snapshots.sh <pr-branch>
+
+BRANCH="${1:-}"
+SUBMODULE_PATH="SnapshotReferences"
+SUBMODULE_REPO="duckduckgo/apple-browsers-snapshots"
+BASE_BRANCH="main"
+
+if [ -z "$BRANCH" ]; then
+	echo "❌ Usage: $0 <pr-branch>"
+	exit 1
+fi
+
+PR_NUMBER="$(gh pr list -R "$SUBMODULE_REPO" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+if [ -n "$PR_NUMBER" ]; then
+	echo "🔀 Merging $SUBMODULE_REPO PR #$PR_NUMBER..."
+	gh pr merge "$PR_NUMBER" -R "$SUBMODULE_REPO" --merge
+else
+	echo "ℹ️  No open companion PR on '$BRANCH'; assuming it is already merged."
+fi
+
+NEW_POINTER="$(gh api "repos/$SUBMODULE_REPO/commits/$BASE_BRANCH" --jq '.sha')"
+CURRENT_POINTER="$(git rev-parse "HEAD:$SUBMODULE_PATH")"
+
+if [ "$NEW_POINTER" = "$CURRENT_POINTER" ]; then
+	echo "✅ Pointer already at $SUBMODULE_REPO@$BASE_BRANCH ($NEW_POINTER) — nothing to update."
+	exit 0
+fi
+
+echo "📌 Repointing $SUBMODULE_PATH: $CURRENT_POINTER → $NEW_POINTER"
+git update-index --cacheinfo "160000,$NEW_POINTER,$SUBMODULE_PATH"
+git -c user.name="github-actions[bot]" \
+	-c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+	commit -m "Update $SUBMODULE_PATH pointer to merged $BASE_BRANCH"
+git push origin "HEAD:$BRANCH"
+
+echo "✅ Merged the companion PR and repointed $SUBMODULE_PATH to $NEW_POINTER."

--- a/scripts/merge-snapshots.sh
+++ b/scripts/merge-snapshots.sh
@@ -23,15 +23,33 @@ if [ -z "$BRANCH" ]; then
 	exit 1
 fi
 
-PR_NUMBER="$(gh pr list -R "$SUBMODULE_REPO" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
-if [ -n "$PR_NUMBER" ]; then
+PR_NUMBER="$(gh pr list -R "$SUBMODULE_REPO" --base "$BASE_BRANCH" --head "$BRANCH" --state all --limit 100 --json number --jq 'sort_by(.number) | last | .number // empty')"
+if [ -z "$PR_NUMBER" ]; then
+	echo "❌ No companion PR targeting '$BASE_BRANCH' was found for branch '$BRANCH'."
+	exit 1
+fi
+
+MERGED_AT="$(gh pr view "$PR_NUMBER" -R "$SUBMODULE_REPO" --json mergedAt --jq '.mergedAt // empty')"
+if [ -z "$MERGED_AT" ]; then
+	PR_STATE="$(gh pr view "$PR_NUMBER" -R "$SUBMODULE_REPO" --json state --jq '.state')"
+	if [ "$PR_STATE" != "OPEN" ]; then
+		echo "❌ Companion PR #$PR_NUMBER is '$PR_STATE', not merged."
+		exit 1
+	fi
+
 	echo "🔀 Merging $SUBMODULE_REPO PR #$PR_NUMBER..."
 	gh pr merge "$PR_NUMBER" -R "$SUBMODULE_REPO" --merge
 else
-	echo "ℹ️  No open companion PR on '$BRANCH'; assuming it is already merged."
+	echo "ℹ️  Companion PR #$PR_NUMBER is already merged."
 fi
 
-NEW_POINTER="$(gh api "repos/$SUBMODULE_REPO/commits/$BASE_BRANCH" --jq '.sha')"
+MERGED_AT="$(gh pr view "$PR_NUMBER" -R "$SUBMODULE_REPO" --json mergedAt --jq '.mergedAt // empty')"
+NEW_POINTER="$(gh pr view "$PR_NUMBER" -R "$SUBMODULE_REPO" --json mergeCommit --jq '.mergeCommit.oid // empty')"
+if [ -z "$MERGED_AT" ] || [ -z "$NEW_POINTER" ]; then
+	echo "❌ Companion PR #$PR_NUMBER has not merged yet; refusing to update the submodule pointer."
+	exit 1
+fi
+
 CURRENT_POINTER="$(git rev-parse "HEAD:$SUBMODULE_PATH")"
 
 if [ "$NEW_POINTER" = "$CURRENT_POINTER" ]; then
@@ -46,4 +64,4 @@ git -c user.name="github-actions[bot]" \
 	commit -m "Update $SUBMODULE_PATH pointer to merged $BASE_BRANCH"
 git push origin "HEAD:$BRANCH"
 
-echo "✅ Merged the companion PR and repointed $SUBMODULE_PATH to $NEW_POINTER."
+echo "✅ Verified companion PR #$PR_NUMBER is merged and repointed $SUBMODULE_PATH to $NEW_POINTER."

--- a/scripts/merge-snapshots.sh
+++ b/scripts/merge-snapshots.sh
@@ -43,10 +43,21 @@ else
 	echo "ℹ️  Companion PR #$PR_NUMBER is already merged."
 fi
 
-MERGED_AT="$(gh pr view "$PR_NUMBER" -R "$SUBMODULE_REPO" --json mergedAt --jq '.mergedAt // empty')"
-NEW_POINTER="$(gh pr view "$PR_NUMBER" -R "$SUBMODULE_REPO" --json mergeCommit --jq '.mergeCommit.oid // empty')"
+MERGED_AT=""
+NEW_POINTER=""
+for attempt in 1 2 3 4 5; do
+	MERGED_AT="$(gh pr view "$PR_NUMBER" -R "$SUBMODULE_REPO" --json mergedAt --jq '.mergedAt // empty')"
+	NEW_POINTER="$(gh pr view "$PR_NUMBER" -R "$SUBMODULE_REPO" --json mergeCommit --jq '.mergeCommit.oid // empty')"
+	if [ -n "$MERGED_AT" ] && [ -n "$NEW_POINTER" ]; then
+		break
+	fi
+	if [ "$attempt" -lt 5 ]; then
+		echo "⏳ Merge commit not reported yet (attempt $attempt/5); retrying in 3s..."
+		sleep 3
+	fi
+done
 if [ -z "$MERGED_AT" ] || [ -z "$NEW_POINTER" ]; then
-	echo "❌ Companion PR #$PR_NUMBER has not merged yet; refusing to update the submodule pointer."
+	echo "❌ Companion PR #$PR_NUMBER did not report a merge commit after retries; refusing to update the submodule pointer."
 	exit 1
 fi
 

--- a/scripts/open-snapshot-submodule-pr.sh
+++ b/scripts/open-snapshot-submodule-pr.sh
@@ -15,18 +15,26 @@ SUBMODULE_PATH="SnapshotReferences"
 SUBMODULE_REPO="duckduckgo/apple-browsers-snapshots"
 BASE_BRANCH="main"
 
-DIRTY="$(git -C "$SUBMODULE_PATH" status --porcelain)"
-ON_REMOTE="$(git -C "$SUBMODULE_PATH" branch -r --contains HEAD 2>/dev/null || true)"
-
-if [ -z "$DIRTY" ] && [ -n "$ON_REMOTE" ]; then
-	echo "ℹ️  $SUBMODULE_PATH is clean and already pushed — nothing to sync."
-	exit 0
+TOP_LEVEL="$(git rev-parse --show-toplevel)"
+SUBMODULE_ROOT="$(git -C "$SUBMODULE_PATH" rev-parse --show-toplevel 2>/dev/null || true)"
+if [ "$SUBMODULE_ROOT" != "$TOP_LEVEL/$SUBMODULE_PATH" ]; then
+	echo "❌ $SUBMODULE_PATH is not initialized. Run 'git submodule update --init $SUBMODULE_PATH' first."
+	exit 1
 fi
+
+DIRTY="$(git -C "$SUBMODULE_PATH" status --porcelain)"
+SUBMODULE_HEAD="$(git -C "$SUBMODULE_PATH" rev-parse HEAD)"
+COMMITTED_SUBMODULE_HEAD="$(git rev-parse "HEAD:$SUBMODULE_PATH")"
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 if [ "$BRANCH" = "HEAD" ] || [ "$BRANCH" = "$BASE_BRANCH" ]; then
 	echo "❌ Refusing to sync from '$BRANCH'. Check out a feature branch first."
 	exit 1
+fi
+
+if [ -z "$DIRTY" ] && [ "$SUBMODULE_HEAD" = "$COMMITTED_SUBMODULE_HEAD" ]; then
+	echo "ℹ️  $SUBMODULE_PATH has no changes to sync."
+	exit 0
 fi
 
 echo "🔄 Syncing snapshot references on branch '$BRANCH'..."

--- a/scripts/open-snapshot-submodule-pr.sh
+++ b/scripts/open-snapshot-submodule-pr.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Opens (or updates) the companion PR in the apple-browsers-snapshots submodule
+# whenever the current branch changes reference images, then stages the updated
+# submodule pointer so the monorepo PR points at a pushed commit.
+#
+# Run from the monorepo root, on the feature branch you are about to open a PR
+# from. Requires an authenticated `gh`.
+#
+# Usage: ./scripts/open-snapshot-submodule-pr.sh
+
+SUBMODULE_PATH="SnapshotReferences"
+SUBMODULE_REPO="duckduckgo/apple-browsers-snapshots"
+BASE_BRANCH="main"
+
+DIRTY="$(git -C "$SUBMODULE_PATH" status --porcelain)"
+ON_REMOTE="$(git -C "$SUBMODULE_PATH" branch -r --contains HEAD 2>/dev/null || true)"
+
+if [ -z "$DIRTY" ] && [ -n "$ON_REMOTE" ]; then
+	echo "ℹ️  $SUBMODULE_PATH is clean and already pushed — nothing to sync."
+	exit 0
+fi
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$BRANCH" = "HEAD" ] || [ "$BRANCH" = "$BASE_BRANCH" ]; then
+	echo "❌ Refusing to sync from '$BRANCH'. Check out a feature branch first."
+	exit 1
+fi
+
+echo "🔄 Syncing snapshot references on branch '$BRANCH'..."
+
+git -C "$SUBMODULE_PATH" checkout -B "$BRANCH"
+if [ -n "$DIRTY" ]; then
+	git -C "$SUBMODULE_PATH" add -A
+	git -C "$SUBMODULE_PATH" commit -m "Update snapshot references for $BRANCH"
+fi
+git -C "$SUBMODULE_PATH" push -u origin "$BRANCH"
+
+PR_URL="$(gh pr list -R "$SUBMODULE_REPO" --head "$BRANCH" --state open --json url --jq '.[0].url // empty')"
+if [ -z "$PR_URL" ]; then
+	PR_URL="$(gh pr create -R "$SUBMODULE_REPO" \
+		--base "$BASE_BRANCH" \
+		--head "$BRANCH" \
+		--title "Snapshot references for $BRANCH" \
+		--body "Companion reference-image changes for the \`$BRANCH\` branch in duckduckgo/apple-browsers.")"
+	echo "✅ Opened submodule PR: $PR_URL"
+else
+	echo "♻️  Reusing existing submodule PR: $PR_URL"
+fi
+
+git add "$SUBMODULE_PATH"
+
+echo ""
+echo "🔗 Submodule PR: $PR_URL"
+echo "📌 Staged updated '$SUBMODULE_PATH' pointer. Add the link above to your monorepo PR description."


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217231921687425
Tech Design URL: https://app.asana.com/1/137249556945/task/1216991493996402

### Description
Adds the `Merge snapshots` label automation for snapshot-testing PRs. When a monorepo PR changes reference images, the companion PR lives in the `apple-browsers-snapshots` submodule. Applying the `Merge snapshots` label merges that companion PR into its `main` and repoints the monorepo submodule at the merged commit, so the monorepo PR references a permanent commit and can be merged.

### Testing Steps
1. On a branch with reference-image changes, run `./scripts/open-snapshot-submodule-pr.sh` to open the companion PR and stage the monorepo pointer.
2. Open the monorepo PR, then apply the `Merge snapshots` label.
3. Confirm the workflow merges the companion PR, repoints the submodule at `apple-browsers-snapshots@main`, pushes the pointer commit, and removes the label.

### Prerequisites (config, not code)
- `GHA_ELEVATED_PERMISSIONS_TOKEN` must have write access to `apple-browsers-snapshots`.
- A `Merge snapshots` label must exist on the repo.
- `apple-browsers-snapshots`: merge commits allowed + auto-delete head branches on.

### Impact
None — internal dev/CI tooling.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uses `pull_request_target` with an elevated token to merge external-repo PRs and push to contributor branches; misconfiguration or token scope could have broader write impact, though the job is gated on a specific label and same-repo heads.
> 
> **Overview**
> Adds automation so snapshot reference changes in the **`SnapshotReferences`** submodule stay tied to permanent commits on **`apple-browsers-snapshots`** `main` before the monorepo PR merges.
> 
> **`./scripts/open-snapshot-submodule-pr.sh`** pushes submodule work on the feature branch, opens or reuses a companion PR in **`duckduckgo/apple-browsers-snapshots`**, and stages the updated submodule pointer in the monorepo. **`AGENTS.md`** now tells contributors to run that script before opening a monorepo PR when snapshot refs changed.
> 
> **`.github/workflows/merge_snapshots.yml`** runs on the **`Merge snapshots`** label (same-repo PRs only): it checks out trusted **`merge-snapshots.sh`** separately from the PR branch, then **`scripts/merge-snapshots.sh`** merges the companion submodule PR, repoints **`SnapshotReferences`** at the merge commit, pushes to the PR branch, and the workflow removes the label afterward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afdf9cbcd99ca9f0cbf456360dac4d7db03f3341. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->