### PR TITLE
[iOS] Add m_aichat_entry_point and m_aichat_duck_ai_direct_navigation

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1681,6 +1681,7 @@ extension Pixel {
         case serpSettingsUnrecognizedValue
 
         case aiChatOpen
+        case aiChatEntryPoint
         case aiChatMetricStartNewConversation
         case aiChatMetricStartNewConversationButtonClicked
         case aiChatMetricOpenHistory
@@ -3593,6 +3594,7 @@ extension Pixel.Event {
         case .aiChatSettingsSearchInputTurnedOn: return "m_aichat_settings_search_input_turned_on"
 
         case .aiChatOpen: return "m_aichat_open"
+        case .aiChatEntryPoint: return "m_aichat_entry_point"
         case .aiChatMetricStartNewConversation: return "m_aichat_start_new_conversation"
         case .aiChatMetricStartNewConversationButtonClicked: return "m_aichat_start_new_conversation_button_clicked"
         case .aiChatMetricOpenHistory: return "m_aichat_open_history"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1681,7 +1681,6 @@ extension Pixel {
         case serpSettingsUnrecognizedValue
 
         case aiChatOpen
-        case aiChatEntryPoint
         case aiChatMetricStartNewConversation
         case aiChatMetricStartNewConversationButtonClicked
         case aiChatMetricOpenHistory
@@ -3594,7 +3593,6 @@ extension Pixel.Event {
         case .aiChatSettingsSearchInputTurnedOn: return "m_aichat_settings_search_input_turned_on"
 
         case .aiChatOpen: return "m_aichat_open"
-        case .aiChatEntryPoint: return "m_aichat_entry_point"
         case .aiChatMetricStartNewConversation: return "m_aichat_start_new_conversation"
         case .aiChatMetricStartNewConversationButtonClicked: return "m_aichat_start_new_conversation_button_clicked"
         case .aiChatMetricOpenHistory: return "m_aichat_open_history"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1897,6 +1897,7 @@ extension Pixel {
         case unifiedToggleInputSubmitChangeModel
         case unifiedToggleInputSubmitChangeModelPromptSent
         case unifiedToggleInputDuckAIDirectNavigation
+        case aiChatDuckAIDirectNavigation
 
         // MARK: Unified Toggle Input - Duck.ai autocomplete suggestion clicks
         case autocompleteDuckAIClickWebsite
@@ -3810,6 +3811,7 @@ extension Pixel.Event {
         case .unifiedToggleInputSubmitChangeModel: return "aichat_unified_input_submit_change_model"
         case .unifiedToggleInputSubmitChangeModelPromptSent: return "aichat_unified_input_submit_change_model_prompt_sent"
         case .unifiedToggleInputDuckAIDirectNavigation: return "m_aichat_unified_input_duck_ai_direct_navigation"
+        case .aiChatDuckAIDirectNavigation: return "m_aichat_duck_ai_direct_navigation"
 
         case .autocompleteDuckAIClickWebsite: return "m_autocomplete_duckai_click_website"
         case .autocompleteDuckAIClickBookmark: return "m_autocomplete_duckai_click_bookmark"

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 		31CE145C2D5505520027F11D /* OmnibarDependencyProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CE145B2D5505520027F11D /* OmnibarDependencyProvider.swift */; };
 		31CF26792E6F14AF004D52C2 /* LaunchSourceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CF26782E6F14A9004D52C2 /* LaunchSourceManager.swift */; };
 		31D2D2A22D40F7E900549D12 /* AIChatDeepLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D2D2A12D40F7E900549D12 /* AIChatDeepLinkHandler.swift */; };
+		D3D3D3D3AABB0001CAFE0001 /* AIChatEntryPointSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D3D3D3AABB0001CAFE0002 /* AIChatEntryPointSource.swift */; };
 		31D2D2A42D40F98800549D12 /* WidgetSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D2D2A32D40F98800549D12 /* WidgetSourceType.swift */; };
 		31D2D2A52D40F99100549D12 /* WidgetSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D2D2A32D40F98800549D12 /* WidgetSourceType.swift */; };
 		31D4CD4B2D4D1C2D00BC27C6 /* ToolbarStateHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D4CD4A2D4D1C2600BC27C6 /* ToolbarStateHandling.swift */; };
@@ -3181,6 +3182,7 @@
 		31CE145B2D5505520027F11D /* OmnibarDependencyProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnibarDependencyProvider.swift; sourceTree = "<group>"; };
 		31CF26782E6F14A9004D52C2 /* LaunchSourceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchSourceManager.swift; sourceTree = "<group>"; };
 		31D2D2A12D40F7E900549D12 /* AIChatDeepLinkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatDeepLinkHandler.swift; sourceTree = "<group>"; };
+		D3D3D3D3AABB0001CAFE0002 /* AIChatEntryPointSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatEntryPointSource.swift; sourceTree = "<group>"; };
 		31D2D2A32D40F98800549D12 /* WidgetSourceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSourceType.swift; sourceTree = "<group>"; };
 		31D49A3C2DC294E500262F26 /* UIComponents */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = UIComponents; path = ../SharedPackages/UIComponents; sourceTree = SOURCE_ROOT; };
 		31D4CD4A2D4D1C2600BC27C6 /* ToolbarStateHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarStateHandling.swift; sourceTree = "<group>"; };
@@ -6434,6 +6436,7 @@
 				31D2D2A32D40F98800549D12 /* WidgetSourceType.swift */,
 				31C314A32D2EF9DF009A412A /* UserScript */,
 				31D2D2A12D40F7E900549D12 /* AIChatDeepLinkHandler.swift */,
+				D3D3D3D3AABB0001CAFE0002 /* AIChatEntryPointSource.swift */,
 				3105BCF02DF214A000EB755E /* AIChatPixelMetricHandler.swift */,
 				31F43E1E2F472F3C001BBCDA /* AIChatAddressBarExperience.swift */,
 				31A2B6DF2E1C3BDF00391020 /* SubscriptionAIChatStateHandler.swift */,
@@ -14457,6 +14460,7 @@
 				85DFEDEF24C7EA3B00973FE7 /* SmallOmniBarState.swift in Sources */,
 				80A09D542F6B88BC00AACDEE /* AutoConsentFireWorker.swift in Sources */,
 				31D2D2A22D40F7E900549D12 /* AIChatDeepLinkHandler.swift in Sources */,
+				D3D3D3D3AABB0001CAFE0001 /* AIChatEntryPointSource.swift in Sources */,
 				9F989C142E9CB9ED00EC2701 /* PromoCoordinationService.swift in Sources */,
 				1E908BF129827C480008C8F3 /* AutoconsentUserScript.swift in Sources */,
 				1D200C972BA3157A00108701 /* SettingsNextStepsView.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1055,6 +1055,7 @@
 		9770D4AC2F7B000100293610 /* VoiceSessionStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9770D4AD2F7B000100293610 /* VoiceSessionStateManager.swift */; };
 		9770D4AE2F7B000200293610 /* VoiceSessionStateManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9770D4AF2F7B000200293610 /* VoiceSessionStateManagerTests.swift */; };
 		9770D4B02F7B000300293610 /* VoiceEntryPointPixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9770D4B12F7B000300293610 /* VoiceEntryPointPixelTests.swift */; };
+		9770D4C02F7C000100293610 /* AIChatEntryPointSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9770D4C12F7C000100293610 /* AIChatEntryPointSourceTests.swift */; };
 		97770B712EC1ED2600CACA68 /* OnboardingSearchExperiencePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97770B6C2EC1ED2600CACA68 /* OnboardingSearchExperiencePickerViewModel.swift */; };
 		97770B722EC1ED2600CACA68 /* OnboardingSearchExperienceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97770B6D2EC1ED2600CACA68 /* OnboardingSearchExperienceProvider.swift */; };
 		97770B732EC1ED2600CACA68 /* OnboardingSearchExperienceSelectionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97770B6E2EC1ED2600CACA68 /* OnboardingSearchExperienceSelectionHandler.swift */; };
@@ -3914,6 +3915,7 @@
 		9770D4AD2F7B000100293610 /* VoiceSessionStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSessionStateManager.swift; sourceTree = "<group>"; };
 		9770D4AF2F7B000200293610 /* VoiceSessionStateManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSessionStateManagerTests.swift; sourceTree = "<group>"; };
 		9770D4B12F7B000300293610 /* VoiceEntryPointPixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceEntryPointPixelTests.swift; sourceTree = "<group>"; };
+		9770D4C12F7C000100293610 /* AIChatEntryPointSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatEntryPointSourceTests.swift; sourceTree = "<group>"; };
 		97770B6C2EC1ED2600CACA68 /* OnboardingSearchExperiencePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSearchExperiencePickerViewModel.swift; sourceTree = "<group>"; };
 		97770B6D2EC1ED2600CACA68 /* OnboardingSearchExperienceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSearchExperienceProvider.swift; sourceTree = "<group>"; };
 		97770B6E2EC1ED2600CACA68 /* OnboardingSearchExperienceSelectionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSearchExperienceSelectionHandler.swift; sourceTree = "<group>"; };
@@ -11847,6 +11849,7 @@
 				CBAD0F1E2D02EE45006267B8 /* IdleReturnEvaluatorTests.swift */,
 				9770D4AF2F7B000200293610 /* VoiceSessionStateManagerTests.swift */,
 				9770D4B12F7B000300293610 /* VoiceEntryPointPixelTests.swift */,
+				9770D4C12F7C000100293610 /* AIChatEntryPointSourceTests.swift */,
 				A7B001112F6B000100000001 /* VoiceSearchFeedbackViewTests.swift */,
 				A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */,
 				A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */,
@@ -14824,6 +14827,7 @@
 				97D99E642F7420A900EE34E7 /* AIVoiceChatIntentTests.swift in Sources */,
 				9770D4AE2F7B000200293610 /* VoiceSessionStateManagerTests.swift in Sources */,
 				9770D4B02F7B000300293610 /* VoiceEntryPointPixelTests.swift in Sources */,
