### PR TITLE
[iOS] Add toggle_visible param to experimental omnibar shown pixel

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1768,7 +1768,6 @@ extension Pixel {
         case aiChatNewAddressBarPickerV2Confirmed
         
         // MARK: Experimental Omnibar Metrics
-        case aiChatExperimentalOmnibarShown
         case aiChatExperimentalOmnibarPromptSubmitted
         case aiChatExperimentalOmnibarQuerySubmitted
         case aiChatExperimentalOmnibarModeSwitched
@@ -3708,7 +3707,6 @@ extension Pixel.Event {
         case .aiChatNewAddressBarPickerV2Confirmed: return "m_aichat_new_address_bar_picker_v2_confirmed"
         
         // MARK: Experimental Omnibar Metrics
-        case .aiChatExperimentalOmnibarShown: return "m_aichat_experimental_omnibar_shown"
         case .aiChatExperimentalOmnibarPromptSubmitted: return "m_aichat_experimental_omnibar_prompt_submitted"
         case .aiChatExperimentalOmnibarQuerySubmitted: return "m_aichat_experimental_omnibar_query_submitted"
         case .aiChatExperimentalOmnibarModeSwitched: return "m_aichat_experimental_omnibar_mode_switched"

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -232,8 +232,9 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
         super.viewDidAppear(animated)
 
         DailyPixel.fireDailyAndCount(pixel: .aiChatInternalSwitchBarDisplayed)
-        PixelKit.fire(ExperimentalOmnibarPixel.omnibarShown(isToggleVisible: switchBarHandler.isToggleEnabled),
-                      frequency: .dailyAndCount)
+        let isToggleVisible = switchBarHandler.isToggleEnabled
+        PixelKit.fire(ExperimentalOmnibarPixel.omnibarShownDaily(isToggleVisible: isToggleVisible), frequency: .legacyDailyNoSuffix)
+        PixelKit.fire(ExperimentalOmnibarPixel.omnibarShownCount(isToggleVisible: isToggleVisible), frequency: .standard)
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -231,7 +231,8 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
         super.viewDidAppear(animated)
 
         DailyPixel.fireDailyAndCount(pixel: .aiChatInternalSwitchBarDisplayed)
-        DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarShown)
+        DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarShown,
+                                     withAdditionalParameters: ["toggle_visible": String(switchBarHandler.isToggleEnabled)])
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -30,6 +30,7 @@ import SwiftUI
 import AIChat
 import RemoteMessaging
 import FeatureFlags_iOS
+import PixelKit
 
 protocol OmniBarEditingStateViewControllerDelegate: AnyObject {
     func onQueryUpdated(_ query: String)
@@ -231,8 +232,8 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
         super.viewDidAppear(animated)
 
         DailyPixel.fireDailyAndCount(pixel: .aiChatInternalSwitchBarDisplayed)
-        DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarShown,
-                                     withAdditionalParameters: ["toggle_visible": String(switchBarHandler.isToggleEnabled)])
+        PixelKit.fire(ExperimentalOmnibarPixel.omnibarShown(isToggleVisible: switchBarHandler.isToggleEnabled),
+                      frequency: .dailyAndCount)
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
@@ -24,13 +24,12 @@ import PixelKit
 
 /// Injectable pixel-firing seam: bundles the legacy firers (`Core.PixelFiring` for one-off pixels,
 /// `DailyPixelFiring` for daily-and-count) and PixelKit behind one value so UTI pixel firing has a single
