### PR TITLE
Keep Sync protected key wrappers aligned across credentials

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -625,12 +625,20 @@ public class DDGSync: DDGSyncing {
             return
         }
 
-        guard let encodedKeys = try? JSONEncoder.snakeCaseKeys.encode(keys.removingDuplicateWrappingIdentities()) else {
+        let keysToCache = keys.preservingCachedWrappersForMatchingKeys(cachedProtectedKeys())
+        guard let encodedKeys = try? JSONEncoder.snakeCaseKeys.encode(keysToCache) else {
             try? dependencies.secureStore.removeProtectedKeys()
             return
         }
 
         try? dependencies.secureStore.persistProtectedKeys(encodedKeys)
+    }
+
+    private func cachedProtectedKeys() -> [ProtectedKey] {
+        guard let data = try? dependencies.secureStore.protectedKeys() else {
+            return []
+        }
+        return (try? JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: data)) ?? []
     }
 
     private func ensureAccountInfoProtectedKeysIfNeeded(for account: SyncAccount) async -> [ProtectedKey] {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
@@ -335,6 +335,16 @@ public struct ProtectedKeyPublicKey: Codable, Sendable, Equatable {
     public let kty: String
     public let n: String?
     public let use: String?
+
+    fileprivate func hasSameKeyMaterial(as other: ProtectedKeyPublicKey) -> Bool {
+        guard let modulus = n,
+              let exponent = e,
+              let otherModulus = other.n,
+              let otherExponent = other.e else {
+            return false
+        }
+        return kty == other.kty && modulus == otherModulus && exponent == otherExponent
+    }
 }
 
 private struct ProtectedKeyWrappingIdentity: Hashable {
@@ -361,13 +371,20 @@ extension Sequence where Element == ProtectedKey {
     func preservingCachedWrappersForMatchingKeys(_ cachedKeys: [ProtectedKey]) -> [ProtectedKey] {
         let incomingKeys = removingDuplicateWrappingIdentities()
         let incomingWrappingIdentities = Set(incomingKeys.map { ProtectedKeyWrappingIdentity(key: $0) })
-        let cachedWrappersToPreserve = cachedKeys.removingDuplicateWrappingIdentities().filter { cachedKey in
-            !incomingWrappingIdentities.contains(ProtectedKeyWrappingIdentity(key: cachedKey))
-            && incomingKeys.contains { incomingKey in
-                incomingKey.kid == cachedKey.kid
-                && incomingKey.purpose == cachedKey.purpose
-                && incomingKey.publicKey == cachedKey.publicKey
+        let cachedWrappersToPreserve = cachedKeys.removingDuplicateWrappingIdentities().compactMap { cachedKey -> ProtectedKey? in
+            guard !incomingWrappingIdentities.contains(ProtectedKeyWrappingIdentity(key: cachedKey)),
+                  let matchingIncomingKey = incomingKeys.first(where: { incomingKey in
+                      incomingKey.kid == cachedKey.kid
+                      && incomingKey.purpose == cachedKey.purpose
+                      && incomingKey.publicKey.hasSameKeyMaterial(as: cachedKey.publicKey)
+                  }) else {
+                return nil
             }
+            return ProtectedKey(kid: cachedKey.kid,
+                                encryptedPrivateKey: cachedKey.encryptedPrivateKey,
+                                publicKey: matchingIncomingKey.publicKey,
+                                encryptedWith: cachedKey.encryptedWith,
+                                purpose: cachedKey.purpose)
         }
         return incomingKeys + cachedWrappersToPreserve
     }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncModels.swift
@@ -356,6 +356,21 @@ extension Sequence where Element == ProtectedKey {
             seenIdentities.insert(ProtectedKeyWrappingIdentity(key: key)).inserted
         }
     }
+
+    /// Preserves cached wrapping variants for the same key so an out-of-order snapshot cannot remove a newly added wrapper.
+    func preservingCachedWrappersForMatchingKeys(_ cachedKeys: [ProtectedKey]) -> [ProtectedKey] {
+        let incomingKeys = removingDuplicateWrappingIdentities()
+        let incomingWrappingIdentities = Set(incomingKeys.map { ProtectedKeyWrappingIdentity(key: $0) })
+        let cachedWrappersToPreserve = cachedKeys.removingDuplicateWrappingIdentities().filter { cachedKey in
+            !incomingWrappingIdentities.contains(ProtectedKeyWrappingIdentity(key: cachedKey))
+            && incomingKeys.contains { incomingKey in
+                incomingKey.kid == cachedKey.kid
+                && incomingKey.purpose == cachedKey.purpose
+                && incomingKey.publicKey == cachedKey.publicKey
+            }
+        }
+        return incomingKeys + cachedWrappersToPreserve
+    }
 }
 
 enum SyncProtocolVersion {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -88,7 +88,8 @@ struct ProductionDependencies: SyncDependencies {
         let scopedAccess = ScopedAccessCredentialManager(endpoints: endpoints,
                                                          api: api,
                                                          crypter: crypter,
-                                                         accountInfoKeyFactory: DefaultAccountInfoKeyFactory(crypter: crypter))
+                                                         accountInfoKeyFactory: DefaultAccountInfoKeyFactory(crypter: crypter),
+                                                         canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() })
         accountInfoKeys = AccountInfoKeyManager(secureStore: secureStore,
                                                 scopedAccess: scopedAccess,
                                                 crypter: crypter)
@@ -147,7 +148,8 @@ struct ProductionDependencies: SyncDependencies {
                                             api: api,
                                             crypter: crypter,
                                             scopedAccess: scopedAccess,
-                                            account: account)
+                                            account: account,
+                                            canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() })
     }
 
     func createTokenRescope() -> TokenRescoping {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -148,8 +148,7 @@ struct ProductionDependencies: SyncDependencies {
                                             api: api,
                                             crypter: crypter,
                                             scopedAccess: scopedAccess,
-                                            account: account,
-                                            canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() })
+                                            account: account)
     }
 
     func createTokenRescope() -> TokenRescoping {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
@@ -93,7 +93,8 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
     }
 
     private func cache(_ protectedKeys: [ProtectedKey]) {
-        guard let encodedKeys = try? JSONEncoder.snakeCaseKeys.encode(protectedKeys) else {
+        let protectedKeysToCache = protectedKeys.preservingCachedWrappersForMatchingKeys(cachedProtectedKeys() ?? [])
+        guard let encodedKeys = try? JSONEncoder.snakeCaseKeys.encode(protectedKeysToCache) else {
             return
         }
         try? secureStore.persistProtectedKeys(encodedKeys)

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -411,11 +411,13 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
                                                              scopedPassword: scopedPassword)
         var repairedKeys = accountInfoKeys
         if needsDefaultWrapper {
+            Logger.sync.debug("Sync-UnifiedDevices: repairing missing account_info ddg wrapper")
             repairedKeys.append(try makeDefaultAccountInfoWrapper(sourceKey: sourceKey,
                                                                   privateKeyPKCS8: privateKeyPKCS8,
                                                                   accountSecretKey: account.secretKey))
         }
         if needsThirdPartyWrapper {
+            Logger.sync.debug("Sync-UnifiedDevices: repairing missing account_info 3party wrapper")
             repairedKeys.append(try makeThirdPartyAccountInfoWrapper(sourceKey: sourceKey,
                                                                      privateKeyPKCS8: privateKeyPKCS8,
                                                                      scopedPassword: scopedPassword,
@@ -427,8 +429,10 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
                                      for: account)
         let storedKeys = try await fetchStoredProtectedKeys(for: ProtectedKeyPurpose.accountInfo,
                                                            account: account)
-        return try validateAccountInfoProtectedKeys(storedKeys,
-                                                    requiresThirdPartyWrapper: requiresThirdPartyWrapper)
+        let validatedKeys = try validateAccountInfoProtectedKeys(storedKeys,
+                                                                 requiresThirdPartyWrapper: requiresThirdPartyWrapper)
+        Logger.sync.debug("Sync-UnifiedDevices: account_info wrapper repair complete")
+        return validatedKeys
     }
 
     private func validateAccountInfoProtectedKeyIdentity(_ keys: [ProtectedKey]) throws -> [ProtectedKey] {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -33,8 +33,21 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
     let api: RemoteAPIRequestCreating
     let crypter: CryptingInternal
     let accountInfoKeyFactory: AccountInfoKeyFactory
+    private let canWriteUnifiedDeviceList: () -> Bool
     private let jweCompactCodec = JWECompactCodec()
     private let scopedAccessCredentialEnvelope = ScopedAccessCredentialEnvelope()
+
+    init(endpoints: Endpoints,
+         api: RemoteAPIRequestCreating,
+         crypter: CryptingInternal,
+         accountInfoKeyFactory: AccountInfoKeyFactory,
+         canWriteUnifiedDeviceList: @escaping () -> Bool) {
+        self.endpoints = endpoints
+        self.api = api
+        self.crypter = crypter
+        self.accountInfoKeyFactory = accountInfoKeyFactory
+        self.canWriteUnifiedDeviceList = canWriteUnifiedDeviceList
+    }
 
     func recoverScopedPassword(from accessCredentials: [AccessCredential]?, primaryKey: Data, userID: String) throws -> Data? {
         guard let thirdPartyCredential = accessCredentials?.first(where: { $0.id == SyncCode.RecoveryKeyV2.thirdPartyCredentialId }) else {
@@ -77,6 +90,10 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
     }
 
     func ensureAccountInfoProtectedKeys(for account: SyncAccount) async throws -> [ProtectedKey] {
+        guard canWriteUnifiedDeviceList() else {
+            return []
+        }
+
         let storedKeys = try await fetchProtectedKeys(account)
         let storedAccountInfoKeys = protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: storedKeys)
         if !storedAccountInfoKeys.isEmpty {
@@ -247,7 +264,9 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
                                                       account: SyncAccount) async throws -> ProtectedKeysForThirdPartyCredential {
         let fetchedProtectedKeys = try await fetchProtectedKeys(account)
         let fetchedDefaultCredentialKeys = defaultCredentialKeys(in: fetchedProtectedKeys)
-        let accountInfoKeys = protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: fetchedProtectedKeys)
+        let accountInfoKeys = canWriteUnifiedDeviceList()
+            ? protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: fetchedProtectedKeys)
+            : []
         if fetchedDefaultCredentialKeys.contains(where: { $0.purpose == purpose }) {
             let protectedKeys = (protectedKeys(for: purpose, in: fetchedProtectedKeys) + accountInfoKeys)
                 .removingDuplicateWrappingIdentities()

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -100,7 +100,9 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         } else {
             Logger.sync.debug("Sync-UnifiedDevices: adopted existing account_info key")
         }
-        return try validateAccountInfoProtectedKeys(registeredKeys,
+        let persistedKeys = try await fetchStoredProtectedKeys(for: ProtectedKeyPurpose.accountInfo,
+                                                              account: account)
+        return try validateAccountInfoProtectedKeys(persistedKeys,
                                                     requiresThirdPartyWrapper: scopedPassword != nil)
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -66,7 +66,7 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
             let ensuredScopedPassword = try await ensureThirdPartyAccessCredential(for: account,
                                                                                   scopedPassword: scopedPassword,
                                                                                   keys: keyPreparation.protectedKeys,
-                                                                                  shouldUploadDefaultCredentialKeys: keyPreparation.shouldUploadDefaultCredentialKeys)
+                                                                                  defaultCredentialKeysToUpload: keyPreparation.defaultCredentialKeysToUpload)
             return EnsuredThirdPartyCredential(scopedPassword: ensuredScopedPassword,
                                                protectedKeysToCache: keyPreparation.protectedKeysToCache)
         } catch let error as ScopedAccessCredentialError {
@@ -79,9 +79,15 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
     func ensureAccountInfoProtectedKeys(for account: SyncAccount) async throws -> [ProtectedKey] {
         let storedKeys = try await fetchProtectedKeys(account)
         let storedAccountInfoKeys = protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: storedKeys)
-        guard storedAccountInfoKeys.isEmpty else {
+        if !storedAccountInfoKeys.isEmpty {
             Logger.sync.debug("Sync-UnifiedDevices: account_info key already exists")
-            return storedAccountInfoKeys
+            if storedAccountInfoKeys.contains(where: { $0.encryptedWith == SyncCredentialID.thirdParty }) {
+                return try validateAccountInfoProtectedKeys(storedAccountInfoKeys, requiresThirdPartyWrapper: true)
+            }
+            let accessCredentials = try await fetchAccessCredentials(account)
+            let requiresThirdPartyWrapper = accessCredentials.contains { $0.id == SyncCredentialID.thirdParty }
+            return try validateAccountInfoProtectedKeys(storedAccountInfoKeys,
+                                                        requiresThirdPartyWrapper: requiresThirdPartyWrapper)
         }
 
         let accessCredentials = try await fetchAccessCredentials(account)
@@ -100,7 +106,8 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         } else {
             Logger.sync.debug("Sync-UnifiedDevices: adopted existing account_info key")
         }
-        return registeredKeys
+        return try validateAccountInfoProtectedKeys(registeredKeys,
+                                                    requiresThirdPartyWrapper: scopedPassword != nil)
     }
 
     func makeRecoveryCode(for account: SyncAccount, scopedPassword: Data) -> String? {
@@ -125,7 +132,7 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
     private func ensureThirdPartyAccessCredential(for account: SyncAccount,
                                                   scopedPassword: Data,
                                                   keys protectedKeys: [ProtectedKey],
-                                                  shouldUploadDefaultCredentialKeys: Bool) async throws -> Data {
+                                                  defaultCredentialKeysToUpload: [ProtectedKey]) async throws -> Data {
         guard let token = account.token else {
             throw SyncError.noToken
         }
@@ -141,7 +148,7 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         let createCredentialKeys = try accessCredentialProtectedKeys(from: protectedKeys,
                                                                      scopedPassword: scopedPassword,
                                                                      account: account,
-                                                                     shouldUploadDefaultCredentialKeys: shouldUploadDefaultCredentialKeys)
+                                                                     defaultCredentialKeysToUpload: defaultCredentialKeysToUpload)
             .removingDuplicateWrappingIdentities()
 
         do {
@@ -244,15 +251,20 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
                                                       account: SyncAccount) async throws -> ProtectedKeysForThirdPartyCredential {
         let fetchedProtectedKeys = try await fetchProtectedKeys(account)
         let fetchedDefaultCredentialKeys = defaultCredentialKeys(in: fetchedProtectedKeys)
+        let accountInfoKeys = protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: fetchedProtectedKeys)
         if fetchedDefaultCredentialKeys.contains(where: { $0.purpose == purpose }) {
-            return ProtectedKeysForThirdPartyCredential(protectedKeys: protectedKeys(for: purpose, in: fetchedProtectedKeys),
-                                                        shouldUploadDefaultCredentialKeys: false,
+            let protectedKeys = (protectedKeys(for: purpose, in: fetchedProtectedKeys) + accountInfoKeys)
+                .removingDuplicateWrappingIdentities()
+            return ProtectedKeysForThirdPartyCredential(protectedKeys: protectedKeys,
+                                                        defaultCredentialKeysToUpload: [],
                                                         protectedKeysToCache: fetchedProtectedKeys)
         }
 
         let protectedKey = try makeDefaultCredentialProtectedKey(purpose: purpose, account: account)
-        return ProtectedKeysForThirdPartyCredential(protectedKeys: [protectedKey],
-                                                    shouldUploadDefaultCredentialKeys: true,
+        let protectedKeys = ([protectedKey] + accountInfoKeys)
+            .removingDuplicateWrappingIdentities()
+        return ProtectedKeysForThirdPartyCredential(protectedKeys: protectedKeys,
+                                                    defaultCredentialKeysToUpload: [protectedKey],
                                                     protectedKeysToCache: fetchedProtectedKeys + [protectedKey])
     }
 
@@ -354,10 +366,29 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         return keysForPurpose
     }
 
+    private func validateAccountInfoProtectedKeys(_ keys: [ProtectedKey],
+                                                  requiresThirdPartyWrapper: Bool) throws -> [ProtectedKey] {
+        let accountInfoKeys = protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: keys)
+        guard let defaultCredentialKey = accountInfoKeys.first(where: { $0.encryptedWith == SyncCredentialID.defaultCredential }),
+              !defaultCredentialKey.kid.isEmpty else {
+            throw SyncError.invalidDataInResponse("account_info protected keys are missing a ddg wrapper")
+        }
+        guard accountInfoKeys.allSatisfy({
+            $0.kid == defaultCredentialKey.kid && $0.publicKey == defaultCredentialKey.publicKey
+        }) else {
+            throw SyncError.invalidDataInResponse("account_info protected key wrappers do not describe the same key")
+        }
+        if requiresThirdPartyWrapper,
+           !accountInfoKeys.contains(where: { $0.encryptedWith == SyncCredentialID.thirdParty }) {
+            throw SyncError.invalidDataInResponse("account_info protected keys are missing a 3party wrapper")
+        }
+        return accountInfoKeys
+    }
+
     private func accessCredentialProtectedKeys(from protectedKeys: [ProtectedKey],
                                                scopedPassword: Data,
                                                account: SyncAccount,
-                                               shouldUploadDefaultCredentialKeys: Bool) throws -> [ProtectedKey] {
+                                               defaultCredentialKeysToUpload: [ProtectedKey]) throws -> [ProtectedKey] {
         let existingThirdPartyKeys = protectedKeys
             .filter { $0.encryptedWith == SyncCode.RecoveryKeyV2.thirdPartyCredentialId }
             .removingDuplicateWrappingIdentities()
@@ -368,7 +399,6 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
                     thirdPartyKey.kid == key.kid && thirdPartyKey.purpose == key.purpose
                 }
             }
-        let defaultCredentialKeysToUpload = shouldUploadDefaultCredentialKeys ? defaultCredentialKeysToRewrap : []
         let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
         let thirdPartyCredentialKeys = try rewrapProtectedKeys(defaultCredentialKeysToRewrap,
                                                                toWrappingKey: thirdPartyMainKey,
@@ -435,7 +465,7 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
 
     private struct ProtectedKeysForThirdPartyCredential {
         let protectedKeys: [ProtectedKey]
-        let shouldUploadDefaultCredentialKeys: Bool
+        let defaultCredentialKeysToUpload: [ProtectedKey]
         let protectedKeysToCache: [ProtectedKey]
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -81,13 +81,7 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         let storedAccountInfoKeys = protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: storedKeys)
         if !storedAccountInfoKeys.isEmpty {
             Logger.sync.debug("Sync-UnifiedDevices: account_info key already exists")
-            if storedAccountInfoKeys.contains(where: { $0.encryptedWith == SyncCredentialID.thirdParty }) {
-                return try validateAccountInfoProtectedKeys(storedAccountInfoKeys, requiresThirdPartyWrapper: true)
-            }
-            let accessCredentials = try await fetchAccessCredentials(account)
-            let requiresThirdPartyWrapper = accessCredentials.contains { $0.id == SyncCredentialID.thirdParty }
-            return try validateAccountInfoProtectedKeys(storedAccountInfoKeys,
-                                                        requiresThirdPartyWrapper: requiresThirdPartyWrapper)
+            return try await repairAccountInfoProtectedKeysIfNeeded(storedAccountInfoKeys, account: account)
         }
 
         let accessCredentials = try await fetchAccessCredentials(account)
@@ -366,23 +360,120 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         return keysForPurpose
     }
 
-    private func validateAccountInfoProtectedKeys(_ keys: [ProtectedKey],
-                                                  requiresThirdPartyWrapper: Bool) throws -> [ProtectedKey] {
+    private func repairAccountInfoProtectedKeysIfNeeded(_ keys: [ProtectedKey],
+                                                        account: SyncAccount) async throws -> [ProtectedKey] {
+        let accountInfoKeys = try validateAccountInfoProtectedKeyIdentity(keys)
+        let hasDefaultWrapper = accountInfoKeys.contains { $0.encryptedWith == SyncCredentialID.defaultCredential }
+        let hasThirdPartyWrapper = accountInfoKeys.contains { $0.encryptedWith == SyncCredentialID.thirdParty }
+        if hasDefaultWrapper && hasThirdPartyWrapper {
+            return try validateAccountInfoProtectedKeys(accountInfoKeys, requiresThirdPartyWrapper: true)
+        }
+
+        let accessCredentials = try await fetchAccessCredentials(account)
+        let requiresThirdPartyWrapper = accessCredentials.contains { $0.id == SyncCredentialID.thirdParty }
+        let needsDefaultWrapper = !hasDefaultWrapper
+        let needsThirdPartyWrapper = requiresThirdPartyWrapper && !hasThirdPartyWrapper
+        guard needsDefaultWrapper || needsThirdPartyWrapper else {
+            return try validateAccountInfoProtectedKeys(accountInfoKeys, requiresThirdPartyWrapper: false)
+        }
+
+        guard let scopedPassword = try recoverScopedPassword(from: accessCredentials,
+                                                             primaryKey: account.primaryKey,
+                                                             userID: account.userId) else {
+            throw SyncError.invalidDataInResponse("account_info protected keys cannot be repaired without a 3party credential")
+        }
+        guard let sourceKey = accountInfoKeys.first else {
+            throw SyncError.invalidDataInResponse("account_info protected keys are missing")
+        }
+        let privateKeyPKCS8 = try unwrapAccountInfoPrivateKey(from: accountInfoKeys,
+                                                             account: account,
+                                                             scopedPassword: scopedPassword)
+        var repairedKeys = accountInfoKeys
+        if needsDefaultWrapper {
+            repairedKeys.append(try makeDefaultAccountInfoWrapper(sourceKey: sourceKey,
+                                                                  privateKeyPKCS8: privateKeyPKCS8,
+                                                                  accountSecretKey: account.secretKey))
+        }
+        if needsThirdPartyWrapper {
+            repairedKeys.append(try makeThirdPartyAccountInfoWrapper(sourceKey: sourceKey,
+                                                                     privateKeyPKCS8: privateKeyPKCS8,
+                                                                     scopedPassword: scopedPassword,
+                                                                     userID: account.userId))
+        }
+
+        let storedKeys = try await setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                                  keys: repairedKeys,
+                                                  for: account)
+        return try validateAccountInfoProtectedKeys(storedKeys,
+                                                    requiresThirdPartyWrapper: requiresThirdPartyWrapper)
+    }
+
+    private func validateAccountInfoProtectedKeyIdentity(_ keys: [ProtectedKey]) throws -> [ProtectedKey] {
         let accountInfoKeys = protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: keys)
-        guard let defaultCredentialKey = accountInfoKeys.first(where: { $0.encryptedWith == SyncCredentialID.defaultCredential }),
-              !defaultCredentialKey.kid.isEmpty else {
-            throw SyncError.invalidDataInResponse("account_info protected keys are missing a ddg wrapper")
+        guard let firstKey = accountInfoKeys.first, !firstKey.kid.isEmpty else {
+            throw SyncError.invalidDataInResponse("account_info protected keys are missing")
         }
         guard accountInfoKeys.allSatisfy({
-            $0.kid == defaultCredentialKey.kid && $0.publicKey == defaultCredentialKey.publicKey
+            $0.kid == firstKey.kid && $0.publicKey == firstKey.publicKey
         }) else {
             throw SyncError.invalidDataInResponse("account_info protected key wrappers do not describe the same key")
+        }
+        return accountInfoKeys
+    }
+
+    private func validateAccountInfoProtectedKeys(_ keys: [ProtectedKey],
+                                                  requiresThirdPartyWrapper: Bool) throws -> [ProtectedKey] {
+        let accountInfoKeys = try validateAccountInfoProtectedKeyIdentity(keys)
+        guard accountInfoKeys.contains(where: { $0.encryptedWith == SyncCredentialID.defaultCredential }) else {
+            throw SyncError.invalidDataInResponse("account_info protected keys are missing a ddg wrapper")
         }
         if requiresThirdPartyWrapper,
            !accountInfoKeys.contains(where: { $0.encryptedWith == SyncCredentialID.thirdParty }) {
             throw SyncError.invalidDataInResponse("account_info protected keys are missing a 3party wrapper")
         }
         return accountInfoKeys
+    }
+
+    private func unwrapAccountInfoPrivateKey(from keys: [ProtectedKey],
+                                             account: SyncAccount,
+                                             scopedPassword: Data) throws -> Data {
+        if let defaultWrapper = keys.first(where: { $0.encryptedWith == SyncCredentialID.defaultCredential }) {
+            return try decryptDefaultCredentialPrivateKeyForRewrap(defaultWrapper,
+                                                                   accountSecretKey: account.secretKey)
+        }
+        guard let thirdPartyWrapper = keys.first(where: { $0.encryptedWith == SyncCredentialID.thirdParty }) else {
+            throw SyncError.invalidDataInResponse("account_info protected keys have no supported wrapper")
+        }
+        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        return try jweCompactCodec.decryptDirect(token: thirdPartyWrapper.encryptedPrivateKey,
+                                                 contentEncryptionKey: thirdPartyMainKey,
+                                                 expectedKid: SyncCredentialID.thirdParty)
+    }
+
+    private func makeDefaultAccountInfoWrapper(sourceKey: ProtectedKey,
+                                               privateKeyPKCS8: Data,
+                                               accountSecretKey: Data) throws -> ProtectedKey {
+        let encryptedPrivateKey = try crypter.encrypt(privateKeyPKCS8, using: accountSecretKey)
+        return ProtectedKey(kid: sourceKey.kid,
+                            encryptedPrivateKey: Base64URL.encode(encryptedPrivateKey),
+                            publicKey: sourceKey.publicKey,
+                            encryptedWith: SyncCredentialID.defaultCredential,
+                            purpose: ProtectedKeyPurpose.accountInfo)
+    }
+
+    private func makeThirdPartyAccountInfoWrapper(sourceKey: ProtectedKey,
+                                                  privateKeyPKCS8: Data,
+                                                  scopedPassword: Data,
+                                                  userID: String) throws -> ProtectedKey {
+        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: userID)
+        let encryptedPrivateKey = try jweCompactCodec.encryptDirect(payload: privateKeyPKCS8,
+                                                                    contentEncryptionKey: thirdPartyMainKey,
+                                                                    kid: SyncCredentialID.thirdParty)
+        return ProtectedKey(kid: sourceKey.kid,
+                            encryptedPrivateKey: encryptedPrivateKey,
+                            publicKey: sourceKey.publicKey,
+                            encryptedWith: SyncCredentialID.thirdParty,
+                            purpose: ProtectedKeyPurpose.accountInfo)
     }
 
     private func accessCredentialProtectedKeys(from protectedKeys: [ProtectedKey],

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -401,9 +401,11 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
                                                                      userID: account.userId))
         }
 
