### PR TITLE
iOS: Selection-scoped suggestions and auto-attach skip (3/5)

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1993,6 +1993,7 @@
 		C11F41152F2CCBE900C126C3 /* AIChatContextualChatSessionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11F41142F2CCBE900C126C3 /* AIChatContextualChatSessionStateTests.swift */; };
 		AD5E1ED02B0000000000F004 /* AIChatTextSelectionFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E1ED02B0000000000F003 /* AIChatTextSelectionFeatureTests.swift */; };
 		AD5E1ED02B0000000000F008 /* AIChatSelectionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E1ED02B0000000000F007 /* AIChatSelectionContextTests.swift */; };
+		AD5E1ED02B0000000000F00C /* AIChatTextSelectionActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E1ED02B0000000000F00B /* AIChatTextSelectionActionTests.swift */; };
 		C12324C32C4697C900FBB26B /* AutofillBreakageReportTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1836CE42C35A0EA0016D057 /* AutofillBreakageReportTableViewCell.swift */; };
 		C124027C2F2922E700F87332 /* AIChatContextualModePixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C124027B2F2922E700F87332 /* AIChatContextualModePixelHandler.swift */; };
 		C124027E2F2935F600F87332 /* AIChatContextualModePixelHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C124027D2F2935F600F87332 /* AIChatContextualModePixelHandlerTests.swift */; };
@@ -2136,6 +2137,7 @@
 		C1AIREPO2F2E000100E35AD5 /* AIChatPageContextHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AIREPO2F2E000000E35AD5 /* AIChatPageContextHandler.swift */; };
 		AD5E1ED02B0000000000F002 /* AIChatTextSelectionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E1ED02B0000000000F001 /* AIChatTextSelectionFeature.swift */; };
 		AD5E1ED02B0000000000F006 /* AIChatSelectionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E1ED02B0000000000F005 /* AIChatSelectionContext.swift */; };
+		AD5E1ED02B0000000000F00A /* AIChatTextSelectionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E1ED02B0000000000F009 /* AIChatTextSelectionAction.swift */; };
 		C1AITEST2F2E000500E35AD5 /* AIChatPageContextHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1AITEST2F2E000400E35AD5 /* AIChatPageContextHandlerTests.swift */; };
 		C1B3BF472D8D99DA00EE1D43 /* AutofillCreditCardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B3BF432D8D99DA00EE1D43 /* AutofillCreditCardListView.swift */; };
 		C1B3BF482D8D99DA00EE1D43 /* AutofillCreditCardListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B3BF442D8D99DA00EE1D43 /* AutofillCreditCardListViewModel.swift */; };
@@ -4805,6 +4807,7 @@
 		C11F41142F2CCBE900C126C3 /* AIChatContextualChatSessionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualChatSessionStateTests.swift; sourceTree = "<group>"; };
 		AD5E1ED02B0000000000F003 /* AIChatTextSelectionFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTextSelectionFeatureTests.swift; sourceTree = "<group>"; };
 		AD5E1ED02B0000000000F007 /* AIChatSelectionContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSelectionContextTests.swift; sourceTree = "<group>"; };
+		AD5E1ED02B0000000000F00B /* AIChatTextSelectionActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTextSelectionActionTests.swift; sourceTree = "<group>"; };
 		C124027B2F2922E700F87332 /* AIChatContextualModePixelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualModePixelHandler.swift; sourceTree = "<group>"; };
 		C124027D2F2935F600F87332 /* AIChatContextualModePixelHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualModePixelHandlerTests.swift; sourceTree = "<group>"; };
 		C124F0522E686CBB008D0F49 /* SwitchBarFunnel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchBarFunnel.swift; sourceTree = "<group>"; };
@@ -4972,6 +4975,7 @@
 		C1AIREPO2F2E000000E35AD5 /* AIChatPageContextHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatPageContextHandler.swift; sourceTree = "<group>"; };
 		AD5E1ED02B0000000000F001 /* AIChatTextSelectionFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTextSelectionFeature.swift; sourceTree = "<group>"; };
 		AD5E1ED02B0000000000F005 /* AIChatSelectionContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSelectionContext.swift; sourceTree = "<group>"; };
+		AD5E1ED02B0000000000F009 /* AIChatTextSelectionAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTextSelectionAction.swift; sourceTree = "<group>"; };
 		C1AITEST2F2E000400E35AD5 /* AIChatPageContextHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatPageContextHandlerTests.swift; sourceTree = "<group>"; };
 		C1B3BF432D8D99DA00EE1D43 /* AutofillCreditCardListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillCreditCardListView.swift; sourceTree = "<group>"; };
 		C1B3BF442D8D99DA00EE1D43 /* AutofillCreditCardListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutofillCreditCardListViewModel.swift; sourceTree = "<group>"; };
@@ -6289,6 +6293,7 @@
 				C11F41142F2CCBE900C126C3 /* AIChatContextualChatSessionStateTests.swift */,
 				AD5E1ED02B0000000000F003 /* AIChatTextSelectionFeatureTests.swift */,
 				AD5E1ED02B0000000000F007 /* AIChatSelectionContextTests.swift */,
+				AD5E1ED02B0000000000F00B /* AIChatTextSelectionActionTests.swift */,
 				FADE0001C0FFEE00A5311008 /* ContextualSuggestionsMatcherTests.swift */,
 				31F43E202F4734B8001BBCDA /* AIChatAddressBarExperienceTests.swift */,
 				C124027D2F2935F600F87332 /* AIChatContextualModePixelHandlerTests.swift */,
@@ -9874,6 +9879,7 @@
 				C1AIREPO2F2E000000E35AD5 /* AIChatPageContextHandler.swift */,
 				AD5E1ED02B0000000000F001 /* AIChatTextSelectionFeature.swift */,
 				AD5E1ED02B0000000000F005 /* AIChatSelectionContext.swift */,
+				AD5E1ED02B0000000000F009 /* AIChatTextSelectionAction.swift */,
 				CB6D179C2FA38CAF00ECD5AE /* Logger+ContextualUTI.swift */,
 				CB6D17A72FA39FC900ECD5AE /* AIChatContextualUTIHost.swift */,
 			);
@@ -14270,6 +14276,7 @@
 				C1AIREPO2F2E000100E35AD5 /* AIChatPageContextHandler.swift in Sources */,
 				AD5E1ED02B0000000000F002 /* AIChatTextSelectionFeature.swift in Sources */,
 				AD5E1ED02B0000000000F006 /* AIChatSelectionContext.swift in Sources */,
+				AD5E1ED02B0000000000F00A /* AIChatTextSelectionAction.swift in Sources */,
 				6F1422822D314A5300B6D3DE /* TabInteractionStateDiskSource.swift in Sources */,
 				9FBE2B922EAEEC8200658BAB /* EmbeddedWebViewController.swift in Sources */,
 				EE01EB432AFC1E0A0096AAC9 /* NetworkProtectionVPNLocationView.swift in Sources */,
@@ -14890,6 +14897,7 @@
 				C11F41152F2CCBE900C126C3 /* AIChatContextualChatSessionStateTests.swift in Sources */,
 				AD5E1ED02B0000000000F004 /* AIChatTextSelectionFeatureTests.swift in Sources */,
 				AD5E1ED02B0000000000F008 /* AIChatSelectionContextTests.swift in Sources */,
