### PR TITLE
Fix of fire animation when closing Fire Window

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -2440,6 +2440,8 @@
 		8400DC4C2C6E26AE006509D2 /* BookmarksBarCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400DC4A2C6E26AE006509D2 /* BookmarksBarCollectionView.swift */; };
 		8400DC4E2C6E2770006509D2 /* SteppedScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400DC4D2C6E2770006509D2 /* SteppedScrollView.swift */; };
 		8400DC4F2C6E2770006509D2 /* SteppedScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400DC4D2C6E2770006509D2 /* SteppedScrollView.swift */; };
+		7B1F0A112F0100000000FA01 /* FireWindowClosingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1F0A102F0100000000FA01 /* FireWindowClosingTests.swift */; };
+		7B1F0A122F0100000000FA01 /* FireWindowClosingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B1F0A102F0100000000FA01 /* FireWindowClosingTests.swift */; };
 		8402A7BD2E9F8C5B00ACA20C /* FireCoordinatorIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8402A7BA2E9F7CA000ACA20C /* FireCoordinatorIntegrationTests.swift */; };
 		8402A7BE2E9F8C5B00ACA20C /* FireCoordinatorIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8402A7BA2E9F7CA000ACA20C /* FireCoordinatorIntegrationTests.swift */; };
 		8409BD782ED878C400E39FA7 /* popup-delayed.html in Resources */ = {isa = PBXBuildFile; fileRef = 8409BD752ED878C400E39FA7 /* popup-delayed.html */; };
@@ -6024,6 +6026,7 @@
 		7FD43DAF77B35315FBE6255D /* UpdateNotificationPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateNotificationPresenterTests.swift; sourceTree = "<group>"; };
 		8400DC4A2C6E26AE006509D2 /* BookmarksBarCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksBarCollectionView.swift; sourceTree = "<group>"; };
 		8400DC4D2C6E2770006509D2 /* SteppedScrollView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SteppedScrollView.swift; sourceTree = "<group>"; };
+		7B1F0A102F0100000000FA01 /* FireWindowClosingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireWindowClosingTests.swift; sourceTree = "<group>"; };
 		8402A7BA2E9F7CA000ACA20C /* FireCoordinatorIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireCoordinatorIntegrationTests.swift; sourceTree = "<group>"; };
 		8409BD752ED878C400E39FA7 /* popup-delayed.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "popup-delayed.html"; sourceTree = "<group>"; };
 		8409BD762ED878C400E39FA7 /* popup-links.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "popup-links.html"; sourceTree = "<group>"; };
@@ -10201,6 +10204,7 @@
 			isa = PBXGroup;
 			children = (
 				8402A7BA2E9F7CA000ACA20C /* FireCoordinatorIntegrationTests.swift */,
+				7B1F0A102F0100000000FA01 /* FireWindowClosingTests.swift */,
 				84E4A4952E79BDDC00D6A1E7 /* FireMock.swift */,
 				845F57312E98021F00C7F78A /* FireproofDomainsStoreMock.swift */,
 				AA9C362F25518CA9004B1BA3 /* FireTests.swift */,
@@ -17327,6 +17331,7 @@
 				84537A092C99C203008723BC /* DeallocationTests.swift in Sources */,
 				84524C072D79E6BB00F723D6 /* FireTests.swift in Sources */,
 				8402A7BE2E9F8C5B00ACA20C /* FireCoordinatorIntegrationTests.swift in Sources */,
+				7B1F0A122F0100000000FA01 /* FireWindowClosingTests.swift in Sources */,
 				1E33A5522EBB632E000E828B /* AutoconsentStatsMock.swift in Sources */,
 				84524C112D79E9AA00F723D6 /* RecentlyClosedCoordinatorMock.swift in Sources */,
 				8434E6B12DB01483008FFA3D /* BookmarksBarVisibilityManagerTests.swift in Sources */,
@@ -17395,6 +17400,7 @@
 				84537A082C99C203008723BC /* DeallocationTests.swift in Sources */,
 				84524C062D79E6BB00F723D6 /* FireTests.swift in Sources */,
 				8402A7BD2E9F8C5B00ACA20C /* FireCoordinatorIntegrationTests.swift in Sources */,