+				9770D4C02F7C000100293610 /* AIChatEntryPointSourceTests.swift in Sources */,
 				A7B001102F6B000100000001 /* VoiceSearchFeedbackViewTests.swift in Sources */,
 				A1B2C3D4E5F60001AABB0001 /* NTPAfterIdleInstrumentationTests.swift in Sources */,
 				9FB484A6301ADA9300125636 /* OnboardingAIModelsFallbackTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/AIChatDeepLinkHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatDeepLinkHandler.swift
@@ -34,6 +34,7 @@ protocol AIChatDeepLinkPresenting: UIViewController {
         reasoningEffort: AIChatReasoningEffort?,
         images: [AIChatNativePrompt.NativePromptImage]?,
         files: [AIChatNativePrompt.NativePromptFile]?,
+        reportsNewTab: Bool?,
         fromDeepLink: Bool
     )
 }
@@ -52,6 +53,7 @@ extension AIChatDeepLinkPresenting {
             reasoningEffort: nil,
             images: nil,
             files: nil,
+            reportsNewTab: nil,
             fromDeepLink: fromDeepLink
         )
     }

--- a/iOS/DuckDuckGo/AIChat/AIChatDeepLinkHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatDeepLinkHandler.swift
@@ -22,7 +22,7 @@ import Core
 import AIChat
 
 protocol AIChatDeepLinkPresenting: UIViewController {
-    func openAIVoiceChatFromDeepLink()
+    func openAIVoiceChatFromDeepLink(source: AIChatEntryPointSource)
     func openAIChat(
         source: AIChatEntryPointSource,
         _ query: String?,
@@ -40,9 +40,9 @@ protocol AIChatDeepLinkPresenting: UIViewController {
 
 extension AIChatDeepLinkPresenting {
 
-    func openAIChat(fromDeepLink: Bool) {
+    func openAIChat(fromDeepLink: Bool, source: AIChatEntryPointSource = .deepLinkOther) {
         openAIChat(
-            source: .deepLinkOther,
+            source: source,
             nil,
             autoSend: false,
             payload: nil,
@@ -74,11 +74,14 @@ struct AIChatDeepLinkHandler {
             }
         }
 
+        // Widget, Control Center and lock-screen entries carry their own source, so they land on
+        // `m_aichat_entry_point` as themselves rather than collapsing into `deep_link_other`.
+        let source = AIChatEntryPointSource.forDeepLink(url)
         mainViewController.dismiss(animated: true) {
             if voiceMode {
-                mainViewController.openAIVoiceChatFromDeepLink()
+                mainViewController.openAIVoiceChatFromDeepLink(source: source)
             } else {
-                mainViewController.openAIChat(fromDeepLink: true)
+                mainViewController.openAIChat(fromDeepLink: true, source: source)
             }
         }
     }

--- a/iOS/DuckDuckGo/AIChat/AIChatDeepLinkHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatDeepLinkHandler.swift
@@ -24,6 +24,7 @@ import AIChat
 protocol AIChatDeepLinkPresenting: UIViewController {
     func openAIVoiceChatFromDeepLink()
     func openAIChat(
+        source: AIChatEntryPointSource,
         _ query: String?,
         autoSend: Bool,
         payload: Any?,
@@ -41,6 +42,7 @@ extension AIChatDeepLinkPresenting {
 
     func openAIChat(fromDeepLink: Bool) {
         openAIChat(
+            source: .deepLinkOther,
             nil,
             autoSend: false,
             payload: nil,

--- a/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
@@ -18,6 +18,21 @@
 //
 
 import Foundation
+import PixelKit
+
+/// Fires as `m_aichat_entry_point`; the `m_` prefix plus the platform suffix are applied by PixelKit.
+enum AIChatEntryPointPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+
+    case entryPoint
+
+    var name: String { "aichat_entry_point" }
+
+    var parameters: [String: String]? { nil }
+
+    var standardParameters: [PixelKitStandardParameter]? { nil }
+
+    var namePrefix: String { "m_" }
+}
 
 /// Where a Duck.ai entry began. Reported as `source` on `m_aichat_entry_point`;
 /// the raw values are a dashboard contract — renaming one breaks its series.

--- a/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
@@ -34,8 +34,7 @@ enum AIChatEntryPointPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
 
     var namePrefix: String { "m_" }
 
-    /// Shared so entry paths outside `MainViewController` can report too. Prefer
-    /// `MainViewController.fireAIChatEntryPointPixel`, which also records the source for `origin`.
+    /// Shared so entry paths outside `MainViewController` can report too.
     static func fire(source: AIChatEntryPointSource,
                      duckAIEnabled: Bool,
                      toggleEnabled: Bool,

--- a/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
@@ -22,7 +22,7 @@ import Core
 import PixelKit
 
 /// Fires as `m_aichat_entry_point`; the `m_` prefix plus the platform suffix are applied by PixelKit.
-enum AIChatEntryPointPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+enum AIChatEntryPointPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
 
     case entryPoint
 

--- a/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
@@ -70,7 +70,39 @@ enum AIChatEntryPointSource: String {
     case onboarding
     case directURL = "direct_url"
     case iconShortcut = "icon_shortcut"
-    case restoredTab = "restored_tab"
     case contextualChat = "contextual_chat"
+    case widgetQuickActions = "widget_quick_actions"
+    case widgetQuickActionsMedium = "widget_quick_actions_medium"
+    case widgetFavorite = "widget_favorite"
+    case widgetLockScreen = "widget_lock_screen"
+    case widgetControlCenter = "widget_control_center"
+    case siri
     case deepLinkOther = "deep_link_other"
+}
+
+extension AIChatEntryPointSource {
+
+    /// Resolves the `source` parameter a Duck.ai deep link carries. Falls back to `.deepLinkOther`
+    /// for links with no recognised source, e.g. the URL scheme invoked from outside the app.
+    static func forDeepLink(_ url: URL) -> AIChatEntryPointSource {
+        guard let rawValue = url.getParameter(named: WidgetSourceType.sourceKey) else { return .deepLinkOther }
+        if let widgetSource = WidgetSourceType(rawValue: rawValue) {
+            return widgetSource.aiChatEntryPointSource
+        }
+        // `AIVoiceChatIntent` writes this one, and it is not a `WidgetSourceType`.
+        return rawValue == VoiceEntryPointSource.siri.rawValue ? .siri : .deepLinkOther
+    }
+}
+
+extension WidgetSourceType {
+
+    var aiChatEntryPointSource: AIChatEntryPointSource {
+        switch self {
+        case .quickActions: return .widgetQuickActions
+        case .quickActionsMedium: return .widgetQuickActionsMedium
+        case .favorite: return .widgetFavorite
+        case .lockscreenComplication: return .widgetLockScreen
+        case .controlCenter: return .widgetControlCenter
+        }
+    }
 }

--- a/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
@@ -1,0 +1,44 @@
+//
+//  AIChatEntryPointSource.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Where a Duck.ai entry began. Reported as `source` on `m_aichat_entry_point`;
+/// the raw values are a dashboard contract — renaming one breaks its series.
+enum AIChatEntryPointSource: String {
+    case addressBarPrompt = "address_bar_prompt"
+    case addressBarIcon = "address_bar_icon"
+    case addressBarShortcutChip = "address_bar_shortcut_chip"
+    case addressBarEditingState = "address_bar_editing_state"
+    case suggestionAskAI = "suggestion_ask_ai"
+    case ipadTogglePrompt = "ipad_toggle_prompt"
+    case browsingMenuNTP = "browsing_menu_ntp"
+    case browsingMenuWebpage = "browsing_menu_webpage"
+    case tabSwitcher = "tab_switcher"
+    case tabsBarButton = "tabs_bar_button"
+    case chatHistoryNewChat = "chat_history_new_chat"
+    case chatHistoryOpenChat = "chat_history_open_chat"
+    case voice
+    case onboarding
+    case directURL = "direct_url"
+    case iconShortcut = "icon_shortcut"
+    case restoredTab = "restored_tab"
+    case contextualChat = "contextual_chat"
+    case deepLinkOther = "deep_link_other"
+}

--- a/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
@@ -66,6 +66,7 @@ enum AIChatEntryPointSource: String {
     case voice
     case onboarding
     case directURL = "direct_url"
+    case serp
     case iconShortcut = "icon_shortcut"
     case contextualChat = "contextual_chat"
     case widgetQuickActions = "widget_quick_actions"
@@ -88,6 +89,13 @@ extension AIChatEntryPointSource {
         }
         // `AIVoiceChatIntent` writes this one, and it is not a `WidgetSourceType`.
         return rawValue == VoiceEntryPointSource.siri.rawValue ? .siri : .deepLinkOther
+    }
+
+    /// Names the page behind an `openAIChat` user-script request so it is not reported as a typed
+    /// address. `nil` for duck.ai and debug hosts, which have no entry of their own.
+    static func forFrontEndOpenRequest(messageHost: String?) -> AIChatEntryPointSource? {
+        guard let messageHost, messageHost == URL.ddg.host else { return nil }
+        return .serp
     }
 }
 

--- a/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
@@ -18,6 +18,7 @@
 //
 
 import Foundation
+import Core
 import PixelKit
 
 /// Fires as `m_aichat_entry_point`; the `m_` prefix plus the platform suffix are applied by PixelKit.
@@ -32,6 +33,22 @@ enum AIChatEntryPointPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
     var standardParameters: [PixelKitStandardParameter]? { nil }
 
     var namePrefix: String { "m_" }
+
+    /// Shared so entry paths outside `MainViewController` can report too. Prefer
+    /// `MainViewController.fireAIChatEntryPointPixel`, which also records the source for `origin`.
+    static func fire(source: AIChatEntryPointSource,
+                     duckAIEnabled: Bool,
+                     toggleEnabled: Bool,
+                     opensNewTab: Bool,
+                     hasPrompt: Bool) {
+        PixelKit.fire(AIChatEntryPointPixel.entryPoint, frequency: .dailyAndCount, withAdditionalParameters: [
+            PixelParameters.source: source.rawValue,
+            "duckai_enabled": String(duckAIEnabled),
+            "toggle_enabled": String(toggleEnabled),
+            "opens_new_tab": String(opensNewTab),
+            "has_prompt": String(hasPrompt)
+        ])
+    }
 }
 
 /// Where a Duck.ai entry began. Reported as `source` on `m_aichat_entry_point`;

--- a/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
@@ -50,8 +50,6 @@ enum AIChatEntryPointPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
     }
 }
 
-/// Where a Duck.ai entry began. Reported as `source` on `m_aichat_entry_point`; the raw values are a dashboard
-/// contract mirrored by that pixel's `source` enum in ai_chat_entry_points.json5 — renaming one breaks its series.
 enum AIChatEntryPointSource: String {
     case addressBarPrompt = "address_bar_prompt"
     case addressBarIcon = "address_bar_icon"

--- a/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
@@ -50,8 +50,8 @@ enum AIChatEntryPointPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
     }
 }
 
-/// Where a Duck.ai entry began. Reported as `source` on `m_aichat_entry_point`;
-/// the raw values are a dashboard contract — renaming one breaks its series.
+/// Where a Duck.ai entry began. Reported as `source` on `m_aichat_entry_point`; the raw values are a dashboard
+/// contract mirrored by that pixel's `source` enum in ai_chat_entry_points.json5 — renaming one breaks its series.
 enum AIChatEntryPointSource: String {
     case addressBarPrompt = "address_bar_prompt"
     case addressBarIcon = "address_bar_icon"

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/MainViewController+DuckAIAddressBarMenu.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/MainViewController+DuckAIAddressBarMenu.swift
@@ -56,6 +56,9 @@ extension MainViewController {
     func askAboutCurrentPageFromAddressBar() {
         guard let currentTab else { return }
         omniBar.endEditing()
+        // The floating input is a contextual surface that bypasses `openAIChat` and the sheet, so
+        // report the entry here; promoting it to the sheet later must not report a second one.
+        fireAIChatEntryPointPixel(source: .contextualChat, opensNewTab: false, hasPrompt: false)
         currentTab.presentContextualFloatingInput(from: self)
     }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/MainViewController+DuckAIAddressBarMenu.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/MainViewController+DuckAIAddressBarMenu.swift
@@ -101,6 +101,6 @@ extension MainViewController {
     /// a prompt whenever the field is being edited, and New Chat must always open empty.
     private func openFreshDuckAIChatFromAddressBarMenu() {
         omniBar.endEditing()
-        openAIChat()
+        openAIChat(source: .addressBarIcon)
     }
 }

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -286,7 +286,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         NotificationCenter.default.post(
             name: .urlInterceptAIChat,
             object: payload,
-            userInfo: nil
+            userInfo: [TabURLInterceptorParameter.aiChatRequestHost: message.messageHost]
         )
 
         return nil

--- a/iOS/DuckDuckGo/MainViewController+AIChatHistoryViewModelDelegate.swift
+++ b/iOS/DuckDuckGo/MainViewController+AIChatHistoryViewModelDelegate.swift
@@ -31,7 +31,7 @@ extension MainViewController: AIChatHistoryViewModelDelegate {
             }
         } else {
             dismiss(animated: true) { [weak self] in
-                self?.openAIChat()
+                self?.openAIChat(source: .chatHistoryNewChat)
             }
         }
     }

--- a/iOS/DuckDuckGo/MainViewController+DuckAIFireOnboarding.swift
+++ b/iOS/DuckDuckGo/MainViewController+DuckAIFireOnboarding.swift
@@ -272,7 +272,7 @@ extension MainViewController {
         if let tabToClose = currentTab?.tabModel {
             closeTab(tabToClose, behavior: .createEmptyTabAtSamePosition, clearTabHistory: false)
         }
-        openAIChat(query, autoSend: query.map { !$0.isEmpty } ?? false, flowType: .mobileAppOnboarding)
+        openAIChat(source: .onboarding, query, autoSend: query.map { !$0.isEmpty } ?? false, flowType: .mobileAppOnboarding)
     }
 
     func clearDuckAIWebsiteDataForResumeIfNeeded() async {
@@ -481,7 +481,7 @@ extension MainViewController {
         }
 
         setDuckAIFireControlsLocked(shouldArmDuckAIFireOnboarding)
-        openAIChat(query, autoSend: autoSend, flowType: flowType)
+        openAIChat(source: .onboarding, query, autoSend: autoSend, flowType: flowType)
     }
 
     func clearDuckAIOnboardingResumeStepIfNeeded() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3690,8 +3690,12 @@ class MainViewController: UIViewController {
 
                 // The direct-navigation pixels are not fired here: the interceptor sees every
                 // duck.ai navigation, so it cannot tell a typed address from an in-page link.
-                // An entry that already deferred to us reports under its own source, not `direct_url`.
-                let source = self?.consumeInterceptedDuckAIEntrySource() ?? .directURL
+                // An entry that already deferred to us reports under its own source, not `direct_url`;
+                // next the page that asked us to open Duck.ai; `direct_url` is only what the interceptor saw.
+                let requestHost = notification.userInfo?[TabURLInterceptorParameter.aiChatRequestHost] as? String
+                let source = self?.consumeInterceptedDuckAIEntrySource()
+                    ?? AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: requestHost)
+                    ?? .directURL
                 if let query = query {
                     self?.openAIChat(source: source, query, autoSend: shouldAutoSend, payload: payload)
                 } else {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3684,10 +3684,9 @@ class MainViewController: UIViewController {
                     query = queryItems.first(where: { $0.name == AIChatURLParameters.promptQueryName })?.value
                     shouldAutoSend = queryItems.first(where: { $0.name == AIChatURLParameters.autoSubmitPromptQueryName })?.value == AIChatURLParameters.autoSubmitPromptQueryValue
                 }
-                
-                // The interceptor is the enabled-side path for typed duck.ai URLs; the UTI path
-                // only covers disabled users, so this fire completes the direct-navigation series.
-                self?.fireDirectDuckAINavigationPixel()
+
+                // The direct-navigation pixels are not fired here: the interceptor sees every
+                // duck.ai navigation, so it cannot tell a typed address from an in-page link.
                 if let query = query {
                     self?.openAIChat(source: .directURL, query, autoSend: shouldAutoSend, payload: payload)
                 } else {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4110,6 +4110,12 @@ class MainViewController: UIViewController {
         Pixel.fire(pixel: pixel, withAdditionalParameters: pixelParameters)
     }
 
+    /// Mirrors `TabURLInterceptor`'s duck.ai condition: it cancels the navigation and
+    /// reopens Duck.ai itself, so callers must not also report that navigation.
+    var duckAINavigationIsIntercepted: Bool {
+        !(aichatFullModeFeature.isAvailable || DevicePlatform.isIpad)
+    }
+
     /// `source` has no default on purpose: the compiler enumerates every entry
     /// path, so a new Duck.ai entry point can't ship without attribution.
     func openAIChat(source: AIChatEntryPointSource,
@@ -4160,13 +4166,11 @@ class MainViewController: UIViewController {
     }
 
     func fireAIChatEntryPointPixel(source: AIChatEntryPointSource, opensNewTab: Bool, hasPrompt: Bool) {
-        PixelKit.fire(AIChatEntryPointPixel.entryPoint, frequency: .dailyAndCount, withAdditionalParameters: [
-            PixelParameters.source: source.rawValue,
-            "duckai_enabled": String(aiChatSettings.isAIChatEnabled),
-            "toggle_enabled": String(aiChatSettings.isAIChatSearchInputUserSettingsEnabled),
-            "opens_new_tab": String(opensNewTab),
-            "has_prompt": String(hasPrompt)
-        ])
+        AIChatEntryPointPixel.fire(source: source,
+                                   duckAIEnabled: aiChatSettings.isAIChatEnabled,
+                                   toggleEnabled: aiChatSettings.isAIChatSearchInputUserSettingsEnabled,
+                                   opensNewTab: opensNewTab,
+                                   hasPrompt: hasPrompt)
     }
 
     func onDuckAIVoiceModeRequested() {
@@ -4184,15 +4188,17 @@ class MainViewController: UIViewController {
 
     private func openAIChatInVoiceMode(fromDeepLink: Bool = false) {
         // Voice mode bypasses `openAIChat`, so fire the entry pixel directly.
-        fireAIChatEntryPointPixel(source: fromDeepLink ? .deepLinkOther : .voice, opensNewTab: false, hasPrompt: false)
+        let source: AIChatEntryPointSource = fromDeepLink ? .deepLinkOther : .voice
         if aichatFullModeFeature.isAvailable || DevicePlatform.isIpad {
-            openAIChatVoiceModeInTab(fromDeepLink: fromDeepLink)
+            // Fired inside, once the new-tab decision is known.
+            openAIChatVoiceModeInTab(source: source, fromDeepLink: fromDeepLink)
         } else {
+            fireAIChatEntryPointPixel(source: source, opensNewTab: false, hasPrompt: false)
             aiChatViewControllerManager.openAIChatVoiceMode(on: self)
         }
     }
 
-    private func openAIChatVoiceModeInTab(fromDeepLink: Bool = false) {
+    private func openAIChatVoiceModeInTab(source: AIChatEntryPointSource, fromDeepLink: Bool = false) {
         guard tabManager.current(createIfNeeded: true) != nil else {
             assertionFailure("openAIChatVoiceModeInTab: no current tab available")
             return
@@ -4206,6 +4212,7 @@ class MainViewController: UIViewController {
         // Voice always opens a new tab over existing content (chat included) — voice over a chat would replace the prior conversation. NTP stays in-place via `link != nil`.
         let hasContent = currentTab.tabModel.link != nil
         let openInNewTab = hasContent && (unifiedToggleInputFeature.isAvailable || fromDeepLink)
+        fireAIChatEntryPointPixel(source: source, opensNewTab: openInNewTab, hasPrompt: false)
 
         if openInNewTab {
             let voiceURL = currentTab.aiChatContentHandler.buildVoiceModeURL()
@@ -5537,13 +5544,13 @@ extension MainViewController: OmniBarDelegate {
         onAIChatPressed(prefilledText: nil)
     }
 
-    func onAIChatPressed(prefilledText: String?) {
+    func onAIChatPressed(prefilledText: String?, source: AIChatEntryPointSource = .addressBarIcon) {
         recordNewTabPageSessionAction { $0.tapDuckaiButton() }
         ViewHighlighter.hideAll()
         hideSuggestionTray()
 
         guard prefilledText == nil else {
-            openAIChatFromAddressBar(prefilledText: prefilledText)
+            openAIChatFromAddressBar(prefilledText: prefilledText, source: source)
             return
         }
 
@@ -5555,11 +5562,13 @@ extension MainViewController: OmniBarDelegate {
         case .contextualSheet:
             guard let currentTab else { return }
             omniBar.endEditing()
+            // The sheet bypasses `openAIChat`, so fire the entry pixel directly.
+            fireAIChatEntryPointPixel(source: .contextualChat, opensNewTab: false, hasPrompt: false)
             currentTab.presentContextualAIChatSheet(from: self)
         case .dismissContextualSurface:
             dismissContextualDuckAISurface()
         case .legacyDuckAI:
-            openAIChatFromAddressBar(prefilledText: nil)
+            openAIChatFromAddressBar(prefilledText: nil, source: source)
         }
     }
 
@@ -5576,7 +5585,7 @@ extension MainViewController: OmniBarDelegate {
         currentTab?.onShareAction(forLink: link, fromView: targetView)
     }
 
-    private func openAIChatFromAddressBar(prefilledText: String?) {
+    private func openAIChatFromAddressBar(prefilledText: String?, source: AIChatEntryPointSource = .addressBarIcon) {
 
         let isEditing: Bool
         let textFieldValue: String?
@@ -5594,10 +5603,10 @@ extension MainViewController: OmniBarDelegate {
             textFieldValue: textFieldValue,
             currentURL: currentTab?.url,
             openWithPromptAndSend: {
-                openAIChat(source: .addressBarIcon, $0, autoSend: true)
+                openAIChat(source: source, $0, autoSend: true)
             },
             open: {
-                openAIChat(source: .addressBarIcon)
+                openAIChat(source: source)
             }
         )
 
@@ -6560,6 +6569,8 @@ extension MainViewController: TabDelegate {
     }
 
     func tab(_ tab: TabViewController, didRequestAIChatForSelectedText text: String) {
+        // The sheet bypasses `openAIChat`, so fire the entry pixel directly.
+        fireAIChatEntryPointPixel(source: .contextualChat, opensNewTab: false, hasPrompt: true)
         Task { @MainActor in
             await tab.presentContextualAIChatSheet(withSelectedText: text, from: self)
         }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4181,13 +4181,17 @@ class MainViewController: UIViewController {
         openAIChatInVoiceMode()
     }
 
-    func openAIVoiceChatFromDeepLink() {
-        openAIChatInVoiceMode(fromDeepLink: true)
+    func openAIVoiceChatFromDeepLink(source: AIChatEntryPointSource) {
+        openAIChatInVoiceMode(deepLinkSource: source)
     }
 
-    private func openAIChatInVoiceMode(fromDeepLink: Bool = false) {
+    /// - Parameter deepLinkSource: The resolved deep-link entry, or nil when voice was started
+    ///   in-app. Reported as `source`, so a widget voice entry is attributed to the widget;
+    ///   `m_aichat_voice_entry_point_tapped` is what separates voice from text.
+    private func openAIChatInVoiceMode(deepLinkSource: AIChatEntryPointSource? = nil) {
         // Voice mode bypasses `openAIChat`, so fire the entry pixel directly.
-        let source: AIChatEntryPointSource = fromDeepLink ? .deepLinkOther : .voice
+        let source = deepLinkSource ?? .voice
+        let fromDeepLink = deepLinkSource != nil
         if aichatFullModeFeature.isAvailable || DevicePlatform.isIpad {
             // Fired inside, once the new-tab decision is known.
             openAIChatVoiceModeInTab(source: source, fromDeepLink: fromDeepLink)

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4160,7 +4160,7 @@ class MainViewController: UIViewController {
     }
 
     func fireAIChatEntryPointPixel(source: AIChatEntryPointSource, opensNewTab: Bool, hasPrompt: Bool) {
-        DailyPixel.fireDailyAndCount(pixel: .aiChatEntryPoint, withAdditionalParameters: [
+        PixelKit.fire(AIChatEntryPointPixel.entryPoint, frequency: .dailyAndCount, withAdditionalParameters: [
             PixelParameters.source: source.rawValue,
             "duckai_enabled": String(aiChatSettings.isAIChatEnabled),
             "toggle_enabled": String(aiChatSettings.isAIChatSearchInputUserSettingsEnabled),

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -209,6 +209,9 @@ class MainViewController: UIViewController {
     /// VPN connection state as the user left the New Tab Page for the VPN screen, so a toggle made
     /// there can be told apart from a reconnect that happened on its own.
     var vpnConnectedWhenLeavingNewTabPage: Bool?
+    /// The entry whose duck.ai navigation `TabURLInterceptor` is about to cancel, so the
+    /// re-entry reports that source instead of a second `direct_url`.
+    private var interceptedDuckAIEntrySource: AIChatEntryPointSource?
     let duckAIWideEventInstrumentation: DuckAIWideEventInstrumentation
     let syncAutoRestoreHandler: SyncAutoRestoreHandling
     private let lastActiveTabStore: LastActiveTabStoring
@@ -3687,10 +3690,12 @@ class MainViewController: UIViewController {
 
                 // The direct-navigation pixels are not fired here: the interceptor sees every
                 // duck.ai navigation, so it cannot tell a typed address from an in-page link.
+                // An entry that already deferred to us reports under its own source, not `direct_url`.
+                let source = self?.consumeInterceptedDuckAIEntrySource() ?? .directURL
                 if let query = query {
-                    self?.openAIChat(source: .directURL, query, autoSend: shouldAutoSend, payload: payload)
+                    self?.openAIChat(source: source, query, autoSend: shouldAutoSend, payload: payload)
                 } else {
-                    self?.openAIChat(source: .directURL, payload: payload)
+                    self?.openAIChat(source: source, payload: payload)
                 }
             }
             .store(in: &urlInterceptorCancellables)
@@ -4115,6 +4120,24 @@ class MainViewController: UIViewController {
         !(aichatFullModeFeature.isAvailable || DevicePlatform.isIpad)
     }
 
+    /// Reports an entry that is about to load a duck.ai URL itself. When `TabURLInterceptor` is
+    /// active it cancels that navigation and re-enters `openAIChat`, so defer to the interceptor
+    /// with the real source rather than reporting the same entry twice.
+    func reportDuckAIEntryForUpcomingNavigation(source: AIChatEntryPointSource, opensNewTab: Bool, hasPrompt: Bool) {
+        guard !duckAINavigationIsIntercepted else {
+            interceptedDuckAIEntrySource = source
+            return
+        }
+        fireAIChatEntryPointPixel(source: source, opensNewTab: opensNewTab, hasPrompt: hasPrompt)
+    }
+
+    /// Set only immediately before the navigation the interceptor is about to cancel, so a stale
+    /// value cannot outlive it.
+    private func consumeInterceptedDuckAIEntrySource() -> AIChatEntryPointSource? {
+        defer { interceptedDuckAIEntrySource = nil }
+        return interceptedDuckAIEntrySource
+    }
+
     /// `source` has no default on purpose: the compiler enumerates every entry
     /// path, so a new Duck.ai entry point can't ship without attribution.
     func openAIChat(source: AIChatEntryPointSource,
@@ -4127,6 +4150,7 @@ class MainViewController: UIViewController {
                     reasoningEffort: AIChatReasoningEffort? = nil,
                     images: [AIChatNativePrompt.NativePromptImage]? = nil,
                     files: [AIChatNativePrompt.NativePromptFile]? = nil,
+                    reportsNewTab: Bool? = nil,
                     fromDeepLink: Bool = false) {
 
         // A query means the user asked something and a response is what they are waiting for;
@@ -4145,10 +4169,11 @@ class MainViewController: UIViewController {
                 reasoningEffort: reasoningEffort,
                 images: images,
                 files: files,
+                reportsNewTab: reportsNewTab,
                 fromDeepLink: fromDeepLink
             )
         } else {
-            fireAIChatEntryPointPixel(source: source, opensNewTab: false, hasPrompt: query?.isEmpty == false)
+            fireAIChatEntryPointPixel(source: source, opensNewTab: reportsNewTab ?? false, hasPrompt: query?.isEmpty == false)
             aiChatViewControllerManager.openAIChat(
                 query,
                 payload: payload,
@@ -4185,9 +4210,8 @@ class MainViewController: UIViewController {
         openAIChatInVoiceMode(deepLinkSource: source)
     }
 
-    /// - Parameter deepLinkSource: The resolved deep-link entry, or nil when voice was started
-    ///   in-app. Reported as `source`, so a widget voice entry is attributed to the widget;
-    ///   `m_aichat_voice_entry_point_tapped` is what separates voice from text.
+    /// `deepLinkSource` is nil when voice was started in-app, so a widget voice entry is
+    /// attributed to the widget; `m_aichat_voice_entry_point_tapped` separates voice from text.
     private func openAIChatInVoiceMode(deepLinkSource: AIChatEntryPointSource? = nil) {
         // Voice mode bypasses `openAIChat`, so fire the entry pixel directly.
         let source = deepLinkSource ?? .voice
@@ -4255,6 +4279,7 @@ class MainViewController: UIViewController {
                                  reasoningEffort: AIChatReasoningEffort? = nil,
                                  images: [AIChatNativePrompt.NativePromptImage]? = nil,
                                  files: [AIChatNativePrompt.NativePromptFile]? = nil,
+                                 reportsNewTab: Bool? = nil,
                                  fromDeepLink: Bool = false) {
         guard tabManager.current(createIfNeeded: true) != nil else {
             assertionFailure("openAIChatInTab: no current tab available")
@@ -4272,7 +4297,11 @@ class MainViewController: UIViewController {
                 unifiedToggleInputAvailable: unifiedToggleInputFeature.isAvailable
             ) == .openInNewTab
         }()
-        fireAIChatEntryPointPixel(source: source, opensNewTab: shouldOpenInNewTab, hasPrompt: query?.isEmpty == false)
+        // `reportsNewTab` only overrides what is reported: callers that created the tab themselves
+        // land here with a blank current tab, which would otherwise read as no new tab.
+        fireAIChatEntryPointPixel(source: source,
+                                  opensNewTab: reportsNewTab ?? shouldOpenInNewTab,
+                                  hasPrompt: query?.isEmpty == false)
         if shouldOpenInNewTab, let currentTab {
             // Dismiss contextual onboarding before opening duck.ai via UTI.
             currentTab.contextualOnboardingPresenter.dismissContextualOnboardingIfNeeded(from: currentTab)
@@ -4866,7 +4895,7 @@ extension MainViewController: OmniBarDelegate {
             targetIsAI: true,
             unifiedToggleInputAvailable: unifiedToggleInputFeature.isAvailable
         ) == .openInNewTab
-        fireAIChatEntryPointPixel(source: .chatHistoryOpenChat, opensNewTab: opensNewTab, hasPrompt: false)
+        reportDuckAIEntryForUpcomingNavigation(source: .chatHistoryOpenChat, opensNewTab: opensNewTab, hasPrompt: false)
         // Route through boundary helper so NTP transforms in-place; web→chat spawns a new tab; chat→chat stays. Matches `onPromptSubmitted`.
         loadUrlRespectingAIBoundary(url)
     }
@@ -6566,9 +6595,19 @@ extension MainViewController: TabDelegate {
         fireAIChatUsagePixelAndSetFeatureUsed(tab.link == nil ? .browsingMenuAIChatNewTabPage : .browsingMenuAIChatWebPage)
         let source: AIChatEntryPointSource = tab.link == nil ? .browsingMenuNTP : .browsingMenuWebpage
         if DevicePlatform.isIpad {
+            // The tab is created here, so `openAIChatInTab` would see it blank and report no new tab.
             newTab(allowingKeyboard: false, startsNewTabPageSessionVisit: false)
+            openAIChat(source: source, reportsNewTab: true)
+            return
         }
         openAIChat(source: source)
+    }
+
+    func tabDidRequestNewAIChatTab(tab: TabViewController) {
+        reportDuckAIEntryForUpcomingNavigation(source: tab.link == nil ? .browsingMenuNTP : .browsingMenuWebpage,
+                                               opensNewTab: true,
+                                               hasPrompt: false)
+        tab.openNewChatInNewTab()
     }
 
     func tab(_ tab: TabViewController, didRequestAIChatForSelectedText text: String) {
@@ -7012,8 +7051,9 @@ extension MainViewController: TabSwitcherDelegate {
 
     func tabSwitcherDidRequestAIChatTab(tabSwitcher: TabSwitcherViewController) {
         fireAIChatUsagePixelAndSetFeatureUsed(.openAIChatFromTabManager)
+        // The tab is created here, so `openAIChatInTab` would see it blank and report no new tab.
         newTab(allowingKeyboard: false)
-        openAIChat(source: .tabSwitcher)
+        openAIChat(source: .tabSwitcher, reportsNewTab: true)
     }
 
     private func tabSwitcherNewTabWithAnimation() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3685,10 +3685,13 @@ class MainViewController: UIViewController {
                     shouldAutoSend = queryItems.first(where: { $0.name == AIChatURLParameters.autoSubmitPromptQueryName })?.value == AIChatURLParameters.autoSubmitPromptQueryValue
                 }
                 
+                // The interceptor is the enabled-side path for typed duck.ai URLs; the UTI path
+                // only covers disabled users, so this fire completes the direct-navigation series.
+                self?.fireDirectDuckAINavigationPixel()
                 if let query = query {
-                    self?.openAIChat(query, autoSend: shouldAutoSend, payload: payload)
+                    self?.openAIChat(source: .directURL, query, autoSend: shouldAutoSend, payload: payload)
                 } else {
-                    self?.openAIChat(payload: payload)
+                    self?.openAIChat(source: .directURL, payload: payload)
                 }
             }
             .store(in: &urlInterceptorCancellables)
@@ -4107,7 +4110,10 @@ class MainViewController: UIViewController {
         Pixel.fire(pixel: pixel, withAdditionalParameters: pixelParameters)
     }
 
-    func openAIChat(_ query: String? = nil,
+    /// `source` has no default on purpose: the compiler enumerates every entry
+    /// path, so a new Duck.ai entry point can't ship without attribution.
+    func openAIChat(source: AIChatEntryPointSource,
+                    _ query: String? = nil,
                     autoSend: Bool = false,
                     payload: Any? = nil,
                     flowType: AIChatOnboardingFlowType = .default,
@@ -4124,6 +4130,7 @@ class MainViewController: UIViewController {
 
         if aichatFullModeFeature.isAvailable || DevicePlatform.isIpad {
             openAIChatInTab(
+                source: source,
                 query,
                 autoSend: autoSend,
                 payload: payload,
@@ -4136,6 +4143,7 @@ class MainViewController: UIViewController {
                 fromDeepLink: fromDeepLink
             )
         } else {
+            fireAIChatEntryPointPixel(source: source, opensNewTab: false, hasPrompt: query?.isEmpty == false)
             aiChatViewControllerManager.openAIChat(
                 query,
                 payload: payload,
@@ -4149,6 +4157,16 @@ class MainViewController: UIViewController {
                 on: self
             )
         }
+    }
+
+    func fireAIChatEntryPointPixel(source: AIChatEntryPointSource, opensNewTab: Bool, hasPrompt: Bool) {
+        DailyPixel.fireDailyAndCount(pixel: .aiChatEntryPoint, withAdditionalParameters: [
+            PixelParameters.source: source.rawValue,
+            "duckai_enabled": String(aiChatSettings.isAIChatEnabled),
+            "toggle_enabled": String(aiChatSettings.isAIChatSearchInputUserSettingsEnabled),
+            "opens_new_tab": String(opensNewTab),
+            "has_prompt": String(hasPrompt)
+        ])
     }
 
     func onDuckAIVoiceModeRequested() {
@@ -4165,6 +4183,8 @@ class MainViewController: UIViewController {
     }
 
     private func openAIChatInVoiceMode(fromDeepLink: Bool = false) {
+        // Voice mode bypasses `openAIChat`, so fire the entry pixel directly.
+        fireAIChatEntryPointPixel(source: fromDeepLink ? .deepLinkOther : .voice, opensNewTab: false, hasPrompt: false)
         if aichatFullModeFeature.isAvailable || DevicePlatform.isIpad {
             openAIChatVoiceModeInTab(fromDeepLink: fromDeepLink)
         } else {
@@ -4215,7 +4235,8 @@ class MainViewController: UIViewController {
     ///   - tools: Optional RAG tools available in AI Chat
     ///   - modelId: Optional model ID to use for AI Chat
     ///   - images: Optional images to send to AI Chat
-    private func openAIChatInTab(_ query: String? = nil,
+    private func openAIChatInTab(source: AIChatEntryPointSource,
+                                 _ query: String? = nil,
                                  autoSend: Bool = false,
                                  payload: Any? = nil,
                                  flowType: AIChatOnboardingFlowType = .default,
@@ -4241,6 +4262,7 @@ class MainViewController: UIViewController {
                 unifiedToggleInputAvailable: unifiedToggleInputFeature.isAvailable
             ) == .openInNewTab
         }()
+        fireAIChatEntryPointPixel(source: source, opensNewTab: shouldOpenInNewTab, hasPrompt: query?.isEmpty == false)
         if shouldOpenInNewTab, let currentTab {
             // Dismiss contextual onboarding before opening duck.ai via UTI.
             currentTab.contextualOnboardingPresenter.dismissContextualOnboardingIfNeeded(from: currentTab)
@@ -4782,7 +4804,7 @@ extension MainViewController: BrowserChromeDelegate {
             // We intentionally don't forward the resolved model config: the suggestion is offered
             // from Search mode where the model chip is hidden and the user hasn't chosen a model.
             _ = unifiedToggleInputCoordinator?.prepareExternalPromptSubmission()
-            openAIChat(value, autoSend: true)
+            openAIChat(source: .suggestionAskAI, value, autoSend: true)
 
         case .unknown(value: let value), .internalPage(title: let value, url: _, _):
             assertionFailure("Unknown suggestion: \(value)")
@@ -4816,7 +4838,7 @@ extension MainViewController: OmniBarDelegate {
         recordNewTabPageSessionAction { $0.hitSubmit() }
 
         let controlValues = viewCoordinator.omniBar.iPadDuckAIControlValues
-        openAIChat(query, autoSend: true, tools: tools ?? controlValues.selectedTools,
+        openAIChat(source: .ipadTogglePrompt, query, autoSend: true, tools: tools ?? controlValues.selectedTools,
                    modelId: controlValues.selectedModelId,
                    reasoningEffort: controlValues.selectedReasoningEffort,
                    images: controlValues.selectedImages,
@@ -4826,6 +4848,15 @@ extension MainViewController: OmniBarDelegate {
     func onChatHistorySelected(url: URL) {
         postIdleSessionInstrumentation.sessionEnded(reason: .chatSelected)
         newTabPageSessionInstrumentation.visitEnded(terminalAction: .loadPreviousChat)
+
+        // Bypasses `openAIChat` (routes via the boundary helper), so fire the entry pixel directly.
+        let opensNewTab = AIBoundaryNavigationDecision.forProgrammaticNavigation(
+            currentIsAI: currentTab?.isAITab == true,
+            currentHasContent: currentTab?.tabModel.link != nil,
+            targetIsAI: true,
+            unifiedToggleInputAvailable: unifiedToggleInputFeature.isAvailable
+        ) == .openInNewTab
+        fireAIChatEntryPointPixel(source: .chatHistoryOpenChat, opensNewTab: opensNewTab, hasPrompt: false)
         // Route through boundary helper so NTP transforms in-place; web→chat spawns a new tab; chat→chat stays. Matches `onPromptSubmitted`.
         loadUrlRespectingAIBoundary(url)
     }
@@ -5563,10 +5594,10 @@ extension MainViewController: OmniBarDelegate {
             textFieldValue: textFieldValue,
             currentURL: currentTab?.url,
             openWithPromptAndSend: {
-                openAIChat($0, autoSend: true)
+                openAIChat(source: .addressBarIcon, $0, autoSend: true)
             },
             open: {
-                openAIChat()
+                openAIChat(source: .addressBarIcon)
             }
         )
 
@@ -6521,10 +6552,11 @@ extension MainViewController: TabDelegate {
 
     func tabDidRequestAIChat(tab: TabViewController) {
         fireAIChatUsagePixelAndSetFeatureUsed(tab.link == nil ? .browsingMenuAIChatNewTabPage : .browsingMenuAIChatWebPage)
+        let source: AIChatEntryPointSource = tab.link == nil ? .browsingMenuNTP : .browsingMenuWebpage
         if DevicePlatform.isIpad {
             newTab(allowingKeyboard: false, startsNewTabPageSessionVisit: false)
         }
-        openAIChat()
+        openAIChat(source: source)
     }
 
     func tab(_ tab: TabViewController, didRequestAIChatForSelectedText text: String) {
@@ -6959,13 +6991,15 @@ extension MainViewController: TabSwitcherDelegate {
 
     func tabSwitcherDidRequestAIChat(tabSwitcher: TabSwitcherViewController) {
         fireAIChatUsagePixelAndSetFeatureUsed(.openAIChatFromTabManager)
+        // Bypasses `openAIChat` (presents on the switcher), so fire the entry pixel directly.
+        fireAIChatEntryPointPixel(source: .tabSwitcher, opensNewTab: false, hasPrompt: false)
         self.aiChatViewControllerManager.openAIChat(on: tabSwitcher)
     }
-    
+
     func tabSwitcherDidRequestAIChatTab(tabSwitcher: TabSwitcherViewController) {
         fireAIChatUsagePixelAndSetFeatureUsed(.openAIChatFromTabManager)
         newTab(allowingKeyboard: false)
-        openAIChat()
+        openAIChat(source: .tabSwitcher)
     }
 
     private func tabSwitcherNewTabWithAnimation() {
@@ -7709,7 +7743,7 @@ extension MainViewController: VoiceSearchViewControllerDelegate {
                 coordinator.submitVoicePrompt(query)
             } else {
                 performCancel()
-                openAIChat(query, autoSend: true)
+                openAIChat(source: .voice, query, autoSend: true)
             }
         }
     }

--- a/iOS/DuckDuckGo/Subscription/Onboarding/Features/DuckAI/SubscriptionOnboardingDuckAIChatLauncher.swift
+++ b/iOS/DuckDuckGo/Subscription/Onboarding/Features/DuckAI/SubscriptionOnboardingDuckAIChatLauncher.swift
@@ -29,7 +29,7 @@ struct SubscriptionOnboardingDuckAIChatLauncher {
             return
         }
         mainViewController.dismiss(animated: true) {
-            mainViewController.openAIChat(flowType: .mobileAppOnboarding, modelId: modelID)
+            mainViewController.openAIChat(source: .onboarding, flowType: .mobileAppOnboarding, modelId: modelID)
         }
     }
 }

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -102,6 +102,10 @@ protocol TabDelegate: AnyObject {
 
     func tabDidRequestAIChat(tab: TabViewController)
 
+    /// Called for the browsing menu's new-chat entries, which load a duck.ai URL in a new tab.
+    /// Routed through the delegate so the entry pixel is reported alongside the interceptor state.
+    func tabDidRequestNewAIChatTab(tab: TabViewController)
+
     /// Called when the user picks Ask Duck.ai from the web view's text-selection edit menu.
     func tab(_ tab: TabViewController, didRequestAIChatForSelectedText text: String)
 

--- a/iOS/DuckDuckGo/TabURLInterceptor.swift
+++ b/iOS/DuckDuckGo/TabURLInterceptor.swift
@@ -137,4 +137,7 @@ extension NSNotification.Name {
 public enum TabURLInterceptorParameter {
     public static let interceptedURLComponents = "interceptedURLComponents"
     public static let interceptedURL = "interceptedURL"
+    /// Set only by the front-end `openAIChat` message, never by the interceptor: the page that asked
+    /// native to open Duck.ai, so its entry is attributed to that page rather than to a typed address.
+    public static let aiChatRequestHost = "aiChatRequestHost"
 }

--- a/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
@@ -555,6 +555,7 @@ extension TabViewController {
                  action: { [weak self] in
             DailyPixel.fireDailyAndCount(pixel: .aiChatSettingsMenuNewChatTabTapped)
             Pixel.fire(pixel: .browsingMenuAIChat)
+            self?.fireAIChatEntryPointPixelForMenu()
             self?.openNewChatInNewTab()
         })
     }
@@ -568,8 +569,19 @@ extension TabViewController {
                  action: { [weak self] in
             DailyPixel.fireDailyAndCount(pixel: .aiChatSettingsMenuNewChatTabTapped)
             Pixel.fire(pixel: .browsingMenuAIChat)
+            self?.fireAIChatEntryPointPixelForMenu()
             self?.openNewChatInNewTab()
         })
+    }
+
+    /// `openNewChatInNewTab` loads a URL directly instead of going through
+    /// `openAIChat(source:)`, so the entry pixel has to be fired here.
+    private func fireAIChatEntryPointPixelForMenu() {
+        AIChatEntryPointPixel.fire(source: link == nil ? .browsingMenuNTP : .browsingMenuWebpage,
+                                   duckAIEnabled: aiChatSettings.isAIChatEnabled,
+                                   toggleEnabled: aiChatSettings.isAIChatSearchInputUserSettingsEnabled,
+                                   opensNewTab: true,
+                                   hasPrompt: false)
     }
 
     private func buildDuckAiChatsEntry(withSmallIcon smallIcon: Bool = true) -> BrowsingMenuEntry {

--- a/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
@@ -555,8 +555,7 @@ extension TabViewController {
                  action: { [weak self] in
             DailyPixel.fireDailyAndCount(pixel: .aiChatSettingsMenuNewChatTabTapped)
             Pixel.fire(pixel: .browsingMenuAIChat)
-            self?.fireAIChatEntryPointPixelForMenu()
-            self?.openNewChatInNewTab()
+            self?.requestNewAIChatTabFromMenu()
         })
     }
 
@@ -569,19 +568,14 @@ extension TabViewController {
                  action: { [weak self] in
             DailyPixel.fireDailyAndCount(pixel: .aiChatSettingsMenuNewChatTabTapped)
             Pixel.fire(pixel: .browsingMenuAIChat)
-            self?.fireAIChatEntryPointPixelForMenu()
-            self?.openNewChatInNewTab()
+            self?.requestNewAIChatTabFromMenu()
         })
     }
 
-    /// `openNewChatInNewTab` loads a URL directly instead of going through
-    /// `openAIChat(source:)`, so the entry pixel has to be fired here.
-    private func fireAIChatEntryPointPixelForMenu() {
-        AIChatEntryPointPixel.fire(source: link == nil ? .browsingMenuNTP : .browsingMenuWebpage,
-                                   duckAIEnabled: aiChatSettings.isAIChatEnabled,
-                                   toggleEnabled: aiChatSettings.isAIChatSearchInputUserSettingsEnabled,
-                                   opensNewTab: true,
-                                   hasPrompt: false)
+    /// The delegate reports the entry, because `TabURLInterceptor` may cancel this navigation
+    /// and re-enter `openAIChat`, which would otherwise report the same entry a second time.
+    private func requestNewAIChatTabFromMenu() {
+        delegate?.tabDidRequestNewAIChatTab(tab: self)
     }
 
     private func buildDuckAiChatsEntry(withSmallIcon smallIcon: Bool = true) -> BrowsingMenuEntry {

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -999,6 +999,8 @@ extension MainViewController: TabsBarDelegate {
         } else {
             // Route through TabViewController so the cold-restore `contextualChatURL`
             // is honored — presenting the coordinator directly would skip it and open a blank chat.
+            // The sheet bypasses `openAIChat`, so fire the entry pixel directly.
+            fireAIChatEntryPointPixel(source: .contextualChat, opensNewTab: false, hasPrompt: false)
             currentTab.presentContextualAIChatSheet(from: self)
         }
     }

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -978,9 +978,11 @@ extension MainViewController: TabsBarDelegate {
     func tabsBarDidRequestAIChat(_ controller: TabsBarViewController) {
         // Chrome button always opens Duck.ai in a new tab unless current tab is blank — matches macOS.
         if let currentTab, currentTab.tabModel.link != nil {
+            // Bypasses `openAIChat`, so fire the entry pixel directly.
+            fireAIChatEntryPointPixel(source: .tabsBarButton, opensNewTab: true, hasPrompt: false)
             currentTab.openNewChatInNewTab()
         } else {
-            openAIChat()
+            openAIChat(source: .tabsBarButton)
         }
     }
 

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -823,7 +823,7 @@ extension MainCoordinator: URLHandling {
           controller.clearNavigationStack()
           // Give the `clearNavigationStack` call time to complete.
           DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
-              self.controller.openAIChat()
+              self.controller.openAIChat(source: .iconShortcut)
           }
           Pixel.fire(pixel: .openAIChatFromIconShortcut)
       }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1188,18 +1188,30 @@ extension MainViewController {
         loadQuery(query)
     }
 
-    /// Fires when the user reaches Duck.ai by typing its address into the UTI, regardless of the
-    /// Duck.ai setting; `duckai_enabled=false` isolates residual demand among users who turned it
-    /// off. Mirrors `loadQuery`'s URL resolution so detection matches what actually gets navigated.
-    /// Skipped when `TabURLInterceptor` will cancel the navigation and report from there instead,
-    /// which would otherwise count one submission twice.
+    /// Reports a typed duck.ai address submitted through the UTI. This is the only place a typed
+    /// address can be told apart from an in-page link or deep link to Duck.ai, and it runs whether
+    /// or not `TabURLInterceptor` goes on to cancel the navigation. Mirrors `loadQuery`'s URL
+    /// resolution so detection matches what actually gets navigated.
     private func fireDirectDuckAINavigationPixelIfNeeded(for query: String) {
-        guard !duckAINavigationIsIntercepted else { return }
         guard let url = URL.makeSearchURL(query: query,
                                           useUnifiedLogic: isUnifiedURLPredictionEnabled,
                                           queryContext: currentTab?.url),
               url.isDuckAIURL else { return }
-        fireDirectDuckAINavigationPixel()
+
+        DailyPixel.fireDailyAndCount(pixel: .aiChatDuckAIDirectNavigation, withAdditionalParameters: [
+            "duckai_enabled": String(aiChatSettings.isAIChatEnabled),
+            "toggle_enabled": String(aiChatSettings.isAIChatSearchInputUserSettingsEnabled)
+        ])
+
+        // Superseded by the pixel above, kept firing on its original condition so its series stays
+        // comparable. Disabling Duck.ai also forces the toggle off, so this check is sufficient.
+        if !aiChatSettings.isAIChatEnabled {
+            DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputDuckAIDirectNavigation)
+        }
+
+        // Skipped when `TabURLInterceptor` cancels the navigation and reports the entry from there,
+        // which would otherwise attribute one submission twice.
+        guard !duckAINavigationIsIntercepted else { return }
         // `loadQuery` loads duck.ai in-tab without going through `openAIChat`, so this is the
         // only place the `direct_url` entry can be reported when the interceptor does not run.
         let decision = AIBoundaryNavigationDecision.forProgrammaticNavigation(
@@ -1211,13 +1223,6 @@ extension MainViewController {
         fireAIChatEntryPointPixel(source: .directURL,
                                   opensNewTab: decision == .openInNewTab,
                                   hasPrompt: false)
-    }
-
-    func fireDirectDuckAINavigationPixel() {
-        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputDuckAIDirectNavigation, withAdditionalParameters: [
-            "duckai_enabled": String(aiChatSettings.isAIChatEnabled),
-            "toggle_enabled": String(aiChatSettings.isAIChatSearchInputUserSettingsEnabled)
-        ])
     }
 
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1201,8 +1201,6 @@ extension MainViewController {
             "toggle_enabled": String(aiChatSettings.isAIChatSearchInputUserSettingsEnabled)
         ])
 
-        // Superseded by the pixel above, kept firing on its original condition so its series stays
-        // comparable. Disabling Duck.ai also forces the toggle off, so this check is sufficient.
         if !aiChatSettings.isAIChatEnabled {
             DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputDuckAIDirectNavigation)
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1188,10 +1188,8 @@ extension MainViewController {
         loadQuery(query)
     }
 
-    /// Reports a typed duck.ai address submitted through the UTI. This is the only place a typed
-    /// address can be told apart from an in-page link or deep link to Duck.ai, and it runs whether
-    /// or not `TabURLInterceptor` goes on to cancel the navigation. Mirrors `loadQuery`'s URL
-    /// resolution so detection matches what actually gets navigated.
+    /// The only place a typed duck.ai address can be told apart from an in-page or deep link.
+    /// Mirrors `loadQuery`'s URL resolution so detection matches what gets navigated.
     private func fireDirectDuckAINavigationPixelIfNeeded(for query: String) {
         guard let url = URL.makeSearchURL(query: query,
                                           useUnifiedLogic: isUnifiedURLPredictionEnabled,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1191,12 +1191,26 @@ extension MainViewController {
     /// Fires when the user reaches Duck.ai by typing its address into the UTI, regardless of the
     /// Duck.ai setting; `duckai_enabled=false` isolates residual demand among users who turned it
     /// off. Mirrors `loadQuery`'s URL resolution so detection matches what actually gets navigated.
+    /// Skipped when `TabURLInterceptor` will cancel the navigation and report from there instead,
+    /// which would otherwise count one submission twice.
     private func fireDirectDuckAINavigationPixelIfNeeded(for query: String) {
+        guard !duckAINavigationIsIntercepted else { return }
         guard let url = URL.makeSearchURL(query: query,
                                           useUnifiedLogic: isUnifiedURLPredictionEnabled,
                                           queryContext: currentTab?.url),
               url.isDuckAIURL else { return }
         fireDirectDuckAINavigationPixel()
+        // `loadQuery` loads duck.ai in-tab without going through `openAIChat`, so this is the
+        // only place the `direct_url` entry can be reported when the interceptor does not run.
+        let decision = AIBoundaryNavigationDecision.forProgrammaticNavigation(
+            currentIsAI: currentTab?.isAITab == true,
+            currentHasContent: currentTab?.tabModel.link != nil,
+            targetIsAI: true,
+            unifiedToggleInputAvailable: unifiedToggleInputFeature.isAvailable
+        )
+        fireAIChatEntryPointPixel(source: .directURL,
+                                  opensNewTab: decision == .openInNewTab,
+                                  hasPrompt: false)
     }
 
     func fireDirectDuckAINavigationPixel() {
@@ -1311,7 +1325,7 @@ extension MainViewController: UnifiedToggleInputDelegate {
             }
             return
         }
-        onAIChatPressed(prefilledText: prompt)
+        onAIChatPressed(prefilledText: prompt, source: .addressBarShortcutChip)
     }
 
     func unifiedToggleInputDidChangeHeight() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1188,18 +1188,22 @@ extension MainViewController {
         loadQuery(query)
     }
 
-    /// Fires when Duck.ai is disabled under AI Features settings yet the user still reaches Duck.ai by
-    /// typing its address into the UTI. Counts those direct navigations to gauge residual Duck.ai
-    /// demand among users who have turned it off. (Disabling Duck.ai also forces the Search↔Duck.ai
-    /// toggle off, so the `isAIChatEnabled` check is sufficient.) Mirrors `loadQuery`'s URL resolution
-    /// so detection matches what actually gets navigated.
+    /// Fires when the user reaches Duck.ai by typing its address into the UTI, regardless of the
+    /// Duck.ai setting; `duckai_enabled=false` isolates residual demand among users who turned it
+    /// off. Mirrors `loadQuery`'s URL resolution so detection matches what actually gets navigated.
     private func fireDirectDuckAINavigationPixelIfNeeded(for query: String) {
-        guard !aiChatSettings.isAIChatEnabled,
-              let url = URL.makeSearchURL(query: query,
+        guard let url = URL.makeSearchURL(query: query,
                                           useUnifiedLogic: isUnifiedURLPredictionEnabled,
                                           queryContext: currentTab?.url),
               url.isDuckAIURL else { return }
-        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputDuckAIDirectNavigation)
+        fireDirectDuckAINavigationPixel()
+    }
+
+    func fireDirectDuckAINavigationPixel() {
+        DailyPixel.fireDailyAndCount(pixel: .unifiedToggleInputDuckAIDirectNavigation, withAdditionalParameters: [
+            "duckai_enabled": String(aiChatSettings.isAIChatEnabled),
+            "toggle_enabled": String(aiChatSettings.isAIChatSearchInputUserSettingsEnabled)
+        ])
     }
 
 }
@@ -1265,7 +1269,7 @@ extension MainViewController: UnifiedToggleInputDelegate {
             loadUrlRespectingAIBoundary(url)
             return
         }
-        openAIChat(prompt, autoSend: true, tools: tools, modelId: modelId, reasoningEffort: reasoningEffort, images: images, files: files)
+        openAIChat(source: .addressBarPrompt, prompt, autoSend: true, tools: tools, modelId: modelId, reasoningEffort: reasoningEffort, images: images, files: files)
     }
 
     func unifiedToggleInputDidSubmitQuery(_ query: String) {
@@ -1301,9 +1305,9 @@ extension MainViewController: UnifiedToggleInputDelegate {
         // This opens the chip handoff in a fresh chat tab and avoids the contextual-sheet branch in onAIChatPressed.
         if currentTab?.isAITab == true {
             if prompt.isEmpty {
-                openAIChat()
+                openAIChat(source: .addressBarShortcutChip)
             } else {
-                openAIChat(prompt, autoSend: true)
+                openAIChat(source: .addressBarShortcutChip, prompt, autoSend: true)
             }
             return
         }
@@ -1355,6 +1359,7 @@ extension MainViewController: UnifiedInputContentContainerViewControllerDelegate
         unifiedToggleInputCoordinator?.clearText()
         unifiedToggleInputCoordinator?.handleExternalSubmission(.prompt)
         openAIChat(
+            source: .addressBarEditingState,
             query,
             autoSend: true,
             tools: tools,

--- a/iOS/DuckDuckGoTests/AIChatEntryPointSourceTests.swift
+++ b/iOS/DuckDuckGoTests/AIChatEntryPointSourceTests.swift
@@ -69,6 +69,21 @@ struct AIChatEntryPointSourceTests {
         #expect(AIChatEntryPointSource.forDeepLink(deepLink(source: "widget.something.new")) == .deepLinkOther)
     }
 
+    @available(iOS 16, *)
+    @Test("A front-end open request from the search results page resolves to serp", .timeLimit(.minutes(1)))
+    func serpOpenRequestResolves() {
+        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: URL.ddg.host) == .serp)
+    }
+
+    /// Returning nil leaves the caller's own fallback in place rather than mislabelling the entry.
+    @available(iOS 16, *)
+    @Test("Other hosts have no front-end open request source", .timeLimit(.minutes(1)))
+    func otherHostsResolveToNil() {
+        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: URL.duckAi.host) == nil)
+        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: "localhost:8080") == nil)
+        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: nil) == nil)
+    }
+
     /// The raw values are a dashboard contract: renaming one silently breaks its series.
     @available(iOS 16, *)
     @Test("Entry point raw values are stable", .timeLimit(.minutes(1)))
@@ -80,5 +95,7 @@ struct AIChatEntryPointSourceTests {
         #expect(AIChatEntryPointSource.widgetControlCenter.rawValue == "widget_control_center")
         #expect(AIChatEntryPointSource.siri.rawValue == "siri")
         #expect(AIChatEntryPointSource.deepLinkOther.rawValue == "deep_link_other")
+        #expect(AIChatEntryPointSource.serp.rawValue == "serp")
+        #expect(AIChatEntryPointSource.directURL.rawValue == "direct_url")
     }
 }

--- a/iOS/DuckDuckGoTests/AIChatEntryPointSourceTests.swift
+++ b/iOS/DuckDuckGoTests/AIChatEntryPointSourceTests.swift
@@ -1,0 +1,84 @@
+//
+//  AIChatEntryPointSourceTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Testing
+@testable import Core
+@testable import DuckDuckGo
+
+@Suite("AI Chat Entry Point Source")
+struct AIChatEntryPointSourceTests {
+
+    private func deepLink(source: String?) -> URL {
+        let url = AppDeepLinkSchemes.openAIChat.url
+        guard let source else { return url }
+        return url.appendingParameter(name: WidgetSourceType.sourceKey, value: source)
+    }
+
+    @available(iOS 16, *)
+    @Test("Every widget source resolves to its own entry point", .timeLimit(.minutes(1)))
+    func widgetSourcesResolve() {
+        let expected: [WidgetSourceType: AIChatEntryPointSource] = [
+            .quickActions: .widgetQuickActions,
+            .quickActionsMedium: .widgetQuickActionsMedium,
+            .favorite: .widgetFavorite,
+            .lockscreenComplication: .widgetLockScreen,
+            .controlCenter: .widgetControlCenter
+        ]
+
+        for (widgetSource, entryPoint) in expected {
+            #expect(AIChatEntryPointSource.forDeepLink(deepLink(source: widgetSource.rawValue)) == entryPoint)
+        }
+    }
+
+    /// `AIVoiceChatIntent` writes this source and it is not a `WidgetSourceType`, so it needs
+    /// its own branch or Siri chats fall into the unattributed bucket.
+    @available(iOS 16, *)
+    @Test("Siri shortcut resolves to siri", .timeLimit(.minutes(1)))
+    func siriSourceResolves() {
+        let url = AppDeepLinkSchemes.openAIVoiceChat.url
+            .appendingParameter(name: WidgetSourceType.sourceKey, value: VoiceEntryPointSource.siri.rawValue)
+
+        #expect(AIChatEntryPointSource.forDeepLink(url) == .siri)
+    }
+
+    @available(iOS 16, *)
+    @Test("A deep link with no source falls back to deep_link_other", .timeLimit(.minutes(1)))
+    func missingSourceFallsBack() {
+        #expect(AIChatEntryPointSource.forDeepLink(deepLink(source: nil)) == .deepLinkOther)
+    }
+
+    @available(iOS 16, *)
+    @Test("An unrecognised source falls back to deep_link_other", .timeLimit(.minutes(1)))
+    func unknownSourceFallsBack() {
+        #expect(AIChatEntryPointSource.forDeepLink(deepLink(source: "widget.something.new")) == .deepLinkOther)
+    }
+
+    /// The raw values are a dashboard contract: renaming one silently breaks its series.
+    @available(iOS 16, *)
+    @Test("Entry point raw values are stable", .timeLimit(.minutes(1)))
+    func rawValues() {
+        #expect(AIChatEntryPointSource.widgetQuickActions.rawValue == "widget_quick_actions")
+        #expect(AIChatEntryPointSource.widgetQuickActionsMedium.rawValue == "widget_quick_actions_medium")
+        #expect(AIChatEntryPointSource.widgetFavorite.rawValue == "widget_favorite")
+        #expect(AIChatEntryPointSource.widgetLockScreen.rawValue == "widget_lock_screen")
+        #expect(AIChatEntryPointSource.widgetControlCenter.rawValue == "widget_control_center")
+        #expect(AIChatEntryPointSource.siri.rawValue == "siri")
+        #expect(AIChatEntryPointSource.deepLinkOther.rawValue == "deep_link_other")
+    }
+}

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
@@ -33,5 +33,24 @@
                 "type": "boolean"
             }
         ]
+    },
+    "m_aichat_duck_ai_direct_navigation": {
+        "description": "Fires when the user reaches Duck.ai by typing its address into the address bar and submitting, for all users rather than only those who turned Duck.ai off. duckai_enabled=false isolates residual demand among users who disabled it, which is the population the superseded m_aichat_unified_input_duck_ai_direct_navigation reports on; that pixel keeps firing unchanged so its series stays comparable. Does not fire for the in-input Duck.ai shortcut button or other Duck.ai entry points, and not for in-page links or deep links to Duck.ai — only a typed address counts.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "duckai_enabled",
+                "description": "Whether Duck.ai is enabled under AI Features settings: true or false",
+                "type": "boolean"
+            },
+            {
+                "key": "toggle_enabled",
+                "description": "Whether the Search/Duck.ai toggle user setting is enabled: true or false",
+                "type": "boolean"
+            }
+        ]
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
@@ -4,7 +4,7 @@
         "description": "Fires when the user enters Duck.ai, with the entry path as a source param. Threaded through openAIChat(source:) with no default so the compiler enumerates every call site; the per-surface legacy pixels remain as a rollout cross-check.",
         "owners": ["fbunn"],
         "triggers": ["other"],
-        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "suffixes": ["platform", "form_factor", "first_daily_count"],
         "parameters": [
             "appVersion",
             {

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
@@ -9,7 +9,7 @@
             "appVersion",
             {
                 "key": "source",
-                "description": "The entry path: address_bar_prompt, address_bar_icon, address_bar_shortcut_chip, address_bar_editing_state, suggestion_ask_ai, ipad_toggle_prompt, browsing_menu_ntp, browsing_menu_webpage, tab_switcher, tabs_bar_button, chat_history_new_chat, chat_history_open_chat, voice, onboarding, direct_url, icon_shortcut, restored_tab, contextual_chat, deep_link_other",
+                "description": "The entry path: address_bar_prompt, address_bar_icon, address_bar_shortcut_chip, address_bar_editing_state, suggestion_ask_ai, ipad_toggle_prompt, browsing_menu_ntp, browsing_menu_webpage, tab_switcher, tabs_bar_button, chat_history_new_chat, chat_history_open_chat, voice, onboarding, direct_url, icon_shortcut, contextual_chat, widget_quick_actions, widget_quick_actions_medium, widget_favorite, widget_lock_screen, widget_control_center, siri, deep_link_other. The widget_* and siri values also cover a voice deep link started from there, since the entry point is the widget or the Siri shortcut; m_aichat_voice_entry_point_tapped is what separates voice from text. deep_link_other is a Duck.ai deep link carrying no recognised source, e.g. the URL scheme invoked from outside the app. contextual_chat conflates the sheet's openers (address-bar icon, shortcut chip, tabs-bar button, text-selection menu), so it is not a substitute for those values. Resuming an already-open or restored Duck.ai tab is not an entry and does not fire.",
                 "type": "string"
             },
             {

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
@@ -9,8 +9,34 @@
             "appVersion",
             {
                 "key": "source",
-                "description": "The entry path: address_bar_prompt, address_bar_icon, address_bar_shortcut_chip, address_bar_editing_state, suggestion_ask_ai, ipad_toggle_prompt, browsing_menu_ntp, browsing_menu_webpage, tab_switcher, tabs_bar_button, chat_history_new_chat, chat_history_open_chat, voice, onboarding, direct_url, icon_shortcut, contextual_chat, widget_quick_actions, widget_quick_actions_medium, widget_favorite, widget_lock_screen, widget_control_center, siri, deep_link_other. The widget_* and siri values also cover a voice deep link started from there, since the entry point is the widget or the Siri shortcut; m_aichat_voice_entry_point_tapped is what separates voice from text. deep_link_other is a Duck.ai deep link carrying no recognised source, e.g. the URL scheme invoked from outside the app. contextual_chat conflates the sheet's openers (address-bar icon, shortcut chip, tabs-bar button, text-selection menu), so it is not a substitute for those values. Resuming an already-open or restored Duck.ai tab is not an entry and does not fire.",
-                "type": "string"
+                "description": "The entry path into Duck.ai, one value per case of the AIChatEntryPointSource Swift enum. Resuming an already-open or restored Duck.ai tab is not an entry and does not fire.",
+                "type": "string",
+                "enum": [
+                    "address_bar_prompt",
+                    "address_bar_icon",
+                    "address_bar_shortcut_chip",
+                    "address_bar_editing_state",
+                    "suggestion_ask_ai",
+                    "ipad_toggle_prompt",
+                    "browsing_menu_ntp",
+                    "browsing_menu_webpage",
+                    "tab_switcher",
+                    "tabs_bar_button",
+                    "chat_history_new_chat",
+                    "chat_history_open_chat",
+                    "voice",
+                    "onboarding",
+                    "direct_url",
+                    "icon_shortcut",
+                    "contextual_chat",
+                    "widget_quick_actions",
+                    "widget_quick_actions_medium",
+                    "widget_favorite",
+                    "widget_lock_screen",
+                    "widget_control_center",
+                    "siri",
+                    "deep_link_other"
+                ]
             },
             {
                 "key": "duckai_enabled",

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
@@ -9,7 +9,7 @@
             "appVersion",
             {
                 "key": "source",
-                "description": "The entry path into Duck.ai, one value per case of the AIChatEntryPointSource Swift enum. Resuming an already-open or restored Duck.ai tab is not an entry and does not fire.",
+                "description": "The entry path into Duck.ai, one value per case of the AIChatEntryPointSource Swift enum. serp is any Duck.ai open the search results page asks native for, e.g. Search Assist, and covers every such SERP affordance because the request does not say which one it was. direct_url is a duck.ai navigation TabURLInterceptor saw with no other attribution, so it mixes a typed address with an in-page link. Resuming an already-open or restored Duck.ai tab is not an entry and does not fire.",
                 "type": "string",
                 "enum": [
                     "address_bar_prompt",
@@ -27,6 +27,7 @@
                     "voice",
                     "onboarding",
                     "direct_url",
+                    "serp",
                     "icon_shortcut",
                     "contextual_chat",
                     "widget_quick_actions",

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
@@ -1,0 +1,37 @@
+// Duck.ai entry-point attribution: one pixel with a source param covering every path into Duck.ai.
+{
+    "m_aichat_entry_point": {
+        "description": "Fires when the user enters Duck.ai, with the entry path as a source param. Threaded through openAIChat(source:) with no default so the compiler enumerates every call site; the per-surface legacy pixels remain as a rollout cross-check.",
+        "owners": ["fbunn"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "description": "The entry path: address_bar_prompt, address_bar_icon, address_bar_shortcut_chip, address_bar_editing_state, suggestion_ask_ai, ipad_toggle_prompt, browsing_menu_ntp, browsing_menu_webpage, tab_switcher, tabs_bar_button, chat_history_new_chat, chat_history_open_chat, voice, onboarding, direct_url, icon_shortcut, restored_tab, contextual_chat, deep_link_other",
+                "type": "string"
+            },
+            {
+                "key": "duckai_enabled",
+                "description": "Whether Duck.ai is enabled under AI Features settings: true or false",
+                "type": "boolean"
+            },
+            {
+                "key": "toggle_enabled",
+                "description": "Whether the Search/Duck.ai toggle user setting is enabled: true or false",
+                "type": "boolean"
+            },
+            {
+                "key": "opens_new_tab",
+                "description": "Whether this entry opened Duck.ai in a new tab (vs in place or as a sheet): true or false",
+                "type": "boolean"
+            },
+            {
+                "key": "has_prompt",
+                "description": "Whether the entry carried a prompt: true or false",
+                "type": "boolean"
+            }
+        ]
+    }
+}

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
@@ -2,7 +2,7 @@
 {
     "m_aichat_entry_point": {
         "description": "Fires when the user enters Duck.ai, with the entry path as a source param. Threaded through openAIChat(source:) with no default so the compiler enumerates every call site; the per-surface legacy pixels remain as a rollout cross-check.",
-        "owners": ["fbunn"],
+        "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor", "first_daily_count"],
         "parameters": [

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -427,23 +427,13 @@
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": ["appVersion", "unified_input_surface"]
     },
+    // Superseded by m_aichat_duck_ai_direct_navigation, which covers all users rather than
+    // only those who turned Duck.ai off. Left exactly as shipped so its series stays intact.
     "m_aichat_unified_input_duck_ai_direct_navigation": {
-        "description": "Fires when the user navigates directly to Duck.ai by typing its address — from the Unified Toggle Input or the URL interceptor — regardless of the Duck.ai setting. duckai_enabled=false isolates residual demand among users who turned Duck.ai off. Does not fire for the in-input Duck.ai shortcut button or other Duck.ai entry points.",
-        "owners": ["aataraxiaa", "Bunn"],
+        "description": "Fires when Duck.ai is disabled under AI Features settings yet the user navigates directly to Duck.ai by typing its address into the Unified Toggle Input and submitting. Does not fire for the in-input Duck.ai shortcut button or other Duck.ai entry points.",
+        "owners": ["aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
-        "parameters": [
-            "appVersion",
-            {
-                "key": "duckai_enabled",
-                "description": "Whether Duck.ai is enabled under AI Features settings: true or false",
-                "type": "boolean"
-            },
-            {
-                "key": "toggle_enabled",
-                "description": "Whether the Search/Duck.ai toggle user setting is enabled: true or false",
-                "type": "boolean"
-            }
-        ]
+        "parameters": ["appVersion"]
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -428,10 +428,22 @@
         "parameters": ["appVersion", "unified_input_surface"]
     },
     "m_aichat_unified_input_duck_ai_direct_navigation": {
-        "description": "Fires when Duck.ai is disabled under AI Features settings yet the user navigates directly to Duck.ai by typing its address into the Unified Toggle Input and submitting. Does not fire for the in-input Duck.ai shortcut button or other Duck.ai entry points.",
-        "owners": ["aataraxiaa"],
+        "description": "Fires when the user navigates directly to Duck.ai by typing its address — from the Unified Toggle Input or the URL interceptor — regardless of the Duck.ai setting. duckai_enabled=false isolates residual demand among users who turned Duck.ai off. Does not fire for the in-input Duck.ai shortcut button or other Duck.ai entry points.",
+        "owners": ["aataraxiaa", "fbunn"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "duckai_enabled",
+                "description": "Whether Duck.ai is enabled under AI Features settings: true or false",
+                "type": "boolean"
+            },
+            {
+                "key": "toggle_enabled",
+                "description": "Whether the Search/Duck.ai toggle user setting is enabled: true or false",
+                "type": "boolean"
+            }
+        ]
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -427,8 +427,6 @@
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": ["appVersion", "unified_input_surface"]
     },
-    // Superseded by m_aichat_duck_ai_direct_navigation, which covers all users rather than
-    // only those who turned Duck.ai off. Left exactly as shipped so its series stays intact.
     "m_aichat_unified_input_duck_ai_direct_navigation": {
         "description": "Fires when Duck.ai is disabled under AI Features settings yet the user navigates directly to Duck.ai by typing its address into the Unified Toggle Input and submitting. Does not fire for the in-input Duck.ai shortcut button or other Duck.ai entry points.",
         "owners": ["aataraxiaa"],

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -429,7 +429,7 @@
     },
     "m_aichat_unified_input_duck_ai_direct_navigation": {
         "description": "Fires when the user navigates directly to Duck.ai by typing its address — from the Unified Toggle Input or the URL interceptor — regardless of the Duck.ai setting. duckai_enabled=false isolates residual demand among users who turned Duck.ai off. Does not fire for the in-input Duck.ai shortcut button or other Duck.ai entry points.",
-        "owners": ["aataraxiaa", "fbunn"],
+        "owners": ["aataraxiaa", "Bunn"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": [

--- a/iOS/SharedTestUtils/Mocks/CustomProductPage/MockAppStoreCustomProductPagePresenter.swift
+++ b/iOS/SharedTestUtils/Mocks/CustomProductPage/MockAppStoreCustomProductPagePresenter.swift
@@ -23,7 +23,7 @@ import AIChat
 
 final class MockAppStoreCustomProductPagePresenter: UIViewController, AppStoreCustomProductPagePresenter {
 
-    func openAIVoiceChatFromDeepLink() {}
+    func openAIVoiceChatFromDeepLink(source: AIChatEntryPointSource) {}
 
     func openAIChat(
         source: AIChatEntryPointSource,

--- a/iOS/SharedTestUtils/Mocks/CustomProductPage/MockAppStoreCustomProductPagePresenter.swift
+++ b/iOS/SharedTestUtils/Mocks/CustomProductPage/MockAppStoreCustomProductPagePresenter.swift
@@ -26,6 +26,7 @@ final class MockAppStoreCustomProductPagePresenter: UIViewController, AppStoreCu
     func openAIVoiceChatFromDeepLink() {}
 
     func openAIChat(
+        source: AIChatEntryPointSource,
         _ query: String?,
         autoSend: Bool,
         payload: Any?,

--- a/iOS/SharedTestUtils/Mocks/CustomProductPage/MockAppStoreCustomProductPagePresenter.swift
+++ b/iOS/SharedTestUtils/Mocks/CustomProductPage/MockAppStoreCustomProductPagePresenter.swift
@@ -36,6 +36,7 @@ final class MockAppStoreCustomProductPagePresenter: UIViewController, AppStoreCu
         reasoningEffort: AIChat.AIChatReasoningEffort?,
         images: [AIChatNativePrompt.NativePromptImage]?,
         files: [AIChat.AIChatNativePrompt.NativePromptFile]?,
+        reportsNewTab: Bool?,
         fromDeepLink: Bool
     ) {}
 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
@@ -90,6 +90,8 @@ final class MockTabDelegate: TabDelegate {
 
     func tabDidRequestAIChat(tab: TabViewController) {}
 
+    func tabDidRequestNewAIChatTab(tab: TabViewController) {}
+
     func tab(_ tab: TabViewController, didRequestAIChatForSelectedText text: String) {}
 
     func tab(_ tab: TabViewController, didRequestSearchForSelectedText text: String) {}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217261030452901
Tech Design URL:
CC:

### Description

Adds `m_aichat_entry_point` (daily + count) with a `source` param covering every path into Duck.ai, threaded through `openAIChat(source:)` with no default so the compiler enumerates all call sites;
### Testing Steps

1. Enter Duck.ai via several paths (address-bar icon, browsing menu on NTP and on a website, suggestion "Ask Duck.ai", app-icon shortcut) and verify `m_aichat_entry_point` fires with the matching `source`.
2. Type `duck.ai` in the address bar with Duck.ai enabled and disabled. Verify `m_aichat_duck_ai_direct_navigation` fires in both cases with the correct `duckai_enabled`, and that `m_aichat_unified_input_duck_ai_direct_navigation` still fires **only** in the disabled case.
3. Follow an in-page link to a duck.ai URL and verify neither direct-navigation pixel fires.
4. Compare a legacy per-surface pixel (e.g. `m_aichat_addressbar_icon`) against the same-source entry pixel — counts should track.

### Impact and Risks

Low for existing consumers — no shipped pixel changes its name, firing conditions or field set. Both additions are new pixels.

#### What could go wrong?

A missed bypass path would under-count that source relative to its legacy pixel — which is exactly what the rollout cross-check against the per-surface pixels is for.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes with no auth, payment, or data-handling logic; main risk is missed or double-fired entry pixels on edge paths, which the PR explicitly guards and cross-checks against legacy per-surface pixels.
> 
> **Overview**
> Introduces unified Duck.ai **entry attribution** via `m_aichat_entry_point` (daily + count), with `source`, `duckai_enabled`, `toggle_enabled`, `opens_new_tab`, and `has_prompt`. A new `AIChatEntryPointSource` enum and `openAIChat(source:)` (no default) thread that source through every call site; paths that skip `openAIChat` (contextual sheet/floating input, tab switcher sheet, tabs bar new tab, chat history URL loads) fire the pixel directly or defer through `reportDuckAIEntryForUpcomingNavigation` when `TabURLInterceptor` cancels duck.ai navigation.
> 
> Deep links resolve widget, lock screen, control center, and Siri sources via `AIChatEntryPointSource.forDeepLink`; SERP-initiated opens use `messageHost` on the `urlInterceptAIChat` notification (`forFrontEndOpenRequest` → `serp`). Typed duck.ai in the unified toggle input now also fires `m_aichat_duck_ai_direct_navigation` for all users (with settings flags), while keeping `m_aichat_unified_input_duck_ai_direct_navigation` only when Duck.ai is disabled.
> 
> Browsing menu “new chat” routes through `tabDidRequestNewAIChatTab` so entry pixels stay aligned with interceptor re-entry. Pixel definitions land in `ai_chat_entry_points.json5`; unit tests cover deep link and SERP source resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 885293c40575ece235f5afb92ae2bf0526f1a085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->