-        let storedKeys = try await setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
-                                                  keys: repairedKeys,
-                                                  for: account)
+        _ = try await setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                     keys: repairedKeys,
+                                     for: account)
+        let storedKeys = try await fetchStoredProtectedKeys(for: ProtectedKeyPurpose.accountInfo,
+                                                           account: account)
         return try validateAccountInfoProtectedKeys(storedKeys,
                                                     requiresThirdPartyWrapper: requiresThirdPartyWrapper)
     }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -70,18 +70,34 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         do {
             let accessCredentials = try await fetchAccessCredentials(account)
             if let scopedPassword = try recoverScopedPassword(from: accessCredentials, primaryKey: account.primaryKey, userID: account.userId) {
-                return EnsuredThirdPartyCredential(scopedPassword: scopedPassword, protectedKeysToCache: [])
+                let protectedKeysToCache = try await protectedKeysAfterRecoveringThirdPartyCredential(
+                    for: account,
+                    scopedPassword: scopedPassword)
+                return EnsuredThirdPartyCredential(scopedPassword: scopedPassword,
+                                                   protectedKeysToCache: protectedKeysToCache)
             }
 
             let scopedPassword = try scopedPasswordForNewThirdPartyCredential(cachedScopedPassword: cachedScopedPassword)
             let keyPreparation = try await protectedKeysForThirdPartyCredential(purpose: purpose,
                                                                                 account: account)
-            let ensuredScopedPassword = try await ensureThirdPartyAccessCredential(for: account,
-                                                                                  scopedPassword: scopedPassword,
-                                                                                  keys: keyPreparation.protectedKeys,
-                                                                                  defaultCredentialKeysToUpload: keyPreparation.defaultCredentialKeysToUpload)
-            return EnsuredThirdPartyCredential(scopedPassword: ensuredScopedPassword,
-                                               protectedKeysToCache: keyPreparation.protectedKeysToCache)
+            let ensuredCredential = try await ensureThirdPartyAccessCredential(
+                for: account,
+                scopedPassword: scopedPassword,
+                keys: keyPreparation.protectedKeys,
+                defaultCredentialKeysToUpload: keyPreparation.defaultCredentialKeysToUpload)
+            let protectedKeysToCache: [ProtectedKey]
+            if let createdProtectedKeys = ensuredCredential.createdProtectedKeys {
+                // The credential was created with these wrappers
+                protectedKeysToCache = (keyPreparation.protectedKeysToCache + createdProtectedKeys)
+                    .removingDuplicateWrappingIdentities()
+            } else {
+                // The credential already existed, so reconcile with server state
+                protectedKeysToCache = try await protectedKeysAfterRecoveringThirdPartyCredential(
+                    for: account,
+                    scopedPassword: ensuredCredential.scopedPassword)
+            }
+            return EnsuredThirdPartyCredential(scopedPassword: ensuredCredential.scopedPassword,
+                                               protectedKeysToCache: protectedKeysToCache)
         } catch let error as ScopedAccessCredentialError {
             throw error
         } catch {
@@ -98,7 +114,9 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         let storedAccountInfoKeys = protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: storedKeys)
         if !storedAccountInfoKeys.isEmpty {
             Logger.sync.debug("Sync-UnifiedDevices: account_info key already exists")
-            return try await repairAccountInfoProtectedKeysIfNeeded(storedAccountInfoKeys, account: account)
+            let reconciledKeys = try await repairAccountInfoProtectedKeysIfNeeded(storedKeys,
+                                                                                  account: account)
+            return protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: reconciledKeys)
         }
 
         let accessCredentials = try await fetchAccessCredentials(account)
@@ -117,8 +135,7 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         } else {
             Logger.sync.debug("Sync-UnifiedDevices: adopted existing account_info key")
         }
-        let persistedKeys = try await fetchStoredProtectedKeys(for: ProtectedKeyPurpose.accountInfo,
-                                                              account: account)
+        let persistedKeys = try await fetchProtectedKeys(account)
         return try validateAccountInfoProtectedKeys(persistedKeys,
                                                     requiresThirdPartyWrapper: scopedPassword != nil)
     }
@@ -145,7 +162,7 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
     private func ensureThirdPartyAccessCredential(for account: SyncAccount,
                                                   scopedPassword: Data,
                                                   keys protectedKeys: [ProtectedKey],
-                                                  defaultCredentialKeysToUpload: [ProtectedKey]) async throws -> Data {
+                                                  defaultCredentialKeysToUpload: [ProtectedKey]) async throws -> EnsuredThirdPartyAccessCredential {
         guard let token = account.token else {
             throw SyncError.noToken
         }
@@ -173,11 +190,13 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         } catch SyncError.unexpectedStatusCode(let statusCode) where statusCode == 409 {
             let accessCredentials = try await fetchAccessCredentials(account)
             if let scopedPassword = try recoverScopedPassword(from: accessCredentials, primaryKey: account.primaryKey, userID: account.userId) {
-                return scopedPassword
+                return EnsuredThirdPartyAccessCredential(scopedPassword: scopedPassword,
+                                                         createdProtectedKeys: nil)
             }
             throw SyncError.unexpectedStatusCode(statusCode)
         }