-/// injection point. `.live` fires for real; tests pass `PixelFiringMock`/`PixelKitMock` to assert what was fired.
+/// injection point. `.live` fires for real; tests pass `PixelFiringMock`/`PixelKitMock`.
 struct UTIPixelFiring {
     var pixel: Core.PixelFiring.Type = Pixel.self
     var daily: DailyPixelFiring.Type = DailyPixel.self
-    /// A closure, not a `PixelFiring`: the `PixelKit` class shadows its module so the protocol can't be
-    /// named here, and bare `PixelFiring` would collide with `Core.PixelFiring` above.
-    var pixelKit: (PixelKitEvent, PixelKit.Frequency) -> Void = { PixelKit.fire($0, frequency: $1) }
+    /// Resolved at fire time so it picks up `PixelKit.setUp` regardless of when this value was created.
+    var pixelKit: () -> (any PixelKitFiring)? = { PixelKit.shared }
 
     static let live = UTIPixelFiring()
 
@@ -43,7 +42,7 @@ struct UTIPixelFiring {
     }
 
     func fire(_ event: PixelKitEvent, frequency: PixelKit.Frequency) {
-        pixelKit(event, frequency)
+        pixelKit()?.fire(event, frequency: frequency)
     }
 }
 
@@ -77,7 +76,10 @@ final class UTIPixelReporter {
     /// The pair fired whenever the unified input surface first appears in the omnibar host.
     func reportOmnibarInputSurfaceShown() {
         firing.fireDailyAndCount(.aiChatInternalSwitchBarDisplayed)
-        withContext { firing.fire(ExperimentalOmnibarPixel.omnibarShown(isToggleVisible: $0.isToggleVisible), frequency: .dailyAndCount) }
+        withContext {
+            firing.fire(ExperimentalOmnibarPixel.omnibarShownDaily(isToggleVisible: $0.isToggleVisible), frequency: .legacyDailyNoSuffix)
+            firing.fire(ExperimentalOmnibarPixel.omnibarShownCount(isToggleVisible: $0.isToggleVisible), frequency: .standard)
+        }
     }
 
     func reportBackButtonPressed() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
@@ -20,13 +20,17 @@
 import AIChat
 import Core
 import Foundation
+import PixelKit
 
-/// Injectable pixel-firing seam: bundles the two standard firers (`PixelFiring` for one-off pixels,
-/// `DailyPixelFiring` for daily-and-count) behind one value so UTI pixel firing has a single
-/// injection point. `.live` fires for real; tests pass `PixelFiringMock` to assert what was fired.
+/// Injectable pixel-firing seam: bundles the legacy firers (`Core.PixelFiring` for one-off pixels,
+/// `DailyPixelFiring` for daily-and-count) and PixelKit behind one value so UTI pixel firing has a single
+/// injection point. `.live` fires for real; tests pass `PixelFiringMock`/`PixelKitMock` to assert what was fired.
 struct UTIPixelFiring {
-    var pixel: PixelFiring.Type = Pixel.self
+    var pixel: Core.PixelFiring.Type = Pixel.self
     var daily: DailyPixelFiring.Type = DailyPixel.self
+    /// A closure, not a `PixelFiring`: the `PixelKit` class shadows its module so the protocol can't be
+    /// named here, and bare `PixelFiring` would collide with `Core.PixelFiring` above.
+    var pixelKit: (PixelKitEvent, PixelKit.Frequency) -> Void = { PixelKit.fire($0, frequency: $1) }
 
     static let live = UTIPixelFiring()
 
@@ -36,6 +40,10 @@ struct UTIPixelFiring {
 
     func fireDailyAndCount(_ event: Pixel.Event, _ parameters: [String: String] = [:]) {
         daily.fireDailyAndCount(event, error: nil, withAdditionalParameters: parameters)
+    }
+
+    func fire(_ event: PixelKitEvent, frequency: PixelKit.Frequency) {
+        pixelKit(event, frequency)
     }
 }
 
@@ -69,7 +77,7 @@ final class UTIPixelReporter {
     /// The pair fired whenever the unified input surface first appears in the omnibar host.
     func reportOmnibarInputSurfaceShown() {
         firing.fireDailyAndCount(.aiChatInternalSwitchBarDisplayed)
-        withContext { firing.fireDailyAndCount(.aiChatExperimentalOmnibarShown, ["toggle_visible": String($0.isToggleVisible)]) }
+        withContext { firing.fire(ExperimentalOmnibarPixel.omnibarShown(isToggleVisible: $0.isToggleVisible), frequency: .dailyAndCount) }
     }
 
     func reportBackButtonPressed() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
@@ -46,6 +46,7 @@ struct UTIPixelContext {
     let surface: UnifiedToggleInputPixelSurface
     let isDuckAISurfaceForAttribution: Bool
     let inputMode: TextEntryMode
+    let isToggleVisible: Bool
 }
 
 /// Owns the omnibar UTI's pixel firing. Resolves the surface (and the other live inputs) through a
@@ -68,7 +69,7 @@ final class UTIPixelReporter {
     /// The pair fired whenever the unified input surface first appears in the omnibar host.
     func reportOmnibarInputSurfaceShown() {
         firing.fireDailyAndCount(.aiChatInternalSwitchBarDisplayed)
-        firing.fireDailyAndCount(.aiChatExperimentalOmnibarShown)
+        withContext { firing.fireDailyAndCount(.aiChatExperimentalOmnibarShown, ["toggle_visible": String($0.isToggleVisible)]) }
     }
 
     func reportBackButtonPressed() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -349,7 +349,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             return UTIPixelContext(
                 surface: self.pixelSurface,
                 isDuckAISurfaceForAttribution: self.isDuckAISurfaceForAttribution,
-                inputMode: self.inputMode
+                inputMode: self.inputMode,
+                isToggleVisible: self.isToggleVisible
             )
         })
         wideEventReporter = UTIWideEventReporter(

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
@@ -23,28 +23,31 @@ import Foundation
 import PixelKit
 import Subscription
 
-/// PixelKit home for the experimental omnibar pixels, fired from both the UTI coordinator and the legacy
-/// switch-bar editing state so a single daily ledger covers the whole pixel.
+/// The schedule suffix is part of the name, fired with frequencies that append nothing, so PixelKit's
+/// platform suffix lands after it and the wire name stays `..._daily_ios_phone` as the legacy pixel reports it.
 enum ExperimentalOmnibarPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
 
     /// `isToggleVisible`: whether the Search/Duck.ai toggle was on screen when the surface appeared.
-    case omnibarShown(isToggleVisible: Bool)
+    case omnibarShownDaily(isToggleVisible: Bool)
+    case omnibarShownCount(isToggleVisible: Bool)
 
     var name: String {
         switch self {
-        case .omnibarShown: "aichat_experimental_omnibar_shown"
+        case .omnibarShownDaily: "m_aichat_experimental_omnibar_shown_daily"
+        case .omnibarShownCount: "m_aichat_experimental_omnibar_shown_count"
         }
     }
 
     var parameters: [String: String]? {
         switch self {
-        case .omnibarShown(let isToggleVisible): ["toggle_visible": String(isToggleVisible)]
+        case .omnibarShownDaily(let isToggleVisible), .omnibarShownCount(let isToggleVisible):
+            ["toggle_visible": String(isToggleVisible)]
         }
     }
 
     var standardParameters: [PixelKitStandardParameter]? { [.pixelSource] }
 
-    var namePrefix: String { "m_" }
+    var namePrefix: String { "" }
 }
 
 /// The UTI surface a pixel is fired from, sent as the `surface` param (`voice_tapped` reuses `source`).

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
@@ -20,7 +20,32 @@
 import AIChat
 import Core
 import Foundation
+import PixelKit
 import Subscription
+
+/// PixelKit home for the experimental omnibar pixels, fired from both the UTI coordinator and the legacy
+/// switch-bar editing state so a single daily ledger covers the whole pixel.
+enum ExperimentalOmnibarPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+
+    /// `isToggleVisible`: whether the Search/Duck.ai toggle was on screen when the surface appeared.
+    case omnibarShown(isToggleVisible: Bool)
+
+    var name: String {
+        switch self {
+        case .omnibarShown: "aichat_experimental_omnibar_shown"
+        }
+    }
+
+    var parameters: [String: String]? {
+        switch self {
+        case .omnibarShown(let isToggleVisible): ["toggle_visible": String(isToggleVisible)]
+        }
+    }
+
+    var standardParameters: [PixelKitStandardParameter]? { [.pixelSource] }
+
+    var namePrefix: String { "m_" }
+}
 
 /// The UTI surface a pixel is fired from, sent as the `surface` param (`voice_tapped` reuses `source`).
 enum UnifiedToggleInputPixelSurface: String {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIAttachmentControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIAttachmentControllerTests.swift
@@ -220,7 +220,7 @@ final class UTIAttachmentControllerTests: XCTestCase {
         return UTIAttachmentController(
             pixelReporter: UTIPixelReporter(
                 firing: UTIPixelFiring(pixel: PixelFiringMock.self, daily: PixelFiringMock.self),
-                context: { UTIPixelContext(surface: .addressBar, isDuckAISurfaceForAttribution: false, inputMode: .aiChat) }
+                context: { UTIPixelContext(surface: .addressBar, isDuckAISurfaceForAttribution: false, inputMode: .aiChat, isToggleVisible: false) }
             ),
             view: view.surface,
             environment: .init(

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIPixelReporterTests.swift
@@ -42,10 +42,31 @@ final class UTIPixelReporterTests: XCTestCase {
 
     private func context(surface: UnifiedToggleInputPixelSurface = .addressBar,
                          isDuckAISurfaceForAttribution: Bool = false,
-                         inputMode: TextEntryMode = .search) -> UTIPixelContext {
+                         inputMode: TextEntryMode = .search,
+                         isToggleVisible: Bool = false) -> UTIPixelContext {
         UTIPixelContext(surface: surface,
                         isDuckAISurfaceForAttribution: isDuckAISurfaceForAttribution,
-                        inputMode: inputMode)
+                        inputMode: inputMode,
+                        isToggleVisible: isToggleVisible)
+    }
+
+    // MARK: - Omnibar surface shown (toggle visibility from live context)
+
+    func testWhenOmnibarSurfaceShownWithToggleVisibleThenPixelReportsToggleVisibleTrue() {
+        let reporter = makeReporter { self.context(isToggleVisible: true) }
+
+        reporter.reportOmnibarInputSurfaceShown()
+
+        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.pixelName, Pixel.Event.aiChatExperimentalOmnibarShown.name)
+        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params, ["toggle_visible": "true"])
+    }
+
+    func testWhenOmnibarSurfaceShownWithToggleHiddenThenPixelReportsToggleVisibleFalse() {
+        let reporter = makeReporter { self.context(isToggleVisible: false) }
+
+        reporter.reportOmnibarInputSurfaceShown()
+
+        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params, ["toggle_visible": "false"])
     }
 
     // MARK: - Mode switch (non-trivial params, passed per call)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIPixelReporterTests.swift
@@ -44,9 +44,7 @@ final class UTIPixelReporterTests: XCTestCase {
     private func makeReporter(context: @escaping () -> UTIPixelContext?) -> UTIPixelReporter {
         UTIPixelReporter(firing: UTIPixelFiring(pixel: PixelFiringMock.self,
                                                 daily: PixelFiringMock.self,
-                                                pixelKit: { [unowned self] event, frequency in
-                                                    pixelKitMock.fire(event, frequency: frequency)
-                                                }),
+                                                pixelKit: { [unowned self] in pixelKitMock }),
                          context: context)
     }
 
@@ -67,10 +65,13 @@ final class UTIPixelReporterTests: XCTestCase {
 
         reporter.reportOmnibarInputSurfaceShown()
 
-        XCTAssertEqual(pixelKitMock.actualFireCalls.count, 1)
-        XCTAssertEqual(pixelKitMock.actualFireCalls.first?.pixel.name, "aichat_experimental_omnibar_shown")
+        XCTAssertEqual(pixelKitMock.actualFireCalls.count, 2)
+        XCTAssertEqual(pixelKitMock.actualFireCalls.first?.pixel.name, "m_aichat_experimental_omnibar_shown_daily")
+        XCTAssertEqual(pixelKitMock.actualFireCalls.first?.frequency, .legacyDailyNoSuffix)
+        XCTAssertEqual(pixelKitMock.actualFireCalls.last?.pixel.name, "m_aichat_experimental_omnibar_shown_count")
+        XCTAssertEqual(pixelKitMock.actualFireCalls.last?.frequency, .standard)
         XCTAssertEqual(pixelKitMock.actualFireCalls.first?.pixel.parameters, ["toggle_visible": "true"])
-        XCTAssertEqual(pixelKitMock.actualFireCalls.first?.frequency, .dailyAndCount)
+        XCTAssertEqual(pixelKitMock.actualFireCalls.last?.pixel.parameters, ["toggle_visible": "true"])
     }
 
     func testWhenOmnibarSurfaceShownWithToggleHiddenThenPixelReportsToggleVisibleFalse() {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIPixelReporterTests.swift
@@ -19,24 +19,34 @@
 
 import AIChat
 import Core
+import PixelKit
+import PixelKitTestingUtilities
 import XCTest
 @testable import DuckDuckGo
 
 @MainActor
 final class UTIPixelReporterTests: XCTestCase {
 
+    private var pixelKitMock: PixelKitMock!
+
     override func setUp() {
         super.setUp()
         PixelFiringMock.tearDown()
+        pixelKitMock = PixelKitMock()
     }
 
     override func tearDown() {
         PixelFiringMock.tearDown()
+        pixelKitMock = nil
         super.tearDown()
     }
 
     private func makeReporter(context: @escaping () -> UTIPixelContext?) -> UTIPixelReporter {
-        UTIPixelReporter(firing: UTIPixelFiring(pixel: PixelFiringMock.self, daily: PixelFiringMock.self),
+        UTIPixelReporter(firing: UTIPixelFiring(pixel: PixelFiringMock.self,
+                                                daily: PixelFiringMock.self,
+                                                pixelKit: { [unowned self] event, frequency in
+                                                    pixelKitMock.fire(event, frequency: frequency)
+                                                }),
                          context: context)
     }
 
@@ -57,8 +67,10 @@ final class UTIPixelReporterTests: XCTestCase {
 
         reporter.reportOmnibarInputSurfaceShown()
 
-        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.pixelName, Pixel.Event.aiChatExperimentalOmnibarShown.name)
-        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params, ["toggle_visible": "true"])
+        XCTAssertEqual(pixelKitMock.actualFireCalls.count, 1)
+        XCTAssertEqual(pixelKitMock.actualFireCalls.first?.pixel.name, "aichat_experimental_omnibar_shown")
+        XCTAssertEqual(pixelKitMock.actualFireCalls.first?.pixel.parameters, ["toggle_visible": "true"])
+        XCTAssertEqual(pixelKitMock.actualFireCalls.first?.frequency, .dailyAndCount)
     }
 
     func testWhenOmnibarSurfaceShownWithToggleHiddenThenPixelReportsToggleVisibleFalse() {
@@ -66,7 +78,7 @@ final class UTIPixelReporterTests: XCTestCase {
 
         reporter.reportOmnibarInputSurfaceShown()
 
-        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params, ["toggle_visible": "false"])
+        XCTAssertEqual(pixelKitMock.actualFireCalls.first?.pixel.parameters, ["toggle_visible": "false"])
     }
 
     // MARK: - Mode switch (non-trivial params, passed per call)

--- a/iOS/PixelDefinitions/pixels/definitions/experimental_omnibar_metrics.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/experimental_omnibar_metrics.json5
@@ -9,7 +9,15 @@
             ["first_daily_count", "platform", "form_factor"],
             ["platform", "form_factor"]
         ],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "toggle_visible",
+                "description": "Whether the Search/Duck.ai toggle was actually on screen when the surface was shown: true or false",
+                "type": "boolean"
+            }
+        ]
     },
     "m_aichat_experimental_omnibar_prompt_submitted": {
         "description": "Fires when user submits an AI chat prompt through the experimental omnibar",

--- a/iOS/PixelDefinitions/pixels/definitions/experimental_omnibar_metrics.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/experimental_omnibar_metrics.json5
@@ -6,7 +6,7 @@
         "owners": ["aataraxiaa"],
         "triggers": ["other"],
         "suffixes": [
-            ["platform", "form_factor", "first_daily_count"],
+            ["first_daily_count", "platform", "form_factor"],
             ["platform", "form_factor"]
         ],
         "parameters": [

--- a/iOS/PixelDefinitions/pixels/definitions/experimental_omnibar_metrics.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/experimental_omnibar_metrics.json5
@@ -6,7 +6,7 @@
         "owners": ["aataraxiaa"],
         "triggers": ["other"],
         "suffixes": [
-            ["first_daily_count", "platform", "form_factor"],
+            ["platform", "form_factor", "first_daily_count"],
             ["platform", "form_factor"]
         ],
         "parameters": [


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1217261030452898?focus=true
Tech Design URL:
CC:

### Description

Adds a `toggle_visible` parameter to `m_aichat_experimental_omnibar_shown` at both fire points — the UTI coordinator path (resolved live from `isToggleVisible` via the pixel context) and the legacy editing state (`SwitchBarHandler.isToggleEnabled`). This lets omnibar impressions be split by whether the Search/Duck.ai toggle was actually on screen, which the Duck.ai discovery/entry/return measurement dashboard needs for its "% of app opens with a toggle-visible impression" panel. Purely additive: pixel name, firing mode, and volume are unchanged.

### Testing Steps

1. With the Search/Duck.ai toggle enabled, focus the address bar and verify `m_aichat_experimental_omnibar_shown` fires with `toggle_visible=true` in the pixel logs.
2. Open the omnibar input on a Duck.ai tab (toggle hidden there) and verify the pixel fires with `toggle_visible=false`.
3. Run `UTIPixelReporterTests` — includes two new cases covering both parameter values.

### Impact and Risks

Low — additive parameter on an existing measurement pixel; no user-facing behavior change.

#### What could go wrong?

If toggle visibility were read from stale state the true/false split would be miscounted, but both fire points resolve it live at fire time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change with no user-facing behavior; risk is miscounted toggle visibility if state were stale, but both fire sites read visibility at fire time.
> 
> **Overview**
> Adds **`toggle_visible`** to omnibar “shown” analytics so dashboards can split impressions by whether the Search/Duck.ai toggle was on screen.
> 
> **`m_aichat_experimental_omnibar_shown`** no longer goes through the legacy `Pixel.Event` / `DailyPixel.fireDailyAndCount` path. It now fires via **PixelKit** as **`ExperimentalOmnibarPixel`** (daily + count), each carrying `toggle_visible` from live state at fire time.
> 
> The **UTI** path resolves visibility from **`isToggleVisible`** on **`UTIPixelContext`** (wired from the coordinator). The **legacy switch-bar editing** path uses **`switchBarHandler.isToggleEnabled`**. **`UTIPixelFiring`** is extended so reporters can fire PixelKit events with injectable mocks in tests.
> 
> Pixel definitions for **`m_aichat_experimental_omnibar_shown`** document the new boolean parameter; **`UTIPixelReporterTests`** assert both `true` and `false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de59566b3a2c4d87e4e4ee8acabeae43bf07f7d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->