### PR TITLE
Prevent Screen Time data cleaning from hanging

### DIFF
--- a/SharedPackages/ScreenTimeDataCleaner/Sources/ScreenTimeDataCleaner/ScreenTimeDataCleaner.swift
+++ b/SharedPackages/ScreenTimeDataCleaner/Sources/ScreenTimeDataCleaner/ScreenTimeDataCleaner.swift
@@ -21,19 +21,93 @@ import WebKit
 @available(iOS 26, macOS 26, *)
 public struct ScreenTimeDataCleaner {
 
+    private static let removalTimeoutNanoseconds: UInt64 = 2_000_000_000
+
     public init() { }
 
     @MainActor
     public func removeScreenTimeData() async {
         let uids = await WKWebsiteDataStore.allDataStoreIdentifiers
-        let stores = uids.map { WKWebsiteDataStore(forIdentifier: $0) }
-            + [WKWebsiteDataStore.default()]
 
-        // Perform sequentially because it has to run on the main thread anyway, so even
-        // in a group they would still run sequentially.
-        for store in stores {
-            await store.removeData(ofTypes: [WKWebsiteDataTypeScreenTime], modifiedSince: .distantPast)
+        for uid in uids {
+            guard !Task.isCancelled else { return }
+            guard await removeScreenTimeData(from: .identified(uid)) else { return }
         }
+
+        guard !Task.isCancelled else { return }
+        _ = await removeScreenTimeData(from: .default)
+    }
+
+    @MainActor
+    private func removeScreenTimeData(from dataStore: DataStore) async -> Bool {
+        let result = FirstRemovalResult()
+        let removalTask = Task { @MainActor in
+            let store: WKWebsiteDataStore
+            switch dataStore {
+            case .identified(let uid):
+                store = WKWebsiteDataStore(forIdentifier: uid)
+            case .default:
+                store = .default()
+            }
+
+            await store.removeData(ofTypes: [WKWebsiteDataTypeScreenTime], modifiedSince: .distantPast)
+            await result.resolve(with: .completed)
+        }
+        let timeoutTask = Task.detached {
+            do {
+                try await Task.sleep(nanoseconds: Self.removalTimeoutNanoseconds)
+                await result.resolve(with: .timedOut)
+            } catch {
+                return
+            }
+        }
+
+        switch await result.value() {
+        case .completed:
+            timeoutTask.cancel()
+            return true
+        case .timedOut:
+            removalTask.cancel()
+            return false
+        }
+    }
+
+}
+
+@available(iOS 26, macOS 26, *)
+private extension ScreenTimeDataCleaner {
+
+    enum DataStore: Sendable {
+        case identified(UUID)
+        case `default`
+    }
+
+}
+
+private enum RemovalResult: Sendable {
+    case completed
+    case timedOut
+}
+
+private actor FirstRemovalResult {
+
+    private var result: RemovalResult?
+    private var continuation: CheckedContinuation<RemovalResult, Never>?
+
+    func value() async -> RemovalResult {
+        if let result {
+            return result
+        }
+
+        return await withCheckedContinuation { continuation = $0 }
+    }
+
+    func resolve(with result: RemovalResult) {
+        guard self.result == nil else { return }
+
+        self.result = result
+        continuation?.resume(returning: result)
+        continuation = nil
     }
 
 }

--- a/SharedPackages/ScreenTimeDataCleaner/Sources/ScreenTimeDataCleaner/ScreenTimeDataCleaner.swift
+++ b/SharedPackages/ScreenTimeDataCleaner/Sources/ScreenTimeDataCleaner/ScreenTimeDataCleaner.swift
@@ -29,13 +29,13 @@ public struct ScreenTimeDataCleaner {
     public func removeScreenTimeData() async {
         let uids = await WKWebsiteDataStore.allDataStoreIdentifiers
 
+        guard !Task.isCancelled else { return }
+        guard await removeScreenTimeData(from: .default) else { return }
+
         for uid in uids {
             guard !Task.isCancelled else { return }
             guard await removeScreenTimeData(from: .identified(uid)) else { return }
         }
-
-        guard !Task.isCancelled else { return }
-        _ = await removeScreenTimeData(from: .default)
     }
 
     @MainActor

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Background.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Background.swift
@@ -78,12 +78,8 @@ struct Background: BackgroundHandling {
         guard appDependencies.featureFlagger.isFeatureOn(.screenTimeCleaning) else { return }
         guard #available(iOS 26, *) else { return }
 
-        let backgroundTask = ScreenTimeDataCleaningBackgroundTask()
-        guard backgroundTask.begin() else { return }
-
-        Task { @MainActor in
+        ScreenTimeDataCleaningBackgroundTask().start {
             await ScreenTimeDataCleaner().removeScreenTimeData()
-            backgroundTask.end()
         }
     }
 
@@ -168,15 +164,27 @@ private final class ScreenTimeDataCleaningBackgroundTask {
     private static let name = "Screen Time Data Cleaning"
 
     private var identifier: UIBackgroundTaskIdentifier = .invalid
+    private var cleanupTask: Task<Void, Never>?
 
-    func begin() -> Bool {
+    func start(cleanup: @escaping @MainActor @Sendable () async -> Void) {
         identifier = UIApplication.shared.beginBackgroundTask(withName: Self.name) { [weak self] in
-            self?.end()
+            self?.cancel()
         }
-        return identifier != .invalid
+        guard identifier != .invalid else { return }
+
+        cleanupTask = Task { @MainActor [self] in
+            await cleanup()
+            end()
+        }
     }
 
-    func end() {
+    private func cancel() {
+        cleanupTask?.cancel()
+        end()
+    }
+
+    private func end() {
+        cleanupTask = nil
         guard identifier != .invalid else { return }
 
         UIApplication.shared.endBackgroundTask(identifier)

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Background.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Background.swift
@@ -77,8 +77,13 @@ struct Background: BackgroundHandling {
     private func cleanScreenTimeDataOniOS26() {
         guard appDependencies.featureFlagger.isFeatureOn(.screenTimeCleaning) else { return }
         guard #available(iOS 26, *) else { return }
-        Task {
+
+        let backgroundTask = ScreenTimeDataCleaningBackgroundTask()
+        guard backgroundTask.begin() else { return }
+
+        Task { @MainActor in
             await ScreenTimeDataCleaner().removeScreenTimeData()
+            backgroundTask.end()
         }
     }
 
@@ -153,3 +158,30 @@ extension Background {
     }
 
 }
+
+// MARK: - Background tasks
+
+@available(iOS 26, *)
+@MainActor
+private final class ScreenTimeDataCleaningBackgroundTask {
+
+    private static let name = "Screen Time Data Cleaning"
+
+    private var identifier: UIBackgroundTaskIdentifier = .invalid
+
+    func begin() -> Bool {
+        identifier = UIApplication.shared.beginBackgroundTask(withName: Self.name) { [weak self] in
+            self?.end()
+        }
+        return identifier != .invalid
+    }
+
+    func end() {
+        guard identifier != .invalid else { return }
+
+        UIApplication.shared.endBackgroundTask(identifier)
+        identifier = .invalid
+    }
+
+}
+

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Background.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Background.swift
@@ -184,4 +184,3 @@ private final class ScreenTimeDataCleaningBackgroundTask {
     }
 
 }
-


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1216744184761157?focus=true
Tech Design URL:
CC:

### Description
Prevents an iOS 26 watchdog termination when the app enters the background while Screen Time data is being cleared. Cleanup now has bounded execution time and protected background runtime.

### Testing Steps
* On iOS 26, enable the Screen Time cleaning feature flag.
* Visit several websites in DuckDuckGo.
* Send the app to the background → the app remains running without crashing.
* Open Screen Time and refresh its website activity → visited DuckDuckGo domains are absent.
* Return to DuckDuckGo and repeat the foreground/background transition several times → the app remains stable.
* Validate no breakage on macOS - launch the app, browse websites, background app

### Impact
Medium: Failure could leave browsing activity visible in Screen Time or affect app stability during background transitions.

#### What could go wrong?
* Cleanup could exceed the available background runtime → mitigated by a per-store timeout that stops scheduling further work.
* Cleanup could fail to remove data from every profile → mitigated by retrying the cleanup on the next background transition.
* Unexpected platform behavior could cause regressions → mitigated by the existing iOS 26 availability check and remotely controlled feature flag.

### Quality Considerations
The cleanup remains on WebKit’s required UI actor. A dedicated background execution window protects the transition, while the timeout prevents multiple slow data stores from accumulating unbounded work. No additional browsing data is collected or persisted.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches background lifecycle and WebKit data-store cleanup on iOS 26; a timeout or early stop could leave Screen Time entries until the next background pass, but bounded work reduces watchdog risk.
> 
> **Overview**
> Addresses iOS 26 watchdog kills when Screen Time WebKit cleanup runs during backgrounding by **bounding work** and **requesting protected background time**.
> 
> **`ScreenTimeDataCleaner`** no longer runs `removeData` across every `WKWebsiteDataStore` in one unbounded loop. It clears the default store first, then each identified store, and **stops the whole run** if the task is cancelled or a single store does not finish within **2 seconds**. Each store uses a race between the removal task and a detached sleep; a small `FirstRemovalResult` actor ensures only the first outcome wins and cancels the loser.
> 
> On iOS, **`Background`** no longer fires cleanup in a bare `Task`. **`ScreenTimeDataCleaningBackgroundTask`** starts a named `beginBackgroundTask`, runs the async cleanup on the main actor, cancels on expiration, and always ends the background task when work finishes or is cut off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ad9163bd36ec29d945c943eb5f5916ef60885ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->