-        return scopedPassword
+        return EnsuredThirdPartyAccessCredential(scopedPassword: scopedPassword,
+                                                 createdProtectedKeys: createCredentialKeys)
     }
 
     func fetchAccessCredentials(_ account: SyncAccount) async throws -> [AccessCredential] {
@@ -262,21 +281,17 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
 
     private func protectedKeysForThirdPartyCredential(purpose: String,
                                                       account: SyncAccount) async throws -> ProtectedKeysForThirdPartyCredential {
+        // The backend rejects credential creation unless every existing ddg key has a matching 3party wrapper
         let fetchedProtectedKeys = try await fetchProtectedKeys(account)
         let fetchedDefaultCredentialKeys = defaultCredentialKeys(in: fetchedProtectedKeys)
-        let accountInfoKeys = canWriteUnifiedDeviceList()
-            ? protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: fetchedProtectedKeys)
-            : []
         if fetchedDefaultCredentialKeys.contains(where: { $0.purpose == purpose }) {
-            let protectedKeys = (protectedKeys(for: purpose, in: fetchedProtectedKeys) + accountInfoKeys)
-                .removingDuplicateWrappingIdentities()
-            return ProtectedKeysForThirdPartyCredential(protectedKeys: protectedKeys,
+            return ProtectedKeysForThirdPartyCredential(protectedKeys: fetchedProtectedKeys.removingDuplicateWrappingIdentities(),
                                                         defaultCredentialKeysToUpload: [],
                                                         protectedKeysToCache: fetchedProtectedKeys)
         }
 
         let protectedKey = try makeDefaultCredentialProtectedKey(purpose: purpose, account: account)
-        let protectedKeys = ([protectedKey] + accountInfoKeys)
+        let protectedKeys = ([protectedKey] + fetchedProtectedKeys)
             .removingDuplicateWrappingIdentities()
         return ProtectedKeysForThirdPartyCredential(protectedKeys: protectedKeys,
                                                     defaultCredentialKeysToUpload: [protectedKey],
@@ -381,26 +396,56 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         return keysForPurpose
     }
 
-    private func repairAccountInfoProtectedKeysIfNeeded(_ keys: [ProtectedKey],
-                                                        account: SyncAccount) async throws -> [ProtectedKey] {
+    private func protectedKeysAfterRecoveringThirdPartyCredential(for account: SyncAccount, scopedPassword: Data) async throws -> [ProtectedKey] {
+        // Credential recovery is always allowed; repairing its account_info wrapper is write-gated.
+        guard canWriteUnifiedDeviceList() else {
+            return []
+        }
+
+        let storedKeys = try await fetchProtectedKeys(account)
+        guard storedKeys.contains(where: { $0.purpose == ProtectedKeyPurpose.accountInfo }) else {
+            return storedKeys
+        }
+        return try await repairAccountInfoProtectedKeysIfNeeded(
+            storedKeys,
+            account: account,
+            thirdPartyCredential: ThirdPartyCredentialContext(isPresent: true,
+                                                               scopedPassword: scopedPassword))
+    }
+
+    private func repairAccountInfoProtectedKeysIfNeeded(
+        _ keys: [ProtectedKey],
+        account: SyncAccount,
+        thirdPartyCredential providedThirdPartyCredential: ThirdPartyCredentialContext? = nil
+    ) async throws -> [ProtectedKey] {
         let accountInfoKeys = try validateAccountInfoProtectedKeyIdentity(keys)
         let hasDefaultWrapper = accountInfoKeys.contains { $0.encryptedWith == SyncCredentialID.defaultCredential }
         let hasThirdPartyWrapper = accountInfoKeys.contains { $0.encryptedWith == SyncCredentialID.thirdParty }
         if hasDefaultWrapper && hasThirdPartyWrapper {
-            return try validateAccountInfoProtectedKeys(accountInfoKeys, requiresThirdPartyWrapper: true)
+            _ = try validateAccountInfoProtectedKeys(accountInfoKeys, requiresThirdPartyWrapper: true)
+            return keys
         }
 
-        let accessCredentials = try await fetchAccessCredentials(account)
-        let requiresThirdPartyWrapper = accessCredentials.contains { $0.id == SyncCredentialID.thirdParty }
+        let thirdPartyCredential: ThirdPartyCredentialContext
+        if let providedThirdPartyCredential {
+            // Avoid fetching and recovering the credential again
+            thirdPartyCredential = providedThirdPartyCredential
+        } else {
+            let accessCredentials = try await fetchAccessCredentials(account)
+            thirdPartyCredential = ThirdPartyCredentialContext(
+                isPresent: accessCredentials.contains { $0.id == SyncCredentialID.thirdParty },
+                scopedPassword: try recoverScopedPassword(from: accessCredentials,
+                                                          primaryKey: account.primaryKey,
+                                                          userID: account.userId))
+        }
         let needsDefaultWrapper = !hasDefaultWrapper
-        let needsThirdPartyWrapper = requiresThirdPartyWrapper && !hasThirdPartyWrapper
+        let needsThirdPartyWrapper = thirdPartyCredential.isPresent && !hasThirdPartyWrapper
         guard needsDefaultWrapper || needsThirdPartyWrapper else {
-            return try validateAccountInfoProtectedKeys(accountInfoKeys, requiresThirdPartyWrapper: false)
+            _ = try validateAccountInfoProtectedKeys(accountInfoKeys, requiresThirdPartyWrapper: false)
+            return keys
         }
 
-        guard let scopedPassword = try recoverScopedPassword(from: accessCredentials,
-                                                             primaryKey: account.primaryKey,
-                                                             userID: account.userId) else {
+        guard let scopedPassword = thirdPartyCredential.scopedPassword else {
             throw SyncError.invalidDataInResponse("account_info protected keys cannot be repaired without a 3party credential")
         }
         guard let sourceKey = accountInfoKeys.first else {
@@ -427,12 +472,11 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         _ = try await setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
                                      keys: repairedKeys,
                                      for: account)
-        let storedKeys = try await fetchStoredProtectedKeys(for: ProtectedKeyPurpose.accountInfo,
-                                                           account: account)
-        let validatedKeys = try validateAccountInfoProtectedKeys(storedKeys,
-                                                                 requiresThirdPartyWrapper: requiresThirdPartyWrapper)
+        let storedKeys = try await fetchProtectedKeys(account)
+        _ = try validateAccountInfoProtectedKeys(storedKeys,
+                                                 requiresThirdPartyWrapper: thirdPartyCredential.isPresent)
         Logger.sync.debug("Sync-UnifiedDevices: account_info wrapper repair complete")
-        return validatedKeys
+        return storedKeys
     }
 
     private func validateAccountInfoProtectedKeyIdentity(_ keys: [ProtectedKey]) throws -> [ProtectedKey] {
@@ -585,6 +629,16 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         let protectedKeys: [ProtectedKey]
         let defaultCredentialKeysToUpload: [ProtectedKey]
         let protectedKeysToCache: [ProtectedKey]
+    }
+
+    private struct EnsuredThirdPartyAccessCredential {
+        let scopedPassword: Data
+        let createdProtectedKeys: [ProtectedKey]?
+    }
+
+    private struct ThirdPartyCredentialContext {
+        let isPresent: Bool
+        let scopedPassword: Data?
     }
 
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -136,8 +136,13 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
             Logger.sync.debug("Sync-UnifiedDevices: adopted existing account_info key")
         }
         let persistedKeys = try await fetchProtectedKeys(account)
-        return try validateAccountInfoProtectedKeys(persistedKeys,
-                                                    requiresThirdPartyWrapper: scopedPassword != nil)
+        let reconciledKeys = try await repairAccountInfoProtectedKeysIfNeeded(
+            persistedKeys,
+            account: account,
+            thirdPartyCredential: ThirdPartyCredentialContext(
+                isPresent: accessCredentials.contains { $0.id == SyncCredentialID.thirdParty },
+                scopedPassword: scopedPassword))
+        return protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: reconciledKeys)
     }
 
     func makeRecoveryCode(for account: SyncAccount, scopedPassword: Data) -> String? {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ThirdPartyAccountUpgradeCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ThirdPartyAccountUpgradeCoordinator.swift
@@ -66,6 +66,7 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
     let crypter: CryptingInternal
     let scopedAccess: ScopedAccessCredentialManaging
     let account: AccountManaging
+    private let canWriteUnifiedDeviceList: () -> Bool
 
     /// Back-off delays for retrying the final native login on transient failures after the credential
     /// is created. Nanoseconds; default is 0.5s then 1s — two retries.
@@ -81,6 +82,7 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
          crypter: CryptingInternal,
          scopedAccess: ScopedAccessCredentialManaging,
          account: AccountManaging,
+         canWriteUnifiedDeviceList: @escaping () -> Bool,
          finalNativeLoginRetryDelays: [UInt64] = [500_000_000, 1_000_000_000],
          retrySleep: @escaping @Sendable (UInt64) async throws -> Void = { try await Task.sleep(nanoseconds: $0) }) {
         self.endpoints = endpoints
@@ -88,6 +90,7 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
         self.crypter = crypter
         self.scopedAccess = scopedAccess
         self.account = account
+        self.canWriteUnifiedDeviceList = canWriteUnifiedDeviceList
         self.finalNativeLoginRetryDelays = finalNativeLoginRetryDelays
         self.retrySleep = retrySleep
     }
@@ -186,8 +189,10 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
             throw ThirdPartyAccountUpgradeError.protectedKeysFetchFailed
         }
 
+        let shouldIncludeAccountInfoKeys = canWriteUnifiedDeviceList()
         let thirdPartyProtectedKeys = protectedKeys
             .filter { $0.encryptedWith == SyncCode.RecoveryKeyV2.thirdPartyCredentialId }
+            .filter { shouldIncludeAccountInfoKeys || $0.purpose != ProtectedKeyPurpose.accountInfo }
             .removingDuplicateWrappingIdentities()
         guard !thirdPartyProtectedKeys.isEmpty else {
             throw ThirdPartyAccountUpgradeError.noUsableThirdPartyProtectedKeys

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ThirdPartyAccountUpgradeCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ThirdPartyAccountUpgradeCoordinator.swift
@@ -66,7 +66,6 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
     let crypter: CryptingInternal
     let scopedAccess: ScopedAccessCredentialManaging
     let account: AccountManaging
-    private let canWriteUnifiedDeviceList: () -> Bool
 
     /// Back-off delays for retrying the final native login on transient failures after the credential
     /// is created. Nanoseconds; default is 0.5s then 1s — two retries.
@@ -82,7 +81,6 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
          crypter: CryptingInternal,
          scopedAccess: ScopedAccessCredentialManaging,
          account: AccountManaging,
-         canWriteUnifiedDeviceList: @escaping () -> Bool,
          finalNativeLoginRetryDelays: [UInt64] = [500_000_000, 1_000_000_000],
          retrySleep: @escaping @Sendable (UInt64) async throws -> Void = { try await Task.sleep(nanoseconds: $0) }) {
         self.endpoints = endpoints
@@ -90,7 +88,6 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
         self.crypter = crypter
         self.scopedAccess = scopedAccess
         self.account = account
-        self.canWriteUnifiedDeviceList = canWriteUnifiedDeviceList
         self.finalNativeLoginRetryDelays = finalNativeLoginRetryDelays
         self.retrySleep = retrySleep
     }
@@ -189,10 +186,9 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
             throw ThirdPartyAccountUpgradeError.protectedKeysFetchFailed
         }
 
-        let shouldIncludeAccountInfoKeys = canWriteUnifiedDeviceList()
+        // Native credential creation rewraps every 3party-protected purpose, including account_info.
         let thirdPartyProtectedKeys = protectedKeys
             .filter { $0.encryptedWith == SyncCode.RecoveryKeyV2.thirdPartyCredentialId }
