### PR TITLE
[iOS] add memory warning handling and tab eviction

### DIFF
--- a/iOS/DuckDuckGo/TabManager.swift
+++ b/iOS/DuckDuckGo/TabManager.swift
@@ -63,14 +63,20 @@ enum FireModeSwitchSource: String {
     case aiChatHeaderPlusMenu = "ai_chat_header_plus_menu"
 }
 
+enum TabControllerCacheEvictionReason: Equatable {
+    case webContentProcessTermination
+    case memoryWarning
+    case lruCapacity
+}
+
 /// Receives lifecycle events for TabViewController instances managed by TabManager.
 @MainActor
 protocol TabControllerCacheDelegate: AnyObject {
     /// Called when a new TabViewController has been created and added to the cache for the first time.
     func tabManager(_ tabManager: TabManager, didCreateController controller: TabViewController)
-    /// Called when a background tab's WebKit process terminated and its controller was evicted
-    /// from the cache. The tab still exists in the model; a replacement will be created on next activation.
-    func tabManager(_ tabManager: TabManager, didInvalidateController controller: TabViewController)
+    func tabManager(_ tabManager: TabManager,
+                    didEvictController controller: TabViewController,
+                    reason: TabControllerCacheEvictionReason)
 }
 
 @MainActor
@@ -139,6 +145,9 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
     private let onboardingPixelReporter: OnboardingPixelReporting
     private let featureFlagger: FeatureFlagger
     private let tabTerminationTelemetry: any TabTerminationTelemetry
+    private let tabEvictionSettings: TabEvictionSettings
+    private let applicationState: @MainActor () -> UIApplication.State
+    private let isPad: Bool
     private let contentScopeExperimentManager: ContentScopeExperimentsManaging
     private let textZoomCoordinatorProvider: TextZoomCoordinatorProviding
     private let autoconsentManagementProvider: AutoconsentManagementProviding
@@ -221,7 +230,9 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
          duckAiFireModeStorageHandler: DuckAiNativeStorageHandling? = nil,
          toggleModeStorage: ToggleModeStoring = ToggleModeStorage(),
          adBlockingAvailability: AdBlockingAvailabilityProviding,
-         tabTerminationTelemetry: (any TabTerminationTelemetry)? = nil
+         tabTerminationTelemetry: (any TabTerminationTelemetry)? = nil,
+         applicationState: (@MainActor () -> UIApplication.State)? = nil,
+         isPad: Bool? = nil
     ) {
         self.duckAiNativeStorageHandler = duckAiNativeStorageHandler
         self.duckAiFireModeStorageHandler = duckAiFireModeStorageHandler
@@ -239,9 +250,14 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
         self.contextualOnboardingLogic = contextualOnboardingLogic
         self.onboardingPixelReporter = onboardingPixelReporter
         self.featureFlagger = featureFlagger
+        let tabEvictionSettings = TabEvictionSettings(privacyConfigurationManager: privacyConfigurationManager)
+        self.tabEvictionSettings = tabEvictionSettings
         self.tabTerminationTelemetry = tabTerminationTelemetry ?? DefaultTabTerminationTelemetry(
             featureFlagger: featureFlagger,
-            keyValueStore: UserDefaults.app)
+            keyValueStore: UserDefaults.app,
+            memoryWarningTelemetryWindow: { tabEvictionSettings.memoryWarningTelemetryWindow })
+        self.applicationState = applicationState ?? { UIApplication.shared.applicationState }
+        self.isPad = isPad ?? (UIDevice.current.userInterfaceIdiom == .pad)
         self.contentScopeExperimentManager = contentScopeExperimentManager
         self.appSettings = appSettings
         self.autoplaySettings = autoplaySettings
@@ -376,8 +392,7 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
             Logger.general.debug("Tab not in cache, creating")
             let tabInteractionState = interactionStateSource?.popLastStateForTab(tab)
             let controller = buildController(forTab: tab, inheritedAttribution: nil, interactionState: tabInteractionState)
-            tabControllerCache.append(controller)
-            cacheDelegate?.tabManager(self, didCreateController: controller)
+            addToCache(controller)
             return controller
         } else {
             return nil
@@ -397,8 +412,7 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
 
         let tabInteractionState = interactionStateSource?.popLastStateForTab(tab)
         let controller = buildController(forTab: tab, inheritedAttribution: nil, interactionState: tabInteractionState)
-        tabControllerCache.append(controller)
-        cacheDelegate?.tabManager(self, didCreateController: controller)
+        addToCache(controller)
         return controller
     }
 
@@ -493,8 +507,7 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
         controller.delegate = delegate
         controller.loadViewIfNeeded()
         controller.applyInheritedAttribution(inheritedAttribution)
-        tabControllerCache.append(controller)
-        cacheDelegate?.tabManager(self, didCreateController: controller)
+        addToCache(controller)
 
         _ = save()
         return controller
@@ -547,7 +560,9 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
         }
         model.select(tab: tab)
         _ = save()
-        return current(createIfNeeded: true)
+        let controller = current(createIfNeeded: true)
+        markAsMostRecentlyViewed(controller)
+        return controller
     }
 
     @MainActor
@@ -564,14 +579,12 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
         let link = url == nil ? nil : Link(title: nil, url: url!)
         let tab = Tab(link: link, fireTab: model.shouldCreateFireTabs)
         let controller = buildController(forTab: tab, url: url, inheritedAttribution: inheritedAttribution, interactionState: nil)
-        tabControllerCache.append(controller)
-
         model.insert(tab: tab, placement: .afterCurrentTab, selectNewTab: !inBackground)
         if !inBackground {
             tab.viewed = true
         }
 
-        cacheDelegate?.tabManager(self, didCreateController: controller)
+        addToCache(controller)
 
         _ = save()
         return controller
@@ -638,6 +651,41 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
         controller.dismiss()
     }
 
