### PR TITLE
Load and cache Sync account info protected keys

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -25,6 +25,7 @@ import Foundation
 import os.log
 import Persistence
 import PrivacyConfig
+import Security
 
 public class DDGSync: DDGSyncing {
 
@@ -299,6 +300,18 @@ public class DDGSync: DDGSyncing {
         }
 
         return try await dependencies.scopedAccess.ensureAccountInfoProtectedKeys(for: account).count
+    }
+
+    public func validateAccountInfoKeyForDebug() async throws -> (refreshedKeyID: String, reloadedKeyID: String, keySizeInBits: Int) {
+        guard let account = try dependencies.secureStore.account() else {
+            throw SyncError.accountNotFound
+        }
+
+        let refreshedKey = try await dependencies.accountInfoKeys.refreshKey(for: account)
+        let reloadedKey = try await dependencies.accountInfoKeys.loadKey(for: account)
+        return (refreshedKeyID: refreshedKey.kid,
+                reloadedKeyID: reloadedKey.kid,
+                keySizeInBits: SecKeyGetBlockSize(reloadedKey.publicKey) * 8)
     }
 
     public func prepareThirdPartyRecoveryCode(purpose: String) async throws -> String {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSyncing.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSyncing.swift
@@ -287,10 +287,16 @@ public protocol DDGSyncingDebuggingSupport {
     func updateServerEnvironment(_ serverEnvironment: ServerEnvironment)
     /// Creates or fetches the account_info key and returns its wrapper count.
     func ensureAccountInfoKeyForDebug() async throws -> Int
+    /// Refreshes the account_info key and returns metadata from a subsequent cache-first reload.
+    func validateAccountInfoKeyForDebug() async throws -> (refreshedKeyID: String, reloadedKeyID: String, keySizeInBits: Int)
 }
 
 public extension DDGSyncingDebuggingSupport {
     func ensureAccountInfoKeyForDebug() async throws -> Int {
+        throw SyncError.accountNotFound
+    }
+
+    func validateAccountInfoKeyForDebug() async throws -> (refreshedKeyID: String, reloadedKeyID: String, keySizeInBits: Int) {
         throw SyncError.accountNotFound
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/JWECompactCodec.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/JWECompactCodec.swift
@@ -90,12 +90,16 @@ final class JWECompactCodec {
 
     /// Decrypts direct JWE compact tokens created by `encryptDirect`.
     func decryptDirect(token: String,
-                       contentEncryptionKey: Data) throws -> Data {
+                       contentEncryptionKey: Data,
+                       expectedKid: String? = nil) throws -> Data {
         guard contentEncryptionKey.count == Self.contentEncryptionKeyLength else {
             throw JWECompactCodecError.invalidContentEncryptionKeyLength(contentEncryptionKey.count)
         }
         let components = try decodeCompactToken(token)
-        _ = try decodeDirectProtectedHeader(components.protectedHeader)
+        let protectedHeader = try decodeDirectProtectedHeader(components.protectedHeader)
+        if let expectedKid, protectedHeader.kid != expectedKid {
+            throw JWECompactCodecError.unsupportedProtectedHeader
+        }
         guard components.encryptedContentEncryptionKey.isEmpty else {
             throw JWECompactCodecError.invalidDirectTokenShape
         }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -28,6 +28,7 @@ struct ProductionDependencies: SyncDependencies {
     let endpoints: Endpoints
     let account: AccountManaging
     let scopedAccess: ScopedAccessCredentialManaging
+    let accountInfoKeys: AccountInfoKeyManaging
     let api: RemoteAPIRequestCreating
     let payloadCompressor: SyncPayloadCompressing
     var keyValueStore: ThrowingKeyValueStoring
@@ -88,6 +89,9 @@ struct ProductionDependencies: SyncDependencies {
                                                          api: api,
                                                          crypter: crypter,
                                                          accountInfoKeyFactory: DefaultAccountInfoKeyFactory(crypter: crypter))
+        accountInfoKeys = AccountInfoKeyManager(secureStore: secureStore,
+                                                scopedAccess: scopedAccess,
+                                                crypter: crypter)
         let registeredDeviceMapper = RegisteredDeviceMapper(crypter: crypter,
                                                             scopedAccess: scopedAccess,
                                                             cachedScopedPassword: secureStore.scopedPassword,

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RSAKeyUtilities.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RSAKeyUtilities.swift
@@ -267,7 +267,7 @@ private enum ASN1DER {
             contents.removeFirst()
         }
         if let first = contents.first, first & 0x80 != 0 {
-            contents.insert(0x00, at: 0)
+            contents.insert(0x00, at: contents.startIndex)
         }
         return wrap(tag: 0x02, contents: contents)
     }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RSAKeyUtilities.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RSAKeyUtilities.swift
@@ -30,6 +30,12 @@ enum RSAKeyPairGeneratorError: Error {
     case externalRepresentationFailed
 }
 
+enum RSAKeyImportError: Error, Equatable {
+    case unsupportedPublicKey
+    case invalidPublicKey
+    case invalidPrivateKey
+}
+
 enum RSAKeyPairGenerator {
 
     static func makeKeyPair(keySizeInBits: Int = 2048) throws -> RSAKeyPair {
@@ -59,6 +65,58 @@ enum RSAKeyPairGenerator {
     }
 }
 
+enum RSAKeyImporter {
+
+    static func makePublicKey(from jwk: ProtectedKeyPublicKey) throws -> SecKey {
+        guard jwk.kty == "RSA",
+              jwk.alg == "RSA-OAEP-256",
+              jwk.use == nil || jwk.use == "enc",
+              jwk.keyOps == nil || jwk.keyOps?.contains("encrypt") == true else {
+            throw RSAKeyImportError.unsupportedPublicKey
+        }
+        guard let encodedModulus = jwk.n,
+              let encodedExponent = jwk.e,
+              let modulus = Base64URL.decode(encodedModulus),
+              let exponent = Base64URL.decode(encodedExponent),
+              !modulus.isEmpty,
+              !exponent.isEmpty else {
+            throw RSAKeyImportError.invalidPublicKey
+        }
+
+        let keyData = RSAKeyDER.makeRSAPublicKeyPKCS1(modulus: modulus, exponent: exponent)
+        let attributes: [String: Any] = [
+            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+            kSecAttrKeyClass as String: kSecAttrKeyClassPublic,
+            kSecAttrKeySizeInBits as String: modulus.count * 8
+        ]
+        guard let key = SecKeyCreateWithData(keyData as CFData, attributes as CFDictionary, nil) else {
+            throw RSAKeyImportError.invalidPublicKey
+        }
+        return key
+    }
+
+    static func makePrivateKey(fromPKCS8 privateKeyPKCS8: Data) throws -> SecKey {
+        let privateKeyPKCS1: Data
+        let keySizeInBits: Int
+        do {
+            privateKeyPKCS1 = try RSAKeyDER.unwrapRSAPrivateKeyPKCS8(privateKeyPKCS8)
+            keySizeInBits = try RSAKeyDER.rsaPrivateKeySizeInBits(fromPKCS1DER: privateKeyPKCS1)
+        } catch {
+            throw RSAKeyImportError.invalidPrivateKey
+        }
+
+        let attributes: [String: Any] = [
+            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+            kSecAttrKeyClass as String: kSecAttrKeyClassPrivate,
+            kSecAttrKeySizeInBits as String: keySizeInBits
+        ]
+        guard let key = SecKeyCreateWithData(privateKeyPKCS1 as CFData, attributes as CFDictionary, nil) else {
+            throw RSAKeyImportError.invalidPrivateKey
+        }
+        return key
+    }
+}
+
 enum RSAKeyDERError: Error {
     case invalidDER
 }
@@ -69,14 +127,27 @@ enum RSAKeyDER {
     private static let null = Data([0x05, 0x00])
     private static let integerZero = Data([0x02, 0x01, 0x00])
 
+    private static var rsaAlgorithmIdentifierContents: Data {
+        var contents = rsaEncryptionOID
+        contents.append(null)
+        return contents
+    }
+
     private static var rsaAlgorithmIdentifier: Data {
-        ASN1DER.sequence([rsaEncryptionOID, null])
+        ASN1DER.sequence([rsaAlgorithmIdentifierContents])
     }
 
     static func wrapRSAPublicKeyInSPKI(_ publicKeyPKCS1: Data) -> Data {
         ASN1DER.sequence([
             rsaAlgorithmIdentifier,
             ASN1DER.bitString(publicKeyPKCS1)
+        ])
+    }
+
+    static func makeRSAPublicKeyPKCS1(modulus: Data, exponent: Data) -> Data {
+        ASN1DER.sequence([
+            ASN1DER.unsignedInteger(modulus),
+            ASN1DER.unsignedInteger(exponent)
         ])
     }
 
@@ -104,6 +175,48 @@ enum RSAKeyDER {
         ])
     }
 
+    static func unwrapRSAPrivateKeyPKCS8(_ pkcs8: Data) throws -> Data {
+        var cursor = DERCursor(bytes: [UInt8](pkcs8))
+        let sequence = try cursor.readElement(tag: 0x30)
+        guard cursor.isAtEnd else {
+            throw RSAKeyDERError.invalidDER
+        }
+
+        var sequenceCursor = DERCursor(bytes: sequence)
+        let version = try sequenceCursor.readElement(tag: 0x02)
+        guard version == [0x00] else {
+            throw RSAKeyDERError.invalidDER
+        }
+        let algorithmIdentifier = try sequenceCursor.readElement(tag: 0x30)
+        guard Data(algorithmIdentifier) == rsaAlgorithmIdentifierContents else {
+            throw RSAKeyDERError.invalidDER
+        }
+        let privateKey = try sequenceCursor.readElement(tag: 0x04)
+        guard sequenceCursor.isAtEnd, !privateKey.isEmpty else {
+            throw RSAKeyDERError.invalidDER
+        }
+        return Data(privateKey)
+    }
+
+    static func rsaPrivateKeySizeInBits(fromPKCS1DER der: Data) throws -> Int {
+        var cursor = DERCursor(bytes: [UInt8](der))
+        let sequence = try cursor.readElement(tag: 0x30)
+        guard cursor.isAtEnd else {
+            throw RSAKeyDERError.invalidDER
+        }
+
+        var sequenceCursor = DERCursor(bytes: sequence)
+        let version = try sequenceCursor.readElement(tag: 0x02)
+        guard version == [0x00] else {
+            throw RSAKeyDERError.invalidDER
+        }
+        let modulus = normalizedUnsignedInteger(try sequenceCursor.readElement(tag: 0x02))
+        guard !modulus.isEmpty else {
+            throw RSAKeyDERError.invalidDER
+        }
+        return modulus.count * 8
+    }
+
     static func parseRSAPublicKeyComponents(fromPKCS1DER der: Data) throws -> (modulus: Data, exponent: Data) {
         var cursor = DERCursor(bytes: [UInt8](der))
 
@@ -119,6 +232,14 @@ enum RSAKeyDER {
         let exponent = try cursor.readBytes(count: exponentLength)
 
         return (Data(modulus), Data(exponent))
+    }
+
+    private static func normalizedUnsignedInteger(_ value: [UInt8]) -> ArraySlice<UInt8> {
+        var value = value[...]
+        while value.count > 1, value.first == 0x00 {
+            value = value.dropFirst()
+        }
+        return value
     }
 }
 
@@ -138,6 +259,17 @@ private enum ASN1DER {
 
     static func octetString(_ data: Data) -> Data {
         wrap(tag: 0x04, contents: data)
+    }
+
+    static func unsignedInteger(_ data: Data) -> Data {
+        var contents = data
+        while contents.count > 1, contents.first == 0x00 {
+            contents.removeFirst()
+        }
+        if let first = contents.first, first & 0x80 != 0 {
+            contents.insert(0x00, at: 0)
+        }
+        return wrap(tag: 0x02, contents: contents)
     }
 
     private static func wrap(tag: UInt8, contents: Data) -> Data {
@@ -168,6 +300,10 @@ private enum ASN1DER {
 private struct DERCursor {
     let bytes: [UInt8]
     var index = 0
+
+    var isAtEnd: Bool {
+        index == bytes.count
+    }
 
     mutating func expect(tag: UInt8) throws {
         guard index < bytes.count, bytes[index] == tag else {
@@ -202,6 +338,11 @@ private struct DERCursor {
             index += 1
         }
         return length
+    }
+
+    mutating func readElement(tag: UInt8) throws -> [UInt8] {
+        try expect(tag: tag)
+        return try readBytes(count: readLength())
     }
 
     mutating func readBytes(count: Int) throws -> [UInt8] {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import os.log
 import Security
 
 struct AccountInfoKey: @unchecked Sendable {
@@ -58,7 +59,9 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
     func loadKey(for account: SyncAccount) async throws -> AccountInfoKey {
         if let protectedKeys = cachedProtectedKeys() {
             do {
-                return try await makeAccountInfoKey(from: protectedKeys, account: account)
+                let key = try await makeAccountInfoKey(from: protectedKeys, account: account)
+                Logger.sync.debug("Sync-UnifiedDevices: loaded account_info key from secure storage")
+                return key
             } catch {
                 // Preserve structurally valid cached keys until an authoritative refresh succeeds.
             }
@@ -67,6 +70,7 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
     }
 
     func refreshKey(for account: SyncAccount) async throws -> AccountInfoKey {
+        Logger.sync.debug("Sync-UnifiedDevices: fetching account_info key from server")
         let protectedKeys = try await scopedAccess.fetchProtectedKeys(account)
             .removingDuplicateWrappingIdentities()
         let key = try await makeAccountInfoKey(from: protectedKeys, account: account)
@@ -115,7 +119,13 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
             hasSupportedWrapper = true
             do {
                 let privateKeyPKCS8 = try await unwrapPrivateKey(protectedKey, account: account)
-                return try makeAccountInfoKey(protectedKey: protectedKey, privateKeyPKCS8: privateKeyPKCS8)
+                let key = try makeAccountInfoKey(protectedKey: protectedKey, privateKeyPKCS8: privateKeyPKCS8)
+                if protectedKey.encryptedWith == SyncCredentialID.defaultCredential {
+                    Logger.sync.debug("Sync-UnifiedDevices: unwrapped account_info key with ddg credential")
+                } else {
+                    Logger.sync.debug("Sync-UnifiedDevices: unwrapped account_info key with 3party credential")
+                }
+                return key
             } catch {
                 lastError = error
             }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
@@ -60,7 +60,7 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
             do {
                 return try await makeAccountInfoKey(from: protectedKeys, account: account)
             } catch {
-                try? secureStore.removeProtectedKeys()
+                // Preserve structurally valid cached keys until an authoritative refresh succeeds.
             }
         }
         return try await refreshKey(for: account)

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
@@ -19,7 +19,7 @@
 import Foundation
 import Security
 
-struct AccountInfoKeyMaterial: @unchecked Sendable {
+struct AccountInfoKey: @unchecked Sendable {
     let kid: String
     let publicKey: SecKey
     let privateKey: SecKey
@@ -34,8 +34,8 @@ enum AccountInfoKeyManagerError: Error, Equatable {
 }
 
 protocol AccountInfoKeyManaging {
-    func loadKey(for account: SyncAccount) async throws -> AccountInfoKeyMaterial
-    func refreshKey(for account: SyncAccount) async throws -> AccountInfoKeyMaterial
+    func loadKey(for account: SyncAccount) async throws -> AccountInfoKey
+    func refreshKey(for account: SyncAccount) async throws -> AccountInfoKey
 }
 
 actor AccountInfoKeyManager: AccountInfoKeyManaging {
@@ -55,10 +55,10 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
         self.jweCompactCodec = jweCompactCodec
     }
 
-    func loadKey(for account: SyncAccount) async throws -> AccountInfoKeyMaterial {
+    func loadKey(for account: SyncAccount) async throws -> AccountInfoKey {
         if let protectedKeys = cachedProtectedKeys() {
             do {
-                return try await makeKeyMaterial(from: protectedKeys, account: account)
+                return try await makeAccountInfoKey(from: protectedKeys, account: account)
             } catch {
                 try? secureStore.removeProtectedKeys()
             }
@@ -66,10 +66,10 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
         return try await refreshKey(for: account)
     }
 
-    func refreshKey(for account: SyncAccount) async throws -> AccountInfoKeyMaterial {
+    func refreshKey(for account: SyncAccount) async throws -> AccountInfoKey {
         let protectedKeys = try await scopedAccess.fetchProtectedKeys(account)
             .removingDuplicateWrappingIdentities()
-        let key = try await makeKeyMaterial(from: protectedKeys, account: account)
+        let key = try await makeAccountInfoKey(from: protectedKeys, account: account)
         cache(protectedKeys)
         return key
     }
@@ -92,8 +92,8 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
         try? secureStore.persistProtectedKeys(encodedKeys)
     }
 
-    private func makeKeyMaterial(from protectedKeys: [ProtectedKey],
-                                 account: SyncAccount) async throws -> AccountInfoKeyMaterial {
+    private func makeAccountInfoKey(from protectedKeys: [ProtectedKey],
+                                    account: SyncAccount) async throws -> AccountInfoKey {
         let accountInfoKeys = protectedKeys.filter { $0.purpose == ProtectedKeyPurpose.accountInfo }
         guard let firstKey = accountInfoKeys.first else {
             throw AccountInfoKeyManagerError.missingProtectedKey
@@ -115,7 +115,7 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
             hasSupportedWrapper = true
             do {
                 let privateKeyPKCS8 = try await unwrapPrivateKey(protectedKey, account: account)
-                return try makeKeyMaterial(protectedKey: protectedKey, privateKeyPKCS8: privateKeyPKCS8)
+                return try makeAccountInfoKey(protectedKey: protectedKey, privateKeyPKCS8: privateKeyPKCS8)
             } catch {
                 lastError = error
             }
@@ -164,8 +164,8 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
         return scopedPassword
     }
 
-    private func makeKeyMaterial(protectedKey: ProtectedKey,
-                                 privateKeyPKCS8: Data) throws -> AccountInfoKeyMaterial {
+    private func makeAccountInfoKey(protectedKey: ProtectedKey,
+                                    privateKeyPKCS8: Data) throws -> AccountInfoKey {
         let publicKey = try RSAKeyImporter.makePublicKey(from: protectedKey.publicKey)
         let privateKey = try RSAKeyImporter.makePrivateKey(fromPKCS8: privateKeyPKCS8)
         guard let derivedPublicKey = SecKeyCopyPublicKey(privateKey),
@@ -174,8 +174,8 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
               expectedPublicKeyData == derivedPublicKeyData else {
             throw AccountInfoKeyManagerError.publicKeyMismatch
         }
-        return AccountInfoKeyMaterial(kid: protectedKey.kid,
-                                      publicKey: publicKey,
-                                      privateKey: privateKey)
+        return AccountInfoKey(kid: protectedKey.kid,
+                              publicKey: publicKey,
+                              privateKey: privateKey)
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
@@ -1,0 +1,181 @@
+//
+//  AccountInfoKeyManager.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Security
+
+struct AccountInfoKeyMaterial: @unchecked Sendable {
+    let kid: String
+    let publicKey: SecKey
+    let privateKey: SecKey
+}
+
+enum AccountInfoKeyManagerError: Error, Equatable {
+    case missingProtectedKey
+    case invalidProtectedKeySet
+    case unavailableWrappingKey
+    case unableToUnwrapPrivateKey
+    case publicKeyMismatch
+}
+
+protocol AccountInfoKeyManaging {
+    func loadKey(for account: SyncAccount) async throws -> AccountInfoKeyMaterial
+    func refreshKey(for account: SyncAccount) async throws -> AccountInfoKeyMaterial
+}
+
+actor AccountInfoKeyManager: AccountInfoKeyManaging {
+
+    private let secureStore: SecureStoring
+    private let scopedAccess: ScopedAccessCredentialManaging
+    private let crypter: CryptingInternal
+    private let jweCompactCodec: JWECompactCodec
+
+    init(secureStore: SecureStoring,
+         scopedAccess: ScopedAccessCredentialManaging,
+         crypter: CryptingInternal,
+         jweCompactCodec: JWECompactCodec = JWECompactCodec()) {
+        self.secureStore = secureStore
+        self.scopedAccess = scopedAccess
+        self.crypter = crypter
+        self.jweCompactCodec = jweCompactCodec
+    }
+
+    func loadKey(for account: SyncAccount) async throws -> AccountInfoKeyMaterial {
+        if let protectedKeys = cachedProtectedKeys() {
+            do {
+                return try await makeKeyMaterial(from: protectedKeys, account: account)
+            } catch {
+                try? secureStore.removeProtectedKeys()
+            }
+        }
+        return try await refreshKey(for: account)
+    }
+
+    func refreshKey(for account: SyncAccount) async throws -> AccountInfoKeyMaterial {
+        let protectedKeys = try await scopedAccess.fetchProtectedKeys(account)
+            .removingDuplicateWrappingIdentities()
+        let key = try await makeKeyMaterial(from: protectedKeys, account: account)
+        cache(protectedKeys)
+        return key
+    }
+
+    private func cachedProtectedKeys() -> [ProtectedKey]? {
+        guard let data = try? secureStore.protectedKeys() else {
+            return nil
+        }
+        guard let protectedKeys = try? JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: data) else {
+            try? secureStore.removeProtectedKeys()
+            return nil
+        }
+        return protectedKeys.removingDuplicateWrappingIdentities()
+    }
+
+    private func cache(_ protectedKeys: [ProtectedKey]) {
+        guard let encodedKeys = try? JSONEncoder.snakeCaseKeys.encode(protectedKeys) else {
+            return
+        }
+        try? secureStore.persistProtectedKeys(encodedKeys)
+    }
+
+    private func makeKeyMaterial(from protectedKeys: [ProtectedKey],
+                                 account: SyncAccount) async throws -> AccountInfoKeyMaterial {
+        let accountInfoKeys = protectedKeys.filter { $0.purpose == ProtectedKeyPurpose.accountInfo }
+        guard let firstKey = accountInfoKeys.first else {
+            throw AccountInfoKeyManagerError.missingProtectedKey
+        }
+        guard !firstKey.kid.isEmpty,
+              accountInfoKeys.allSatisfy({ $0.kid == firstKey.kid && $0.publicKey == firstKey.publicKey }) else {
+            throw AccountInfoKeyManagerError.invalidProtectedKeySet
+        }
+
+        let defaultCredentialKeys = accountInfoKeys.filter { $0.encryptedWith == SyncCredentialID.defaultCredential }
+        let otherKeys = accountInfoKeys.filter { $0.encryptedWith != SyncCredentialID.defaultCredential }
+        let orderedKeys = defaultCredentialKeys + otherKeys
+        var hasSupportedWrapper = false
+        var lastError: Error?
+        for protectedKey in orderedKeys {
+            guard [SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty].contains(protectedKey.encryptedWith) else {
+                continue
+            }
+            hasSupportedWrapper = true
+            do {
+                let privateKeyPKCS8 = try await unwrapPrivateKey(protectedKey, account: account)
+                return try makeKeyMaterial(protectedKey: protectedKey, privateKeyPKCS8: privateKeyPKCS8)
+            } catch {
+                lastError = error
+            }
+        }
+
+        guard hasSupportedWrapper else {
+            throw AccountInfoKeyManagerError.unavailableWrappingKey
+        }
+        if let lastError {
+            throw lastError
+        }
+        throw AccountInfoKeyManagerError.unableToUnwrapPrivateKey
+    }
+
+    private func unwrapPrivateKey(_ protectedKey: ProtectedKey, account: SyncAccount) async throws -> Data {
+        switch protectedKey.encryptedWith {
+        case SyncCredentialID.defaultCredential:
+            guard let encryptedPrivateKey = Base64URL.decode(protectedKey.encryptedPrivateKey) else {
+                throw AccountInfoKeyManagerError.unableToUnwrapPrivateKey
+            }
+            return try crypter.decryptData(encryptedPrivateKey, using: account.secretKey)
+        case SyncCredentialID.thirdParty:
+            let scopedPassword = try await scopedPassword(for: account)
+            let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+            return try jweCompactCodec.decryptDirect(token: protectedKey.encryptedPrivateKey,
+                                                     contentEncryptionKey: thirdPartyMainKey,
+                                                     expectedKid: SyncCredentialID.thirdParty)
+        default:
+            throw AccountInfoKeyManagerError.unavailableWrappingKey
+        }
+    }
+
+    private func scopedPassword(for account: SyncAccount) async throws -> Data {
+        if let scopedPassword = try secureStore.scopedPassword(), !scopedPassword.isEmpty {
+            return scopedPassword
+        }
+
+        let accessCredentials = try await scopedAccess.fetchAccessCredentials(account)
+        guard let scopedPassword = try scopedAccess.recoverScopedPassword(from: accessCredentials,
+                                                                          primaryKey: account.primaryKey,
+                                                                          userID: account.userId),
+              !scopedPassword.isEmpty else {
+            throw AccountInfoKeyManagerError.unavailableWrappingKey
+        }
+        try? secureStore.persistScopedPassword(scopedPassword)
+        return scopedPassword
+    }
+
+    private func makeKeyMaterial(protectedKey: ProtectedKey,
+                                 privateKeyPKCS8: Data) throws -> AccountInfoKeyMaterial {
+        let publicKey = try RSAKeyImporter.makePublicKey(from: protectedKey.publicKey)
+        let privateKey = try RSAKeyImporter.makePrivateKey(fromPKCS8: privateKeyPKCS8)
+        guard let derivedPublicKey = SecKeyCopyPublicKey(privateKey),
+              let expectedPublicKeyData = SecKeyCopyExternalRepresentation(publicKey, nil) as Data?,
+              let derivedPublicKeyData = SecKeyCopyExternalRepresentation(derivedPublicKey, nil) as Data?,
+              expectedPublicKeyData == derivedPublicKeyData else {
+            throw AccountInfoKeyManagerError.publicKeyMismatch
+        }
+        return AccountInfoKeyMaterial(kid: protectedKey.kid,
+                                      publicKey: publicKey,
+                                      privateKey: privateKey)
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
@@ -62,7 +62,10 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
                 let key = try await makeAccountInfoKey(from: protectedKeys, account: account)
                 Logger.sync.debug("Sync-UnifiedDevices: loaded account_info key from secure storage")
                 return key
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
+                try Task.checkCancellation()
                 // Preserve structurally valid cached keys until an authoritative refresh succeeds.
             }
         }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SecureStorage.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SecureStorage.swift
@@ -160,6 +160,19 @@ struct SecureStorage: SecureStoring {
         }
     }
 
+    func protectedKeys() throws -> Data? {
+        var query = Self.protectedKeysQuery
+        query[kSecReturnData] = true
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard [errSecSuccess, errSecItemNotFound].contains(status) else {
+            throw SyncError.failedToReadSecureStore(status: status)
+        }
+
+        return item as? Data
+    }
+
     func removeProtectedKeys() throws {
         let status = SecItemDelete(Self.protectedKeysQuery as CFDictionary)
         guard [errSecSuccess, errSecItemNotFound].contains(status) else {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
@@ -32,6 +32,7 @@ protocol SyncDependencies: SyncDependenciesDebuggingSupport {
     var endpoints: Endpoints { get }
     var account: AccountManaging { get }
     var scopedAccess: ScopedAccessCredentialManaging { get }
+    var accountInfoKeys: AccountInfoKeyManaging { get }
     var api: RemoteAPIRequestCreating { get }
     var payloadCompressor: SyncPayloadCompressing { get }
     var keyValueStore: ThrowingKeyValueStoring { get }
@@ -99,6 +100,7 @@ protocol SecureStoring {
     func scopedPassword() throws -> Data?
     func removeScopedPassword() throws
     func persistProtectedKeys(_ data: Data) throws
+    func protectedKeys() throws -> Data?
     func removeProtectedKeys() throws
 }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/JWECompactCodecTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/JWECompactCodecTests.swift
@@ -63,6 +63,20 @@ final class JWECompactCodecTests: XCTestCase {
         XCTAssertEqual(decrypted, payload)
     }
 
+    func testWhenDecryptingDirectTokenWithUnexpectedKidThenThrows() throws {
+        let codec = JWECompactCodec()
+        let contentEncryptionKey = Data(repeating: 0x2B, count: 32)
+        let token = try codec.encryptDirect(payload: Data("payload".utf8),
+                                            contentEncryptionKey: contentEncryptionKey,
+                                            kid: "3party")
+
+        XCTAssertThrowsError(try codec.decryptDirect(token: token,
+                                                     contentEncryptionKey: contentEncryptionKey,
+                                                     expectedKid: "ddg")) { error in
+            XCTAssertEqual(error as? JWECompactCodecError, .unsupportedProtectedHeader)
+        }
+    }
+
     func testWhenRoundTrippingRSAOAEP256ModeThenRecoversPayloadAndProducesExpectedCompactShape() throws {
         let codec = JWECompactCodec()
         let keyPair = try RSAKeyPairGenerator.makeKeyPair()

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -387,9 +387,9 @@ final class AccountInfoKeyFactoryMock: AccountInfoKeyFactory {
 
 final class AccountInfoKeyManagingMock: AccountInfoKeyManaging {
     var loadKeyCalls: [SyncAccount] = []
-    var loadKeyStub: AccountInfoKeyMaterial?
+    var loadKeyStub: AccountInfoKey?
     var loadKeyError: Error?
-    func loadKey(for account: SyncAccount) async throws -> AccountInfoKeyMaterial {
+    func loadKey(for account: SyncAccount) async throws -> AccountInfoKey {
         loadKeyCalls.append(account)
         if let loadKeyError {
             throw loadKeyError
@@ -401,9 +401,9 @@ final class AccountInfoKeyManagingMock: AccountInfoKeyManaging {
     }
 
     var refreshKeyCalls: [SyncAccount] = []
-    var refreshKeyStub: AccountInfoKeyMaterial?
+    var refreshKeyStub: AccountInfoKey?
     var refreshKeyError: Error?
-    func refreshKey(for account: SyncAccount) async throws -> AccountInfoKeyMaterial {
+    func refreshKey(for account: SyncAccount) async throws -> AccountInfoKey {
         refreshKeyCalls.append(account)
         if let refreshKeyError {
             throw refreshKeyError

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -240,6 +240,7 @@ final class MockSyncDependencies: SyncDependencies, SyncDependenciesDebuggingSup
     var endpoints: Endpoints = Endpoints(baseURL: URL(string: "https://dev.null")!)
     var account: AccountManaging = AccountManagingMock()
     var scopedAccess: ScopedAccessCredentialManaging = ScopedAccessCredentialManagingMock()
+    var accountInfoKeys: AccountInfoKeyManaging = AccountInfoKeyManagingMock()
     var api: RemoteAPIRequestCreating = RemoteAPIRequestCreatingMock()
     var payloadCompressor: SyncPayloadCompressing = SyncGzipPayloadCompressorMock()
     var secureStore: SecureStoring = SecureStorageStub()
@@ -381,6 +382,36 @@ final class AccountInfoKeyFactoryMock: AccountInfoKeyFactory {
             throw makeProtectedKeysError
         }
         return makeProtectedKeysStub
+    }
+}
+
+final class AccountInfoKeyManagingMock: AccountInfoKeyManaging {
+    var loadKeyCalls: [SyncAccount] = []
+    var loadKeyStub: AccountInfoKeyMaterial?
+    var loadKeyError: Error?
+    func loadKey(for account: SyncAccount) async throws -> AccountInfoKeyMaterial {
+        loadKeyCalls.append(account)
+        if let loadKeyError {
+            throw loadKeyError
+        }
+        guard let loadKeyStub else {
+            throw AccountInfoKeyManagerError.missingProtectedKey
+        }
+        return loadKeyStub
+    }
+
+    var refreshKeyCalls: [SyncAccount] = []
+    var refreshKeyStub: AccountInfoKeyMaterial?
+    var refreshKeyError: Error?
+    func refreshKey(for account: SyncAccount) async throws -> AccountInfoKeyMaterial {
+        refreshKeyCalls.append(account)
+        if let refreshKeyError {
+            throw refreshKeyError
+        }
+        guard let refreshKeyStub else {
+            throw AccountInfoKeyManagerError.missingProtectedKey
+        }
+        return refreshKeyStub
     }
 }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
@@ -1,0 +1,139 @@
+//
+//  AccountInfoKeyManagerTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+@testable import DDGSync
+
+final class AccountInfoKeyManagerTests: XCTestCase {
+
+    private let account = SyncAccount.mock
+    private let crypter = CryptingMock()
+
+    func testWhenDefaultCredentialKeyIsCachedThenLoadsWithoutFetching() async throws {
+        let protectedKey = try makeDefaultCredentialProtectedKey()
+        let secureStore = SecureStorageStub()
+        secureStore.theProtectedKeysData = try JSONEncoder.snakeCaseKeys.encode([protectedKey])
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        let key = try await manager.loadKey(for: account)
+
+        XCTAssertEqual(key.kid, protectedKey.kid)
+        XCTAssertTrue(scopedAccess.fetchProtectedKeysCalls.isEmpty)
+    }
+
+    func testWhenCacheIsCorruptThenFetchesAndCachesServerKeys() async throws {
+        let protectedKey = try makeDefaultCredentialProtectedKey()
+        let secureStore = SecureStorageStub()
+        secureStore.theProtectedKeysData = Data("invalid".utf8)
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        scopedAccess.fetchProtectedKeysStub = [protectedKey]
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        let key = try await manager.loadKey(for: account)
+
+        let cachedData = try XCTUnwrap(secureStore.theProtectedKeysData)
+        let cachedKeys = try JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: cachedData)
+        XCTAssertEqual(key.kid, protectedKey.kid)
+        XCTAssertEqual(scopedAccess.fetchProtectedKeysCalls.map(\.userId), [account.userId])
+        XCTAssertEqual(cachedKeys.map(\.kid), [protectedKey.kid])
+    }
+
+    func testWhenOnlyThirdPartyWrapperIsCachedThenLoadsUsingScopedPassword() async throws {
+        let scopedPassword = Data(repeating: 0x03, count: 32)
+        let protectedKey = try makeThirdPartyCredentialProtectedKey(scopedPassword: scopedPassword)
+        let secureStore = SecureStorageStub()
+        secureStore.theScopedPassword = scopedPassword
+        secureStore.theProtectedKeysData = try JSONEncoder.snakeCaseKeys.encode([protectedKey])
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        let key = try await manager.loadKey(for: account)
+
+        XCTAssertEqual(key.kid, protectedKey.kid)
+        XCTAssertTrue(scopedAccess.fetchProtectedKeysCalls.isEmpty)
+    }
+
+    func testWhenThirdPartyWrapperIsCachedWithoutScopedPasswordThenRecoversAndCachesPassword() async throws {
+        let scopedPassword = Data(repeating: 0x03, count: 32)
+        let protectedKey = try makeThirdPartyCredentialProtectedKey(scopedPassword: scopedPassword)
+        let secureStore = SecureStorageStub()
+        secureStore.theProtectedKeysData = try JSONEncoder.snakeCaseKeys.encode([protectedKey])
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        scopedAccess.fetchAccessCredentialsStub = [
+            AccessCredential(id: SyncCredentialID.thirdParty, scope: "sync", encrypted3PartyCredential: "encrypted")
+        ]
+        scopedAccess.recoverScopedPasswordStub = scopedPassword
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        let key = try await manager.loadKey(for: account)
+
+        XCTAssertEqual(key.kid, protectedKey.kid)
+        XCTAssertEqual(scopedAccess.fetchAccessCredentialsCalls.map(\.userId), [account.userId])
+        XCTAssertEqual(scopedAccess.recoverScopedPasswordCalls.map(\.userID), [account.userId])
+        XCTAssertEqual(secureStore.theScopedPassword, scopedPassword)
+    }
+
+    func testWhenServerHasNoAccountInfoKeyThenThrows() async throws {
+        let secureStore = SecureStorageStub()
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        scopedAccess.fetchProtectedKeysStub = []
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        do {
+            _ = try await manager.loadKey(for: account)
+            XCTFail("Expected missing protected key error")
+        } catch {
+            XCTAssertEqual(error as? AccountInfoKeyManagerError, .missingProtectedKey)
+        }
+    }
+
+    private func makeDefaultCredentialProtectedKey() throws -> ProtectedKey {
+        let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
+        let encryptedPrivateKey = try crypter.encrypt(keyMaterial.privateKeyPKCS8, using: account.secretKey)
+        return ProtectedKey(kid: UUID().uuidString,
+                            encryptedPrivateKey: Base64URL.encode(encryptedPrivateKey),
+                            publicKey: keyMaterial.publicKeyJWK,
+                            encryptedWith: SyncCredentialID.defaultCredential,
+                            purpose: ProtectedKeyPurpose.accountInfo)
+    }
+
+    private func makeThirdPartyCredentialProtectedKey(scopedPassword: Data) throws -> ProtectedKey {
+        let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
+        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        let encryptedPrivateKey = try JWECompactCodec().encryptDirect(payload: keyMaterial.privateKeyPKCS8,
+                                                                      contentEncryptionKey: thirdPartyMainKey,
+                                                                      kid: SyncCredentialID.thirdParty)
+        return ProtectedKey(kid: UUID().uuidString,
+                            encryptedPrivateKey: encryptedPrivateKey,
+                            publicKey: keyMaterial.publicKeyJWK,
+                            encryptedWith: SyncCredentialID.thirdParty,
+                            purpose: ProtectedKeyPurpose.accountInfo)
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
@@ -129,6 +129,51 @@ final class AccountInfoKeyManagerTests: XCTestCase {
         XCTAssertEqual(scopedAccess.fetchProtectedKeysCalls.map(\.userId), [account.userId])
     }
 
+    func testWhenAccountInfoWrappersDescribeDifferentPublicKeysThenThrowsInvalidProtectedKeySet() async throws {
+        let protectedKey = try makeDefaultCredentialProtectedKey()
+        let differentPublicKey = try ScopedAccessKeyFactory.makeRSAKeyMaterial().publicKeyJWK
+        let inconsistentWrapper = ProtectedKey(kid: protectedKey.kid,
+                                               encryptedPrivateKey: "unused",
+                                               publicKey: differentPublicKey,
+                                               encryptedWith: SyncCredentialID.thirdParty,
+                                               purpose: ProtectedKeyPurpose.accountInfo)
+
+        await assertRefreshing([protectedKey, inconsistentWrapper], expectedError: .invalidProtectedKeySet)
+    }
+
+    func testWhenAccountInfoKeyHasUnsupportedWrapperThenThrowsUnavailableWrappingKey() async {
+        let protectedKey = ProtectedKey(kid: "account-info-key",
+                                        encryptedPrivateKey: "unused",
+                                        publicKey: .mock,
+                                        encryptedWith: "unsupported",
+                                        purpose: ProtectedKeyPurpose.accountInfo)
+
+        await assertRefreshing([protectedKey], expectedError: .unavailableWrappingKey)
+    }
+
+    func testWhenDefaultWrapperIsNotBase64URLThenThrowsUnableToUnwrapPrivateKey() async {
+        let protectedKey = ProtectedKey(kid: "account-info-key",
+                                        encryptedPrivateKey: "%",
+                                        publicKey: .mock,
+                                        encryptedWith: SyncCredentialID.defaultCredential,
+                                        purpose: ProtectedKeyPurpose.accountInfo)
+
+        await assertRefreshing([protectedKey], expectedError: .unableToUnwrapPrivateKey)
+    }
+
+    func testWhenPrivateKeyDoesNotMatchPublicKeyThenThrowsPublicKeyMismatch() async throws {
+        let privateKeyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
+        let publicKeyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
+        let encryptedPrivateKey = try crypter.encrypt(privateKeyMaterial.privateKeyPKCS8, using: account.secretKey)
+        let protectedKey = ProtectedKey(kid: "account-info-key",
+                                        encryptedPrivateKey: Base64URL.encode(encryptedPrivateKey),
+                                        publicKey: publicKeyMaterial.publicKeyJWK,
+                                        encryptedWith: SyncCredentialID.defaultCredential,
+                                        purpose: ProtectedKeyPurpose.accountInfo)
+
+        await assertRefreshing([protectedKey], expectedError: .publicKeyMismatch)
+    }
+
     func testWhenServerHasNoAccountInfoKeyThenThrows() async throws {
         let secureStore = SecureStorageStub()
         let scopedAccess = ScopedAccessCredentialManagingMock()
@@ -142,6 +187,24 @@ final class AccountInfoKeyManagerTests: XCTestCase {
             XCTFail("Expected missing protected key error")
         } catch {
             XCTAssertEqual(error as? AccountInfoKeyManagerError, .missingProtectedKey)
+        }
+    }
+
+    private func assertRefreshing(_ protectedKeys: [ProtectedKey],
+                                  expectedError: AccountInfoKeyManagerError,
+                                  file: StaticString = #filePath,
+                                  line: UInt = #line) async {
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        scopedAccess.fetchProtectedKeysStub = protectedKeys
+        let manager = AccountInfoKeyManager(secureStore: SecureStorageStub(),
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        do {
+            _ = try await manager.refreshKey(for: account)
+            XCTFail("Expected key refresh to fail", file: file, line: line)
+        } catch {
+            XCTAssertEqual(error as? AccountInfoKeyManagerError, expectedError, file: file, line: line)
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
@@ -98,6 +98,37 @@ final class AccountInfoKeyManagerTests: XCTestCase {
         XCTAssertEqual(secureStore.theScopedPassword, scopedPassword)
     }
 
+    func testWhenCachedThirdPartyKeyAndRefreshFailTransientlyThenPreservesProtectedKeyCache() async throws {
+        let scopedPassword = Data(repeating: 0x03, count: 32)
+        let accountInfoKey = try makeThirdPartyCredentialProtectedKey(scopedPassword: scopedPassword)
+        let unrelatedKey = ProtectedKey(kid: "unrelated-key",
+                                        encryptedPrivateKey: "unrelated-encrypted-key",
+                                        publicKey: accountInfoKey.publicKey,
+                                        encryptedWith: SyncCredentialID.defaultCredential,
+                                        purpose: "unrelated-purpose")
+        let cachedData = try JSONEncoder.snakeCaseKeys.encode([accountInfoKey, unrelatedKey])
+        let secureStore = SecureStorageStub()
+        secureStore.theProtectedKeysData = cachedData
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        let transientError = URLError(.notConnectedToInternet)
+        scopedAccess.fetchAccessCredentialsError = transientError
+        scopedAccess.fetchProtectedKeysError = transientError
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        do {
+            _ = try await manager.loadKey(for: account)
+            XCTFail("Expected transient key loading error")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, transientError.code)
+        }
+
+        XCTAssertEqual(secureStore.theProtectedKeysData, cachedData)
+        XCTAssertEqual(scopedAccess.fetchAccessCredentialsCalls.map(\.userId), [account.userId])
+        XCTAssertEqual(scopedAccess.fetchProtectedKeysCalls.map(\.userId), [account.userId])
+    }
+
     func testWhenServerHasNoAccountInfoKeyThenThrows() async throws {
         let secureStore = SecureStorageStub()
         let scopedAccess = ScopedAccessCredentialManagingMock()

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
@@ -16,15 +16,18 @@
 //  limitations under the License.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import DDGSync
 
-final class AccountInfoKeyManagerTests: XCTestCase {
+@Suite("Account info key manager")
+struct AccountInfoKeyManagerTests {
 
     private let account = SyncAccount.mock
     private let crypter = CryptingMock()
 
+    @Test("A cached default-credential key loads without fetching")
     func testWhenDefaultCredentialKeyIsCachedThenLoadsWithoutFetching() async throws {
         let protectedKey = try makeDefaultCredentialProtectedKey()
         let secureStore = SecureStorageStub()
@@ -36,10 +39,11 @@ final class AccountInfoKeyManagerTests: XCTestCase {
 
         let key = try await manager.loadKey(for: account)
 
-        XCTAssertEqual(key.kid, protectedKey.kid)
-        XCTAssertTrue(scopedAccess.fetchProtectedKeysCalls.isEmpty)
+        #expect(key.kid == protectedKey.kid)
+        #expect(scopedAccess.fetchProtectedKeysCalls.isEmpty)
     }
 
+    @Test("A corrupt cache is replaced with server keys")
     func testWhenCacheIsCorruptThenFetchesAndCachesServerKeys() async throws {
         let protectedKey = try makeDefaultCredentialProtectedKey()
         let secureStore = SecureStorageStub()
@@ -52,13 +56,14 @@ final class AccountInfoKeyManagerTests: XCTestCase {
 
         let key = try await manager.loadKey(for: account)
 
-        let cachedData = try XCTUnwrap(secureStore.theProtectedKeysData)
+        let cachedData = try #require(secureStore.theProtectedKeysData)
         let cachedKeys = try JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: cachedData)
-        XCTAssertEqual(key.kid, protectedKey.kid)
-        XCTAssertEqual(scopedAccess.fetchProtectedKeysCalls.map(\.userId), [account.userId])
-        XCTAssertEqual(cachedKeys.map(\.kid), [protectedKey.kid])
+        #expect(key.kid == protectedKey.kid)
+        #expect(scopedAccess.fetchProtectedKeysCalls.map(\.userId) == [account.userId])
+        #expect(cachedKeys.map(\.kid) == [protectedKey.kid])
     }
 
+    @Test("A cached third-party wrapper loads using the scoped password")
     func testWhenOnlyThirdPartyWrapperIsCachedThenLoadsUsingScopedPassword() async throws {
         let scopedPassword = Data(repeating: 0x03, count: 32)
         let protectedKey = try makeThirdPartyCredentialProtectedKey(scopedPassword: scopedPassword)
@@ -72,10 +77,11 @@ final class AccountInfoKeyManagerTests: XCTestCase {
 
         let key = try await manager.loadKey(for: account)
 
-        XCTAssertEqual(key.kid, protectedKey.kid)
-        XCTAssertTrue(scopedAccess.fetchProtectedKeysCalls.isEmpty)
+        #expect(key.kid == protectedKey.kid)
+        #expect(scopedAccess.fetchProtectedKeysCalls.isEmpty)
     }
 
+    @Test("A failed default wrapper falls back to the third-party wrapper")
     func testWhenDefaultWrapperCannotBeUnwrappedThenFallsBackToThirdPartyWrapper() async throws {
         let scopedPassword = Data(repeating: 0x03, count: 32)
         let protectedKeys = try makeDualWrappedProtectedKeys(scopedPassword: scopedPassword)
@@ -97,11 +103,12 @@ final class AccountInfoKeyManagerTests: XCTestCase {
 
         let key = try await manager.loadKey(for: account)
 
-        XCTAssertEqual(key.kid, protectedKeys.thirdParty.kid)
-        XCTAssertTrue(scopedAccess.fetchProtectedKeysCalls.isEmpty)
-        XCTAssertTrue(scopedAccess.fetchAccessCredentialsCalls.isEmpty)
+        #expect(key.kid == protectedKeys.thirdParty.kid)
+        #expect(scopedAccess.fetchProtectedKeysCalls.isEmpty)
+        #expect(scopedAccess.fetchAccessCredentialsCalls.isEmpty)
     }
 
+    @Test("The default wrapper is preferred without recovering a scoped password")
     func testWhenBothWrappersAreCachedThenPrefersDefaultWithoutRecoveringScopedPassword() async throws {
         let scopedPassword = Data(repeating: 0x03, count: 32)
         let protectedKeys = try makeDualWrappedProtectedKeys(scopedPassword: scopedPassword)
@@ -117,12 +124,13 @@ final class AccountInfoKeyManagerTests: XCTestCase {
 
         let key = try await manager.loadKey(for: account)
 
-        XCTAssertEqual(key.kid, protectedKeys.defaultCredential.kid)
-        XCTAssertTrue(scopedAccess.fetchProtectedKeysCalls.isEmpty)
-        XCTAssertTrue(scopedAccess.fetchAccessCredentialsCalls.isEmpty)
-        XCTAssertTrue(scopedAccess.recoverScopedPasswordCalls.isEmpty)
+        #expect(key.kid == protectedKeys.defaultCredential.kid)
+        #expect(scopedAccess.fetchProtectedKeysCalls.isEmpty)
+        #expect(scopedAccess.fetchAccessCredentialsCalls.isEmpty)
+        #expect(scopedAccess.recoverScopedPasswordCalls.isEmpty)
     }
 
+    @Test("A missing scoped password is recovered and cached")
     func testWhenThirdPartyWrapperIsCachedWithoutScopedPasswordThenRecoversAndCachesPassword() async throws {
         let scopedPassword = Data(repeating: 0x03, count: 32)
         let protectedKey = try makeThirdPartyCredentialProtectedKey(scopedPassword: scopedPassword)
@@ -139,12 +147,13 @@ final class AccountInfoKeyManagerTests: XCTestCase {
 
         let key = try await manager.loadKey(for: account)
 
-        XCTAssertEqual(key.kid, protectedKey.kid)
-        XCTAssertEqual(scopedAccess.fetchAccessCredentialsCalls.map(\.userId), [account.userId])
-        XCTAssertEqual(scopedAccess.recoverScopedPasswordCalls.map(\.userID), [account.userId])
-        XCTAssertEqual(secureStore.theScopedPassword, scopedPassword)
+        #expect(key.kid == protectedKey.kid)
+        #expect(scopedAccess.fetchAccessCredentialsCalls.map(\.userId) == [account.userId])
+        #expect(scopedAccess.recoverScopedPasswordCalls.map(\.userID) == [account.userId])
+        #expect(secureStore.theScopedPassword == scopedPassword)
     }
 
+    @Test("Transient refresh failures preserve the protected-key cache")
     func testWhenCachedThirdPartyKeyAndRefreshFailTransientlyThenPreservesProtectedKeyCache() async throws {
         let scopedPassword = Data(repeating: 0x03, count: 32)
         let accountInfoKey = try makeThirdPartyCredentialProtectedKey(scopedPassword: scopedPassword)
@@ -166,16 +175,17 @@ final class AccountInfoKeyManagerTests: XCTestCase {
 
         do {
             _ = try await manager.loadKey(for: account)
-            XCTFail("Expected transient key loading error")
+            Issue.record("Expected transient key loading error")
         } catch {
-            XCTAssertEqual((error as? URLError)?.code, transientError.code)
+            #expect((error as? URLError)?.code == transientError.code)
         }
 
-        XCTAssertEqual(secureStore.theProtectedKeysData, cachedData)
-        XCTAssertEqual(scopedAccess.fetchAccessCredentialsCalls.map(\.userId), [account.userId])
-        XCTAssertEqual(scopedAccess.fetchProtectedKeysCalls.map(\.userId), [account.userId])
+        #expect(secureStore.theProtectedKeysData == cachedData)
+        #expect(scopedAccess.fetchAccessCredentialsCalls.map(\.userId) == [account.userId])
+        #expect(scopedAccess.fetchProtectedKeysCalls.map(\.userId) == [account.userId])
     }
 
+    @Test("Inconsistent public keys are rejected")
     func testWhenAccountInfoWrappersDescribeDifferentPublicKeysThenThrowsInvalidProtectedKeySet() async throws {
         let protectedKey = try makeDefaultCredentialProtectedKey()
         let differentPublicKey = try ScopedAccessKeyFactory.makeRSAKeyMaterial().publicKeyJWK
@@ -188,6 +198,7 @@ final class AccountInfoKeyManagerTests: XCTestCase {
         await assertRefreshing([protectedKey, inconsistentWrapper], expectedError: .invalidProtectedKeySet)
     }
 
+    @Test("Unsupported wrappers are rejected")
     func testWhenAccountInfoKeyHasUnsupportedWrapperThenThrowsUnavailableWrappingKey() async {
         let protectedKey = ProtectedKey(kid: "account-info-key",
                                         encryptedPrivateKey: "unused",
@@ -198,6 +209,7 @@ final class AccountInfoKeyManagerTests: XCTestCase {
         await assertRefreshing([protectedKey], expectedError: .unavailableWrappingKey)
     }
 
+    @Test("Malformed default wrappers are rejected")
     func testWhenDefaultWrapperIsNotBase64URLThenThrowsUnableToUnwrapPrivateKey() async {
         let protectedKey = ProtectedKey(kid: "account-info-key",
                                         encryptedPrivateKey: "%",
@@ -208,6 +220,7 @@ final class AccountInfoKeyManagerTests: XCTestCase {
         await assertRefreshing([protectedKey], expectedError: .unableToUnwrapPrivateKey)
     }
 
+    @Test("A private key that does not match the public key is rejected")
     func testWhenPrivateKeyDoesNotMatchPublicKeyThenThrowsPublicKeyMismatch() async throws {
         let privateKeyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
         let publicKeyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
@@ -221,6 +234,7 @@ final class AccountInfoKeyManagerTests: XCTestCase {
         await assertRefreshing([protectedKey], expectedError: .publicKeyMismatch)
     }
 
+    @Test("A missing account info key is reported")
     func testWhenServerHasNoAccountInfoKeyThenThrows() async throws {
         let secureStore = SecureStorageStub()
         let scopedAccess = ScopedAccessCredentialManagingMock()
@@ -231,16 +245,18 @@ final class AccountInfoKeyManagerTests: XCTestCase {
 
         do {
             _ = try await manager.loadKey(for: account)
-            XCTFail("Expected missing protected key error")
+            Issue.record("Expected missing protected key error")
         } catch {
-            XCTAssertEqual(error as? AccountInfoKeyManagerError, .missingProtectedKey)
+            #expect((error as? AccountInfoKeyManagerError) == .missingProtectedKey)
         }
     }
 
     private func assertRefreshing(_ protectedKeys: [ProtectedKey],
                                   expectedError: AccountInfoKeyManagerError,
-                                  file: StaticString = #filePath,
-                                  line: UInt = #line) async {
+                                  sourceLocation: SourceLocation = SourceLocation(fileID: #fileID,
+                                                                                 filePath: #filePath,
+                                                                                 line: #line,
+                                                                                 column: #column)) async {
         let scopedAccess = ScopedAccessCredentialManagingMock()
         scopedAccess.fetchProtectedKeysStub = protectedKeys
         let manager = AccountInfoKeyManager(secureStore: SecureStorageStub(),
@@ -249,9 +265,9 @@ final class AccountInfoKeyManagerTests: XCTestCase {
 
         do {
             _ = try await manager.refreshKey(for: account)
-            XCTFail("Expected key refresh to fail", file: file, line: line)
+            Issue.record("Expected key refresh to fail", sourceLocation: sourceLocation)
         } catch {
-            XCTAssertEqual(error as? AccountInfoKeyManagerError, expectedError, file: file, line: line)
+            #expect((error as? AccountInfoKeyManagerError) == expectedError, sourceLocation: sourceLocation)
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
@@ -27,7 +27,8 @@ struct AccountInfoKeyManagerTests {
     private let account = SyncAccount.mock
     private let crypter = CryptingMock()
 
-    @Test("A cached default-credential key loads without fetching")
+    @available(iOS 16, macOS 13, *)
+    @Test("A cached default-credential key loads without fetching", .timeLimit(.minutes(1)))
     func testWhenDefaultCredentialKeyIsCachedThenLoadsWithoutFetching() async throws {
         let protectedKey = try makeDefaultCredentialProtectedKey()
         let secureStore = SecureStorageStub()
@@ -43,7 +44,8 @@ struct AccountInfoKeyManagerTests {
         #expect(scopedAccess.fetchProtectedKeysCalls.isEmpty)
     }
 
-    @Test("A corrupt cache is replaced with server keys")
+    @available(iOS 16, macOS 13, *)
+    @Test("A corrupt cache is replaced with server keys", .timeLimit(.minutes(1)))
     func testWhenCacheIsCorruptThenFetchesAndCachesServerKeys() async throws {
         let protectedKey = try makeDefaultCredentialProtectedKey()
         let secureStore = SecureStorageStub()
@@ -63,7 +65,8 @@ struct AccountInfoKeyManagerTests {
         #expect(cachedKeys.map(\.kid) == [protectedKey.kid])
     }
 
-    @Test("A cached third-party wrapper loads using the scoped password")
+    @available(iOS 16, macOS 13, *)
+    @Test("A cached third-party wrapper loads using the scoped password", .timeLimit(.minutes(1)))
     func testWhenOnlyThirdPartyWrapperIsCachedThenLoadsUsingScopedPassword() async throws {
         let scopedPassword = Data(repeating: 0x03, count: 32)
         let protectedKey = try makeThirdPartyCredentialProtectedKey(scopedPassword: scopedPassword)
@@ -81,7 +84,8 @@ struct AccountInfoKeyManagerTests {
         #expect(scopedAccess.fetchProtectedKeysCalls.isEmpty)
     }
 
-    @Test("A failed default wrapper falls back to the third-party wrapper")
+    @available(iOS 16, macOS 13, *)
+    @Test("A failed default wrapper falls back to the third-party wrapper", .timeLimit(.minutes(1)))
     func testWhenDefaultWrapperCannotBeUnwrappedThenFallsBackToThirdPartyWrapper() async throws {
         let scopedPassword = Data(repeating: 0x03, count: 32)
         let protectedKeys = try makeDualWrappedProtectedKeys(scopedPassword: scopedPassword)
@@ -108,7 +112,8 @@ struct AccountInfoKeyManagerTests {
         #expect(scopedAccess.fetchAccessCredentialsCalls.isEmpty)
     }
 
-    @Test("The default wrapper is preferred without recovering a scoped password")
+    @available(iOS 16, macOS 13, *)
+    @Test("The default wrapper is preferred without recovering a scoped password", .timeLimit(.minutes(1)))
     func testWhenBothWrappersAreCachedThenPrefersDefaultWithoutRecoveringScopedPassword() async throws {
         let scopedPassword = Data(repeating: 0x03, count: 32)
         let protectedKeys = try makeDualWrappedProtectedKeys(scopedPassword: scopedPassword)
@@ -130,7 +135,8 @@ struct AccountInfoKeyManagerTests {
         #expect(scopedAccess.recoverScopedPasswordCalls.isEmpty)
     }
 
-    @Test("A missing scoped password is recovered and cached")
+    @available(iOS 16, macOS 13, *)
+    @Test("A missing scoped password is recovered and cached", .timeLimit(.minutes(1)))
     func testWhenThirdPartyWrapperIsCachedWithoutScopedPasswordThenRecoversAndCachesPassword() async throws {
         let scopedPassword = Data(repeating: 0x03, count: 32)
         let protectedKey = try makeThirdPartyCredentialProtectedKey(scopedPassword: scopedPassword)
@@ -153,7 +159,29 @@ struct AccountInfoKeyManagerTests {
         #expect(secureStore.theScopedPassword == scopedPassword)
     }
 
-    @Test("Transient refresh failures preserve the protected-key cache")
+    @available(iOS 16, macOS 13, *)
+    @Test("Cancellation during cached-key recovery does not trigger a refresh", .timeLimit(.minutes(1)))
+    func testWhenCachedKeyRecoveryIsCancelledThenDoesNotRefresh() async throws {
+        let scopedPassword = Data(repeating: 0x03, count: 32)
+        let protectedKey = try makeThirdPartyCredentialProtectedKey(scopedPassword: scopedPassword)
+        let secureStore = SecureStorageStub()
+        secureStore.theProtectedKeysData = try JSONEncoder.snakeCaseKeys.encode([protectedKey])
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        scopedAccess.fetchAccessCredentialsError = CancellationError()
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        await #expect(throws: CancellationError.self) {
+            try await manager.loadKey(for: account)
+        }
+
+        #expect(scopedAccess.fetchAccessCredentialsCalls.map(\.userId) == [account.userId])
+        #expect(scopedAccess.fetchProtectedKeysCalls.isEmpty)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Transient refresh failures preserve the protected-key cache", .timeLimit(.minutes(1)))
     func testWhenCachedThirdPartyKeyAndRefreshFailTransientlyThenPreservesProtectedKeyCache() async throws {
         let scopedPassword = Data(repeating: 0x03, count: 32)
         let accountInfoKey = try makeThirdPartyCredentialProtectedKey(scopedPassword: scopedPassword)
@@ -185,7 +213,8 @@ struct AccountInfoKeyManagerTests {
         #expect(scopedAccess.fetchProtectedKeysCalls.map(\.userId) == [account.userId])
     }
 
-    @Test("Inconsistent public keys are rejected")
+    @available(iOS 16, macOS 13, *)
+    @Test("Inconsistent public keys are rejected", .timeLimit(.minutes(1)))
     func testWhenAccountInfoWrappersDescribeDifferentPublicKeysThenThrowsInvalidProtectedKeySet() async throws {
         let protectedKey = try makeDefaultCredentialProtectedKey()
         let differentPublicKey = try ScopedAccessKeyFactory.makeRSAKeyMaterial().publicKeyJWK
@@ -198,7 +227,8 @@ struct AccountInfoKeyManagerTests {
         await assertRefreshing([protectedKey, inconsistentWrapper], expectedError: .invalidProtectedKeySet)
     }
 
-    @Test("Unsupported wrappers are rejected")
+    @available(iOS 16, macOS 13, *)
+    @Test("Unsupported wrappers are rejected", .timeLimit(.minutes(1)))
     func testWhenAccountInfoKeyHasUnsupportedWrapperThenThrowsUnavailableWrappingKey() async {
         let protectedKey = ProtectedKey(kid: "account-info-key",
                                         encryptedPrivateKey: "unused",
@@ -209,7 +239,8 @@ struct AccountInfoKeyManagerTests {
         await assertRefreshing([protectedKey], expectedError: .unavailableWrappingKey)
     }
 
-    @Test("Malformed default wrappers are rejected")
+    @available(iOS 16, macOS 13, *)
+    @Test("Malformed default wrappers are rejected", .timeLimit(.minutes(1)))
     func testWhenDefaultWrapperIsNotBase64URLThenThrowsUnableToUnwrapPrivateKey() async {
         let protectedKey = ProtectedKey(kid: "account-info-key",
                                         encryptedPrivateKey: "%",
@@ -220,7 +251,8 @@ struct AccountInfoKeyManagerTests {
         await assertRefreshing([protectedKey], expectedError: .unableToUnwrapPrivateKey)
     }
 
-    @Test("A private key that does not match the public key is rejected")
+    @available(iOS 16, macOS 13, *)
+    @Test("A private key that does not match the public key is rejected", .timeLimit(.minutes(1)))
     func testWhenPrivateKeyDoesNotMatchPublicKeyThenThrowsPublicKeyMismatch() async throws {
         let privateKeyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
         let publicKeyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
@@ -234,7 +266,8 @@ struct AccountInfoKeyManagerTests {
         await assertRefreshing([protectedKey], expectedError: .publicKeyMismatch)
     }
 
-    @Test("A missing account info key is reported")
+    @available(iOS 16, macOS 13, *)
+    @Test("A missing account info key is reported", .timeLimit(.minutes(1)))
     func testWhenServerHasNoAccountInfoKeyThenThrows() async throws {
         let secureStore = SecureStorageStub()
         let scopedAccess = ScopedAccessCredentialManagingMock()

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
@@ -76,6 +76,53 @@ final class AccountInfoKeyManagerTests: XCTestCase {
         XCTAssertTrue(scopedAccess.fetchProtectedKeysCalls.isEmpty)
     }
 
+    func testWhenDefaultWrapperCannotBeUnwrappedThenFallsBackToThirdPartyWrapper() async throws {
+        let scopedPassword = Data(repeating: 0x03, count: 32)
+        let protectedKeys = try makeDualWrappedProtectedKeys(scopedPassword: scopedPassword)
+        let malformedDefaultWrapper = ProtectedKey(kid: protectedKeys.defaultCredential.kid,
+                                                    encryptedPrivateKey: "%",
+                                                    publicKey: protectedKeys.defaultCredential.publicKey,
+                                                    encryptedWith: SyncCredentialID.defaultCredential,
+                                                    purpose: ProtectedKeyPurpose.accountInfo)
+        let secureStore = SecureStorageStub()
+        secureStore.theScopedPassword = scopedPassword
+        secureStore.theProtectedKeysData = try JSONEncoder.snakeCaseKeys.encode([
+            malformedDefaultWrapper,
+            protectedKeys.thirdParty
+        ])
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        let key = try await manager.loadKey(for: account)
+
+        XCTAssertEqual(key.kid, protectedKeys.thirdParty.kid)
+        XCTAssertTrue(scopedAccess.fetchProtectedKeysCalls.isEmpty)
+        XCTAssertTrue(scopedAccess.fetchAccessCredentialsCalls.isEmpty)
+    }
+
+    func testWhenBothWrappersAreCachedThenPrefersDefaultWithoutRecoveringScopedPassword() async throws {
+        let scopedPassword = Data(repeating: 0x03, count: 32)
+        let protectedKeys = try makeDualWrappedProtectedKeys(scopedPassword: scopedPassword)
+        let secureStore = SecureStorageStub()
+        secureStore.theProtectedKeysData = try JSONEncoder.snakeCaseKeys.encode([
+            protectedKeys.thirdParty,
+            protectedKeys.defaultCredential
+        ])
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        let key = try await manager.loadKey(for: account)
+
+        XCTAssertEqual(key.kid, protectedKeys.defaultCredential.kid)
+        XCTAssertTrue(scopedAccess.fetchProtectedKeysCalls.isEmpty)
+        XCTAssertTrue(scopedAccess.fetchAccessCredentialsCalls.isEmpty)
+        XCTAssertTrue(scopedAccess.recoverScopedPasswordCalls.isEmpty)
+    }
+
     func testWhenThirdPartyWrapperIsCachedWithoutScopedPasswordThenRecoversAndCachesPassword() async throws {
         let scopedPassword = Data(repeating: 0x03, count: 32)
         let protectedKey = try makeThirdPartyCredentialProtectedKey(scopedPassword: scopedPassword)
@@ -229,5 +276,26 @@ final class AccountInfoKeyManagerTests: XCTestCase {
                             publicKey: keyMaterial.publicKeyJWK,
                             encryptedWith: SyncCredentialID.thirdParty,
                             purpose: ProtectedKeyPurpose.accountInfo)
+    }
+
+    private func makeDualWrappedProtectedKeys(scopedPassword: Data) throws -> (defaultCredential: ProtectedKey, thirdParty: ProtectedKey) {
+        let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
+        let kid = UUID().uuidString
+        let encryptedDefaultPrivateKey = try crypter.encrypt(keyMaterial.privateKeyPKCS8, using: account.secretKey)
+        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        let encryptedThirdPartyPrivateKey = try JWECompactCodec().encryptDirect(payload: keyMaterial.privateKeyPKCS8,
+                                                                                contentEncryptionKey: thirdPartyMainKey,
+                                                                                kid: SyncCredentialID.thirdParty)
+        return (
+            defaultCredential: ProtectedKey(kid: kid,
+                                            encryptedPrivateKey: Base64URL.encode(encryptedDefaultPrivateKey),
+                                            publicKey: keyMaterial.publicKeyJWK,
+                                            encryptedWith: SyncCredentialID.defaultCredential,
+                                            purpose: ProtectedKeyPurpose.accountInfo),
+            thirdParty: ProtectedKey(kid: kid,
+                                     encryptedPrivateKey: encryptedThirdPartyPrivateKey,
+                                     publicKey: keyMaterial.publicKeyJWK,
+                                     encryptedWith: SyncCredentialID.thirdParty,
+                                     purpose: ProtectedKeyPurpose.accountInfo))
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/RSAKeyUtilitiesTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/RSAKeyUtilitiesTests.swift
@@ -1,0 +1,77 @@
+//
+//  RSAKeyUtilitiesTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Security
+import XCTest
+
+@testable import DDGSync
+
+final class RSAKeyUtilitiesTests: XCTestCase {
+
+    func testWhenImportingRSA3072PKCS8ThenPublicAndPrivateKeysMatch() throws {
+        let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial(keySizeInBits: 3072)
+
+        XCTAssertNotEqual(keyMaterial.privateKeyPKCS8[1] & 0x80, 0)
+
+        let publicKey = try RSAKeyImporter.makePublicKey(from: keyMaterial.publicKeyJWK)
+        let privateKey = try RSAKeyImporter.makePrivateKey(fromPKCS8: keyMaterial.privateKeyPKCS8)
+        let derivedPublicKey = try XCTUnwrap(SecKeyCopyPublicKey(privateKey))
+        let publicKeyData = try XCTUnwrap(SecKeyCopyExternalRepresentation(publicKey, nil) as Data?)
+        let derivedPublicKeyData = try XCTUnwrap(SecKeyCopyExternalRepresentation(derivedPublicKey, nil) as Data?)
+
+        XCTAssertEqual(SecKeyGetBlockSize(privateKey), 384)
+        XCTAssertEqual(derivedPublicKeyData, publicKeyData)
+    }
+
+    func testWhenImportingMalformedPKCS8ThenThrowsInvalidPrivateKey() {
+        assertInvalidPrivateKey(Data([0x30, 0x82, 0x01]))
+    }
+
+    func testWhenImportingTruncatedPKCS8ThenThrowsInvalidPrivateKey() throws {
+        let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
+
+        assertInvalidPrivateKey(Data(keyMaterial.privateKeyPKCS8.dropLast()))
+    }
+
+    func testWhenImportingPKCS8WithTrailingBytesThenThrowsInvalidPrivateKey() throws {
+        let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
+        var privateKeyPKCS8 = keyMaterial.privateKeyPKCS8
+        privateKeyPKCS8.append(0x00)
+
+        assertInvalidPrivateKey(privateKeyPKCS8)
+    }
+
+    func testWhenEncodingUnsignedPublicKeyComponentsThenLeadingZerosAreCanonicalized() throws {
+        let publicKeyPKCS1 = RSAKeyDER.makeRSAPublicKeyPKCS1(
+            modulus: Data([0x00, 0x00, 0x80, 0x01]),
+            exponent: Data([0x80, 0x01]))
+
+        let components = try RSAKeyDER.parseRSAPublicKeyComponents(fromPKCS1DER: publicKeyPKCS1)
+
+        XCTAssertEqual(components.modulus, Data([0x00, 0x80, 0x01]))
+        XCTAssertEqual(components.exponent, Data([0x00, 0x80, 0x01]))
+    }
+
+    private func assertInvalidPrivateKey(_ privateKeyPKCS8: Data,
+                                         file: StaticString = #filePath,
+                                         line: UInt = #line) {
+        XCTAssertThrowsError(try RSAKeyImporter.makePrivateKey(fromPKCS8: privateKeyPKCS8), file: file, line: line) { error in
+            XCTAssertEqual(error as? RSAKeyImportError, .invalidPrivateKey, file: file, line: line)
+        }
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/RSAKeyUtilitiesTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/RSAKeyUtilitiesTests.swift
@@ -7,7 +7,7 @@
 //  you may not use this file except in compliance with the License.
 //  You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
 //  Unless required by applicable law or agreed to in writing, software
 //  distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,7 +25,8 @@ import Testing
 @Suite("RSA key utilities")
 struct RSAKeyUtilitiesTests {
 
-    @Test("RSA-3072 PKCS#8 import produces matching public and private keys")
+    @available(iOS 16, macOS 13, *)
+    @Test("RSA-3072 PKCS#8 import produces matching public and private keys", .timeLimit(.minutes(1)))
     func testWhenImportingRSA3072PKCS8ThenPublicAndPrivateKeysMatch() throws {
         let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial(keySizeInBits: 3072)
 
@@ -42,7 +43,8 @@ struct RSAKeyUtilitiesTests {
         #expect(derivedPublicKeyData == publicKeyData)
     }
 
-    @Test("Public keys with unsupported metadata are rejected")
+    @available(iOS 16, macOS 13, *)
+    @Test("Public keys with unsupported metadata are rejected", .timeLimit(.minutes(1)))
     func testWhenImportingPublicKeyWithUnsupportedMetadataThenThrowsUnsupportedPublicKey() throws {
         let publicKey = try ScopedAccessKeyFactory.makeRSAKeyMaterial().publicKeyJWK
         let unsupportedPublicKeys = [
@@ -83,7 +85,8 @@ struct RSAKeyUtilitiesTests {
         }
     }
 
-    @Test("Public keys with missing or malformed components are rejected")
+    @available(iOS 16, macOS 13, *)
+    @Test("Public keys with missing or malformed components are rejected", .timeLimit(.minutes(1)))
     func testWhenImportingPublicKeyWithMissingOrMalformedComponentsThenThrowsInvalidPublicKey() throws {
         let publicKey = try ScopedAccessKeyFactory.makeRSAKeyMaterial().publicKeyJWK
         let invalidPublicKeys = [
@@ -124,19 +127,22 @@ struct RSAKeyUtilitiesTests {
         }
     }
 
-    @Test("Malformed PKCS#8 is rejected")
+    @available(iOS 16, macOS 13, *)
+    @Test("Malformed PKCS#8 is rejected", .timeLimit(.minutes(1)))
     func testWhenImportingMalformedPKCS8ThenThrowsInvalidPrivateKey() {
         assertInvalidPrivateKey(Data([0x30, 0x82, 0x01]))
     }
 
-    @Test("Truncated PKCS#8 is rejected")
+    @available(iOS 16, macOS 13, *)
+    @Test("Truncated PKCS#8 is rejected", .timeLimit(.minutes(1)))
     func testWhenImportingTruncatedPKCS8ThenThrowsInvalidPrivateKey() throws {
         let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
 
         assertInvalidPrivateKey(Data(keyMaterial.privateKeyPKCS8.dropLast()))
     }
 
-    @Test("PKCS#8 with trailing bytes is rejected")
+    @available(iOS 16, macOS 13, *)
+    @Test("PKCS#8 with trailing bytes is rejected", .timeLimit(.minutes(1)))
     func testWhenImportingPKCS8WithTrailingBytesThenThrowsInvalidPrivateKey() throws {
         let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
         var privateKeyPKCS8 = keyMaterial.privateKeyPKCS8
@@ -145,7 +151,8 @@ struct RSAKeyUtilitiesTests {
         assertInvalidPrivateKey(privateKeyPKCS8)
     }
 
-    @Test("Unsigned public-key components have canonical leading zeros")
+    @available(iOS 16, macOS 13, *)
+    @Test("Unsigned public-key components have canonical leading zeros", .timeLimit(.minutes(1)))
     func testWhenEncodingUnsignedPublicKeyComponentsThenLeadingZerosAreCanonicalized() throws {
         let publicKeyPKCS1 = RSAKeyDER.makeRSAPublicKeyPKCS1(
             modulus: Data([0x00, 0x00, 0x80, 0x01]),

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/RSAKeyUtilitiesTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/RSAKeyUtilitiesTests.swift
@@ -16,29 +16,33 @@
 //  limitations under the License.
 //
 
+import Foundation
 import Security
-import XCTest
+import Testing
 
 @testable import DDGSync
 
-final class RSAKeyUtilitiesTests: XCTestCase {
+@Suite("RSA key utilities")
+struct RSAKeyUtilitiesTests {
 
+    @Test("RSA-3072 PKCS#8 import produces matching public and private keys")
     func testWhenImportingRSA3072PKCS8ThenPublicAndPrivateKeysMatch() throws {
         let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial(keySizeInBits: 3072)
 
         // RSA-3072 makes the outer PKCS#8 sequence use DER's multi-byte length form.
-        XCTAssertNotEqual(keyMaterial.privateKeyPKCS8[1] & 0x80, 0)
+        #expect(keyMaterial.privateKeyPKCS8[1] & 0x80 != 0)
 
         let publicKey = try RSAKeyImporter.makePublicKey(from: keyMaterial.publicKeyJWK)
         let privateKey = try RSAKeyImporter.makePrivateKey(fromPKCS8: keyMaterial.privateKeyPKCS8)
-        let derivedPublicKey = try XCTUnwrap(SecKeyCopyPublicKey(privateKey))
-        let publicKeyData = try XCTUnwrap(SecKeyCopyExternalRepresentation(publicKey, nil) as Data?)
-        let derivedPublicKeyData = try XCTUnwrap(SecKeyCopyExternalRepresentation(derivedPublicKey, nil) as Data?)
+        let derivedPublicKey = try #require(SecKeyCopyPublicKey(privateKey))
+        let publicKeyData = try #require(SecKeyCopyExternalRepresentation(publicKey, nil) as Data?)
+        let derivedPublicKeyData = try #require(SecKeyCopyExternalRepresentation(derivedPublicKey, nil) as Data?)
 
-        XCTAssertEqual(SecKeyGetBlockSize(privateKey), 384)
-        XCTAssertEqual(derivedPublicKeyData, publicKeyData)
+        #expect(SecKeyGetBlockSize(privateKey) == 384)
+        #expect(derivedPublicKeyData == publicKeyData)
     }
 
+    @Test("Public keys with unsupported metadata are rejected")
     func testWhenImportingPublicKeyWithUnsupportedMetadataThenThrowsUnsupportedPublicKey() throws {
         let publicKey = try ScopedAccessKeyFactory.makeRSAKeyMaterial().publicKeyJWK
         let unsupportedPublicKeys = [
@@ -73,12 +77,13 @@ final class RSAKeyUtilitiesTests: XCTestCase {
         ]
 
         for unsupportedPublicKey in unsupportedPublicKeys {
-            XCTAssertThrowsError(try RSAKeyImporter.makePublicKey(from: unsupportedPublicKey)) { error in
-                XCTAssertEqual(error as? RSAKeyImportError, .unsupportedPublicKey)
+            #expect(throws: RSAKeyImportError.unsupportedPublicKey) {
+                try RSAKeyImporter.makePublicKey(from: unsupportedPublicKey)
             }
         }
     }
 
+    @Test("Public keys with missing or malformed components are rejected")
     func testWhenImportingPublicKeyWithMissingOrMalformedComponentsThenThrowsInvalidPublicKey() throws {
         let publicKey = try ScopedAccessKeyFactory.makeRSAKeyMaterial().publicKeyJWK
         let invalidPublicKeys = [
@@ -113,22 +118,25 @@ final class RSAKeyUtilitiesTests: XCTestCase {
         ]
 
         for invalidPublicKey in invalidPublicKeys {
-            XCTAssertThrowsError(try RSAKeyImporter.makePublicKey(from: invalidPublicKey)) { error in
-                XCTAssertEqual(error as? RSAKeyImportError, .invalidPublicKey)
+            #expect(throws: RSAKeyImportError.invalidPublicKey) {
+                try RSAKeyImporter.makePublicKey(from: invalidPublicKey)
             }
         }
     }
 
+    @Test("Malformed PKCS#8 is rejected")
     func testWhenImportingMalformedPKCS8ThenThrowsInvalidPrivateKey() {
         assertInvalidPrivateKey(Data([0x30, 0x82, 0x01]))
     }
 
+    @Test("Truncated PKCS#8 is rejected")
     func testWhenImportingTruncatedPKCS8ThenThrowsInvalidPrivateKey() throws {
         let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
 
         assertInvalidPrivateKey(Data(keyMaterial.privateKeyPKCS8.dropLast()))
     }
 
+    @Test("PKCS#8 with trailing bytes is rejected")
     func testWhenImportingPKCS8WithTrailingBytesThenThrowsInvalidPrivateKey() throws {
         let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial()
         var privateKeyPKCS8 = keyMaterial.privateKeyPKCS8
@@ -137,6 +145,7 @@ final class RSAKeyUtilitiesTests: XCTestCase {
         assertInvalidPrivateKey(privateKeyPKCS8)
     }
 
+    @Test("Unsigned public-key components have canonical leading zeros")
     func testWhenEncodingUnsignedPublicKeyComponentsThenLeadingZerosAreCanonicalized() throws {
         let publicKeyPKCS1 = RSAKeyDER.makeRSAPublicKeyPKCS1(
             modulus: Data([0x00, 0x00, 0x80, 0x01]),
@@ -144,15 +153,13 @@ final class RSAKeyUtilitiesTests: XCTestCase {
 
         let components = try RSAKeyDER.parseRSAPublicKeyComponents(fromPKCS1DER: publicKeyPKCS1)
 
-        XCTAssertEqual(components.modulus, Data([0x00, 0x80, 0x01]))
-        XCTAssertEqual(components.exponent, Data([0x00, 0x80, 0x01]))
+        #expect(components.modulus == Data([0x00, 0x80, 0x01]))
+        #expect(components.exponent == Data([0x00, 0x80, 0x01]))
     }
 
-    private func assertInvalidPrivateKey(_ privateKeyPKCS8: Data,
-                                         file: StaticString = #filePath,
-                                         line: UInt = #line) {
-        XCTAssertThrowsError(try RSAKeyImporter.makePrivateKey(fromPKCS8: privateKeyPKCS8), file: file, line: line) { error in
-            XCTAssertEqual(error as? RSAKeyImportError, .invalidPrivateKey, file: file, line: line)
+    private func assertInvalidPrivateKey(_ privateKeyPKCS8: Data) {
+        #expect(throws: RSAKeyImportError.invalidPrivateKey) {
+            try RSAKeyImporter.makePrivateKey(fromPKCS8: privateKeyPKCS8)
         }
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/RSAKeyUtilitiesTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/RSAKeyUtilitiesTests.swift
@@ -26,6 +26,7 @@ final class RSAKeyUtilitiesTests: XCTestCase {
     func testWhenImportingRSA3072PKCS8ThenPublicAndPrivateKeysMatch() throws {
         let keyMaterial = try ScopedAccessKeyFactory.makeRSAKeyMaterial(keySizeInBits: 3072)
 
+        // RSA-3072 makes the outer PKCS#8 sequence use DER's multi-byte length form.
         XCTAssertNotEqual(keyMaterial.privateKeyPKCS8[1] & 0x80, 0)
 
         let publicKey = try RSAKeyImporter.makePublicKey(from: keyMaterial.publicKeyJWK)
@@ -36,6 +37,86 @@ final class RSAKeyUtilitiesTests: XCTestCase {
 
         XCTAssertEqual(SecKeyGetBlockSize(privateKey), 384)
         XCTAssertEqual(derivedPublicKeyData, publicKeyData)
+    }
+
+    func testWhenImportingPublicKeyWithUnsupportedMetadataThenThrowsUnsupportedPublicKey() throws {
+        let publicKey = try ScopedAccessKeyFactory.makeRSAKeyMaterial().publicKeyJWK
+        let unsupportedPublicKeys = [
+            ProtectedKeyPublicKey(alg: "RS256",
+                                  e: publicKey.e,
+                                  ext: publicKey.ext,
+                                  keyOps: publicKey.keyOps,
+                                  kty: publicKey.kty,
+                                  n: publicKey.n,
+                                  use: publicKey.use),
+            ProtectedKeyPublicKey(alg: publicKey.alg,
+                                  e: publicKey.e,
+                                  ext: publicKey.ext,
+                                  keyOps: publicKey.keyOps,
+                                  kty: "EC",
+                                  n: publicKey.n,
+                                  use: publicKey.use),
+            ProtectedKeyPublicKey(alg: publicKey.alg,
+                                  e: publicKey.e,
+                                  ext: publicKey.ext,
+                                  keyOps: publicKey.keyOps,
+                                  kty: publicKey.kty,
+                                  n: publicKey.n,
+                                  use: "sig"),
+            ProtectedKeyPublicKey(alg: publicKey.alg,
+                                  e: publicKey.e,
+                                  ext: publicKey.ext,
+                                  keyOps: ["verify"],
+                                  kty: publicKey.kty,
+                                  n: publicKey.n,
+                                  use: publicKey.use)
+        ]
+
+        for unsupportedPublicKey in unsupportedPublicKeys {
+            XCTAssertThrowsError(try RSAKeyImporter.makePublicKey(from: unsupportedPublicKey)) { error in
+                XCTAssertEqual(error as? RSAKeyImportError, .unsupportedPublicKey)
+            }
+        }
+    }
+
+    func testWhenImportingPublicKeyWithMissingOrMalformedComponentsThenThrowsInvalidPublicKey() throws {
+        let publicKey = try ScopedAccessKeyFactory.makeRSAKeyMaterial().publicKeyJWK
+        let invalidPublicKeys = [
+            ProtectedKeyPublicKey(alg: publicKey.alg,
+                                  e: publicKey.e,
+                                  ext: publicKey.ext,
+                                  keyOps: publicKey.keyOps,
+                                  kty: publicKey.kty,
+                                  n: nil,
+                                  use: publicKey.use),
+            ProtectedKeyPublicKey(alg: publicKey.alg,
+                                  e: publicKey.e,
+                                  ext: publicKey.ext,
+                                  keyOps: publicKey.keyOps,
+                                  kty: publicKey.kty,
+                                  n: "%",
+                                  use: publicKey.use),
+            ProtectedKeyPublicKey(alg: publicKey.alg,
+                                  e: nil,
+                                  ext: publicKey.ext,
+                                  keyOps: publicKey.keyOps,
+                                  kty: publicKey.kty,
+                                  n: publicKey.n,
+                                  use: publicKey.use),
+            ProtectedKeyPublicKey(alg: publicKey.alg,
+                                  e: "%",
+                                  ext: publicKey.ext,
+                                  keyOps: publicKey.keyOps,
+                                  kty: publicKey.kty,
+                                  n: publicKey.n,
+                                  use: publicKey.use)
+        ]
+
+        for invalidPublicKey in invalidPublicKeys {
+            XCTAssertThrowsError(try RSAKeyImporter.makePublicKey(from: invalidPublicKey)) { error in
+                XCTAssertEqual(error as? RSAKeyImportError, .invalidPublicKey)
+            }
+        }
     }
 
     func testWhenImportingMalformedPKCS8ThenThrowsInvalidPrivateKey() {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SecureStorageStub.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SecureStorageStub.swift
@@ -80,6 +80,13 @@ class SecureStorageStub: SecureStoring {
         theProtectedKeysData = data
     }
 
+    func protectedKeys() throws -> Data? {
+        if let mockReadError {
+            throw mockReadError
+        }
+        return theProtectedKeysData
+    }
+
     func removeProtectedKeys() throws {
         theProtectedKeysData = nil
     }

--- a/iOS/DuckDuckGo/SyncDebugViewController.swift
+++ b/iOS/DuckDuckGo/SyncDebugViewController.swift
@@ -44,6 +44,7 @@ class SyncDebugViewController: UITableViewController {
 
         case syncNow
         case ensureAccountInfoKey
+        case validateAccountInfoKey
         case logOut
         case toggleFavoritesDisplayMode
         case resetFaviconsFetcherOnboardingDialog
@@ -115,6 +116,8 @@ class SyncDebugViewController: UITableViewController {
                 cell.textLabel?.text = "Sync now"
             case .ensureAccountInfoKey:
                 cell.textLabel?.text = "Ensure account_info key"
+            case .validateAccountInfoKey:
+                cell.textLabel?.text = "Validate account_info key"
             case .logOut:
                 cell.textLabel?.text = "Log out of sync in 10 seconds"
             case .toggleFavoritesDisplayMode:
@@ -198,6 +201,8 @@ class SyncDebugViewController: UITableViewController {
                 sync.scheduler.requestSyncImmediately()
             case .ensureAccountInfoKey:
                 ensureAccountInfoKey()
+            case .validateAccountInfoKey:
+                validateAccountInfoKey()
             case .logOut:
                 Task {
                     try await Task.sleep(nanoseconds: UInt64(10e9))
@@ -281,6 +286,33 @@ class SyncDebugViewController: UITableViewController {
                 showAlert(title: "Account Info Key Ensured", message: message)
             } catch {
                 showAlert(title: "Unable to Ensure Account Info Key", message: String(reflecting: error))
+            }
+        }
+    }
+
+    private func validateAccountInfoKey() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            do {
+                let result = try await sync.validateAccountInfoKeyForDebug()
+                guard result.refreshedKeyID == result.reloadedKeyID else {
+                    let message = """
+                    Refreshed key ID: \(result.refreshedKeyID)
+                    Reloaded key ID: \(result.reloadedKeyID)
+                    """
+                    showAlert(title: "Account Info Key Reload Mismatch", message: message)
+                    return
+                }
+
+                let message = """
+                Key ID: \(result.reloadedKeyID)
+                Key size: \(result.keySizeInBits) bits
+                Cache-first reload: succeeded
+                """
+                showAlert(title: "Account Info Key Validated", message: message)
+            } catch {
+                showAlert(title: "Unable to Validate Account Info Key", message: String(reflecting: error))
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1217213092722100?focus=true
Tech Design URL:
CC:

### Description

Adds secure loading and local caching of the Sync key needed for unified device information. The key can be recovered using either a native or third-party credential, is validated before use, and can be refreshed from the server when local data is missing or unusable. Valid cached keys remain available through transient failures.

An iOS debug action verifies the server refresh and cache-first reload path.

### Testing Steps

Prerequisite: Test on iOS because the validation action is available in the iOS debug screen; the underlying key-loading and caching functionality is shared with macOS.

1. Ensure feature flag `syncCanWriteUnifiedDeviceList` is enabled & enable Sync
2. From the Debug menu, open **Sync**.
3. Tap **Ensure account_info key** → an **Account Info Key Ensured** alert reports one or more wrappers.
4. Tap **Validate account_info key** → an **Account Info Key Validated** alert reports a 3072-bit key and `Cache-first reload: succeeded`.
5. Verify CI is green for new tests


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Sync key unwrap, keychain caching, and RSA/JWE crypto paths; mistakes could break unified device flows or mishandle private key material.
> 
> **Overview**
> Introduces **`AccountInfoKeyManager`** to load the Sync **`account_info`** RSA key: read cached protected keys from the keychain, unwrap the private key with the **default (account secret)** or **third-party (JWE direct + scoped password)** wrapper (preferring default), validate consistency, and **refresh from the server** when cache is missing or unusable while **keeping valid cache** on transient failures.
> 
> Supporting crypto changes add **`RSAKeyImporter`** / PKCS#8 and JWK DER helpers, optional **`expectedKid`** checks on **`JWECompactCodec.decryptDirect`**, and **`protectedKeys()`** on secure storage. **`ProductionDependencies`** exposes the manager via **`accountInfoKeys`**.
> 
> Debug: **`validateAccountInfoKeyForDebug`** (refresh then cache-first reload) and an iOS Sync debug row **Validate account_info key**, plus unit tests for the manager, RSA import, and JWE kid validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b31eee29146041c41460099196fcbdd088c3a73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->