### PR TITLE
iOS: Don't repaint the nav bar container on iPhone

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3177,6 +3177,10 @@ class MainViewController: UIViewController {
     /// clipping (keeps the pill shadow and below-bar overflow) and tints the exposed container darker
     /// so the notch shows.
     private func updateWindowedAddressBarCorners() {
+        // Runs every layout pass; on iPhone it can only repaint the container over the unified
+        // toggle input chrome, which owns it there.
+        guard AppWidthObserver.shared.isPad else { return }
+
         // Floating UI and the move animation own the container background; don't fight them. Both
         // re-run this via decorate().
         guard !isFloatingUIEnabled, !isAddressBarMoveInProgress else { return }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1217186458699689
Tech Design URL:
CC:

### Description
`updateWindowedAddressBarCorners()` (added in #6033) runs on every layout pass and unconditionally writes `navigationBarContainer.backgroundColor`. It is not required on iPhone (feature is iPad only) and this adds a guard for that purpose.

### Testing Steps
1. On iPhone, enable UTI feature. Open Duck.ai and switch to full screen. Make sure the gradient around the input looks good and there’s no solid gray background.
2. On iPad, put the app into Split View
3. Confirm the top address bar's top corners round and the container behind it is tinted.
4. Return to full screen, confirm the corners go square again.
5. Revalidate 3 in Slide Over and Stage Manager.
6. Drag a Split View divider until the app is at compact width, confirm the address bar corners go square rather than staying rounded.

### Impact and Risks
Low. Excludes running code that should have no effect on iPhone.

#### What could go wrong?
—

### Quality Considerations
—

### Notes to Reviewer
`updateWindowedAddressBarCorners()` was entirely new in #6033, so this guard is not dropping behaviour that some earlier caller relied on. Before that commit the container was written only by `decorate()` and the unified toggle input paths on iPhone.

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ba24bc282175ca3c4d4e551054307f3141d7bb80. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>