### PR TITLE
[iOS] Add m_app_return pixel fired on every foreground transition

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -93,7 +93,6 @@ extension Pixel {
         case tabSwitcherOpenedDaily
         case appOpenTabCountIdleNTPDaily
         case appOpenTabCountIdleLastTabDaily
-        case appReturn
         case tabManagerSwitchToAITab
         case tabManagerSwitchToWebTab
         case tabManagerCloseAITab
@@ -2189,7 +2188,6 @@ extension Pixel.Event {
         case .tabSwitcherOpenedDaily: return "m_tab_manager_opened_daily"
         case .appOpenTabCountIdleNTPDaily: return "m_app_open_tab_count_idle_ntp_daily"
         case .appOpenTabCountIdleLastTabDaily: return "m_app_open_tab_count_idle_last_tab_daily"
-        case .appReturn: return "m_app_return"
         case .tabManagerSwitchToAITab: return "m_tab_manager_switch_to_ai_tab"
         case .tabManagerSwitchToWebTab: return "m_tab_manager_switch_to_web_tab"
         case .tabManagerCloseAITab: return "m_tab_manager_close_ai_tab"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -93,6 +93,7 @@ extension Pixel {
         case tabSwitcherOpenedDaily
         case appOpenTabCountIdleNTPDaily
         case appOpenTabCountIdleLastTabDaily
+        case appReturn
         case tabManagerSwitchToAITab
         case tabManagerSwitchToWebTab
         case tabManagerCloseAITab
@@ -2188,6 +2189,7 @@ extension Pixel.Event {
         case .tabSwitcherOpenedDaily: return "m_tab_manager_opened_daily"
         case .appOpenTabCountIdleNTPDaily: return "m_app_open_tab_count_idle_ntp_daily"
         case .appOpenTabCountIdleLastTabDaily: return "m_app_open_tab_count_idle_last_tab_daily"
+        case .appReturn: return "m_app_return"
         case .tabManagerSwitchToAITab: return "m_tab_manager_switch_to_ai_tab"
         case .tabManagerSwitchToWebTab: return "m_tab_manager_switch_to_web_tab"
         case .tabManagerCloseAITab: return "m_tab_manager_close_ai_tab"

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		2B5B218965D5E0474F9B4763 /* SubscriptionOnboardingVPNActivationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5AFF89CFA3BC33889AEAD0 /* SubscriptionOnboardingVPNActivationViewModelTests.swift */; };
 		2CCD716C578642B8BC760D55 /* NTPAfterIdleInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0742FD8DD5F46AB8243103F /* NTPAfterIdleInstrumentation.swift */; };
 		2CCD716C578642B8BCA1A001 /* IdleReturnTabCountInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0742FD8DD5F46AB8243A001 /* IdleReturnTabCountInstrumentation.swift */; };
+		2CCD716C578642B8BCA1A0B1 /* AppReturnInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0742FD8DD5F46AB8243A0B1 /* AppReturnInstrumentation.swift */; };
 		2CE746E172B444FABF361C7B /* ContextualSheetAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C7E64D7A9241698BA2243F /* ContextualSheetAction.swift */; };
 		2DC3FC65C6D9DA634426672D /* AutofillNoAuthAvailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC3FBD62FBAF21E87610FA8 /* AutofillNoAuthAvailableView.swift */; };
 		3105BCF12DF214A000EB755E /* AIChatPixelMetricHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3105BCF02DF214A000EB755E /* AIChatPixelMetricHandler.swift */; };
@@ -1816,6 +1817,7 @@
 		A1B2C3D4E5F60001AABB0001 /* NTPAfterIdleInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */; };
 		A1B2C3D4E5F60002A1B2C3D4 /* UnifiedInputContentContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001A1B2C3D4 /* UnifiedInputContentContainerViewController.swift */; };
 		A1B2C3D4E5F60002AABBA001 /* IdleReturnTabCountInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */; };
+		A1B2C3D4E5F60002AABBA0B1 /* AppReturnInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002AABBA0B2 /* AppReturnInstrumentationTests.swift */; };
 		A1B2C3D4E5F60012A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60011A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift */; };
 		A1B2C3D4E5F60014A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60013A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift */; };
 		A1B2C3D72F7F111100ABCDEF /* SyncSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D62F7F111100ABCDEF /* SyncSettingsViewModelTests.swift */; };