+				7B1F0A112F0100000000FA01 /* FireWindowClosingTests.swift in Sources */,
 				1E33A5512EBB632E000E828B /* AutoconsentStatsMock.swift in Sources */,
 				84524C102D79E9AA00F723D6 /* RecentlyClosedCoordinatorMock.swift in Sources */,
 				8434E6B02DB01483008FFA3D /* BookmarksBarVisibilityManagerTests.swift in Sources */,

--- a/macOS/DuckDuckGo/Fire/View/FirePopoverViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FirePopoverViewController.swift
@@ -236,9 +236,11 @@ final class FirePopoverViewController: NSViewController {
             assertionFailure("No TabCollectionViewModel or MainWindowController")
             return
         }
-        // Going through the window controller rather than closing the window directly: `NSWindow.close()`
-        // skips `windowShouldClose(_:)`, which is what plays the fire animation and warns about downloads.
-        // The popover is torn down by `FireViewController.closeAllChildWindows()` as the animation starts.
+        // The burn can put up a downloads warning sheet and defer the close, so close the popover now
+        // instead of relying on the window teardown to take it along.
+        (nextResponder as? NSPopover)?.close()
+        // Closing the window directly would skip `windowShouldClose(_:)` — the only place that plays the
+        // fire animation and warns about in-progress downloads.
         windowController.burnAndClose(window)
     }
 }

