### PR TITLE
Fix the Duck.ai panel's outline at the bottom corners

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -1122,7 +1122,12 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         var frame = superview.convert(winFrame, from: nil)
 
         /// Do not overlap shadow of main address bar
-        frame.size.height -= themeManager.isAppRebranded ? Constants.shadowOverlapHeight : Constants.legacyShadowOverlapHeight
+        let overlap = themeManager.isAppRebranded ? Constants.shadowOverlapHeight : Constants.legacyShadowOverlapHeight
+        /// `ShadowView` clamps its corner radius to half its shorter side, so trimming a collapsed
+        /// panel's shadow below twice the radius rounds its bottom corners tighter than the panel's
+        /// own background and reads as a mismatched outline. Trim less rather than lose the radius —
+        /// the shadow doesn't draw its top edge anyway, so the extra height costs nothing visually.
+        frame.size.height = max(shadowView.cornerRadius * 2, frame.height - overlap)
 
         shadowView.frame = frame
     }

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -86,8 +86,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         static let legacyContainerTopPadding: CGFloat = 0
         static let contentLeadingInset: CGFloat = 2
         static let legacyContentLeadingInset: CGFloat = 0
-        /// How far the inner border sits inside the outer one. Also the difference between their
-        /// corner radii — see `innerBorderCornerRadius(for:)`.
+        /// Also the difference between the two borders' radii — see `innerBorderCornerRadius(for:)`.
         static let innerBorderInset: CGFloat = 1
     }
 
@@ -658,15 +657,8 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         omnibarController.surface.drawsOwnChrome
     }
 
-    /// Radius the inner border needs to stay concentric with the outer one.
-    ///
-    /// Both borders are `CALayer` strokes drawn along a rounded-rect path. Sharing one radius while
-    /// the inner rect is inset by `innerBorderInset` leaves the arcs non-concentric: the inner arc's
-    /// centre shifts diagonally, so through the corner sweep the two strokes drift to
-    /// `inset * sqrt(2)` apart against `inset` along the straight edges, and the pair reads as one
-    /// thickened, misplaced outline. Shrinking the radius by the inset keeps the arcs parallel.
-    ///
-    /// Only the bottom corners are rounded in the rebranded theme, which is where the artefact shows.
+    /// Sharing the outer radius across a 1pt inset leaves the arcs non-concentric, so the two
+    /// strokes drift apart through the corner and read as one thickened line.
     static func innerBorderCornerRadius(for outerRadius: CGFloat) -> CGFloat {
         max(0, outerRadius - Constants.innerBorderInset)
     }
@@ -1123,10 +1115,8 @@ final class AIChatOmnibarContainerViewController: NSViewController {
 
         /// Do not overlap shadow of main address bar
         let overlap = themeManager.isAppRebranded ? Constants.shadowOverlapHeight : Constants.legacyShadowOverlapHeight
-        /// `ShadowView` clamps its corner radius to half its shorter side, so trimming a collapsed
-        /// panel's shadow below twice the radius rounds its bottom corners tighter than the panel's
-        /// own background and reads as a mismatched outline. Trim less rather than lose the radius —
-        /// the shadow doesn't draw its top edge anyway, so the extra height costs nothing visually.
+        /// `ShadowView` clamps its radius to half its shorter side, so trimming further would round
+        /// the corners tighter than the background. Costs nothing: it draws no top edge anyway.
         frame.size.height = max(shadowView.cornerRadius * 2, frame.height - overlap)
 
         shadowView.frame = frame

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -86,6 +86,9 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         static let legacyContainerTopPadding: CGFloat = 0
         static let contentLeadingInset: CGFloat = 2
         static let legacyContentLeadingInset: CGFloat = 0
+        /// How far the inner border sits inside the outer one. Also the difference between their
+        /// corner radii — see `innerBorderCornerRadius(for:)`.
+        static let innerBorderInset: CGFloat = 1
     }
 
     private let backgroundView = MouseBlockingBackgroundView()
@@ -655,6 +658,19 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         omnibarController.surface.drawsOwnChrome
     }
 
