### PR TITLE
[Test] Danger: unmerged snapshot commit

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -22,4 +22,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npx --yes -p danger@13.0.4 -p typescript@6 -- \
-            danger ci --dangerfile duckduckgo/danger-settings/org/allPRs.ts@main
+            danger ci --dangerfile duckduckgo/danger-settings/org/allPRs.ts@pau/snapshots-ci-check


### PR DESCRIPTION
### Description
Test PR for the new snapshot-submodule Danger check (dangerfile pinned to `duckduckgo/danger-settings@pau/snapshots-ci-check`). Moves the `SnapshotReferences` gitlink to a commit that **exists in the submodule repo but is not merged into its default branch**.

**Expected Danger outcome:** warn/fail — the snapshot commit exists but is not yet merged.

⚠️ Test PR — do not merge.

### Impact
None (CI tooling only).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes which remote Dangerfile branch CI uses; no app, auth, or data-path changes. Intended as a temporary test PR.
> 
> **Overview**
> **CI-only test change:** the Danger workflow now loads `duckduckgo/danger-settings/org/allPRs.ts` from branch **`pau/snapshots-ci-check`** instead of **`main`**.
> 
> This exercises the in-progress **snapshot submodule** Danger rules (e.g. warnings when the `SnapshotReferences` gitlink points to a commit not merged on the submodule default branch). **Do not merge** — revert the pin to `@main` after validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a202ea46fd856ba00cfbf8a99ad1e01a89f7a4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->