### PR TITLE
[macOS] Fire Dialog: Improve time formatting for history overlay

### DIFF
--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -95,8 +95,6 @@ struct FireDialogView: ModalView {
     }
     @State private var isAnimatingHistoryOverlay: Bool = false
 
-    private let historyDateFormatter: HistoryViewDateFormatting = DefaultHistoryViewDateFormatter()
-
     private var isShowingAnyOverlay: Bool {
         isShowingSitesOverlay || isShowingChatsOverlay || isShowingHistoryOverlay
     }
@@ -796,7 +794,7 @@ struct FireDialogView: ModalView {
             .frame(maxWidth: .infinity, alignment: .leading)
             .help(visitViewModel.title)
 
-            Text(historyDateFormatter.timeString(for: visit.date))
+            Text(viewModel.historyDateFormatter.shortString(for: visit.date))
                 .font(.system(size: 11))
                 .foregroundColor(Color(designSystemColor: .textTertiary))
                 .fixedSize()

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -164,6 +164,7 @@ final class FireDialogViewModel: ObservableObject {
          tld: TLD,
          windowControllersManager: WindowControllersManagerProtocol,
          dataClearingPreferences: DataClearingPreferences,
+         historyDateFormatter: HistoryViewDateFormatting = DefaultHistoryViewDateFormatter(),
          pixelFiring: PixelFiring?) {
 
         self.fireViewModel = fireViewModel
@@ -175,6 +176,7 @@ final class FireDialogViewModel: ObservableObject {
         self.aiChatHistoryCleaner = aiChatHistoryCleaner
         self.windowControllersManager = windowControllersManager
         self.dataClearingPreferences = dataClearingPreferences
+        self.historyDateFormatter = historyDateFormatter
         self.pixelFiring = pixelFiring
 
         self.tld = tld
@@ -232,6 +234,7 @@ final class FireDialogViewModel: ObservableObject {
     let pixelFiring: PixelFiring?
     let tld: TLD
     let mode: Mode
+    let historyDateFormatter: HistoryViewDateFormatting
     private let scopeVisits: [Visit]?
 
     private(set) var hasOnlySingleFireproofDomain: Bool = false

--- a/macOS/DuckDuckGo/History/View/HistoryViewDateFormatter.swift
+++ b/macOS/DuckDuckGo/History/View/HistoryViewDateFormatter.swift
@@ -44,7 +44,6 @@ protocol HistoryViewDateFormatting {
      *
      * Rules:
      *   - when date is "today" -> display only the time
-     *   - when date is "yesterday" -> display "Yesterday" (localized).
      *   - when date is older -> display month and day, without time.
      */
     func shortString(for date: Date) -> String

--- a/macOS/DuckDuckGo/History/View/HistoryViewDateFormatter.swift
+++ b/macOS/DuckDuckGo/History/View/HistoryViewDateFormatter.swift
@@ -38,6 +38,16 @@ protocol HistoryViewDateFormatting {
      * Returns string representation of time for a given `date`.
      */
     func timeString(for date: Date) -> String
+
+    /**
+     * Returns a textual representation of a given `date` suitable for use in compact views.
+     *
+     * Rules:
+     *   - when date is "today" -> display only the time
+     *   - when date is "yesterday" -> display "Yesterday" (localized).
+     *   - when date is older -> display month and day, without time.
+     */
+    func shortString(for date: Date) -> String
 }
 
 struct DefaultHistoryViewDateFormatter: HistoryViewDateFormatting {
@@ -45,6 +55,13 @@ struct DefaultHistoryViewDateFormatter: HistoryViewDateFormatting {
         let formatter = DateFormatter()
         formatter.dateStyle = .full
         formatter.timeStyle = .none
+        formatter.formattingContext = .beginningOfSentence
+        return formatter
+    }()
+
+    let shortDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMMd")
         formatter.formattingContext = .beginningOfSentence
         return formatter
     }()
@@ -74,5 +91,10 @@ struct DefaultHistoryViewDateFormatter: HistoryViewDateFormatting {
 
     func timeString(for date: Date) -> String {
         timeFormatter.string(from: date)
+    }
+
+    func shortString(for date: Date) -> String {
+        let isSameDay = currentDate().isSameDay(date)
+        return isSameDay ? timeString(for: date) : shortDateFormatter.string(from: date)
     }
 }

--- a/macOS/UnitTests/History/Services/HistoryViewDataProviderTests.swift
+++ b/macOS/UnitTests/History/Services/HistoryViewDataProviderTests.swift
@@ -1197,6 +1197,10 @@ final class MockHistoryViewDateFormatter: HistoryViewDateFormatting {
         "10:08"
     }
 
+    func shortString(for date: Date) -> String {
+        "Jun 2"
+    }
+
     var date: Date = Date()
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1216831005511465?focus=true

### Description
Use HH:mm format for visits from current day, and month + day for older dates.

### Testing Steps
1. Enable `fireDialogSimplified` feature flag and close and re-open a window.
2. Debug -> History -> Add 10 history visits each day.
3. Open Fire Dialog, set mode to All Data and click History visits count label.
4. Verify that visit dates for older days are formatted correctly (month + day).

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting in the Fire dialog history overlay; no data clearing or auth changes.
> 
> **Overview**
> The Fire dialog **history overlay** now shows visit timestamps in a **compact format**: **time only** for today’s visits, and **month + day** (no time) for older entries.
> 
> This is implemented by adding **`shortString(for:)`** to `HistoryViewDateFormatting` / `DefaultHistoryViewDateFormatter`, and routing the overlay through **`FireDialogViewModel.historyDateFormatter`** instead of a local formatter in `FireDialogView`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d63bd7ca15a62fcc78074bf0d2ec4483c77c3c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->