### PR TITLE
iOS: Update colours used in purple and alpha app icons

### DIFF
--- a/iOS/DuckDuckGo/Icons/AppIcon-Alpha.icon/icon.json
+++ b/iOS/DuckDuckGo/Icons/AppIcon-Alpha.icon/icon.json
@@ -3,8 +3,8 @@
     {
       "value" : {
         "linear-gradient" : [
-          "display-p3:0.51520,0.29264,0.61000,1.00000",
-          "display-p3:0.49020,0.27843,0.58039,1.00000"
+          "display-p3:0.46033,0.18590,0.54000,1.00000",
+          "display-p3:0.40784,0.16471,0.47843,1.00000"
         ],
         "orientation" : {
           "start" : {
@@ -52,7 +52,7 @@
             {
               "appearance" : "dark",
               "value" : {
-                "solid" : "display-p3:0.51520,0.29264,0.61000,1.00000"
+                "solid" : "display-p3:0.46033,0.18590,0.54000,1.00000"
               }
             }
           ],
@@ -351,7 +351,7 @@
           "fill-specializations" : [
             {
               "value" : {
-                "solid" : "gray:1.00000,1.00000"
+                "solid" : "extended-gray:1.00000,1.00000"
               }
             },
             {

--- a/iOS/DuckDuckGo/Icons/AppIcon-purple.icon/icon.json
+++ b/iOS/DuckDuckGo/Icons/AppIcon-purple.icon/icon.json
@@ -3,8 +3,8 @@
     {
       "value" : {
         "linear-gradient" : [
-          "display-p3:0.51520,0.29264,0.61000,1.00000",
-          "display-p3:0.46453,0.26385,0.55000,1.00000"
+          "display-p3:0.46033,0.18590,0.54000,1.00000",
+          "display-p3:0.40784,0.16471,0.47843,1.00000"
         ],
         "orientation" : {
           "start" : {
@@ -273,12 +273,6 @@
               }
             },
             {
-              "appearance" : "dark",
-              "value" : {
-                "solid" : "display-p3:0.94118,0.75294,0.27843,1.00000"
-              }
-            },
-            {
               "appearance" : "tinted",
               "value" : {
                 "solid" : "gray:0.50000,1.00000"
@@ -301,13 +295,13 @@
           "fill-specializations" : [
             {
               "value" : {
-                "solid" : "gray:1.00000,1.00000"
+                "solid" : "extended-gray:1.00000,1.00000"
               }
             },
             {
               "appearance" : "dark",
               "value" : {
-                "solid" : "gray:1.00000,1.00000"
+                "solid" : "extended-gray:1.00000,1.00000"
               }
             }
           ],
@@ -363,8 +357,8 @@
               "appearance" : "dark",
               "value" : {
                 "linear-gradient" : [
-                  "display-p3:0.51520,0.29264,0.61000,1.00000",
-                  "display-p3:0.49020,0.27843,0.58039,1.00000"
+                  "display-p3:0.46033,0.18590,0.54000,1.00000",
+                  "display-p3:0.40784,0.16471,0.47843,1.00000"
                 ]
               }
             }
@@ -391,7 +385,7 @@
         ]
       },
       "shadow" : {
-        "kind" : "layer-color",
+        "kind" : "neutral",
         "opacity" : 0.5
       },
       "translucency" : {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1176956903599313/task/1217272588407091?focus=true
Tech Design URL:
CC:

### Description

This PR simply updates the purples used in the purple / blossom app icon (and alpha) to blossom-70:

<img width="220" height="133" alt="image" src="https://github.com/user-attachments/assets/d24e14fc-4460-485b-933b-640f7b1157ef" />
(new icon on left, old on right)

### Testing Steps

1. Build and run the iOS app.
2. Change the app icon to purple - ensure it looks like the left icon above.
OR, inspect the purple and alpha app icons in Xcode.

### Impact

Low: Minor visual changes, small bug fixes, improvement to existing features


---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Asset-only color and metadata tweaks in icon JSON; no runtime logic, networking, or security surface.
> 
> **Overview**
> Updates **purple** and **alpha** alternate app icon assets so their purple tones match the **blossom-70** palette instead of the older purple gradient values.
> 
> In `AppIcon-purple.icon` and `AppIcon-Alpha.icon`, root **linear-gradient** fills and related **dark** appearance purples now use the new display-p3 stops (`0.46033…` / `0.40784…`). The alpha icon’s **dark** alpha-badge fill uses the same blossom purple. **Head and Ring** white fills switch from `gray` to **`extended-gray`** for consistency with the icon format.
> 
> On the purple icon only: the **Beak** layer drops a redundant **dark** solid fill (default appearance unchanged). The **Circle BG** group’s **dark** background gradient uses the new purples, and its shadow **`kind`** changes from **`layer-color`** to **`neutral`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 397c4addf0e14507c6bf29f5fd6a16db19b092e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->