-            .filter { shouldIncludeAccountInfoKeys || $0.purpose != ProtectedKeyPurpose.accountInfo }
             .removingDuplicateWrappingIdentities()
         guard !thirdPartyProtectedKeys.isEmpty else {
             throw ThirdPartyAccountUpgradeError.noUsableThirdPartyProtectedKeys

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
@@ -80,7 +80,7 @@ protocol ScopedAccessCredentialManaging {
     func ensureThirdPartyScopedPassword(for account: SyncAccount,
                                         purpose: String,
                                         cachedScopedPassword: () throws -> Data?) async throws -> EnsuredThirdPartyCredential
-    /// Returns stored account_info key wrappers, creating and registering them when the purpose is absent.
+    /// Returns complete account_info wrappers, creating the key when absent and repairing wrappers missing for account credentials.
     func ensureAccountInfoProtectedKeys(for account: SyncAccount) async throws -> [ProtectedKey]
     /// Builds the Base64URL recovery code that shares the account via the scoped password, or nil if the password is empty.
     func makeRecoveryCode(for account: SyncAccount, scopedPassword: Data) -> String?
@@ -88,7 +88,7 @@ protocol ScopedAccessCredentialManaging {
     func fetchAccessCredentials(_ account: SyncAccount) async throws -> [AccessCredential]
     /// Fetches the account's protected keys (empty if none exist).
     func fetchProtectedKeys(_ account: SyncAccount) async throws -> [ProtectedKey]
-    /// Uploads every wrapper for a protected-key purpose atomically if the purpose is absent, returning the wrappers stored by the server.
+    /// Registers wrapper candidates without replacing existing key material, returning the wrappers stored by the server.
     func setKeysIfAbsent(purpose: String, keys: [ProtectedKey], for account: SyncAccount) async throws -> [ProtectedKey]
 }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
@@ -76,7 +76,8 @@ protocol ScopedAccessCredentialManaging {
     func recoverScopedPassword(from accessCredentials: [AccessCredential]?,
                                primaryKey: Data,
                                userID: String) throws -> Data?
-    /// Returns the account's scoped password, creating and uploading the 3party credential (and its protected keys) if absent; reuses `cachedScopedPassword` when creating.
+    /// Returns the account's scoped password, creating the credential and rewrapping existing protected keys when absent.
+    /// Reconciliation after credential creation remains gated by unified-device writes.
     func ensureThirdPartyScopedPassword(for account: SyncAccount,
                                         purpose: String,
                                         cachedScopedPassword: () throws -> Data?) async throws -> EnsuredThirdPartyCredential

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -896,7 +896,8 @@ final class DDGSyncTests: XCTestCase {
         let code = try XCTUnwrap(ScopedAccessCredentialManager(endpoints: Endpoints(baseURL: URL(string: "https://example.com")!),
                                                                api: RemoteAPIRequestCreatingMock(),
                                                                crypter: CryptingMock(),
-                                                               accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                               accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                               canWriteUnifiedDeviceList: { true })
             .makeRecoveryCode(for: .mock, scopedPassword: scopedPassword))
         let decoded = try SyncCode.decodeBase64URLString(code)
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -860,18 +860,52 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(Base64URL.decode(payload.secret), scopedPassword)
     }
 
-    func testWhenPreparingThirdPartyRecoveryCodeAndNewProtectedKeysAreReturnedThenKeysAreCached() async throws {
+    func testWhenPreparingThirdPartyRecoveryCodeAndReturnedSnapshotIsMissingMatchingWrapperThenCachedWrapperIsPreserved() async throws {
         let scopedAccess = try XCTUnwrap(dependencies.scopedAccess as? ScopedAccessCredentialManagingMock)
-        let protectedKey = makeProtectedKey(kid: "key-ddg", encryptedWith: "ddg")
+        let defaultWrapper = makeProtectedKey(kid: "account-info-key",
+                                              encryptedWith: SyncCredentialID.defaultCredential,
+                                              purpose: ProtectedKeyPurpose.accountInfo)
+        let thirdPartyWrapper = makeProtectedKey(kid: "account-info-key",
+                                                 encryptedWith: SyncCredentialID.thirdParty,
+                                                 purpose: ProtectedKeyPurpose.accountInfo)
+        let unrelatedKey = makeProtectedKey(kid: "other-key", encryptedWith: SyncCredentialID.defaultCredential)
+        let secureStore = try XCTUnwrap(dependencies.secureStore as? SecureStorageStub)
+        secureStore.theProtectedKeysData = try JSONEncoder.snakeCaseKeys.encode([
+            defaultWrapper,
+            thirdPartyWrapper,
+            unrelatedKey
+        ])
         scopedAccess.ensureThirdPartyScopedPasswordStub = EnsuredThirdPartyCredential(scopedPassword: Data(repeating: 6, count: 32),
-                                                                                     protectedKeysToCache: [protectedKey])
+                                                                                     protectedKeysToCache: [defaultWrapper, unrelatedKey])
         let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
 
         _ = try await syncService.prepareThirdPartyRecoveryCode(purpose: "ai_chats")
 
-        let cachedProtectedKeysData = try XCTUnwrap((dependencies.secureStore as? SecureStorageStub)?.theProtectedKeysData)
+        let cachedProtectedKeysData = try XCTUnwrap(secureStore.theProtectedKeysData)
         let cachedProtectedKeys = try JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: cachedProtectedKeysData)
-        XCTAssertEqual(cachedProtectedKeys.map(\.kid), ["key-ddg"])
+        XCTAssertEqual(cachedProtectedKeys.count, 3)
+        XCTAssertEqual(Set(cachedProtectedKeys.filter { $0.purpose == ProtectedKeyPurpose.accountInfo }.map(\.encryptedWith)),
+                       Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
+    }
+
+    func testWhenPreparingThirdPartyRecoveryCodeFailsThenExistingProtectedKeysCacheIsPreserved() async throws {
+        let cachedKey = makeProtectedKey(kid: "cached-key", encryptedWith: SyncCredentialID.defaultCredential)
+        let cachedData = try JSONEncoder.snakeCaseKeys.encode([cachedKey])
+        let secureStore = try XCTUnwrap(dependencies.secureStore as? SecureStorageStub)
+        secureStore.theProtectedKeysData = cachedData
+        let scopedAccess = try XCTUnwrap(dependencies.scopedAccess as? ScopedAccessCredentialManagingMock)
+        scopedAccess.ensureThirdPartyScopedPasswordError = ScopedAccessCredentialError.accountExtendFailed
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        do {
+            _ = try await syncService.prepareThirdPartyRecoveryCode(purpose: "ai_chats")
+            XCTFail("Expected scoped credential preparation to fail")
+        } catch ScopedAccessCredentialError.accountExtendFailed {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(secureStore.theProtectedKeysData, cachedData)
     }
 
     func testWhenUpgradingThirdPartyAccountAndScopedAccessFeatureIsDisabledThenAccountIsUpgraded() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
@@ -85,6 +85,58 @@ struct AccountInfoKeyManagerTests {
     }
 
     @available(iOS 16, macOS 13, *)
+    @Test("A stale refresh cannot remove a cached wrapper for the same key", .timeLimit(.minutes(1)))
+    func testWhenRefreshReturnsFewerWrappersForMatchingKeyThenPreservesCachedWrapper() async throws {
+        let scopedPassword = Data(repeating: 0x03, count: 32)
+        let protectedKeys = try makeDualWrappedProtectedKeys(scopedPassword: scopedPassword)
+        let secureStore = SecureStorageStub()
+        secureStore.theProtectedKeysData = try JSONEncoder.snakeCaseKeys.encode([
+            protectedKeys.defaultCredential,
+            protectedKeys.thirdParty
+        ])
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        scopedAccess.fetchProtectedKeysStub = [protectedKeys.defaultCredential]
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        _ = try await manager.refreshKey(for: account)
+
+        let cachedData = try #require(secureStore.theProtectedKeysData)
+        let cachedKeys = try JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: cachedData)
+        #expect(Set(cachedKeys.map(\.encryptedWith)) == Set([
+            SyncCredentialID.defaultCredential,
+            SyncCredentialID.thirdParty
+        ]))
+        #expect(cachedKeys.allSatisfy { $0.kid == protectedKeys.defaultCredential.kid })
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("A refreshed key identity replaces wrappers for the old key", .timeLimit(.minutes(1)))
+    func testWhenRefreshReturnsDifferentKeyThenDoesNotPreserveCachedWrappers() async throws {
+        let scopedPassword = Data(repeating: 0x03, count: 32)
+        let cachedKeys = try makeDualWrappedProtectedKeys(scopedPassword: scopedPassword)
+        let refreshedKey = try makeDefaultCredentialProtectedKey()
+        let secureStore = SecureStorageStub()
+        secureStore.theProtectedKeysData = try JSONEncoder.snakeCaseKeys.encode([
+            cachedKeys.defaultCredential,
+            cachedKeys.thirdParty
+        ])
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        scopedAccess.fetchProtectedKeysStub = [refreshedKey]
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        _ = try await manager.refreshKey(for: account)
+
+        let cachedData = try #require(secureStore.theProtectedKeysData)
+        let persistedKeys = try JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: cachedData)
+        #expect(persistedKeys.map(\.kid) == [refreshedKey.kid])
+        #expect(persistedKeys.map(\.encryptedWith) == [SyncCredentialID.defaultCredential])
+    }
+
+    @available(iOS 16, macOS 13, *)
     @Test("A failed default wrapper falls back to the third-party wrapper", .timeLimit(.minutes(1)))
     func testWhenDefaultWrapperCannotBeUnwrappedThenFallsBackToThirdPartyWrapper() async throws {
         let scopedPassword = Data(repeating: 0x03, count: 32)

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
@@ -112,6 +112,47 @@ struct AccountInfoKeyManagerTests {
     }
 
     @available(iOS 16, macOS 13, *)
+    @Test("Optional public-key metadata does not prevent preserving a cached wrapper", .timeLimit(.minutes(1)))
+    func testWhenRefreshNormalizesOptionalPublicKeyMetadataThenPreservesCachedWrapper() async throws {
+        let scopedPassword = Data(repeating: 0x03, count: 32)
+        let protectedKeys = try makeDualWrappedProtectedKeys(scopedPassword: scopedPassword)
+        let fetchedPublicKey = ProtectedKeyPublicKey(alg: protectedKeys.defaultCredential.publicKey.alg,
+                                                     e: protectedKeys.defaultCredential.publicKey.e,
+                                                     ext: nil,
+                                                     keyOps: nil,
+                                                     kty: protectedKeys.defaultCredential.publicKey.kty,
+                                                     n: protectedKeys.defaultCredential.publicKey.n,
+                                                     use: nil)
+        let fetchedDefaultWrapper = ProtectedKey(kid: protectedKeys.defaultCredential.kid,
+                                                 encryptedPrivateKey: protectedKeys.defaultCredential.encryptedPrivateKey,
+                                                 publicKey: fetchedPublicKey,
+                                                 encryptedWith: SyncCredentialID.defaultCredential,
+                                                 purpose: ProtectedKeyPurpose.accountInfo)
+        let secureStore = SecureStorageStub()
+        secureStore.theProtectedKeysData = try JSONEncoder.snakeCaseKeys.encode([
+            protectedKeys.defaultCredential,
+            protectedKeys.thirdParty
+        ])
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        scopedAccess.fetchProtectedKeysStub = [fetchedDefaultWrapper]
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        _ = try await manager.refreshKey(for: account)
+        _ = try await manager.loadKey(for: account)
+
+        let cachedData = try #require(secureStore.theProtectedKeysData)
+        let cachedKeys = try JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: cachedData)
+        #expect(Set(cachedKeys.map(\.encryptedWith)) == Set([
+            SyncCredentialID.defaultCredential,
+            SyncCredentialID.thirdParty
+        ]))
+        #expect(cachedKeys.allSatisfy { $0.publicKey == fetchedPublicKey })
+        #expect(scopedAccess.fetchProtectedKeysCalls.map(\.userId) == [account.userId])
+    }
+
+    @available(iOS 16, macOS 13, *)
     @Test("A refreshed key identity replaces wrappers for the old key", .timeLimit(.minutes(1)))
     func testWhenRefreshReturnsDifferentKeyThenDoesNotPreserveCachedWrappers() async throws {
         let scopedPassword = Data(repeating: 0x03, count: 32)

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
@@ -437,7 +437,19 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                              scope: "sync",
                              encrypted3PartyCredential: encryptedCredential)
         ]
-        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([storedKey]))
+        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        let storedThirdPartyEncryptedKey = try JWECompactCodec().encryptDirect(payload: privateKeyPKCS8,
+                                                                               contentEncryptionKey: thirdPartyMainKey,
+                                                                               kid: SyncCredentialID.thirdParty)
+        let storedThirdPartyKey = ProtectedKey(kid: storedKey.kid,
+                                               encryptedPrivateKey: storedThirdPartyEncryptedKey,
+                                               publicKey: storedKey.publicKey,
+                                               encryptedWith: SyncCredentialID.thirdParty,
+                                               purpose: ProtectedKeyPurpose.accountInfo)
+        api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
+            .init(data: Data(try protectedKeysBody([storedKey]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
+            .init(data: Data(try protectedKeysBody([storedKey, storedThirdPartyKey]).utf8), response: makeHTTPURLResponse(statusCode: 200))
+        ])
         api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
         api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 201)
 
@@ -450,16 +462,19 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
             endpoints.keys,
             endpoints.accessCredentials,
-            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)
+            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
+            endpoints.keys
         ])
 
-        let requestBody = try XCTUnwrap(api.createRequestCallArgs.last?.body)
+        let repairRequest = try XCTUnwrap(
+            api.createRequestCallArgs.first { $0.url == endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo) }
+        )
+        let requestBody = try XCTUnwrap(repairRequest.body)
         let payload = try decodeJSONObject(requestBody)
         let keys = try XCTUnwrap(payload["keys"] as? [[String: Any]])
         let thirdPartyWrapper = try XCTUnwrap(keys.first { $0["encrypted_with"] as? String == SyncCredentialID.thirdParty })
         XCTAssertEqual(thirdPartyWrapper["kid"] as? String, storedKey.kid)
         let encryptedPrivateKey = try XCTUnwrap(thirdPartyWrapper["encrypted_private_key"] as? String)
-        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
         let decryptedPrivateKey = try JWECompactCodec().decryptDirect(token: encryptedPrivateKey,
                                                                      contentEncryptionKey: thirdPartyMainKey,
                                                                      expectedKid: SyncCredentialID.thirdParty)
@@ -496,7 +511,16 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                              scope: "sync",
                              encrypted3PartyCredential: encryptedCredential)
         ]
-        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([storedKey]))
+        let storedDefaultEncryptedKey = try crypter.encrypt(privateKeyPKCS8, using: account.secretKey)
+        let storedDefaultKey = ProtectedKey(kid: storedKey.kid,
+                                            encryptedPrivateKey: Base64URL.encode(storedDefaultEncryptedKey),
+                                            publicKey: storedKey.publicKey,
+                                            encryptedWith: SyncCredentialID.defaultCredential,
+                                            purpose: ProtectedKeyPurpose.accountInfo)
+        api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
+            .init(data: Data(try protectedKeysBody([storedKey]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
+            .init(data: Data(try protectedKeysBody([storedKey, storedDefaultKey]).utf8), response: makeHTTPURLResponse(statusCode: 200))
+        ])
         api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
         api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 201)
 
@@ -509,10 +533,14 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
             endpoints.keys,
             endpoints.accessCredentials,
-            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)
+            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
+            endpoints.keys
         ])
 
-        let requestBody = try XCTUnwrap(api.createRequestCallArgs.last?.body)
+        let repairRequest = try XCTUnwrap(
+            api.createRequestCallArgs.first { $0.url == endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo) }
+        )
+        let requestBody = try XCTUnwrap(repairRequest.body)
         let payload = try decodeJSONObject(requestBody)
         let keys = try XCTUnwrap(payload["keys"] as? [[String: Any]])
         let defaultWrapper = try XCTUnwrap(keys.first { $0["encrypted_with"] as? String == SyncCredentialID.defaultCredential })
@@ -521,6 +549,55 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let encryptedDefaultPrivateKey = try XCTUnwrap(Base64URL.decode(encodedPrivateKey))
         let decryptedPrivateKey = try crypter.decryptData(encryptedDefaultPrivateKey, using: account.secretKey)
         XCTAssertEqual(decryptedPrivateKey, privateKeyPKCS8)
+    }
+
+    func testWhenServerDoesNotPersistRepairedAccountInfoWrapperThenThrows() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let crypter = CryptingMock()
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: crypter,
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+        let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
+        let scopedPassword = Data((32..<64).map(UInt8.init))
+        let storedKey = try makeNativeEncryptedProtectedKey(privateKey: Data("account-info-private-key".utf8),
+                                                            account: account,
+                                                            crypter: crypter,
+                                                            purpose: ProtectedKeyPurpose.accountInfo)
+        let defaultCredentialMainKey = ScopedAccessKeyDerivation.mainKey(from: account.primaryKey, userID: account.userId)
+        let encryptedCredential = try ScopedAccessCredentialEnvelope().encryptScopedPassword(scopedPassword,
+                                                                                             using: defaultCredentialMainKey,
+                                                                                             kid: SyncCredentialID.defaultCredential)
+        let accessCredentials = [
+            AccessCredential(id: SyncCredentialID.thirdParty,
+                             scope: "sync",
+                             encrypted3PartyCredential: encryptedCredential)
+        ]
+        let storedKeysResponse = HTTPResult(data: Data(try protectedKeysBody([storedKey]).utf8),
+                                            response: makeHTTPURLResponse(statusCode: 200))
+        api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
+            storedKeysResponse,
+            storedKeysResponse
+        ])
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 201)
+
+        do {
+            _ = try await manager.ensureAccountInfoProtectedKeys(for: account)
+            XCTFail("Expected an unmerged wrapper set to be rejected")
+        } catch SyncError.invalidDataInResponse(let message) {
+            XCTAssertTrue(message.contains("missing a 3party wrapper"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
+            endpoints.keys,
+            endpoints.accessCredentials,
+            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
+            endpoints.keys
+        ])
     }
 
     func testWhenEnsuringAccountInfoProtectedKeysWithoutThirdPartyCredentialThenCreatesAndRegistersDefaultWrapper() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
@@ -412,37 +412,115 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.keys])
     }
 
-    func testWhenEnsuringStoredAccountInfoKeyWithThirdPartyCredentialAndMissingWrapperThenThrows() async throws {
+    func testWhenEnsuringStoredDefaultAccountInfoKeyWithThirdPartyCredentialThenAddsThirdPartyWrapper() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let crypter = CryptingMock()
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
-                                                    crypter: CryptingMock(),
+                                                    crypter: crypter,
                                                     accountInfoKeyFactory: accountInfoKeyFactory)
-        let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
-        let storedKey = makeProtectedKey(kid: "account-info",
-                                         encryptedWith: SyncCredentialID.defaultCredential,
-                                         purpose: ProtectedKeyPurpose.accountInfo)
+        let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
+        let scopedPassword = Data((32..<64).map(UInt8.init))
+        let privateKeyPKCS8 = Data("account-info-private-key".utf8)
+        let storedKey = try makeNativeEncryptedProtectedKey(privateKey: privateKeyPKCS8,
+                                                            account: account,
+                                                            crypter: crypter,
+                                                            purpose: ProtectedKeyPurpose.accountInfo)
+        let defaultCredentialMainKey = ScopedAccessKeyDerivation.mainKey(from: account.primaryKey, userID: account.userId)
+        let encryptedCredential = try ScopedAccessCredentialEnvelope().encryptScopedPassword(scopedPassword,
+                                                                                             using: defaultCredentialMainKey,
+                                                                                             kid: SyncCredentialID.defaultCredential)
         let accessCredentials = [
             AccessCredential(id: SyncCredentialID.thirdParty,
                              scope: "sync",
-                             encrypted3PartyCredential: "encrypted-credential")
+                             encrypted3PartyCredential: encryptedCredential)
         ]
         api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([storedKey]))
         api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 201)
 
