### PR TITLE
[iOS] fix flakey maestro test - add some wait for settings to appear

### DIFF
--- a/.maestro/release_tests/application-lock.yaml
+++ b/.maestro/release_tests/application-lock.yaml
@@ -11,6 +11,9 @@ tags:
     file: ../shared/setup.yaml
 
 - tapOn: "Browsing Menu"
+- extendedWaitUntil:
+    visible: "Settings"
+    timeout: 10000
 - tapOn: "Settings"
 - scrollUntilVisible:
     element: "General"
@@ -42,6 +45,9 @@ tags:
 - assertVisible: ".*Privacy Test Pages.*"
 
 - tapOn: "Browsing Menu"
+- extendedWaitUntil:
+    visible: "Settings"
+    timeout: 10000
 - tapOn: "Settings"
 - scrollUntilVisible:
     element: "General"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1217301742497848?focus=true
Tech Design URL:
CC:

### Description
Make a test more stable

### Testing Steps
1. Check this is green: https://github.com/duckduckgo/apple-browsers/actions/runs/31392125845

### Impact
None: Internal tooling, documentation

#### What could go wrong?
Not much 

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only Maestro YAML test steps changed; no production iOS app code.
> 
> **Overview**
> Stabilizes the **application-lock** Maestro release test by waiting for **Settings** to appear after opening the browsing menu, instead of tapping immediately.
> 
> The same **`extendedWaitUntil`** step (10s timeout) is added in both places the flow opens Settings—before configuring app lock and after unlocking and browsing—matching how other Maestro flows handle slow or async menu UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2bbc38451434a92d6084e47dfb9edb921496ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->