### PR TITLE
iOS: Fix voice search pixel definitions failing live validation

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/voice_search.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/voice_search.json5
@@ -4,14 +4,14 @@
         "description": "Fires when a voice search session ends with a recognition or audio-session error and no usable transcription, so neither a done nor a cancelled pixel is sent. Signals recording/recognition failures behind the auto-close reports.",
         "owners": ["Bunn"],
         "triggers": ["exception"],
-        "suffixes": ["daily_count"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": ["appVersion", "errorDomain", "errorCode", "underlyingErrorDomain", "underlyingErrorCode"]
     },
     "voice_search_no_speech": {
         "description": "Fires when a voice search session finishes on silence with no recognized words, so neither a done nor a cancelled pixel is sent. Completes the open->done funnel.",
         "owners": ["Bunn"],
         "triggers": ["other"],
-        "suffixes": ["daily_count"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217301050620219?focus=true
Tech Design URL:
CC:

### Description
The `voice_search_error` pixel failed live validation with "must NOT have additional properties" for the `ios`, `phone`, and `tablet` suffixes. Every iOS pixel gets `_ios_<phone|tablet>` appended at fire time, but the definition only declared `daily_count`, so the schema rejected the real pixel names. This declares the `platform` and `form_factor` suffixes on both pixels in the file — `voice_search_no_speech` was not in the report but has the identical defect and would fail the next one.

### Testing Steps
1. From `iOS/`, run `npm run validate-pixel-defs` → validation and the Prettier check both pass.
2. Confirm `iOS/PixelDefinitions/pixels/definitions/voice_search.json5` lists `["daily_count", "platform", "form_factor"]` for both pixels, matching the suffix keys in `suffixes_dictionary.json5`.

### Impact
None

#### What could go wrong?
This only changes the validation schema and not the emitted pixels, so the reports will keep flagging these until a release ships with the updated definitions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only pixel definition updates; no change to when or how pixels are emitted at runtime.
> 
> **Overview**
> **Fixes live pixel validation** for `voice_search_error` and `voice_search_no_speech` by declaring `platform` and `form_factor` in `voice_search.json5`, alongside the existing `daily_count` suffix.
> 
> iOS appends `_ios` and `_phone`/`_tablet` at fire time; definitions that only listed `daily_count` caused schema errors (“must NOT have additional properties”). This aligns both voice-search outcome pixels with the same suffix pattern used elsewhere in iOS pixel definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08d9603130505e5d1f542322644b7c400134dc68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->