-        do {
-            _ = try await manager.ensureAccountInfoProtectedKeys(for: account)
-            XCTFail("Expected the incomplete wrapper set to be rejected")
-        } catch SyncError.invalidDataInResponse(let message) {
-            XCTAssertTrue(message.contains("missing a 3party wrapper"))
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
+        let result = try await manager.ensureAccountInfoProtectedKeys(for: account)
 
+        XCTAssertEqual(result.map(\.kid), [storedKey.kid, storedKey.kid])
+        XCTAssertEqual(Set(result.map(\.encryptedWith)), Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
+        XCTAssertTrue(result.allSatisfy { $0.publicKey == storedKey.publicKey })
         XCTAssertTrue(accountInfoKeyFactory.makeProtectedKeysCalls.isEmpty)
-        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.keys, endpoints.accessCredentials])
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
+            endpoints.keys,
+            endpoints.accessCredentials,
+            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)
+        ])
+
+        let requestBody = try XCTUnwrap(api.createRequestCallArgs.last?.body)
+        let payload = try decodeJSONObject(requestBody)
+        let keys = try XCTUnwrap(payload["keys"] as? [[String: Any]])
+        let thirdPartyWrapper = try XCTUnwrap(keys.first { $0["encrypted_with"] as? String == SyncCredentialID.thirdParty })
+        XCTAssertEqual(thirdPartyWrapper["kid"] as? String, storedKey.kid)
+        let encryptedPrivateKey = try XCTUnwrap(thirdPartyWrapper["encrypted_private_key"] as? String)
+        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        let decryptedPrivateKey = try JWECompactCodec().decryptDirect(token: encryptedPrivateKey,
+                                                                     contentEncryptionKey: thirdPartyMainKey,
+                                                                     expectedKid: SyncCredentialID.thirdParty)
+        XCTAssertEqual(decryptedPrivateKey, privateKeyPKCS8)
+    }
+
+    func testWhenEnsuringStoredThirdPartyAccountInfoKeyOnNativeThenAddsDefaultWrapper() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let crypter = CryptingMock()
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: crypter,
+                                                    accountInfoKeyFactory: accountInfoKeyFactory)
+        let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
+        let scopedPassword = Data((32..<64).map(UInt8.init))
+        let privateKeyPKCS8 = Data("account-info-private-key".utf8)
+        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        let encryptedPrivateKey = try JWECompactCodec().encryptDirect(payload: privateKeyPKCS8,
+                                                                      contentEncryptionKey: thirdPartyMainKey,
+                                                                      kid: SyncCredentialID.thirdParty)
+        let storedKey = ProtectedKey(kid: "account-info-key",
+                                     encryptedPrivateKey: encryptedPrivateKey,
+                                     publicKey: .mock,
+                                     encryptedWith: SyncCredentialID.thirdParty,
+                                     purpose: ProtectedKeyPurpose.accountInfo)
+        let defaultCredentialMainKey = ScopedAccessKeyDerivation.mainKey(from: account.primaryKey, userID: account.userId)
+        let encryptedCredential = try ScopedAccessCredentialEnvelope().encryptScopedPassword(scopedPassword,
+                                                                                             using: defaultCredentialMainKey,
+                                                                                             kid: SyncCredentialID.defaultCredential)
+        let accessCredentials = [
+            AccessCredential(id: SyncCredentialID.thirdParty,
+                             scope: "sync",
+                             encrypted3PartyCredential: encryptedCredential)
+        ]
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([storedKey]))
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 201)
+
+        let result = try await manager.ensureAccountInfoProtectedKeys(for: account)
+
+        XCTAssertEqual(result.map(\.kid), [storedKey.kid, storedKey.kid])
+        XCTAssertEqual(Set(result.map(\.encryptedWith)), Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
+        XCTAssertTrue(result.allSatisfy { $0.publicKey == storedKey.publicKey })
+        XCTAssertTrue(accountInfoKeyFactory.makeProtectedKeysCalls.isEmpty)
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
+            endpoints.keys,
+            endpoints.accessCredentials,
+            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)
+        ])
+
+        let requestBody = try XCTUnwrap(api.createRequestCallArgs.last?.body)
+        let payload = try decodeJSONObject(requestBody)
+        let keys = try XCTUnwrap(payload["keys"] as? [[String: Any]])
+        let defaultWrapper = try XCTUnwrap(keys.first { $0["encrypted_with"] as? String == SyncCredentialID.defaultCredential })
+        XCTAssertEqual(defaultWrapper["kid"] as? String, storedKey.kid)
+        let encodedPrivateKey = try XCTUnwrap(defaultWrapper["encrypted_private_key"] as? String)
+        let encryptedDefaultPrivateKey = try XCTUnwrap(Base64URL.decode(encodedPrivateKey))
+        let decryptedPrivateKey = try crypter.decryptData(encryptedDefaultPrivateKey, using: account.secretKey)
+        XCTAssertEqual(decryptedPrivateKey, privateKeyPKCS8)
     }
 
     func testWhenEnsuringAccountInfoProtectedKeysWithoutThirdPartyCredentialThenCreatesAndRegistersDefaultWrapper() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
@@ -26,7 +26,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
 
     private static let baseURL = URL(string: "https://dev.null")!
 
-    func testWhenEnsuringScopedPasswordAndCredentialExistsThenRecoversPasswordWithoutCreatingCredential() async throws {
+    func testWhenExistingThirdPartyCredentialAndAccountInfoWrappersAreCompleteThenReturnsSnapshotWithoutMutation() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
@@ -42,7 +42,13 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                                                            using: defaultCredentialMainKey,
                                                                                            kid: "ddg")
         let accessCredentials = [AccessCredential(id: "3party", scope: "sync", encrypted3PartyCredential: encryptedCredential)]
+        let storedKeys = [
+            makeProtectedKey(kid: "account-info", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
+            makeProtectedKey(kid: "account-info", encryptedWith: SyncCredentialID.thirdParty, purpose: ProtectedKeyPurpose.accountInfo),
+            makeProtectedKey(kid: "other", encryptedWith: SyncCredentialID.defaultCredential, purpose: "ai_chats")
+        ]
         api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody(storedKeys))
 
         let result = try await manager.ensureThirdPartyScopedPassword(for: account,
                                                                       purpose: "ai_chats",
@@ -50,6 +56,134 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                                           XCTFail("Existing credentials should not read cached scoped password")
                                                                           return nil
                                                                       })
+
+        XCTAssertEqual(result.scopedPassword, scopedPassword)
+        XCTAssertEqual(result.protectedKeysToCache.map(\.kid), storedKeys.map(\.kid))
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.accessCredentials, endpoints.keys])
+    }
+
+    func testWhenExistingThirdPartyCredentialHasDefaultAccountInfoWrapperThenRepairsAndReturnsRefetchedSnapshot() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let crypter = CryptingMock()
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: crypter,
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
+        let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
+        let scopedPassword = Data((32..<64).map(UInt8.init))
+        let privateKeyPKCS8 = Data([0xFF] + Array("account-info-private-key".utf8))
+        let defaultWrapper = try makeNativeEncryptedProtectedKey(privateKey: privateKeyPKCS8,
+                                                                 account: account,
+                                                                 crypter: crypter,
+                                                                 purpose: ProtectedKeyPurpose.accountInfo)
+        let unrelatedKey = makeProtectedKey(kid: "other",
+                                            encryptedWith: SyncCredentialID.defaultCredential,
+                                            purpose: "ai_chats")
+        let defaultCredentialMainKey = ScopedAccessKeyDerivation.mainKey(from: account.primaryKey, userID: account.userId)
+        let encryptedCredential = try ScopedAccessCredentialEnvelope().encryptScopedPassword(scopedPassword,
+                                                                                             using: defaultCredentialMainKey,
+                                                                                             kid: SyncCredentialID.defaultCredential)
+        let accessCredentials = [
+            AccessCredential(id: SyncCredentialID.thirdParty,
+                             scope: "sync",
+                             encrypted3PartyCredential: encryptedCredential)
+        ]
+        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        let thirdPartyWrapper = ProtectedKey(
+            kid: defaultWrapper.kid,
+            encryptedPrivateKey: try JWECompactCodec().encryptDirect(payload: privateKeyPKCS8,
+                                                                      contentEncryptionKey: thirdPartyMainKey,
+                                                                      kid: SyncCredentialID.thirdParty),
+            publicKey: defaultWrapper.publicKey,
+            encryptedWith: SyncCredentialID.thirdParty,
+            purpose: ProtectedKeyPurpose.accountInfo)
+        let repairedSnapshot = [defaultWrapper, thirdPartyWrapper, unrelatedKey]
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
+        api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
+            .init(data: Data(try protectedKeysBody([defaultWrapper, unrelatedKey]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
+            .init(data: Data(try protectedKeysBody(repairedSnapshot).utf8), response: makeHTTPURLResponse(statusCode: 200))
+        ])
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 201)
+
+        let result = try await manager.ensureThirdPartyScopedPassword(for: account,
+                                                                      purpose: "ai_chats",
+                                                                      cachedScopedPassword: {
+                                                                          XCTFail("Existing credentials should not read cached scoped password")
+                                                                          return nil
+                                                                      })
+
+        XCTAssertEqual(result.scopedPassword, scopedPassword)
+        XCTAssertEqual(result.protectedKeysToCache.map(\.kid), repairedSnapshot.map(\.kid))
+        XCTAssertEqual(Set(result.protectedKeysToCache.filter { $0.purpose == ProtectedKeyPurpose.accountInfo }.map(\.encryptedWith)),
+                       Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
+            endpoints.accessCredentials,
+            endpoints.keys,
+            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
+            endpoints.keys
+        ])
+    }
+
+    func testWhenExistingThirdPartyCredentialProtectedKeyFetchFailsThenDoesNotAttemptRepair() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
+        let scopedPassword = Data(repeating: 8, count: 32)
+        let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
+        let defaultCredentialMainKey = ScopedAccessKeyDerivation.mainKey(from: account.primaryKey, userID: account.userId)
+        let encryptedCredential = try ScopedAccessCredentialEnvelope().encryptScopedPassword(scopedPassword,
+                                                                                             using: defaultCredentialMainKey,
+                                                                                             kid: SyncCredentialID.defaultCredential)
+        let accessCredentials = [AccessCredential(id: SyncCredentialID.thirdParty,
+                                                  scope: "sync",
+                                                  encrypted3PartyCredential: encryptedCredential)]
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
+        api.fakeRequests[endpoints.keys] = makeFailingRequest(statusCode: 500)
+
+        do {
+            _ = try await manager.ensureThirdPartyScopedPassword(for: account,
+                                                                 purpose: "ai_chats",
+                                                                 cachedScopedPassword: { nil })
+            XCTFail("Expected protected-key fetch failure")
+        } catch ScopedAccessCredentialError.accountExtendFailed {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.accessCredentials, endpoints.keys])
+        XCTAssertFalse(api.createRequestCallArgs.contains {
+            $0.url == endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)
+        })
+    }
+
+    func testWhenRecoveringExistingThirdPartyCredentialWithUnifiedDeviceListWriteDisabledThenDoesNotFetchProtectedKeys() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { false })
+        let scopedPassword = Data(repeating: 8, count: 32)
+        let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
+        let defaultCredentialMainKey = ScopedAccessKeyDerivation.mainKey(from: account.primaryKey, userID: account.userId)
+        let encryptedCredential = try ScopedAccessCredentialEnvelope().encryptScopedPassword(scopedPassword,
+                                                                                             using: defaultCredentialMainKey,
+                                                                                             kid: SyncCredentialID.defaultCredential)
+        let accessCredentials = [AccessCredential(id: SyncCredentialID.thirdParty,
+                                                  scope: "sync",
+                                                  encrypted3PartyCredential: encryptedCredential)]
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
+
+        let result = try await manager.ensureThirdPartyScopedPassword(for: account,
+                                                                      purpose: "ai_chats",
+                                                                      cachedScopedPassword: { nil })
 
         XCTAssertEqual(result.scopedPassword, scopedPassword)
         XCTAssertTrue(result.protectedKeysToCache.isEmpty)
@@ -84,7 +218,9 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                                       cachedScopedPassword: { scopedPassword })
 
         XCTAssertEqual(result.scopedPassword, scopedPassword)
-        XCTAssertEqual(result.protectedKeysToCache.map(\.kid), [protectedKey.kid])
+        XCTAssertEqual(result.protectedKeysToCache.map(\.kid), [protectedKey.kid, protectedKey.kid])
+        XCTAssertEqual(Set(result.protectedKeysToCache.map(\.encryptedWith)),
+                       Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
 
         let requestBody = try XCTUnwrap(api.createRequestCallArgs.last?.body)
         let payload = try decodeJSONObject(requestBody)
@@ -265,7 +401,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertEqual(decryptedRewrappedPrivateKey, originalPrivateKey)
     }
 
-    func testWhenCreatingThirdPartyCredentialThenRewrapsExistingAccountInfoKey() async throws {
+    func testWhenCreatingThirdPartyCredentialThenRewrapsAllExistingDefaultCredentialKeys() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         var crypter = CryptingMock()
@@ -291,20 +427,31 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                                 account: account,
                                                                 crypter: crypter,
                                                                 purpose: ProtectedKeyPurpose.accountInfo)
+        let bookmarksKey = try makeNativeEncryptedProtectedKey(privateKey: Data("bookmarks-private-key".utf8),
+                                                               account: account,
+                                                               crypter: crypter,
+                                                               purpose: "bookmarks")
         api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody([]))
-        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([aiChatKey, accountInfoKey]))
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200,
+                                                       body: try protectedKeysBody([aiChatKey, accountInfoKey, bookmarksKey]))
         api.fakeRequests[endpoints.accessCredential(SyncCredentialID.thirdParty)] = makeRequest(statusCode: 201)
 
         let result = try await manager.ensureThirdPartyScopedPassword(for: account,
                                                                       purpose: "ai_chats",
                                                                       cachedScopedPassword: { scopedPassword })
 
-        XCTAssertEqual(Set(result.protectedKeysToCache.map(\.kid)), Set([aiChatKey.kid, accountInfoKey.kid]))
+        XCTAssertEqual(Set(result.protectedKeysToCache.map(\.kid)), Set([aiChatKey.kid, accountInfoKey.kid, bookmarksKey.kid]))
+        XCTAssertEqual(Set(result.protectedKeysToCache.filter { $0.purpose == ProtectedKeyPurpose.accountInfo }.map(\.encryptedWith)),
+                       Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
+        XCTAssertEqual(Set(result.protectedKeysToCache.filter { $0.purpose == "bookmarks" }.map(\.encryptedWith)),
+                       Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
         let requestBody = try XCTUnwrap(api.createRequestCallArgs.last?.body)
         let payload = try decodeJSONObject(requestBody)
         let keys = try XCTUnwrap(payload["keys"] as? [[String: Any]])
-        XCTAssertEqual(keys.count, 2)
+        XCTAssertEqual(keys.count, 3)
         XCTAssertTrue(keys.allSatisfy { $0["encrypted_with"] as? String == SyncCredentialID.thirdParty })
+        XCTAssertEqual(Set(keys.compactMap { $0["purpose"] as? String }),
+                       Set(["ai_chats", ProtectedKeyPurpose.accountInfo, "bookmarks"]))
 
         let accountInfoWrapper = try XCTUnwrap(keys.first { $0["purpose"] as? String == ProtectedKeyPurpose.accountInfo })
         XCTAssertEqual(accountInfoWrapper["kid"] as? String, accountInfoKey.kid)
@@ -316,7 +463,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertEqual(decryptedPrivateKey, accountInfoPrivateKey)
     }
 
-    func testWhenCreatingThirdPartyCredentialWithUnifiedDeviceListWriteDisabledThenDoesNotRewrapAccountInfoKey() async throws {
+    func testWhenCreatingThirdPartyCredentialWithUnifiedDeviceListWriteDisabledThenRewrapsExistingAccountInfoKey() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         var crypter = CryptingMock()
@@ -352,9 +499,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let requestBody = try XCTUnwrap(api.createRequestCallArgs.last?.body)
         let payload = try decodeJSONObject(requestBody)
         let keys = try XCTUnwrap(payload["keys"] as? [[String: Any]])
-        XCTAssertEqual(keys.count, 1)
-        XCTAssertEqual(keys.first?["purpose"] as? String, "ai_chats")
-        XCTAssertNil(keys.first { $0["purpose"] as? String == ProtectedKeyPurpose.accountInfo })
+        XCTAssertEqual(keys.count, 2)
+        XCTAssertTrue(keys.allSatisfy { $0["encrypted_with"] as? String == SyncCredentialID.thirdParty })
+        XCTAssertEqual(keys.first { $0["purpose"] as? String == ProtectedKeyPurpose.accountInfo }?["kid"] as? String,
+                       accountInfoKey.kid)
     }
 
     func testWhenCreatingThirdPartyScopedPasswordReturns409ThenRefetchesAndRecoversScopedPassword() async throws {
@@ -398,7 +546,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
             endpoints.accessCredentials,
             endpoints.keys,
             endpoints.accessCredential("3party"),
-            endpoints.accessCredentials
+            endpoints.accessCredentials,
+            endpoints.keys
         ])
     }
 
@@ -835,11 +984,16 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         ])
     }
 
-    func testWhenEnsuringAccountInfoProtectedKeysAndThirdPartyCredentialCannotBeRecoveredThenDoesNotCreateOrRegisterKeys() async throws {
+    func testWhenRepairingAccountInfoProtectedKeysAndThirdPartyCredentialCannotBeRecoveredThenDoesNotRegisterKeys() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let crypter = CryptingMock()
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
+        let storedKey = try makeNativeEncryptedProtectedKey(privateKey: Data("account-info-private-key".utf8),
+                                                            account: account,
+                                                            crypter: crypter,
+                                                            purpose: ProtectedKeyPurpose.accountInfo)
         let accessCredentials = [
             AccessCredential(id: SyncCredentialID.thirdParty,
                              scope: "sync",
@@ -847,14 +1001,15 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         ]
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
-                                                    crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: accountInfoKeyFactory)
-        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([]))
+                                                    crypter: crypter,
+                                                    accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    canWriteUnifiedDeviceList: { true })
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([storedKey]))
         api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
 
         do {
             _ = try await manager.ensureAccountInfoProtectedKeys(for: account)
-            XCTFail("Expected account_info key creation to fail")
+            XCTFail("Expected account_info wrapper repair to fail")
         } catch ScopedAccessCredentialError.undecryptableThirdPartyCredential {
         } catch {
             XCTFail("Unexpected error: \(error)")
@@ -865,6 +1020,9 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
             endpoints.keys,
             endpoints.accessCredentials
         ])