@@ -4642,6 +4644,7 @@
 		A1B2C3D4E5F60001A1B2C3D4 /* UnifiedInputContentContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedInputContentContainerViewController.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPAfterIdleInstrumentationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnTabCountInstrumentationTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60002AABBA0B2 /* AppReturnInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReturnInstrumentationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60011A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AIChatReasoningMode+UnifiedToggleInput.swift"; sourceTree = "<group>"; };
 		A1B2C3D4E5F60013A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputReasoningTests.swift; sourceTree = "<group>"; };
 		A1B2C3D62F7F111100ABCDEF /* SyncSettingsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncSettingsViewModelTests.swift; sourceTree = "<group>"; };
@@ -5387,6 +5390,7 @@
 		DDCC0FF100000000A0A0A001 /* SettingsNextStepsDismissalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsNextStepsDismissalTests.swift; sourceTree = "<group>"; };
 		E0742FD8DD5F46AB8243103F /* NTPAfterIdleInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPAfterIdleInstrumentation.swift; sourceTree = "<group>"; };
 		E0742FD8DD5F46AB8243A001 /* IdleReturnTabCountInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnTabCountInstrumentation.swift; sourceTree = "<group>"; };
+		E0742FD8DD5F46AB8243A0B1 /* AppReturnInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReturnInstrumentation.swift; sourceTree = "<group>"; };
 		E1A4A4D42F2A111100AA11BB /* TabViewController+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabViewController+UI.swift"; sourceTree = "<group>"; };
 		E3663DD21563403B96D50EF0 /* AfterInactivityOptionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterInactivityOptionAdapter.swift; sourceTree = "<group>"; };
 		E44F90E856A0488A976B6AFE /* FileCorruptErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCorruptErrorView.swift; sourceTree = "<group>"; };
@@ -10751,6 +10755,7 @@
 				CBAD0F2C2D02EE4F006267B8 /* IdleReturnEligibilityManager.swift */,
 				E0742FD8DD5F46AB8243103F /* NTPAfterIdleInstrumentation.swift */,
 				E0742FD8DD5F46AB8243A001 /* IdleReturnTabCountInstrumentation.swift */,
+				E0742FD8DD5F46AB8243A0B1 /* AppReturnInstrumentation.swift */,
 				D1A2B3C4E5F60001AABB0002 /* PostIdleSessionWideEventData.swift */,
 				D1A2B3C4E5F60001AABB0006 /* PostIdleSessionInstrumentation.swift */,
 				CBAD0F242D02EE48006267B8 /* LastBackgroundDateStore.swift */,
@@ -11707,6 +11712,7 @@
 				A7B001112F6B000100000001 /* VoiceSearchFeedbackViewTests.swift */,
 				A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */,
 				A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */,
+				A1B2C3D4E5F60002AABBA0B2 /* AppReturnInstrumentationTests.swift */,
 				D1A2B3C4E5F60001AABB0004 /* PostIdleSessionWideEventDataTests.swift */,
 				D1A2B3C4E5F60001AABB0008 /* PostIdleSessionInstrumentationTests.swift */,
 				CBAD0F302D02EE50006267B8 /* IdleReturnEligibilityManagerTests.swift */,
@@ -13448,6 +13454,7 @@
 				CBAD0F2D2D02EE50006267B8 /* IdleReturnEligibilityManager.swift in Sources */,
 				2CCD716C578642B8BC760D55 /* NTPAfterIdleInstrumentation.swift in Sources */,
 				2CCD716C578642B8BCA1A001 /* IdleReturnTabCountInstrumentation.swift in Sources */,
+				2CCD716C578642B8BCA1A0B1 /* AppReturnInstrumentation.swift in Sources */,
 				D1A2B3C4E5F60001AABB0001 /* PostIdleSessionWideEventData.swift in Sources */,
 				D1A2B3C4E5F60001AABB0005 /* PostIdleSessionInstrumentation.swift in Sources */,
 				CBAD0F252D02EE49006267B8 /* LastBackgroundDateStore.swift in Sources */,
@@ -14652,6 +14659,7 @@
 				9FB484A6301ADA9300125636 /* OnboardingAIModelsFallbackTests.swift in Sources */,
 				9FB484A7301ADA9300125636 /* OnboardingAIModelsResolverTests.swift in Sources */,
 				A1B2C3D4E5F60002AABBA001 /* IdleReturnTabCountInstrumentationTests.swift in Sources */,
