### PR TITLE
Register account_info key after Sync login

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -293,6 +293,14 @@ public class DDGSync: DDGSyncing {
         initializeIfNeeded()
     }
 
+    public func ensureAccountInfoKeyForDebug() async throws -> Int {
+        guard let account = try dependencies.secureStore.account() else {
+            throw SyncError.accountNotFound
+        }
+
+        return try await dependencies.scopedAccess.ensureAccountInfoProtectedKeys(for: account).count
+    }
+
     public func prepareThirdPartyRecoveryCode(purpose: String) async throws -> String {
         guard let account else {
             throw SyncError.accountNotFound

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -122,7 +122,8 @@ public class DDGSync: DDGSyncing {
         let result = try await dependencies.account.login(recoveryKey, deviceName: deviceName, deviceType: deviceType)
         try updateAccount(result.account)
         persistRecoveredThirdPartyScopedPasswordIfAvailable(from: result.accessCredentials, account: result.account)
-        updateProtectedKeysCache(with: result.keys)
+        let accountInfoKeys = await ensureAccountInfoProtectedKeysIfNeeded(for: result.account)
+        updateProtectedKeysCache(with: (result.keys ?? []) + accountInfoKeys)
         scheduler.requestSyncImmediately()
         return result.devices
     }
@@ -609,6 +610,20 @@ public class DDGSync: DDGSyncing {
         }
 
         try? dependencies.secureStore.persistProtectedKeys(encodedKeys)
+    }
+
+    private func ensureAccountInfoProtectedKeysIfNeeded(for account: SyncAccount) async -> [ProtectedKey] {
+        guard dependencies.syncFeatureFlags.canWriteUnifiedDeviceList() else {
+            return []
+        }
+
+        do {
+            return try await dependencies.scopedAccess.ensureAccountInfoProtectedKeys(for: account)
+        } catch {
+            let errorType = String(describing: type(of: error))
+            Logger.sync.error("Failed to ensure account_info protected keys after login: \(errorType, privacy: .public)")
+            return []
+        }
     }
 
     private func persistRecoveredThirdPartyScopedPasswordIfAvailable(from accessCredentials: [AccessCredential]?, account: SyncAccount) {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -628,8 +628,8 @@ public class DDGSync: DDGSyncing {
         do {
             return try await dependencies.scopedAccess.ensureAccountInfoProtectedKeys(for: account)
         } catch {
-            let errorType = String(describing: type(of: error))
-            Logger.sync.error("Failed to ensure account_info protected keys after login: \(errorType, privacy: .public)")
+            let errorType = String(describing: Swift.type(of: error))
+            Logger.sync.error("Sync-UnifiedDevices: failed to ensure account_info protected keys after login: \(errorType)")
             return []
         }
     }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSyncing.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSyncing.swift
@@ -285,6 +285,14 @@ public protocol DDGSyncing: DDGSyncingDebuggingSupport {
 public protocol DDGSyncingDebuggingSupport {
     var serverEnvironment: ServerEnvironment { get }
     func updateServerEnvironment(_ serverEnvironment: ServerEnvironment)
+    /// Creates or fetches the account_info key and returns its wrapper count.
+    func ensureAccountInfoKeyForDebug() async throws -> Int
+}
+
+public extension DDGSyncingDebuggingSupport {
+    func ensureAccountInfoKeyForDebug() async throws -> Int {
+        throw SyncError.accountNotFound
+    }
 }
 
 public enum ServerEnvironment: LosslessStringConvertible {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
@@ -349,12 +349,6 @@ private struct ProtectedKeyWrappingIdentity: Hashable {
     }
 }
 
-extension ProtectedKey {
-    func hasSameWrappingIdentity(as other: ProtectedKey) -> Bool {
-        kid == other.kid && encryptedWith == other.encryptedWith && purpose == other.purpose
-    }
-}
-
 extension Sequence where Element == ProtectedKey {
     func removingDuplicateWrappingIdentities() -> [ProtectedKey] {
         var seenIdentities: Set<ProtectedKeyWrappingIdentity> = []

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -84,7 +84,10 @@ struct ProductionDependencies: SyncDependencies {
         payloadCompressor = SyncGzipPayloadCompressor()
 
         crypter = Crypter(secureStore: secureStore)
-        let scopedAccess = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: crypter)
+        let scopedAccess = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                         api: api,
+                                                         crypter: crypter,
+                                                         accountInfoKeyFactory: DefaultAccountInfoKeyFactory(crypter: crypter))
         let registeredDeviceMapper = RegisteredDeviceMapper(crypter: crypter,
                                                             scopedAccess: scopedAccess,
                                                             cachedScopedPassword: secureStore.scopedPassword,

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyFactory.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyFactory.swift
@@ -18,7 +18,11 @@
 
 import Foundation
 
-struct AccountInfoKeyFactory {
+protocol AccountInfoKeyFactory {
+    func makeProtectedKeys(accountSecretKey: Data, thirdPartyMainKey: Data?) throws -> [ProtectedKey]
+}
+
+struct DefaultAccountInfoKeyFactory: AccountInfoKeyFactory {
 
     private static let keySizeInBits = 3072
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -31,6 +31,7 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
     let endpoints: Endpoints
     let api: RemoteAPIRequestCreating
     let crypter: CryptingInternal
+    let accountInfoKeyFactory: AccountInfoKeyFactory
     private let jweCompactCodec = JWECompactCodec()
     private let scopedAccessCredentialEnvelope = ScopedAccessCredentialEnvelope()
 
@@ -72,6 +73,25 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         } catch {
             throw ScopedAccessCredentialError.accountExtendFailed
         }
+    }
+
+    func ensureAccountInfoProtectedKeys(for account: SyncAccount) async throws -> [ProtectedKey] {
+        let storedKeys = try await fetchProtectedKeys(account)
+        let storedAccountInfoKeys = protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: storedKeys)
+        guard storedAccountInfoKeys.isEmpty else {
+            return storedAccountInfoKeys
+        }
+
+        let accessCredentials = try await fetchAccessCredentials(account)
+        let scopedPassword = try recoverScopedPassword(from: accessCredentials,
+                                                       primaryKey: account.primaryKey,
+                                                       userID: account.userId)
+        let thirdPartyMainKey = scopedPassword.map {
+            ScopedAccessKeyDerivation.mainKey(from: $0, userID: account.userId)
+        }
+        let keys = try accountInfoKeyFactory.makeProtectedKeys(accountSecretKey: account.secretKey,
+                                                              thirdPartyMainKey: thirdPartyMainKey)
+        return try await setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo, keys: keys, for: account)
     }
 
     func makeRecoveryCode(for account: SyncAccount, scopedPassword: Data) -> String? {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -18,6 +18,7 @@
 
 import CryptoKit
 import Foundation
+import os.log
 
 enum ScopedAccessCredentialError: Error, Equatable {
     case missingThirdPartyCredential
@@ -79,6 +80,7 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         let storedKeys = try await fetchProtectedKeys(account)
         let storedAccountInfoKeys = protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: storedKeys)
         guard storedAccountInfoKeys.isEmpty else {
+            Logger.sync.debug("Sync-UnifiedDevices: account_info key already exists")
             return storedAccountInfoKeys
         }
 
@@ -91,7 +93,14 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         }
         let keys = try accountInfoKeyFactory.makeProtectedKeys(accountSecretKey: account.secretKey,
                                                               thirdPartyMainKey: thirdPartyMainKey)
-        return try await setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo, keys: keys, for: account)
+        Logger.sync.debug("Sync-UnifiedDevices: registering account_info key")
+        let registeredKeys = try await setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo, keys: keys, for: account)
+        if keys.first?.kid == registeredKeys.first?.kid {
+            Logger.sync.debug("Sync-UnifiedDevices: registered new account_info key")
+        } else {
+            Logger.sync.debug("Sync-UnifiedDevices: adopted existing account_info key")
+        }
+        return registeredKeys
     }
 
     func makeRecoveryCode(for account: SyncAccount, scopedPassword: Data) -> String? {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -171,32 +171,41 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         }
     }
 
