### PR TITLE
[Test] Danger: snapshot commit merged on submodule main

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -22,4 +22,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npx --yes -p danger@13.0.4 -p typescript@6 -- \
-            danger ci --dangerfile duckduckgo/danger-settings/org/allPRs.ts@main
+            danger ci --dangerfile duckduckgo/danger-settings/org/allPRs.ts@pau/snapshots-ci-check


### PR DESCRIPTION
### Description
Test PR for the new snapshot-submodule Danger check (dangerfile pinned to `duckduckgo/danger-settings@pau/snapshots-ci-check`). Moves the `SnapshotReferences` gitlink to a commit that is already **merged into the submodule's default branch** (contained/reachable).

**Expected Danger outcome:** pass — the referenced snapshot commit is reachable from the submodule's default branch.

⚠️ Test PR — do not merge.

### Impact
None (CI tooling only).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change on a labeled test branch; no runtime or security impact if not merged.
> 
> **Overview**
> **Test PR — do not merge.** Temporarily pins the shared Danger workflow to `duckduckgo/danger-settings@pau/snapshots-ci-check` instead of `@main`, so CI runs the in-development **snapshot submodule** rule (verifying `SnapshotReferences` gitlink commits are reachable from the submodule default branch).
> 
> No app or product code changes; only `.github/workflows/danger.yml` is touched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd8d96eef3882d3ee99b76a7a65a8b8d4b75c802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->