### PR TITLE
macOS: Fixes Close Button Layout Glitch

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -959,7 +959,7 @@ final class TabBarViewItem: NSCollectionViewItem {
     }
 
     private func refreshLayoutIfNeeded(isSelected: Bool, wasSelected: Bool) {
-        guard isSelected, isSelected != wasSelected else {
+        guard isSelected != wasSelected else {
             return
         }
 

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -707,6 +707,11 @@ final class TabBarViewItem: NSCollectionViewItem {
                 view.layer?.shadowOpacity = 0
             }
 
+            /// Fix: Ensure the Close button layout is re-evaluated whenever the Item gets selected
+            if isSelected, isSelected != oldValue {
+                view.needsLayout = true
+            }
+
             updateSubviews()
 
             cell.refreshStateIfNeeded(isSelected: isSelected, isDragged: isDragged, isMouseOver: isMouseOver)

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -707,11 +707,7 @@ final class TabBarViewItem: NSCollectionViewItem {
                 view.layer?.shadowOpacity = 0
             }
 
-            /// Fix: Ensure the Close button layout is re-evaluated whenever the Item gets selected
-            if isSelected, isSelected != oldValue {
-                view.needsLayout = true
-            }
-
+            refreshLayoutIfNeeded(isSelected: isSelected, wasSelected: oldValue)
             updateSubviews()
 
             cell.refreshStateIfNeeded(isSelected: isSelected, isDragged: isDragged, isMouseOver: isMouseOver)
@@ -960,6 +956,15 @@ final class TabBarViewItem: NSCollectionViewItem {
         let tintColor: NSColor? = isBurnerTab ? .textColor : nil
 
         cell.faviconView.imageTintColor = tintColor
+    }
+
+    private func refreshLayoutIfNeeded(isSelected: Bool, wasSelected: Bool) {
+        guard isSelected, isSelected != wasSelected else {
+            return
+        }
+
+        /// Fix: Ensure the Close button layout is re-evaluated whenever the `TabBarViewItem` is selected
+        view.needsLayout = true
     }
 
     private var usedPermissions = Permissions() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/inbox/1211150618028591/item/1217349194572041/story/1217349361944280?focus=true
Tech Design URL:
CC:

### Description
This PR fixes a visual glitch that causes the Tab's `x` button to end up misplaced.

### Testing Steps
1. Open a new Fire Window
2. On the first tab, visit a website with a long title - https://www.ycombinator.com/about
3. Open a bunch of new tabs using keyboard shortcut
4. Close all new tabs using keyboard shortcut until the first tab is selected

- [ ] Verify the Close Button is properly placed

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
This PR itself shouldn't cause issues, as we're guarding against re-entrancy.

### Quality Considerations
Nothing in particular

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change gated on selection transitions; no auth, data, or behavioral logic beyond triggering layout.
> 
> **Overview**
> Fixes a **tab close (×) button misplacement** when selection moves via keyboard shortcuts (e.g. closing many tabs in a Fire window until the original tab is selected again).
> 
> When `isSelected` changes, the item now calls **`refreshLayoutIfNeeded`**, which sets **`view.needsLayout = true`** only if the selection state actually changed. That forces another layout pass so **`TabBarItemCellView`** can re-run close-button positioning (driven by **`widthStage`**, which switches to **`.full`** for the selected tab).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa580f20578a7b54005a5b2f82662b8825288a8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->