-    func setKeyIfAbsent(purpose: String, key: ProtectedKey, for account: SyncAccount) async throws -> ProtectedKey? {
-        try await setKeysIfAbsent(purpose: purpose, keys: [key], for: account)
-            .first
-    }
-
-    private func setKeysIfAbsent(purpose: String, keys: [ProtectedKey], for account: SyncAccount) async throws -> [ProtectedKey] {
+    func setKeysIfAbsent(purpose: String, keys: [ProtectedKey], for account: SyncAccount) async throws -> [ProtectedKey] {
         guard let token = account.token else {
             throw SyncError.noToken
         }
 
         let deduplicatedKeys = keys.removingDuplicateWrappingIdentities()
+        guard !deduplicatedKeys.isEmpty else {
+            throw SyncError.invalidDataInResponse("set-if-absent requires at least one protected key")
+        }
+        guard deduplicatedKeys.allSatisfy({ $0.purpose == purpose }) else {
+            throw SyncError.invalidDataInResponse("set-if-absent keys must match purpose=\(purpose)")
+        }
+
         let params = SetKeyIfAbsentParameters(keys: deduplicatedKeys)
         let requestJSON = try JSONEncoder.snakeCaseKeys.encode(params)
         let request = api.createAuthenticatedJSONRequest(url: setKeyIfAbsentURL(purpose: purpose), method: .post, authToken: token, json: requestJSON)
         do {
             let result = try await request.execute()
-            guard result.response.statusCode == 201 else {
+            switch result.response.statusCode {
+            case 201:
+                guard let body = result.data, !body.isEmpty else {
+                    return deduplicatedKeys
+                }
+                return try decodeProtectedKeys(for: purpose, from: body)
+            case 200:
+                guard let body = result.data, !body.isEmpty else {
+                    return try await fetchStoredProtectedKeys(for: purpose, account: account)
+                }
+                return try decodeProtectedKeys(for: purpose, from: body)
+            default:
                 throw SyncError.unexpectedStatusCode(result.response.statusCode)
             }
-            guard let body = result.data, !body.isEmpty else {
-                return deduplicatedKeys
-            }
-            return try decodeProtectedKeys(from: body, expectedKeys: deduplicatedKeys)
         } catch SyncError.unexpectedStatusCode(let statusCode) {
             if statusCode == 409 {
-                return try await reconcileConflictingProtectedKeys(purpose: purpose, expectedKeys: deduplicatedKeys, account: account)
+                return try await fetchStoredProtectedKeys(for: purpose, account: account)
             }
             throw SyncError.unexpectedStatusCode(statusCode)
         }
@@ -288,21 +297,13 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         return keys
     }
 
-    private func reconcileConflictingProtectedKeys(purpose: String, expectedKeys: [ProtectedKey], account: SyncAccount) async throws -> [ProtectedKey] {
+    private func fetchStoredProtectedKeys(for purpose: String, account: SyncAccount) async throws -> [ProtectedKey] {
         let keys = try await fetchProtectedKeys(account)
-        let matchingKeys = selectBestMatchingKeys(in: keys, expectedKeys: expectedKeys)
-        if matchingKeys.count == expectedKeys.count {
-            return matchingKeys
-        }
-        throw SyncError.invalidDataInResponse("set-if-absent returned 409 for purpose=\(purpose), but no matching keys were found after refetch")
+        return try requiredProtectedKeys(for: purpose, in: keys)
     }
 
-    private func decodeProtectedKeys(from data: Data, expectedKeys: [ProtectedKey]) throws -> [ProtectedKey] {
-        let result = try JSONDecoder.snakeCaseKeys.decode(SetKeyIfAbsentResult.self, from: data)
-        guard let keys = result.keys else {
-            throw SyncError.unableToDecodeResponse("Failed to decode protected keys")
-        }
-        return selectBestMatchingKeys(in: keys, expectedKeys: expectedKeys)
+    private func decodeProtectedKeys(for purpose: String, from data: Data) throws -> [ProtectedKey] {
+        try requiredProtectedKeys(for: purpose, in: decodeProtectedKeys(from: data))
     }
 
     private func accessCredentialURL(id: String) -> URL {
@@ -316,11 +317,12 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
             .appendingPathComponent("set-if-absent")
     }
 
-    private func selectBestMatchingKeys(in keys: [ProtectedKey],
-                                        expectedKeys: [ProtectedKey]) -> [ProtectedKey] {
-        expectedKeys.compactMap { expectedKey in
-            keys.first(where: { $0.hasSameWrappingIdentity(as: expectedKey) })
+    private func requiredProtectedKeys(for purpose: String, in keys: [ProtectedKey]) throws -> [ProtectedKey] {
+        let keysForPurpose = protectedKeys(for: purpose, in: keys)
+        guard !keysForPurpose.isEmpty else {
+            throw SyncError.invalidDataInResponse("set-if-absent returned no protected keys for purpose=\(purpose)")
         }
+        return keysForPurpose
     }
 
     private func accessCredentialProtectedKeys(from protectedKeys: [ProtectedKey],
@@ -400,10 +402,6 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
 
     struct SetKeyIfAbsentParameters: Encodable {
         let keys: [ProtectedKey]
-    }
-
-    struct SetKeyIfAbsentResult: Decodable {
-        let keys: [ProtectedKey]?
     }
 
     private struct ProtectedKeysForThirdPartyCredential {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
@@ -79,13 +79,15 @@ protocol ScopedAccessCredentialManaging {
     func ensureThirdPartyScopedPassword(for account: SyncAccount,
                                         purpose: String,
                                         cachedScopedPassword: () throws -> Data?) async throws -> EnsuredThirdPartyCredential
+    /// Returns stored account_info key wrappers, creating and registering them when the purpose is absent.
+    func ensureAccountInfoProtectedKeys(for account: SyncAccount) async throws -> [ProtectedKey]
     /// Builds the Base64URL recovery code that shares the account via the scoped password, or nil if the password is empty.
     func makeRecoveryCode(for account: SyncAccount, scopedPassword: Data) -> String?
     /// Fetches the account's access credentials (empty if none exist).
     func fetchAccessCredentials(_ account: SyncAccount) async throws -> [AccessCredential]
     /// Fetches the account's protected keys (empty if none exist).
     func fetchProtectedKeys(_ account: SyncAccount) async throws -> [ProtectedKey]
-    /// Uploads every wrapper for a protected-key purpose atomically if the purpose is absent, returning the canonical stored wrappers.
+    /// Uploads every wrapper for a protected-key purpose atomically if the purpose is absent, returning the wrappers stored by the server.
     func setKeysIfAbsent(purpose: String, keys: [ProtectedKey], for account: SyncAccount) async throws -> [ProtectedKey]
 }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
@@ -85,8 +85,8 @@ protocol ScopedAccessCredentialManaging {
     func fetchAccessCredentials(_ account: SyncAccount) async throws -> [AccessCredential]
     /// Fetches the account's protected keys (empty if none exist).
     func fetchProtectedKeys(_ account: SyncAccount) async throws -> [ProtectedKey]
-    /// Uploads a protected key for the given purpose only if one isn't already stored, returning the stored key (existing or new).
-    func setKeyIfAbsent(purpose: String, key: ProtectedKey, for account: SyncAccount) async throws -> ProtectedKey?
+    /// Uploads every wrapper for a protected-key purpose atomically if the purpose is absent, returning the canonical stored wrappers.
+    func setKeysIfAbsent(purpose: String, keys: [ProtectedKey], for account: SyncAccount) async throws -> [ProtectedKey]
 }
 
 protocol SecureStoring {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -823,7 +823,8 @@ final class DDGSyncTests: XCTestCase {
 
         let code = try XCTUnwrap(ScopedAccessCredentialManager(endpoints: Endpoints(baseURL: URL(string: "https://example.com")!),
                                                                api: RemoteAPIRequestCreatingMock(),
-                                                               crypter: CryptingMock())
+                                                               crypter: CryptingMock(),
+                                                               accountInfoKeyFactory: AccountInfoKeyFactoryMock())
             .makeRecoveryCode(for: .mock, scopedPassword: scopedPassword))
         let decoded = try SyncCode.decodeBase64URLString(code)
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -611,6 +611,78 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(cachedProtectedKeys.count, 3)
     }
 
+    func testWhenUnifiedDeviceListWritingIsEnabledThenLoginEnsuresAndCachesAccountInfoKeys() async throws {
+        dependencies.canWriteUnifiedDeviceList = { true }
+        (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil
+        let loginKey = makeProtectedKey(kid: "ai-chat-key", encryptedWith: "ddg", purpose: "ai_chats")
+        let accountInfoKey = makeProtectedKey(kid: "account-info-key", encryptedWith: "ddg", purpose: "account_info")
+        (dependencies.account as? AccountManagingMock)?.loginStub = LoginResult(account: .mock,
+                                                                                devices: [],
+                                                                                keys: [loginKey])
+        let scopedAccess = try XCTUnwrap(dependencies.scopedAccess as? ScopedAccessCredentialManagingMock)
+        scopedAccess.ensureAccountInfoProtectedKeysStub = [accountInfoKey]
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        _ = try await syncService.login(.init(userId: "userId", primaryKey: Data()),
+                                        deviceName: "iPhone",
+                                        deviceType: "iOS")
+
+        let cachedProtectedKeysData = try XCTUnwrap((dependencies.secureStore as? SecureStorageStub)?.theProtectedKeysData)
+        let cachedProtectedKeys = try JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: cachedProtectedKeysData)
+
+        XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.map(\.userId), [SyncAccount.mock.userId])
+        XCTAssertEqual(Set(cachedProtectedKeys.map(\.kid)), Set(["ai-chat-key", "account-info-key"]))
+        XCTAssertEqual(cachedProtectedKeys.count, 2)
+    }
+
+    func testWhenUnifiedDeviceListWritingIsDisabledThenLoginDoesNotEnsureAccountInfoKeys() async throws {
+        dependencies.canWriteUnifiedDeviceList = { false }
+        (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil
+        let loginKey = makeProtectedKey(kid: "ai-chat-key", encryptedWith: "ddg", purpose: "ai_chats")
+        (dependencies.account as? AccountManagingMock)?.loginStub = LoginResult(account: .mock,
+                                                                                devices: [],
+                                                                                keys: [loginKey])
+        let scopedAccess = try XCTUnwrap(dependencies.scopedAccess as? ScopedAccessCredentialManagingMock)
+        scopedAccess.ensureAccountInfoProtectedKeysStub = [
+            makeProtectedKey(kid: "account-info-key", encryptedWith: "ddg", purpose: "account_info")
+        ]
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        _ = try await syncService.login(.init(userId: "userId", primaryKey: Data()),
+                                        deviceName: "iPhone",
+                                        deviceType: "iOS")
+
+        let cachedProtectedKeysData = try XCTUnwrap((dependencies.secureStore as? SecureStorageStub)?.theProtectedKeysData)
+        let cachedProtectedKeys = try JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: cachedProtectedKeysData)
+
+        XCTAssertTrue(scopedAccess.ensureAccountInfoProtectedKeysCalls.isEmpty)
+        XCTAssertEqual(cachedProtectedKeys.map(\.kid), ["ai-chat-key"])
+    }
+
+    func testWhenEnsuringAccountInfoKeysFailsThenLoginStillSucceedsAndResponseKeysAreCached() async throws {
+        dependencies.canWriteUnifiedDeviceList = { true }
+        (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil
+        let loginKey = makeProtectedKey(kid: "ai-chat-key", encryptedWith: "ddg", purpose: "ai_chats")
+        (dependencies.account as? AccountManagingMock)?.loginStub = LoginResult(account: .mock,
+                                                                                devices: [.mock],
+                                                                                keys: [loginKey])
+        let scopedAccess = try XCTUnwrap(dependencies.scopedAccess as? ScopedAccessCredentialManagingMock)
+        scopedAccess.ensureAccountInfoProtectedKeysError = SyncError.invalidDataInResponse("account_info registration failed")
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        let devices = try await syncService.login(.init(userId: "userId", primaryKey: Data()),
+                                                  deviceName: "iPhone",
+                                                  deviceType: "iOS")
+
+        let cachedProtectedKeysData = try XCTUnwrap((dependencies.secureStore as? SecureStorageStub)?.theProtectedKeysData)
+        let cachedProtectedKeys = try JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: cachedProtectedKeysData)
+
+        XCTAssertEqual(devices.map(\.id), [RegisteredDevice.mock.id])
+        XCTAssertNotNil((dependencies.secureStore as? SecureStorageStub)?.theAccount)
+        XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.count, 1)
+        XCTAssertEqual(cachedProtectedKeys.map(\.kid), ["ai-chat-key"])
+    }
+
     func testWhenScopedPasswordRecoveryFailsDuringLoginThenNativeLoginStillSucceeds() async throws {
         (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil
         (dependencies.secureStore as? SecureStorageStub)?.theScopedPassword = Data(repeating: 9, count: 32)
@@ -914,12 +986,12 @@ final class DDGSyncTests: XCTestCase {
         }
     }
 
-    private func makeProtectedKey(kid: String, encryptedWith: String) -> ProtectedKey {
+    private func makeProtectedKey(kid: String, encryptedWith: String, purpose: String = "browser") -> ProtectedKey {
         ProtectedKey(kid: kid,
                      encryptedPrivateKey: "encrypted-private-key",
                      publicKey: .mock,
                      encryptedWith: encryptedWith,
-                     purpose: "browser")
+                     purpose: purpose)
     }
 
     private func scopedAccessMainKey(from secret: Data, userID: String) -> Data {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -444,15 +444,15 @@ final class ScopedAccessCredentialManagingMock: ScopedAccessCredentialManaging {
         return fetchProtectedKeysStub
     }
 
-    var setKeyIfAbsentCalls: [(purpose: String, key: ProtectedKey, account: SyncAccount)] = []
-    var setKeyIfAbsentStub: ProtectedKey?
-    var setKeyIfAbsentError: Error?
-    func setKeyIfAbsent(purpose: String, key: ProtectedKey, for account: SyncAccount) async throws -> ProtectedKey? {
-        setKeyIfAbsentCalls.append((purpose: purpose, key: key, account: account))
-        if let setKeyIfAbsentError {
-            throw setKeyIfAbsentError
+    var setKeysIfAbsentCalls: [(purpose: String, keys: [ProtectedKey], account: SyncAccount)] = []
+    var setKeysIfAbsentStub: [ProtectedKey] = []
+    var setKeysIfAbsentError: Error?
+    func setKeysIfAbsent(purpose: String, keys: [ProtectedKey], for account: SyncAccount) async throws -> [ProtectedKey] {
+        setKeysIfAbsentCalls.append((purpose: purpose, keys: keys, account: account))
+        if let setKeysIfAbsentError {
+            throw setKeysIfAbsentError
         }
-        return setKeyIfAbsentStub
+        return setKeysIfAbsentStub
     }
 }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -370,6 +370,20 @@ final class PairingV2MessageExchangingMock: PairingV2MessageExchanging {
     }
 }
 
+final class AccountInfoKeyFactoryMock: AccountInfoKeyFactory {
+    var makeProtectedKeysCalls: [(accountSecretKey: Data, thirdPartyMainKey: Data?)] = []
+    var makeProtectedKeysStub: [ProtectedKey] = []
+    var makeProtectedKeysError: Error?
+
+    func makeProtectedKeys(accountSecretKey: Data, thirdPartyMainKey: Data?) throws -> [ProtectedKey] {
+        makeProtectedKeysCalls.append((accountSecretKey: accountSecretKey, thirdPartyMainKey: thirdPartyMainKey))
+        if let makeProtectedKeysError {
+            throw makeProtectedKeysError
+        }
+        return makeProtectedKeysStub
+    }
+}
+
 final class ScopedAccessCredentialManagingMock: ScopedAccessCredentialManaging {
 
     var recoverScopedPasswordCalls: [(accessCredentials: [AccessCredential]?, primaryKey: Data, userID: String)] = []
@@ -398,6 +412,17 @@ final class ScopedAccessCredentialManagingMock: ScopedAccessCredentialManaging {
         }
         return EnsuredThirdPartyCredential(scopedPassword: try cachedScopedPassword() ?? Data(repeating: 1, count: 32),
                                            protectedKeysToCache: [])
+    }
+
+    var ensureAccountInfoProtectedKeysCalls: [SyncAccount] = []
+    var ensureAccountInfoProtectedKeysStub: [ProtectedKey] = []
+    var ensureAccountInfoProtectedKeysError: Error?
+    func ensureAccountInfoProtectedKeys(for account: SyncAccount) async throws -> [ProtectedKey] {
+        ensureAccountInfoProtectedKeysCalls.append(account)
+        if let ensureAccountInfoProtectedKeysError {
+            throw ensureAccountInfoProtectedKeysError
+        }
+        return ensureAccountInfoProtectedKeysStub
     }
 
     var makeRecoveryCodeCalls: [(account: SyncAccount, scopedPassword: Data)] = []

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyFactoryTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyFactoryTests.swift
@@ -27,7 +27,7 @@ final class AccountInfoKeyFactoryTests: XCTestCase {
 
     func testWhenThirdPartyMainKeyIsUnavailableThenCreatesRSA3072DefaultCredentialWrapper() throws {
         let crypter = CryptingMock()
-        let factory = AccountInfoKeyFactory(crypter: crypter)
+        let factory = DefaultAccountInfoKeyFactory(crypter: crypter)
 
         let protectedKeys = try factory.makeProtectedKeys(accountSecretKey: accountSecretKey)
 
@@ -41,7 +41,7 @@ final class AccountInfoKeyFactoryTests: XCTestCase {
 
     func testWhenThirdPartyMainKeyIsAvailableThenWrapsSameRSA3072PrivateKeyForBothCredentials() throws {
         let crypter = CryptingMock()
-        let factory = AccountInfoKeyFactory(crypter: crypter)
+        let factory = DefaultAccountInfoKeyFactory(crypter: crypter)
 
         let protectedKeys = try factory.makeProtectedKeys(accountSecretKey: accountSecretKey,
                                                           thirdPartyMainKey: thirdPartyMainKey)

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
@@ -29,7 +29,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
     func testWhenEnsuringScopedPasswordAndCredentialExistsThenRecoversPasswordWithoutCreatingCredential() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
 
         let scopedPassword = Data(repeating: 8, count: 32)
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
@@ -62,7 +65,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                passwordHash: Data([0xAB]),
                                stretchedPrimaryKey: Data())
         }
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: crypter)
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: crypter,
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
 
         let scopedPassword = Data((32..<64).map(UInt8.init))
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
@@ -96,7 +102,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                passwordHash: Data([0xAB]),
                                stretchedPrimaryKey: Data())
         }
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: crypter)
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: crypter,
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
 
         let scopedPassword = Data((32..<64).map(UInt8.init))
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
@@ -123,7 +132,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
     func testWhenFetchingAccessCredentialsReturns404ThenReturnsEmptyCredentials() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         api.fakeRequests[endpoints.accessCredentials] = makeFailingRequest(statusCode: 404)
 
@@ -135,7 +147,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
     func testWhenFetchingProtectedKeysReturns404ThenReturnsEmptyKeys() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         api.fakeRequests[endpoints.keys] = makeFailingRequest(statusCode: 404)
 
@@ -154,7 +169,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                passwordHash: Data([0xAB]),
                                stretchedPrimaryKey: Data())
         }
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: crypter)
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: crypter,
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
 
         let accountPrimaryKey = Data((0..<32).map(UInt8.init))
         let scopedPassword = Data((32..<64).map(UInt8.init))
@@ -206,7 +224,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                passwordHash: Data([0xAB]),
                                stretchedPrimaryKey: Data())
         }
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: crypter)
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: crypter,
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
 
         let accountPrimaryKey = Data((0..<32).map(UInt8.init))
         let scopedPassword = Data((32..<64).map(UInt8.init))
