### PR TITLE
Fix sync E2E tests

### DIFF
--- a/.maestro/shared/open_debug_menu.yaml
+++ b/.maestro/shared/open_debug_menu.yaml
@@ -3,5 +3,6 @@ appId: com.duckduckgo.mobile.ios
 
 - scrollUntilVisible:
     element: All debug options
+    centerElement: true
 - assertVisible: All debug options
 - tapOn: All debug options

--- a/.maestro/shared/sync_recover_data.yaml
+++ b/.maestro/shared/sync_recover_data.yaml
@@ -6,10 +6,8 @@ appId: com.duckduckgo.mobile.ios
 
 - assertVisible: Use Recovery Code
 - tapOn: Use Recovery Code
-- assertVisible: Recover your synced data
-- tapOn: Recover Synced Data
-# Authenticate only if prompted. Depending on the current auth session and iOS
-# version, this can appear before or after the recovery confirmation sheet.
+# Authenticate only if prompted — beginRecoverFlow authenticates before presenting
+# the recovery confirmation sheet, but the auth session may still be valid.
 - runFlow:
     when:
       visible: Passcode field
@@ -23,6 +21,8 @@ appId: com.duckduckgo.mobile.ios
     commands:
       - inputText: "0000"
       - pressKey: Enter
+- assertVisible: Recover your synced data
+- tapOn: Recover Synced Data
 - runFlow:
     when:
       visible: Allows you to upload photographs and videos

--- a/.maestro/shared/sync_recover_data.yaml
+++ b/.maestro/shared/sync_recover_data.yaml
@@ -6,11 +6,23 @@ appId: com.duckduckgo.mobile.ios
 
 - assertVisible: Use Recovery Code
 - tapOn: Use Recovery Code
-- tapOn: Passcode field
-- inputText: "0000"
-- pressKey: Enter
 - assertVisible: Recover your synced data
 - tapOn: Recover Synced Data
+# Authenticate only if prompted. Depending on the current auth session and iOS
+# version, this can appear before or after the recovery confirmation sheet.
+- runFlow:
+    when:
+      visible: Passcode field
+    commands:
+      - tapOn: Passcode field
+      - inputText: "0000"
+      - pressKey: Enter
+- runFlow:
+    when:
+      visible: Unlock device to set up Sync & Backup
+    commands:
+      - inputText: "0000"
+      - pressKey: Enter
 - runFlow:
     when:
       visible: Allows you to upload photographs and videos

--- a/.maestro/sync_tests/04_sync_data_setup.yaml
+++ b/.maestro/sync_tests/04_sync_data_setup.yaml
@@ -15,6 +15,11 @@ name: 04_sync_data_setup
     file: ../shared/add_bookmarks_and_favorites.yaml
 - runFlow:
     file: ../shared/use_firebutton.yaml
+- runFlow:
+    when:
+      visible: Back
+    commands:
+      - tapOn: Back
 
 # Add local login
 - runFlow:

--- a/.maestro/sync_tests/06_delete_account.yaml
+++ b/.maestro/sync_tests/06_delete_account.yaml
@@ -30,9 +30,20 @@ name: 06_delete_account
 # Try to login and check for error
 - assertVisible: Sync With Another Device
 - tapOn: Sync With Another Device
-- tapOn: Passcode field
-- inputText: "0000"
-- pressKey: Enter
+# Authenticate only if prompted — the auth session may still be valid from account creation.
+- runFlow:
+    when:
+      visible: Passcode field
+    commands:
+      - tapOn: Passcode field
+      - inputText: "0000"
+      - pressKey: Enter
+- runFlow:
+    when:
+      visible: Unlock device to set up Sync & Backup
+    commands:
+      - inputText: "0000"
+      - pressKey: Enter
 - runFlow:
     when:
       visible: Allows you to upload photographs and videos

--- a/.maestro/sync_v2_tests/04_sync_data_setup.yaml
+++ b/.maestro/sync_v2_tests/04_sync_data_setup.yaml
@@ -15,6 +15,11 @@ name: 04_sync_data_setup_v2
     file: ../shared/add_bookmarks_and_favorites.yaml
 - runFlow:
     file: ../shared/use_firebutton.yaml
+- runFlow:
+    when:
+      visible: Back
+    commands:
+      - tapOn: Back
 
 # Add local login
 - runFlow:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1217261829198108?focus=true

### Description
Fixes flakiness in the Sync Maestro E2E tests (both V1 and V2 flows):

- Make device authentication conditional. Depending on the current auth session and iOS version, the sync flows may or may not prompt for a passcode, and the prompt can appear as either "Passcode field" or "Unlock device to set up Sync & Backup". Auth steps now run only when the relevant element is visible instead of assuming a fixed prompt.
- Dismiss a stray "Back" screen (when present) in `04_sync_data_setup` after the fire button flow, before adding a local login.
- Center the "All debug options" element when scrolling in `open_debug_menu` so the tap lands reliably.

### Testing Steps
1. Run the Sync E2E suites (`sync_tests` and `sync_v2_tests`) → flows complete without stalling on the passcode/unlock prompts.

### Impact
None — Maestro E2E test changes only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Maestro YAML test flows; no production app code is modified.
> 
> **Overview**
> **Stabilizes Sync Maestro suites** (`sync_tests` and `sync_v2_tests`) by handling optional UI states instead of assuming fixed screens.
> 
> **Device auth** in recovery and post-delete login flows is now **conditional**: passcode entry runs only when `Passcode field` or `Unlock device to set up Sync & Backup` appears, matching varying auth sessions and iOS versions.
> 
> **Navigation** after the fire-button step in `04_sync_data_setup` taps **Back** when that control is visible so the flow can continue to local login setup.
> 
> **Debug menu** scrolling uses `centerElement: true` on `All debug options` so the subsequent tap is reliable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b25f6b65040be8cbfb3678fc0e2f2a1021cdbd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

