### PR TITLE
[macOS] Fix build break from Reorder by Name bookmarks bar changes

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/Services/BookmarksContextMenu.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Services/BookmarksContextMenu.swift
@@ -19,7 +19,7 @@
 import AppKit
 import Bookmarks
 import DesignResourcesKitIcons
-import FeatureFlags
+import FeatureFlags_macOS
 import PrivacyConfig
 
 protocol BookmarksContextMenuDelegate: NSMenuDelegate, BookmarkSearchMenuItemSelectors {

--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
@@ -21,7 +21,7 @@ import Combine
 import Common
 import ConcurrencyExtensions
 import DesignResourcesKitIcons
-import FeatureFlags
+import FeatureFlags_macOS
 import Foundation
 import FoundationExtensions
 import os.log

--- a/macOS/UnitTests/Bookmarks/Model/ContextualMenuTests.swift
+++ b/macOS/UnitTests/Bookmarks/Model/ContextualMenuTests.swift
@@ -17,7 +17,7 @@
 //
 
 import Common
-import FeatureFlags
+import FeatureFlags_macOS
 import FoundationExtensions
 import History
 import HistoryView


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216562341335231/task/1217121031488192?focus=true
Tech Design URL:
CC:

### Description
The Reorder by Name work on the bookmarks bar imported the shared `FeatureFlags` module instead of the macOS-specific one, which broke the build. This switches those three files to the module the rest of the macOS target uses. No behaviour change.

### Testing Steps
1. Build the iOS target → build succeeds.
2. Build and run the macOS target → build succeeds.
3. Right-click a folder in the bookmarks bar → Reorder by Name still appears and works as before.

### Impact
None — build fix only, no functional change.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only alignment with the macOS feature-flag module; no logic, data, or security surface changes.
> 
> **Overview**
> Fixes a **macOS build break** from the Reorder by Name bookmarks work by changing three files from `import FeatureFlags` to `import FeatureFlags_macOS`, matching how the rest of the macOS target resolves `FeatureFlagger` and flags like `.bookmarksReorderByName`.
> 
> Touches `BookmarksContextMenu`, `BookmarksBarViewController`, and `ContextualMenuTests`. **No runtime or menu behavior change**—only which module is imported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c376b1ba065eddb4951ac2351749e6e493f9d22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