@@ -247,7 +268,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                passwordHash: Data([0xAB]),
                                stretchedPrimaryKey: Data())
         }
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: crypter)
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: crypter,
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
 
         let accountPrimaryKey = Data((0..<32).map(UInt8.init))
         let localScopedPassword = Data((32..<64).map(UInt8.init))
@@ -288,7 +312,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                passwordHash: Data([0xAB]),
                                stretchedPrimaryKey: Data())
         }
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: crypter)
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: crypter,
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
 
         let accountPrimaryKey = Data((0..<32).map(UInt8.init))
         let scopedPassword = Data((32..<64).map(UInt8.init))
@@ -311,10 +338,105 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         }
     }
 
+    func testWhenEnsuringAccountInfoProtectedKeysAndKeysAreStoredThenReturnsThemWithoutCreatingKeys() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: accountInfoKeyFactory)
+        let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
+        let storedKeys = [
+            makeProtectedKey(kid: "account-info", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
+            makeProtectedKey(kid: "account-info", encryptedWith: SyncCredentialID.thirdParty, purpose: ProtectedKeyPurpose.accountInfo),
+            makeProtectedKey(kid: "other", encryptedWith: SyncCredentialID.defaultCredential, purpose: "bookmarks")
+        ]
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody(storedKeys))
+
+        let result = try await manager.ensureAccountInfoProtectedKeys(for: account)
+
+        XCTAssertEqual(result.map(\.kid), ["account-info", "account-info"])
+        XCTAssertEqual(Set(result.map(\.encryptedWith)), Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
+        XCTAssertTrue(accountInfoKeyFactory.makeProtectedKeysCalls.isEmpty)
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.keys])
+    }
+
+    func testWhenEnsuringAccountInfoProtectedKeysWithoutThirdPartyCredentialThenCreatesAndRegistersDefaultWrapper() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let account = makeAccount(primaryKey: Data(repeating: 0x2, count: 32))
+        let createdKey = makeProtectedKey(kid: "created",
+                                          encryptedWith: SyncCredentialID.defaultCredential,
+                                          purpose: ProtectedKeyPurpose.accountInfo)
+        accountInfoKeyFactory.makeProtectedKeysStub = [createdKey]
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: accountInfoKeyFactory)
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([]))
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody([]))
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 201)
+
+        let result = try await manager.ensureAccountInfoProtectedKeys(for: account)
+
+        XCTAssertEqual(result.map(\.kid), ["created"])
+        let factoryCall = try XCTUnwrap(accountInfoKeyFactory.makeProtectedKeysCalls.first)
+        XCTAssertEqual(factoryCall.accountSecretKey, account.secretKey)
+        XCTAssertNil(factoryCall.thirdPartyMainKey)
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
+            endpoints.keys,
+            endpoints.accessCredentials,
+            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)
+        ])
+    }
+
+    func testWhenEnsuringAccountInfoProtectedKeysWithThirdPartyCredentialThenCreatesAndRegistersBothWrappers() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let accountPrimaryKey = Data((0..<32).map(UInt8.init))
+        let scopedPassword = Data((32..<64).map(UInt8.init))
+        let account = makeAccount(primaryKey: accountPrimaryKey)
+        let defaultCredentialMainKey = hkdf(input: accountPrimaryKey, salt: account.userId, info: "Main Key")
+        let encryptedCredential = try ScopedAccessCredentialEnvelope().encryptScopedPassword(scopedPassword,
+                                                                                             using: defaultCredentialMainKey,
+                                                                                             kid: SyncCredentialID.defaultCredential)
+        let accessCredentials = [
+            AccessCredential(id: SyncCredentialID.thirdParty,
+                             scope: "sync",
+                             encrypted3PartyCredential: encryptedCredential)
+        ]
+        let createdKeys = [
+            makeProtectedKey(kid: "created", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
+            makeProtectedKey(kid: "created", encryptedWith: SyncCredentialID.thirdParty, purpose: ProtectedKeyPurpose.accountInfo)
+        ]
+        accountInfoKeyFactory.makeProtectedKeysStub = createdKeys
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: accountInfoKeyFactory)
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([]))
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 201)
+
+        let result = try await manager.ensureAccountInfoProtectedKeys(for: account)
+
+        XCTAssertEqual(result.map(\.kid), ["created", "created"])
+        XCTAssertEqual(Set(result.map(\.encryptedWith)), Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
+        let factoryCall = try XCTUnwrap(accountInfoKeyFactory.makeProtectedKeysCalls.first)
+        XCTAssertEqual(factoryCall.accountSecretKey, account.secretKey)
+        XCTAssertEqual(factoryCall.thirdPartyMainKey, hkdf(input: scopedPassword, salt: account.userId, info: "Main Key"))
+    }
+
     func testWhenSetKeysIfAbsentReturns409ThenRefetchesStoredKeysForPurpose() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
         let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
         let requestedKeys = [
             makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
@@ -343,7 +465,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
     func testWhenSetKeysIfAbsentReturns409AndRefetchHasNoRequestedPurposeThenThrows() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
         let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
         let requestedKeys = [
             makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo)
@@ -374,7 +499,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
     func testWhenSetKeysIfAbsentCreatesKeysThenUploadsAllWrappersAndReturnsKeysForPurpose() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
         let account = makeAccount(primaryKey: Data(repeating: 0x3, count: 32))
         let requestedKeys = [
             makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
@@ -406,7 +534,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
     func testWhenSetKeysIfAbsentCreatesKeysWithoutResponseBodyThenReturnsUploadedKeys() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
         let account = makeAccount(primaryKey: Data(repeating: 0x4, count: 32))
         let requestedKeys = [
             makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
@@ -426,7 +557,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
     func testWhenSetKeysIfAbsentReturnsExistingKeysThenUsesStoredKeysFromResponse() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
         let account = makeAccount(primaryKey: Data(repeating: 0x5, count: 32))
         let requestedKeys = [
             makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo)
@@ -452,7 +586,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
     func testWhenSetKeysIfAbsentReturnsExistingWithoutResponseBodyThenRefetchesStoredKeys() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
         let account = makeAccount(primaryKey: Data(repeating: 0x6, count: 32))
         let requestedKeys = [
             makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo)
@@ -474,7 +611,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
     func testWhenSetKeysIfAbsentPayloadIsRejectedThenThrowsUnexpectedStatusCode() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
         let account = makeAccount(primaryKey: Data(repeating: 0x9, count: 32))
         let requestedKeys = [
             makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo)
@@ -501,7 +641,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
     func testWhenFetchingProtectedKeysFailsThenCachedKeysAreNotUsedForThirdPartyCredentialCreation() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody([]))
         api.fakeRequests[endpoints.keys] = makeFailingRequest(statusCode: 500)

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
@@ -311,81 +311,59 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         }
     }
 