+        XCTAssertFalse(api.createRequestCallArgs.contains {
+            $0.url == endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)
+        })
     }
 
     func testWhenSetKeysIfAbsentReceivesNoKeysThenThrowsWithoutCreatingRequest() async throws {
@@ -872,7 +1030,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: Endpoints(baseURL: Self.baseURL),
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
 
         do {
@@ -894,7 +1053,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: Endpoints(baseURL: Self.baseURL),
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
         let key = makeProtectedKey(kid: "candidate",
                                    encryptedWith: SyncCredentialID.defaultCredential,
@@ -1048,7 +1208,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data(repeating: 0x4, count: 32))
         let defaultKey = makeProtectedKey(kid: "candidate",
                                           encryptedWith: SyncCredentialID.defaultCredential,
@@ -1132,7 +1293,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
             let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                         api: api,
                                                         crypter: CryptingMock(),
-                                                        accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                        accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                        canWriteUnifiedDeviceList: { true })
             let account = makeAccount(primaryKey: Data(repeating: 0x7, count: 32))
             let requestedKey = makeProtectedKey(kid: "candidate",
                                                 encryptedWith: SyncCredentialID.defaultCredential,
@@ -1165,7 +1327,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
             let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                         api: api,
                                                         crypter: CryptingMock(),
-                                                        accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                        accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                        canWriteUnifiedDeviceList: { true })
             let account = makeAccount(primaryKey: Data(repeating: 0x8, count: 32))
             let requestedKey = makeProtectedKey(kid: "candidate",
                                                 encryptedWith: SyncCredentialID.defaultCredential,

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
@@ -32,7 +32,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
 
         let scopedPassword = Data(repeating: 8, count: 32)
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
@@ -68,7 +69,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: crypter,
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
 
         let scopedPassword = Data((32..<64).map(UInt8.init))
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
@@ -105,7 +107,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: crypter,
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
 
         let scopedPassword = Data((32..<64).map(UInt8.init))
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
@@ -135,7 +138,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         api.fakeRequests[endpoints.accessCredentials] = makeFailingRequest(statusCode: 404)
 
@@ -150,7 +154,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         api.fakeRequests[endpoints.keys] = makeFailingRequest(statusCode: 404)
 
@@ -172,7 +177,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: crypter,
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
 
         let accountPrimaryKey = Data((0..<32).map(UInt8.init))
         let scopedPassword = Data((32..<64).map(UInt8.init))
@@ -227,7 +233,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: crypter,
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
 
         let accountPrimaryKey = Data((0..<32).map(UInt8.init))
         let scopedPassword = Data((32..<64).map(UInt8.init))
@@ -271,7 +278,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: crypter,
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
 
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         let scopedPassword = Data((32..<64).map(UInt8.init))
@@ -308,6 +316,47 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertEqual(decryptedPrivateKey, accountInfoPrivateKey)
     }
 
+    func testWhenCreatingThirdPartyCredentialWithUnifiedDeviceListWriteDisabledThenDoesNotRewrapAccountInfoKey() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        var crypter = CryptingMock()
+        crypter._extractLoginInfo = { recoveryKey in
+            ExtractedLoginInfo(userId: recoveryKey.userId,
+                               primaryKey: recoveryKey.primaryKey,
+                               passwordHash: Data([0xAB]),
+                               stretchedPrimaryKey: Data())
+        }
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: crypter,
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { false })
+
+        let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
+        let scopedPassword = Data((32..<64).map(UInt8.init))
+        let aiChatKey = try makeNativeEncryptedProtectedKey(privateKey: Data("ai-chat-private-key".utf8),
+                                                           account: account,
+                                                           crypter: crypter)
+        let accountInfoKey = try makeNativeEncryptedProtectedKey(privateKey: Data("account-info-private-key".utf8),
+                                                                account: account,
+                                                                crypter: crypter,
+                                                                purpose: ProtectedKeyPurpose.accountInfo)
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody([]))
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([aiChatKey, accountInfoKey]))
+        api.fakeRequests[endpoints.accessCredential(SyncCredentialID.thirdParty)] = makeRequest(statusCode: 201)
+
+        _ = try await manager.ensureThirdPartyScopedPassword(for: account,
+                                                            purpose: "ai_chats",
+                                                            cachedScopedPassword: { scopedPassword })
+
+        let requestBody = try XCTUnwrap(api.createRequestCallArgs.last?.body)
+        let payload = try decodeJSONObject(requestBody)
+        let keys = try XCTUnwrap(payload["keys"] as? [[String: Any]])
+        XCTAssertEqual(keys.count, 1)
+        XCTAssertEqual(keys.first?["purpose"] as? String, "ai_chats")
+        XCTAssertNil(keys.first { $0["purpose"] as? String == ProtectedKeyPurpose.accountInfo })
+    }
+
     func testWhenCreatingThirdPartyScopedPasswordReturns409ThenRefetchesAndRecoversScopedPassword() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
@@ -321,7 +370,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: crypter,
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
 
         let accountPrimaryKey = Data((0..<32).map(UInt8.init))
         let localScopedPassword = Data((32..<64).map(UInt8.init))
@@ -365,7 +415,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: crypter,
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
 
         let accountPrimaryKey = Data((0..<32).map(UInt8.init))
         let scopedPassword = Data((32..<64).map(UInt8.init))
@@ -388,6 +439,51 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         }
     }
 
+    func testWhenEnsuringAccountInfoProtectedKeysWithUnifiedDeviceListWriteDisabledThenDoesNotMakeNetworkRequests() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let manager = ScopedAccessCredentialManager(endpoints: Endpoints(baseURL: Self.baseURL),
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { false })
+
+        let result = try await manager.ensureAccountInfoProtectedKeys(for: makeAccount(primaryKey: Data(repeating: 0x1, count: 32)))
+
+        XCTAssertTrue(result.isEmpty)
+        XCTAssertTrue(api.createRequestCallArgs.isEmpty)
+    }
+
+    func testWhenEnsuringAccountInfoWrappersWithDifferentKidsThenThrowsInvalidData() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
+        let storedKeys = [
+            makeProtectedKey(kid: "first-key",
+                             encryptedWith: SyncCredentialID.defaultCredential,
+                             purpose: ProtectedKeyPurpose.accountInfo),
+            makeProtectedKey(kid: "second-key",
+                             encryptedWith: SyncCredentialID.thirdParty,
+                             purpose: ProtectedKeyPurpose.accountInfo)
+        ]
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody(storedKeys))
+
+        do {
+            _ = try await manager.ensureAccountInfoProtectedKeys(
+                for: makeAccount(primaryKey: Data(repeating: 0x1, count: 32)))
+            XCTFail("Expected inconsistent account_info wrappers to be rejected")
+        } catch SyncError.invalidDataInResponse(let message) {
+            XCTAssertEqual(message, "account_info protected key wrappers do not describe the same key")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.keys])
+    }
+
     func testWhenEnsuringAccountInfoProtectedKeysAndKeysAreStoredThenReturnsThemWithoutCreatingKeys() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
@@ -395,7 +491,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: accountInfoKeyFactory)
+                                                    accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
         let storedKeys = [
             makeProtectedKey(kid: "account-info", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
@@ -420,7 +517,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: crypter,
-                                                    accountInfoKeyFactory: accountInfoKeyFactory)
+                                                    accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         let scopedPassword = Data((32..<64).map(UInt8.init))
         let privateKeyPKCS8 = Data([0xFF] + Array("account-info-private-key".utf8))
@@ -489,7 +587,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: crypter,
-                                                    accountInfoKeyFactory: accountInfoKeyFactory)
+                                                    accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         let scopedPassword = Data((32..<64).map(UInt8.init))
         let privateKeyPKCS8 = Data([0xFF] + Array("account-info-private-key".utf8))
@@ -558,7 +657,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: crypter,
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         let scopedPassword = Data((32..<64).map(UInt8.init))
         let storedKey = try makeNativeEncryptedProtectedKey(privateKey: Data([0xFF] + Array("account-info-private-key".utf8)),
@@ -612,7 +712,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: accountInfoKeyFactory)
+                                                    accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    canWriteUnifiedDeviceList: { true })
         api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
             .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
             .init(data: Data(try protectedKeysBody([createdKey]).utf8), response: makeHTTPURLResponse(statusCode: 200))
@@ -658,7 +759,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: accountInfoKeyFactory)
+                                                    accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    canWriteUnifiedDeviceList: { true })
         api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
             .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
             .init(data: Data(try protectedKeysBody(createdKeys).utf8), response: makeHTTPURLResponse(statusCode: 200))
@@ -707,7 +809,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: accountInfoKeyFactory)
+                                                    accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    canWriteUnifiedDeviceList: { true })
         api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
             .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
             .init(data: Data(try protectedKeysBody([defaultWrapper]).utf8), response: makeHTTPURLResponse(statusCode: 200))
@@ -817,7 +920,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
         let requestedKeys = [
             makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
@@ -849,7 +953,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
         let requestedKeys = [
             makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo)
@@ -883,7 +988,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data(repeating: 0x3, count: 32))
         let requestedKeys = [
             makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
@@ -918,7 +1024,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data(repeating: 0x4, count: 32))
         let requestedKeys = [
             makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
@@ -968,7 +1075,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data(repeating: 0x5, count: 32))
         let requestedKeys = [
             makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo)
@@ -997,7 +1105,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data(repeating: 0x6, count: 32))
         let requestedKeys = [
             makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo)
@@ -1085,7 +1194,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data(repeating: 0x9, count: 32))
         let requestedKeys = [
             makeProtectedKey(kid: "candidate", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo)
@@ -1115,7 +1225,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody([]))
         api.fakeRequests[endpoints.keys] = makeFailingRequest(statusCode: 500)

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
@@ -932,6 +932,73 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         ])
     }
 
+    func testWhenAnotherClientRegistersIncompleteAccountInfoKeyThenRepairsAdoptedKey() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let crypter = CryptingMock()
+        let accountPrimaryKey = Data((0..<32).map(UInt8.init))
+        let scopedPassword = Data((32..<64).map(UInt8.init))
+        let account = makeAccount(primaryKey: accountPrimaryKey)
+        let defaultCredentialMainKey = ScopedAccessKeyDerivation.mainKey(from: accountPrimaryKey, userID: account.userId)
+        let encryptedCredential = try ScopedAccessCredentialEnvelope().encryptScopedPassword(scopedPassword,
+                                                                                             using: defaultCredentialMainKey,
+                                                                                             kid: SyncCredentialID.defaultCredential)
+        let accessCredentials = [
+            AccessCredential(id: SyncCredentialID.thirdParty,
+                             scope: "sync",
+                             encrypted3PartyCredential: encryptedCredential)
+        ]
+        let createdKeys = [
+            makeProtectedKey(kid: "created", encryptedWith: SyncCredentialID.defaultCredential, purpose: ProtectedKeyPurpose.accountInfo),
+            makeProtectedKey(kid: "created", encryptedWith: SyncCredentialID.thirdParty, purpose: ProtectedKeyPurpose.accountInfo)
+        ]
+        accountInfoKeyFactory.makeProtectedKeysStub = createdKeys
+        let adoptedPrivateKey = Data([0xFF] + Array("adopted-account-info-private-key".utf8))
+        let adoptedDefaultWrapper = try makeNativeEncryptedProtectedKey(privateKey: adoptedPrivateKey,
+                                                                         account: account,
+                                                                         crypter: crypter,
+                                                                         purpose: ProtectedKeyPurpose.accountInfo)
+        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        let adoptedThirdPartyEncryptedKey = try JWECompactCodec().encryptDirect(payload: adoptedPrivateKey,
+                                                                                 contentEncryptionKey: thirdPartyMainKey,
+                                                                                 kid: SyncCredentialID.thirdParty)
+        let adoptedThirdPartyWrapper = ProtectedKey(kid: adoptedDefaultWrapper.kid,
+                                                     encryptedPrivateKey: adoptedThirdPartyEncryptedKey,
+                                                     publicKey: adoptedDefaultWrapper.publicKey,
+                                                     encryptedWith: SyncCredentialID.thirdParty,
+                                                     purpose: ProtectedKeyPurpose.accountInfo)
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: crypter,
+                                                    accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    canWriteUnifiedDeviceList: { true })
+        api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
+            .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
+            .init(data: Data(try protectedKeysBody([adoptedDefaultWrapper]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
+            .init(data: Data(try protectedKeysBody([adoptedDefaultWrapper, adoptedThirdPartyWrapper]).utf8),
+                  response: makeHTTPURLResponse(statusCode: 200))
+        ])
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = SequencedHTTPRequestingMock(results: [
+            .init(data: Data(try protectedKeysBody([adoptedDefaultWrapper]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
+            .init(data: nil, response: makeHTTPURLResponse(statusCode: 201))
+        ])
+
+        let result = try await manager.ensureAccountInfoProtectedKeys(for: account)
+
+        XCTAssertEqual(result.map(\.kid), [adoptedDefaultWrapper.kid, adoptedDefaultWrapper.kid])
+        XCTAssertEqual(Set(result.map(\.encryptedWith)), Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
+            endpoints.keys,
+            endpoints.accessCredentials,
+            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
+            endpoints.keys,
+            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
+            endpoints.keys
+        ])
+    }
+
     func testWhenServerDoesNotPersistAllCreatedAccountInfoWrappersThenThrows() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
@@ -962,6 +1029,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                     canWriteUnifiedDeviceList: { true })
         api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
             .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
+            .init(data: Data(try protectedKeysBody([defaultWrapper]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
             .init(data: Data(try protectedKeysBody([defaultWrapper]).utf8), response: makeHTTPURLResponse(statusCode: 200))
         ])
         api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
@@ -979,6 +1047,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
             endpoints.keys,
             endpoints.accessCredentials,
+            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
+            endpoints.keys,
             endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
             endpoints.keys
         ])

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
@@ -258,6 +258,56 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertEqual(decryptedRewrappedPrivateKey, originalPrivateKey)
     }
 
+    func testWhenCreatingThirdPartyCredentialThenRewrapsExistingAccountInfoKey() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        var crypter = CryptingMock()
+        crypter._extractLoginInfo = { recoveryKey in
+            ExtractedLoginInfo(userId: recoveryKey.userId,
+                               primaryKey: recoveryKey.primaryKey,
+                               passwordHash: Data([0xAB]),
+                               stretchedPrimaryKey: Data())
+        }
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: crypter,
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+
+        let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
+        let scopedPassword = Data((32..<64).map(UInt8.init))
+        let accountInfoPrivateKey = Data("account-info-private-key".utf8)
+        let aiChatKey = try makeNativeEncryptedProtectedKey(privateKey: Data("ai-chat-private-key".utf8),
+                                                           account: account,
+                                                           crypter: crypter)
+        let accountInfoKey = try makeNativeEncryptedProtectedKey(privateKey: accountInfoPrivateKey,
+                                                                account: account,
+                                                                crypter: crypter,
+                                                                purpose: ProtectedKeyPurpose.accountInfo)
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody([]))
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([aiChatKey, accountInfoKey]))
+        api.fakeRequests[endpoints.accessCredential(SyncCredentialID.thirdParty)] = makeRequest(statusCode: 201)
+
+        let result = try await manager.ensureThirdPartyScopedPassword(for: account,
+                                                                      purpose: "ai_chats",
+                                                                      cachedScopedPassword: { scopedPassword })
+
+        XCTAssertEqual(Set(result.protectedKeysToCache.map(\.kid)), Set([aiChatKey.kid, accountInfoKey.kid]))
+        let requestBody = try XCTUnwrap(api.createRequestCallArgs.last?.body)
+        let payload = try decodeJSONObject(requestBody)
+        let keys = try XCTUnwrap(payload["keys"] as? [[String: Any]])
+        XCTAssertEqual(keys.count, 2)
+        XCTAssertTrue(keys.allSatisfy { $0["encrypted_with"] as? String == SyncCredentialID.thirdParty })
+
+        let accountInfoWrapper = try XCTUnwrap(keys.first { $0["purpose"] as? String == ProtectedKeyPurpose.accountInfo })
+        XCTAssertEqual(accountInfoWrapper["kid"] as? String, accountInfoKey.kid)
+        let encryptedPrivateKey = try XCTUnwrap(accountInfoWrapper["encrypted_private_key"] as? String)
+        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        let decryptedPrivateKey = try JWECompactCodec().decryptDirect(token: encryptedPrivateKey,
+                                                                     contentEncryptionKey: thirdPartyMainKey,
+                                                                     expectedKid: SyncCredentialID.thirdParty)
+        XCTAssertEqual(decryptedPrivateKey, accountInfoPrivateKey)
+    }
+
     func testWhenCreatingThirdPartyScopedPasswordReturns409ThenRefetchesAndRecoversScopedPassword() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