+    /// Radius the inner border needs to stay concentric with the outer one.
+    ///
+    /// Both borders are `CALayer` strokes drawn along a rounded-rect path. Sharing one radius while
+    /// the inner rect is inset by `innerBorderInset` leaves the arcs non-concentric: the inner arc's
+    /// centre shifts diagonally, so through the corner sweep the two strokes drift to
+    /// `inset * sqrt(2)` apart against `inset` along the straight edges, and the pair reads as one
+    /// thickened, misplaced outline. Shrinking the radius by the inset keeps the arcs parallel.
+    ///
+    /// Only the bottom corners are rounded in the rebranded theme, which is where the artefact shows.
+    static func innerBorderCornerRadius(for outerRadius: CGFloat) -> CGFloat {
+        max(0, outerRadius - Constants.innerBorderInset)
+    }
+
     private func applyTopClipMask() {
         view.wantsLayer = true
         guard !hostDrawsChrome else {
@@ -831,10 +847,10 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             backgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             backgroundView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
-            innerBorderView.topAnchor.constraint(equalTo: backgroundView.topAnchor, constant: 1),
-            innerBorderView.leadingAnchor.constraint(equalTo: backgroundView.leadingAnchor, constant: 1),
-            innerBorderView.trailingAnchor.constraint(equalTo: backgroundView.trailingAnchor, constant: -1),
-            innerBorderView.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor, constant: -1),
+            innerBorderView.topAnchor.constraint(equalTo: backgroundView.topAnchor, constant: Constants.innerBorderInset),
+            innerBorderView.leadingAnchor.constraint(equalTo: backgroundView.leadingAnchor, constant: Constants.innerBorderInset),
+            innerBorderView.trailingAnchor.constraint(equalTo: backgroundView.trailingAnchor, constant: -Constants.innerBorderInset),
+            innerBorderView.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor, constant: -Constants.innerBorderInset),
 
             containerView.topAnchor.constraint(equalTo: backgroundView.topAnchor),
             containerView.leadingAnchor.constraint(equalTo: backgroundView.leadingAnchor),
@@ -2084,7 +2100,9 @@ final class AIChatOmnibarContainerViewController: NSViewController {
 
         innerBorderView.borderColor = hostDrawsChrome ? .clear : NSColor(named: "AddressBarInnerBorderColor")
         innerBorderView.backgroundColor = NSColor.clear
-        innerBorderView.cornerRadius = barStyleProvider.addressBarActiveBackgroundViewRadiusWithSuggestions
+        innerBorderView.cornerRadius = Self.innerBorderCornerRadius(
+            for: barStyleProvider.addressBarActiveBackgroundViewRadiusWithSuggestions
+        )
 
         if isAppRebranding {
             innerBorderView.roundedCorners = [.bottomLeft, .bottomRight]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217147045669816

### Description

This PR fixes Duck.ai panel's outline in the corner. See Asana task for more details

Before:
<img width="194" height="182" alt="Screenshot 2026-08-07 at 13 11 28" src="https://github.com/user-attachments/assets/d83e8534-7c04-4476-a932-83d6fc691db4" />


After
<img width="44" height="34" alt="Screenshot 2026-08-07 at 14 20 13" src="https://github.com/user-attachments/assets/65f67386-d17b-46b4-8902-2f6fb837a22f" />



### Testing Steps
1. Focus the address bar and switch to Duck.ai mode → a suggestion appears; zoom into the panel's bottom-left and bottom-right corners. The outline follows the background's curve.
2. Type two characters so the suggestion disappears and the panel collapses → the corners still match. Before this change the curve behind them became visibly tighter at this point.
3. Check where the panel meets the address bar → no extra shadow darkening has crept upwards.
4. Switch to dark mode and repeat steps 1–2 → the inner border traces the outer one instead of reading as a single thick line.

### Impact

Low — drawing only. No layout or behaviour change; the shadow's height changes by 4pt in the collapsed state.

#### What could go wrong?

The taller collapsed shadow could overlap the address bar's own → it stops at twice the corner radius rather than growing freely, and the shadow omits its top edge, so the added height casts nothing.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only changes to corner radius and shadow frame sizing; no behavior or layout logic changes beyond drawing.
> 
> **Overview**
> Fixes **Duck.ai omnibar panel** bottom-corner rendering so the inner outline tracks the outer background curve instead of looking thicker or tighter.
> 
> The inner border now uses **`innerBorderCornerRadius(for:)`** — outer radius minus the 1pt inset — so the two strokes stay concentric through rounded corners. Layout pins the inner border with **`Constants.innerBorderInset`** instead of hard-coded `1`.
> 
> **Shadow layout** no longer shrinks the shadow view past what `ShadowView` can represent: height is **`max(cornerRadius * 2, frame.height - overlap)`**, so collapsed panels don’t get corners rounded tighter than the background (about 4pt taller shadow in that state, with no extra top-edge shadow).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6df6b90cbf140f89f5f1a76f0d28e1314705e868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->