-    func testWhenSetKeyIfAbsentReturns409ThenRefetchesAndReconciles() async throws {
+    func testWhenSetKeysIfAbsentReturns409ThenRefetchesStoredKeysForPurpose() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
         let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
-        let requestedKey = makeProtectedKey(kid: "requested", encryptedWith: "ddg", purpose: "ai_chats")
+        let requestedKeys = [
+            makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
+            makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.thirdParty, purpose: ProtectedKeyPurpose.accountInfo)
+        ]
+        let storedKeys = [
+            makeProtectedKey(kid: "server", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
+            makeProtectedKey(kid: "server", encryptedWith: SyncCredentialID.thirdParty, purpose: ProtectedKeyPurpose.accountInfo),
+            makeProtectedKey(kid: "other", encryptedWith: SyncCredentialID.defaultCredential, purpose: "bookmarks")
+        ]
 
         let conflictRequest = HTTPRequestingMock()
         conflictRequest.error = SyncError.unexpectedStatusCode(409)
-        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: "ai_chats")] = conflictRequest
-        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200,
-                                                       body: """
-                                                       {
-                                                         "keys": [
-                                                           {
-                                                             "kid": "requested",
-                                                             "encrypted_private_key": "enc-private",
-                                                             "public_key": {
-                                                               "kty": "RSA",
-                                                               "alg": "RSA-OAEP-256",
-                                                               "use": "enc",
-                                                               "n": "mod",
-                                                               "e": "AQAB"
-                                                             },
-                                                             "encrypted_with": "ddg",
-                                                             "purpose": "ai_chats"
-                                                           }
-                                                         ]
-                                                       }
-                                                       """)
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = conflictRequest
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody(storedKeys))
 
