### PR TITLE
[Test] Danger: unchanged snapshot pointer

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -22,4 +22,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npx --yes -p danger@13.0.4 -p typescript@6 -- \
-            danger ci --dangerfile duckduckgo/danger-settings/org/allPRs.ts@main
+            danger ci --dangerfile duckduckgo/danger-settings/org/allPRs.ts@pau/snapshots-ci-check


### PR DESCRIPTION
### Description
Test PR for the new snapshot-submodule Danger check (dangerfile pinned to `duckduckgo/danger-settings@pau/snapshots-ci-check`). This branch only points `danger.yml` at the test dangerfile and leaves the `SnapshotReferences` submodule pointer **unchanged**.

**Expected Danger outcome:** no-op / pass — there is no snapshot gitlink change to validate.

⚠️ Test PR — do not merge.

### Impact
None (CI tooling only).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only tooling change on a labeled test branch; no product code, secrets, or data handling.
> 
> **Overview**
> **Test PR — do not merge.**
> 
> The shared Danger workflow now loads `allPRs.ts` from `duckduckgo/danger-settings` at branch **`pau/snapshots-ci-check`** instead of **`main`**, so CI can exercise the new snapshot-submodule check without changing production Danger rules yet.
> 
> The **`SnapshotReferences`** submodule pointer is intentionally **unchanged** on this branch. Expected CI behavior is a **pass** (no gitlink change for Danger to validate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1de3b66f4b24ac8b24e652a9a751101a8b3dfede. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->