### PR TITLE
fix hang rate regression

### DIFF
--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -1180,6 +1180,7 @@ class OmniBarCell: UICollectionViewCell {
 
     weak var omniBar: OmniBar? {
         willSet {
+            guard omniBar !== newValue else { return }
             let isFloatingUIEnabled = isFloatingUIEnabledProvider?() ?? false
             if isFloatingUIEnabled {
                 guard let currentBarView = omniBar?.barView, currentBarView.superview === self else { return }
@@ -1191,6 +1192,7 @@ class OmniBarCell: UICollectionViewCell {
             }
         }
         didSet {
+            guard oldValue !== omniBar else { return }
             guard let omniBarView = omniBar?.barView else { return }
             let isFloatingUIEnabled = isFloatingUIEnabledProvider?() ?? false
             if isFloatingUIEnabled {

--- a/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
+++ b/iOS/DuckDuckGo/SwipeTabsCoordinator.swift
@@ -1180,7 +1180,7 @@ class OmniBarCell: UICollectionViewCell {
 
     weak var omniBar: OmniBar? {
         willSet {
-            guard omniBar !== newValue else { return }
+            guard omniBar !== newValue || omniBar?.barView.superview !== self else { return }
             let isFloatingUIEnabled = isFloatingUIEnabledProvider?() ?? false
             if isFloatingUIEnabled {
                 guard let currentBarView = omniBar?.barView, currentBarView.superview === self else { return }
@@ -1192,7 +1192,7 @@ class OmniBarCell: UICollectionViewCell {
             }
         }
         didSet {
-            guard oldValue !== omniBar else { return }
+            guard oldValue !== omniBar || omniBar?.barView.superview !== self else { return }
             guard let omniBarView = omniBar?.barView else { return }
             let isFloatingUIEnabled = isFloatingUIEnabledProvider?() ?? false
             if isFloatingUIEnabled {

--- a/iOS/DuckDuckGoTests/OmniBarEqualityCheckTests.swift
+++ b/iOS/DuckDuckGoTests/OmniBarEqualityCheckTests.swift
@@ -22,6 +22,20 @@ import XCTest
 import BrowserServicesKit
 
 final class OmniBarEqualityCheckTests: XCTestCase {
+    func testOmniBarCellDoesNotReparentSameOmniBar() {
+        let cell = OmniBarCell()
+        let omniBar = MockOmniBar()
+        cell.isFloatingUIEnabledProvider = { false }
+        cell.omniBar = omniBar
+        let initialConstraints = cell.constraints
+
+        cell.omniBar = omniBar
+
+        XCTAssertTrue(omniBar.barView.superview === cell)
+        XCTAssertEqual(cell.constraints.count, initialConstraints.count)
+        XCTAssertTrue(zip(cell.constraints, initialConstraints).allSatisfy { $0.0 === $0.1 })
+    }
+
     func testRequiresUpdateChecksForIsLoading() {
         let loadingOmniBarState = DummyOmniBarState(isLoading: true)
         let notLoadingOmniBarState = DummyOmniBarState(isLoading: false)

--- a/iOS/DuckDuckGoTests/OmniBarEqualityCheckTests.swift
+++ b/iOS/DuckDuckGoTests/OmniBarEqualityCheckTests.swift
@@ -36,6 +36,20 @@ final class OmniBarEqualityCheckTests: XCTestCase {
         XCTAssertTrue(zip(cell.constraints, initialConstraints).allSatisfy { $0.0 === $0.1 })
     }
 
+    func testOmniBarCellReattachesSameOmniBarAfterItMovesToAnotherCell() {
+        let firstCell = OmniBarCell()
+        let secondCell = OmniBarCell()
+        let omniBar = MockOmniBar()
+        firstCell.isFloatingUIEnabledProvider = { false }
+        secondCell.isFloatingUIEnabledProvider = { false }
+        firstCell.omniBar = omniBar
+        secondCell.omniBar = omniBar
+
+        firstCell.omniBar = omniBar
+
+        XCTAssertTrue(omniBar.barView.superview === firstCell)
+    }
+
     func testRequiresUpdateChecksForIsLoading() {
         let loadingOmniBarState = DummyOmniBarState(isLoading: true)
         let notLoadingOmniBarState = DummyOmniBarState(isLoading: false)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1217249860630868?focus=true
Tech Design URL:
CC: @aataraxiaa @bwaresiak 

### Description
Avoids unnecessarily removing and re-adding an address bar that is already in the correct tab. This reduces expensive view hierarchy work responsible for browser hangs while preserving necessary address bar moves between tabs.

### Testing Steps

1. Disable Floating UI and enable Unified Input Toggle.
2. Place the address bar at the top.
3. Open a content-heavy page and scroll while it loads → the browser remains responsive.
4. Wait for loading to finish → the address bar retains its previous visibility.
5. Rapidly switch between and dismiss tabs → the address bar remains correctly positioned without freezing.
6. Ensure no regression from https://github.com/duckduckgo/apple-browsers/pull/5947

### Impact
Low: Performance improvement to existing address bar and tab behavior.

#### What could go wrong?
The address bar could fail to move back to a previously used tab → mitigated by only skipping work when it is already attached to the correct tab, with regression coverage for both unchanged and moved states.

### Quality Considerations
* Reduces synchronous main-thread view hierarchy work across page loads, rotation, deep links, and tab transitions. Necessary reattachment remains supported. No privacy, security, analytics, or data-handling impact.
* Focused tests passed on the iOS Browser scheme: 6 passed, 0 failed.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b4b8db44873b7dd715fdb79d96099fdcdd735e7d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->