-        let result = try await manager.setKeyIfAbsent(purpose: "ai_chats", key: requestedKey, for: account)
+        let result = try await manager.setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                                       keys: requestedKeys,
+                                                       for: account)
 
-        XCTAssertEqual(result?.kid, "requested")
-        XCTAssertEqual(result?.encryptedWith, "ddg")
-        XCTAssertEqual(result?.purpose, "ai_chats")
+        XCTAssertEqual(result.map(\.kid), ["server", "server"])
+        XCTAssertEqual(Set(result.map(\.encryptedWith)), Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
         XCTAssertEqual(api.createRequestCallArgs.count, 2)
     }
 
-    func testWhenSetKeyIfAbsentReturns409WithOnlyPurposeMatchThenThrows() async throws {
+    func testWhenSetKeysIfAbsentReturns409AndRefetchHasNoRequestedPurposeThenThrows() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
         let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
-        let requestedKey = makeProtectedKey(kid: "requested", encryptedWith: "ddg", purpose: "ai_chats")
+        let requestedKeys = [
+            makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo)
+        ]
+        let otherPurposeKeys = [
+            makeProtectedKey(kid: "other", encryptedWith: SyncCredentialID.defaultCredential, purpose: "bookmarks")
+        ]
 
         let conflictRequest = HTTPRequestingMock()
         conflictRequest.error = SyncError.unexpectedStatusCode(409)
