### PR TITLE
[iOS] Add m_aichat_unified_input_query_submitted, the Search-side counterpart

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1898,6 +1898,7 @@ extension Pixel {
         case unifiedToggleInputSubmitChangeModelPromptSent
         case unifiedToggleInputDuckAIDirectNavigation
         case aiChatDuckAIDirectNavigation
+        case unifiedToggleInputQuerySubmitted
 
         // MARK: Unified Toggle Input - Duck.ai autocomplete suggestion clicks
         case autocompleteDuckAIClickWebsite
@@ -3812,6 +3813,7 @@ extension Pixel.Event {
         case .unifiedToggleInputSubmitChangeModelPromptSent: return "aichat_unified_input_submit_change_model_prompt_sent"
         case .unifiedToggleInputDuckAIDirectNavigation: return "m_aichat_unified_input_duck_ai_direct_navigation"
         case .aiChatDuckAIDirectNavigation: return "m_aichat_duck_ai_direct_navigation"
+        case .unifiedToggleInputQuerySubmitted: return "m_aichat_unified_input_query_submitted"
 
         case .autocompleteDuckAIClickWebsite: return "m_autocomplete_duckai_click_website"
         case .autocompleteDuckAIClickBookmark: return "m_autocomplete_duckai_click_bookmark"

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
@@ -198,7 +198,8 @@ final class UTIPixelReporter {
                                selectedTool: AIChatRAGTool?,
                                attachments: [UnifiedToggleInputAttachment],
                                reasoningMode: AIChatReasoningMode?,
-                               modelId: String?) {
+                               modelId: String?,
+                               defaultOmnibarMode: DefaultOmnibarMode) {
         withContext {
             UnifiedToggleInputCoordinatorPixelHelper.fireUnifiedPromptSubmittedPixel(
                 hasText: hasText,
@@ -209,6 +210,21 @@ final class UTIPixelReporter {
                 surface: $0.surface,
                 pageType: $0.pageType,
                 origin: Self.promptOrigin(for: $0),
+                defaultMode: defaultOmnibarMode,
+                firing: firing
+            )
+        }
+    }
+
+    /// The `.search` counterpart of `reportPromptSubmitted`, giving the Search vs Duck.ai mix a
+    /// denominator at the same granularity as the prompt side.
+    func reportQuerySubmitted(defaultOmnibarMode: DefaultOmnibarMode) {
+        withContext {
+            UnifiedToggleInputCoordinatorPixelHelper.fireUnifiedQuerySubmittedPixel(
+                surface: $0.surface,
+                pageType: $0.pageType,
+                isToggleVisible: $0.isToggleVisible,
+                defaultMode: defaultOmnibarMode,
                 firing: firing
             )
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1542,6 +1542,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
                 switchBarSubmissionMetrics.process(text, for: .search)
             }
             sessionMonitor.recordActivity(mode: .search)
+            pixelReporter.reportQuerySubmitted(defaultOmnibarMode: aiChatSettings.defaultOmnibarMode)
             clearStoreEntryAfterSubmission()
             if isAITabState {
                 hide()
@@ -1585,7 +1586,8 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
             selectedTool: toolsController.selectedTool,
             attachments: viewController.currentAttachments,
             reasoningMode: reasoningModeForSubmitPixel,
-            modelId: modelStore.persistedModelId
+            modelId: modelStore.persistedModelId,
+            defaultOmnibarMode: aiChatSettings.defaultOmnibarMode
         )
         pixelReporter.reportToolSubmittedIfNeeded(
             selectedTool: toolsController.selectedTool,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
@@ -199,6 +199,7 @@ final class UnifiedToggleInputCoordinatorPixelHelper {
         surface: UnifiedToggleInputPixelSurface,
         pageType: UnifiedToggleInputPromptPageType? = nil,
         origin: AIChatEntryPointSource? = nil,
+        defaultMode: DefaultOmnibarMode? = nil,
         firing: UTIPixelFiring = .live
     ) {
         let selectedToolValue = UnifiedPromptSubmittedSelectedToolPixelValue(selectedTool: selectedTool).rawValue
@@ -216,8 +217,28 @@ final class UnifiedToggleInputCoordinatorPixelHelper {
         ]
         parameters["page_type"] = pageType?.rawValue
         parameters["origin"] = origin?.rawValue
+        parameters["default_mode"] = defaultMode?.rawValue
 
         firing.fireDailyAndCount(.unifiedToggleInputPromptSubmitted, parameters)
+    }
+
+    /// The `.search` counterpart of `fireUnifiedPromptSubmittedPixel`. Shares `page_type`,
+    /// `surface` and `default_mode` with it so the Search vs Duck.ai mix is a ratio of the two.
+    static func fireUnifiedQuerySubmittedPixel(
+        surface: UnifiedToggleInputPixelSurface,
+        pageType: UnifiedToggleInputPromptPageType? = nil,
+        isToggleVisible: Bool,
+        defaultMode: DefaultOmnibarMode? = nil,
+        firing: UTIPixelFiring = .live
+    ) {
+        var parameters = [
+            "surface": surface.rawValue,
+            "toggle_visible": isToggleVisible ? "true" : "false"
+        ]
+        parameters["page_type"] = pageType?.rawValue
+        parameters["default_mode"] = defaultMode?.rawValue
+
+        firing.fireDailyAndCount(.unifiedToggleInputQuerySubmitted, parameters)
     }
 
     static func fireModelSelectedPixel(modelId: String, surface: UnifiedToggleInputPixelSurface, firing: UTIPixelFiring = .live) {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIPixelReporterTests.swift
@@ -122,7 +122,8 @@ final class UTIPixelReporterTests: XCTestCase {
                                        selectedTool: nil,
                                        attachments: [],
                                        reasoningMode: nil,
-                                       modelId: "gpt-x")
+                                       modelId: "gpt-x",
+                                       defaultOmnibarMode: .search)
 
         XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.pixelName, Pixel.Event.unifiedToggleInputPromptSubmitted.name)
         XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params, [
@@ -134,7 +135,8 @@ final class UTIPixelReporterTests: XCTestCase {
             "has_text": "true",
             "surface": "duck_ai",
             "page_type": "duck_ai",
-            "origin": "address_bar_icon"
+            "origin": "address_bar_icon",
+            "default_mode": "search"
         ])
     }
 
@@ -145,7 +147,8 @@ final class UTIPixelReporterTests: XCTestCase {
                                        selectedTool: nil,
                                        attachments: [],
                                        reasoningMode: nil,
-                                       modelId: nil)
+                                       modelId: nil,
+                                       defaultOmnibarMode: .lastUsed)
 
         XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params?["origin"], "address_bar_prompt")
         XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params?["page_type"], "serp")
