### PR TITLE
[iOS] fix button highlighting

### DIFF
--- a/iOS/DuckDuckGo/BrowserChromeButton.swift
+++ b/iOS/DuckDuckGo/BrowserChromeButton.swift
@@ -239,7 +239,9 @@ private extension UIButton.Configuration {
 
 extension BrowserChromeButton {
 
-    static func createToolbarButton(title: String, image: UIImage?, fixedWidth: CGFloat? = 34, action: (() -> Void)? = nil) -> BrowserChromeButton {
+    static let toolbarButtonSize: CGFloat = 44
+
+    static func createToolbarButton(title: String, image: UIImage?, fixedWidth: CGFloat? = toolbarButtonSize, action: (() -> Void)? = nil) -> BrowserChromeButton {
         let button = BrowserChromeButton(.toolbar)
         if let image {
             button.setImage(image)
@@ -256,7 +258,7 @@ extension BrowserChromeButton {
 
         button.accessibilityLabel = title
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        button.heightAnchor.constraint(equalToConstant: toolbarButtonSize).isActive = true
         // Icon buttons use a fixed width; text buttons pass nil and size to their title (see applyTextConstraints).
         if let fixedWidth {
             button.widthAnchor.constraint(equalToConstant: fixedWidth).isActive = true
@@ -265,7 +267,7 @@ extension BrowserChromeButton {
         return button
     }
 
-    static func createToolbarButtonItem(title: String, image: UIImage?, fixedWidth: CGFloat? = 34, action: (() -> Void)? = nil) -> UIBarButtonItem {
+    static func createToolbarButtonItem(title: String, image: UIImage?, fixedWidth: CGFloat? = toolbarButtonSize, action: (() -> Void)? = nil) -> UIBarButtonItem {
         let button = createToolbarButton(title: title, image: image, fixedWidth: fixedWidth, action: action)
 
         let barItem = UIBarButtonItem(customView: button)

--- a/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
+++ b/iOS/DuckDuckGo/TabSwitcherBarsStateHandler.swift
@@ -360,12 +360,12 @@ class DefaultTabSwitcherBarsStateHandler: TabSwitcherBarsStateHandling {
         button.alpha = 0
         button.isUserInteractionEnabled = false
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.frame = CGRect(x: 0, y: 0, width: 34, height: 44)
+        button.frame = CGRect(x: 0, y: 0, width: BrowserChromeButton.toolbarButtonSize, height: BrowserChromeButton.toolbarButtonSize)
         // Match the real toolbar buttons' fixed size so the equal-spacing stack (used when the
         // bottom bar is a BrowserToolbarView) distributes this placeholder identically.
         NSLayoutConstraint.activate([
-            button.widthAnchor.constraint(equalToConstant: 34),
-            button.heightAnchor.constraint(equalToConstant: 44),
+            button.widthAnchor.constraint(equalToConstant: BrowserChromeButton.toolbarButtonSize),
+            button.heightAnchor.constraint(equalToConstant: BrowserChromeButton.toolbarButtonSize),
         ])
 
         let barItem = UIBarButtonItem(customView: button)

--- a/iOS/DuckDuckGo/ToolbarStateHandling.swift
+++ b/iOS/DuckDuckGo/ToolbarStateHandling.swift
@@ -99,6 +99,11 @@ final class ToolbarHandler: ToolbarStateHandling {
     // MARK: - Public Methods
 
     func setTabSwitcherView(_ view: UIView) {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            view.widthAnchor.constraint(equalToConstant: BrowserChromeButton.toolbarButtonSize),
+            view.heightAnchor.constraint(equalToConstant: BrowserChromeButton.toolbarButtonSize),
+        ])
         tabSwitcherView = view
         if let state {
             applyToolbarLayout(for: state)

--- a/iOS/DuckDuckGoTests/Toolbar/ToolbarHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/Toolbar/ToolbarHandlerTests.swift
@@ -82,6 +82,28 @@ class ToolbarHandlerTests: XCTestCase {
         XCTAssertEqual(mockToolbar.arrangedToolbarButtonViews, initialItems)
     }
 
+    func testToolbarButtonsHaveSquareTouchTargets() {
+        toolbarHandler.updateToolbarWithState(.pageLoaded(currentTab: mockNavigatable))
+
+        for button in mockToolbar.arrangedToolbarButtonViews {
+            XCTAssertTrue(button.constraints.contains { $0.firstAttribute == .width && $0.constant == BrowserChromeButton.toolbarButtonSize })
+            XCTAssertTrue(button.constraints.contains { $0.firstAttribute == .height && $0.constant == BrowserChromeButton.toolbarButtonSize })
+        }
+    }
+
+    func testReplacementTabSwitcherHasSquareTouchTarget() {
+        let tabSwitcherButton = TabSwitcherStaticButton(showMenuOnLongPress: false)
+
+        toolbarHandler.setTabSwitcherView(tabSwitcherButton)
+
+        XCTAssertTrue(tabSwitcherButton.constraints.contains {
+            $0.firstAttribute == .width && $0.constant == BrowserChromeButton.toolbarButtonSize
+        })
+        XCTAssertTrue(tabSwitcherButton.constraints.contains {
+            $0.firstAttribute == .height && $0.constant == BrowserChromeButton.toolbarButtonSize
+        })
+    }
+
     func testBackButtonEnabledState() {
         mockNavigatable = MockNavigatable(canGoBack: true, canGoForward: false)
         toolbarHandler.updateToolbarWithState(.pageLoaded(currentTab: mockNavigatable))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1217295905076304?focus=true
Tech Design URL:
CC:

### Description
Makes tab bar buttons square so their touch targets and pressed highlights are consistent. Applies to both the standard and floating tab bars.

### Testing Steps
1. Open the browser with the standard tab bar and press each button → every highlight is square and consistently sized.
2. Enable the floating tab bar and press each button → every highlight remains square and consistently sized.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Could break the toolbar -> limited changes

### Quality Considerations
The shared sizing applies to both standard and floating tab bar layouts. Automated coverage verifies regular buttons and the tab switcher use matching square touch targets.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and touch-target sizing with no auth, data, or networking changes; minor visual risk if toolbar spacing looks tighter on some devices.
> 
> **Overview**
> Toolbar chrome buttons now use a shared **44×44** size (`BrowserChromeButton.toolbarButtonSize`) instead of **34×44** for icon buttons, so press highlights and hit areas are square and consistent on standard and floating tab bars.
> 
> `createToolbarButton` / `createToolbarButtonItem` default width and height constraints use that constant. The tab switcher invisible balancing placeholder in `TabSwitcherBarsStateHandler` matches the same dimensions. When a custom tab switcher view is injected via `setTabSwitcherView`, it gets the same width and height constraints.
> 
> Tests verify all arranged toolbar buttons and replacement `TabSwitcherStaticButton` instances expose matching square constraints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14fdee9d1906dd168f0ee3d3faaabea9d01ef12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->