-        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: "ai_chats")] = conflictRequest
-        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200,
-                                                       body: """
-                                                       {
-                                                         "keys": [
-                                                           {
-                                                             "kid": "server-3party",
-                                                             "encrypted_private_key": "enc-private",
-                                                             "public_key": {
-                                                               "kty": "RSA",
-                                                               "alg": "RSA-OAEP-256",
-                                                               "use": "enc",
-                                                               "n": "mod",
-                                                               "e": "AQAB"
-                                                             },
-                                                             "encrypted_with": "3party",
-                                                             "purpose": "ai_chats"
-                                                           }
-                                                         ]
-                                                       }
-                                                       """)
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = conflictRequest
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody(otherPurposeKeys))
 
         do {
-            _ = try await manager.setKeyIfAbsent(purpose: "ai_chats", key: requestedKey, for: account)
-            XCTFail("Expected setKeyIfAbsent to throw")
+            _ = try await manager.setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                                  keys: requestedKeys,
+                                                  for: account)
+            XCTFail("Expected setKeysIfAbsent to throw")
         } catch SyncError.invalidDataInResponse(let message) {
-            XCTAssertTrue(message.contains("no matching key"))
+            XCTAssertTrue(message.contains("no protected keys for purpose=account_info"))
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
@@ -393,91 +371,124 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertEqual(api.createRequestCallArgs.count, 2)
     }
 
-    func testWhenSetKeyIfAbsentReturnsWrappedKeysThenMatchingKeyIsReturned() async throws {
+    func testWhenSetKeysIfAbsentCreatesKeysThenUploadsAllWrappersAndReturnsKeysForPurpose() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
         let account = makeAccount(primaryKey: Data(repeating: 0x3, count: 32))
-        let requestedKey = makeProtectedKey(kid: "requested", encryptedWith: "ddg", purpose: "ai_chats")
+        let requestedKeys = [
+            makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
+            makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.thirdParty, purpose: ProtectedKeyPurpose.accountInfo)
+        ]
+        let responseKeys = [
+            makeProtectedKey(kid: "other", encryptedWith: SyncCredentialID.defaultCredential, purpose: "bookmarks")
+        ] + requestedKeys
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(
+            statusCode: 201,
+            body: try protectedKeysBody(responseKeys)
+        )
 
-        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: "ai_chats")] = makeRequest(statusCode: 201,
-                                                                                       body: """
-                                                                                       {
-                                                                                         "keys": [
-                                                                                           {
-                                                                                             "kid": "server-other",
-                                                                                             "encrypted_private_key": "enc-private-other",
-                                                                                             "public_key": {
-                                                                                               "kty": "RSA",
-                                                                                               "alg": "RSA-OAEP-256",
-                                                                                               "use": "enc",
-                                                                                               "n": "mod",
-                                                                                               "e": "AQAB"
-                                                                                             },
-                                                                                             "encrypted_with": "3party",
-                                                                                             "purpose": "bookmarks"
-                                                                                           },
-                                                                                           {
-                                                                                             "kid": "requested",
-                                                                                             "encrypted_private_key": "enc-private",
-                                                                                             "public_key": {
-                                                                                               "kty": "RSA",
-                                                                                               "alg": "RSA-OAEP-256",
-                                                                                               "use": "enc",
-                                                                                               "n": "mod",
-                                                                                               "e": "AQAB"
-                                                                                             },
-                                                                                             "encrypted_with": "ddg",
-                                                                                             "purpose": "ai_chats"
-                                                                                           }
-                                                                                         ]
-                                                                                       }
-                                                                                       """)
+        let result = try await manager.setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                                       keys: requestedKeys,
+                                                       for: account)
 
-        let result = try await manager.setKeyIfAbsent(purpose: "ai_chats", key: requestedKey, for: account)
+        XCTAssertEqual(result.map(\.kid), ["candidate", "candidate"])
+        XCTAssertEqual(Set(result.map(\.encryptedWith)), Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
 
-        XCTAssertEqual(result?.kid, "requested")
-        XCTAssertEqual(result?.encryptedWith, "ddg")
-        XCTAssertEqual(result?.purpose, "ai_chats")
+        let requestBody = try XCTUnwrap(api.createRequestCallArgs.last?.body)
+        let payload = try decodeJSONObject(requestBody)
+        let uploadedKeys = try XCTUnwrap(payload["keys"] as? [[String: Any]])
+        XCTAssertEqual(uploadedKeys.count, 2)
+        XCTAssertEqual(Set(uploadedKeys.compactMap { $0["encrypted_with"] as? String }),
+                       Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
     }
 
-    func testWhenSetKeyIfAbsentReturns200ThenThrowsUnexpectedStatusCode() async throws {
+    func testWhenSetKeysIfAbsentCreatesKeysWithoutResponseBodyThenReturnsUploadedKeys() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
         let account = makeAccount(primaryKey: Data(repeating: 0x4, count: 32))
-        let requestedKey = makeProtectedKey(kid: "requested", encryptedWith: "ddg", purpose: "ai_chats")
+        let requestedKeys = [
+            makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
+            makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.thirdParty, purpose: ProtectedKeyPurpose.accountInfo)
+        ]
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 201)
 
-        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: "ai_chats")] = makeRequest(statusCode: 200)
+        let result = try await manager.setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                                       keys: requestedKeys,
+                                                       for: account)
 
