### PR TITLE
Define DEBUG for SPM packages in CI so package snapshot tests compile

### DIFF
--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -276,6 +276,8 @@ jobs:
 
     - name: Build for testing
       id: build-for-testing
+      env:
+        SPM_FORCE_DEBUG_FOR_SNAPSHOTS: "1"
       run: |
         echo "Runner ${RUNNER_NAME} (${RUNNER_TRACKING_ID})"
 

--- a/macOS/LocalPackages/SyncUI-macOS/Package.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Package.swift
@@ -2,6 +2,12 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+import Foundation
+
+// Set by the "Build for testing" step in .github/workflows/macos_pr_checks.yml. Under CI the package builds
+// in release configuration (SPM maps the CI configuration to .release), so `.when(configuration: .debug)` below
+// doesn't fire and the DEBUG-only snapshot tests wouldn't compile. This forces DEBUG on for that CI build.
+let forceDebugForSnapshots = ProcessInfo.processInfo.environment["SPM_FORCE_DEBUG_FOR_SNAPSHOTS"] == "1"
 
 let package = Package(
     name: "SyncUI-macOS",
@@ -35,7 +41,7 @@ let package = Package(
             ],
             swiftSettings: [
                 .define("DEBUG", .when(configuration: .debug))
-            ]
+            ] + (forceDebugForSnapshots ? [.define("DEBUG")] : [])
         ),
         .testTarget(
             name: "SyncUI-macOSTests",

--- a/macOS/LocalPackages/SyncUI-macOS/Tests/SyncUI-macOSTests/ManagementViewTests.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Tests/SyncUI-macOSTests/ManagementViewTests.swift
@@ -21,7 +21,6 @@ import SnapshotTestingSupport
 import Testing
 @testable import SyncUI_macOS
 
-#if DEBUG
 @MainActor
 @Suite("Management View Tests", .disabled("Snapshot testing is opt-in until the sync automations land"))
 final class ManagementViewTests {
@@ -35,4 +34,3 @@ final class ManagementViewTests {
         )
     }
 }
-#endif

--- a/macOS/LocalPackages/SyncUI-macOS/Tests/SyncUI-macOSTests/SyncSetupViewV2Tests.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Tests/SyncUI-macOSTests/SyncSetupViewV2Tests.swift
@@ -21,7 +21,6 @@ import SnapshotTestingSupport
 import Testing
 @testable import SyncUI_macOS
 
-#if DEBUG
 @MainActor
 @Suite("Sync Setup View V2 Tests", .disabled("Snapshot testing is opt-in until the sync automations land"))
 final class SyncSetupViewV2Tests {
@@ -35,4 +34,3 @@ final class SyncSetupViewV2Tests {
         )
     }
 }
-#endif


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1217362000068446

### Description
CI builds with `-configuration CI`, which SwiftPM maps to `.release`, so a package's `.define("DEBUG", .when(configuration: .debug))` never fires. As a result the `#if DEBUG` PreviewProviders that `SyncUI-macOS`'s snapshot suites reference aren't compiled, and the package test target fails to build under CI.

This gates an **unconditional `DEBUG` define in `SyncUI-macOS/Package.swift` behind a `SPM_FORCE_DEBUG_FOR_SNAPSHOTS` env var**, set only on the macOS PR `Build for testing` step. DEBUG is scoped to the single local package that needs it — vendored dependencies are never touched — and release/notarized workflows (which don't set the var) keep building as `.release`, so no debug code ships. The now-unnecessary `#if DEBUG` guards on the two snapshot suites are dropped.

### Testing Steps
1. CI green — `Build for testing` compiles the `SyncUI-macOSTests` target (the snapshot suites remain `.disabled`, so they compile without running).

### Impact
Low — CI test-build configuration only; release/notarized builds are untouched, so no debug code ships.
