### PR TITLE
[Test] Danger: newly created snapshot gitlink

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -22,4 +22,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npx --yes -p danger@13.0.4 -p typescript@6 -- \
-            danger ci --dangerfile duckduckgo/danger-settings/org/allPRs.ts@main
+            danger ci --dangerfile duckduckgo/danger-settings/org/allPRs.ts@pau/snapshots-ci-check


### PR DESCRIPTION
### Description
Test PR for the new snapshot-submodule Danger check (dangerfile pinned to `duckduckgo/danger-settings@pau/snapshots-ci-check`). Adds a **newly created gitlink** (`SnapshotReferences-E2E`) rather than modifying an existing one.

**Expected Danger outcome:** the check handles a freshly added snapshot submodule gitlink (not just modifications).

⚠️ Test PR — do not merge.

### Impact
None (CI tooling only).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only pin to a non-main Danger branch; revert before merge per test PR intent.
> 
> **Overview**
> **CI-only test change:** the shared Danger workflow now loads `duckduckgo/danger-settings/org/allPRs.ts` from branch **`pau/snapshots-ci-check`** instead of **`main`**, so PR Danger runs can exercise the new snapshot-submodule gitlink check described in the PR (e.g. newly added `SnapshotReferences-E2E`).
> 
> No app or library code changes appear in this diff—only `.github/workflows/danger.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f7175cb14fb74532d96ba937131eb1841c74f0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->