-        do {
-            _ = try await manager.setKeyIfAbsent(purpose: "ai_chats", key: requestedKey, for: account)
-            XCTFail("Expected setKeyIfAbsent to throw")
-        } catch SyncError.unexpectedStatusCode(let statusCode) {
-            XCTAssertEqual(statusCode, 200)
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
-
+        XCTAssertEqual(result.map(\.kid), ["candidate", "candidate"])
+        XCTAssertEqual(Set(result.map(\.encryptedWith)), Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
         XCTAssertEqual(api.createRequestCallArgs.count, 1)
     }
 
-    func testWhenKeysPayloadIsRejectedThenThrowsUnexpectedStatusCode() async throws {
+    func testWhenSetKeysIfAbsentReturnsExistingKeysThenUsesStoredKeysFromResponse() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
+        let account = makeAccount(primaryKey: Data(repeating: 0x5, count: 32))
+        let requestedKeys = [
+            makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo)
+        ]
+        let storedKeys = [
+            makeProtectedKey(kid: "server", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
+            makeProtectedKey(kid: "server", encryptedWith: SyncCredentialID.thirdParty, purpose: ProtectedKeyPurpose.accountInfo)
+        ]
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(
+            statusCode: 200,
+            body: try protectedKeysBody(storedKeys)
+        )
+
+        let result = try await manager.setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                                       keys: requestedKeys,
+                                                       for: account)
+
+        XCTAssertEqual(result.map(\.kid), ["server", "server"])
+        XCTAssertEqual(Set(result.map(\.encryptedWith)), Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
+        XCTAssertEqual(api.createRequestCallArgs.count, 1)
+    }
+
+    func testWhenSetKeysIfAbsentReturnsExistingWithoutResponseBodyThenRefetchesStoredKeys() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
+        let account = makeAccount(primaryKey: Data(repeating: 0x6, count: 32))
+        let requestedKeys = [
+            makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo)
+        ]
+        let storedKeys = [
+            makeProtectedKey(kid: "server", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo)
+        ]
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 200)
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody(storedKeys))
+
+        let result = try await manager.setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                                       keys: requestedKeys,
+                                                       for: account)
+
+        XCTAssertEqual(result.map(\.kid), ["server"])
+        XCTAssertEqual(api.createRequestCallArgs.count, 2)
+    }
+
+    func testWhenSetKeysIfAbsentPayloadIsRejectedThenThrowsUnexpectedStatusCode() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: CryptingMock())
         let account = makeAccount(primaryKey: Data(repeating: 0x9, count: 32))
-        let requestedKey = makeProtectedKey(kid: "requested",
-                                            encryptedWith: "ddg",
-                                            purpose: "ai_chats")
+        let requestedKeys = [
+            makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo)
+        ]
 
         let rejectingRequest = HTTPRequestingMock()
         rejectingRequest.error = SyncError.unexpectedStatusCode(422)
-        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: "ai_chats")] = rejectingRequest
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = rejectingRequest
 
         do {
-            _ = try await manager.setKeyIfAbsent(purpose: "ai_chats", key: requestedKey, for: account)
-            XCTFail("Expected setKeyIfAbsent to throw")
+            _ = try await manager.setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                                  keys: requestedKeys,
+                                                  for: account)
+            XCTFail("Expected setKeysIfAbsent to throw")
         } catch SyncError.unexpectedStatusCode(let statusCode) {
             XCTAssertEqual(statusCode, 422)
         } catch {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
@@ -430,6 +430,85 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertEqual(factoryCall.thirdPartyMainKey, hkdf(input: scopedPassword, salt: account.userId, info: "Main Key"))
     }
 
+    func testWhenEnsuringAccountInfoProtectedKeysAndThirdPartyCredentialCannotBeRecoveredThenDoesNotCreateOrRegisterKeys() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
+        let accessCredentials = [
+            AccessCredential(id: SyncCredentialID.thirdParty,
+                             scope: "sync",
+                             encrypted3PartyCredential: "invalid")
+        ]
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: accountInfoKeyFactory)
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([]))
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
+
+        do {
+            _ = try await manager.ensureAccountInfoProtectedKeys(for: account)
+            XCTFail("Expected account_info key creation to fail")
+        } catch ScopedAccessCredentialError.undecryptableThirdPartyCredential {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertTrue(accountInfoKeyFactory.makeProtectedKeysCalls.isEmpty)
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
+            endpoints.keys,
+            endpoints.accessCredentials
+        ])
+    }
+
+    func testWhenSetKeysIfAbsentReceivesNoKeysThenThrowsWithoutCreatingRequest() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let manager = ScopedAccessCredentialManager(endpoints: Endpoints(baseURL: Self.baseURL),
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+        let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
+
+        do {
+            _ = try await manager.setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                                  keys: [],
+                                                  for: account)
+            XCTFail("Expected setKeysIfAbsent to throw")
+        } catch SyncError.invalidDataInResponse(let message) {
+            XCTAssertTrue(message.contains("requires at least one protected key"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertTrue(api.createRequestCallArgs.isEmpty)
+    }
+
+    func testWhenSetKeysIfAbsentReceivesKeyForDifferentPurposeThenThrowsWithoutCreatingRequest() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let manager = ScopedAccessCredentialManager(endpoints: Endpoints(baseURL: Self.baseURL),
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+        let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
+        let key = makeProtectedKey(kid: "candidate",
+                                   encryptedWith: SyncCredentialID.defaultCredential,
+                                   purpose: "bookmarks")
+
+        do {
+            _ = try await manager.setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                                  keys: [key],
+                                                  for: account)
+            XCTFail("Expected setKeysIfAbsent to throw")
+        } catch SyncError.invalidDataInResponse(let message) {
+            XCTAssertTrue(message.contains("must match purpose=account_info"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertTrue(api.createRequestCallArgs.isEmpty)
+    }
+
     func testWhenSetKeysIfAbsentReturns409ThenRefetchesStoredKeysForPurpose() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
@@ -554,6 +633,33 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertEqual(api.createRequestCallArgs.count, 1)
     }
 
+    func testWhenSetKeysIfAbsentReceivesDuplicateWrappersThenUploadsEachIdentityOnce() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+        let account = makeAccount(primaryKey: Data(repeating: 0x4, count: 32))
+        let defaultKey = makeProtectedKey(kid: "candidate",
+                                          encryptedWith: SyncCredentialID.defaultCredential,
+                                          purpose: ProtectedKeyPurpose.accountInfo)
+        let thirdPartyKey = makeProtectedKey(kid: "candidate",
+                                             encryptedWith: SyncCredentialID.thirdParty,
+                                             purpose: ProtectedKeyPurpose.accountInfo)
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 201)
+
+        let result = try await manager.setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                                       keys: [defaultKey, defaultKey, thirdPartyKey, thirdPartyKey],
+                                                       for: account)
+
+        XCTAssertEqual(result.count, 2)
+        let requestBody = try XCTUnwrap(api.createRequestCallArgs.last?.body)
+        let payload = try decodeJSONObject(requestBody)
+        let uploadedKeys = try XCTUnwrap(payload["keys"] as? [[String: Any]])
+        XCTAssertEqual(uploadedKeys.count, 2)
+    }
+
     func testWhenSetKeysIfAbsentReturnsExistingKeysThenUsesStoredKeysFromResponse() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
@@ -606,6 +712,69 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
 
         XCTAssertEqual(result.map(\.kid), ["server"])
         XCTAssertEqual(api.createRequestCallArgs.count, 2)
