### PR TITLE
iOS: Fix failing maestro test

### DIFF
--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
@@ -25,6 +25,7 @@ name: test_contextual_immediate_uti_pre_submit_context
         ff.contextualDuckAIMode: "true"
         ff.aiChatContextualUnifiedToggleInput: "true"
         ff.aiChatAutoAttachContextByDefault: "true"
+        ff.contextualSuggestedPrompts: "true"
 
 - runFlow:
     file: ../shared/dismiss_chat_open_modals.yaml

--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
@@ -39,7 +39,8 @@ name: test_contextual_immediate_uti_pre_submit_context
     id: "Browser.OmniBar.Button.AIChat"
 - assertVisible:
     id: "AIChat.ContextualSheet"
-- assertVisible: "Summarize page"
+- assertVisible:
+    id: "summarize-page"
 - assertNotVisible:
     id: "AIChatNativeInputView.submitButton"
 - extendedWaitUntil:

--- a/SharedPackages/AIChat/Sources/AIChat/iOS/Views/QuickActions/AIChatQuickActionChipView.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/Views/QuickActions/AIChatQuickActionChipView.swift
@@ -90,6 +90,7 @@ public final class AIChatQuickActionChipView: UIView {
         iconView.image = action.icon?.withRenderingMode(.alwaysTemplate)
         iconView.isHidden = action.icon == nil
         accessibilityLabel = action.title
+        accessibilityIdentifier = action.id
     }
 }
 

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatQuickActionChipViewTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatQuickActionChipViewTests.swift
@@ -69,6 +69,14 @@ final class AIChatQuickActionChipViewTests: XCTestCase {
         XCTAssertNotNil(sut)
     }
 
+    func testConfigureSetsAccessibilityIdentifierFromActionID() {
+        // When
+        sut.configure(with: MockQuickAction.testAction)
+
+        // Then
+        XCTAssertEqual(sut.accessibilityIdentifier, MockQuickAction.testAction.id)
+    }
+
     func testReconfigureWithDifferentAction() {
         // Given
         sut.configure(with: MockQuickAction.testAction)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1217321614079449?focus=true
Tech Design URL:
CC:

### Description
FIx maestro test

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Wait for `test_contextual_immediate_uti_pre_submit_context` to pass
<img width="657" height="288" alt="Screenshot 2026-08-10 at 18 28 29" src="https://github.com/user-attachments/assets/371eff64-6c15-477e-ab96-8754c9fd45eb" />

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low, test bug fixes

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and accessibility-identifier changes only; no production chat or navigation logic is modified.
> 
> **Overview**
> Fixes a failing Maestro flow for immediate contextual UTI by aligning UI tests with **contextual suggested prompts** instead of a static **Summarize page** label.
> 
> **`AIChatQuickActionChipView`** now sets **`accessibilityIdentifier`** from the quick action’s **`id`** (alongside the existing label), so chips like **`summarize-page`** can be targeted reliably in automation. A unit test verifies the identifier matches the action id.
> 
> The Maestro scenario enables **`ff.contextualSuggestedPrompts`**, replaces the text assertion with **`id: summarize-page`**, and keeps the rest of the pre-submit context behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df57540033776e02e1b406ad4f4223ae8c8ef704. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->