+    @MainActor
+    private func addToCache(_ controller: TabViewController) {
+        tabControllerCache.append(controller)
+        cacheDelegate?.tabManager(self, didCreateController: controller)
+        enforceCacheCapacityIfNeeded()
+    }
+
+    @MainActor
+    private func markAsMostRecentlyViewed(_ controller: TabViewController?) {
+        guard let controller,
+              let index = tabControllerCache.firstIndex(of: controller),
+              index != tabControllerCache.count - 1 else { return }
+        tabControllerCache.remove(at: index)
+        tabControllerCache.append(controller)
+    }
+
+    @MainActor
+    private func enforceCacheCapacityIfNeeded() {
+        guard featureFlagger.isFeatureOn(.tabLRUEviction) else { return }
+        let maximumCapacity = tabEvictionSettings.maximumCapacity(isPad: isPad)
+        while tabControllerCache.count > maximumCapacity {
+            guard let controller = tabControllerCache.first(where: { $0 !== current() }) else { return }
+            evictFromCache(controller, reason: .lruCapacity)
+        }
+    }
+
+    @MainActor
+    private func evictFromCache(_ controller: TabViewController, reason: TabControllerCacheEvictionReason) {
+        if reason != .webContentProcessTermination {
+            interactionStateSource?.saveState(controller.webView.interactionState, for: controller.tabModel)
+        }
+        removeFromCache(controller)
+        cacheDelegate?.tabManager(self, didEvictController: controller, reason: reason)
+    }
+
     func removeLeftoverInteractionStates() {
         _ = interactionStateSource?.removeAll(excluding: allTabsModel.tabs)
     }
@@ -658,8 +706,7 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
 
             current()?.reload()
         } else {
-            removeFromCache(controller)
-            cacheDelegate?.tabManager(self, didInvalidateController: controller)
+            evictFromCache(controller, reason: .webContentProcessTermination)
         }
     }
 