+    }
+
+    func testWhenSetKeysIfAbsentReturnsBodyWithoutRequestedPurposeThenThrowsForSuccessStatuses() async throws {
+        for statusCode in [200, 201] {
+            let api = RemoteAPIRequestCreatingMock()
+            let endpoints = Endpoints(baseURL: Self.baseURL)
+            let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                        api: api,
+                                                        crypter: CryptingMock(),
+                                                        accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+            let account = makeAccount(primaryKey: Data(repeating: 0x7, count: 32))
+            let requestedKey = makeProtectedKey(kid: "candidate",
+                                                encryptedWith: SyncCredentialID.defaultCredential,
+                                                purpose: ProtectedKeyPurpose.accountInfo)
+            let otherPurposeKey = makeProtectedKey(kid: "other",
+                                                   encryptedWith: SyncCredentialID.defaultCredential,
+                                                   purpose: "bookmarks")
+            api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(
+                statusCode: statusCode,
+                body: try protectedKeysBody([otherPurposeKey])
+            )
+
+            do {
+                _ = try await manager.setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                                      keys: [requestedKey],
+                                                      for: account)
+                XCTFail("Expected setKeysIfAbsent to throw for HTTP \(statusCode)")
+            } catch SyncError.invalidDataInResponse(let message) {
+                XCTAssertTrue(message.contains("no protected keys for purpose=account_info"))
+            } catch {
+                XCTFail("Unexpected error for HTTP \(statusCode): \(error)")
+            }
+        }
+    }
+
+    func testWhenSetKeysIfAbsentReturnsBodyWithoutKeysThenThrowsForSuccessStatuses() async throws {
+        for statusCode in [200, 201] {
+            let api = RemoteAPIRequestCreatingMock()
+            let endpoints = Endpoints(baseURL: Self.baseURL)
+            let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                        api: api,
+                                                        crypter: CryptingMock(),
+                                                        accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+            let account = makeAccount(primaryKey: Data(repeating: 0x8, count: 32))
+            let requestedKey = makeProtectedKey(kid: "candidate",
+                                                encryptedWith: SyncCredentialID.defaultCredential,
+                                                purpose: ProtectedKeyPurpose.accountInfo)
+            api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(
+                statusCode: statusCode,
+                body: "{}"
+            )
+
+            do {
+                _ = try await manager.setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                                      keys: [requestedKey],
+                                                      for: account)
+                XCTFail("Expected setKeysIfAbsent to throw for HTTP \(statusCode)")
+            } catch SyncError.unableToDecodeResponse(let message) {
+                XCTAssertEqual(message, "Failed to decode protected keys")
+            } catch {
+                XCTFail("Unexpected error for HTTP \(statusCode): \(error)")
+            }
+        }
     }
 
     func testWhenSetKeysIfAbsentPayloadIsRejectedThenThrowsUnexpectedStatusCode() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ThirdPartyAccountUpgradeCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ThirdPartyAccountUpgradeCoordinatorTests.swift
@@ -340,7 +340,10 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
         }
         crypter._extractSecretKey = { _, _ in extractedSecretKey }
 
-        let manager = ScopedAccessCredentialManager(endpoints: endpoints, api: api, crypter: crypter)
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: crypter,
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
         let coordinator = ThirdPartyAccountUpgradeCoordinator(endpoints: endpoints,
                                                               api: api,
                                                               crypter: crypter,

--- a/iOS/DuckDuckGo/SyncDebugViewController.swift
+++ b/iOS/DuckDuckGo/SyncDebugViewController.swift
@@ -43,6 +43,7 @@ class SyncDebugViewController: UITableViewController {
     enum InfoRows: Int, CaseIterable {
 
         case syncNow
+        case ensureAccountInfoKey
         case logOut
         case toggleFavoritesDisplayMode
         case resetFaviconsFetcherOnboardingDialog
@@ -112,6 +113,8 @@ class SyncDebugViewController: UITableViewController {
             switch InfoRows(rawValue: indexPath.row) {
             case .syncNow:
                 cell.textLabel?.text = "Sync now"
+            case .ensureAccountInfoKey:
+                cell.textLabel?.text = "Ensure account_info key"
             case .logOut:
                 cell.textLabel?.text = "Log out of sync in 10 seconds"
             case .toggleFavoritesDisplayMode:
@@ -193,6 +196,8 @@ class SyncDebugViewController: UITableViewController {
             switch InfoRows(rawValue: indexPath.row) {
             case .syncNow:
                 sync.scheduler.requestSyncImmediately()
+            case .ensureAccountInfoKey:
+                ensureAccountInfoKey()
             case .logOut:
                 Task {
                     try await Task.sleep(nanoseconds: UInt64(10e9))
@@ -257,6 +262,33 @@ class SyncDebugViewController: UITableViewController {
         }
 
         tableView.deselectRow(at: indexPath, animated: true)
+    }
+
+    private func ensureAccountInfoKey() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            do {
+                let wrapperCount = try await sync.ensureAccountInfoKeyForDebug()
+                let message: String
+                if wrapperCount == 0 {
+                    message = "No wrappers were returned."
+                } else if wrapperCount == 1 {
+                    message = "Ensured 1 wrapper."
+                } else {
+                    message = "Ensured \(wrapperCount) wrappers."
+                }
+                showAlert(title: "Account Info Key Ensured", message: message)
+            } catch {
+                showAlert(title: "Unable to Ensure Account Info Key", message: String(reflecting: error))
+            }
+        }
+    }
+
+    private func showAlert(title: String, message: String) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alertController, animated: true)
     }
 
     private func showCopyPasteCodeAlert() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1217213092722099?focus=true
Tech Design URL:
CC:

### Description
The unified device list needs an `account_info` key to encrypt device names and types. This makes sure the account has one. 

When unified device-list writes are enabled, a successful Sync login now ensures the account has an `account_info` key wrapped for each available credential. Existing server keys are adopted safely, and registration failures remain non-blocking so they never prevent login.

Adds an iOS Sync debug action for manually ensuring the key and checking its wrapper count.

### Testing Steps
Test on iOS as the debug screen changes are iOS-only. The underlying key-registration functionality is shared by both platforms
1. Settings → Debug → Feature Flags, enable `syncCanWriteUnifiedDeviceList`.
2. Settings → Sync & Backup, set up a new sync account → sync enabled.
3. Settings → Debug → Sync, tap "Ensure account_info key" → alert reports "Ensured 1 wrapper".
4. Tap it again → same count, so no duplicate key.
5. Log out, log back in with the recovery code → login completes normally.
6. Tap "Ensure account_info key" → count unchanged, so login already registered it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches post-login crypto key registration and server set-if-absent behavior; failures are non-blocking for login but incorrect handling could affect unified device list encryption.
> 
> **Overview**
> When **unified device list writes** are enabled (`canWriteUnifiedDeviceList`), a successful Sync **login** now ensures the account has an **`account_info`** protected key (for encrypting device name/type), merges those wrappers into the local protected-keys cache, and **does not block login** if registration fails.
> 
> **`ScopedAccessCredentialManager`** gains `ensureAccountInfoProtectedKeys`: reuse server keys when present, otherwise build wrappers via an injectable **`AccountInfoKeyFactory`** (`DefaultAccountInfoKeyFactory`) and register them with **`setKeysIfAbsent`** (batch upload per purpose). **`set-if-absent`** handling is updated to accept **200/201**, treat **409** as “already exists” by refetching keys for that purpose, and validate purpose/consistency instead of matching by wrapping identity.
> 
> Adds **`ensureAccountInfoKeyForDebug()`** on sync debugging support and an iOS **Sync debug** row to trigger it manually. Tests and mocks cover login caching, flag gating, and the new key-registration paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd46f098e63827758756a743487e80ef917d6010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->