--- a/macOS/DuckDuckGo/Fire/View/FirePopoverViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FirePopoverViewController.swift
@@ -231,11 +231,15 @@ final class FirePopoverViewController: NSViewController {
 #endif
         let windowControllersManager = Application.appDelegate.windowControllersManager
         guard let tabCollectionViewModel = tabCollectionViewModel,
-              let windowController = windowControllersManager.windowController(for: tabCollectionViewModel) else {
+              let windowController = windowControllersManager.windowController(for: tabCollectionViewModel),
+              let window = windowController.window else {
             assertionFailure("No TabCollectionViewModel or MainWindowController")
             return
         }
-        windowController.window?.close()
+        // Going through the window controller rather than closing the window directly: `NSWindow.close()`
+        // skips `windowShouldClose(_:)`, which is what plays the fire animation and warns about downloads.
+        // The popover is torn down by `FireViewController.closeAllChildWindows()` as the animation starts.
+        windowController.burnAndClose(window)
     }
 }
 

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -1405,9 +1405,8 @@ extension MainViewController: BrowserTabViewControllerDelegate {
         }()
 
         if noPinnedTabs || (isSharedPinnedTabsMode && areOtherWindowsWithPinnedTabsAvailable) {
-            // A Fire Window disappearing because its last tab was closed still owes the user the fire
-            // animation, and `NSWindow.close()` would skip it. `burnAndClose` closes directly when a
-            // burn is already in progress, which is how Fire closes windows after burning.
+            // A Fire Window vanishing because its last tab closed still owes the user the fire animation,
+            // and `NSWindow.close()` would skip it.
             if tabCollectionViewModel.isBurner,
                let windowController = window.windowController as? MainWindowController {
                 windowController.burnAndClose(window)

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -1405,7 +1405,15 @@ extension MainViewController: BrowserTabViewControllerDelegate {
         }()
 
         if noPinnedTabs || (isSharedPinnedTabsMode && areOtherWindowsWithPinnedTabsAvailable) {
-            window.close()
+            // A Fire Window disappearing because its last tab was closed still owes the user the fire
+            // animation, and `NSWindow.close()` would skip it. `burnAndClose` closes directly when a
+            // burn is already in progress, which is how Fire closes windows after burning.
+            if tabCollectionViewModel.isBurner,
+               let windowController = window.windowController as? MainWindowController {
+                windowController.burnAndClose(window)
+            } else {
+                window.close()
+            }
             return true
         }
         return false

--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -597,11 +597,8 @@ extension MainWindowController: NSWindowDelegate {
         return false
     }
 
-    /// Closes a Fire Window the way its close button does: warn about in-progress downloads, then play
-    /// the fire animation before the window goes away.
-    ///
-    /// `NSWindow.close()` bypasses `windowShouldClose(_:)`, so programmatic Fire Window closes have to
-    /// come through here or the user loses both the animation and the downloads warning.
+    /// `NSWindow.close()` bypasses `windowShouldClose(_:)`, so programmatic Fire Window closes have to come
+    /// through here or they lose the fire animation and the in-progress downloads warning.
     func burnAndClose(_ window: NSWindow) {
         // A burn already has the animation on screen and closes windows itself (see Fire.closeWindows).
         guard fireViewModel.fire.burningData == nil else {

--- a/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainWindowController.swift
@@ -287,6 +287,7 @@ final class MainWindowController: NSWindowController {
     private var burningDataCancellable: AnyCancellable?
     private var delayedBlockingWorkItem: DispatchWorkItem?
     private var didMoveTabBarForFireAnimation = false
+    private var isClosingAndBurning = false
 
     private func subscribeToBurningData() {
         burningDataCancellable = fireViewModel.fire.burningDataPublisher
@@ -592,12 +593,27 @@ extension MainWindowController: NSWindowDelegate {
     func windowShouldClose(_ window: NSWindow) -> Bool {
         guard mainViewController.tabCollectionViewModel.isBurner else { return true }
 
+        burnAndClose(window)
+        return false
+    }
+
+    /// Closes a Fire Window the way its close button does: warn about in-progress downloads, then play
+    /// the fire animation before the window goes away.
+    ///
+    /// `NSWindow.close()` bypasses `windowShouldClose(_:)`, so programmatic Fire Window closes have to
+    /// come through here or the user loses both the animation and the downloads warning.
+    func burnAndClose(_ window: NSWindow) {
+        // A burn already has the animation on screen and closes windows itself (see Fire.closeWindows).
+        guard fireViewModel.fire.burningData == nil else {
+            window.close()
+            return
+        }
+
         if showAlertIfActiveDownloadsPresent(in: window) {
-            return false
+            return
         }
 
         animateBurningIfNeededAndClose(window)
-        return false
     }
 
     private func showAlertIfActiveDownloadsPresent(in window: NSWindow) -> Bool {
@@ -635,6 +651,10 @@ extension MainWindowController: NSWindowDelegate {
     }
 
     private func animateBurningIfNeededAndClose(_ window: NSWindow) {
+        // The animation is awaited, so the window stays around and closable in the meantime.
+        guard !isClosingAndBurning else { return }
+        isClosingAndBurning = true
+
         guard !window.isPopUpWindow else {
             window.close()
             return

--- a/macOS/IntegrationTests/Fire/FireWindowClosingTests.swift
+++ b/macOS/IntegrationTests/Fire/FireWindowClosingTests.swift
@@ -1,0 +1,132 @@
+//
+//  FireWindowClosingTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import XCTest
+
+@testable import DuckDuckGo_Privacy_Browser
+
+/// Fire Windows must play the fire animation before they disappear, no matter how the close was triggered.
+///
+/// `NSWindow.close()` doesn't invoke `windowShouldClose(_:)`, so every programmatic close has to go through
+/// `MainWindowController.burnAndClose(_:)` — these tests cover the two paths that used to call `close()` directly.
+///
+/// Outside the `.normal` run type the Lottie animation view is never loaded, so `animateFireWhenClosing()`
+/// flips `isAnimationPlaying` on and straight back off. That's enough to tell "the animation ran" from
+/// "it was skipped", which is exactly what the popover button used to get wrong.
+final class FireWindowClosingTests: XCTestCase {
+
+    private var cancellables = Set<AnyCancellable>()
+    private var initialFireAnimationEnabled = true
+
+    @MainActor
+    override func setUp() {
+        initialFireAnimationEnabled = Application.appDelegate.dataClearingPreferences.isFireAnimationEnabled
+        Application.appDelegate.dataClearingPreferences.isFireAnimationEnabled = true
+    }
+
+    @MainActor
+    override func tearDown() {
+        Application.appDelegate.dataClearingPreferences.isFireAnimationEnabled = initialFireAnimationEnabled
+        cancellables = []
+        autoreleasepool {
+            WindowsManager.closeWindows()
+            for controller in Application.appDelegate.windowControllersManager.mainWindowControllers {
+                Application.appDelegate.windowControllersManager.unregister(controller)
+            }
+        }
+        // Allow WebKit IPC to settle after closing windows
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.5))
+    }
+
+    // MARK: - Tests
+
+    @MainActor
+    func testWhenFirePopoverCloseButtonClicked_thenFireAnimationPlaysAndWindowCloses() async throws {
+        let windowController = try openFireWindow()
+        let window = try XCTUnwrap(windowController.window)
+
+        var animationStates = [Bool]()
+        subscribeToAnimationStates(of: windowController) { animationStates.append($0) }
+
+        // Not going through `FireCoordinator.showFirePopover` on purpose: the coordinator holds on to the
+        // popover for the lifetime of the app, so its views would outlive the test and trip the harness'
+        // deallocation checks. The action doesn't touch the view hierarchy, so a bare controller is enough.
+        let popoverViewController = FirePopoverViewController(
+            fireViewModel: windowController.mainViewController.fireViewController.fireViewModel,
+            tabCollectionViewModel: windowController.mainViewController.tabCollectionViewModel
+        )
+
+        let windowClosed = expectation(forNotification: NSWindow.willCloseNotification, object: window)
+        popoverViewController.closeBurnerWindowButtonAction(self)
+        await fulfillment(of: [windowClosed], timeout: 5)
+
+        XCTAssertEqual(animationStates, [true, false])
+    }
+
+    @MainActor
+    func testWhenLastTabOfFireWindowClosed_thenFireAnimationPlaysAndWindowCloses() async throws {
+        let windowController = try openFireWindow()
+        let window = try XCTUnwrap(windowController.window)
+
+        var animationStates = [Bool]()
+        subscribeToAnimationStates(of: windowController) { animationStates.append($0) }
+
+        let windowClosed = expectation(forNotification: NSWindow.willCloseNotification, object: window)
+        windowController.mainViewController.tabCollectionViewModel.remove(at: .unpinned(0))
+        await fulfillment(of: [windowClosed], timeout: 5)
+
+        XCTAssertEqual(animationStates, [true, false])
+    }
+
+    @MainActor
+    func testWhenFireAnimationDisabled_thenFireWindowClosesWithoutAnimating() async throws {
+        Application.appDelegate.dataClearingPreferences.isFireAnimationEnabled = false
+
+        let windowController = try openFireWindow()
+        let window = try XCTUnwrap(windowController.window)
+
+        var animationStates = [Bool]()
+        subscribeToAnimationStates(of: windowController) { animationStates.append($0) }
+
+        let windowClosed = expectation(forNotification: NSWindow.willCloseNotification, object: window)
+        windowController.burnAndClose(window)
+        await fulfillment(of: [windowClosed], timeout: 5)
+
+        XCTAssertEqual(animationStates, [])
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func openFireWindow() throws -> MainWindowController {
+        // `showWindow: false` would still open a window, but not activate it, which seems to upset CI
+        _=WindowsManager.openNewWindow(with: URL(string: "data:,Hello%2C%20World%21")!, source: .ui, isBurner: true)
+        let windowController = try XCTUnwrap(Application.appDelegate.windowControllersManager.mainWindowControllers.last)
+        XCTAssertTrue(windowController.mainViewController.tabCollectionViewModel.isBurner)
+        return windowController
+    }
+
+    @MainActor
+    private func subscribeToAnimationStates(of windowController: MainWindowController, onChange: @escaping (Bool) -> Void) {
+        windowController.mainViewController.fireViewController.fireViewModel.$isAnimationPlaying
+            .dropFirst()
+            .sink { onChange($0) }
+            .store(in: &cancellables)
+    }
+}

--- a/macOS/IntegrationTests/Fire/FireWindowClosingTests.swift
+++ b/macOS/IntegrationTests/Fire/FireWindowClosingTests.swift
@@ -21,14 +21,8 @@ import XCTest
 
 @testable import DuckDuckGo_Privacy_Browser
 
-/// Fire Windows must play the fire animation before they disappear, no matter how the close was triggered.
-///
-/// `NSWindow.close()` doesn't invoke `windowShouldClose(_:)`, so every programmatic close has to go through
-/// `MainWindowController.burnAndClose(_:)` — these tests cover the two paths that used to call `close()` directly.
-///
-/// Outside the `.normal` run type the Lottie animation view is never loaded, so `animateFireWhenClosing()`
-/// flips `isAnimationPlaying` on and straight back off. That's enough to tell "the animation ran" from
-/// "it was skipped", which is exactly what the popover button used to get wrong.
+/// Outside the `.normal` run type the Lottie view is never loaded, so `animateFireWhenClosing()` flips
+/// `isAnimationPlaying` on and straight back off — enough to tell "the animation ran" from "it was skipped".
 final class FireWindowClosingTests: XCTestCase {
 
     private var cancellables = Set<AnyCancellable>()
@@ -64,9 +58,8 @@ final class FireWindowClosingTests: XCTestCase {
         var animationStates = [Bool]()
         subscribeToAnimationStates(of: windowController) { animationStates.append($0) }
 
-        // Not going through `FireCoordinator.showFirePopover` on purpose: the coordinator holds on to the
-        // popover for the lifetime of the app, so its views would outlive the test and trip the harness'
-        // deallocation checks. The action doesn't touch the view hierarchy, so a bare controller is enough.
+        // Not going through `FireCoordinator.showFirePopover`: it holds the popover for the app's lifetime,
+        // so the popover's views would outlive the test and trip the harness' deallocation checks.
         let popoverViewController = FirePopoverViewController(
             fireViewModel: windowController.mainViewController.fireViewController.fireViewModel,
             tabCollectionViewModel: windowController.mainViewController.tabCollectionViewModel


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1217290532816492?focus=true
Tech Design URL:
CC:

### Description

Closing a Fire Window with the fire popover's "Close and Burn This Window" button made the window vanish with no fire animation. The same button also cancelled any in-progress downloads in that window without warning.

### Testing Steps

Settings → Data Clearing → "Show inferno animation when deleting data" must be on for steps 1 and 3–6.

1. Open a new Fire Window, load any URL, click the fire button → "Close and Burn This Window" → the fire animation plays, then the window closes.
2. Turn the animation setting off, repeat step 1 → the window closes immediately, with no animation and no alert sound.
3. In a Fire Window, start a large download, then "Close and Burn This Window" → a warning sheet appears; "Don't Close" keeps the window and the download, "Close" cancels it and burns.
4. Fire Window with a single tab → click the tab's X → the animation plays, then the window closes.
5. Fire Window with two tabs → close one → no animation, the window stays open.
6. With a regular window and a Fire Window both open, click the fire button in the regular window and burn everything → the Fire Window closes with a single animation.
7. Regression check: closing a Fire Window with the traffic-light button and with ⌘⇧W still animates.

### Impact

Low — restores an animation and adds a data-loss warning that was missing on one close path.

#### What could go wrong?

- Repeated close attempts could stack animations or double-close → mitigated by an `isClosingAndBurning` guard.
- Closing a Fire Window while a burn is already running could play a second animation over the first → mitigated by short-circuiting to a direct close when a burn is in progress; covered by the existing `FireTests` and `FireCoordinatorIntegrationTests` suites.
- The window now stays alive for the animation's duration on paths that previously closed instantly → covered by three new cases in `FireWindowClosingTests`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to Fire Window close UX (animation, download warning, popover dismiss); guards limit double-close and overlap with an active burn. New integration tests cover the main paths.
> 
> **Overview**
> Fixes Fire Window closes that bypassed `windowShouldClose(_:)` and skipped the inferno animation and in-progress download warning.
> 
> **`MainWindowController`** adds **`burnAndClose(_:)`** as the shared path for programmatic burner closes: it short-circuits to a direct close when a burn is already running, shows the active-downloads sheet when needed, then runs **`animateFireWhenClosing()`** before closing. An **`isClosingAndBurning`** guard avoids stacking animations while the async close runs.
> 
> **`FirePopoverViewController`** no longer calls **`window.close()`** on “Close and Burn This Window”; it dismisses the popover first and calls **`burnAndClose`**. **`MainViewController.closeWindowIfNeeded()`** uses **`burnAndClose`** when the last tab of a Fire Window is closed instead of **`window.close()`**.
> 
> Adds **`FireWindowClosingTests`** integration coverage for popover close, last-tab close, and animation-disabled close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c4faa2a9135c7c382e49f67c072145aff8650fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->