### PR TITLE
[iOS] Fix loc_update.sh corrupting emoji during UTF-16 to UTF-8 conversion

### DIFF
--- a/iOS/scripts/loc_update.sh
+++ b/iOS/scripts/loc_update.sh
@@ -34,7 +34,20 @@ update_localizable_strings() {
 		return 1
 	fi
 
-	if ! iconv -f UTF-16 -t UTF8 "${generated_strings}" > "${tmp_utf8_strings}"; then
+	# `extractLocStrings` writes UTF-16LE with a leading byte-order mark. Decode it
+	# with an explicit little-endian encoding instead of `iconv -f UTF-16`: the latter
+	# infers endianness from the BOM, but macOS iconv can lose that inferred byte order
+	# at an internal buffer boundary and byte-swap the rest of the file, corrupting
+	# non-BMP characters (e.g. emoji like U+1F525, encoded as a surrogate pair) and
+	# every entry after them. Strip the 2-byte BOM so the result matches the committed
+	# (BOM-less) Localizable.strings and the `cmp` check below stays meaningful.
+	bom=$(od -An -tx1 -N2 "${generated_strings}" | tr -d ' \n')
+	if [ "${bom}" != "fffe" ]; then
+		echo "error: expected UTF-16LE BOM (fffe) at the start of ${generated_strings}, found '${bom}'" >&2
+		return 1
+	fi
+
+	if ! tail -c +3 "${generated_strings}" | iconv -f UTF-16LE -t UTF8 > "${tmp_utf8_strings}"; then
 		rm -f "${tmp_utf8_strings}"
 		echo "error: Failed to convert ${generated_strings} to UTF-8" >&2
 		return 1


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1217283347344771?focus=true
Tech Design URL:
CC:

### Description

**Problem**

- `iOS/scripts/loc_update.sh` regenerates `en.lproj/Localizable.strings` during the build, converting `extractLocStrings`' UTF‑16 output to UTF‑8 via `iconv -f UTF-16`.
- That auto‑endianness mode loses its byte‑order state at iconv's 16KiB read boundary, so when a non‑BMP surrogate pair (e.g. the 🔥 emoji) straddles the boundary, everything after it is byte‑swapped into garbage and the build fails with "Couldn't parse property list."
- Which characters land on the boundary depends on total file length, so any unrelated string change can shift offsets and trigger it — which is why it shows up intermittently across branches.

Example failure from https://github.com/duckduckgo/apple-browsers/pull/6173 can be seen in [this CI workflow.](https://github.com/duckduckgo/apple-browsers/actions/runs/31192074471/job/92911128524?pr=6173)

**Fix**

- Decode as explicit `UTF-16LE` (BOM stripped, so output still matches the committed BOM‑less file), which reassembles split surrogate pairs correctly.
- Add a guard asserting the expected little‑endian BOM, so a future toolchain change can't silently re‑corrupt the file.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Confirm checks pass.

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal build script only; no runtime app behavior or user data paths change.
> 
> **Overview**
> Fixes intermittent iOS build failures when `loc_update.sh` converts `extractLocStrings` output to UTF-8 for `Localizable.strings`.
> 
> The script no longer uses `iconv -f UTF-16`, which on macOS can mis-handle surrogate pairs (e.g. emoji) that cross iconv’s read boundary and corrupt the rest of the file. It now verifies the UTF-16LE BOM (`fffe`), strips those two bytes, and decodes with **`UTF-16LE`** so output still matches the committed BOM-less strings and the existing `cmp` check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2035e0902f22d71b6fa79c41cf611707df91de0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->