@@ -360,6 +410,39 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertEqual(Set(result.map(\.encryptedWith)), Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
         XCTAssertTrue(accountInfoKeyFactory.makeProtectedKeysCalls.isEmpty)
         XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.keys])
+    }
+
+    func testWhenEnsuringStoredAccountInfoKeyWithThirdPartyCredentialAndMissingWrapperThenThrows() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: accountInfoKeyFactory)
+        let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
+        let storedKey = makeProtectedKey(kid: "account-info",
+                                         encryptedWith: SyncCredentialID.defaultCredential,
+                                         purpose: ProtectedKeyPurpose.accountInfo)
+        let accessCredentials = [
+            AccessCredential(id: SyncCredentialID.thirdParty,
+                             scope: "sync",
+                             encrypted3PartyCredential: "encrypted-credential")
+        ]
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([storedKey]))
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
+
+        do {
+            _ = try await manager.ensureAccountInfoProtectedKeys(for: account)
+            XCTFail("Expected the incomplete wrapper set to be rejected")
+        } catch SyncError.invalidDataInResponse(let message) {
+            XCTAssertTrue(message.contains("missing a 3party wrapper"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertTrue(accountInfoKeyFactory.makeProtectedKeysCalls.isEmpty)
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.keys, endpoints.accessCredentials])
     }
 
     func testWhenEnsuringAccountInfoProtectedKeysWithoutThirdPartyCredentialThenCreatesAndRegistersDefaultWrapper() async throws {
@@ -858,13 +941,14 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
 
     private func makeNativeEncryptedProtectedKey(privateKey: Data,
                                                  account: SyncAccount,
-                                                 crypter: CryptingInternal) throws -> ProtectedKey {
+                                                 crypter: CryptingInternal,
+                                                 purpose: String = "ai_chats") throws -> ProtectedKey {
         let encryptedPrivateKey = try crypter.encrypt(privateKey, using: account.secretKey)
         return ProtectedKey(kid: UUID().uuidString,
                             encryptedPrivateKey: Base64URL.encode(encryptedPrivateKey),
                             publicKey: .mock,
                             encryptedWith: "ddg",
-                            purpose: "ai_chats")
+                            purpose: purpose)
     }
 
     private func makeRequest(statusCode: Int, body: String? = nil) -> HTTPRequestingMock {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
@@ -275,7 +275,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
 
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         let scopedPassword = Data((32..<64).map(UInt8.init))
-        let accountInfoPrivateKey = Data("account-info-private-key".utf8)
+        let accountInfoPrivateKey = Data([0xFF] + Array("account-info-private-key".utf8))
         let aiChatKey = try makeNativeEncryptedProtectedKey(privateKey: Data("ai-chat-private-key".utf8),
                                                            account: account,
                                                            crypter: crypter)
@@ -423,7 +423,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                     accountInfoKeyFactory: accountInfoKeyFactory)
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         let scopedPassword = Data((32..<64).map(UInt8.init))
-        let privateKeyPKCS8 = Data("account-info-private-key".utf8)
+        let privateKeyPKCS8 = Data([0xFF] + Array("account-info-private-key".utf8))
         let storedKey = try makeNativeEncryptedProtectedKey(privateKey: privateKeyPKCS8,
                                                             account: account,
                                                             crypter: crypter,
@@ -492,7 +492,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                     accountInfoKeyFactory: accountInfoKeyFactory)
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         let scopedPassword = Data((32..<64).map(UInt8.init))
-        let privateKeyPKCS8 = Data("account-info-private-key".utf8)
+        let privateKeyPKCS8 = Data([0xFF] + Array("account-info-private-key".utf8))
         let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
         let encryptedPrivateKey = try JWECompactCodec().encryptDirect(payload: privateKeyPKCS8,
                                                                       contentEncryptionKey: thirdPartyMainKey,
@@ -561,7 +561,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                     accountInfoKeyFactory: AccountInfoKeyFactoryMock())
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         let scopedPassword = Data((32..<64).map(UInt8.init))
-        let storedKey = try makeNativeEncryptedProtectedKey(privateKey: Data("account-info-private-key".utf8),
+        let storedKey = try makeNativeEncryptedProtectedKey(privateKey: Data([0xFF] + Array("account-info-private-key".utf8)),
                                                             account: account,
                                                             crypter: crypter,
                                                             purpose: ProtectedKeyPurpose.accountInfo)
@@ -613,7 +613,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                     api: api,
                                                     crypter: CryptingMock(),
                                                     accountInfoKeyFactory: accountInfoKeyFactory)
-        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([]))
+        api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
+            .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
+            .init(data: Data(try protectedKeysBody([createdKey]).utf8), response: makeHTTPURLResponse(statusCode: 200))
+        ])
         api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody([]))
         api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 201)
 
@@ -626,7 +629,8 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
             endpoints.keys,
             endpoints.accessCredentials,
-            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)
+            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
+            endpoints.keys
         ])
     }
 
@@ -655,7 +659,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                     api: api,
                                                     crypter: CryptingMock(),
                                                     accountInfoKeyFactory: accountInfoKeyFactory)
-        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([]))
+        api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
+            .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
+            .init(data: Data(try protectedKeysBody(createdKeys).utf8), response: makeHTTPURLResponse(statusCode: 200))
+        ])
         api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
         api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 201)
 
@@ -666,6 +673,63 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let factoryCall = try XCTUnwrap(accountInfoKeyFactory.makeProtectedKeysCalls.first)
         XCTAssertEqual(factoryCall.accountSecretKey, account.secretKey)
         XCTAssertEqual(factoryCall.thirdPartyMainKey, hkdf(input: scopedPassword, salt: account.userId, info: "Main Key"))
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
+            endpoints.keys,
+            endpoints.accessCredentials,
+            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
+            endpoints.keys
+        ])
+    }
+
+    func testWhenServerDoesNotPersistAllCreatedAccountInfoWrappersThenThrows() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let accountPrimaryKey = Data((0..<32).map(UInt8.init))
+        let scopedPassword = Data((32..<64).map(UInt8.init))
+        let account = makeAccount(primaryKey: accountPrimaryKey)
+        let defaultCredentialMainKey = hkdf(input: accountPrimaryKey, salt: account.userId, info: "Main Key")
+        let encryptedCredential = try ScopedAccessCredentialEnvelope().encryptScopedPassword(scopedPassword,
+                                                                                             using: defaultCredentialMainKey,
+                                                                                             kid: SyncCredentialID.defaultCredential)
+        let accessCredentials = [
+            AccessCredential(id: SyncCredentialID.thirdParty,
+                             scope: "sync",
+                             encrypted3PartyCredential: encryptedCredential)
+        ]
+        let defaultWrapper = makeProtectedKey(kid: "created",
+                                              encryptedWith: SyncCredentialID.defaultCredential,
+                                              purpose: ProtectedKeyPurpose.accountInfo)
+        let thirdPartyWrapper = makeProtectedKey(kid: "created",
+                                                 encryptedWith: SyncCredentialID.thirdParty,
+                                                 purpose: ProtectedKeyPurpose.accountInfo)
+        accountInfoKeyFactory.makeProtectedKeysStub = [defaultWrapper, thirdPartyWrapper]
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: accountInfoKeyFactory)
+        api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
+            .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
+            .init(data: Data(try protectedKeysBody([defaultWrapper]).utf8), response: makeHTTPURLResponse(statusCode: 200))
+        ])
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 201)
+
+        do {
+            _ = try await manager.ensureAccountInfoProtectedKeys(for: account)
+            XCTFail("Expected an incomplete persisted wrapper set to be rejected")
+        } catch SyncError.invalidDataInResponse(let message) {
+            XCTAssertTrue(message.contains("missing a 3party wrapper"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
+            endpoints.keys,
+            endpoints.accessCredentials,
+            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
+            endpoints.keys
+        ])
     }
 
     func testWhenEnsuringAccountInfoProtectedKeysAndThirdPartyCredentialCannotBeRecoveredThenDoesNotCreateOrRegisterKeys() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
@@ -1003,6 +1003,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let crypter = CryptingMock()
         let accountPrimaryKey = Data((0..<32).map(UInt8.init))
         let scopedPassword = Data((32..<64).map(UInt8.init))
         let account = makeAccount(primaryKey: accountPrimaryKey)
@@ -1015,16 +1016,19 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                              scope: "sync",
                              encrypted3PartyCredential: encryptedCredential)
         ]
-        let defaultWrapper = makeProtectedKey(kid: "created",
-                                              encryptedWith: SyncCredentialID.defaultCredential,
-                                              purpose: ProtectedKeyPurpose.accountInfo)
-        let thirdPartyWrapper = makeProtectedKey(kid: "created",
+        let defaultWrapper = try makeNativeEncryptedProtectedKey(
+            privateKey: Data([0xFF] + Array("account-info-private-key".utf8)),
+            account: account,
+            crypter: crypter,
+            purpose: ProtectedKeyPurpose.accountInfo)
+        let thirdPartyWrapper = makeProtectedKey(kid: defaultWrapper.kid,
                                                  encryptedWith: SyncCredentialID.thirdParty,
-                                                 purpose: ProtectedKeyPurpose.accountInfo)
+                                                 purpose: ProtectedKeyPurpose.accountInfo,
+                                                 publicKey: defaultWrapper.publicKey)
         accountInfoKeyFactory.makeProtectedKeysStub = [defaultWrapper, thirdPartyWrapper]
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
-                                                    crypter: CryptingMock(),
+                                                    crypter: crypter,
                                                     accountInfoKeyFactory: accountInfoKeyFactory,
                                                     canWriteUnifiedDeviceList: { true })
         api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ThirdPartyAccountUpgradeCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ThirdPartyAccountUpgradeCoordinatorTests.swift
@@ -33,7 +33,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     private let extractedSecretKey = Data((160..<192).map(UInt8.init))
 
     func testWhenUpgradeSucceedsThenReturnsNativeAccountDevicesScopedPasswordAndRewrappedKeys() async throws {
-        let setup = try makeSUT()
+        let setup = try makeSUT(canWriteUnifiedDeviceList: { true })
 
         let result = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
             recoveryCode(),
@@ -68,8 +68,32 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
         XCTAssertEqual(keys.first?["encrypted_with"] as? String, SyncCredentialID.defaultCredential)
     }
 