+				AD5E1ED02B0000000000F00C /* AIChatTextSelectionActionTests.swift in Sources */,
 				FADE0001C0FFEE00A5311007 /* ContextualSuggestionsMatcherTests.swift in Sources */,
 				9F06EB8C2D10578000905426 /* MaliciousSiteProtectionSettingsViewModelTests.swift in Sources */,
 				9F6454332F99D04F00D5FB71 /* MockAppStoreCustomProductPagePresenter.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -129,12 +129,19 @@ final class AIChatContextualChatSessionState {
     private(set) var contextualChatURL: URL?
     private(set) var latestContext: AIChatPageContext?
 
+    /// Last page collected for signals only — page-type signals and URL for the suggestion matcher, from a
+    /// page that is deliberately not attached. Separate from `latestContext` so it cannot reach the paths
+    /// that turn a collected page into an attachment.
+    private(set) var latestSignalsOnlyContext: AIChatPageContext?
+
+    /// The page the suggestion matcher resolves against: the attachable one when there is one, otherwise
+    /// the signals-only page collected for a page we deliberately did not attach.
+    private var contextForSuggestions: AIChatPageContext? {
+        latestContext ?? latestSignalsOnlyContext
+    }
+
     /// Text selections attached from the page's selection menu, in attach order.
     private(set) var attachedSelections: [AIChatSelectionContextData] = []
-
-    /// Title of the page the most recent selection came from. Distinct from
-    /// `AIChatSelectionContextData.title`, which is the generic payload title ("Text selection").
-    private(set) var attachedSelectionPageTitle: String?
 
     /// URL included in the last submitted prompt with no navigation since; used to spot a stale auto-attach echo.
     private var deliveredContextURLWithNoNavigationSince: URL?
@@ -320,7 +327,7 @@ final class AIChatContextualChatSessionState {
     /// taps on the omnibar icon each read the selection asynchronously, so both can arrive here with
     /// identical text, and the resulting chips would be indistinguishable while costing two cap slots.
     @discardableResult
-    func attachSelection(_ selection: AIChatSelectionContextData, pageTitle: String? = nil) -> Bool {
+    func attachSelection(_ selection: AIChatSelectionContextData) -> Bool {
         guard !attachedSelections.contains(where: { $0.content == selection.content && $0.url == selection.url }) else {
             return true
         }
@@ -328,7 +335,6 @@ final class AIChatContextualChatSessionState {
             return false
         }
         attachedSelections.append(selection)
-        attachedSelectionPageTitle = pageTitle
         resolveSuggestionsForScopeChange()
         rebuildViewState()
         return true
@@ -338,9 +344,6 @@ final class AIChatContextualChatSessionState {
     func removeAttachedSelection(id: String) {
         guard attachedSelections.contains(where: { $0.id == id }) else { return }
         attachedSelections.removeAll { $0.id == id }
-        if attachedSelections.isEmpty {
-            attachedSelectionPageTitle = nil
-        }
         resolveSuggestionsForScopeChange()
         rebuildViewState()
     }
@@ -350,13 +353,13 @@ final class AIChatContextualChatSessionState {
     func consumeAttachedSelections() {
         guard !attachedSelections.isEmpty else { return }
         attachedSelections = []
-        attachedSelectionPageTitle = nil
+        resolveSuggestionsForScopeChange()
     }
 
     func clearAttachedSelections() {
         guard !attachedSelections.isEmpty else { return }
         attachedSelections = []
-        attachedSelectionPageTitle = nil
+        resolveSuggestionsForScopeChange()
         rebuildViewState()
     }
 
@@ -367,8 +370,8 @@ final class AIChatContextualChatSessionState {
     func resetToNoChat(preservingSelections: Bool = false) {
         if !preservingSelections {
             attachedSelections = []
-            attachedSelectionPageTitle = nil
         }
+        latestSignalsOnlyContext = nil
         frontendState = .noChat
         chipState = .placeholder
         contextualChatURL = nil
@@ -460,9 +463,11 @@ final class AIChatContextualChatSessionState {
     /// "Summarize this page".
     private func resolveSuggestionsForScopeChange() {
         guard frontendState == .noChat, showsSuggestionsStartSurface, !hasActiveChat else { return }
-        suggestionsResolveTask?.cancel()
-        suggestionsLoadState = .loading
-        resolveSuggestionsIfLoading(from: latestContext)
+        // Goes through `beginLoadingSuggestions` rather than setting `.loading` directly so the previous
+        // scope's chips are cleared — the loading view is inserted alongside them, not over them, so a
+        // stale "Summarize this page" would otherwise sit beside the spinner — and so the timeout is armed.
+        beginLoadingSuggestions()
+        resolveSuggestionsIfLoading(from: contextForSuggestions)
     }
 
     /// Re-renders after something outside this object changed the attachment count — an image added to
@@ -550,6 +555,11 @@ final class AIChatContextualChatSessionState {
             pendingSignalsOnlyCollection = false
             isProcessingNavigation = false
             if let context {
+                // Kept separately from `latestContext` on purpose. This page is deliberately *not*
+                // attached, and `latestContext` feeds paths that would attach it — a new UTI host starts
+                // with it as a pending-submit attachment. Suggestions only need its signals and URL, so
+                // they get their own reference and nothing else changes behaviour.
+                latestSignalsOnlyContext = context
                 let payload = signalsOnlyPayload(from: context.contextData)
                 emit(.deliverPageContext(payload, targets: .frontendBridge))
             }
@@ -565,6 +575,7 @@ final class AIChatContextualChatSessionState {
             }
             Logger.aiChat.debug("[SessionState] Context collection returned nil/empty - clearing context and downgrading to placeholder")
             latestContext = nil
+            latestSignalsOnlyContext = nil
             chipState = .placeholder
             // Clear the persistent UTI host chip
             emit(.deliverPageContext(nil, targets: .utiChip))
@@ -626,6 +637,7 @@ final class AIChatContextualChatSessionState {
 
         chipState = .placeholder
         latestContext = nil
+        latestSignalsOnlyContext = nil
         userDowngradedToPlaceholder = false
         rebuildViewState()
         Logger.aiChat.debug("[SessionState] Cleared stale manual context on sheet present")

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -124,13 +124,9 @@ final class AIChatContextualChatSessionState {
     private(set) var contextualChatURL: URL?
     private(set) var latestContext: AIChatPageContext?
 
-    /// Kept out of `latestContext` so a page collected without being attached cannot reach the paths
-    /// that would attach it.
-    private(set) var latestSignalsOnlyContext: AIChatPageContext?
-
-    private var contextForSuggestions: AIChatPageContext? {
-        latestContext ?? latestSignalsOnlyContext
-    }
+    /// Most recent page read, attached or not. Suggestions resolve against this; keeping it out of
+    /// `latestContext` stops an unattached page reaching the paths that would attach it.
+    private(set) var lastCollectedContext: AIChatPageContext?
 
     /// Text selections attached from the page's selection menu, in attach order.
     private(set) var attachedSelections: [AIChatSelectionContextData] = []
@@ -363,7 +359,7 @@ final class AIChatContextualChatSessionState {
         if !preservingSelections {
             attachedSelections = []
         }
-        latestSignalsOnlyContext = nil
+        lastCollectedContext = nil
         frontendState = .noChat
         chipState = .placeholder
         contextualChatURL = nil
@@ -449,14 +445,10 @@ final class AIChatContextualChatSessionState {
         }
     }
 
-    /// Called when a selection is attached, removed or cleared: the page-scoped and selection-scoped
-    /// sets are different catalog entries, so the row has to be resolved again.
     private func resolveSuggestionsForScopeChange() {
         guard frontendState == .noChat, showsSuggestionsStartSurface, !hasActiveChat else { return }
-        // Via `beginLoadingSuggestions` so the old scope's chips are cleared: the loading view is
-        // inserted beside them, not over them.
         beginLoadingSuggestions()
-        resolveSuggestionsIfLoading(from: contextForSuggestions)
+        resolveSuggestionsIfLoading(from: lastCollectedContext)
     }
 
     func refreshForAttachmentChange() {
@@ -541,9 +533,10 @@ final class AIChatContextualChatSessionState {
         if pendingSignalsOnlyCollection {
             pendingSignalsOnlyCollection = false
             isProcessingNavigation = false
+            // Assigned even when nil, so a page that returned nothing drops the previous page's signals
+            // rather than leaving suggestions resolving against it.
+            lastCollectedContext = context
             if let context {
-                // Not `latestContext`: that feeds the paths that attach a page, and this one must not be.
-                latestSignalsOnlyContext = context
                 let payload = signalsOnlyPayload(from: context.contextData)
                 emit(.deliverPageContext(payload, targets: .frontendBridge))
             }
@@ -559,7 +552,7 @@ final class AIChatContextualChatSessionState {
             }
             Logger.aiChat.debug("[SessionState] Context collection returned nil/empty - clearing context and downgrading to placeholder")
             latestContext = nil
-            latestSignalsOnlyContext = nil
+            lastCollectedContext = nil
             chipState = .placeholder
             // Clear the persistent UTI host chip
             emit(.deliverPageContext(nil, targets: .utiChip))
@@ -569,6 +562,7 @@ final class AIChatContextualChatSessionState {
         }
 
         latestContext = context
+        lastCollectedContext = context
         Logger.aiChat.debug("[SessionState] Context updated: \(context.title)")
 
         if isManualAttachInProgress {
@@ -621,7 +615,7 @@ final class AIChatContextualChatSessionState {
 
         chipState = .placeholder
         latestContext = nil
-        latestSignalsOnlyContext = nil
+        lastCollectedContext = nil
         userDowngradedToPlaceholder = false
         rebuildViewState()
         Logger.aiChat.debug("[SessionState] Cleared stale manual context on sheet present")

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -114,6 +114,14 @@ final class AIChatContextualChatSessionState {
     /// When false, page-context quick actions are suppressed. Fail-open (always attachable) by default.
     private let isCurrentPageAttachable: () -> Bool
 
+    /// Images and files currently in the input. Lives in `UTIAttachmentController`, which the session
+    /// state has no view of, so it is supplied from outside — and defaults to zero, which is correct for
+    /// the basic native input (no attachment affordance) and for tests.
+    ///
+    /// Settable rather than an init parameter because the unified-input host that answers it is created
+    /// after this object.
+    var inputAttachmentCount: () -> Int = { 0 }
+
     // MARK: - Core State (private(set) - mutations happen via methods)
 
     private(set) var frontendState: FrontendChatState = .noChat
@@ -123,6 +131,10 @@ final class AIChatContextualChatSessionState {
 
     /// Text selections attached from the page's selection menu, in attach order.
     private(set) var attachedSelections: [AIChatSelectionContextData] = []
+
+    /// Title of the page the most recent selection came from. Distinct from
+    /// `AIChatSelectionContextData.title`, which is the generic payload title ("Text selection").
+    private(set) var attachedSelectionPageTitle: String?
 
     /// URL included in the last submitted prompt with no navigation since; used to spot a stale auto-attach echo.
     private var deliveredContextURLWithNoNavigationSince: URL?
@@ -308,7 +320,7 @@ final class AIChatContextualChatSessionState {
     /// taps on the omnibar icon each read the selection asynchronously, so both can arrive here with
     /// identical text, and the resulting chips would be indistinguishable while costing two cap slots.
     @discardableResult
-    func attachSelection(_ selection: AIChatSelectionContextData) -> Bool {
+    func attachSelection(_ selection: AIChatSelectionContextData, pageTitle: String? = nil) -> Bool {
         guard !attachedSelections.contains(where: { $0.content == selection.content && $0.url == selection.url }) else {
             return true
         }
@@ -316,6 +328,8 @@ final class AIChatContextualChatSessionState {
             return false
         }
         attachedSelections.append(selection)
+        attachedSelectionPageTitle = pageTitle
+        resolveSuggestionsForScopeChange()
         rebuildViewState()
         return true
     }
@@ -324,6 +338,10 @@ final class AIChatContextualChatSessionState {
     func removeAttachedSelection(id: String) {
         guard attachedSelections.contains(where: { $0.id == id }) else { return }
         attachedSelections.removeAll { $0.id == id }
+        if attachedSelections.isEmpty {
+            attachedSelectionPageTitle = nil
+        }
+        resolveSuggestionsForScopeChange()
         rebuildViewState()
     }
 
@@ -332,11 +350,13 @@ final class AIChatContextualChatSessionState {
     func consumeAttachedSelections() {
         guard !attachedSelections.isEmpty else { return }
         attachedSelections = []
+        attachedSelectionPageTitle = nil
     }
 
     func clearAttachedSelections() {
         guard !attachedSelections.isEmpty else { return }
         attachedSelections = []
+        attachedSelectionPageTitle = nil
         rebuildViewState()
     }
 
@@ -347,6 +367,7 @@ final class AIChatContextualChatSessionState {
     func resetToNoChat(preservingSelections: Bool = false) {
         if !preservingSelections {
             attachedSelections = []
+            attachedSelectionPageTitle = nil
         }
         frontendState = .noChat
         chipState = .placeholder
@@ -431,6 +452,23 @@ final class AIChatContextualChatSessionState {
             userDowngradedToPlaceholder = false
             Logger.aiChat.debug("[SessionState] Page navigation cleared temporary context removal")
         }
+    }
+
+    /// Re-resolves the suggestions because their scope changed: a selection was attached or removed, and
+    /// the page-scoped and selection-scoped sets are different catalog entries. Without this the row
+    /// keeps whichever set was resolved last, so an attached selection would still be offered
+    /// "Summarize this page".
+    private func resolveSuggestionsForScopeChange() {
+        guard frontendState == .noChat, showsSuggestionsStartSurface, !hasActiveChat else { return }
+        suggestionsResolveTask?.cancel()
+        suggestionsLoadState = .loading
+        resolveSuggestionsIfLoading(from: latestContext)
+    }
+
+    /// Re-renders after something outside this object changed the attachment count — an image added to
+    /// or removed from the input — since that decides whether suggestions are offered.
+    func refreshForAttachmentChange() {
+        rebuildViewState()
     }
 
     /// Re-evaluate the sheet view state (e.g. "Ask about page" quick action) for the current page's
@@ -749,7 +787,36 @@ private extension AIChatContextualChatSessionState {
         shouldAutoCollectContext || isManualAttachInProgress || isProcessingNavigation
     }
 
+    /// How many attachments the prompt currently carries: the page-context chip, each text selection,
+    /// and each image or file in the input.
+    ///
+    /// Auto-attached page context counts the same as manually attached — the user sees one chip either
+    /// way, and distinguishing them would mean recording provenance that nothing tracks today.
+    private var attachmentCount: Int {
+        let pageContextCount = if case .attached = chipState { 1 } else { 0 }
+        return pageContextCount + attachedSelections.count + inputAttachmentCount()
+    }
+
+    /// Suggestions are offered only while exactly one thing is attached, or nothing is.
+    ///
+    /// Beyond that the user has assembled something specific, and a one-line suggestion can no longer
+    /// say which part of it it acts on — the same reasoning that already hides suggestions when several
+    /// tabs are attached, generalised to attachments of any kind. So a selection plus an image, or page
+    /// context plus an image, offers nothing.
+    private var shouldHideSuggestions: Bool {
+        attachmentCount > 1
+    }
+
     private func resolveQuickActions() -> [AIChatContextualQuickAction] {
+        // Every quick action here is page-scoped ("Ask about page", "Summarize page"), so beside an
+        // attached selection they offer to act on the wrong thing — the same reason the page
+        // suggestions go. Pre-submit only: once a chat is running the frontend drives the UI.
+        //
+        // A selection and page context are still not mutually exclusive: the unified input's attach
+        // affordance carries its own page-context action, so that route survives the chip being hidden.
+        if !attachedSelections.isEmpty, frontendState == .noChat {
+            return []
+        }
         // No "Ask about page" for pages that can't be attached — it would no-op on tap.
         guard isCurrentPageAttachable() else { return [] }
         if featureFlagger.isFeatureOn(.contextualSuggestedPrompts) {
@@ -785,10 +852,14 @@ private extension AIChatContextualChatSessionState {
 
         suggestionsTimeoutTask?.cancel()
 
+        // A selection is attached, so offer the selection-scoped pair instead of page-derived ones.
+        // `pageTypeSignals` still travels: translate's `differentLanguage` condition compares the source
+        // page's language against the UI language, and a selection's source is that page.
         let input = ResolvePageSuggestionsInput(
             pageTypeSignals: context?.contextData.pageTypeSignals,
             url: context?.contextData.url,
-            uiLocale: Locale.current.identifier
+            uiLocale: Locale.current.identifier,
+            scope: attachedSelections.isEmpty ? .page : .selection
         )
 
         suggestionsResolveTask?.cancel()
@@ -821,7 +892,7 @@ private extension AIChatContextualChatSessionState {
             shouldShowNewChatButton: frontendState != .noChat,
             chipState: chipState,
             quickActions: quickActions,
-            suggestions: visibleSuggestions(reserving: quickActions.count),
+            suggestions: shouldHideSuggestions ? [] : visibleSuggestions(reserving: quickActions.count),
             suggestionsLoadState: suggestionsLoadState,
             suggestionsAreSmart: suggestionsAreSmart,
             suggestionsPageType: suggestionsPageType

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -114,12 +114,7 @@ final class AIChatContextualChatSessionState {
     /// When false, page-context quick actions are suppressed. Fail-open (always attachable) by default.
     private let isCurrentPageAttachable: () -> Bool
 
-    /// Images and files currently in the input. Lives in `UTIAttachmentController`, which the session
-    /// state has no view of, so it is supplied from outside — and defaults to zero, which is correct for
-    /// the basic native input (no attachment affordance) and for tests.
-    ///
-    /// Settable rather than an init parameter because the unified-input host that answers it is created
-    /// after this object.
+    /// Supplied from outside because the host that answers it is created after this object.
     var inputAttachmentCount: () -> Int = { 0 }
 
     // MARK: - Core State (private(set) - mutations happen via methods)
@@ -129,13 +124,10 @@ final class AIChatContextualChatSessionState {
     private(set) var contextualChatURL: URL?
     private(set) var latestContext: AIChatPageContext?
 
-    /// Last page collected for signals only — page-type signals and URL for the suggestion matcher, from a
-    /// page that is deliberately not attached. Separate from `latestContext` so it cannot reach the paths
-    /// that turn a collected page into an attachment.
+    /// Kept out of `latestContext` so a page collected without being attached cannot reach the paths
+    /// that would attach it.
     private(set) var latestSignalsOnlyContext: AIChatPageContext?
 
-    /// The page the suggestion matcher resolves against: the attachable one when there is one, otherwise
-    /// the signals-only page collected for a page we deliberately did not attach.
     private var contextForSuggestions: AIChatPageContext? {
         latestContext ?? latestSignalsOnlyContext
     }
@@ -457,21 +449,16 @@ final class AIChatContextualChatSessionState {
         }
     }
 
-    /// Re-resolves the suggestions because their scope changed: a selection was attached or removed, and
-    /// the page-scoped and selection-scoped sets are different catalog entries. Without this the row
-    /// keeps whichever set was resolved last, so an attached selection would still be offered
-    /// "Summarize this page".
+    /// Called when a selection is attached, removed or cleared: the page-scoped and selection-scoped
+    /// sets are different catalog entries, so the row has to be resolved again.
     private func resolveSuggestionsForScopeChange() {
         guard frontendState == .noChat, showsSuggestionsStartSurface, !hasActiveChat else { return }
-        // Goes through `beginLoadingSuggestions` rather than setting `.loading` directly so the previous
-        // scope's chips are cleared — the loading view is inserted alongside them, not over them, so a
-        // stale "Summarize this page" would otherwise sit beside the spinner — and so the timeout is armed.
+        // Via `beginLoadingSuggestions` so the old scope's chips are cleared: the loading view is
+        // inserted beside them, not over them.
         beginLoadingSuggestions()
         resolveSuggestionsIfLoading(from: contextForSuggestions)
     }
 
-    /// Re-renders after something outside this object changed the attachment count — an image added to
-    /// or removed from the input — since that decides whether suggestions are offered.
     func refreshForAttachmentChange() {
         rebuildViewState()
     }
@@ -555,10 +542,7 @@ final class AIChatContextualChatSessionState {
             pendingSignalsOnlyCollection = false
             isProcessingNavigation = false
             if let context {
-                // Kept separately from `latestContext` on purpose. This page is deliberately *not*
-                // attached, and `latestContext` feeds paths that would attach it — a new UTI host starts
-                // with it as a pending-submit attachment. Suggestions only need its signals and URL, so
-                // they get their own reference and nothing else changes behaviour.
+                // Not `latestContext`: that feeds the paths that attach a page, and this one must not be.
                 latestSignalsOnlyContext = context
                 let payload = signalsOnlyPayload(from: context.contextData)
                 emit(.deliverPageContext(payload, targets: .frontendBridge))
@@ -799,33 +783,19 @@ private extension AIChatContextualChatSessionState {
         shouldAutoCollectContext || isManualAttachInProgress || isProcessingNavigation
     }
 
-    /// How many attachments the prompt currently carries: the page-context chip, each text selection,
-    /// and each image or file in the input.
-    ///
-    /// Auto-attached page context counts the same as manually attached — the user sees one chip either
-    /// way, and distinguishing them would mean recording provenance that nothing tracks today.
     private var attachmentCount: Int {
         let pageContextCount = if case .attached = chipState { 1 } else { 0 }
         return pageContextCount + attachedSelections.count + inputAttachmentCount()
     }
 
-    /// Suggestions are offered only while exactly one thing is attached, or nothing is.
-    ///
-    /// Beyond that the user has assembled something specific, and a one-line suggestion can no longer
-    /// say which part of it it acts on — the same reasoning that already hides suggestions when several
-    /// tabs are attached, generalised to attachments of any kind. So a selection plus an image, or page
-    /// context plus an image, offers nothing.
+    /// Beyond one attachment a single-line suggestion can no longer say which part of the prompt it
+    /// acts on.
     private var shouldHideSuggestions: Bool {
         attachmentCount > 1
     }
 
     private func resolveQuickActions() -> [AIChatContextualQuickAction] {
-        // Every quick action here is page-scoped ("Ask about page", "Summarize page"), so beside an
-        // attached selection they offer to act on the wrong thing — the same reason the page
-        // suggestions go. Pre-submit only: once a chat is running the frontend drives the UI.
-        //
-        // A selection and page context are still not mutually exclusive: the unified input's attach
-        // affordance carries its own page-context action, so that route survives the chip being hidden.
+        // These are all page-scoped, so beside an attached selection they act on the wrong thing.
         if !attachedSelections.isEmpty, frontendState == .noChat {
             return []
         }
@@ -864,9 +834,8 @@ private extension AIChatContextualChatSessionState {
 
         suggestionsTimeoutTask?.cancel()
 
-        // A selection is attached, so offer the selection-scoped pair instead of page-derived ones.
-        // `pageTypeSignals` still travels: translate's `differentLanguage` condition compares the source
-        // page's language against the UI language, and a selection's source is that page.
+        // Signals still travel under selection scope: translate compares the source page's language
+        // against the UI language, and a selection's source is that page.
         let input = ResolvePageSuggestionsInput(
             pageTypeSignals: context?.contextData.pageTypeSignals,
             url: context?.contextData.url,

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -177,6 +177,8 @@ final class AIChatContextualSheetCoordinator {
             isCurrentPageAttachable: { [weak pageContextHandler] in pageContextHandler?.isCurrentPageAttachable() ?? true }
         )
         self.sessionState.updateUnifiedToggleInputActive(isWebUTIEnabled, isImmediateContextual: isImmediateContextualUTIEnabled)
+        // Set here rather than passed in: the host that answers this is created later.
+        self.sessionState.inputAttachmentCount = { [weak self] in self?.persistentUTIHost?.attachmentCount ?? 0 }
         self.sessionEffectCancellable = self.sessionState.effects
             .sink { [weak self] effect in
                 guard case .deliverPageContext(let context, let targets) = effect else { return }
@@ -205,15 +207,29 @@ final class AIChatContextualSheetCoordinator {
     // MARK: - Public Methods
 
     /// Presents the contextual AI chat sheet.
+    ///
+    /// - Parameter skippingAutoAttach: pass `true` when the sheet is being opened *because* the user
+    ///   attached something specific — a text selection. Auto-attaching the whole page on top of that
+    ///   makes the selection the second attachment, which hides the selection's own suggestions and
+    ///   buries the passage the user chose under page content they didn't ask for. Page signals are
+    ///   still collected, so the Translate suggestion's language condition keeps working.
     func presentSheet(from presentingViewController: UIViewController,
-                      restoreURL: URL? = nil) async {
+                      restoreURL: URL? = nil,
+                      skippingAutoAttach: Bool = false) async {
         sessionState.refreshAutoAttachSetting()
         sessionState.updateUnifiedToggleInputActive(isWebUTIEnabled, isImmediateContextual: isImmediateContextualUTIEnabled)
         clearStaleManualContextIfNeeded()
 
         startObservingContextUpdates()
 
-        if currentPageURL != nil, sessionState.shouldTriggerAutoCollect(for: currentPageURL) {
+        if skippingAutoAttach, currentPageURL != nil {
+            // Signals-only: no page chip, but the page-type signals the suggestions need still arrive.
+            sessionState.markPendingSignalsOnlyCollection()
+            if sessionState.showsSuggestionsStartSurface {
+                sessionState.beginLoadingSuggestions()
+            }
+            pageContextHandler.triggerContextCollection(trigger: .tabContent)
+        } else if currentPageURL != nil, sessionState.shouldTriggerAutoCollect(for: currentPageURL) {
             if sessionState.showsSuggestionsStartSurface {
                 sessionState.beginLoadingSuggestions()
             }
@@ -235,21 +251,37 @@ final class AIChatContextualSheetCoordinator {
         }
     }
 
-    /// Attaches text selected on the page and presents the sheet, submitting nothing. At the cap the
-    /// selection is refused with a banner and the sheet still presents.
-    func attachSelection(text: String,
-                         url: URL?,
-                         faviconBase64: String?,
-                         restoreURL: URL? = nil,
-                         from presentingViewController: UIViewController) async {
+    /// Runs a Duck.ai action on text selected in the page, presenting the sheet either way.
+    ///
+    /// - `ask` attaches the selection as a chip and submits nothing, leaving the user to write their own
+    ///   question. At the cap the selection is refused with a banner and the sheet still presents, so the
+    ///   user can see the chips they already have and act on them.
+    /// - `summarize` and `translate` carry the text inside their tool payload and attach nothing — a chip
+    ///   would be a second, redundant copy. Submitting clears any selections already attached, matching
+    ///   macOS's `clearSelectionContexts()` on submit. **Delivering that payload needs the native-prompt
+    ///   channel, which does not exist yet**, so today these only clear and present.
+    func handleSelectionAction(_ action: AIChatTextSelectionAction,
+                               text: String,
+                               url: URL?,
+                               faviconBase64: String?,
+                               pageTitle: String? = nil,
+                               restoreURL: URL? = nil,
+                               from presentingViewController: UIViewController) async {
         let selection = AIChatSelectionContextBuilder.makeSelection(
             text: text,
             url: url,
             faviconBase64: faviconBase64
         )
-        let didHitCap = !sessionState.attachSelection(selection)
 
-        await presentSheet(from: presentingViewController, restoreURL: restoreURL)
+        var didHitCap = false
+        if action.attachesSelection {
+            didHitCap = !sessionState.attachSelection(selection, pageTitle: pageTitle)
+        } else {
+            // Submitting consumes whatever was collected, so the input is clean for the next question.
+            sessionState.clearAttachedSelections()
+        }
+
+        await presentSheet(from: presentingViewController, restoreURL: restoreURL, skippingAutoAttach: true)
         refreshSelectionChips()
 
         if didHitCap {
@@ -456,6 +488,9 @@ private extension AIChatContextualSheetCoordinator {
         }
         host.onPromptDelivered = { [weak self] in
             self?.sessionState.markUTIContextDelivered()
+        }
+        host.onAttachmentsChanged = { [weak self] in
+            self?.sessionState.refreshForAttachmentChange()
         }
         host.onAIVoiceChatRequested = { [weak self] in
             guard let self else { return }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -177,7 +177,6 @@ final class AIChatContextualSheetCoordinator {
             isCurrentPageAttachable: { [weak pageContextHandler] in pageContextHandler?.isCurrentPageAttachable() ?? true }
         )
         self.sessionState.updateUnifiedToggleInputActive(isWebUTIEnabled, isImmediateContextual: isImmediateContextualUTIEnabled)
-        // Set here rather than passed in: the host that answers this is created later.
         self.sessionState.inputAttachmentCount = { [weak self] in self?.persistentUTIHost?.attachmentCount ?? 0 }
         self.sessionEffectCancellable = self.sessionState.effects
             .sink { [weak self] effect in
@@ -208,11 +207,8 @@ final class AIChatContextualSheetCoordinator {
 
     /// Presents the contextual AI chat sheet.
     ///
-    /// - Parameter skippingAutoAttach: pass `true` when the sheet is being opened *because* the user
-    ///   attached something specific — a text selection. Auto-attaching the whole page on top of that
-    ///   makes the selection the second attachment, which hides the selection's own suggestions and
-    ///   buries the passage the user chose under page content they didn't ask for. Page signals are
-    ///   still collected, so the Translate suggestion's language condition keeps working.
+    /// - Parameter skippingAutoAttach: `true` when the sheet opens because the user attached a text
+    ///   selection. The page is not attached on top of it; its signals are still collected.
     func presentSheet(from presentingViewController: UIViewController,
                       restoreURL: URL? = nil,
                       skippingAutoAttach: Bool = false) async {
@@ -223,8 +219,7 @@ final class AIChatContextualSheetCoordinator {
         startObservingContextUpdates()
 
         if skippingAutoAttach, currentPageURL != nil {
-            // Signals-only: no page chip, but the page-type signals the suggestions need still arrive.
-            // `markPendingSignalsOnlyCollection` already begins the loading state.
+            // No page chip, but the signals the suggestions need still arrive.
             sessionState.markPendingSignalsOnlyCollection()
             pageContextHandler.triggerContextCollection(trigger: .tabContent)
         } else if currentPageURL != nil, sessionState.shouldTriggerAutoCollect(for: currentPageURL) {
@@ -251,13 +246,9 @@ final class AIChatContextualSheetCoordinator {
 
     /// Runs a Duck.ai action on text selected in the page, presenting the sheet either way.
     ///
-    /// - `ask` attaches the selection as a chip and submits nothing, leaving the user to write their own
-    ///   question. At the cap the selection is refused with a banner and the sheet still presents, so the
-    ///   user can see the chips they already have and act on them.
-    /// - `summarize` and `translate` carry the text inside their tool payload and attach nothing — a chip
-    ///   would be a second, redundant copy. Submitting clears any selections already attached, matching
-    ///   macOS's `clearSelectionContexts()` on submit. **Delivering that payload needs the native-prompt
-    ///   channel, which does not exist yet**, so today these only clear and present.
+    /// `ask` attaches the selection and submits nothing; at the cap it is refused with a banner and the
+    /// sheet still presents. The submitting actions carry the text in their own payload, so they attach
+    /// nothing and clear any selections already attached, matching macOS on submit.
     func handleSelectionAction(_ action: AIChatTextSelectionAction,
                                selection selectedText: AIChatPageTextSelection,
                                restoreURL: URL? = nil,

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -224,10 +224,8 @@ final class AIChatContextualSheetCoordinator {
 
         if skippingAutoAttach, currentPageURL != nil {
             // Signals-only: no page chip, but the page-type signals the suggestions need still arrive.
+            // `markPendingSignalsOnlyCollection` already begins the loading state.
             sessionState.markPendingSignalsOnlyCollection()
-            if sessionState.showsSuggestionsStartSurface {
-                sessionState.beginLoadingSuggestions()
-            }
             pageContextHandler.triggerContextCollection(trigger: .tabContent)
         } else if currentPageURL != nil, sessionState.shouldTriggerAutoCollect(for: currentPageURL) {
             if sessionState.showsSuggestionsStartSurface {
@@ -261,21 +259,18 @@ final class AIChatContextualSheetCoordinator {
     ///   macOS's `clearSelectionContexts()` on submit. **Delivering that payload needs the native-prompt
     ///   channel, which does not exist yet**, so today these only clear and present.
     func handleSelectionAction(_ action: AIChatTextSelectionAction,
-                               text: String,
-                               url: URL?,
-                               faviconBase64: String?,
-                               pageTitle: String? = nil,
+                               selection selectedText: AIChatPageTextSelection,
                                restoreURL: URL? = nil,
                                from presentingViewController: UIViewController) async {
         let selection = AIChatSelectionContextBuilder.makeSelection(
-            text: text,
-            url: url,
-            faviconBase64: faviconBase64
+            text: selectedText.text,
+            url: selectedText.url,
+            faviconBase64: selectedText.faviconBase64
         )
 
         var didHitCap = false
         if action.attachesSelection {
-            didHitCap = !sessionState.attachSelection(selection, pageTitle: pageTitle)
+            didHitCap = !sessionState.attachSelection(selection)
         } else {
             // Submitting consumes whatever was collected, so the input is clean for the next question.
             sessionState.clearAttachedSelections()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -218,10 +218,15 @@ final class AIChatContextualSheetCoordinator {
 
         startObservingContextUpdates()
 
-        if skippingAutoAttach, currentPageURL != nil {
-            // No page chip, but the signals the suggestions need still arrive.
-            sessionState.markPendingSignalsOnlyCollection()
-            pageContextHandler.triggerContextCollection(trigger: .tabContent)
+        if skippingAutoAttach {
+            // An already-attached page keeps its own signals, and pushing the stripped signals-only
+            // payload over it would clear the attached context on the frontend.
+            if currentPageURL != nil, sessionState.intendedAttachedContext == nil {
+                sessionState.markPendingSignalsOnlyCollection()
+                pageContextHandler.triggerContextCollection(trigger: .tabContent)
+            } else {
+                pageContextHandler.reportAttachabilityMeasurement(trigger: .navigation)
+            }
         } else if currentPageURL != nil, sessionState.shouldTriggerAutoCollect(for: currentPageURL) {
             if sessionState.showsSuggestionsStartSurface {
                 sessionState.beginLoadingSuggestions()
@@ -246,9 +251,8 @@ final class AIChatContextualSheetCoordinator {
 
     /// Runs a Duck.ai action on text selected in the page, presenting the sheet either way.
     ///
-    /// `ask` attaches the selection and submits nothing; at the cap it is refused with a banner and the
-    /// sheet still presents. The submitting actions carry the text in their own payload, so they attach
-    /// nothing and clear any selections already attached, matching macOS on submit.
+    /// `ask` attaches the selection; at the cap it is refused with a banner and the sheet still presents.
+    /// The submitting actions attach nothing and clear any selections already attached.
     func handleSelectionAction(_ action: AIChatTextSelectionAction,
                                selection selectedText: AIChatPageTextSelection,
                                restoreURL: URL? = nil,

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -869,6 +869,12 @@ extension AIChatContextualSheetViewController: AIChatContextualInputViewControll
 
     func contextualInputViewController(_ viewController: AIChatContextualInputViewController, didSelectSuggestion suggestion: ContextualSuggestedPrompt) {
         guard featureFlagger.isFeatureOn(.contextualSuggestedPrompts) else { return }
+        // Selection-scoped suggestions must not take the page-suggestion route below: it attaches the whole
+        // page (the `.attached` guard misses, because opening from a selection deliberately leaves the chip
+        // state as `.placeholder`) and submits the label as prompt text. Both are the opposite of what these
+        // two do. They act on the attached selection via a tool payload, which needs the native-prompt
+        // channel — until that exists, tapping them does nothing.
+        guard AIChatTextSelectionAction(selectionSuggestionID: suggestion.id) == nil else { return }
         cancelSuggestionSubmission()
         pixelHandler.fireSuggestionSelected(suggestionId: suggestion.id, pageType: sessionState.viewState.suggestionsPageType)
         contextualInputViewController.setStartActionsDimmed(true)

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -869,11 +869,8 @@ extension AIChatContextualSheetViewController: AIChatContextualInputViewControll
 
     func contextualInputViewController(_ viewController: AIChatContextualInputViewController, didSelectSuggestion suggestion: ContextualSuggestedPrompt) {
         guard featureFlagger.isFeatureOn(.contextualSuggestedPrompts) else { return }
-        // Selection-scoped suggestions must not take the page-suggestion route below: it attaches the whole
-        // page (the `.attached` guard misses, because opening from a selection deliberately leaves the chip
-        // state as `.placeholder`) and submits the label as prompt text. Both are the opposite of what these
-        // two do. They act on the attached selection via a tool payload, which needs the native-prompt
-        // channel — until that exists, tapping them does nothing.
+        // These act on the attached selection, so they must not take the page route below: it attaches
+        // the whole page and submits the label as prompt text.
         guard AIChatTextSelectionAction(selectionSuggestionID: suggestion.id) == nil else { return }
         cancelSuggestionSubmission()
         pixelHandler.fireSuggestionSelected(suggestionId: suggestion.id, pageType: sessionState.viewState.suggestionsPageType)

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -131,6 +131,17 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate {
         coordinator.viewController.setSelectionContextChips(items, onRemove: onRemove)
     }
 
+    /// Images and files currently in the input.
+    var attachmentCount: Int {
+        coordinator.attachmentCount
+    }
+
+    /// Fires when the input's attachments change.
+    var onAttachmentsChanged: (() -> Void)? {
+        get { coordinator.onAttachmentsChanged }
+        set { coordinator.onAttachmentsChanged = newValue }
+    }
+
     func presentRejectionBanner(_ message: String) {
         coordinator.presentRejectionBanner(message)
     }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatTextSelectionAction.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatTextSelectionAction.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-/// Text the user selected in a page, with what is needed to identify where it came from.
+/// Text selected in a page, and where it came from.
 struct AIChatPageTextSelection {
     let text: String
     let url: URL?
@@ -46,16 +46,14 @@ enum AIChatTextSelectionAction: String, CaseIterable, Equatable {
         }
     }
 
-    /// Whether the selected text becomes an attachment.
-    ///
-    /// Only ask does. Summarize and translate carry their text inside the tool payload (`TextSummary` /
-    /// `Translation`), so attaching it as well would send the model the same text twice.
+    /// Only ask does: the submitting actions carry the text with them, so attaching it as well would
+    /// send the model the same passage twice.
     var attachesSelection: Bool {
         !autoSubmits
     }
 
-    /// Catalog id of the suggestion that performs this action on an attached selection. Ask has none —
-    /// it is what attaches the selection in the first place, so there is nothing left to suggest.
+    /// Catalog id of the suggestion that performs this action on an attached selection. Ask has none: it
+    /// is what attaches the selection in the first place.
     var selectionSuggestionID: String? {
         switch self {
         case .summarize: return "summarize-selection"

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatTextSelectionAction.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatTextSelectionAction.swift
@@ -19,6 +19,13 @@
 
 import Foundation
 
+/// Text the user selected in a page, with what is needed to identify where it came from.
+struct AIChatPageTextSelection {
+    let text: String
+    let url: URL?
+    let faviconBase64: String?
+}
+
 /// The Duck.ai actions that can be taken on a text selection.
 ///
 /// Only `ask` is offered in the selection edit menu — see `WebView.buildMenu`. Summarize and translate

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatTextSelectionAction.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatTextSelectionAction.swift
@@ -1,0 +1,67 @@
+//
+//  AIChatTextSelectionAction.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// The Duck.ai actions that can be taken on a text selection.
+///
+/// Only `ask` is offered in the selection edit menu — see `WebView.buildMenu`. Summarize and translate
+/// are offered inside the sheet instead, once the user has already chosen to involve Duck.ai.
+enum AIChatTextSelectionAction: String, CaseIterable, Equatable {
+    case summarize
+    case ask
+    case translate
+
+    /// Whether picking this action submits a prompt straight away.
+    ///
+    /// Matches macOS: summarize acts immediately, while ask only attaches the selection and waits for
+    /// the user to write their own question.
+    var autoSubmits: Bool {
+        switch self {
+        case .summarize, .translate: return true
+        case .ask: return false
+        }
+    }
+
+    /// Whether the selected text becomes an attachment.
+    ///
+    /// Only ask does. Summarize and translate carry their text inside the tool payload (`TextSummary` /
+    /// `Translation`), so attaching it as well would send the model the same text twice.
+    var attachesSelection: Bool {
+        !autoSubmits
+    }
+
+    /// Catalog id of the suggestion that performs this action on an attached selection. Ask has none —
+    /// it is what attaches the selection in the first place, so there is nothing left to suggest.
+    var selectionSuggestionID: String? {
+        switch self {
+        case .summarize: return "summarize-selection"
+        case .translate: return "translate-selection"
+        case .ask: return nil
+        }
+    }
+
+    /// Suggestion ids offered against an attached selection, in display order.
+    static let selectionSuggestionIDs = [summarize, translate].compactMap(\.selectionSuggestionID)
+
+    init?(selectionSuggestionID id: String) {
+        guard let match = Self.allCases.first(where: { $0.selectionSuggestionID == id }) else { return nil }
+        self = match
+    }
+}

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatTextSelectionAction.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatTextSelectionAction.swift
@@ -28,17 +28,13 @@ struct AIChatPageTextSelection {
 
 /// The Duck.ai actions that can be taken on a text selection.
 ///
-/// Only `ask` is offered in the selection edit menu — see `WebView.buildMenu`. Summarize and translate
-/// are offered inside the sheet instead, once the user has already chosen to involve Duck.ai.
+/// Only `ask` is offered in the selection edit menu; the others are offered inside the sheet.
 enum AIChatTextSelectionAction: String, CaseIterable, Equatable {
     case summarize
     case ask
     case translate
 
-    /// Whether picking this action submits a prompt straight away.
-    ///
-    /// Matches macOS: summarize acts immediately, while ask only attaches the selection and waits for
-    /// the user to write their own question.
+    /// Ask only attaches the selection and waits for the user's own question.
     var autoSubmits: Bool {
         switch self {
         case .summarize, .translate: return true
@@ -46,14 +42,12 @@ enum AIChatTextSelectionAction: String, CaseIterable, Equatable {
         }
     }
 
-    /// Only ask does: the submitting actions carry the text with them, so attaching it as well would
-    /// send the model the same passage twice.
+    /// The submitting actions carry the text themselves, so attaching it too would send it twice.
     var attachesSelection: Bool {
         !autoSubmits
     }
 
-    /// Catalog id of the suggestion that performs this action on an attached selection. Ask has none: it
-    /// is what attaches the selection in the first place.
+    /// Catalog id of the suggestion for this action. Ask has none: it is what attaches the selection.
     var selectionSuggestionID: String? {
         switch self {
         case .summarize: return "summarize-selection"

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestedPromptsProviding.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestedPromptsProviding.swift
@@ -21,9 +21,27 @@ import AIChat
 import Foundation
 
 struct ResolvePageSuggestionsInput {
+
+    /// What the offered suggestions should act on.
+    enum Scope {
+        /// The current page, matched against its type signals, URL and domain.
+        case page
+        /// An attached text selection. Only the selection-scoped catalog entries are offered —
+        /// page-derived ones would act on the wrong thing.
+        case selection
+    }
+
     let pageTypeSignals: AIChatPageTypeSignals?
     let url: String?
     let uiLocale: String
+    let scope: Scope
+
+    init(pageTypeSignals: AIChatPageTypeSignals?, url: String?, uiLocale: String, scope: Scope = .page) {
+        self.pageTypeSignals = pageTypeSignals
+        self.url = url
+        self.uiLocale = uiLocale
+        self.scope = scope
+    }
 }
 
 /// Coarse, pixel-safe classification of the current page, mirroring the frontend's `PageType`.

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestedPromptsProviding.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestedPromptsProviding.swift
@@ -24,10 +24,7 @@ struct ResolvePageSuggestionsInput {
 
     /// What the offered suggestions should act on.
     enum Scope {
-        /// The current page, matched against its type signals, URL and domain.
         case page
-        /// An attached text selection. Only the selection-scoped catalog entries are offered —
-        /// page-derived ones would act on the wrong thing.
         case selection
     }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionUserText.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionUserText.swift
@@ -18,6 +18,7 @@
 //
 
 import Foundation
+import FoundationExtensions
 
 extension UserText {
 
@@ -26,6 +27,16 @@ extension UserText {
 
     public static let aiChatSuggestionTranslatePageLabel = NSLocalizedString("duckai.suggestion.translate-page.label", value: "Translate this page", comment: "Suggested prompt chip: translate the current page")
     public static let aiChatSuggestionTranslatePagePrompt = NSLocalizedString("duckai.suggestion.translate-page.prompt", value: "Translate this page into %@.", comment: "Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language.")
+
+    /// `NotLocalizedString` so the selection stack can merge ahead of translations — see the
+    /// implementation plan §5a. The `prompt` values are unused for these two ids: tapping a selection
+    /// suggestion submits a tool payload rather than prompt text. They are populated so the entries
+    /// match the shape of every other catalog entry.
+    public static let aiChatSuggestionSummarizeSelectionLabel = NotLocalizedString("duckai.suggestion.summarize-selection.label", value: "Summarize this selection", comment: "Suggested prompt chip shown when the user has attached a text selection: summarize that selection")
+    public static let aiChatSuggestionSummarizeSelectionPrompt = NotLocalizedString("duckai.suggestion.summarize-selection.prompt", value: "Summarize this selection.", comment: "Suggested prompt submitted text: summarize the attached text selection")
+
+    public static let aiChatSuggestionTranslateSelectionLabel = NotLocalizedString("duckai.suggestion.translate-selection.label", value: "Translate this selection", comment: "Suggested prompt chip shown when the user has attached a text selection: translate that selection")
+    public static let aiChatSuggestionTranslateSelectionPrompt = NotLocalizedString("duckai.suggestion.translate-selection.prompt", value: "Translate this selection into %@.", comment: "Suggested prompt submitted text: translate the attached text selection. %@ is replaced with the name of the user's language.")
 
     public static let aiChatSuggestionKeyTakeawaysLabel = NSLocalizedString("duckai.suggestion.key-takeaways.label", value: "What are the key takeaways?", comment: "Suggested prompt chip: key takeaways of an article")
     public static let aiChatSuggestionKeyTakeawaysPrompt = NSLocalizedString("duckai.suggestion.key-takeaways.prompt", value: "What are the key takeaways from this article?", comment: "Suggested prompt submitted text: key takeaways of an article")

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionUserText.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionUserText.swift
@@ -29,9 +29,9 @@ extension UserText {
     public static let aiChatSuggestionTranslatePagePrompt = NSLocalizedString("duckai.suggestion.translate-page.prompt", value: "Translate this page into %@.", comment: "Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language.")
 
     /// `NotLocalizedString` so the selection stack can merge ahead of translations — see the
-    /// implementation plan §5a. The `prompt` values are unused for these two ids: tapping a selection
-    /// suggestion submits a tool payload rather than prompt text. They are populated so the entries
-    /// match the shape of every other catalog entry.
+    /// implementation plan §5a. Only the `label` values are shown today; the `prompt` values are populated
+    /// so these entries match the shape of every other catalog entry, and are deliberately not submitted —
+    /// these two act on the attached selection through a tool payload, not as prompt text.
     public static let aiChatSuggestionSummarizeSelectionLabel = NotLocalizedString("duckai.suggestion.summarize-selection.label", value: "Summarize this selection", comment: "Suggested prompt chip shown when the user has attached a text selection: summarize that selection")
     public static let aiChatSuggestionSummarizeSelectionPrompt = NotLocalizedString("duckai.suggestion.summarize-selection.prompt", value: "Summarize this selection.", comment: "Suggested prompt submitted text: summarize the attached text selection")
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionUserText.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionUserText.swift
@@ -28,10 +28,8 @@ extension UserText {
     public static let aiChatSuggestionTranslatePageLabel = NSLocalizedString("duckai.suggestion.translate-page.label", value: "Translate this page", comment: "Suggested prompt chip: translate the current page")
     public static let aiChatSuggestionTranslatePagePrompt = NSLocalizedString("duckai.suggestion.translate-page.prompt", value: "Translate this page into %@.", comment: "Suggested prompt submitted text: translate the page. %@ is replaced with the name of the user's language.")
 
-    /// `NotLocalizedString` so the selection stack can merge ahead of translations — see the
-    /// implementation plan §5a. Only the `label` values are shown today; the `prompt` values are populated
-    /// so these entries match the shape of every other catalog entry, and are deliberately not submitted —
-    /// these two act on the attached selection through a tool payload, not as prompt text.
+    /// `NotLocalizedString` so this can merge ahead of translations. Only the labels are shown; the
+    /// prompts exist so these entries match the shape of every other catalog entry.
     public static let aiChatSuggestionSummarizeSelectionLabel = NotLocalizedString("duckai.suggestion.summarize-selection.label", value: "Summarize this selection", comment: "Suggested prompt chip shown when the user has attached a text selection: summarize that selection")
     public static let aiChatSuggestionSummarizeSelectionPrompt = NotLocalizedString("duckai.suggestion.summarize-selection.prompt", value: "Summarize this selection.", comment: "Suggested prompt submitted text: summarize the attached text selection")
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionsMatcher.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionsMatcher.swift
@@ -65,9 +65,17 @@ struct ContextualSuggestionsMatcher {
 
     private init() {}
 
+    /// Catalog ids offered against an attached text selection. Translate carries the
+    /// `differentLanguage` condition, so a selection from a page in the user's own language offers one
+    /// suggestion rather than two.
+    private static let selectionScopedIDs = AIChatTextSelectionAction.selectionSuggestionIDs
+
     static func resolve(_ input: ResolvePageSuggestionsInput, catalog: SuggestionCatalog) -> ResolvedPageSuggestions {
         let cap = max(1, catalog.maxSuggestedPrompts)
-        let candidates = collectCandidateIds(input, catalog: catalog, cap: cap)
+        // Selection-scoped suggestions are a fixed pair, not page-matched, so they are never "smart".
+        let candidates = input.scope == .selection
+            ? (ids: selectionScopedIDs, isSmart: false)
+            : collectCandidateIds(input, catalog: catalog, cap: cap)
         var seen = Set<String>()
         var resolved: [ContextualSuggestedPrompt] = []
 
@@ -244,6 +252,8 @@ struct ContextualSuggestionsMatcher {
     private static let localizedCopyByID: [String: (label: String, prompt: String)] = [
         "summarize-page": (UserText.aiChatSuggestionSummarizePageLabel, UserText.aiChatSuggestionSummarizePagePrompt),
         "translate-page": (UserText.aiChatSuggestionTranslatePageLabel, UserText.aiChatSuggestionTranslatePagePrompt),
+        "summarize-selection": (UserText.aiChatSuggestionSummarizeSelectionLabel, UserText.aiChatSuggestionSummarizeSelectionPrompt),
+        "translate-selection": (UserText.aiChatSuggestionTranslateSelectionLabel, UserText.aiChatSuggestionTranslateSelectionPrompt),
         "key-takeaways": (UserText.aiChatSuggestionKeyTakeawaysLabel, UserText.aiChatSuggestionKeyTakeawaysPrompt),
         "explain-simply": (UserText.aiChatSuggestionExplainSimplyLabel, UserText.aiChatSuggestionExplainSimplyPrompt),
         "counterarguments": (UserText.aiChatSuggestionCounterargumentsLabel, UserText.aiChatSuggestionCounterargumentsPrompt),

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionsMatcher.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSuggestionsMatcher.swift
@@ -65,14 +65,13 @@ struct ContextualSuggestionsMatcher {
 
     private init() {}
 
-    /// Catalog ids offered against an attached text selection. Translate carries the
-    /// `differentLanguage` condition, so a selection from a page in the user's own language offers one
-    /// suggestion rather than two.
+    /// Translate carries the `differentLanguage` condition, so a selection from a page in the user's own
+    /// language offers one suggestion rather than two.
     private static let selectionScopedIDs = AIChatTextSelectionAction.selectionSuggestionIDs
 
     static func resolve(_ input: ResolvePageSuggestionsInput, catalog: SuggestionCatalog) -> ResolvedPageSuggestions {
         let cap = max(1, catalog.maxSuggestedPrompts)
-        // Selection-scoped suggestions are a fixed pair, not page-matched, so they are never "smart".
+        // A fixed pair, not page-matched, so never "smart".
         let candidates = input.scope == .selection
             ? (ids: selectionScopedIDs, isSmart: false)
             : collectCandidateIds(input, catalog: catalog, cap: cap)

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/PageSuggestionsCatalog.json
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/PageSuggestionsCatalog.json
@@ -6,6 +6,9 @@
     "summarize-page":      { "label": "Summarize this page", "icon": "summary", "prompt": "Summarize this page." },
     "translate-page":      { "label": "Translate this page", "icon": "translate", "prompt": "Translate this page into {language}.", "condition": "differentLanguage" },
 
+    "summarize-selection": { "label": "Summarize this selection", "icon": "summary", "prompt": "Summarize this selection." },
+    "translate-selection": { "label": "Translate this selection", "icon": "translate", "prompt": "Translate this selection into {language}.", "condition": "differentLanguage" },
+
     "key-takeaways":       { "label": "What are the key takeaways?", "icon": "summary", "prompt": "What are the key takeaways from this article?" },
     "explain-simply":      { "label": "Explain this simply", "prompt": "Explain this in simple, plain language." },
     "counterarguments":    { "label": "What are the counterarguments?", "prompt": "What are the main counterarguments or criticisms of this?" },

--- a/iOS/DuckDuckGo/TabViewControllerContextualAIChatExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerContextualAIChatExtension.swift
@@ -53,16 +53,18 @@ extension TabViewController {
         }
     }
 
-    /// Presents the sheet with `text` attached as its own context, alongside any page context. Nothing
-    /// is submitted — the selection is there for the user to ask about.
+    /// Presents the sheet with `text` attached as its own context. Nothing is submitted — the selection
+    /// is there for the user to ask about, so the page is not auto-attached on top of it.
     @MainActor
     func presentContextualAIChatSheet(withSelectedText text: String,
                                       from presentingViewController: UIViewController) async {
         let url = webView.url
-        await aiChatContextualSheetCoordinator.attachSelection(
+        await aiChatContextualSheetCoordinator.handleSelectionAction(
+            .ask,
             text: text,
             url: url,
             faviconBase64: url.flatMap { getFaviconBase64(for: $0) },
+            pageTitle: webView.title,
             restoreURL: restoreURLForContextualSheet(),
             from: presentingViewController
         )

--- a/iOS/DuckDuckGo/TabViewControllerContextualAIChatExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerContextualAIChatExtension.swift
@@ -61,10 +61,11 @@ extension TabViewController {
         let url = webView.url
         await aiChatContextualSheetCoordinator.handleSelectionAction(
             .ask,
-            text: text,
-            url: url,
-            faviconBase64: url.flatMap { getFaviconBase64(for: $0) },
-            pageTitle: webView.title,
+            selection: AIChatPageTextSelection(
+                text: text,
+                url: url,
+                faviconBase64: url.flatMap { getFaviconBase64(for: $0) }
+            ),
             restoreURL: restoreURLForContextualSheet(),
             from: presentingViewController
         )

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIAttachmentController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIAttachmentController.swift
@@ -414,6 +414,12 @@ final class UTIAttachmentController {
         view.showValidationError(message)
     }
 
+    /// Images and files currently in the input. Read by the contextual sheet, which offers suggestions
+    /// only while at most one thing is attached.
+    var attachmentCount: Int {
+        view.currentAttachments().count
+    }
+
     /// For something the input refused that isn't an attachment.
     func presentRejectionBanner(_ message: String) {
         presentTransientValidationError(message)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIAttachmentController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIAttachmentController.swift
@@ -416,8 +416,16 @@ final class UTIAttachmentController {
 
     /// Images and files currently in the input. Read by the contextual sheet, which offers suggestions
     /// only while at most one thing is attached.
+    ///
+    /// Rejected files are excluded: they show a validation error and are never sent, so counting them
+    /// would hide the suggestions over something the user cannot actually submit.
     var attachmentCount: Int {
-        view.currentAttachments().count
+        view.currentAttachments().filter {
+            switch $0 {
+            case .image, .file: return true
+            case .invalidFile: return false
+            }
+        }.count
     }
 
     /// For something the input refused that isn't an attachment.

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIAttachmentController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIAttachmentController.swift
@@ -414,11 +414,8 @@ final class UTIAttachmentController {
         view.showValidationError(message)
     }
 
-    /// Images and files currently in the input. Read by the contextual sheet, which offers suggestions
-    /// only while at most one thing is attached.
-    ///
-    /// Rejected files are excluded: they show a validation error and are never sent, so counting them
-    /// would hide the suggestions over something the user cannot actually submit.
+    /// Rejected files are excluded: they are never sent, so counting them would hide the contextual
+    /// sheet's suggestions over something the user cannot submit.
     var attachmentCount: Int {
         view.currentAttachments().filter {
             switch $0 {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -122,8 +122,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
     @Published var attachmentUsage: AIChatAttachmentUsage?
 
-    /// Fires when the input's attachments change, so a host that renders off the attachment count can
-    /// re-evaluate. Rides the draft-changed callback, which is the existing signal for the same event.
+    /// Rides the draft-changed callback, which fires only on attachment mutations.
     var onAttachmentsChanged: (() -> Void)?
 
     @Published private(set) var isEditing: Bool = false {
@@ -1271,7 +1270,6 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         isVoiceSessionActive = false
     }
 
-    /// Images and files currently in the input.
     var attachmentCount: Int {
         attachmentController.attachmentCount
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -122,6 +122,10 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
     @Published var attachmentUsage: AIChatAttachmentUsage?
 
+    /// Fires when the input's attachments change, so a host that renders off the attachment count can
+    /// re-evaluate. Rides the draft-changed callback, which is the existing signal for the same event.
+    var onAttachmentsChanged: (() -> Void)?
+
     @Published private(set) var isEditing: Bool = false {
         didSet {
             guard oldValue != isEditing else { return }
@@ -425,7 +429,10 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
                 presenterViewController: { [weak self] in self?.attachmentPresenterViewController }
             ),
             callbacks: .init(
-                onDraftChanged: { [weak self] in self?.persistDraftToStore() },
+                onDraftChanged: { [weak self] in
+                    self?.persistDraftToStore()
+                    self?.onAttachmentsChanged?()
+                },
                 onExpandIfNeeded: { [weak self] in self?.expandIfOnExpandedInputHost() },
                 updateFloatingReturnKey: { [weak self] in self?.updateFloatingReturnKeyState() }
             )
@@ -1262,6 +1269,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         attachmentUsage = nil
         aiChatInputBoxVisibility = .visible
         isVoiceSessionActive = false
+    }
+
+    /// Images and files currently in the input.
+    var attachmentCount: Int {
+        attachmentController.attachmentCount
     }
 
     /// Surfaces a rejection in the input's validation banner.

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -2163,39 +2163,32 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         AIChatSelectionContextBuilder.makeSelection(text: content, url: URL(string: "https://example.com/article"))
     }
 
-    // MARK: - Selection page title
+    // MARK: - Signals-only collection keeps the page available for later re-resolves
 
-    func testAttachSelectionRecordsThePageTitle() {
-        sessionState.attachSelection(makeSelection(), pageTitle: "Article")
+    func testSignalsOnlyCollectionRetainsSignalsWithoutMakingThePageAttachable() {
+        sessionState.markPendingSignalsOnlyCollection()
 
-        XCTAssertEqual(sessionState.attachedSelectionPageTitle, "Article")
+        sessionState.updateContext(makeTestContext())
+
+        // The signals must survive for a later scope change to re-resolve from, or translate's language
+        // condition loses them. They must NOT land in `latestContext`, which feeds the paths that turn a
+        // collected page into an attachment — a new UTI host would start with the page pending submit.
+        XCTAssertNotNil(sessionState.latestSignalsOnlyContext)
+        XCTAssertNil(sessionState.latestContext)
+        XCTAssertNil(sessionState.intendedAttachedContext)
     }
 
-    func testRemovingTheLastSelectionClearsThePageTitle() {
-        let selection = makeSelection()
-        sessionState.attachSelection(selection, pageTitle: "Article")
+    func testClearingSelectionsResolvesSuggestionsBackToPageScope() {
+        mockFeatureFlagger.enabledFeatureFlags = [.contextualSuggestedPrompts]
+        sessionState.attachSelection(makeSelection())
+        XCTAssertEqual(sessionState.viewState.suggestionsLoadState, .loading)
 
-        sessionState.removeAttachedSelection(id: selection.id)
+        sessionState.clearAttachedSelections()
 
-        XCTAssertNil(sessionState.attachedSelectionPageTitle)
-    }
-
-    func testRemovingOneOfSeveralSelectionsKeepsThePageTitle() {
-        let first = makeSelection("first")
-        sessionState.attachSelection(first, pageTitle: "Article")
-        sessionState.attachSelection(makeSelection("second"), pageTitle: "Article")
-
-        sessionState.removeAttachedSelection(id: first.id)
-
-        XCTAssertEqual(sessionState.attachedSelectionPageTitle, "Article")
-    }
-
-    func testConsumingSelectionsClearsThePageTitle() {
-        sessionState.attachSelection(makeSelection(), pageTitle: "Article")
-
-        sessionState.consumeAttachedSelections()
-
-        XCTAssertNil(sessionState.attachedSelectionPageTitle)
+        // Clearing is a scope change like removal is, so the row must be re-resolved rather than left
+        // showing the selection-scoped pair for selections that are gone.
+        XCTAssertEqual(sessionState.viewState.suggestionsLoadState, .loading)
+        XCTAssertTrue(sessionState.viewState.suggestions.isEmpty)
     }
 
     // MARK: - Suggestions hidden beyond one attachment

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -2163,16 +2163,14 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         AIChatSelectionContextBuilder.makeSelection(text: content, url: URL(string: "https://example.com/article"))
     }
 
-    // MARK: - Signals-only collection keeps the page available for later re-resolves
+    // MARK: - Signals-only collection
 
     func testSignalsOnlyCollectionRetainsSignalsWithoutMakingThePageAttachable() {
         sessionState.markPendingSignalsOnlyCollection()
 
         sessionState.updateContext(makeTestContext())
 
-        // The signals must survive for a later scope change to re-resolve from, or translate's language
-        // condition loses them. They must NOT land in `latestContext`, which feeds the paths that turn a
-        // collected page into an attachment — a new UTI host would start with the page pending submit.
+        // Must not land in `latestContext`, which feeds the paths that would attach the page.
         XCTAssertNotNil(sessionState.latestSignalsOnlyContext)
         XCTAssertNil(sessionState.latestContext)
         XCTAssertNil(sessionState.intendedAttachedContext)
@@ -2185,8 +2183,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
 
         sessionState.clearAttachedSelections()
 
-        // Clearing is a scope change like removal is, so the row must be re-resolved rather than left
-        // showing the selection-scoped pair for selections that are gone.
+        // Clearing is a scope change like removal, so the row must be resolved again.
         XCTAssertEqual(sessionState.viewState.suggestionsLoadState, .loading)
         XCTAssertTrue(sessionState.viewState.suggestions.isEmpty)
     }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -2171,7 +2171,7 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         sessionState.updateContext(makeTestContext())
 
         // Must not land in `latestContext`, which feeds the paths that would attach the page.
-        XCTAssertNotNil(sessionState.latestSignalsOnlyContext)
+        XCTAssertNotNil(sessionState.lastCollectedContext)
         XCTAssertNil(sessionState.latestContext)
         XCTAssertNil(sessionState.intendedAttachedContext)
     }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -2163,6 +2163,65 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         AIChatSelectionContextBuilder.makeSelection(text: content, url: URL(string: "https://example.com/article"))
     }
 
+    // MARK: - Selection page title
+
+    func testAttachSelectionRecordsThePageTitle() {
+        sessionState.attachSelection(makeSelection(), pageTitle: "Article")
+
+        XCTAssertEqual(sessionState.attachedSelectionPageTitle, "Article")
+    }
+
+    func testRemovingTheLastSelectionClearsThePageTitle() {
+        let selection = makeSelection()
+        sessionState.attachSelection(selection, pageTitle: "Article")
+
+        sessionState.removeAttachedSelection(id: selection.id)
+
+        XCTAssertNil(sessionState.attachedSelectionPageTitle)
+    }
+
+    func testRemovingOneOfSeveralSelectionsKeepsThePageTitle() {
+        let first = makeSelection("first")
+        sessionState.attachSelection(first, pageTitle: "Article")
+        sessionState.attachSelection(makeSelection("second"), pageTitle: "Article")
+
+        sessionState.removeAttachedSelection(id: first.id)
+
+        XCTAssertEqual(sessionState.attachedSelectionPageTitle, "Article")
+    }
+
+    func testConsumingSelectionsClearsThePageTitle() {
+        sessionState.attachSelection(makeSelection(), pageTitle: "Article")
+
+        sessionState.consumeAttachedSelections()
+
+        XCTAssertNil(sessionState.attachedSelectionPageTitle)
+    }
+
+    // MARK: - Suggestions hidden beyond one attachment
+
+    func testTwoSelectionsHideTheSuggestions() {
+        sessionState.beginLoadingSuggestions()
+        sessionState.attachSelection(makeSelection("first"))
+        sessionState.attachSelection(makeSelection("second"))
+
+        XCTAssertTrue(sessionState.viewState.suggestions.isEmpty)
+    }
+
+    /// The hide rule counts attachments of *any* kind, so one selection plus one image hides them too.
+    func testASelectionPlusAnInputAttachmentHidesTheSuggestions() {
+        sessionState.inputAttachmentCount = { 1 }
+        sessionState.attachSelection(makeSelection())
+
+        XCTAssertTrue(sessionState.viewState.suggestions.isEmpty)
+    }
+
+    func testAttachedSelectionSuppressesThePageScopedQuickActions() {
+        sessionState.attachSelection(makeSelection())
+
+        XCTAssertTrue(sessionState.viewState.quickActions.isEmpty)
+    }
+
     // MARK: - Attached Text Selections
 
     func testAttachSelectionAppendsAndReportsSuccess() {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -211,7 +211,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
 
     @MainActor
     func testAttachSelectionAttachesAndPresentsTheSheet() async {
-        await sut.handleSelectionAction(.ask, text: "selected text", url: URL(string: "https://example.com"), faviconBase64: nil, from: mockPresentingVC)
+        await sut.handleSelectionAction(.ask, selection: .init(text: "selected text", url: URL(string: "https://example.com"), faviconBase64: nil), from: mockPresentingVC)
 
         XCTAssertEqual(sut.sessionState.attachedSelections.map(\.content), ["selected text"])
         XCTAssertNotNil(sut.sheetViewController)
@@ -223,8 +223,8 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     func testAttachingTheSameSelectionTwiceAttachesItOnce() async {
         let url = URL(string: "https://example.com")
 
-        await sut.handleSelectionAction(.ask, text: "selected text", url: url, faviconBase64: nil, from: mockPresentingVC)
-        await sut.handleSelectionAction(.ask, text: "selected text", url: url, faviconBase64: nil, from: mockPresentingVC)
+        await sut.handleSelectionAction(.ask, selection: .init(text: "selected text", url: url, faviconBase64: nil), from: mockPresentingVC)
+        await sut.handleSelectionAction(.ask, selection: .init(text: "selected text", url: url, faviconBase64: nil), from: mockPresentingVC)
 
         XCTAssertEqual(sut.sessionState.attachedSelections.count, 1)
     }
@@ -234,7 +234,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     func testAttachSelectionRestoresThePersistedChat() async {
         let restoreURL = URL(string: "https://duckduckgo.com/?chatID=abc")!
 
-        await sut.handleSelectionAction(.ask, text: "selected text", url: URL(string: "https://example.com"), faviconBase64: nil, restoreURL: restoreURL, from: mockPresentingVC)
+        await sut.handleSelectionAction(.ask, selection: .init(text: "selected text", url: URL(string: "https://example.com"), faviconBase64: nil), restoreURL: restoreURL, from: mockPresentingVC)
 
         XCTAssertEqual(sut.sessionState.contextualChatURL, restoreURL)
     }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -207,11 +207,11 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - attachSelection Tests
+    // MARK: - handleSelectionAction Tests
 
     @MainActor
     func testAttachSelectionAttachesAndPresentsTheSheet() async {
-        await sut.attachSelection(text: "selected text", url: URL(string: "https://example.com"), faviconBase64: nil, from: mockPresentingVC)
+        await sut.handleSelectionAction(.ask, text: "selected text", url: URL(string: "https://example.com"), faviconBase64: nil, from: mockPresentingVC)
 
         XCTAssertEqual(sut.sessionState.attachedSelections.map(\.content), ["selected text"])
         XCTAssertNotNil(sut.sheetViewController)
@@ -223,8 +223,8 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     func testAttachingTheSameSelectionTwiceAttachesItOnce() async {
         let url = URL(string: "https://example.com")
 
-        await sut.attachSelection(text: "selected text", url: url, faviconBase64: nil, from: mockPresentingVC)
-        await sut.attachSelection(text: "selected text", url: url, faviconBase64: nil, from: mockPresentingVC)
+        await sut.handleSelectionAction(.ask, text: "selected text", url: url, faviconBase64: nil, from: mockPresentingVC)
+        await sut.handleSelectionAction(.ask, text: "selected text", url: url, faviconBase64: nil, from: mockPresentingVC)
 
         XCTAssertEqual(sut.sessionState.attachedSelections.count, 1)
     }
@@ -234,7 +234,7 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     func testAttachSelectionRestoresThePersistedChat() async {
         let restoreURL = URL(string: "https://duckduckgo.com/?chatID=abc")!
 
-        await sut.attachSelection(text: "selected text", url: URL(string: "https://example.com"), faviconBase64: nil, restoreURL: restoreURL, from: mockPresentingVC)
+        await sut.handleSelectionAction(.ask, text: "selected text", url: URL(string: "https://example.com"), faviconBase64: nil, restoreURL: restoreURL, from: mockPresentingVC)
 
         XCTAssertEqual(sut.sessionState.contextualChatURL, restoreURL)
     }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -217,6 +217,19 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         XCTAssertNotNil(sut.sheetViewController)
     }
 
+    /// The signals-only payload is content-free and marked unattached, so pushing it while a page is
+    /// attached would clear that page on the frontend while the chip still shows it.
+    @MainActor
+    func testSelectionActionDoesNotCollectSignalsWhileAPageIsAttached() async {
+        sut.sessionState.attachContextFromSuggestionTap(makeTestContext(title: "Attached"))
+        mockPageContextHandler.triggerContextCollectionCallCount = 0
+
+        await sut.handleSelectionAction(.ask, selection: .init(text: "selected text", url: URL(string: "https://example.com"), faviconBase64: nil), from: mockPresentingVC)
+
+        XCTAssertEqual(mockPageContextHandler.triggerContextCollectionCallCount, 0)
+        XCTAssertNotNil(sut.sessionState.intendedAttachedContext)
+    }
+
     /// Reading a selection suspends, so two taps on the omnibar icon can both reach here with the same
     /// text. Each would otherwise mint its own id and burn a second cap slot on one passage.
     @MainActor

--- a/iOS/DuckDuckGoTests/AIChat/AIChatTextSelectionActionTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatTextSelectionActionTests.swift
@@ -1,0 +1,55 @@
+//
+//  AIChatTextSelectionActionTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+final class AIChatTextSelectionActionTests: XCTestCase {
+
+    func testOnlyAskWaitsForTheUsersOwnQuestion() {
+        XCTAssertFalse(AIChatTextSelectionAction.ask.autoSubmits)
+        XCTAssertTrue(AIChatTextSelectionAction.summarize.autoSubmits)
+        XCTAssertTrue(AIChatTextSelectionAction.translate.autoSubmits)
+    }
+
+    /// Summarize and translate carry the text in their tool payload, so attaching it as well would send
+    /// the model the same passage twice.
+    func testOnlyAskAttachesTheSelection() {
+        XCTAssertTrue(AIChatTextSelectionAction.ask.attachesSelection)
+        XCTAssertFalse(AIChatTextSelectionAction.summarize.attachesSelection)
+        XCTAssertFalse(AIChatTextSelectionAction.translate.attachesSelection)
+    }
+
+    func testAskHasNoSuggestionBecauseItIsWhatAttachesTheSelection() {
+        XCTAssertNil(AIChatTextSelectionAction.ask.selectionSuggestionID)
+    }
+
+    func testSuggestionIDsMatchTheCatalogKeysInDisplayOrder() {
+        XCTAssertEqual(AIChatTextSelectionAction.selectionSuggestionIDs, ["summarize-selection", "translate-selection"])
+    }
+
+    func testRoundTripsFromASuggestionID() {
+        XCTAssertEqual(AIChatTextSelectionAction(selectionSuggestionID: "summarize-selection"), .summarize)
+        XCTAssertEqual(AIChatTextSelectionAction(selectionSuggestionID: "translate-selection"), .translate)
+    }
+
+    func testUnknownSuggestionIDDoesNotResolve() {
+        XCTAssertNil(AIChatTextSelectionAction(selectionSuggestionID: "summarize-page"))
+    }
+}

--- a/iOS/DuckDuckGoTests/AIChat/AIChatTextSelectionActionTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatTextSelectionActionTests.swift
@@ -28,8 +28,7 @@ final class AIChatTextSelectionActionTests: XCTestCase {
         XCTAssertTrue(AIChatTextSelectionAction.translate.autoSubmits)
     }
 
-    /// Summarize and translate carry the text in their tool payload, so attaching it as well would send
-    /// the model the same passage twice.
+    /// The submitting actions carry the text with them, so attaching it too would send it twice.
     func testOnlyAskAttachesTheSelection() {
         XCTAssertTrue(AIChatTextSelectionAction.ask.attachesSelection)
         XCTAssertFalse(AIChatTextSelectionAction.summarize.attachesSelection)

--- a/iOS/DuckDuckGoTests/AIChat/ContextualSuggestionsMatcherTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/ContextualSuggestionsMatcherTests.swift
@@ -394,8 +394,7 @@ final class ContextualSuggestionsMatcherTests: XCTestCase {
         XCTAssertFalse(result.isSmart)
     }
 
-    /// Guards Pikor's shipped page suggestions: adding the two ids to the catalog must not leak them
-    /// into the page-scoped sets, which is the regression §6.4 asks to rule out.
+    /// Adding the two ids to the catalog must not leak them into the page-scoped sets.
     func testPageScopeNeverOffersTheSelectionSuggestions() throws {
         let catalog = try standardCatalog()
         let scenarios = [

--- a/iOS/DuckDuckGoTests/AIChat/ContextualSuggestionsMatcherTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/ContextualSuggestionsMatcherTests.swift
@@ -32,6 +32,8 @@ final class ContextualSuggestionsMatcherTests: XCTestCase {
       "catalog": {
         "summarize-page": { "label": "Summarize", "icon": "summary", "prompt": "Summarize this page." },
         "translate-page": { "label": "Translate", "icon": "translate", "prompt": "Translate into {language}.", "condition": "differentLanguage" },
+        "summarize-selection": { "label": "Summarize selection", "icon": "summary", "prompt": "Summarize this selection." },
+        "translate-selection": { "label": "Translate selection", "icon": "translate", "prompt": "Translate selection into {language}.", "condition": "differentLanguage" },
         "recipe-a": { "label": "Shopping list", "prompt": "Make a list." },
         "recipe-b": { "label": "Nutrition", "prompt": "Estimate nutrition." },
         "recipe-c": { "label": "Scale", "prompt": "Scale the recipe." },
@@ -85,8 +87,11 @@ final class ContextualSuggestionsMatcherTests: XCTestCase {
         AIChatPageTypeSignals(jsonLdType: jsonLd, ogType: ogType, lang: lang)
     }
 
-    private func input(_ signals: AIChatPageTypeSignals?, url: String? = nil, uiLocale: String = "en_US") -> ResolvePageSuggestionsInput {
-        ResolvePageSuggestionsInput(pageTypeSignals: signals, url: url, uiLocale: uiLocale)
+    private func input(_ signals: AIChatPageTypeSignals?,
+                       url: String? = nil,
+                       uiLocale: String = "en_US",
+                       scope: ResolvePageSuggestionsInput.Scope = .page) -> ResolvePageSuggestionsInput {
+        ResolvePageSuggestionsInput(pageTypeSignals: signals, url: url, uiLocale: uiLocale, scope: scope)
     }
 
     private func resolvedIDs(_ input: ResolvePageSuggestionsInput, _ catalog: SuggestionCatalog) -> [String] {
@@ -364,5 +369,47 @@ final class ContextualSuggestionsMatcherTests: XCTestCase {
         let provider = DefaultContextualSuggestedPromptsProvider(catalog: catalog)
         let result = await provider.resolveSuggestions(input(signals(jsonLd: ["Recipe"], lang: "en")))
         XCTAssertEqual(result.suggestions.map(\.id), ["recipe-a", "recipe-b", "recipe-c"])
+    }
+
+    // MARK: - Selection scope
+
+    func testSelectionScopeOffersTheSelectionPairAndNoPageSuggestions() throws {
+        let ids = resolvedIDs(input(signals(jsonLd: ["Recipe"], lang: "fr"), scope: .selection), try standardCatalog())
+
+        XCTAssertEqual(ids, ["summarize-selection", "translate-selection"])
+    }
+
+    func testSelectionScopeDropsTranslateWhenThePageIsAlreadyInTheUILanguage() throws {
+        let ids = resolvedIDs(input(signals(lang: "en"), uiLocale: "en_US", scope: .selection), try standardCatalog())
+
+        XCTAssertEqual(ids, ["summarize-selection"])
+    }
+
+    func testSelectionScopeIsNeverSmart() throws {
+        let result = ContextualSuggestionsMatcher.resolve(
+            input(signals(jsonLd: ["Recipe"], lang: "fr"), scope: .selection),
+            catalog: try standardCatalog()
+        )
+
+        XCTAssertFalse(result.isSmart)
+    }
+
+    /// Guards Pikor's shipped page suggestions: adding the two ids to the catalog must not leak them
+    /// into the page-scoped sets, which is the regression §6.4 asks to rule out.
+    func testPageScopeNeverOffersTheSelectionSuggestions() throws {
+        let catalog = try standardCatalog()
+        let scenarios = [
+            input(nil, uiLocale: "en_US"),
+            input(signals(lang: "fr")),
+            input(signals(jsonLd: ["Recipe"], lang: "fr")),
+            input(signals(jsonLd: ["Article"], lang: "fr")),
+            input(signals(ogType: "video", lang: "fr"))
+        ]
+
+        for scenario in scenarios {
+            let ids = resolvedIDs(scenario, catalog)
+            XCTAssertFalse(ids.contains("summarize-selection"))
+            XCTAssertFalse(ids.contains("translate-selection"))
+        }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216945875759265
CC:

### Description

Layer 3 of 5. Behind the `aiChatTextActions` flag (`internalOnly`), [parent task](https://app.asana.com/1/137249556945/project/72649045549333/task/1216945875759265).

Select text in a page and ask Duck.ai about it, and the sheet now offers suggestions about **your selection** — "Summarize this selection", "Translate this selection" — instead of about the page, and it no longer attaches the whole page on top of your selection. Page details are still read, so Translate still knows whether the page is in a different language from yours.

Suggestions are hidden once more than one thing is attached, because a one-line suggestion can no longer say which part of the prompt it acts on.

**Tapping the two new selection suggestions does nothing yet.** Acting on them needs a delivery channel that arrives in the next layer.

### Testing Steps

This layer changes shared page-context code, so **the priority is that page context still behaves exactly as before**. Steps marked **[R]** are that regression gate and come first in each test — no text selection is involved in them.

⚠️ **Suggestions only exist before the first prompt of a chat.** Submitting hands the UI to the frontend and the suggestion row goes away for good, so every step that submits is placed **last** in its test. If you need the start surface back, tap **New Chat**.

There is **one** setting change in the whole pass, between Test 1 and Test 2.

**Setup:** `contextualSuggestedPrompts` on. Settings → AI Features → **Automatically Send Content ON**.

#### Manual Test 1 — Automatically Send Content ON

1. **[R]** Open a normal page → open the Duck.ai sheet → the page chip attaches and the suggestions are page ones.
2. **[R]** With the sheet open, navigate to a different page → chip and suggestions follow the new page.
3. **[R]** Tap **×** on the page chip → then re-attach it via the input's attach affordance → chip and suggestions behave as before.
4. **[R]** With the page chip attached, add an **image** to the input → the suggestion row empties. Remove it → suggestions return. *(New behaviour, and not gated on the selection flag: the rule counts the page chip plus the image.)*
5. With **nothing attached** (fresh tab, or tap **×** on the chip first), select text → **Ask Duck.ai** → the sheet opens with one selection chip and **no page chip**, even though the setting is on. Suggestions read "Summarize this selection”.
6. With **nothing attached** repeat step 6 on a foreign-language page (e.g. French Wikipedia) → **two** suggestions including "Translate this selection"; on an English page with an English UI → **one**. If Translate never appears anywhere, page details aren't reaching the suggestions.
7. Confirm there is no "Ask about page" / "Summarize this page" quick action while a selection is attached.
8. Add a second selection → the row empties. Remove one → it returns. Add an image with one selection attached → empties. Remove it → returns.
9. Remove the last selection → suggestions revert to the page ones, **page-tailored rather than a generic "Summarize this page"**.
10. Tap either selection suggestion → nothing happens. Expected in this layer.
11. With **nothing attached** **[R]** tap a **page** suggestion → it submits and answers with the page attached. *(The suggestion tap path changed in this PR. This ends the start surface — New Chat to continue.)*
12. New Chat. With the **page chip attached**, select text → **Ask Duck.ai** → the selection is added and the **page chip stays**; suggestions are hidden because two things are attached. Submit a typed prompt → **the answer still has the page content**, i.e. the attached page was not silently emptied.

#### Manual Test 2 — Automatically Send Content OFF

**Settings → AI Features → Automatically Send Content OFF.** Nothing else changes.

(tip - use wikipedia and something like [this recipe](https://www.bbc.co.uk/food/recipes/chicken_and_chickpeas_on_06315) to compare suggestions)

1. **[R]** Open the sheet on a normal page → **no page chip**, but suggestions still appear and are **page-tailored**. *(This is the pre-existing "read the page without attaching it" path, which this PR modified.)*
2. **[R]** Navigate with the sheet open → suggestions follow the new page, still with no chip.
3. **[R]** Manually attach the page, then remove it, then navigate to a different page → suggestions are for the **page you are on now**, not the one you detached.
4. Select text → **Ask Duck.ai** → selection chip and selection suggestions, exactly as in Test 1 — the behaviour does not depend on this setting.
5. Manually attach the page, dismiss the sheet, then select text → **Ask Duck.ai** → your manual attachment is **still there**. A selection never discards a page you attached deliberately.
6. **[R]** Tap a **page** suggestion → it attaches the page and submits, as before. *(Ends the start surface.)*

### Impact

Low for the selection behaviour — internal-only and off by default.

**One change is not behind that flag:** hiding suggestions beyond one attachment (Test 1, steps 4–5) applies to anyone with `contextualSuggestedPrompts` on, since it counts the page chip and input attachments as well as selections.

#### What could go wrong?

- Page details stop reaching the suggestions, silently degrading them → Test 1 step 7, Test 2 steps 1–3; a unit test pins that the details are retained without making the page attachable.
- The retained page leaks back in as an invisible attachment → kept out of the value that feeds the attach paths, with a test asserting the page stays unattachable.
- A selection launch wipes an attached page's content on the frontend → no collection is started while a page is attached; Test 1 step 13 and Test 2 step 5 check it, plus a unit test.
- Suggestions resolve against a stale page after a detach or a page that returned nothing → the page they resolve against is written on every collection, including empty ones.

### Quality Considerations

**Verification:** 245 unit tests pass across five suites, 16 of them new here; SwiftLint clean; `Localizable.strings`/`.stringsdict` byte-identical to `main`.

**A manual pass is recommended** — the **[R]** steps are the gate. Unit tests cover the state machine but cannot reach the suggestion-tap delegate path or the page-detail extraction round trip, which is where the most significant defects found in review turned out to live.

The stack's single end-to-end pass still belongs on layer 4, where these actions become usable.