@@ -949,7 +996,13 @@ extension TabManager {
     @MainActor
     @objc
     private func onMemoryWarning(_ notification: NSNotification) {
-        tabTerminationTelemetry.didReceiveMemoryWarning()
+        tabTerminationTelemetry.didReceiveMemoryWarning(activeTabCount: tabControllerCache.count)
+        if featureFlagger.isFeatureOn(.tabEvictionOnMemoryWarning), applicationState() == .background {
+            let currentController = current()
+            tabControllerCache
+                .filter { $0 !== currentController }
+                .forEach { evictFromCache($0, reason: .memoryWarning) }
+        }
         flushPendingSave()
     }
 

--- a/iOS/DuckDuckGo/TabManager.swift
+++ b/iOS/DuckDuckGo/TabManager.swift
@@ -661,18 +661,23 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
     @MainActor
     private func markAsMostRecentlyViewed(_ controller: TabViewController?) {
         guard let controller,
-              let index = tabControllerCache.firstIndex(of: controller),
-              index != tabControllerCache.count - 1 else { return }
-        tabControllerCache.remove(at: index)
-        tabControllerCache.append(controller)
+              let index = tabControllerCache.firstIndex(of: controller) else { return }
+        if index != tabControllerCache.count - 1 {
+            tabControllerCache.remove(at: index)
+            tabControllerCache.append(controller)
+        }
+        enforceCacheCapacityIfNeeded()
     }
 
     @MainActor
     private func enforceCacheCapacityIfNeeded() {
         guard featureFlagger.isFeatureOn(.tabLRUEviction) else { return }
         let maximumCapacity = tabEvictionSettings.maximumCapacity(isPad: isPad)
-        while tabControllerCache.count > maximumCapacity {
-            guard let controller = tabControllerCache.first(where: { $0 !== current() }) else { return }
+        let currentController = current()
+        let effectiveMaximumCapacity = maximumCapacity + (currentController?.tabModel.link == nil ? 1 : 0)
+        while tabControllerCache.count > effectiveMaximumCapacity {
+            let evictionCandidates = tabControllerCache.filter { $0 !== currentController }
+            guard let controller = evictionCandidates.first(where: { $0.tabModel.link == nil }) ?? evictionCandidates.first else { return }
             evictFromCache(controller, reason: .lruCapacity)
         }
     }

--- a/iOS/DuckDuckGo/TabManager.swift
+++ b/iOS/DuckDuckGo/TabManager.swift
@@ -674,7 +674,8 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
         guard featureFlagger.isFeatureOn(.tabLRUEviction) else { return }
         let maximumCapacity = tabEvictionSettings.maximumCapacity(isPad: isPad)
         let currentController = current()
-        let effectiveMaximumCapacity = maximumCapacity + (currentController?.tabModel.link == nil ? 1 : 0)
+        let currentControllerIsNewTabPage = currentController.map { $0.tabModel.link == nil } ?? false
+        let effectiveMaximumCapacity = maximumCapacity + (currentControllerIsNewTabPage ? 1 : 0)
         while tabControllerCache.count > effectiveMaximumCapacity {
             let evictionCandidates = tabControllerCache.filter { $0 !== currentController }
             guard let controller = evictionCandidates.first(where: { $0.tabModel.link == nil }) ?? evictionCandidates.first else { return }

--- a/iOS/DuckDuckGo/TabTerminationTelemetry.swift
+++ b/iOS/DuckDuckGo/TabTerminationTelemetry.swift
@@ -28,7 +28,55 @@ typealias PixelKitFiring = PixelFiring
 @MainActor
 protocol TabTerminationTelemetry {
     func webContentProcessDidTerminate(activeTabCount: Int)
-    func didReceiveMemoryWarning()
+    func didReceiveMemoryWarning(activeTabCount: Int)
+}
+
+struct TabEvictionSettings {
+
+    private enum Constants {
+        static let defaultMemoryWarningTelemetryWindow: TimeInterval = 60
+        static let defaultPhoneCapacity = 20
+        static let defaultPadCapacity = 10
+        static let memoryWarningTelemetryWindowKey = "memoryWarningTelemetryWindowSeconds"
+        static let phoneCapacityKey = "maxCapacityPhone"
+        static let padCapacityKey = "maxCapacityPad"
+    }
+
+    private let privacyConfigurationManager: PrivacyConfigurationManaging
+
+    init(privacyConfigurationManager: PrivacyConfigurationManaging) {
+        self.privacyConfigurationManager = privacyConfigurationManager
+    }
+
+    var memoryWarningTelemetryWindow: TimeInterval {
+        positiveNumber(forKey: Constants.memoryWarningTelemetryWindowKey,
+                       subfeature: .tabEvictionOnMemoryWarning) ?? Constants.defaultMemoryWarningTelemetryWindow
+    }
+
+    func maximumCapacity(isPad: Bool) -> Int {
+        let key = isPad ? Constants.padCapacityKey : Constants.phoneCapacityKey
+        let defaultValue = isPad ? Constants.defaultPadCapacity : Constants.defaultPhoneCapacity
+        guard let value = positiveNumber(forKey: key, subfeature: .tabLRUEviction),
+              value.rounded(.towardZero) == value,
+              value < Double(Int.max) else {
+            return defaultValue
+        }
+        return Int(value)
+    }
+
+    private func positiveNumber(forKey key: String, subfeature: iOSBrowserConfigSubfeature) -> Double? {
+        guard let json = privacyConfigurationManager.privacyConfig.settings(for: subfeature),
+              let data = json.data(using: .utf8),
+              let dictionary = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let value = dictionary[key],
+              !(value is Bool),
+              let number = value as? NSNumber,
+              number.doubleValue.isFinite,
+              number.doubleValue > 0 else {
+            return nil
+        }
+        return number.doubleValue
+    }
 }
 
 @MainActor
@@ -40,19 +88,23 @@ final class DefaultTabTerminationTelemetry: TabTerminationTelemetry {
     private let applicationState: @MainActor () -> UIApplication.State
     private let memoryFootprint: @MainActor () -> UInt64?
     private let date: () -> Date
+    private let memoryWarningTelemetryWindow: () -> TimeInterval
     private var lastMemoryWarningDate: Date?
+    private var memoryWarningDates = [Date]()
 
     init(featureFlagger: FeatureFlagger,
          keyValueStore: KeyValueStoring,
          pixelFiring: (any PixelKitFiring)? = PixelKit.shared,
          applicationState: (@MainActor () -> UIApplication.State)? = nil,
          memoryFootprint: (@MainActor () -> UInt64?)? = nil,
+         memoryWarningTelemetryWindow: @escaping () -> TimeInterval = { 60 },
          date: @escaping () -> Date = Date.init) {
         self.featureFlagger = featureFlagger
         self.occurrenceStore = TabTerminationTelemetryOccurrenceStore(keyValueStore: keyValueStore)
         self.pixelFiring = pixelFiring
         self.applicationState = applicationState ?? { UIApplication.shared.applicationState }
         self.memoryFootprint = memoryFootprint ?? { Self.currentMemoryFootprint() }
+        self.memoryWarningTelemetryWindow = memoryWarningTelemetryWindow
         self.date = date
     }
 
@@ -82,9 +134,17 @@ final class DefaultTabTerminationTelemetry: TabTerminationTelemetry {
         }
     }
 
-    func didReceiveMemoryWarning() {
+    func didReceiveMemoryWarning(activeTabCount: Int) {
         guard featureFlagger.isFeatureOn(.tabTerminationTelemetry) else { return }
-        lastMemoryWarningDate = date()
+        let warningDate = date()
+        lastMemoryWarningDate = warningDate
+        memoryWarningDates.removeAll {
+            $0 > warningDate || warningDate.timeIntervalSince($0) > memoryWarningTelemetryWindow()
+        }
+        memoryWarningDates.append(warningDate)
+
+        pixelFiring?.fire(TabTerminationTelemetryPixel.memoryWarningActiveTabs(.init(activeTabCount)), frequency: .dailyAndCount)
+        pixelFiring?.fire(TabTerminationTelemetryPixel.memoryWarningOccurrence(.init(memoryWarningDates.count)), frequency: .standard)
     }
 
     nonisolated static func currentMemoryFootprint() -> UInt64? {
@@ -136,6 +196,8 @@ enum TabTerminationTelemetryPixel: PixelKitEvent, PixelKitEventWithCustomPrefix 
     case memory(MemoryBucket)
     case activeTabs(ActiveTabBucket)
     case timeSinceMemoryWarning(TimeBucket)
+    case memoryWarningActiveTabs(ActiveTabBucket)
+    case memoryWarningOccurrence(OccurrenceBucket)
 
     var name: String {
         switch self {
@@ -155,6 +217,10 @@ enum TabTerminationTelemetryPixel: PixelKitEvent, PixelKitEventWithCustomPrefix 
             return "debug_webkit_termination_active-tabs_\(bucket.rawValue)"
         case .timeSinceMemoryWarning(let bucket):
             return "debug_webkit_termination_time-since-memory-warning_\(bucket.rawValue)"
+        case .memoryWarningActiveTabs(let bucket):
+            return "debug_memory_warning_active-tabs_\(bucket.rawValue)"
+        case .memoryWarningOccurrence(let bucket):
+            return "debug_memory_warning_occurrence-in-window_\(bucket.rawValue)"
         }
     }
 

--- a/iOS/DuckDuckGo/WebExtensions/WebExtensionEventsCoordinator+iOS.swift
+++ b/iOS/DuckDuckGo/WebExtensions/WebExtensionEventsCoordinator+iOS.swift
@@ -173,12 +173,17 @@ extension WebExtensionEventsCoordinator: TabControllerCacheDelegate {
         didOpenTab(controller)
     }
 
-    // The tab stays in the model, so we must not call didCloseTab — extensions would drop it
-    // entirely. Retain the controller instead and report didReplaceTab on recreation (see above).
-    func tabManager(_ tabManager: TabManager, didInvalidateController controller: TabViewController) {
+    func tabManager(_ tabManager: TabManager,
+                    didEvictController controller: TabViewController,
+                    reason: TabControllerCacheEvictionReason) {
         guard #available(iOS 18.4, *) else { return }
         pruneInvalidatedControllers()
-        invalidatedControllersByTabUID[controller.tabModel.uid] = controller
+        switch reason {
+        case .webContentProcessTermination:
+            invalidatedControllersByTabUID[controller.tabModel.uid] = controller
+        case .memoryWarning, .lruCapacity:
+            didCloseTab(controller)
+        }
     }
 
     /// Reports retained controllers whose tab is gone from the model as closed, so the extension

--- a/iOS/DuckDuckGoTests/TabManagerTests.swift
+++ b/iOS/DuckDuckGoTests/TabManagerTests.swift
@@ -24,6 +24,7 @@ import Combine
 import ConcurrencyExtensions
 import Core
 import PersistenceTestingUtils
+import PrivacyConfig
 import SubscriptionTestingUtilities
 import XCTest
 @testable import DuckDuckGo
@@ -381,7 +382,160 @@ final class TabManagerTests: XCTestCase {
         NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
 
         XCTAssertEqual(telemetry.memoryWarningCallCount, 1)
+        XCTAssertEqual(telemetry.memoryWarningActiveTabCounts, [0])
         withExtendedLifetime(manager) {}
+    }
+
+    func testWhenMemoryWarningIsReceivedInBackgroundThenNonCurrentControllersAreEvicted() throws {
+        let tabs = (0..<3).map {
+            Tab(link: Link(title: "tab-\($0)", url: URL(string: "https://example.com/\($0)")!))
+        }
+        let model = TabsModel(tabs: tabs, desktop: false)
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.tabEvictionOnMemoryWarning])
+        let telemetry = MockTabTerminationTelemetry()
+        let cacheDelegate = MockTabControllerCacheDelegate()
+        let manager = try makeManager(model,
+                                      featureFlagger: featureFlagger,
+                                      tabTerminationTelemetry: telemetry,
+                                      applicationState: { .background })
+        manager.cacheDelegate = cacheDelegate
+
+        _ = manager.current(createIfNeeded: true)
+        _ = manager.select(tabs[1])
+        _ = manager.select(tabs[2])
+        _ = manager.select(tabs[0])
+
+        NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
+
+        XCTAssertEqual(telemetry.memoryWarningActiveTabCounts, [3])
+        XCTAssertNotNil(manager.controller(for: tabs[0]))
+        XCTAssertNil(manager.controller(for: tabs[1]))
+        XCTAssertNil(manager.controller(for: tabs[2]))
+        XCTAssertEqual(cacheDelegate.evictionReasons, [.memoryWarning, .memoryWarning])
+        XCTAssertEqual(model.tabs.count, 3)
+        XCTAssertTrue(model.currentTab === tabs[0])
+    }
+
+    func testWhenMemoryWarningEvictionFlagIsDisabledThenControllersRemainCached() throws {
+        let tabs = (0..<2).map {
+            Tab(link: Link(title: "tab-\($0)", url: URL(string: "https://example.com/\($0)")!))
+        }
+        let model = TabsModel(tabs: tabs, desktop: false)
+        let manager = try makeManager(model, applicationState: { .background })
+
+        _ = manager.current(createIfNeeded: true)
+        _ = manager.select(tabs[1])
+        NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
+
+        XCTAssertNotNil(manager.controller(for: tabs[0]))
+        XCTAssertNotNil(manager.controller(for: tabs[1]))
+    }
+
+    func testWhenMemoryWarningIsReceivedInForegroundThenControllersRemainCached() throws {
+        let tabs = (0..<2).map {
+            Tab(link: Link(title: "tab-\($0)", url: URL(string: "https://example.com/\($0)")!))
+        }
+        let model = TabsModel(tabs: tabs, desktop: false)
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.tabEvictionOnMemoryWarning])
+        let manager = try makeManager(model,
+                                      featureFlagger: featureFlagger,
+                                      applicationState: { .active })
+
+        _ = manager.current(createIfNeeded: true)
+        _ = manager.select(tabs[1])
+        NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
+
+        XCTAssertNotNil(manager.controller(for: tabs[0]))
+        XCTAssertNotNil(manager.controller(for: tabs[1]))
+    }
+
+    func testWhenLRUCapacityIsExceededThenLeastRecentlyViewedControllerIsEvicted() throws {
+        let tabs = (0..<3).map {
+            Tab(link: Link(title: "tab-\($0)", url: URL(string: "https://example.com/\($0)")!))
+        }
+        let model = TabsModel(tabs: tabs, desktop: false)
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.tabLRUEviction])
+        let privacyConfigurationManager = makePrivacyConfigurationManager(settings: "{\"maxCapacityPhone\": 2}")
+        let cacheDelegate = MockTabControllerCacheDelegate()
+        let manager = try makeManager(model,
+                                      featureFlagger: featureFlagger,
+                                      privacyConfigurationManager: privacyConfigurationManager,
+                                      isPad: false)
+        manager.cacheDelegate = cacheDelegate
+
+        _ = manager.current(createIfNeeded: true)
+        _ = manager.select(tabs[1])
+        _ = manager.select(tabs[0])
+        _ = manager.select(tabs[2])
+
+        XCTAssertNotNil(manager.controller(for: tabs[0]))
+        XCTAssertNil(manager.controller(for: tabs[1]))
+        XCTAssertNotNil(manager.controller(for: tabs[2]))
+        XCTAssertEqual(cacheDelegate.evictionReasons, [.lruCapacity])
+        XCTAssertEqual(model.tabs.count, 3)
+        XCTAssertTrue(model.currentTab === tabs[2])
+    }
+
+    func testWhenIPadLRUCapacityIsExceededThenConfiguredPadCapacityIsUsed() throws {
+        let tabs = (0..<3).map {
+            Tab(link: Link(title: "tab-\($0)", url: URL(string: "https://example.com/\($0)")!))
+        }
+        let model = TabsModel(tabs: tabs, desktop: true)
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.tabLRUEviction])
+        let privacyConfigurationManager = makePrivacyConfigurationManager(settings: "{\"maxCapacityPhone\": 3, \"maxCapacityPad\": 2}")
+        let manager = try makeManager(model,
+                                      featureFlagger: featureFlagger,
+                                      privacyConfigurationManager: privacyConfigurationManager,
+                                      isPad: true)
+
+        _ = manager.current(createIfNeeded: true)
+        _ = manager.select(tabs[1])
+        _ = manager.select(tabs[2])
+
+        XCTAssertNil(manager.controller(for: tabs[0]))
+        XCTAssertNotNil(manager.controller(for: tabs[1]))
+        XCTAssertNotNil(manager.controller(for: tabs[2]))
+    }
+
+    func testLRUCapacityIsSharedAcrossNormalAndFireTabs() throws {
+        let normalTabs = (0..<2).map {
+            Tab(link: Link(title: "normal-\($0)", url: URL(string: "https://example.com/normal-\($0)")!))
+        }
+        let fireTab = Tab(link: Link(title: "fire", url: URL(string: "https://example.com/fire")!), fireTab: true)
+        let normalModel = TabsModel(tabs: normalTabs, desktop: false)
+        let fireModel = TabsModel(tabs: [fireTab], desktop: false, mode: .fire)
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.fireMode, .tabLRUEviction])
+        let privacyConfigurationManager = makePrivacyConfigurationManager(settings: "{\"maxCapacityPhone\": 2}")
+        let manager = try makeManager(normalModel,
+                                      fireModel: fireModel,
+                                      featureFlagger: featureFlagger,
+                                      privacyConfigurationManager: privacyConfigurationManager)
+
+        _ = manager.current(createIfNeeded: true)
+        _ = manager.select(normalTabs[1])
+        _ = manager.select(fireTab)
+
+        XCTAssertNil(manager.controller(for: normalTabs[0]))
+        XCTAssertNotNil(manager.controller(for: normalTabs[1]))
+        XCTAssertNotNil(manager.controller(for: fireTab))
+    }
+
+    func testWebContentTerminationUsesDedicatedCacheEvictionReason() throws {
+        let tabs = (0..<2).map {
+            Tab(link: Link(title: "tab-\($0)", url: URL(string: "https://example.com/\($0)")!))
+        }
+        let model = TabsModel(tabs: tabs, desktop: false)
+        let cacheDelegate = MockTabControllerCacheDelegate()
+        let manager = try makeManager(model)
+        manager.cacheDelegate = cacheDelegate
+
+        let firstController = try XCTUnwrap(manager.current(createIfNeeded: true))
+        _ = manager.select(tabs[1])
+        manager.invalidateCache(forController: firstController)
+
+        XCTAssertEqual(cacheDelegate.evictionReasons, [.webContentProcessTermination])
+        XCTAssertNil(manager.controller(for: tabs[0]))
+        XCTAssertEqual(model.tabs.count, 2)
     }
 
     func testWhenWebContentProcessTerminatesThenTabTerminationTelemetryIsNotified() throws {
@@ -400,7 +554,10 @@ final class TabManagerTests: XCTestCase {
                      featureFlagger: MockFeatureFlagger = MockFeatureFlagger(),
                      launchSourceManager: LaunchSourceManaging = MockLaunchSourceManager(),
                      normalStore: ThrowingKeyValueStoring? = nil,
-                     tabTerminationTelemetry: (any TabTerminationTelemetry)? = nil) throws -> TabManager {
+                     tabTerminationTelemetry: (any TabTerminationTelemetry)? = nil,
+                     privacyConfigurationManager: PrivacyConfigurationManaging = MockPrivacyConfigurationManager(),
+                     applicationState: (@MainActor () -> UIApplication.State)? = nil,
+                     isPad: Bool = false) throws -> TabManager {
         FireModeCapability.resolve(using: featureFlagger)
         let normalStore = try normalStore ?? MockKeyValueFileStore(throwOnInit: nil)
         let tabsPersistence = TabsModelPersistence(normalStore: normalStore,
@@ -411,7 +568,7 @@ final class TabManagerTests: XCTestCase {
         return TabManager(tabsModelProvider: modelProvider,
                           previewsSource: previewsSource,
                           interactionStateSource: TabInteractionStateDiskSource(),
-                          privacyConfigurationManager: MockPrivacyConfigurationManager(),
+                          privacyConfigurationManager: privacyConfigurationManager,
                           bookmarksDatabase: MockBookmarksDatabase.make(prepareFolderStructure: false),
                           historyManager: historyManager,
                           syncService: MockDDGSyncing(),
@@ -441,7 +598,17 @@ final class TabManagerTests: XCTestCase {
                           launchSourceManager: launchSourceManager,
                           darkReaderFeatureSettings: MockDarkReaderFeatureSettings(),
                           adBlockingAvailability: StubAdBlockingAvailability(),
-                          tabTerminationTelemetry: tabTerminationTelemetry)
+                          tabTerminationTelemetry: tabTerminationTelemetry,
+                          applicationState: applicationState,
+                          isPad: isPad)
+    }
+
+    private func makePrivacyConfigurationManager(settings: String) -> MockPrivacyConfigurationManager {
+        let config = MockPrivacyConfiguration()
+        config.subfeatureSettings = settings
+        let manager = MockPrivacyConfigurationManager()
+        manager.privacyConfig = config
+        return manager
     }
 
 }
@@ -475,13 +642,28 @@ private final class CountingThrowingKeyValueStore: ThrowingKeyValueStoring, @unc
 @MainActor
 private final class MockTabTerminationTelemetry: TabTerminationTelemetry {
     private(set) var memoryWarningCallCount = 0
+    private(set) var memoryWarningActiveTabCounts: [Int] = []
     private(set) var webContentProcessTerminationActiveTabCounts: [Int] = []
 
     func webContentProcessDidTerminate(activeTabCount: Int) {
         webContentProcessTerminationActiveTabCounts.append(activeTabCount)
     }
 
-    func didReceiveMemoryWarning() {
+    func didReceiveMemoryWarning(activeTabCount: Int) {
         memoryWarningCallCount += 1
+        memoryWarningActiveTabCounts.append(activeTabCount)
+    }
+}
+
+@MainActor
+private final class MockTabControllerCacheDelegate: TabControllerCacheDelegate {
+    private(set) var evictionReasons = [TabControllerCacheEvictionReason]()
+
+    func tabManager(_ tabManager: TabManager, didCreateController controller: TabViewController) {}
+
+    func tabManager(_ tabManager: TabManager,
+                    didEvictController controller: TabViewController,
+                    reason: TabControllerCacheEvictionReason) {
+        evictionReasons.append(reason)
     }
 }

--- a/iOS/DuckDuckGoTests/TabManagerTests.swift
+++ b/iOS/DuckDuckGoTests/TabManagerTests.swift
@@ -497,6 +497,39 @@ final class TabManagerTests: XCTestCase {
         XCTAssertNotNil(manager.controller(for: tabs[2]))
     }
 
+    func testWhenNewTabPagesExceedLRUCapacityThenLoadedTabsArePreserved() throws {
+        let loadedTabs = (0..<2).map {
+            Tab(link: Link(title: "tab-\($0)", url: URL(string: "https://example.com/\($0)")!))
+        }
+        let newTabPages = [Tab(), Tab()]
+        let model = TabsModel(tabs: loadedTabs + newTabPages, desktop: false)
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.tabLRUEviction])
+        let privacyConfigurationManager = makePrivacyConfigurationManager(settings: "{\"maxCapacityPhone\": 2}")
+        let cacheDelegate = MockTabControllerCacheDelegate()
+        let manager = try makeManager(model,
+                                      featureFlagger: featureFlagger,
+                                      privacyConfigurationManager: privacyConfigurationManager,
+                                      isPad: false)
+        manager.cacheDelegate = cacheDelegate
+
+        _ = manager.current(createIfNeeded: true)
+        _ = manager.select(loadedTabs[1])
+        _ = manager.select(newTabPages[0])
+        _ = manager.select(newTabPages[1])
+
+        XCTAssertNotNil(manager.controller(for: loadedTabs[0]))
+        XCTAssertNotNil(manager.controller(for: loadedTabs[1]))
+        XCTAssertNil(manager.controller(for: newTabPages[0]))
+        XCTAssertNotNil(manager.controller(for: newTabPages[1]))
+
+        _ = manager.select(loadedTabs[0])
+
+        XCTAssertNotNil(manager.controller(for: loadedTabs[0]))
+        XCTAssertNotNil(manager.controller(for: loadedTabs[1]))
+        XCTAssertNil(manager.controller(for: newTabPages[1]))
+        XCTAssertEqual(cacheDelegate.evictionReasons, [.lruCapacity, .lruCapacity])
+    }
+
     func testLRUCapacityIsSharedAcrossNormalAndFireTabs() throws {
         let normalTabs = (0..<2).map {
             Tab(link: Link(title: "normal-\($0)", url: URL(string: "https://example.com/normal-\($0)")!))

--- a/iOS/DuckDuckGoTests/TabManagerTests.swift
+++ b/iOS/DuckDuckGoTests/TabManagerTests.swift
@@ -530,6 +530,24 @@ final class TabManagerTests: XCTestCase {
         XCTAssertEqual(cacheDelegate.evictionReasons, [.lruCapacity, .lruCapacity])
     }
 
+    func testWhenCurrentControllerIsMissingThenLRUCapacityIsNotIncreased() throws {
+        let model = TabsModel(desktop: false)
+        let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: [.tabLRUEviction])
+        let privacyConfigurationManager = makePrivacyConfigurationManager(settings: "{\"maxCapacityPhone\": 2}")
+        let manager = try makeManager(model,
+                                      featureFlagger: featureFlagger,
+                                      privacyConfigurationManager: privacyConfigurationManager,
+                                      isPad: false)
+
+        let controllers = (0..<3).map {
+            manager.add(url: URL(string: "https://example.com/\($0)")!, inBackground: true, inheritedAttribution: nil)
+        }
+
+        XCTAssertNil(manager.controller(for: controllers[0].tabModel))
+        XCTAssertNotNil(manager.controller(for: controllers[1].tabModel))
+        XCTAssertNotNil(manager.controller(for: controllers[2].tabModel))
+    }
+
     func testLRUCapacityIsSharedAcrossNormalAndFireTabs() throws {
         let normalTabs = (0..<2).map {
             Tab(link: Link(title: "normal-\($0)", url: URL(string: "https://example.com/normal-\($0)")!))

--- a/iOS/DuckDuckGoTests/TabTerminationTelemetryTests.swift
+++ b/iOS/DuckDuckGoTests/TabTerminationTelemetryTests.swift
@@ -21,6 +21,7 @@ import FeatureFlags_iOS
 import Persistence
 import PersistenceTestingUtils
 import PixelKit
+import PrivacyConfigTestsUtils
 import UIKit
 import XCTest
 @testable import DuckDuckGo
@@ -41,7 +42,7 @@ final class TabTerminationTelemetryTests: XCTestCase {
         let pixelFiring = MockTabTerminationPixelFiring()
         let telemetry = makeTelemetry(featureEnabled: false, pixelFiring: pixelFiring)
 
-        telemetry.didReceiveMemoryWarning()
+        telemetry.didReceiveMemoryWarning(activeTabCount: 1)
         telemetry.webContentProcessDidTerminate(activeTabCount: 1)
 
         XCTAssertTrue(pixelFiring.calls.isEmpty)
@@ -145,7 +146,7 @@ final class TabTerminationTelemetryTests: XCTestCase {
     func testWhenMemoryWarningOccurredThenElapsedTimePixelFires() {
         let pixelFiring = MockTabTerminationPixelFiring()
         let telemetry = makeTelemetry(pixelFiring: pixelFiring)
-        telemetry.didReceiveMemoryWarning()
+        telemetry.didReceiveMemoryWarning(activeTabCount: 1)
         date.addTimeInterval(6)
 
         telemetry.webContentProcessDidTerminate(activeTabCount: 1)
@@ -153,10 +154,60 @@ final class TabTerminationTelemetryTests: XCTestCase {
         XCTAssertEqual(pixelFiring.call(named: "debug_webkit_termination_time-since-memory-warning_10")?.frequency, .standard)
     }
 
+    func testWhenMemoryWarningOccursThenActiveTabsAndRollingOccurrencePixelsFire() {
+        let pixelFiring = MockTabTerminationPixelFiring()
+        let telemetry = makeTelemetry(pixelFiring: pixelFiring, memoryWarningTelemetryWindow: 60)
+
+        telemetry.didReceiveMemoryWarning(activeTabCount: 7)
+        date.addTimeInterval(30)
+        telemetry.didReceiveMemoryWarning(activeTabCount: 7)
+        date.addTimeInterval(31)
+        telemetry.didReceiveMemoryWarning(activeTabCount: 7)
+
+        XCTAssertEqual(pixelFiring.calls.filter { $0.event.name.hasPrefix("debug_memory_warning_active-tabs_") }.map(\.event.name), [
+            "debug_memory_warning_active-tabs_6-10",
+            "debug_memory_warning_active-tabs_6-10",
+            "debug_memory_warning_active-tabs_6-10"
+        ])
+        XCTAssertEqual(pixelFiring.calls.filter { $0.event.name.hasPrefix("debug_memory_warning_occurrence-in-window_") }.map(\.event.name), [
+            "debug_memory_warning_occurrence-in-window_1",
+            "debug_memory_warning_occurrence-in-window_2",
+            "debug_memory_warning_occurrence-in-window_2"
+        ])
+        XCTAssertEqual(pixelFiring.call(named: "debug_memory_warning_active-tabs_6-10")?.frequency, .dailyAndCount)
+        XCTAssertEqual(pixelFiring.call(named: "debug_memory_warning_occurrence-in-window_1")?.frequency, .standard)
+    }
+
+    func testTabEvictionSettingsReadRemoteValues() {
+        let settings = makeSettings(json: "{\"memoryWarningTelemetryWindowSeconds\": 30, \"maxCapacityPhone\": 12, \"maxCapacityPad\": 8}")
+
+        XCTAssertEqual(settings.memoryWarningTelemetryWindow, 30)
+        XCTAssertEqual(settings.maximumCapacity(isPad: false), 12)
+        XCTAssertEqual(settings.maximumCapacity(isPad: true), 8)
+    }
+
+    func testTabEvictionSettingsFallBackForInvalidValues() {
+        let invalidSettings = [
+            nil,
+            "not json",
+            "{}",
+            "{\"memoryWarningTelemetryWindowSeconds\": 0, \"maxCapacityPhone\": -1, \"maxCapacityPad\": 2.5}",
+            "{\"memoryWarningTelemetryWindowSeconds\": \"60\", \"maxCapacityPhone\": true, \"maxCapacityPad\": \"10\"}"
+        ]
+
+        for json in invalidSettings {
+            let settings = makeSettings(json: json)
+            XCTAssertEqual(settings.memoryWarningTelemetryWindow, 60)
+            XCTAssertEqual(settings.maximumCapacity(isPad: false), 20)
+            XCTAssertEqual(settings.maximumCapacity(isPad: true), 10)
+        }
+    }
+
     private func makeTelemetry(featureEnabled: Bool = true,
                                pixelFiring: MockTabTerminationPixelFiring,
                                applicationState: UIApplication.State = .active,
-                               memoryFootprint: UInt64? = 100 * 1_048_576) -> DefaultTabTerminationTelemetry {
+                               memoryFootprint: UInt64? = 100 * 1_048_576,
+                               memoryWarningTelemetryWindow: TimeInterval = 60) -> DefaultTabTerminationTelemetry {
         let featureFlagger = MockFeatureFlagger(enabledFeatureFlags: featureEnabled ? [.tabTerminationTelemetry] : [])
         return DefaultTabTerminationTelemetry(
             featureFlagger: featureFlagger,
@@ -164,7 +215,16 @@ final class TabTerminationTelemetryTests: XCTestCase {
             pixelFiring: pixelFiring,
             applicationState: { applicationState },
             memoryFootprint: { memoryFootprint },
+            memoryWarningTelemetryWindow: { memoryWarningTelemetryWindow },
             date: { self.date })
+    }
+
+    private func makeSettings(json: String?) -> TabEvictionSettings {
+        let config = MockPrivacyConfiguration()
+        config.subfeatureSettings = json
+        let manager = MockPrivacyConfigurationManager()
+        manager.privacyConfig = config
+        return TabEvictionSettings(privacyConfigurationManager: manager)
     }
 }
 

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -385,6 +385,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217109908046478?focus=true
     case tabTerminationTelemetry
 
+    case tabEvictionOnMemoryWarning
+    case tabLRUEviction
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214974217398704?focus=true
     case appRebranding
 
@@ -813,6 +816,10 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.launchTimeMetrics), supportsLocalOverriding: true)
         case .tabTerminationTelemetry:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.tabTerminationTelemetry), supportsLocalOverriding: true)
+        case .tabEvictionOnMemoryWarning:
+            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.tabEvictionOnMemoryWarning), supportsLocalOverriding: true)
+        case .tabLRUEviction:
+            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.tabLRUEviction), supportsLocalOverriding: true)
 
         case .appRebranding:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.appRebranding), supportsLocalOverriding: true)

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -385,7 +385,10 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217109908046478?focus=true
     case tabTerminationTelemetry
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217244101759199?focus=true
     case tabEvictionOnMemoryWarning
