### PR TITLE
Update swift-snapshot-testing to 1.19.4

### DIFF
--- a/SharedPackages/SnapshotTestingSupport/Package.resolved
+++ b/SharedPackages/SnapshotTestingSupport/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
-        "version" : "1.19.2"
+        "revision" : "59a99c458de4d2dee580529b61b4f78dca7b7fa6",
+        "version" : "1.19.4"
       }
     },
     {

--- a/SharedPackages/SnapshotTestingSupport/Package.swift
+++ b/SharedPackages/SnapshotTestingSupport/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", exact: "1.19.2"),
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", exact: "1.19.4"),
     ],
     targets: [
         .target(name: "PreviewSnapshots"),

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
-        "version" : "1.19.2"
+        "revision" : "59a99c458de4d2dee580529b61b4f78dca7b7fa6",
+        "version" : "1.19.4"
       }
     },
     {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
-        "version" : "1.19.2"
+        "revision" : "59a99c458de4d2dee580529b61b4f78dca7b7fa6",
+        "version" : "1.19.4"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216509626086196

### Description
Bumps `swift-snapshot-testing` from 1.19.2 to 1.19.4 (1.19.3 was skipped). Updates the exact pin in `SnapshotTestingSupport/Package.swift` and the resolved revision/version in the iOS, macOS, and `SnapshotTestingSupport` `Package.resolved` files. No transitive dependencies changed.

### Testing Steps
1. Resolve packages on both iOS and macOS → resolves to `swift-snapshot-testing` 1.19.4 with no package-resolution errors.
2. Run the snapshot test suites on iOS and macOS → all pass with no unexpected reference-image diffs.

### Impact
None — test-only dependency, no shipping code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump confined to snapshot test infrastructure; no shipping code or transitive dependency changes in this diff.
> 
> **Overview**
> Bumps the **test-only** `swift-snapshot-testing` dependency from **1.19.2** to **1.19.4** (1.19.3 skipped).
> 
> The exact pin in `SnapshotTestingSupport/Package.swift` is updated, and the resolved revision/version is aligned in the iOS, macOS, and `SnapshotTestingSupport` `Package.resolved` files. No application or shipping code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cedc67c24e2bd9faedcad9c8bfaa3d7e131b29f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->