### PR TITLE
[macOS] Fire Dialog design feedback - improve scroll views

### DIFF
--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedColorPaletteDefinition+DynamicColors.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SharedPalettes/SharedColorPaletteDefinition+DynamicColors.swift
@@ -362,7 +362,7 @@ extension SharedColorPaletteDefinition {
         case .fireDialogKnobFill:
             return DynamicColor(staticColor: Color(0xFFFFFF))
         case .fireDialogTabBackground:
-            return DynamicColor(lightColor: Color(designSystemColor: .containerFillSecondary), darkColor: Color(designSystemColor: .surfaceCanvas))
+            return DynamicColor(lightColor: Color(designSystemColor: .controlsFillPrimary), darkColor: Color(designSystemColor: .surfaceCanvas))
         case .fireDialogTabBackgroundSelected:
             return DynamicColor(lightColor: Color(designSystemColor: .surfaceTertiary), darkColor: Color(designSystemColor: .surfaceSecondary))
         case .fireDialogTabShadowPrimary:

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -560,9 +560,9 @@ struct UserText {
     static let fireDialogHistoryOverlayTitleRegular = NotLocalizedString("fire.dialog.history.overlay.title.regular",
                                                                           value: "will be deleted:",
                                                                           comment: "Regular-weight portion of the simplified Fire dialog's history overlay title, appended after fireDialogHistoryOverlayTitleBold.")
-    static let fireDialogSeeFullHistory = NotLocalizedString("fire.dialog.history.overlay.see.full.history",
-                                                               value: "See full history",
-                                                               comment: "Link button shown below the (capped) history overlay list, opens the full History View.")
+    static let fireDialogShowAllHistory = NotLocalizedString("fire.dialog.history.overlay.show.all.history",
+                                                             value: "Show all history",
+                                                             comment: "Link button shown below the (capped) history overlay list, opens the full History View.")
 
     // MARK: - Fire dialog single-entry contextual titles
     /// Title used when reusing the Fire dialog as a single entry point (from History, menu, etc.) with full-time range

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -706,22 +706,28 @@ struct FireDialogView: ModalView {
 
             Spacer(minLength: 8)
 
-            Button(action: { isShowingHistoryOverlay = false }) {
-                Image(nsImage: DesignSystemImages.Glyphs.Size16.close)
-                    .resizable()
-                    .frame(width: 12, height: 12)
+            HStack(alignment: .center, spacing: 8) {
+                if viewModel.historyVisits.count > Constants.historyOverlayMaxVisibleItems {
+                    seeFullHistoryButton
+                }
+
+                Button(action: { isShowingHistoryOverlay = false }) {
+                    Image(nsImage: DesignSystemImages.Glyphs.Size16.close)
+                        .resizable()
+                        .frame(width: 12, height: 12)
+                }
+                .buttonStyle(
+                    StandardButtonStyle(topPadding: 6,
+                                        bottomPadding: 6,
+                                        horizontalPadding: 6,
+                                        backgroundColor: Color(designSystemColor: .controlsFillPrimary),
+                                        backgroundPressedColor: Color(designSystemColor: .controlsFillPrimary))
+                )
+                .clipShape(Circle())
+                .accessibilityLabel(UserText.close)
+                .accessibilityIdentifier("FireDialogView.historyOverlayCloseButton")
+                .keyboardShortcut(.cancelAction)
             }
-            .buttonStyle(
-                StandardButtonStyle(topPadding: 6,
-                                    bottomPadding: 6,
-                                    horizontalPadding: 6,
-                                    backgroundColor: Color(designSystemColor: .controlsFillPrimary),
-                                    backgroundPressedColor: Color(designSystemColor: .controlsFillPrimary))
-            )
-            .clipShape(Circle())
-            .accessibilityLabel(UserText.close)
-            .accessibilityIdentifier("FireDialogView.historyOverlayCloseButton")
-            .keyboardShortcut(.cancelAction)
         }
         .padding(.top, 24)
         .padding(.horizontal, Constants.horizontalPadding)
@@ -731,19 +737,15 @@ struct FireDialogView: ModalView {
     private var historyOverlayList: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
+                Spacer(minLength: 11)
                 ForEach(viewModel.historyVisits.sorted { $0.date > $1.date }.prefix(Constants.historyOverlayMaxVisibleItems), id: \.self) { visit in
                     historyOverlayRow(for: visit)
-                }
-
-                if viewModel.historyVisits.count > Constants.historyOverlayMaxVisibleItems {
-                    seeFullHistoryButton
                 }
             }
             .padding(.leading, 24)
             .padding(.trailing, 32)
             .padding(.vertical, 4)
         }
-        .padding(.top, 11)
         .padding(.trailing, 8)
         .background(
             CustomRoundedCornersShape(tl: 16, tr: 16, bl: 0, br: 0)
@@ -761,14 +763,21 @@ struct FireDialogView: ModalView {
         Button {
             viewModel.openFullHistory()
         } label: {
-            Text(UserText.fireDialogSeeFullHistory)
-                .font(.system(size: 12, weight: .medium))
-                .foregroundColor(style.selectedForeground)
-                .frame(maxWidth: .infinity, alignment: .center)
+            Text(UserText.fireDialogShowAllHistory)
+                .font(.system(size: 11))
+                .foregroundColor(Color(designSystemColor: .textSecondary))
+                .lineLimit(1)
+                .fixedSize()
         }
-        .buttonStyle(.plain)
+        .buttonStyle(
+            StandardButtonStyle(topPadding: 5,
+                                bottomPadding: 5,
+                                horizontalPadding: 8,
+                                backgroundColor: Color(designSystemColor: .controlsFillPrimary),
+                                backgroundPressedColor: Color(designSystemColor: .controlsFillSecondary),
+                                cornerRadius: 12)
+        )
         .cursor(.pointingHand)
-        .padding(.vertical, 12)
         .accessibilityIdentifier("FireDialogView.seeFullHistoryButton")
     }
 

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -710,7 +710,7 @@ struct FireDialogView: ModalView {
 
             HStack(alignment: .center, spacing: 8) {
                 if viewModel.historyVisits.count > Constants.historyOverlayMaxVisibleItems {
-                    seeFullHistoryButton
+                    seeFullHistoryButton(accessibilityIdentifier: "FireDialogView.seeFullHistoryButton")
                 }
 
                 Button(action: { isShowingHistoryOverlay = false }) {
@@ -743,6 +743,14 @@ struct FireDialogView: ModalView {
                 ForEach(viewModel.historyVisits.sorted { $0.date > $1.date }.prefix(Constants.historyOverlayMaxVisibleItems), id: \.self) { visit in
                     historyOverlayRow(for: visit)
                 }
+
+                if viewModel.historyVisits.count > Constants.historyOverlayMaxVisibleItems {
+                    seeFullHistoryButton(accessibilityIdentifier: "FireDialogView.seeFullHistoryListButton")
+                        .padding(.top, 12)
+                        .padding(.bottom, 20)
+                        .padding(.leading, 8)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
             }
             .padding(.leading, 24)
             .padding(.trailing, 32)
@@ -762,7 +770,9 @@ struct FireDialogView: ModalView {
         .padding(.horizontal, 8)
     }
 
-    private var seeFullHistoryButton: some View {
+    /// The same button appears twice when the list is capped: once in the overlay header and once below the last
+    /// visit, so it stays reachable without scrolling back up. Each instance needs its own accessibility identifier.
+    private func seeFullHistoryButton(accessibilityIdentifier: String) -> some View {
         Button {
             viewModel.openFullHistory()
         } label: {
@@ -781,7 +791,7 @@ struct FireDialogView: ModalView {
                                 cornerRadius: 12)
         )
         .cursor(.pointingHand)
-        .accessibilityIdentifier("FireDialogView.seeFullHistoryButton")
+        .accessibilityIdentifier(accessibilityIdentifier)
     }
 
     private func historyOverlayRow(for visit: Visit) -> some View {

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -746,6 +746,7 @@ struct FireDialogView: ModalView {
             .padding(.trailing, 32)
             .padding(.vertical, 4)
         }
+        .scrollBounceBasedOnSize()
         .padding(.trailing, 8)
         .background(
             CustomRoundedCornersShape(tl: 16, tr: 16, bl: 0, br: 0)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -523,8 +523,8 @@ struct FireDialogView: ModalView {
 
     private var sitesOverlayList: some View {
         ScrollView {
-            Spacer(minLength: 11)
             VStack(alignment: .leading, spacing: 0) {
+                Spacer(minLength: 11)
                 ForEach(viewModel.selectable, id: \.domain) { item in
                     sitesOverlayRow(for: item)
                 }
@@ -641,8 +641,8 @@ struct FireDialogView: ModalView {
 
     private var chatsOverlayList: some View {
         ScrollView {
-            Spacer(minLength: 11)
             VStack(alignment: .leading, spacing: 0) {
+                Spacer(minLength: 11)
                 ForEach(viewModel.chats, id: \.chatId) { chat in
                     HStack(spacing: 12) {
                         Image(nsImage: DesignSystemImages.Glyphs.Size16.aiChat)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -523,6 +523,7 @@ struct FireDialogView: ModalView {
 
     private var sitesOverlayList: some View {
         ScrollView {
+            Spacer(minLength: 11)
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(viewModel.selectable, id: \.domain) { item in
                     sitesOverlayRow(for: item)
@@ -540,7 +541,7 @@ struct FireDialogView: ModalView {
             .padding(.trailing, 32)
             .padding(.vertical, 4)
         }
-        .padding(.top, 11)
+        .scrollBounceBasedOnSize()
         .padding(.trailing, 8)
         .background(
             CustomRoundedCornersShape(tl: 16, tr: 16, bl: 0, br: 0)
@@ -640,6 +641,7 @@ struct FireDialogView: ModalView {
 
     private var chatsOverlayList: some View {
         ScrollView {
+            Spacer(minLength: 11)
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(viewModel.chats, id: \.chatId) { chat in
                     HStack(spacing: 12) {
@@ -662,7 +664,7 @@ struct FireDialogView: ModalView {
             .padding(.trailing, 32)
             .padding(.vertical, 4)
         }
-        .padding(.top, 11)
+        .scrollBounceBasedOnSize()
         .padding(.trailing, 8)
         .background(
             CustomRoundedCornersShape(tl: 16, tr: 16, bl: 0, br: 0)

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -962,10 +962,10 @@ struct FireDialogView: ModalView {
                             Group {
                                 if AppVersion.isLiquidGlassSupported {
                                     Capsule(style: .continuous)
-                                        .fill(Color(designSystemColor: .buttonsSecondaryFillDefault))
+                                        .fill(Color(designSystemColor: .controlsFillPrimary))
                                 } else {
                                     RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                        .fill(Color(designSystemColor: .buttonsSecondaryFillDefault))
+                                        .fill(Color(designSystemColor: .controlsFillPrimary))
                                 }
                             }
                         )

--- a/macOS/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/View+ScrollBounceBehavior.swift
+++ b/macOS/LocalPackages/SwiftUIExtensions/Sources/SwiftUIExtensions/View+ScrollBounceBehavior.swift
@@ -1,0 +1,35 @@
+//
+//  View+ScrollBounceBehavior.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+
+public extension View {
+
+    /// Stops a `ScrollView` from bouncing when its content is small enough to fit fully inside the visible bounds.
+    ///
+    /// By default a `ScrollView` always rubber-bands, which makes short content look scrollable when it is not.
+    /// On macOS 12 and 13.0–13.2 this is a no-op, because `scrollBounceBehavior(_:)` needs macOS 13.3.
+    @ViewBuilder
+    func scrollBounceBasedOnSize() -> some View {
+        if #available(macOS 13.3, *) {
+            self.scrollBounceBehavior(.basedOnSize)
+        } else {
+            self
+        }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217366829996693?focus=true

### Description
A few UI fixes for history/sites/chats overlays in the new Fire Dialog.

### Testing Steps
1. Enable `fireDialogSimplified` feature flag
2. Open Fire Dialog and show history. Verify that the scroll view begins at the very top of the superview:
<img width="468" height="105" alt="Screenshot 2026-08-11 at 15 44 40" src="https://github.com/user-attachments/assets/3e2474c4-70c7-463e-90fd-28ec124a7740" />

3. Verify the same for sites and duck.ai chats overlays
4. Verify that "Show all history" button is in the history overlay header (as in the screenshot above), and verify that it opens full history view.


### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to Fire Dialog overlays, localization, and design tokens; no auth, data handling, or behavioral changes to deletion flows.
> 
> **Overview**
> Polishes **history, sites, and chats overlays** in the simplified Fire Dialog: scroll lists align to the top, short lists no longer rubber-band, and capped history is easier to open in full.
> 
> Overlay **ScrollViews** use a new `scrollBounceBasedOnSize()` helper (macOS 13.3+) instead of padding on the scroll view; top spacing moves inside the content via `Spacer(minLength: 11)`.
> 
> When history exceeds the overlay cap, **“Show all history”** appears in the overlay header (beside close) as well as at the bottom of the list, with pill styling and distinct accessibility IDs. User-facing string changes from “See full history” to **“Show all history”**.
> 
> **Visual tokens**: Fire dialog tab background (light) and cancel button use `controlsFillPrimary` instead of `containerFillSecondary` / `buttonsSecondaryFillDefault`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4abb6c4dea727af9d43d73c3bbe444f2f4d1af12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->