+
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217244101759205?focus=true
     case tabLRUEviction
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214974217398704?focus=true

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
@@ -62,6 +62,9 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217109908046478?focus=true
     case tabTerminationTelemetry
 
+    case tabEvictionOnMemoryWarning
+    case tabLRUEviction
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212835969125260
     case browsingMenuSheetEnabledByDefault
 

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
@@ -62,7 +62,10 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217109908046478?focus=true
     case tabTerminationTelemetry
 
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217244101759199?focus=true
     case tabEvictionOnMemoryWarning
+
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217244101759205?focus=true
     case tabLRUEviction
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212835969125260

--- a/iOS/LocalPackages/FeatureFlags-iOS/Tests/FeatureFlagsTests/FeatureFlagsTests.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Tests/FeatureFlagsTests/FeatureFlagsTests.swift
@@ -63,4 +63,24 @@ final class FeatureFlagsTests: XCTestCase {
         XCTAssertEqual(FeatureFlag.searchTokenExperimentV2.cohortType.map(ObjectIdentifier.init),
                        ObjectIdentifier(FeatureFlag.SearchTokenExperimentCohort.self))
     }
+
+    func testTabEvictionFlagsAreDefaultEnabledRemoteReleasableAndLocallyOverridable() {
+        let cases: [(FeatureFlag, iOSBrowserConfigSubfeature)] = [
+            (.tabEvictionOnMemoryWarning, .tabEvictionOnMemoryWarning),
+            (.tabLRUEviction, .tabLRUEviction)
+        ]
+
+        for (flag, expectedSubfeature) in cases {
+            guard case let .remoteReleasable(subfeature) = flag.source else {
+                XCTFail("Expected remote-releasable source for \(flag.rawValue)")
+                continue
+            }
+            XCTAssertEqual((subfeature as? iOSBrowserConfigSubfeature)?.rawValue, expectedSubfeature.rawValue)
+            guard case .enabled = flag.defaultValue else {
+                XCTFail("Expected enabled default for \(flag.rawValue)")
+                continue
+            }
+            XCTAssertTrue(flag.supportsLocalOverriding)
+        }
+    }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/tab_termination_telemetry.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/tab_termination_telemetry.json5
@@ -71,5 +71,34 @@
         "triggers": ["exception"],
         "suffixes": ["time_bucket", "platform", "form_factor"],
         "parameters": ["appVersion"]
