### PR TITLE
Backport: Bump content scope scripts to v16.6.0 - macOS 1.203

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "4d0f4104cc73557715f2813314fd42d65646df5b63167834655dd7645dd5e7ae",
+  "originHash" : "371ec6a19c0b64fcd02e64ee8ba0168609852ff73d1b742d5ffdd8a776ee416d",
   "pins" : [
     {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "c2c1e53de6b5ea8c5515475c3d4cd8fd7a834fb7",
-        "version" : "16.2.0"
+        "revision" : "d35665e13add70752e51c2442529a2a2d32bd318",
+        "version" : "16.6.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),
         .package(url: "https://github.com/vapor/jwt-kit.git", exact: "4.13.5"),
         .package(url: "https://github.com/pointfreeco/swift-clocks.git", exact: "1.0.6"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "16.2.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "16.6.0"),
         .package(path: "../URLPredictor"),
         .package(path: "../Infrastructure/SystemFrameworksExtensions"),
     ],

--- a/SharedPackages/DataBrokerProtectionCore/Package.resolved
+++ b/SharedPackages/DataBrokerProtectionCore/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "c2c1e53de6b5ea8c5515475c3d4cd8fd7a834fb7",
-        "version" : "16.2.0"
+        "revision" : "d35665e13add70752e51c2442529a2a2d32bd318",
+        "version" : "16.6.0"
       }
     },
     {

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f72e1e70d9ab3e09de67cc143ad9df30167fb1aaa57f92be08c2fe8c0d2b8532",
+  "originHash" : "f893b40e34d394d293a09969026383ab4bbe513a7f7401b6a16a055a8424b2a9",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "c2c1e53de6b5ea8c5515475c3d4cd8fd7a834fb7",
-        "version" : "16.2.0"
+        "revision" : "d35665e13add70752e51c2442529a2a2d32bd318",
+        "version" : "16.6.0"
       }
     },
     {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "942b26548061266a278ec2c8b622799eb888930b4f9327781e0d60ae35fb181c",
+  "originHash" : "44d57b63cd73e215a97d3d1e7e527f0e28284c3e95d8949c0aa22c78d49775ab",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "c2c1e53de6b5ea8c5515475c3d4cd8fd7a834fb7",
-        "version" : "16.2.0"
+        "revision" : "d35665e13add70752e51c2442529a2a2d32bd318",
+        "version" : "16.6.0"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202500774821704/task/1217306942994068?focus=true
Tech Design URL:
CC:

### Description
This PR backports [PR 6255](https://github.com/duckduckgo/apple-browsers/pull/6255) into macOS 1.203

### Testing Steps
- [ ] Ensure CI is green

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Content-scope-scripts run in web views and affect privacy/content behavior site-wide; risk is limited to the external package delta between 16.2.0 and 16.6.0, not new app logic here.
> 
> **Overview**
> Backports the **content-scope-scripts** dependency bump from **16.2.0** to **16.6.0** for the macOS 1.203 release line.
> 
> The only repo change is pinning that version in `BrowserServicesKit/Package.swift` and refreshing **Package.resolved** for BrowserServicesKit, DataBrokerProtectionCore, and the iOS and macOS Xcode workspaces so they resolve the same revision (`d35665e…`). No application Swift code is modified in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fea11e74c94f3e9754b8b5e2eff7e43ec9a25ae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->