### PR TITLE
[macOS] Address Fire Dialog design feedback

### DIFF
--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedColorPaletteDefinition+DynamicColors.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedColorPaletteDefinition+DynamicColors.swift
@@ -359,10 +359,14 @@ extension SharedColorPaletteDefinition {
             return DynamicColor(staticColor: RebrandingColor.Mandarin.mandarin60)
         case .fireButtonPressedGradientEnd:
             return DynamicColor(staticColor: RebrandingColor.Red.red70)
+        case .fireDialogTabBackground:
+            return DynamicColor(lightColor: Color(designSystemColor: .containerFillSecondary), darkColor: Color(designSystemColor: .surfaceCanvas))
+        case .fireDialogTabBackgroundSelected:
+            return DynamicColor(lightColor: Color(designSystemColor: .surfaceTertiary), darkColor: Color(designSystemColor: .surfaceSecondary))
         case .fireDialogTabShadowPrimary:
-            return DynamicColor(lightColor: Color.init(designSystemColor: .shadowPrimary), darkColor: .shade(0.06))
+            return DynamicColor(lightColor: Color(designSystemColor: .shadowPrimary), darkColor: .shade(0.06))
         case .fireDialogTabShadowSecondary:
-            return DynamicColor(lightColor: Color.init(designSystemColor: .shadowTertiary), darkColor: .shade(0.16))
+            return DynamicColor(lightColor: Color(designSystemColor: .shadowTertiary), darkColor: .shade(0.16))
         }
     }
 }

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedColorPaletteDefinition+DynamicColors.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedColorPaletteDefinition+DynamicColors.swift
@@ -359,6 +359,10 @@ extension SharedColorPaletteDefinition {
             return DynamicColor(staticColor: RebrandingColor.Mandarin.mandarin60)
         case .fireButtonPressedGradientEnd:
             return DynamicColor(staticColor: RebrandingColor.Red.red70)
+        case .fireDialogTabShadowPrimary:
+            return DynamicColor(lightColor: Color.init(designSystemColor: .shadowPrimary), darkColor: .shade(0.06))
+        case .fireDialogTabShadowSecondary:
+            return DynamicColor(lightColor: Color.init(designSystemColor: .shadowTertiary), darkColor: .shade(0.16))
         }
     }
 }

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedColorPaletteDefinition+DynamicColors.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedColorPaletteDefinition+DynamicColors.swift
@@ -359,6 +359,8 @@ extension SharedColorPaletteDefinition {
             return DynamicColor(staticColor: RebrandingColor.Mandarin.mandarin60)
         case .fireButtonPressedGradientEnd:
             return DynamicColor(staticColor: RebrandingColor.Red.red70)
+        case .fireDialogKnobFill:
+            return DynamicColor(staticColor: Color(0xFFFFFF))
         case .fireDialogTabBackground:
             return DynamicColor(lightColor: Color(designSystemColor: .containerFillSecondary), darkColor: Color(designSystemColor: .surfaceCanvas))
         case .fireDialogTabBackgroundSelected:

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedColorPaletteDefinition+DynamicColors.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedColorPaletteDefinition+DynamicColors.swift
@@ -352,9 +352,9 @@ extension SharedColorPaletteDefinition {
         case .fireModeAccent:
             return DynamicColor(lightColor: RebrandingColor.Mandarin.mandarin50, darkColor: RebrandingColor.Mandarin.mandarin40)
         case .fireButtonGradientStart:
-            return DynamicColor(staticColor: RebrandingColor.Mandarin.mandarin50)
+            return DynamicColor(lightColor: RebrandingColor.Mandarin.mandarin50, darkColor: RebrandingColor.Mandarin.mandarin40)
         case .fireButtonGradientEnd:
-            return DynamicColor(staticColor: RebrandingColor.Red.red50)
+            return DynamicColor(lightColor: RebrandingColor.Red.red50, darkColor: RebrandingColor.Red.red40)
         case .fireButtonPressedGradientStart:
             return DynamicColor(staticColor: RebrandingColor.Mandarin.mandarin60)
         case .fireButtonPressedGradientEnd:

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
@@ -84,6 +84,7 @@ public enum SingleUseColor {
     case fireButtonGradientEnd
     case fireButtonPressedGradientStart
     case fireButtonPressedGradientEnd
+    case fireDialogKnobFill
     case fireDialogTabBackground
     case fireDialogTabBackgroundSelected
     case fireDialogTabShadowPrimary

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
@@ -84,6 +84,8 @@ public enum SingleUseColor {
     case fireButtonGradientEnd
     case fireButtonPressedGradientStart
     case fireButtonPressedGradientEnd
+    case fireDialogTabBackground
+    case fireDialogTabBackgroundSelected
     case fireDialogTabShadowPrimary
     case fireDialogTabShadowSecondary
 

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
@@ -84,6 +84,8 @@ public enum SingleUseColor {
     case fireButtonGradientEnd
     case fireButtonPressedGradientStart
     case fireButtonPressedGradientEnd
+    case fireDialogTabShadowPrimary
+    case fireDialogTabShadowSecondary
 
 #endif
 

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -512,6 +512,7 @@ struct UserText {
     static let fireDialogModeFromThisTab = NotLocalizedString("fire.dialog.mode.tab", value: "From this tab", comment: "Fire dialog mode for clearing data from current tab")
     static let fireDialogModeAllData = NotLocalizedString("fire.dialog.mode.all.data", value: "All data", comment: "Fire dialog mode for clearing all browsing data")
     static let fireDialogChooseWhatToDelete = NotLocalizedString("fire.dialog.choose.what.to.delete", value: "Choose what to delete", comment: "Fire dialog disclosure label that expands/collapses the data type toggles")
+    static let fireDialogFireproofExplanation = NotLocalizedString("fire.dialog.fireproof.explanation", value: "Fireproof site data won’t be deleted", comment: "Footnote below the Fire dialog data type toggles, explaining that data belonging to Fireproof sites is kept")
     static let fireDialogAccessibilityDetailsExpanded = NotLocalizedString("fire.dialog.accessibility.details.expanded", value: "expanded", comment: "Accessiblity value - The fire dialog details are expanded")
     static let fireDialogAccessibilityDetailsCollapsed = NotLocalizedString("fire.dialog.accessibility.details.collapsed", value: "collapsed", comment: "Accessiblity value - The fire dialog details are collapsed")
     static let fireDialogAccessibilitySelected = NotLocalizedString("fire.dialog.accessibility.selected", value: "selected", comment: "Accessiblity value - The selected fire dialog mode")

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -431,7 +431,6 @@ struct FireDialogView: ModalView {
                 detailActionEnabled: viewModel.includeHistory,
                 detailAccessibilityIdentifier: "FireDialogView.historyDetailButton",
                 isEnabled: isIncludeHistoryEnabled,
-                roundedCorners: .top,
                 toggleId: "FireDialogView.historyToggle"
             )
             .accessibilityHidden(isShowingAnyOverlay)
@@ -449,7 +448,6 @@ struct FireDialogView: ModalView {
                 // grey-out the detail label when the toggle is Off
                 detailActionEnabled: viewModel.includeCookiesAndSiteData,
                 isEnabled: isIncludeCookiesAndSiteDataEnabled,
-                roundedCorners: viewModel.mode.shouldShowFireproofSection ? .none : .bottom,
                 toggleId: "FireDialogView.cookiesToggle"
             )
             .disabled(!isIncludeCookiesAndSiteDataEnabled)
@@ -458,7 +456,7 @@ struct FireDialogView: ModalView {
             if viewModel.shouldShowChatHistoryToggle {
                 sectionDivider()
 
-            // Row 3: Chat History
+                // Row 3: Chat History
                 sectionRow(
                     icon: DesignSystemImages.Glyphs.Size16.aiChat,
                     title: UserText.fireDialogChatHistoryTitle,
@@ -820,56 +818,56 @@ struct FireDialogView: ModalView {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func sectionRow(icon: NSImage, title: String, subtitle: String? = nil, detail: String? = nil, isOn: Binding<Bool>, detailAction: (() -> Void)? = nil, detailActionEnabled: Bool = true, detailAccessibilityIdentifier: String = "FireDialogView.cookiesDetailButton", isEnabled: Bool = true, roundedCorners: RowCornerRadius = .none, toggleId: String) -> some View {
-        RowWithPressEffect(roundedCorners: roundedCorners, rowCornerRadius: style.rowCornerRadius, isEnabled: isEnabled) {
-            guard isEnabled else { return }
-            isOn.wrappedValue.toggle()
-        } content: {
-            HStack(spacing: 8) {
-                HStack(spacing: 12) {
-                    Image(nsImage: icon)
+    private func sectionRow(icon: NSImage, title: String, subtitle: String? = nil, detail: String? = nil, isOn: Binding<Bool>, detailAction: (() -> Void)? = nil, detailActionEnabled: Bool = true, detailAccessibilityIdentifier: String = "FireDialogView.cookiesDetailButton", isEnabled: Bool = true, toggleId: String) -> some View {
+        HStack(spacing: 8) {
+            HStack(spacing: 12) {
+                Image(nsImage: icon)
 
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(title)
-                            .font(.system(size: 13))
-                            .foregroundColor(Color(designSystemColor: .textPrimary))
-                            .lineLimit(1)
-                        if let subtitle {
-                            Text(subtitle)
-                                .font(.system(size: 11))
-                                .foregroundColor(Color(designSystemColor: .textSecondary))
-                                .multilineTextAlignment(.leading)
-                                .fixedSize(horizontal: false, vertical: true)
-                                .layoutPriority(3)
-                        }
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.system(size: 13))
+                        .foregroundColor(Color(designSystemColor: .textPrimary))
+                        .lineLimit(1)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.system(size: 11))
+                            .foregroundColor(Color(designSystemColor: .textSecondary))
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .layoutPriority(3)
                     }
-                }
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel(title)
-                .accessibilityValue(subtitle ?? detail ?? "")
-                .accessibilityAddTraits(.updatesFrequently)
-
-                Spacer()
-
-                HStack(spacing: 8) {
-                    if let detail {
-                        SectionRowDetailLabel(
-                            text: detail,
-                            action: detailAction,
-                            isEnabled: detailActionEnabled,
-                            accessibilityIdentifier: detailAccessibilityIdentifier
-                        )
-                    }
-
-                    Toggle(isOn: isOn)
-                        .toggleStyle(FireToggleStyle(onFill: style.knobFillColor, knobFill: Color(designSystemColor: .accentContentPrimary)))
-                        .accessibilityLabel(title)
-                        .accessibilityIdentifier(toggleId)
                 }
             }
-            .padding(.vertical, 13)
-            .padding(.horizontal, 4)
-            .frame(width: Constants.sectionRowWidth, alignment: .leading)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(title)
+            .accessibilityValue(subtitle ?? detail ?? "")
+            .accessibilityAddTraits(.updatesFrequently)
+
+            Spacer()
+
+            HStack(spacing: 8) {
+                if let detail {
+                    SectionRowDetailLabel(
+                        text: detail,
+                        action: detailAction,
+                        isEnabled: detailActionEnabled,
+                        accessibilityIdentifier: detailAccessibilityIdentifier
+                    )
+                }
+
+                Toggle(isOn: isOn)
+                    .toggleStyle(FireToggleStyle(onFill: style.knobFillColor, knobFill: Color(designSystemColor: .accentContentPrimary)))
+                    .accessibilityLabel(title)
+                    .accessibilityIdentifier(toggleId)
+            }
+        }
+        .padding(.vertical, 13)
+        .padding(.horizontal, 4)
+        .frame(width: Constants.sectionRowWidth, alignment: .leading)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard isEnabled else { return }
+            isOn.wrappedValue.toggle()
         }
     }
 
@@ -1149,61 +1147,6 @@ private struct RowCornerClipModifier: ViewModifier {
             content.clipShape(CustomRoundedCornersShape(tl: roundedCornerRadius, tr: roundedCornerRadius, bl: 0, br: 0))
         case .bottom:
             content.clipShape(CustomRoundedCornersShape(tl: 0, tr: 0, bl: roundedCornerRadius, br: roundedCornerRadius))
-        }
-    }
-}
-
-// Row with press effect - visual feedback without blocking child interactions
-private struct RowWithPressEffect<Content: View>: View {
-    let roundedCorners: RowCornerRadius
-    let rowCornerRadius: CGFloat
-    let isEnabled: Bool
-    let action: () -> Void
-    @ViewBuilder let content: () -> Content
-
-    @State private var showFeedback = false
-
-    var body: some View {
-        ZStack {
-            // Visual feedback overlay
-            pressBackground
-                .opacity(showFeedback ? 1 : 0)
-                .allowsHitTesting(false)
-
-            content()
-        }
-        .contentShape(Rectangle())
-        .onTapGesture {
-            if isEnabled {
-                // Quick flash animation
-                showFeedback = true
-
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) {
-                    showFeedback = false
-                    DispatchQueue.main.async {
-                        action()
-                    }
-                }
-            }
-        }
-        .animation(.easeOut(duration: showFeedback ? 0.06 : 0.12), value: showFeedback)
-        .modifier(RowCornerClipModifier(roundedCorners: roundedCorners, roundedCornerRadius: rowCornerRadius))
-    }
-
-    @ViewBuilder
-    private var pressBackground: some View {
-        let background = Color.buttonMouseDown
-
-        switch roundedCorners {
-        case .top:
-            CustomRoundedCornersShape(tl: rowCornerRadius, tr: rowCornerRadius, bl: 0, br: 0)
-                .fill(background)
-        case .bottom:
-            CustomRoundedCornersShape(tl: 0, tr: 0, bl: rowCornerRadius, br: rowCornerRadius)
-                .fill(background)
-        case .none:
-            Rectangle()
-                .fill(background)
         }
     }
 }

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -208,7 +208,6 @@ struct FireDialogView: ModalView {
 
                 footerView
                     .zIndex(10)
-                    .background(Color(designSystemColor: .surfaceSecondary, palette: themeManager.designColorPalette))
             }
             .readSize { size in
                 // Set exact content height to avoid content shifting and animation jumping when sheet resizes
@@ -260,7 +259,7 @@ struct FireDialogView: ModalView {
         .animation(.easeOut(duration: NSAnimationContext.current.duration),
                    value: isAnimatingSitesOverlay || isAnimatingChatsOverlay || isAnimatingHistoryOverlay)
         .frame(width: Constants.viewSize.width, height: viewHeight, alignment: .top)
-        .background(Color(designSystemColor: .surfaceSecondary))
+        .background(Color(designSystemColor: .surfacePrimary, palette: themeManager.designColorPalette))
         .accessibilityElement(children: .contain)
         .accessibilityLabel(viewModel.mode.dialogTitle)
     }
@@ -953,6 +952,7 @@ struct FireDialogView: ModalView {
                 Toggle(tabsSubtitle, isOn: $viewModel.includeTabsAndWindows)
                     .toggleStyle(.checkbox)
                     .tint(style.knobFillColor)
+                    .foregroundColor(Color(designSystemColor: .textSecondary))
                     .accessibilityLabel(tabsSubtitle)
                     .accessibilityIdentifier("FireDialogView.tabsToggle")
                     .accessibilityHidden(isShowingAnyOverlay)
@@ -1114,7 +1114,7 @@ private struct FireDialogTabButton: View {
             .padding(20)
             .background(
                 RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(isSelected ? Color(designSystemColor: .surfaceTertiary) : Color(designSystemColor: .containerFillSecondary))
+                    .fill(isSelected ? Color(singleUseColor: .fireDialogTabBackgroundSelected) : Color(singleUseColor: .fireDialogTabBackground))
                     .shadow(color: isSelected ? Color(singleUseColor: .fireDialogTabShadowPrimary) : .clear, radius: 4, x: 0, y: 1)
                     .shadow(color: isSelected ? Color(singleUseColor: .fireDialogTabShadowSecondary) : .clear, radius: 1, x: 0, y: 0.25)
             )

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -855,7 +855,7 @@ struct FireDialogView: ModalView {
                 }
 
                 Toggle(isOn: isOn)
-                    .toggleStyle(FireToggleStyle(onFill: style.knobFillColor, knobFill: Color(designSystemColor: .accentContentPrimary)))
+                    .toggleStyle(FireToggleStyle(onFill: style.knobFillColor, knobFill: Color(singleUseColor: .fireDialogKnobFill)))
                     .accessibilityLabel(title)
                     .accessibilityIdentifier(toggleId)
             }

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -163,9 +163,27 @@ struct FireDialogView: ModalView {
                         VStack(spacing: 0) {
                             detailsDisclosureView
                                 .accessibilityHidden(isShowingAnyOverlay)
-                            if viewModel.isSectionsExpanded {
-                                sectionsView
+                            // Self-clipping slot: it grows from zero height, revealing the top-anchored rows,
+                            // so the sheet resize reads as a reveal rather than a snap. Deliberately no
+                            // `.move` transition — that offsets the departing rows up over the disclosure
+                            // row, and since `.clipped()` doesn‘t clip hit testing, a transition SwiftUI
+                            // fails to tear down leaves invisible rows swallowing clicks on the chevron.
+                            ZStack(alignment: .top) {
+                                if viewModel.isSectionsExpanded {
+                                    sectionsView
+                                        .transition(.opacity)
+                                }
                             }
+                            // pin the width, otherwise the slot‘s frame interpolates from zero in *both*
+                            // axes and the clip wipes the rows open from the centre outwards
+                            .frame(width: Constants.sectionRowWidth)
+                            .clipped()
+                            // belt and braces: a lingering collapsed slot can‘t steal clicks or show up in
+                            // the accessibility tree
+                            .allowsHitTesting(viewModel.isSectionsExpanded)
+                            .accessibilityHidden(!viewModel.isSectionsExpanded)
+                            // outside the clip, so the last row‘s press highlight doesn‘t get cut off
+                            .padding(.bottom, viewModel.isSectionsExpanded ? -10 : 0)
                         }
                     }
                     .padding(Constants.boxContentPadding)
@@ -457,7 +475,6 @@ struct FireDialogView: ModalView {
             }
         }
         .padding(.top, 4)
-        .padding(.bottom, -10)
         .fixedSize(horizontal: false, vertical: true)
     }
 

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -163,26 +163,16 @@ struct FireDialogView: ModalView {
                         VStack(spacing: 0) {
                             detailsDisclosureView
                                 .accessibilityHidden(isShowingAnyOverlay)
-                            // Self-clipping slot: it grows from zero height, revealing the top-anchored rows,
-                            // so the sheet resize reads as a reveal rather than a snap. Deliberately no
-                            // `.move` transition — that offsets the departing rows up over the disclosure
-                            // row, and since `.clipped()` doesn‘t clip hit testing, a transition SwiftUI
-                            // fails to tear down leaves invisible rows swallowing clicks on the chevron.
                             ZStack(alignment: .top) {
                                 if viewModel.isSectionsExpanded {
                                     sectionsView
                                         .transition(.opacity)
                                 }
                             }
-                            // pin the width, otherwise the slot‘s frame interpolates from zero in *both*
-                            // axes and the clip wipes the rows open from the centre outwards
                             .frame(width: Constants.sectionRowWidth)
                             .clipped()
-                            // belt and braces: a lingering collapsed slot can‘t steal clicks or show up in
-                            // the accessibility tree
                             .allowsHitTesting(viewModel.isSectionsExpanded)
                             .accessibilityHidden(!viewModel.isSectionsExpanded)
-                            // outside the clip, so the last row‘s press highlight doesn‘t get cut off
                             .padding(.bottom, viewModel.isSectionsExpanded ? -10 : 0)
                         }
                     }

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -1115,8 +1115,8 @@ private struct FireDialogTabButton: View {
             .background(
                 RoundedRectangle(cornerRadius: 16, style: .continuous)
                     .fill(isSelected ? Color(designSystemColor: .surfaceTertiary) : Color(designSystemColor: .containerFillSecondary))
-                    .shadow(color: isSelected ? Color(designSystemColor: .shadowPrimary) : .clear, radius: 4, x: 0, y: 1)
-                    .shadow(color: isSelected ? Color(designSystemColor: .shadowTertiary) : .clear, radius: 1, x: 0, y: 0.25)
+                    .shadow(color: isSelected ? Color(singleUseColor: .fireDialogTabShadowPrimary) : .clear, radius: 4, x: 0, y: 1)
+                    .shadow(color: isSelected ? Color(singleUseColor: .fireDialogTabShadowSecondary) : .clear, radius: 1, x: 0, y: 0.25)
             )
         }
         .buttonStyle(.plain)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -544,14 +544,7 @@ struct FireDialogView: ModalView {
                 }
 
                 if !viewModel.fireproofed.isEmpty {
-                    Text(UserText.fireproofCookiesAndSiteDataExplanation)
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundColor(Color(designSystemColor: .textSecondary))
-                        .multilineTextAlignment(.leading)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.top, 12)
-                        .padding(.bottom, 4)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    fireproofSitesSectionHeader
 
                     ForEach(viewModel.fireproofed, id: \.domain) { item in
                         sitesOverlayRow(for: item)
@@ -574,6 +567,24 @@ struct FireDialogView: ModalView {
                 )
         )
         .padding(.horizontal, 8)
+    }
+
+    /// Separates the sites whose data will be deleted from the Fireproof ones listed below it.
+    private var fireproofSitesSectionHeader: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            sectionDivider(padding: 0)
+
+            Text(UserText.fireDialogFireproofExplanation)
+                .font(.system(size: 11))
+                .foregroundColor(Color(designSystemColor: .textSecondary))
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 20)
+                .padding(.bottom, 5)
+        }
+        // the design hangs this 8pt off the list above; keeping it here is equivalent and self-contained
+        .padding(.top, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func sitesOverlayRow(for item: FireDialogViewModel.Item) -> some View {

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -212,9 +212,12 @@ final class FireDialogViewModel: ObservableObject {
 
     var shouldShowChatHistoryToggle: Bool {
         let isPresentedOnAIChatTab = tabCollectionViewModel?.selectedTab?.url?.isDuckAIURL ?? false
+        // Only hide chats toggle when no chats in the new dialog, so default this to `true` when the flag is off.
+        let hasChats = featureFlagger.isFeatureOn(.fireDialogSimplified) ? chats.count > 0 : true
         return aiChatHistoryCleaner.shouldDisplayCleanAIChatHistoryOption
             && mode.shouldShowChatHistoryToggle
             && (clearingOption.shouldShowChatHistoryToggle || isPresentedOnAIChatTab)
+            && hasChats
     }
 
     let fireViewModel: FireViewModel


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216831005511464?focus=true

### Description
A few changes to colors and animations in the new Fire Dialog.

### Testing Steps
1. Enable `fireDialogSimplified` feature flag and reopen a window.
2. Verify that the fire dialog looks good in dark mode - lighter background, even lighter currently selected mode, darker not selected mode, white knob, lighter Delete button.
<img width="434" height="546" alt="Screenshot 2026-08-10 at 16 09 44" src="https://github.com/user-attachments/assets/49ecf515-790a-4b85-bde2-c18b23205d58" />

3. Have a fireproof domain. Click on the number next to "Cookies & other data" and verify that the bottom "fireproof sites" section looks like below (separator + lighter text):
<img width="446" height="442" alt="Screenshot 2026-08-10 at 16 11 19" src="https://github.com/user-attachments/assets/bbcbb828-280d-4d35-8fc4-36febd5be351" />

4. Delete all Duck.ai chats and verify that the dialog doesn't show chats when there are no chats.
5. Disable `fireDialogSimplified` feature flag and verify that the old dialog is unchanged.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Some changes are leaked to the old dialog - to mitigate this, the only change to the view model is guarded with a feature flag.

### Quality Considerations
N/A

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and localization changes to the Fire Dialog with one feature-flag-gated visibility rule for the chat toggle; no data-clearing logic changes beyond UI gating.
> 
> **Overview**
> Addresses **design feedback** for the simplified macOS Fire Dialog (`fireDialogSimplified`): **dark-mode colors**, **tab/mode styling**, **expand/collapse behavior**, and a **fireproof sites** presentation tweak.
> 
> **Colors & tokens:** Fire button gradients now use **light/dark** dynamic colors instead of static light-only values. New **single-use** tokens cover dialog toggle knob fill, tab backgrounds (selected/unselected), and tab shadows. Dialog shell background moves to **`surfacePrimary`** (palette-aware).
> 
> **UI behavior:** The “choose what to delete” section uses a **clipped `ZStack`** with opacity transition and conditional hit testing to reduce layout jump when expanding/collapsing. Section rows drop **`RowWithPressEffect`** rounded-corner press chrome; rows toggle via **`onTapGesture`** on the row. Segmented tab pills use the new tab background/shadow colors. Footer **close tabs** checkbox uses secondary text color.
> 
> **Fireproof sites overlay:** Replaces the old fireproof explanation string with a **divider + footnote** (`fireDialogFireproofExplanation`: “Fireproof site data won’t be deleted”) above fireproof domain rows.
> 
> **Logic:** When simplified dialog is on, the **Duck.ai chat history** toggle is hidden if there are **no chats** (`hasChats`); legacy dialog behavior keeps the toggle visible when the flag is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f73918eb1f0867ec64e2dc9d44cf736e15a47a2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->