+    },
+    "debug_memory_warning_active-tabs_": {
+        "description": "Fires with the number of in-memory tab view controllers when a memory warning is received.",
+        "owners": ["brindy"],
+        "triggers": ["exception"],
+        "suffixes": [
+            {
+                "description": "In-memory tab view controller count bucket",
+                "enum": ["1", "2-5", "6-10", "11-20", "21-40", "41-60", "61-80", "81-plus"]
+            },
+            "platform",
+            "form_factor",
+            "daily_count"
+        ],
+        "parameters": ["appVersion"]
+    },
+    "debug_memory_warning_occurrence-in-window_": {
+        "description": "Fires for each memory warning with the number received in the configured rolling window.",
+        "owners": ["brindy"],
+        "triggers": ["exception"],
+        "suffixes": [
+            {
+                "description": "Memory warning occurrence bucket in the rolling window",
+                "enum": ["1", "2", "3", "4", "5-plus"]
+            },
+            "platform",
+            "form_factor"
+        ],
+        "parameters": ["appVersion"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217244101759188?focus=true
Tech Design URL:
CC:

### Description
Improves memory management by releasing inactive tab content after background memory warnings and when too many tabs are held in memory. Adds telemetry to measure tab counts and memory-warning frequency. Both behaviors are remotely configurable and enabled by default.

### Testing Steps

1. Open more than 20 tabs on an iPhone, switching through them → all tabs remain visible in the tab switcher and can be reopened normally.
2. Open more than 10 tabs on an iPad, switching through them → all tabs remain visible in the tab switcher and can be reopened normally.
3. Put the app in the background and trigger a memory warning → inactive tab content is released while the current tab remains available.
4. Return to the app and select an evicted tab → the tab reloads without losing its history or preview.
5. Trigger a memory warning while the app is foregrounded → tabs are not evicted.
6. Verify memory-warning pixels → active-tab count and warnings within the configured time window are bucketed correctly.

### Impact
Medium: Incorrect eviction could cause unnecessary tab reloads or increased memory usage, but should not remove tabs or browsing history.

#### What could go wrong?

- The current tab could be evicted → protected explicitly and covered by tests.
- Tabs, history, or previews could be removed → eviction only releases in-memory content and model preservation is tested.
- Too many or too few tabs could remain in memory → device-specific limits, ordering, and configuration fallbacks are tested.
- Web Extension lifecycle events could become inconsistent → termination and eviction paths are distinguished and tested.
- A rollout issue could affect users broadly → both behaviors have remote feature flags and configurable limits.

### Quality Considerations

- Phone and iPad use separate default capacities.
- Normal and Fire tabs share one memory limit.
- Invalid, missing, fractional, or non-positive remote values fall back to safe defaults.
- Telemetry remains independently controlled by its existing kill switch.


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Eviction touches core tab/WebKit lifecycle and web extension tab events; mis-eviction could cause extra reloads or extension inconsistency, though flags, current-tab protection, and broad tests mitigate rollout risk.
> 
> **Overview**
> Adds **remotely configurable** eviction of in-memory `TabViewController` instances while tab models, history, and previews stay in place. Evicted tabs reload when selected again.
> 
> **Background memory warnings** (flag `tabEvictionOnMemoryWarning`): when the app is in the background, all cached controllers except the current tab are evicted; interaction state is saved before eviction. Foreground warnings or a disabled flag leave the cache unchanged.
> 
> **LRU capacity** (flag `tabLRUEviction`): caps how many controllers stay in memory (defaults 20 phone / 10 iPad, overridable via privacy config). Tab selection updates LRU order; eviction prefers new-tab pages over loaded URLs when over capacity, skips the current tab, and shares one limit across normal and Fire tabs.
> 
> Cache delegate callbacks move from `didInvalidateController` to **`didEvictController`** with `TabControllerCacheEvictionReason` (WebKit termination vs memory warning vs LRU). Web extensions treat termination as retain-for-replace; memory/LRU eviction reports tab close.
> 
> **Telemetry**: memory warnings now record active cached tab count and rolling-window occurrence buckets; `TabEvictionSettings` reads capacity and telemetry window from remote config with safe fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a75baaec51d2626d2919d394b65afe1debf02c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->