+				A1B2C3D4E5F60002AABBA0B1 /* AppReturnInstrumentationTests.swift in Sources */,
 				D1A2B3C4E5F60001AABB0003 /* PostIdleSessionWideEventDataTests.swift in Sources */,
 				CBB4A8492FD2FB6600A65956 /* DuckAISuggestionsPipelineTests.swift in Sources */,
 				D1A2B3C4E5F60001AABB0007 /* PostIdleSessionInstrumentationTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
@@ -1,0 +1,94 @@
+//
+//  AppReturnInstrumentation.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Core
+
+/// Ungated per-foreground snapshot: time away, resolved idle threshold, and capability exposure.
+/// Fired from `Foreground.onTransition()` so URL, shortcut and user-activity opens count too,
+/// making it the app-open denominator for "% of app opens" metrics.
+protocol AppReturnInstrumentation {
+    func recordAppForeground(lastBackgroundDate: Date?, launchAction: LaunchAction)
+}
+
+final class DefaultAppReturnInstrumentation: AppReturnInstrumentation {
+
+    private let eligibilityManager: IdleReturnEligibilityManaging
+    private let isUnifiedInputAvailable: () -> Bool
+    private let isToggleEnabled: () -> Bool
+    private let now: () -> Date
+    private let fireDailyAndCount: (Pixel.Event, [String: String]) -> Void
+
+    init(eligibilityManager: IdleReturnEligibilityManaging,
+         isUnifiedInputAvailable: @escaping () -> Bool = { UnifiedToggleInputFeature().isAvailable },
+         isToggleEnabled: @escaping () -> Bool,
+         now: @escaping () -> Date = Date.init,
+         fireDailyAndCount: @escaping (Pixel.Event, [String: String]) -> Void = { event, params in
+             DailyPixel.fireDailyAndCount(pixel: event, withAdditionalParameters: params)
+         }) {
+        self.eligibilityManager = eligibilityManager
+        self.isUnifiedInputAvailable = isUnifiedInputAvailable
+        self.isToggleEnabled = isToggleEnabled
+        self.now = now
+        self.fireDailyAndCount = fireDailyAndCount
+    }
+
+    func recordAppForeground(lastBackgroundDate: Date?, launchAction: LaunchAction) {
+        let thresholdSeconds = eligibilityManager.idleThresholdSeconds()
+        let timeAway = lastBackgroundDate.map { now().timeIntervalSince($0) }
+
+        let afterInactivityOption: String
+        switch eligibilityManager.effectiveAfterInactivityOption() {
+        case .newTab: afterInactivityOption = "new_tab"
+        case .lastUsedTab: afterInactivityOption = "last_used_tab"
+        }
+
+        fireDailyAndCount(.appReturn, [
+            "time_away_bucket": Self.timeAwayBucket(for: timeAway),
+            "exceeded_idle_threshold": String(timeAway.map { $0 >= Double(thresholdSeconds) } ?? false),
+            "idle_threshold_seconds": String(thresholdSeconds),
+            "after_inactivity_option": afterInactivityOption,
+            "feature_eligible": String(eligibilityManager.isFeatureAvailable()),
+            "unified_input_available": String(isUnifiedInputAvailable()),
+            "toggle_enabled": String(isToggleEnabled()),
+            "launch_source": Self.launchSource(for: launchAction)
+        ])
+    }
+
+    static func timeAwayBucket(for timeAway: TimeInterval?) -> String {
+        guard let timeAway else { return "cold_start" }
+        switch timeAway {
+        case ..<60: return "lt_1m"
+        case ..<300: return "1_5m"
+        case ..<900: return "5_15m"
+        case ..<1800: return "15_30m"
+        case ..<3600: return "30_60m"
+        default: return "gt_60m"
+        }
+    }
+
+    static func launchSource(for launchAction: LaunchAction) -> String {
+        switch launchAction {
+        case .openURL: return "url"
+        case .handleShortcutItem: return "shortcut"
+        case .handleUserActivity: return "user_activity"
+        case .standardLaunch: return "standard"
+        }
+    }
+}

--- a/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
@@ -18,7 +18,21 @@
 //
 
 import Foundation
-import Core
+import PixelKit
+
+/// Fires as `m_app_return`; the `m_` prefix plus the platform suffix are applied by PixelKit.
+enum AppReturnPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+
+    case appReturn
+
+    var name: String { "app_return" }
+
+    var parameters: [String: String]? { nil }
+
+    var standardParameters: [PixelKitStandardParameter]? { nil }
+
+    var namePrefix: String { "m_" }
+}
 
 /// Ungated per-foreground snapshot: time away, resolved idle threshold, and capability exposure.
 /// Fired from `Foreground.onTransition()` so URL, shortcut and user-activity opens count too,
@@ -33,14 +47,14 @@ final class DefaultAppReturnInstrumentation: AppReturnInstrumentation {
     private let isUnifiedInputAvailable: () -> Bool
     private let isToggleEnabled: () -> Bool
     private let now: () -> Date
-    private let fireDailyAndCount: (Pixel.Event, [String: String]) -> Void
+    private let fireDailyAndCount: (AppReturnPixel, [String: String]) -> Void
 
     init(eligibilityManager: IdleReturnEligibilityManaging,
          isUnifiedInputAvailable: @escaping () -> Bool = { UnifiedToggleInputFeature().isAvailable },
          isToggleEnabled: @escaping () -> Bool,
          now: @escaping () -> Date = Date.init,
-         fireDailyAndCount: @escaping (Pixel.Event, [String: String]) -> Void = { event, params in
-             DailyPixel.fireDailyAndCount(pixel: event, withAdditionalParameters: params)
+         fireDailyAndCount: @escaping (AppReturnPixel, [String: String]) -> Void = { event, params in
+             PixelKit.fire(event, frequency: .dailyAndCount, withAdditionalParameters: params)
          }) {
         self.eligibilityManager = eligibilityManager
         self.isUnifiedInputAvailable = isUnifiedInputAvailable

--- a/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
@@ -20,7 +20,6 @@
 import Foundation
 import PixelKit
 
-/// Fires as `m_app_return`; the `m_` prefix plus the platform suffix are applied by PixelKit.
 enum AppReturnPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
 
     case appReturn
@@ -34,9 +33,6 @@ enum AppReturnPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
     var namePrefix: String { "m_" }
 }
 
-/// Ungated per-foreground snapshot: time away, resolved idle threshold, and capability exposure.
-/// Fired from `Foreground.onTransition()` so URL, shortcut and user-activity opens count too,
-/// making it the app-open denominator for "% of app opens" metrics.
 protocol AppReturnInstrumentation {
     func recordAppForeground(lastBackgroundDate: Date?, launchAction: LaunchAction)
 }

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
@@ -46,6 +46,7 @@ struct Foreground: ForegroundHandling {
     private let launchActionHandler: LaunchActionHandler
     private let interactionManager: UIInteractionManager
     private let lastBackgroundDateStorage: any ThrowingKeyedStoring<IdleReturnLastBackgroundDateKeys>
+    private let appReturnInstrumentation: AppReturnInstrumentation
 
     init(stateContext: Connected.StateContext, actionToHandle: AppAction?,
          lastBackgroundDateStorage: any ThrowingKeyedStoring<IdleReturnLastBackgroundDateKeys>) {
@@ -89,6 +90,10 @@ struct Foreground: ForegroundHandling {
             isStillOnboarding: { daxDialogsManager.isStillOnboarding() }
         )
         let idleReturnEvaluator = IdleReturnEvaluator(eligibilityManager: idleReturnEligibilityManager)
+        appReturnInstrumentation = DefaultAppReturnInstrumentation(
+            eligibilityManager: idleReturnEligibilityManager,
+            isToggleEnabled: { appDependencies.aiChatSettings.isAIChatSearchInputUserSettingsEnabled }
+        )
         launchActionHandler = LaunchActionHandler(
             urlHandler: appDependencies.mainCoordinator,
             shortcutItemHandler: appDependencies.mainCoordinator,
@@ -171,6 +176,11 @@ struct Foreground: ForegroundHandling {
         switchBarRetentionMetrics.checkDailyAndSendPixelIfApplicable()
 
         fireAIFeaturesStateDailyPixel()
+
+        appReturnInstrumentation.recordAppForeground(
+            lastBackgroundDate: (try? lastBackgroundDateStorage.lastBackgroundDate) ?? nil,
+            launchAction: launchAction
+        )
     }
 
     /// Once-daily snapshot of the three AI settings + the derived "no AI" state, across the active base.

--- a/iOS/DuckDuckGoTests/AppReturnInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/AppReturnInstrumentationTests.swift
@@ -60,7 +60,8 @@ struct AppReturnInstrumentationTests {
 
     // MARK: - Firing is ungated
 
-    @Test("When feature is unavailable then the pixel still fires with feature_eligible false")
+    @available(iOS 16, *)
+    @Test("When feature is unavailable then the pixel still fires with feature_eligible false", .timeLimit(.minutes(1)))
     func whenFeatureUnavailableThenPixelStillFires() {
         let (sut, collector) = makeSUT(featureAvailable: false)
 
@@ -74,7 +75,8 @@ struct AppReturnInstrumentationTests {
 
     // MARK: - Time away buckets
 
-    @Test("When there is no prior background date then the bucket is cold_start")
+    @available(iOS 16, *)
+    @Test("When there is no prior background date then the bucket is cold_start", .timeLimit(.minutes(1)))
     func whenNoBackgroundDateThenColdStart() {
         let (sut, collector) = makeSUT()
 
@@ -85,7 +87,8 @@ struct AppReturnInstrumentationTests {
         #expect(collector.fired.first?.params["exceeded_idle_threshold"] == "false")
     }
 
-    @Test("Bucket boundaries resolve to the expected values")
+    @available(iOS 16, *)
+    @Test("Bucket boundaries resolve to the expected values", .timeLimit(.minutes(1)))
     func bucketBoundaries() {
         #expect(DefaultAppReturnInstrumentation.timeAwayBucket(for: nil) == "cold_start")
         #expect(DefaultAppReturnInstrumentation.timeAwayBucket(for: 59) == "lt_1m")
@@ -102,7 +105,8 @@ struct AppReturnInstrumentationTests {
 
     // MARK: - Idle threshold
 
-    @Test("When time away meets the threshold then exceeded_idle_threshold is true even when ineligible")
+    @available(iOS 16, *)
+    @Test("When time away meets the threshold then exceeded_idle_threshold is true even when ineligible", .timeLimit(.minutes(1)))
     func whenTimeAwayMeetsThresholdThenExceededTrueEvenWhenIneligible() {
         let (sut, collector) = makeSUT(featureAvailable: false, thresholdSeconds: 1800)
 
@@ -113,7 +117,8 @@ struct AppReturnInstrumentationTests {
         #expect(collector.fired.first?.params["idle_threshold_seconds"] == "1800")
     }
 
-    @Test("When time away is below the threshold then exceeded_idle_threshold is false")
+    @available(iOS 16, *)
+    @Test("When time away is below the threshold then exceeded_idle_threshold is false", .timeLimit(.minutes(1)))
     func whenTimeAwayBelowThresholdThenExceededFalse() {
         let (sut, collector) = makeSUT(thresholdSeconds: 1800)
 
@@ -125,7 +130,8 @@ struct AppReturnInstrumentationTests {
 
     // MARK: - Setting and capability params
 
-    @Test("The after-inactivity option is reported in snake_case")
+    @available(iOS 16, *)
+    @Test("The after-inactivity option is reported in snake_case", .timeLimit(.minutes(1)))
     func afterInactivityOptionReportedSnakeCase() {
         let (newTabSUT, newTabCollector) = makeSUT(effectiveOption: .newTab)
         newTabSUT.recordAppForeground(lastBackgroundDate: nil,
@@ -138,7 +144,8 @@ struct AppReturnInstrumentationTests {
         #expect(lutCollector.fired.first?.params["after_inactivity_option"] == "last_used_tab")
     }
 
-    @Test("Capability flags reflect the injected providers")
+    @available(iOS 16, *)
+    @Test("Capability flags reflect the injected providers", .timeLimit(.minutes(1)))
     func capabilityFlagsReflectProviders() {
         let (sut, collector) = makeSUT(unifiedInputAvailable: true, toggleEnabled: true)
 
@@ -151,7 +158,8 @@ struct AppReturnInstrumentationTests {
 
     // MARK: - Launch source
 
-    @Test("Launch actions map to the expected launch_source values")
+    @available(iOS 16, *)
+    @Test("Launch actions map to the expected launch_source values", .timeLimit(.minutes(1)))
     func launchSourceMapping() throws {
         #expect(DefaultAppReturnInstrumentation.launchSource(for: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: true)) == "standard")
         let url = try #require(URL(string: "https://duckduckgo.com"))

--- a/iOS/DuckDuckGoTests/AppReturnInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/AppReturnInstrumentationTests.swift
@@ -1,0 +1,161 @@
+//
+//  AppReturnInstrumentationTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+import Core
+@testable import DuckDuckGo
+
+@Suite("App Return Instrumentation")
+struct AppReturnInstrumentationTests {
+
+    private final class PixelCollector {
+        var fired: [(name: String, params: [String: String])] = []
+    }
+
+    private static let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    private func makeSUT(
+        featureAvailable: Bool = true,
+        effectiveOption: AfterInactivityOption = .newTab,
+        thresholdSeconds: Int = 1800,
+        unifiedInputAvailable: Bool = false,
+        toggleEnabled: Bool = false
+    ) -> (DefaultAppReturnInstrumentation, PixelCollector) {
+        let eligibility = MockIdleReturnEligibilityManager()
+        eligibility.isFeatureAvailableResult = featureAvailable
+        eligibility.effectiveAfterInactivityOptionResult = effectiveOption
+        eligibility.idleThresholdSecondsResult = thresholdSeconds
+        let collector = PixelCollector()
+        let sut = DefaultAppReturnInstrumentation(
+            eligibilityManager: eligibility,
+            isUnifiedInputAvailable: { unifiedInputAvailable },
+            isToggleEnabled: { toggleEnabled },
+            now: { Self.now },
+            fireDailyAndCount: { event, params in
+                collector.fired.append((event.name, params))
+            })
+        return (sut, collector)
+    }
+
+    private func backgroundDate(secondsAgo: TimeInterval) -> Date {
+        Self.now.addingTimeInterval(-secondsAgo)
+    }
+
+    // MARK: - Firing is ungated
+
+    @Test("When feature is unavailable then the pixel still fires with feature_eligible false")
+    func whenFeatureUnavailableThenPixelStillFires() {
+        let (sut, collector) = makeSUT(featureAvailable: false)
+
+        sut.recordAppForeground(lastBackgroundDate: backgroundDate(secondsAgo: 120),
+                                launchAction: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: false))
+
+        #expect(collector.fired.count == 1)
+        #expect(collector.fired.first?.name == "m_app_return")
+        #expect(collector.fired.first?.params["feature_eligible"] == "false")
+    }
+
+    // MARK: - Time away buckets
+
+    @Test("When there is no prior background date then the bucket is cold_start")
+    func whenNoBackgroundDateThenColdStart() {
+        let (sut, collector) = makeSUT()
+
+        sut.recordAppForeground(lastBackgroundDate: nil,
+                                launchAction: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: true))
+
+        #expect(collector.fired.first?.params["time_away_bucket"] == "cold_start")
+        #expect(collector.fired.first?.params["exceeded_idle_threshold"] == "false")
+    }
+
+    @Test("Bucket boundaries resolve to the expected values")
+    func bucketBoundaries() {
+        #expect(DefaultAppReturnInstrumentation.timeAwayBucket(for: nil) == "cold_start")
+        #expect(DefaultAppReturnInstrumentation.timeAwayBucket(for: 59) == "lt_1m")
+        #expect(DefaultAppReturnInstrumentation.timeAwayBucket(for: 60) == "1_5m")
+        #expect(DefaultAppReturnInstrumentation.timeAwayBucket(for: 299) == "1_5m")
+        #expect(DefaultAppReturnInstrumentation.timeAwayBucket(for: 300) == "5_15m")
+        #expect(DefaultAppReturnInstrumentation.timeAwayBucket(for: 899) == "5_15m")
+        #expect(DefaultAppReturnInstrumentation.timeAwayBucket(for: 900) == "15_30m")
+        #expect(DefaultAppReturnInstrumentation.timeAwayBucket(for: 1799) == "15_30m")
+        #expect(DefaultAppReturnInstrumentation.timeAwayBucket(for: 1800) == "30_60m")
+        #expect(DefaultAppReturnInstrumentation.timeAwayBucket(for: 3599) == "30_60m")
+        #expect(DefaultAppReturnInstrumentation.timeAwayBucket(for: 3600) == "gt_60m")
+    }
+
+    // MARK: - Idle threshold
+
+    @Test("When time away meets the threshold then exceeded_idle_threshold is true even when ineligible")
+    func whenTimeAwayMeetsThresholdThenExceededTrueEvenWhenIneligible() {
+        let (sut, collector) = makeSUT(featureAvailable: false, thresholdSeconds: 1800)
+
+        sut.recordAppForeground(lastBackgroundDate: backgroundDate(secondsAgo: 1800),
+                                launchAction: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: false))
+
+        #expect(collector.fired.first?.params["exceeded_idle_threshold"] == "true")
+        #expect(collector.fired.first?.params["idle_threshold_seconds"] == "1800")
+    }
+
+    @Test("When time away is below the threshold then exceeded_idle_threshold is false")
+    func whenTimeAwayBelowThresholdThenExceededFalse() {
+        let (sut, collector) = makeSUT(thresholdSeconds: 1800)
+
+        sut.recordAppForeground(lastBackgroundDate: backgroundDate(secondsAgo: 1799),
+                                launchAction: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: false))
+
+        #expect(collector.fired.first?.params["exceeded_idle_threshold"] == "false")
+    }
+
+    // MARK: - Setting and capability params
+
+    @Test("The after-inactivity option is reported in snake_case")
+    func afterInactivityOptionReportedSnakeCase() {
+        let (newTabSUT, newTabCollector) = makeSUT(effectiveOption: .newTab)
+        newTabSUT.recordAppForeground(lastBackgroundDate: nil,
+                                      launchAction: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: true))
+        #expect(newTabCollector.fired.first?.params["after_inactivity_option"] == "new_tab")
+
+        let (lutSUT, lutCollector) = makeSUT(effectiveOption: .lastUsedTab)
+        lutSUT.recordAppForeground(lastBackgroundDate: nil,
+                                   launchAction: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: true))
+        #expect(lutCollector.fired.first?.params["after_inactivity_option"] == "last_used_tab")
+    }
+
+    @Test("Capability flags reflect the injected providers")
+    func capabilityFlagsReflectProviders() {
+        let (sut, collector) = makeSUT(unifiedInputAvailable: true, toggleEnabled: true)
+
+        sut.recordAppForeground(lastBackgroundDate: nil,
+                                launchAction: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: true))
+
+        #expect(collector.fired.first?.params["unified_input_available"] == "true")
+        #expect(collector.fired.first?.params["toggle_enabled"] == "true")
+    }
+
+    // MARK: - Launch source
+
+    @Test("Launch actions map to the expected launch_source values")
+    func launchSourceMapping() throws {
+        #expect(DefaultAppReturnInstrumentation.launchSource(for: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: true)) == "standard")
+        let url = try #require(URL(string: "https://duckduckgo.com"))
+        #expect(DefaultAppReturnInstrumentation.launchSource(for: .openURL(url)) == "url")
+        #expect(DefaultAppReturnInstrumentation.launchSource(for: .handleUserActivity(NSUserActivity(activityType: "test"))) == "user_activity")
+    }
+}

--- a/iOS/DuckDuckGoTests/AppReturnInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/AppReturnInstrumentationTests.swift
@@ -68,7 +68,7 @@ struct AppReturnInstrumentationTests {
                                 launchAction: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: false))
 
         #expect(collector.fired.count == 1)
-        #expect(collector.fired.first?.name == "m_app_return")
+        #expect(collector.fired.first?.name == "app_return")
         #expect(collector.fired.first?.params["feature_eligible"] == "false")
     }
 

--- a/iOS/PixelDefinitions/pixels/definitions/app_return.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/app_return.json5
@@ -1,5 +1,4 @@
-// App return: ungated per-foreground snapshot of time away and capability exposure.
-// The app-open denominator for "% of app opens" metrics.
+// App return: per-foreground snapshot of time away and capability exposure.
 {
     "m_app_return": {
         "description": "Fires on every foreground transition, ungated and launch-action-independent. Reports how long the user was away, the resolved idle threshold, and which Duck.ai capabilities are available.",

--- a/iOS/PixelDefinitions/pixels/definitions/app_return.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/app_return.json5
@@ -5,7 +5,7 @@
         "description": "Fires on every foreground transition, ungated and launch-action-independent. Reports how long the user was away, the resolved idle threshold, and which Duck.ai capabilities are available.",
         "owners": ["fbunn"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "suffixes": ["platform", "form_factor", "first_daily_count"],
         "parameters": [
             "appVersion",
             {

--- a/iOS/PixelDefinitions/pixels/definitions/app_return.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/app_return.json5
@@ -3,7 +3,7 @@
 {
     "m_app_return": {
         "description": "Fires on every foreground transition, ungated and launch-action-independent. Reports how long the user was away, the resolved idle threshold, and which Duck.ai capabilities are available.",
-        "owners": ["fbunn"],
+        "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor", "first_daily_count"],
         "parameters": [

--- a/iOS/PixelDefinitions/pixels/definitions/app_return.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/app_return.json5
@@ -1,0 +1,53 @@
+// App return: ungated per-foreground snapshot of time away and capability exposure.
+// The app-open denominator for "% of app opens" metrics.
+{
+    "m_app_return": {
+        "description": "Fires on every foreground transition, ungated and launch-action-independent. Reports how long the user was away, the resolved idle threshold, and which Duck.ai capabilities are available.",
+        "owners": ["fbunn"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "time_away_bucket",
+                "description": "Time away before reopening: cold_start (no prior background date), lt_1m, 1_5m, 5_15m, 15_30m, 30_60m, gt_60m",
+                "type": "string"
+            },
+            {
+                "key": "exceeded_idle_threshold",
+                "description": "Whether the time away exceeded the resolved idle threshold, reported even when the after-inactivity feature is ineligible: true or false",
+                "type": "boolean"
+            },
+            {
+                "key": "idle_threshold_seconds",
+                "description": "The resolved idle threshold in seconds (debug override, user preference, or remote config; e.g. 1800)",
+                "type": "integer"
+            },
+            {
+                "key": "after_inactivity_option",
+                "description": "The effective after-inactivity opening setting: new_tab or last_used_tab",
+                "type": "string"
+            },
+            {
+                "key": "feature_eligible",
+                "description": "Whether the NTP-after-idle feature is available (flag on and onboarding complete): true or false",
+                "type": "boolean"
+            },
+            {
+                "key": "unified_input_available",
+                "description": "Whether the Unified Toggle Input experience is available on this device: true or false",
+                "type": "boolean"
+            },
+            {
+                "key": "toggle_enabled",
+                "description": "Whether the Search/Duck.ai toggle user setting is enabled: true or false",
+                "type": "boolean"
+            },
+            {
+                "key": "launch_source",
+                "description": "What triggered this foreground: standard, url, shortcut, or user_activity",
+                "type": "string"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217261030452899
Tech Design URL:
CC:

### Description

Adds `m_app_return` (daily + count), fired ungated from `Foreground.onTransition()` on every foreground transition, covering URL/shortcut/user-activity opens that the `.standardLaunch`-only paths miss. It reports the time-away bucket, the resolved idle threshold and whether it was exceeded (even when the feature is ineligible, enabling the timeout counterfactual), the after-inactivity setting, feature eligibility, Unified Input availability, the toggle setting, and the launch source. This is the app-open denominator every "% of app opens" dashboard panel needs and nothing provides today.

### Testing Steps

1. Foreground the app normally, from a URL, and from a home-screen shortcut; verify `m_app_return` fires each time with the matching `launch_source` and a sensible `time_away_bucket`.
2. Background the app for over 30 minutes, reopen, and verify `exceeded_idle_threshold=true` with `idle_threshold_seconds=1800`.
3. Run `AppReturnInstrumentationTests` (bucket boundaries, threshold, ungated firing, param mapping).

### Impact and Risks

Low — a new additive pixel; one fire call added to the foreground transition, no behavior change.

#### What could go wrong?

Firing on every foreground makes this a high-volume pixel by design; if the fire point were reached more than once per transition it would overcount app opens, but `onTransition()` runs exactly once per background→foreground cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive analytics only; one instrumentation call per foreground transition with no user-facing behavior change.
> 
> **Overview**
> Adds **`m_app_return`** (daily + count), fired **ungated** from **`Foreground.onTransition()`** on every background→foreground transition—including URL, shortcut, and user-activity opens that `.standardLaunch`-only instrumentation misses.
> 
> Each fire reports **`time_away_bucket`** (including `cold_start`), whether **`exceeded_idle_threshold`** vs the resolved **`idle_threshold_seconds`** (even when the after-inactivity feature is ineligible), **`after_inactivity_option`**, **`feature_eligible`**, **`unified_input_available`**, **`toggle_enabled`**, and **`launch_source`**. A new **`AppReturnInstrumentation`** module and **`app_return.json5`** pixel definition accompany unit tests for buckets, threshold logic, and param mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fcbb6052748182ec30f387d4d9f4c151e14993d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->