+    func testWhenUpgradeRunsWithUnifiedDeviceListWriteDisabledThenDoesNotRewrapAccountInfoKey() async throws {
+        let protectedKeys = try [
+            thirdPartyProtectedKey(),
+            thirdPartyProtectedKey(kid: "account-info-key", purpose: ProtectedKeyPurpose.accountInfo)
+        ]
+        let setup = try makeSUT(protectedKeys: protectedKeys,
+                                canWriteUnifiedDeviceList: { false })
+
+        let result = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
+            recoveryCode(),
+            deviceName: "Mac",
+            deviceType: "desktop")
+
+        XCTAssertEqual(result.protectedKeys.map(\.kid), ["key-1"])
+        XCTAssertEqual(result.protectedKeys.map(\.purpose), ["ai_chats"])
+
+        let postBody = try body(for: setup.endpoints.accessCredential(SyncCredentialID.defaultCredential), in: setup.api)
+        let postPayload = try decodeJSONObject(postBody)
+        let keys = try XCTUnwrap(postPayload["keys"] as? [[String: Any]])
+        XCTAssertEqual(keys.count, 1)
+        XCTAssertEqual(keys.first?["kid"] as? String, "key-1")
+        XCTAssertNil(keys.first { $0["purpose"] as? String == ProtectedKeyPurpose.accountInfo })
+    }
+
     func testWhenUpgradeRunsThenTemporaryLoginUsesAIChatsScopeAndFinalNativeLoginUsesSyncScope() async throws {
-        let setup = try makeSUT()
+        let setup = try makeSUT(canWriteUnifiedDeviceList: { true })
 
         _ = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
             recoveryCode(),
@@ -88,7 +112,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenUpgradeSucceedsThenTemporaryThirdPartyDeviceIsLoggedOut() async throws {
-        let setup = try makeSUT()
+        let setup = try makeSUT(canWriteUnifiedDeviceList: { true })
 
         _ = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
             recoveryCode(),
@@ -104,7 +128,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenTemporaryThirdPartyDeviceLogoutFailsThenUpgradeStillReturnsNativeAccount() async throws {
-        let setup = try makeSUT()
+        let setup = try makeSUT(canWriteUnifiedDeviceList: { true })
         setup.account.logoutError = SyncError.unexpectedStatusCode(500)
 
         let result = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
@@ -118,7 +142,8 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
 
     func testWhenUpgradeAbortsAfterTemporaryLoginThenTemporaryThirdPartyDeviceIsLoggedOut() async throws {
         let accessCredentials = [AccessCredential(id: SyncCredentialID.defaultCredential, scope: "sync", encrypted3PartyCredential: nil)]
-        let setup = try makeSUT(accessCredentials: accessCredentials)
+        let setup = try makeSUT(accessCredentials: accessCredentials,
+                                canWriteUnifiedDeviceList: { true })
 
         do {
             _ = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
@@ -135,7 +160,8 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenFinalNativeLoginFailsTransientlyThenRetriesAndReturnsNativeAccount() async throws {
-        let setup = try makeSUT(finalNativeLoginRetryDelays: [0, 0])
+        let setup = try makeSUT(canWriteUnifiedDeviceList: { true },
+                                finalNativeLoginRetryDelays: [0, 0])
         setup.api.fakeRequests[setup.endpoints.login] = SequencedThrowingHTTPRequestingMock(results: [
             .success(.init(data: Data(thirdPartyLoginBody().utf8), response: makeHTTPURLResponse(statusCode: 200))),
             .failure(SyncError.unexpectedStatusCode(500)),
@@ -154,7 +180,8 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenFinalNativeLoginKeepsFailingThenRetriesAndLogsOutTemporaryThirdPartyDevice() async throws {
-        let setup = try makeSUT(finalNativeLoginRetryDelays: [0, 0])
+        let setup = try makeSUT(canWriteUnifiedDeviceList: { true },
+                                finalNativeLoginRetryDelays: [0, 0])
         setup.api.fakeRequests[setup.endpoints.login] = SequencedThrowingHTTPRequestingMock(results: [
             .success(.init(data: Data(thirdPartyLoginBody().utf8), response: makeHTTPURLResponse(statusCode: 200))),
             .failure(SyncError.unexpectedStatusCode(500)),
@@ -179,7 +206,8 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenFinalNativeLoginReturnsUnauthorizedThenDoesNotRetryAndLogsOutTemporaryThirdPartyDevice() async throws {
-        let setup = try makeSUT(finalNativeLoginRetryDelays: [0, 0])
+        let setup = try makeSUT(canWriteUnifiedDeviceList: { true },
+                                finalNativeLoginRetryDelays: [0, 0])
         setup.api.fakeRequests[setup.endpoints.login] = SequencedThrowingHTTPRequestingMock(results: [
             .success(.init(data: Data(thirdPartyLoginBody().utf8), response: makeHTTPURLResponse(statusCode: 200))),
             .failure(SyncError.unexpectedStatusCode(401))
@@ -203,7 +231,8 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
 
     func testWhenDDGCredentialAlreadyExistsThenUpgradeAborts() async throws {
         let accessCredentials = [AccessCredential(id: SyncCredentialID.defaultCredential, scope: "sync", encrypted3PartyCredential: nil)]
-        let setup = try makeSUT(accessCredentials: accessCredentials)
+        let setup = try makeSUT(accessCredentials: accessCredentials,
+                                canWriteUnifiedDeviceList: { true })
 
         do {
             _ = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
@@ -220,7 +249,8 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenNoUsableThirdPartyProtectedKeysExistThenUpgradeAborts() async throws {
-        let setup = try makeSUT(protectedKeys: [])
+        let setup = try makeSUT(protectedKeys: [],
+                                canWriteUnifiedDeviceList: { true })
 
         do {
             _ = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
@@ -237,7 +267,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenAccessCredentialsFetchFailsThenUpgradeAbortsWithTypedError() async throws {
-        let setup = try makeSUT()
+        let setup = try makeSUT(canWriteUnifiedDeviceList: { true })
         let request = HTTPRequestingMock()
         request.error = SyncError.unexpectedStatusCode(500)
         setup.api.fakeRequests[setup.endpoints.accessCredentials] = request
@@ -255,7 +285,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenProtectedKeysFetchFailsThenUpgradeAbortsWithTypedError() async throws {
-        let setup = try makeSUT()
+        let setup = try makeSUT(canWriteUnifiedDeviceList: { true })
         let request = HTTPRequestingMock()
         request.error = SyncError.unexpectedStatusCode(500)
         setup.api.fakeRequests[setup.endpoints.keys] = request
@@ -278,7 +308,8 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
                                                publicKey: .mock,
                                                encryptedWith: SyncCode.RecoveryKeyV2.thirdPartyCredentialId,
                                                purpose: "ai_chats")
-        let setup = try makeSUT(protectedKeys: [invalidProtectedKey])
+        let setup = try makeSUT(protectedKeys: [invalidProtectedKey],
+                                canWriteUnifiedDeviceList: { true })
 
         do {
             _ = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
@@ -293,7 +324,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenNativeCredentialCreationReturnsUnexpectedStatusThenUpgradeAbortsWithTypedError() async throws {
-        let setup = try makeSUT()
+        let setup = try makeSUT(canWriteUnifiedDeviceList: { true })
         setup.api.fakeRequests[setup.endpoints.accessCredential(SyncCredentialID.defaultCredential)] = makeRequest(statusCode: 500)
 
         do {
@@ -311,6 +342,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
 
     private func makeSUT(accessCredentials: [AccessCredential] = [],
                          protectedKeys: [ProtectedKey]? = nil,
+                         canWriteUnifiedDeviceList: @escaping () -> Bool,
                          finalNativeLoginRetryDelays: [UInt64] = []) throws -> (coordinator: ThirdPartyAccountUpgradeCoordinator,
                                                                                  api: RemoteAPIRequestCreatingMock,
                                                                                  account: AccountManagingMock,
@@ -343,12 +375,14 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: crypter,
-                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock())
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    canWriteUnifiedDeviceList: { true })
         let coordinator = ThirdPartyAccountUpgradeCoordinator(endpoints: endpoints,
                                                               api: api,
                                                               crypter: crypter,
                                                               scopedAccess: manager,
                                                               account: account,
+                                                              canWriteUnifiedDeviceList: canWriteUnifiedDeviceList,
                                                               finalNativeLoginRetryDelays: finalNativeLoginRetryDelays)
         let keys = try protectedKeys ?? [thirdPartyProtectedKey()]
 
@@ -371,16 +405,17 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
         return Base64URL.encode(try SyncCode(recovery: .v2(payload)).toJSON())
     }
 
-    private func thirdPartyProtectedKey() throws -> ProtectedKey {
+    private func thirdPartyProtectedKey(kid: String = "key-1",
+                                        purpose: String = "ai_chats") throws -> ProtectedKey {
         let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: userId)
         let encryptedPrivateKey = try JWECompactCodec().encryptDirect(payload: Data("private-key".utf8),
                                                                       contentEncryptionKey: thirdPartyMainKey,
                                                                       kid: SyncCode.RecoveryKeyV2.thirdPartyCredentialId)
-        return ProtectedKey(kid: "key-1",
+        return ProtectedKey(kid: kid,
                             encryptedPrivateKey: encryptedPrivateKey,
                             publicKey: .mock,
                             encryptedWith: SyncCode.RecoveryKeyV2.thirdPartyCredentialId,
-                            purpose: "ai_chats")
+                            purpose: purpose)
     }
 
     private func thirdPartyLoginBody() -> String {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ThirdPartyAccountUpgradeCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ThirdPartyAccountUpgradeCoordinatorTests.swift
@@ -33,7 +33,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     private let extractedSecretKey = Data((160..<192).map(UInt8.init))
 
     func testWhenUpgradeSucceedsThenReturnsNativeAccountDevicesScopedPasswordAndRewrappedKeys() async throws {
-        let setup = try makeSUT(canWriteUnifiedDeviceList: { true })
+        let setup = try makeSUT()
 
         let result = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
             recoveryCode(),
@@ -68,32 +68,35 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
         XCTAssertEqual(keys.first?["encrypted_with"] as? String, SyncCredentialID.defaultCredential)
     }
 
-    func testWhenUpgradeRunsWithUnifiedDeviceListWriteDisabledThenDoesNotRewrapAccountInfoKey() async throws {
-        let protectedKeys = try [
-            thirdPartyProtectedKey(),
-            thirdPartyProtectedKey(kid: "account-info-key", purpose: ProtectedKeyPurpose.accountInfo)
-        ]
-        let setup = try makeSUT(protectedKeys: protectedKeys,
-                                canWriteUnifiedDeviceList: { false })
+    func testWhenUpgradeRunsThenRewrapsAccountInfoKeyForDefaultCredential() async throws {
+        let accountInfoKey = try thirdPartyProtectedKey(kid: "account-info-key",
+                                                        purpose: ProtectedKeyPurpose.accountInfo)
+        let setup = try makeSUT(protectedKeys: [try thirdPartyProtectedKey(), accountInfoKey])
 
         let result = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
             recoveryCode(),
             deviceName: "Mac",
             deviceType: "desktop")
 
-        XCTAssertEqual(result.protectedKeys.map(\.kid), ["key-1"])
-        XCTAssertEqual(result.protectedKeys.map(\.purpose), ["ai_chats"])
+        let rewrappedAccountInfoKey = try XCTUnwrap(result.protectedKeys.first {
+            $0.purpose == ProtectedKeyPurpose.accountInfo
+        })
+        XCTAssertEqual(rewrappedAccountInfoKey.kid, accountInfoKey.kid)
+        XCTAssertEqual(rewrappedAccountInfoKey.publicKey, accountInfoKey.publicKey)
+        XCTAssertEqual(rewrappedAccountInfoKey.encryptedWith, SyncCredentialID.defaultCredential)
 
         let postBody = try body(for: setup.endpoints.accessCredential(SyncCredentialID.defaultCredential), in: setup.api)
         let postPayload = try decodeJSONObject(postBody)
         let keys = try XCTUnwrap(postPayload["keys"] as? [[String: Any]])
-        XCTAssertEqual(keys.count, 1)
-        XCTAssertEqual(keys.first?["kid"] as? String, "key-1")
-        XCTAssertNil(keys.first { $0["purpose"] as? String == ProtectedKeyPurpose.accountInfo })
+        let accountInfoPayload = try XCTUnwrap(keys.first {
+            $0["purpose"] as? String == ProtectedKeyPurpose.accountInfo
+        })
+        XCTAssertEqual(accountInfoPayload["kid"] as? String, accountInfoKey.kid)
+        XCTAssertEqual(accountInfoPayload["encrypted_with"] as? String, SyncCredentialID.defaultCredential)
     }
 
     func testWhenUpgradeRunsThenTemporaryLoginUsesAIChatsScopeAndFinalNativeLoginUsesSyncScope() async throws {
-        let setup = try makeSUT(canWriteUnifiedDeviceList: { true })
+        let setup = try makeSUT()
 
         _ = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
             recoveryCode(),
@@ -112,7 +115,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenUpgradeSucceedsThenTemporaryThirdPartyDeviceIsLoggedOut() async throws {
-        let setup = try makeSUT(canWriteUnifiedDeviceList: { true })
+        let setup = try makeSUT()
 
         _ = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
             recoveryCode(),
@@ -128,7 +131,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenTemporaryThirdPartyDeviceLogoutFailsThenUpgradeStillReturnsNativeAccount() async throws {
-        let setup = try makeSUT(canWriteUnifiedDeviceList: { true })
+        let setup = try makeSUT()
         setup.account.logoutError = SyncError.unexpectedStatusCode(500)
 
         let result = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
@@ -142,8 +145,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
 
     func testWhenUpgradeAbortsAfterTemporaryLoginThenTemporaryThirdPartyDeviceIsLoggedOut() async throws {
         let accessCredentials = [AccessCredential(id: SyncCredentialID.defaultCredential, scope: "sync", encrypted3PartyCredential: nil)]
-        let setup = try makeSUT(accessCredentials: accessCredentials,
-                                canWriteUnifiedDeviceList: { true })
+        let setup = try makeSUT(accessCredentials: accessCredentials)
 
         do {
             _ = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
@@ -160,8 +162,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenFinalNativeLoginFailsTransientlyThenRetriesAndReturnsNativeAccount() async throws {
-        let setup = try makeSUT(canWriteUnifiedDeviceList: { true },
-                                finalNativeLoginRetryDelays: [0, 0])
+        let setup = try makeSUT(finalNativeLoginRetryDelays: [0, 0])
         setup.api.fakeRequests[setup.endpoints.login] = SequencedThrowingHTTPRequestingMock(results: [
             .success(.init(data: Data(thirdPartyLoginBody().utf8), response: makeHTTPURLResponse(statusCode: 200))),
             .failure(SyncError.unexpectedStatusCode(500)),
@@ -180,8 +181,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenFinalNativeLoginKeepsFailingThenRetriesAndLogsOutTemporaryThirdPartyDevice() async throws {
-        let setup = try makeSUT(canWriteUnifiedDeviceList: { true },
-                                finalNativeLoginRetryDelays: [0, 0])
+        let setup = try makeSUT(finalNativeLoginRetryDelays: [0, 0])
         setup.api.fakeRequests[setup.endpoints.login] = SequencedThrowingHTTPRequestingMock(results: [
             .success(.init(data: Data(thirdPartyLoginBody().utf8), response: makeHTTPURLResponse(statusCode: 200))),
             .failure(SyncError.unexpectedStatusCode(500)),
@@ -206,8 +206,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenFinalNativeLoginReturnsUnauthorizedThenDoesNotRetryAndLogsOutTemporaryThirdPartyDevice() async throws {
-        let setup = try makeSUT(canWriteUnifiedDeviceList: { true },
-                                finalNativeLoginRetryDelays: [0, 0])
+        let setup = try makeSUT(finalNativeLoginRetryDelays: [0, 0])
         setup.api.fakeRequests[setup.endpoints.login] = SequencedThrowingHTTPRequestingMock(results: [
             .success(.init(data: Data(thirdPartyLoginBody().utf8), response: makeHTTPURLResponse(statusCode: 200))),
             .failure(SyncError.unexpectedStatusCode(401))
@@ -231,8 +230,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
 
     func testWhenDDGCredentialAlreadyExistsThenUpgradeAborts() async throws {
         let accessCredentials = [AccessCredential(id: SyncCredentialID.defaultCredential, scope: "sync", encrypted3PartyCredential: nil)]
-        let setup = try makeSUT(accessCredentials: accessCredentials,
-                                canWriteUnifiedDeviceList: { true })
+        let setup = try makeSUT(accessCredentials: accessCredentials)
 
         do {
             _ = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
@@ -249,8 +247,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenNoUsableThirdPartyProtectedKeysExistThenUpgradeAborts() async throws {
-        let setup = try makeSUT(protectedKeys: [],
-                                canWriteUnifiedDeviceList: { true })
+        let setup = try makeSUT(protectedKeys: [])
 
         do {
             _ = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
@@ -267,7 +264,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenAccessCredentialsFetchFailsThenUpgradeAbortsWithTypedError() async throws {
-        let setup = try makeSUT(canWriteUnifiedDeviceList: { true })
+        let setup = try makeSUT()
         let request = HTTPRequestingMock()
         request.error = SyncError.unexpectedStatusCode(500)
         setup.api.fakeRequests[setup.endpoints.accessCredentials] = request
@@ -285,7 +282,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenProtectedKeysFetchFailsThenUpgradeAbortsWithTypedError() async throws {
-        let setup = try makeSUT(canWriteUnifiedDeviceList: { true })
+        let setup = try makeSUT()
         let request = HTTPRequestingMock()
         request.error = SyncError.unexpectedStatusCode(500)
         setup.api.fakeRequests[setup.endpoints.keys] = request
@@ -308,8 +305,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
                                                publicKey: .mock,
                                                encryptedWith: SyncCode.RecoveryKeyV2.thirdPartyCredentialId,
                                                purpose: "ai_chats")
-        let setup = try makeSUT(protectedKeys: [invalidProtectedKey],
-                                canWriteUnifiedDeviceList: { true })
+        let setup = try makeSUT(protectedKeys: [invalidProtectedKey])
 
         do {
             _ = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
@@ -324,7 +320,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
     }
 
     func testWhenNativeCredentialCreationReturnsUnexpectedStatusThenUpgradeAbortsWithTypedError() async throws {
-        let setup = try makeSUT(canWriteUnifiedDeviceList: { true })
+        let setup = try makeSUT()
         setup.api.fakeRequests[setup.endpoints.accessCredential(SyncCredentialID.defaultCredential)] = makeRequest(statusCode: 500)
 
         do {
@@ -342,7 +338,6 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
 
     private func makeSUT(accessCredentials: [AccessCredential] = [],
                          protectedKeys: [ProtectedKey]? = nil,
-                         canWriteUnifiedDeviceList: @escaping () -> Bool,
                          finalNativeLoginRetryDelays: [UInt64] = []) throws -> (coordinator: ThirdPartyAccountUpgradeCoordinator,
                                                                                  api: RemoteAPIRequestCreatingMock,
                                                                                  account: AccountManagingMock,
@@ -382,7 +377,6 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
                                                               crypter: crypter,
                                                               scopedAccess: manager,
                                                               account: account,
-                                                              canWriteUnifiedDeviceList: canWriteUnifiedDeviceList,
                                                               finalNativeLoginRetryDelays: finalNativeLoginRetryDelays)
         let keys = try protectedKeys ?? [thirdPartyProtectedKey()]
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1217213092722101?focus=true
Tech Design URL:
CC:

### Description
Keeps protected Sync keys usable when an account gains or recovers a native or third-party credential. Missing wrappers are added without replacing the underlying key, and a newly added credential receives wrappers for all protected keys that already exist.

The feature-flag behavior is:

- With unified-device writes enabled, a missing `account_info` key is created and missing wrappers are repaired.
- With unified-device writes disabled, that automatic setup does not run.
- In either state, adding or upgrading a credential wraps existing protected keys for that credential so it can access the account’s encrypted data (matching agreed cross-platform behaviour)

### Testing Steps
Prerequisite: Test on iOS because it has the debug actions; the underlying Sync functionality is shared with macOS.

1. Ensure feature flag `syncCanWriteUnifiedDeviceList` is enabled & enable Sync
2. Open **Debug > Sync** and tap **Ensure account_info key** → **Account Info Key Ensured** reports one wrapper for a native-only account
3. Pair the account with a Duck.ai/third-party client using **Sync with Another Device** → pairing completes without an account-extension error
4. Return to **Debug > Sync** and tap **Ensure account_info key** → the alert reports two wrappers
5. Tap **Validate account_info key** → **Account Info Key Validated** reports a 3072-bit key and `Cache-first reload: succeeded`

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cryptographic key wrapping, credential creation, and secure-store caching for Sync account_info and third-party access; mistakes could break pairing or leave keys inconsistent across devices.
> 
> **Overview**
> Keeps Sync **protected keys** consistent when accounts gain or recover native (`ddg`) vs third-party (`3party`) credentials, so pairing and credential extension do not drop wrappers or leave `account_info` unusable.
> 
> **Caching:** Persisting protected keys now **merges incoming snapshots with the secure-store cache** (`preservingCachedWrappersForMatchingKeys`), matching keys by `kid`, purpose, and RSA material so a partial or out-of-order server response cannot erase a wrapper that was just added locally. The same merge runs in `DDGSync` and `AccountInfoKeyManager`.
> 
> **Scoped access / credentials:** `ScopedAccessCredentialManager` takes a **`canWriteUnifiedDeviceList`** gate. With writes enabled, `ensureAccountInfoProtectedKeys` **creates** missing `account_info` keys and **repairs** incomplete wrapper sets (missing `ddg` or `3party`) via unwrap/rewrap and `setKeysIfAbsent`, with validation that all wrappers describe the same key. Creating a third-party credential now **rewraps every existing default-credential protected key** (including `account_info`) for upload; recovery paths reconcile server state and return fuller `protectedKeysToCache`. With the flag off, automatic `account_info` setup/repair is skipped, but credential creation still wraps existing keys for access.
> 
> **Tests** cover cache preservation, repair flows, flag behavior, and third-party upgrade rewrapping `account_info`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe3ee1da59f73f26f2119073564687f314b9e930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->