### PR TITLE
Even up the Duck.ai input's bottom padding

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -123,25 +123,25 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     /// Constraint for suggestions view height
     private var suggestionsHeightConstraint: NSLayoutConstraint?
 
-    /// Gap below the suggestions list, driven in step with the height by
-    /// `applySuggestionsBottomPadding(forHeight:)`.
     private var suggestionsBottomConstraint: NSLayoutConstraint?
 
-    /// The gap is dead space while the list is collapsed: it pads the bottom of a zero-height view,
-    /// so the tools row clears the container by 12pt against an 8pt trailing inset. Dropped to zero
-    /// in the rebranded theme to even those up. The legacy theme's trailing inset is 13pt, where the
-    /// same change would make the mismatch worse, so it keeps the padding unconditionally.
+    /// Zero when rebranded: the collapsed list is zero-height, so this padded nothing and just pushed
+    /// the controls row 4pt off an 8pt trailing inset. Legacy's trailing inset is 13pt, so it keeps it.
     private var collapsedSuggestionsBottomPadding: CGFloat {
         themeManager.isAppRebranded ? 0 : Constants.suggestionsBottomPadding
     }
 
-    /// Gap below the list while it's showing. `AIChatSuggestionsView` only reserves 2pt inside its own
-    /// height, so the original 4pt here left the last row crowding the panel's bottom edge. Legacy
-    /// reserves 4pt internally and isn't part of the report, so it keeps the original gap.
+    /// `AIChatSuggestionsView` only reserves 2pt internally when rebranded, so it needs more here.
     private var expandedSuggestionsBottomPadding: CGFloat {
         themeManager.isAppRebranded
             ? Constants.rebrandedExpandedSuggestionsBottomPadding
             : Constants.suggestionsBottomPadding
+    }
+
+    /// Height the controls row occupies above the container's bottom edge. Hosts that stack their own
+    /// content above the panel budget with this rather than restating the arithmetic.
+    var controlsRowHeight: CGFloat {
+        Constants.toolButtonSize + Constants.toolButtonBottomInset + collapsedSuggestionsBottomPadding
     }
 
     private func applySuggestionsBottomPadding(forHeight height: CGFloat) {

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -82,6 +82,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         /// Total panel height the carousel + below-spacing reserves when populated.
         static let attachmentsCarouselTotalPanelReservation: CGFloat = AIChatAttachmentsCarouselView.expandedHeight + (attachmentsCarouselBottomSpacing - AIChatAttachmentsCarouselView.shadowMargin)
         static let suggestionsBottomPadding: CGFloat = 4
+        static let rebrandedExpandedSuggestionsBottomPadding: CGFloat = 6
         static let containerTopPadding: CGFloat = 5
         static let legacyContainerTopPadding: CGFloat = 0
         static let contentLeadingInset: CGFloat = 2
@@ -121,6 +122,32 @@ final class AIChatOmnibarContainerViewController: NSViewController {
 
     /// Constraint for suggestions view height
     private var suggestionsHeightConstraint: NSLayoutConstraint?
+
+    /// Gap below the suggestions list, driven in step with the height by
+    /// `applySuggestionsBottomPadding(forHeight:)`.
+    private var suggestionsBottomConstraint: NSLayoutConstraint?
+
+    /// The gap is dead space while the list is collapsed: it pads the bottom of a zero-height view,
+    /// so the tools row clears the container by 12pt against an 8pt trailing inset. Dropped to zero
+    /// in the rebranded theme to even those up. The legacy theme's trailing inset is 13pt, where the
+    /// same change would make the mismatch worse, so it keeps the padding unconditionally.
+    private var collapsedSuggestionsBottomPadding: CGFloat {
+        themeManager.isAppRebranded ? 0 : Constants.suggestionsBottomPadding
+    }
+
+    /// Gap below the list while it's showing. `AIChatSuggestionsView` only reserves 2pt inside its own
+    /// height, so the original 4pt here left the last row crowding the panel's bottom edge. Legacy
+    /// reserves 4pt internally and isn't part of the report, so it keeps the original gap.
+    private var expandedSuggestionsBottomPadding: CGFloat {
+        themeManager.isAppRebranded
+            ? Constants.rebrandedExpandedSuggestionsBottomPadding
+            : Constants.suggestionsBottomPadding
+    }
+
+    private func applySuggestionsBottomPadding(forHeight height: CGFloat) {
+        let padding = height > 0 ? expandedSuggestionsBottomPadding : collapsedSuggestionsBottomPadding
+        suggestionsBottomConstraint?.constant = -padding
+    }
 
     /// Unified attachments carousel height constraint — 0 when both image and tab attachment
     /// lists are empty, `attachmentsCarouselRowHeight + attachmentsCarouselBottomSpacing` otherwise.
@@ -284,8 +311,8 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     var totalPassthroughHeight: CGFloat {
         var height = suggestionsHeight
         if suggestionsHeight > 0 {
-            // Add bottom padding when there are suggestions
-            height += Constants.suggestionsBottomPadding
+            // Same source as the constraint, so the panel reserves exactly the gap it draws.
+            height += expandedSuggestionsBottomPadding
         }
         if omnibarController.isOmnibarToolsEnabled || !imageUploadButton.isHidden {
             // Add tool buttons area: button size + spacing above suggestions
@@ -914,10 +941,14 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         let heightConstraint = suggestionsView.heightAnchor.constraint(equalToConstant: 0)
         suggestionsHeightConstraint = heightConstraint
 
+        let bottomConstraint = suggestionsView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
+        suggestionsBottomConstraint = bottomConstraint
+        applySuggestionsBottomPadding(forHeight: heightConstraint.constant)
+
         NSLayoutConstraint.activate([
             suggestionsView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             suggestionsView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-            suggestionsView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -Constants.suggestionsBottomPadding),
+            bottomConstraint,
             heightConstraint,
 
             // Submit button sits above suggestions
@@ -1025,6 +1056,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
 
         suggestionsHeight = effectiveHeight
         suggestionsHeightConstraint?.constant = effectiveHeight
+        applySuggestionsBottomPadding(forHeight: effectiveHeight)
 
         // Notify about height change for container resize
         onSuggestionsHeightChanged?(effectiveHeight)
@@ -1076,6 +1108,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         lastKnownSuggestionsHeight = 0
         suggestionsHeight = 0
         suggestionsHeightConstraint?.constant = 0
+        applySuggestionsBottomPadding(forHeight: 0)
     }
 
     private func addShadowToWindow() {

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -82,7 +82,6 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         /// Total panel height the carousel + below-spacing reserves when populated.
         static let attachmentsCarouselTotalPanelReservation: CGFloat = AIChatAttachmentsCarouselView.expandedHeight + (attachmentsCarouselBottomSpacing - AIChatAttachmentsCarouselView.shadowMargin)
         static let suggestionsBottomPadding: CGFloat = 4
-        static let rebrandedExpandedSuggestionsBottomPadding: CGFloat = 6
         static let containerTopPadding: CGFloat = 5
         static let legacyContainerTopPadding: CGFloat = 0
         static let contentLeadingInset: CGFloat = 2
@@ -123,30 +122,20 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     /// Constraint for suggestions view height
     private var suggestionsHeightConstraint: NSLayoutConstraint?
 
-    private var suggestionsBottomConstraint: NSLayoutConstraint?
-
-    /// Zero when rebranded: the collapsed list is zero-height, so this padded nothing and just pushed
-    /// the controls row 4pt off an 8pt trailing inset. Legacy's trailing inset is 13pt, so it keeps it.
-    private var collapsedSuggestionsBottomPadding: CGFloat {
+    /// Zero when rebranded. Hosts size the panel from the suggestions view's own height and don't
+    /// account for a gap below it, so anything reserved here is height the panel never got — a
+    /// constant error while this was 4pt in every state, and a visible jump if it varies by state.
+    /// The gap under an expanded list therefore lives inside `AIChatSuggestionsView`'s height instead.
+    /// Legacy keeps the original 4pt: its trailing inset is 13pt, so the collapsed row already sits
+    /// about right, and its list reserves its own 4pt internally.
+    private var suggestionsBottomPadding: CGFloat {
         themeManager.isAppRebranded ? 0 : Constants.suggestionsBottomPadding
-    }
-
-    /// `AIChatSuggestionsView` only reserves 2pt internally when rebranded, so it needs more here.
-    private var expandedSuggestionsBottomPadding: CGFloat {
-        themeManager.isAppRebranded
-            ? Constants.rebrandedExpandedSuggestionsBottomPadding
-            : Constants.suggestionsBottomPadding
     }
 
     /// Height the controls row occupies above the container's bottom edge. Hosts that stack their own
     /// content above the panel budget with this rather than restating the arithmetic.
     var controlsRowHeight: CGFloat {
-        Constants.toolButtonSize + Constants.toolButtonBottomInset + collapsedSuggestionsBottomPadding
-    }
-
-    private func applySuggestionsBottomPadding(forHeight height: CGFloat) {
-        let padding = height > 0 ? expandedSuggestionsBottomPadding : collapsedSuggestionsBottomPadding
-        suggestionsBottomConstraint?.constant = -padding
+        Constants.toolButtonSize + Constants.toolButtonBottomInset + suggestionsBottomPadding
     }
 
     /// Unified attachments carousel height constraint — 0 when both image and tab attachment
@@ -311,8 +300,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     var totalPassthroughHeight: CGFloat {
         var height = suggestionsHeight
         if suggestionsHeight > 0 {
-            // Same source as the constraint, so the panel reserves exactly the gap it draws.
-            height += expandedSuggestionsBottomPadding
+            height += suggestionsBottomPadding
         }
         if omnibarController.isOmnibarToolsEnabled || !imageUploadButton.isHidden {
             // Add tool buttons area: button size + spacing above suggestions
@@ -941,9 +929,8 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         let heightConstraint = suggestionsView.heightAnchor.constraint(equalToConstant: 0)
         suggestionsHeightConstraint = heightConstraint
 
-        let bottomConstraint = suggestionsView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
-        suggestionsBottomConstraint = bottomConstraint
-        applySuggestionsBottomPadding(forHeight: heightConstraint.constant)
+        let bottomConstraint = suggestionsView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor,
+                                                                      constant: -suggestionsBottomPadding)
 
         NSLayoutConstraint.activate([
             suggestionsView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
@@ -1056,7 +1043,6 @@ final class AIChatOmnibarContainerViewController: NSViewController {
 
         suggestionsHeight = effectiveHeight
         suggestionsHeightConstraint?.constant = effectiveHeight
-        applySuggestionsBottomPadding(forHeight: effectiveHeight)
 
         // Notify about height change for container resize
         onSuggestionsHeightChanged?(effectiveHeight)
@@ -1108,7 +1094,6 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         lastKnownSuggestionsHeight = 0
         suggestionsHeight = 0
         suggestionsHeightConstraint?.constant = 0
-        applySuggestionsBottomPadding(forHeight: 0)
     }
 
     private func addShadowToWindow() {

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -122,18 +122,13 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     /// Constraint for suggestions view height
     private var suggestionsHeightConstraint: NSLayoutConstraint?
 
-    /// Zero when rebranded. Hosts size the panel from the suggestions view's own height and don't
-    /// account for a gap below it, so anything reserved here is height the panel never got — a
-    /// constant error while this was 4pt in every state, and a visible jump if it varies by state.
-    /// The gap under an expanded list therefore lives inside `AIChatSuggestionsView`'s height instead.
-    /// Legacy keeps the original 4pt: its trailing inset is 13pt, so the collapsed row already sits
-    /// about right, and its list reserves its own 4pt internally.
+    /// Zero when rebranded: hosts size the panel from the list's own height, so a gap reserved out
+    /// here is height the panel never got. The expanded gap lives inside the list instead.
     private var suggestionsBottomPadding: CGFloat {
         themeManager.isAppRebranded ? 0 : Constants.suggestionsBottomPadding
     }
 
-    /// Height the controls row occupies above the container's bottom edge. Hosts that stack their own
-    /// content above the panel budget with this rather than restating the arithmetic.
+    /// Exposed so hosts budget for the row instead of restating these anchors.
     var controlsRowHeight: CGFloat {
         Constants.toolButtonSize + Constants.toolButtonBottomInset + suggestionsBottomPadding
     }

--- a/macOS/DuckDuckGo/AIChat/Suggestions/AIChatSuggestionsView.swift
+++ b/macOS/DuckDuckGo/AIChat/Suggestions/AIChatSuggestionsView.swift
@@ -35,9 +35,7 @@ final class AIChatSuggestionsView: NSView {
         static let legacySeparatorHorizontalInset: CGFloat = 12
         static let rowsHorizontalPadding: CGFloat = 6
         static let legacyRowsHorizontalPadding: CGFloat = 4
-        /// Space under the last row. Lives here rather than in the hosting container's constraints
-        /// because this is the height panels are sized from — a gap added outside it is height the
-        /// panel never reserves.
+        /// Space under the last row. Belongs here because this height is what panels are sized from.
         static let bottomPadding: CGFloat = 8
         static let legacyBottomPadding: CGFloat = 4
         static let viewAllChatsSeparatorBottomPadding: CGFloat = 0

--- a/macOS/DuckDuckGo/AIChat/Suggestions/AIChatSuggestionsView.swift
+++ b/macOS/DuckDuckGo/AIChat/Suggestions/AIChatSuggestionsView.swift
@@ -35,7 +35,10 @@ final class AIChatSuggestionsView: NSView {
         static let legacySeparatorHorizontalInset: CGFloat = 12
         static let rowsHorizontalPadding: CGFloat = 6
         static let legacyRowsHorizontalPadding: CGFloat = 4
-        static let bottomPadding: CGFloat = 2
+        /// Space under the last row. Lives here rather than in the hosting container's constraints
+        /// because this is the height panels are sized from — a gap added outside it is height the
+        /// panel never reserves.
+        static let bottomPadding: CGFloat = 8
         static let legacyBottomPadding: CGFloat = 4
         static let viewAllChatsSeparatorBottomPadding: CGFloat = 0
         static let legacyViewAllChatsSeparatorBottomPadding: CGFloat = 8

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarOmnibarContentViewController.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarOmnibarContentViewController.swift
@@ -30,9 +30,7 @@ final class PromptBarOmnibarContentViewController: NSViewController {
         static let promptLeadingInset: CGFloat = 10
         static let promptTrailingInset: CGFloat = 78
         static let promptToControlsSpacing: CGFloat = 8
-        /// The controls row's buttons hang off the suggestions view's top edge, which sits 4pt above
-        /// the container's bottom: 28pt button + 8pt tool inset + that 4pt.
-        static let controlsRowHeight: CGFloat = 40
+        // The controls row's height comes from the container VC — it owns those anchors.
         /// Placeholder for the initial frame, replaced by the first real measurement.
         static let nominalCollapsedHeight: CGFloat = 80
         static let backdropMaterial: NSVisualEffectView.Material = .hudWindow
@@ -240,7 +238,7 @@ extension PromptBarOmnibarContentViewController: PromptBarContentHosting {
         let height = Constants.promptTopInset
             + textViewController.promptContentHeight
             + Constants.promptToControlsSpacing
-            + Constants.controlsRowHeight
+            + containerViewController.controlsRowHeight
             + containerViewController.suggestionsHeight
             + containerViewController.additionalContentHeight
 

--- a/macOS/DuckDuckGo/PromptBar/View/PromptBarOmnibarContentViewController.swift
+++ b/macOS/DuckDuckGo/PromptBar/View/PromptBarOmnibarContentViewController.swift
@@ -30,7 +30,6 @@ final class PromptBarOmnibarContentViewController: NSViewController {
         static let promptLeadingInset: CGFloat = 10
         static let promptTrailingInset: CGFloat = 78
         static let promptToControlsSpacing: CGFloat = 8
-        // The controls row's height comes from the container VC — it owns those anchors.
         /// Placeholder for the initial frame, replaced by the first real measurement.
         static let nominalCollapsedHeight: CGFloat = 80
         static let backdropMaterial: NSVisualEffectView.Material = .hudWindow

--- a/macOS/UnitTests/PromptBar/PromptBarOmnibarContentLayoutTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarOmnibarContentLayoutTests.swift
@@ -113,6 +113,29 @@ final class PromptBarOmnibarContentLayoutTests: XCTestCase {
         }
     }
 
+    /// The suggestions list is collapsed on this surface, and its bottom padding used to apply anyway
+    /// — leaving the controls row 12pt clear of a container whose trailing inset is 8pt.
+    func testWhenSuggestionsAreCollapsedThenTheSubmitButtonClearsTheBottomEdgeByItsTrailingInset() {
+        content = makeContent(isAppRebranded: true)
+        _ = layOutAndMeasureGap(prompt: "what is a duck")
+
+        XCTAssertEqual(containerViewController.suggestionsHeight, 0,
+                       "This measurement only holds while the suggestions list is collapsed")
+
+        let host = containerViewController.view
+        guard let submit = firstDescendant(of: host, ofType: AIChatSubmitButton.self) else {
+            return XCTFail("No submit button in the hierarchy")
+        }
+
+        let frame = host.convert(submit.bounds, from: submit)
+        let bottomInset = host.isFlipped ? host.bounds.maxY - frame.maxY : frame.minY - host.bounds.minY
+        let trailingInset = host.bounds.maxX - frame.maxX
+
+        XCTAssertGreaterThan(bottomInset, 0, "A zero inset means the panel never got laid out")
+        XCTAssertEqual(bottomInset, trailingInset, accuracy: 0.5,
+                       "The submit button no longer clears the bottom and trailing edges equally")
+    }
+
     func testWhenTheDuckAILogoIsLaidOutThenItCentresOnTheToolRowsLeadingButton() {
         let view = content.view
         _ = layOutAndMeasureGap(prompt: "what is a duck")
@@ -231,8 +254,9 @@ final class PromptBarOmnibarContentLayoutTests: XCTestCase {
 
     // MARK: - Assembly
 
-    private func makeContent() -> PromptBarOmnibarContentViewController {
+    private func makeContent(isAppRebranded: Bool = false) -> PromptBarOmnibarContentViewController {
         let featureFlagger = MockFeatureFlagger()
+        featureFlagger.featuresStub[FeatureFlag.appRebranding.rawValue] = isAppRebranded
         let appearancePreferences = AppearancePreferences(
             persistor: AppearancePreferencesPersistorMock(),
             privacyConfigurationManager: MockPrivacyConfigurationManager(),

--- a/macOS/UnitTests/PromptBar/PromptBarOmnibarContentLayoutTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarOmnibarContentLayoutTests.swift
@@ -52,7 +52,17 @@ final class PromptBarOmnibarContentLayoutTests: XCTestCase {
     func testWhenThePromptIsOneLineThenTheControlsRowSitsClearOfIt() {
         let gap = layOutAndMeasureGap(prompt: "what is a duck")
 
-        XCTAssertGreaterThanOrEqual(gap, 8, "The controls row must not touch the prompt text")
+        // Exact, not a lower bound: a panel that over-budgets the controls row widens this gap
+        // instead of failing outright, which is how a stale row height slips through.
+        XCTAssertEqual(gap, 8, accuracy: 1, "The gap between the prompt and the controls row has moved")
+    }
+
+    func testWhenRebrandedThenThePromptToControlsGapIsUnchanged() {
+        content = makeContent(isAppRebranded: true)
+
+        let gap = layOutAndMeasureGap(prompt: "what is a duck")
+
+        XCTAssertEqual(gap, 8, accuracy: 1, "The rebranded panel budgets a different controls row height than it lays out")
     }
 
     func testWhenThePromptGrowsToMoreLinesThenTheGapBelowItDoesNotChange() {
@@ -113,8 +123,6 @@ final class PromptBarOmnibarContentLayoutTests: XCTestCase {
         }
     }
 
-    /// The suggestions list is collapsed on this surface, and its bottom padding used to apply anyway
-    /// — leaving the controls row 12pt clear of a container whose trailing inset is 8pt.
     func testWhenSuggestionsAreCollapsedThenTheSubmitButtonClearsTheBottomEdgeByItsTrailingInset() {
         content = makeContent(isAppRebranded: true)
         _ = layOutAndMeasureGap(prompt: "what is a duck")

--- a/macOS/UnitTests/PromptBar/PromptBarOmnibarContentLayoutTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarOmnibarContentLayoutTests.swift
@@ -165,10 +165,8 @@ final class PromptBarOmnibarContentLayoutTests: XCTestCase {
 
     // MARK: - Measurement
 
-    /// The 8pt the panel puts between the prompt and the controls row, plus whatever it reserves above
-    /// that row — 5pt of container top padding when rebranded, nothing in legacy. Asserting the exact
-    /// figure rather than a lower bound is the point: a panel that over-budgets the controls row shows
-    /// up here as extra slack, which a `>=` assertion waves through.
+    /// Exact rather than a lower bound: a panel that over-budgets the controls row shows up here as
+    /// extra slack, which `>=` waves through.
     private var expectedPromptToControlsGap: CGFloat {
         8 + containerViewController.additionalContentHeight
     }

--- a/macOS/UnitTests/PromptBar/PromptBarOmnibarContentLayoutTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarOmnibarContentLayoutTests.swift
@@ -52,17 +52,17 @@ final class PromptBarOmnibarContentLayoutTests: XCTestCase {
     func testWhenThePromptIsOneLineThenTheControlsRowSitsClearOfIt() {
         let gap = layOutAndMeasureGap(prompt: "what is a duck")
 
-        // Exact, not a lower bound: a panel that over-budgets the controls row widens this gap
-        // instead of failing outright, which is how a stale row height slips through.
-        XCTAssertEqual(gap, 8, accuracy: 1, "The gap between the prompt and the controls row has moved")
+        XCTAssertEqual(gap, expectedPromptToControlsGap, accuracy: 1,
+                       "The gap between the prompt and the controls row has moved")
     }
 
-    func testWhenRebrandedThenThePromptToControlsGapIsUnchanged() {
+    func testWhenRebrandedThenThePanelBudgetsTheControlsRowItLaysOut() {
         content = makeContent(isAppRebranded: true)
 
         let gap = layOutAndMeasureGap(prompt: "what is a duck")
 
-        XCTAssertEqual(gap, 8, accuracy: 1, "The rebranded panel budgets a different controls row height than it lays out")
+        XCTAssertEqual(gap, expectedPromptToControlsGap, accuracy: 1,
+                       "The rebranded panel budgets a different controls row height than it lays out")
     }
 
     func testWhenThePromptGrowsToMoreLinesThenTheGapBelowItDoesNotChange() {
@@ -164,6 +164,14 @@ final class PromptBarOmnibarContentLayoutTests: XCTestCase {
     }
 
     // MARK: - Measurement
+
+    /// The 8pt the panel puts between the prompt and the controls row, plus whatever it reserves above
+    /// that row — 5pt of container top padding when rebranded, nothing in legacy. Asserting the exact
+    /// figure rather than a lower bound is the point: a panel that over-budgets the controls row shows
+    /// up here as extra slack, which a `>=` assertion waves through.
+    private var expectedPromptToControlsGap: CGFloat {
+        8 + containerViewController.additionalContentHeight
+    }
 
     private func duckAILogo(in host: NSView) -> NSImageView? {
         descendants(of: host)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217146980965366

### Description

This PR fixes Duck.ai input's bottom padding.

### Testing Steps
1. Focus the address bar and switch to Duck.ai mode, with no suggestions showing → the gap below the submit button matches the gap to its right.
2. Submit a random chat
3. Open a new tab, focus the address bar and switch to Duck.ai mode. With suggestions showing → the last suggestion has comfortable room below it, in line with the search suggestions list.
4. Go to Settings -> AI Features -> Show Duck.ai shortcut in the menu bar
5. Open the floating Prompt Bar using the Duck.ai shortcut → its bottom gap is even too.
7. Turn the app rebranding flag off → spacing is unchanged from before this PR.

### Impact

Low — spacing only, no behaviour change.

#### What could go wrong?

The panel could reserve one gap while drawing another, clipping the last suggestion → the height calculation and the constraint now read the same value, and a layout test measures the collapsed inset against the trailing inset.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spacing and height-budget changes only; no submission, auth, or data-path changes. Risk is visual clipping if panel height and constraints diverge again—mitigated by shared padding helpers and new layout tests.
> 
> **Overview**
> Fixes **uneven bottom padding** on the Duck.ai omnibar and floating Prompt Bar by keeping panel height math and Auto Layout on the same spacing rules, especially under app rebranding.
> 
> When rebranded, **bottom gap under suggestions moves into** `AIChatSuggestionsView` (`bottomPadding` 2→8) and the container’s **suggestions bottom inset becomes 0**, so the panel isn’t sized for padding it never receives. Passthrough height and the suggestions bottom constraint both use the shared `suggestionsBottomPadding` helper.
> 
> `AIChatOmnibarContainerViewController` now exposes **`controlsRowHeight`** so hosts like the Prompt Bar don’t duplicate tool-row constants; `PromptBarOmnibarContentViewController` budgets height from that property instead of a local 40pt value.
> 
> Layout tests assert an **exact** prompt-to-controls gap, add rebranded budgeting coverage, and check that with suggestions collapsed the submit button’s **bottom inset matches its trailing inset** (8pt).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd3c86ae27adf8400c9a54cc16fb2b196ccd3842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->