@@ -158,9 +161,57 @@ final class UTIPixelReporterTests: XCTestCase {
                                        selectedTool: nil,
                                        attachments: [],
                                        reasoningMode: nil,
-                                       modelId: nil)
+                                       modelId: nil,
+                                       defaultOmnibarMode: .lastUsed)
 
         XCTAssertNil(PixelFiringMock.lastDailyPixelInfo?.params?["origin"])
+    }
+
+    // MARK: - Query submission (the Search-side counterpart of prompt submission)
+
+    func testReportQuerySubmittedFiresDailyWithResolvedSurfacePageTypeAndToggleVisibility() {
+        let reporter = makeReporter { self.context(surface: .addressBar, isToggleVisible: true, pageType: .serp) }
+
+        reporter.reportQuerySubmitted(defaultOmnibarMode: .duckAI)
+
+        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.pixelName, Pixel.Event.unifiedToggleInputQuerySubmitted.name)
+        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params, [
+            "surface": "address_bar",
+            "page_type": "serp",
+            "toggle_visible": "true",
+            "default_mode": "duckAI"
+        ])
+    }
+
+    /// A search submitted with the toggle off screen was not a Search-vs-Duck.ai choice, so it has
+    /// to be excludable from any choice-rate denominator.
+    func testWhenQuerySubmittedWithToggleHiddenThenToggleVisibleIsFalse() {
+        let reporter = makeReporter { self.context(isToggleVisible: false) }
+
+        reporter.reportQuerySubmitted(defaultOmnibarMode: .search)
+
+        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params?["toggle_visible"], "false")
+    }
+
+    /// The query and prompt pixels have to agree on the keys the mix is cut by, or the ratio
+    /// cannot be computed at matching granularity.
+    func testQueryAndPromptSubmittedShareTheKeysTheMixIsCutBy() {
+        let reporter = makeReporter { self.context(surface: .addressBar, isToggleVisible: true, pageType: .ntp) }
+
+        reporter.reportQuerySubmitted(defaultOmnibarMode: .search)
+        let queryParams = PixelFiringMock.lastDailyPixelInfo?.params ?? [:]
+
+        reporter.reportPromptSubmitted(hasText: true,
+                                       selectedTool: nil,
+                                       attachments: [],
+                                       reasoningMode: nil,
+                                       modelId: nil,
+                                       defaultOmnibarMode: .search)
+        let promptParams = PixelFiringMock.lastDailyPixelInfo?.params ?? [:]
+
+        for key in ["surface", "page_type", "default_mode"] {
+            XCTAssertEqual(queryParams[key], promptParams[key], "\(key) must match across the two submission pixels")
+        }
     }
 
     // MARK: - Regular pixel with surface from context

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -357,7 +357,7 @@
         "parameters": ["appVersion"]
     },
     "m_aichat_unified_input_prompt_submitted": {
-        "description": "Fires on every UTI submission in the .aiChat branch, regardless of selected tool. Captures the full submit-time state of the input (tool, model, reasoning effort, attachments, text presence, page type, and the entry origin).",
+        "description": "Fires on every UTI submission in the .aiChat branch, regardless of selected tool. Captures the full submit-time state of the input (tool, model, reasoning effort, attachments, text presence, page type, and the entry origin). Pairs with m_aichat_unified_input_query_submitted, the .search branch's counterpart: the two share suffixes and their page_type / unified_input_surface / default_mode keys, so the Search vs Duck.ai mix is a ratio of the two at matching granularity.",
         "owners": ["pikorddg", "aataraxiaa", "Bunn"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
@@ -367,6 +367,12 @@
                 "key": "page_type",
                 "description": "The page the user was on when submitting: ntp, serp, website, duck_ai, contextual, or unknown",
                 "type": "string"
+            },
+            {
+                "key": "default_mode",
+                "description": "The user's Opening-mode setting for the Search/Duck.ai toggle. Comparing it against the branch that fired separates submissions that accepted the default from ones where the user switched: search here means the user switched to Duck.ai, lastUsed means the toggle restored its previous position. Absent on iPad's separate address-bar toggle path, which has no Search-side counterpart pixel — use its presence to scope a Search-vs-Duck.ai ratio to submissions that have one.",
+                "type": "string",
+                "enum": ["search", "duckAI", "lastUsed"]
             },
             {
                 "key": "origin",
@@ -406,6 +412,32 @@
                 "description": "Whether the input contained non-whitespace text at submission time. Combined with attachment flags allows deriving attachment-only submits.",
                 "type": "boolean"
             }
+        ]
+    },
+    "m_aichat_unified_input_query_submitted": {
+        "description": "Fires on every UTI submission in the .search branch — the Search-side counterpart of m_aichat_unified_input_prompt_submitted, which covers the .aiChat branch. Without it there is no denominator for the Search vs Duck.ai mix. Shares suffixes and the page_type / unified_input_surface / default_mode keys with the prompt pixel so the two divide cleanly. Fired only from UnifiedToggleInputCoordinator: iPad's separate address-bar toggle path fires the prompt pixel without a default_mode and has no counterpart here, so restrict any Search-vs-Duck.ai ratio to rows where default_mode is present or it will read as Duck.ai-only on tablet. No has_text: a search submission cannot be empty (attachments are Duck.ai-only, so text is required to submit), unlike an attachment-only prompt.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "page_type",
+                "description": "The page the user was on when submitting: ntp, serp, website, duck_ai, contextual, or unknown",
+                "type": "string"
+            },
+            {
+                "key": "default_mode",
+                "description": "The user's Opening-mode setting for the Search/Duck.ai toggle. Comparing it against the branch that fired separates submissions that accepted the default from ones where the user switched: duckAI here means the user switched to Search, lastUsed means the toggle restored its previous position.",
+                "type": "string",
+                "enum": ["search", "duckAI", "lastUsed"]
+            },
+            {
+                "key": "toggle_visible",
+                "description": "Whether the Search/Duck.ai toggle was on screen at submission time. false means no choice was available on this submission, so those searches must be excluded from any choice-rate denominator.",
+                "type": "boolean"
+            },
+            "unified_input_surface"
         ]
     },
     "aichat_unified_input_show_model_picker": {


### PR DESCRIPTION
Task/Issue URL:
Tech Design URL:
CC:

### Description

Closes the last gap against the project's north-star questions: **how do users choose between Search and Search + Duck.ai?**

The UTI measured the Duck.ai side via `m_aichat_unified_input_prompt_submitted` but had nothing for the Search branch, so the mix had a numerator and no denominator, and couldn't be cut by page context the way prompts now can. The `m_aichat_experimental_omnibar_*` family does have both halves plus `mode_switched`, but that's the old experiment surface rather than the shipping input.

`m_aichat_unified_input_query_submitted` fires on every `.search` submission with `unified_input_surface`, `page_type` and the same suffixes as the prompt pixel, so the two divide at matching granularity. `toggle_visible` marks submissions where the toggle was off screen — no choice was available, so those have to be excluded from a choice-rate denominator.

`default_mode` (the Opening-mode setting) is added to **both** pixels. Compared against the branch that fired, it separates accepting the default from actively switching, per submission rather than by joining to the separate `mode_switched` series. Adding it to the prompt pixel is additive — no existing series changes.

### Scope limit

Fired only from `UnifiedToggleInputCoordinator`. iPad's separate address-bar toggle path (`DefaultOmniBarViewController.submitIPadDuckAIText`) fires the prompt pixel from its own call site and has several search-submission entries, so wiring it blind would have produced an incomplete denominator — a ratio skewed toward Duck.ai on tablet, which is worse than no data. `default_mode` is absent on that path, so its presence scopes a ratio to submissions that have a counterpart. Both definitions say so explicitly. Wiring iPad properly is follow-up work.

No `has_text` on the query pixel: attachments are Duck.ai-only, so `submitCurrentInputFromCoordinator` requires text to submit in `.search` mode — the flag would always be `true`, unlike the attachment-only prompt case.

### Testing Steps

1. With the toggle in Search mode, submit a search from the NTP, a SERP and a website; verify `m_aichat_unified_input_query_submitted` fires with `page_type` = `ntp` / `serp` / `website`, `toggle_visible=true` and `default_mode` matching the Opening-mode setting.
2. Switch the toggle to Duck.ai and submit a prompt; verify `m_aichat_unified_input_prompt_submitted` carries the same `default_mode`, `page_type` and `surface` values, so the two can be divided.
3. On a surface where the toggle is hidden, submit a search and verify `toggle_visible=false`.
4. Run `UTIPixelReporterTests` and `UnifiedToggleInputCoordinatorTests`.

### Impact and Risks

Low. One new pixel plus one additive param on an existing one; no pixel changes its name, firing conditions or existing fields, so nothing needs migrating.

#### What could go wrong?

A Search-vs-Duck.ai ratio computed without filtering on `default_mode` being present will under-count searches on iPad and read as Duck.ai-heavy there. That's the reason the param exists on both sides and is called out in both definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8Pbg4niDJ5H1N87WcRy5L

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only: one new pixel and an additive parameter on an existing one; no behavior, naming, or migration changes to prior series.
> 
> **Overview**
> Adds **`m_aichat_unified_input_query_submitted`** so every **Search** branch submission in the unified toggle input (UTI) is counted alongside the existing Duck.ai **`prompt_submitted`** pixel. That gives a denominator for Search vs Duck.ai mix at the same **`surface`**, **`page_type`**, and **`default_mode`** granularity.
> 
> **`default_mode`** (Opening-mode setting) is added to both pixels so analytics can separate accepting the default from switching modes per submission. The query pixel also sends **`toggle_visible`** so searches where the toggle was off screen can be excluded from choice-rate denominators.
> 
> Wiring is limited to **`UnifiedToggleInputCoordinator`**; iPad’s separate address-bar path still only fires the prompt side without **`default_mode`**, which the pixel definitions document for scoping ratios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe2cd3fa7dec68cd10c79e7c126459f18af1a1da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->