### PR TITLE
iOS Promo Queue: Add cooldowns and diagnostics

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -647,8 +647,6 @@
 		6FF4943F2DDDDC4000BCF5F0 /* NSLayoutConstraintExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF4943E2DDDDC4000BCF5F0 /* NSLayoutConstraintExtension.swift */; };
 		6FF9AD3F2CE63DD800C5A406 /* TabSwitcherOpenDailyPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9AD3E2CE63DC200C5A406 /* TabSwitcherOpenDailyPixel.swift */; };
 		6FF9AD412CE6610F00C5A406 /* TabSwitcherOpenDailyPixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9AD402CE6610600C5A406 /* TabSwitcherOpenDailyPixelTests.swift */; };
-		7A0308270000000000000002 /* TabTerminationErrorPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0308270000000000000001 /* TabTerminationErrorPage.swift */; };
-		7A0308270000000000000004 /* TabTerminationErrorPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0308270000000000000003 /* TabTerminationErrorPageTests.swift */; };
 		71DFABCA706A402AB4B27F50 /* UnifiedToggleInputFloatingReturnKeyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5BA3FF1041A3BB9396AE65 /* UnifiedToggleInputFloatingReturnKeyViewController.swift */; };
 		735C2A86135E7F02B89D3D05 /* LaunchTimeMetricsProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B013517D758E8CF18834CC /* LaunchTimeMetricsProcessor.swift */; };
 		7560100309BC4006867327B4 /* ContextualSuggestedPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096F16CFD07B443887F47E3F /* ContextualSuggestedPrompt.swift */; };
@@ -657,6 +655,8 @@
 		78BBBA6B2FE42A6700AE8F41 /* VoiceSearchFeedbackView_PreviewMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BBBA6A2FE42A6700AE8F41 /* VoiceSearchFeedbackView_PreviewMocks.swift */; };
 		7A0308260000000000000002 /* TabTerminationTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0308260000000000000001 /* TabTerminationTelemetry.swift */; };
 		7A0308260000000000000004 /* TabTerminationTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0308260000000000000003 /* TabTerminationTelemetryTests.swift */; };
+		7A0308270000000000000002 /* TabTerminationErrorPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0308270000000000000001 /* TabTerminationErrorPage.swift */; };
+		7A0308270000000000000004 /* TabTerminationErrorPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0308270000000000000003 /* TabTerminationErrorPageTests.swift */; };
 		7A11B0C0D0E0F00102030405 /* IPadOmnibarToolPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11B0C0D0E0F00102030406 /* IPadOmnibarToolPickerController.swift */; };
 		7A11B0C0D0E0F00102030407 /* IPadOmnibarToolPickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11B0C0D0E0F00102030408 /* IPadOmnibarToolPickerControllerTests.swift */; };
 		7A1B2C3D2E0000000000F001 /* TabsBarViewControllerSizingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B2C3D2E0000000000F002 /* TabsBarViewControllerSizingTests.swift */; };
@@ -1636,7 +1636,7 @@
 		9F80A98A2EA9E4CF0079C5AD /* PromptCooldownMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F80A9882EA9E4CF0079C5AD /* PromptCooldownMigratorTests.swift */; };
 		9F81E5AD2FECE8F900EAB88E /* OnboardingIntroViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F81E5AC2FECE8F400EAB88E /* OnboardingIntroViewState.swift */; };
 		9F880BEE2F331CDF00BF211E /* FadeInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F880BED2F331CD900BF211E /* FadeInView.swift */; };
-		9F8828482EBAAF68006C878B /* ModalPromptCoordinationDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8828472EBAAF5A006C878B /* ModalPromptCoordinationDebugMenu.swift */; };
+		9F8828482EBAAF68006C878B /* PromptCoordinationDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8828472EBAAF5A006C878B /* PromptCoordinationDebugMenu.swift */; };
 		9F8BCBCE2EB43283004F071E /* RemoteMessagingPixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8BCBCD2EB43278004F071E /* RemoteMessagingPixelReporter.swift */; };
 		9F8E0F2D2CCA618E001EA7C5 /* VideoPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8E0F2C2CCA618E001EA7C5 /* VideoPlayerView.swift */; };
 		9F8FE9492BAE50E50071E372 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8FE9482BAE50E50071E372 /* Lottie */; };
@@ -1655,9 +1655,6 @@
 		9FA09DA62EA71F2900E26F3F /* PromptCooldownIntervalProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DA22EA71F2900E26F3F /* PromptCooldownIntervalProvider.swift */; };
 		9FA09DA72EA71F2900E26F3F /* PromptCooldownStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DA32EA71F2900E26F3F /* PromptCooldownStore.swift */; };
 		9FA09DA82EA71F2900E26F3F /* PromptCooldownManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DA42EA71F2900E26F3F /* PromptCooldownManager.swift */; };
-		B6A7C25131A1000100F00D01 /* PromoQueueCooldownPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25031A1000100F00D01 /* PromoQueueCooldownPolicy.swift */; };
-		B6A7C25331A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25231A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift */; };
-		B6A7C25531A1000100F00D01 /* ModalPromptCoordinationDebugMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25431A1000100F00D01 /* ModalPromptCoordinationDebugMenuTests.swift */; };
 		9FA09DAC2EA7400200E26F3F /* PromptCooldownStorePixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DAB2EA7400200E26F3F /* PromptCooldownStorePixelReporter.swift */; };
 		9FA09DAF2EA84F5D00E26F3F /* ModalPromptScheduling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DAE2EA84F5200E26F3F /* ModalPromptScheduling.swift */; };
 		9FA0AF192EB4855000713387 /* MockRemoteMessagingPixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA0AF182EB4855000713387 /* MockRemoteMessagingPixelReporter.swift */; };
@@ -1906,6 +1903,9 @@
 		B6A7C21A31A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C21931A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift */; };
 		B6A7C21C31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C21B31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift */; };
 		B6A7C21E31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C21D31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift */; };
+		B6A7C25131A1000100F00D01 /* PromoQueueCooldownPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25031A1000100F00D01 /* PromoQueueCooldownPolicy.swift */; };
+		B6A7C25331A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25231A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift */; };
+		B6A7C25531A1000100F00D01 /* ModalPromptCoordinationDebugMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25431A1000100F00D01 /* ModalPromptCoordinationDebugMenuTests.swift */; };
 		B6AD9E3728D4510A0019CDE9 /* ContentBlockingUpdatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AD9E3528D4510A0019CDE9 /* ContentBlockingUpdatingTests.swift */; };
 		B6AD9E3828D4512E0019CDE9 /* EmbeddedTrackerDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9801F08927E4B21100191874 /* EmbeddedTrackerDataTests.swift */; };
 		B6BA95C328891E33004ABA20 /* BrowsingMenuAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6BA95C228891E33004ABA20 /* BrowsingMenuAnimator.swift */; };
@@ -4537,7 +4537,7 @@
 		9F80A9882EA9E4CF0079C5AD /* PromptCooldownMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownMigratorTests.swift; sourceTree = "<group>"; };
 		9F81E5AC2FECE8F400EAB88E /* OnboardingIntroViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingIntroViewState.swift; sourceTree = "<group>"; };
 		9F880BED2F331CD900BF211E /* FadeInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FadeInView.swift; sourceTree = "<group>"; };
-		9F8828472EBAAF5A006C878B /* ModalPromptCoordinationDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationDebugMenu.swift; sourceTree = "<group>"; };
+		9F8828472EBAAF5A006C878B /* PromptCoordinationDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCoordinationDebugMenu.swift; sourceTree = "<group>"; };
 		9F8BCBCD2EB43278004F071E /* RemoteMessagingPixelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMessagingPixelReporter.swift; sourceTree = "<group>"; };
 		9F8E0F2C2CCA618E001EA7C5 /* VideoPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerView.swift; sourceTree = "<group>"; };
 		9F94BBAE2EAB395800185F78 /* WhatsNewModalPromptProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewModalPromptProviderTests.swift; sourceTree = "<group>"; };
@@ -4555,9 +4555,6 @@
 		9FA09DA22EA71F2900E26F3F /* PromptCooldownIntervalProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownIntervalProvider.swift; sourceTree = "<group>"; };
 		9FA09DA32EA71F2900E26F3F /* PromptCooldownStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownStore.swift; sourceTree = "<group>"; };
 		9FA09DA42EA71F2900E26F3F /* PromptCooldownManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownManager.swift; sourceTree = "<group>"; };
-		B6A7C25031A1000100F00D01 /* PromoQueueCooldownPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueCooldownPolicy.swift; sourceTree = "<group>"; };
-		B6A7C25231A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueCooldownPolicyTests.swift; sourceTree = "<group>"; };
-		B6A7C25431A1000100F00D01 /* ModalPromptCoordinationDebugMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationDebugMenuTests.swift; sourceTree = "<group>"; };
 		9FA09DAB2EA7400200E26F3F /* PromptCooldownStorePixelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownStorePixelReporter.swift; sourceTree = "<group>"; };
 		9FA09DAE2EA84F5200E26F3F /* ModalPromptScheduling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptScheduling.swift; sourceTree = "<group>"; };
 		9FA0AF182EB4855000713387 /* MockRemoteMessagingPixelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteMessagingPixelReporter.swift; sourceTree = "<group>"; };
@@ -4771,6 +4768,9 @@
 		B6A7C21931A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationManagerPromoQueueTests.swift; sourceTree = "<group>"; };
 		B6A7C21B31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptRootAttachmentCheckerTests.swift; sourceTree = "<group>"; };
 		B6A7C21D31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationRealUIKitTests.swift; sourceTree = "<group>"; };
+		B6A7C25031A1000100F00D01 /* PromoQueueCooldownPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueCooldownPolicy.swift; sourceTree = "<group>"; };
+		B6A7C25231A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueCooldownPolicyTests.swift; sourceTree = "<group>"; };
+		B6A7C25431A1000100F00D01 /* ModalPromptCoordinationDebugMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationDebugMenuTests.swift; sourceTree = "<group>"; };
 		B6AD9E3528D4510A0019CDE9 /* ContentBlockingUpdatingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentBlockingUpdatingTests.swift; sourceTree = "<group>"; };
 		B6BA95C228891E33004ABA20 /* BrowsingMenuAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingMenuAnimator.swift; sourceTree = "<group>"; };
 		B772933186CDFE9E9DDBD2BF /* FileCorruptErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCorruptErrorViewController.swift; sourceTree = "<group>"; };
@@ -9293,7 +9293,7 @@
 		9F8828462EBAAF46006C878B /* DebugMenu */ = {
 			isa = PBXGroup;
 			children = (
-				9F8828472EBAAF5A006C878B /* ModalPromptCoordinationDebugMenu.swift */,
+				9F8828472EBAAF5A006C878B /* PromptCoordinationDebugMenu.swift */,
 			);
 			path = DebugMenu;
 			sourceTree = "<group>";
@@ -13653,7 +13653,7 @@
 				EEF7091F2DDE77B000BA3C36 /* SyncExtensions.swift in Sources */,
 				EE458D0D2AB1DA4600FC651A /* EventMapping+NetworkProtectionError.swift in Sources */,
 				6F5DCFCE2E854C2000758C8A /* UniversalOmniBarEditingStateTransition.swift in Sources */,
-				9F8828482EBAAF68006C878B /* ModalPromptCoordinationDebugMenu.swift in Sources */,
+				9F8828482EBAAF68006C878B /* PromptCoordinationDebugMenu.swift in Sources */,
 				CBB4A8672FD31A4D00A65956 /* UnifiedSuggestionsView.swift in Sources */,
 				F44D279F27F331BB0037F371 /* AutofillLoginPromptViewController.swift in Sources */,
 				C1BF0BA529B63D7200482B73 /* AutofillLoginPromptHelper.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1657,6 +1657,7 @@
 		9FA09DA82EA71F2900E26F3F /* PromptCooldownManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DA42EA71F2900E26F3F /* PromptCooldownManager.swift */; };
 		B6A7C25131A1000100F00D01 /* PromoQueueCooldownPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25031A1000100F00D01 /* PromoQueueCooldownPolicy.swift */; };
 		B6A7C25331A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25231A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift */; };
+		B6A7C25531A1000100F00D01 /* ModalPromptCoordinationDebugMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25431A1000100F00D01 /* ModalPromptCoordinationDebugMenuTests.swift */; };
 		9FA09DAC2EA7400200E26F3F /* PromptCooldownStorePixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DAB2EA7400200E26F3F /* PromptCooldownStorePixelReporter.swift */; };
 		9FA09DAF2EA84F5D00E26F3F /* ModalPromptScheduling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DAE2EA84F5200E26F3F /* ModalPromptScheduling.swift */; };
 		9FA0AF192EB4855000713387 /* MockRemoteMessagingPixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA0AF182EB4855000713387 /* MockRemoteMessagingPixelReporter.swift */; };
@@ -4556,6 +4557,7 @@
 		9FA09DA42EA71F2900E26F3F /* PromptCooldownManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownManager.swift; sourceTree = "<group>"; };
 		B6A7C25031A1000100F00D01 /* PromoQueueCooldownPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueCooldownPolicy.swift; sourceTree = "<group>"; };
 		B6A7C25231A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueCooldownPolicyTests.swift; sourceTree = "<group>"; };
+		B6A7C25431A1000100F00D01 /* ModalPromptCoordinationDebugMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationDebugMenuTests.swift; sourceTree = "<group>"; };
 		9FA09DAB2EA7400200E26F3F /* PromptCooldownStorePixelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownStorePixelReporter.swift; sourceTree = "<group>"; };
 		9FA09DAE2EA84F5200E26F3F /* ModalPromptScheduling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptScheduling.swift; sourceTree = "<group>"; };
 		9FA0AF182EB4855000713387 /* MockRemoteMessagingPixelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteMessagingPixelReporter.swift; sourceTree = "<group>"; };
@@ -9220,6 +9222,7 @@
 				9F80A9892EA9E4CF0079C5AD /* Migrator */,
 				9F7634BC2EA8633300804550 /* Cooldown */,
 				9F387E052EA9A1D8006861F8 /* Providers */,
+				B6A7C25431A1000100F00D01 /* ModalPromptCoordinationDebugMenuTests.swift */,
 				9F387DE52EA89551006861F8 /* ModalPromptCoordinationManagerTests.swift */,
 				B6A7C21931A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift */,
 				B6A7C21B31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift */,
@@ -15125,6 +15128,7 @@
 				9FE7CD5C2E14C6CD006691AB /* DefaultBrowserPromptUserActivityManagerTests.swift in Sources */,
 				9F387DDA2EA87C0F006861F8 /* PromptCooldownManagerTests.swift in Sources */,
 				B6A7C25331A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift in Sources */,
+				B6A7C25531A1000100F00D01 /* ModalPromptCoordinationDebugMenuTests.swift in Sources */,
 				98E563F72DE8B32D00E6E75F /* OnboardingHostingControllerMock.swift in Sources */,
 				BBFF22EF2F3469160055A710 /* MockFreeTrialConversionInstrumentationService.swift in Sources */,
 				98E563F82DE8B32D00E6E75F /* MockOmniBar.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1655,6 +1655,8 @@
 		9FA09DA62EA71F2900E26F3F /* PromptCooldownIntervalProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DA22EA71F2900E26F3F /* PromptCooldownIntervalProvider.swift */; };
 		9FA09DA72EA71F2900E26F3F /* PromptCooldownStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DA32EA71F2900E26F3F /* PromptCooldownStore.swift */; };
 		9FA09DA82EA71F2900E26F3F /* PromptCooldownManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DA42EA71F2900E26F3F /* PromptCooldownManager.swift */; };
+		B6A7C25131A1000100F00D01 /* PromoQueueCooldownPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25031A1000100F00D01 /* PromoQueueCooldownPolicy.swift */; };
+		B6A7C25331A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25231A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift */; };
 		9FA09DAC2EA7400200E26F3F /* PromptCooldownStorePixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DAB2EA7400200E26F3F /* PromptCooldownStorePixelReporter.swift */; };
 		9FA09DAF2EA84F5D00E26F3F /* ModalPromptScheduling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DAE2EA84F5200E26F3F /* ModalPromptScheduling.swift */; };
 		9FA0AF192EB4855000713387 /* MockRemoteMessagingPixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA0AF182EB4855000713387 /* MockRemoteMessagingPixelReporter.swift */; };
@@ -4552,6 +4554,8 @@
 		9FA09DA22EA71F2900E26F3F /* PromptCooldownIntervalProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownIntervalProvider.swift; sourceTree = "<group>"; };
 		9FA09DA32EA71F2900E26F3F /* PromptCooldownStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownStore.swift; sourceTree = "<group>"; };
 		9FA09DA42EA71F2900E26F3F /* PromptCooldownManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownManager.swift; sourceTree = "<group>"; };
+		B6A7C25031A1000100F00D01 /* PromoQueueCooldownPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueCooldownPolicy.swift; sourceTree = "<group>"; };
+		B6A7C25231A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueCooldownPolicyTests.swift; sourceTree = "<group>"; };
 		9FA09DAB2EA7400200E26F3F /* PromptCooldownStorePixelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownStorePixelReporter.swift; sourceTree = "<group>"; };
 		9FA09DAE2EA84F5200E26F3F /* ModalPromptScheduling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptScheduling.swift; sourceTree = "<group>"; };
 		9FA0AF182EB4855000713387 /* MockRemoteMessagingPixelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteMessagingPixelReporter.swift; sourceTree = "<group>"; };
@@ -9202,6 +9206,7 @@
 		9F7634BC2EA8633300804550 /* Cooldown */ = {
 			isa = PBXGroup;
 			children = (
+				B6A7C25231A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift */,
 				9F7634BB2EA8633300804550 /* PromptCooldownIntervalProviderTests.swift */,
 				9F387DD72EA86CE3006861F8 /* PromptCooldownStoreTests.swift */,
 				9F387DD92EA87C0F006861F8 /* PromptCooldownManagerTests.swift */,
@@ -9374,6 +9379,7 @@
 			isa = PBXGroup;
 			children = (
 				9FA09DAA2EA73FD700E26F3F /* Monitoring */,
+				B6A7C25031A1000100F00D01 /* PromoQueueCooldownPolicy.swift */,
 				9FA09DA22EA71F2900E26F3F /* PromptCooldownIntervalProvider.swift */,
 				9FA09DA32EA71F2900E26F3F /* PromptCooldownStore.swift */,
 				9FA09DA42EA71F2900E26F3F /* PromptCooldownManager.swift */,
@@ -14371,6 +14377,7 @@
 				80A198C72F1AB3A90015521B /* TabViewModel.swift in Sources */,
 				5BF65FDA2F5A2CB800BCC9F4 /* AutoplaySettings.swift in Sources */,
 				9FA09DA82EA71F2900E26F3F /* PromptCooldownManager.swift in Sources */,
+				B6A7C25131A1000100F00D01 /* PromoQueueCooldownPolicy.swift in Sources */,
 				80A09D642F6BBA1F00AACDEE /* DataStoreWarmupWorker.swift in Sources */,
 				1E4DCF4E27B6A69600961E25 /* DownloadsListHostingController.swift in Sources */,
 				850F93DB2B594AB800823EEA /* ZippedPassKitPreviewHelper.swift in Sources */,
@@ -15117,6 +15124,7 @@
 				98E564A22DE8EDCE00E6E75F /* CapturingSyncPausedStateManager.swift in Sources */,
 				9FE7CD5C2E14C6CD006691AB /* DefaultBrowserPromptUserActivityManagerTests.swift in Sources */,
 				9F387DDA2EA87C0F006861F8 /* PromptCooldownManagerTests.swift in Sources */,
+				B6A7C25331A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift in Sources */,
 				98E563F72DE8B32D00E6E75F /* OnboardingHostingControllerMock.swift in Sources */,
 				BBFF22EF2F3469160055A710 /* MockFreeTrialConversionInstrumentationService.swift in Sources */,
 				98E563F82DE8B32D00E6E75F /* MockOmniBar.swift in Sources */,

--- a/iOS/DuckDuckGo/AppServices/PromoCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/PromoCoordinationService.swift
@@ -42,6 +42,23 @@ struct PromoCoordinationForegroundReadinessToken: Equatable {
     fileprivate let id = UUID()
 }
 
+struct PromoQueueDebugSnapshot: Equatable {
+    let mode: PromoCoordinationMode
+    let activeOwner: PromoQueueActiveOwnerSnapshot?
+    let remoteMessageCoordination: PromoQueueRemoteMessageCoordinationSnapshot
+    let modalAttemptPhase: ModalPromptAttemptPhase
+    let hasPendingModalPrompt: Bool
+    let shouldSuppressOtherSessionPromos: Bool
+    let isApplicationActive: Bool
+    let isWaitingForForegroundInteractionReadiness: Bool
+    let cooldown: PromoQueueCooldownSnapshot
+}
+
+@MainActor
+protocol PromoQueueDebugSnapshotProviding: AnyObject {
+    var promoQueueDebugSnapshot: PromoQueueDebugSnapshot { get }
+}
+
 // MARK: - Service
 
 struct ModalPromptProviders {
@@ -65,7 +82,7 @@ enum PromoQueueRemoteMessageDrainContinuationSnapshot: Equatable {
     case endSession
 }
 
-/// Read-only projection of the service-owned RMF state for focused tests and later debug UI integration.
+/// Read-only projection of the service-owned RMF state for focused tests and the debug UI.
 struct PromoQueueRemoteMessageCoordinationSnapshot: Equatable {
     let state: PromoQueueRemoteMessageLogicalStateSnapshot
     let messageID: String?
@@ -928,4 +945,29 @@ extension PromoCoordinationService: NewTabPagePromoCoordinating {
 
 extension PromoCoordinationService: RecentModalPromptStatusProviding {
     var shouldSuppressOtherSessionPromos: Bool { modalPromptCoordinationManager.shouldSuppressOtherSessionPromos }
+}
+
+extension PromoCoordinationService: PromoQueueDebugSnapshotProviding {
+    var promoQueueDebugSnapshot: PromoQueueDebugSnapshot {
+        let cooldownSnapshot: PromoQueueCooldownSnapshot
+        switch promoCoordinationMode {
+        case .legacy:
+            // The legacy path must not activate either persisted Promo Queue history read.
+            cooldownSnapshot = .empty
+        case .coordinated:
+            cooldownSnapshot = promoQueueCooldownPolicy.snapshot(now: dateProvider())
+        }
+
+        return PromoQueueDebugSnapshot(
+            mode: promoCoordinationMode,
+            activeOwner: promoQueueLeaseArbiter.snapshot.activeOwner,
+            remoteMessageCoordination: remoteMessageCoordinationSnapshot,
+            modalAttemptPhase: modalPromptCoordinationManager.modalAttemptPhase,
+            hasPendingModalPrompt: modalPromptCoordinationManager.hasPendingModalPrompt,
+            shouldSuppressOtherSessionPromos: modalPromptCoordinationManager.shouldSuppressOtherSessionPromos,
+            isApplicationActive: isApplicationActive,
+            isWaitingForForegroundInteractionReadiness: isWaitingForForegroundInteractionReadiness,
+            cooldown: cooldownSnapshot
+        )
+    }
 }

--- a/iOS/DuckDuckGo/AppServices/PromoCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/PromoCoordinationService.swift
@@ -957,18 +957,21 @@ extension PromoCoordinationService: RecentModalPromptStatusProviding {
 
 extension PromoCoordinationService: PromoQueueDebugSnapshotProviding {
     var promoQueueDebugSnapshot: PromoQueueDebugSnapshot {
+        let activeOwner: PromoQueueActiveOwnerSnapshot?
         let cooldownSnapshot: PromoQueueCooldownSnapshot
         switch promoCoordinationMode {
         case .legacy:
-            // The legacy path must not activate either persisted Promo Queue history read.
+            // The legacy path must not touch the arbiter or activate either persisted Promo Queue history read.
+            activeOwner = nil
             cooldownSnapshot = .empty
         case .coordinated:
+            activeOwner = promoQueueLeaseArbiter.snapshot.activeOwner
             cooldownSnapshot = promoQueueCooldownDebugSnapshotProvider?.snapshot(now: dateProvider()) ?? .empty
         }
 
         return PromoQueueDebugSnapshot(
             mode: promoCoordinationMode,
-            activeOwner: promoQueueLeaseArbiter.snapshot.activeOwner,
+            activeOwner: activeOwner,
             remoteMessageCoordination: remoteMessageCoordinationSnapshot,
             modalAttemptPhase: modalPromptCoordinationManager.modalAttemptPhase,
             hasPendingModalPrompt: modalPromptCoordinationManager.hasPendingModalPrompt,

--- a/iOS/DuckDuckGo/AppServices/PromoCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/PromoCoordinationService.swift
@@ -159,6 +159,8 @@ final class PromoCoordinationService {
     private let modalPromptCoordinationManager: ModalPromptCoordinationManaging
     private let launchSourceManager: LaunchSourceManaging
     private let promoQueueLeaseArbiter: PromoQueueLeaseArbitrating
+    private let promoQueueCooldownPolicy: PromoQueueCooldownPolicying
+    private let dateProvider: () -> Date
     private var remoteMessageRendererRegistrations = [WeakRemoteMessageRendererRegistration]()
     private var nextRemoteMessageRegistrationOrder: UInt64 = 0
     private var remoteMessageState = RemoteMessageState.idle
@@ -271,6 +273,11 @@ final class PromoCoordinationService {
         let presentationStore = PromptCooldownKeyValueFilesStore(keyValueStore: keyValueStore, eventMapper: PromptCooldownStorePixelReporter())
         let cooldownIntervalProvider = PromptCooldownIntervalProvider(privacyConfigManager: privacyConfigManager)
         let cooldownManager = PromptCooldownManager(presentationStore: presentationStore, cooldownIntervalProvider: cooldownIntervalProvider)
+        let remoteMessagePresentationStore = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        let promoQueueCooldownPolicy = PromoQueueCooldownPolicy(
+            modalPresentationStore: presentationStore,
+            remoteMessagePresentationStore: remoteMessagePresentationStore
+        )
 
         let modalPromptCoordinationManager = ModalPromptCoordinationManager(
             providers: providers,
@@ -282,7 +289,8 @@ final class PromoCoordinationService {
             launchSourceManager: launchSourceManager,
             modalPromptCoordinationManager: modalPromptCoordinationManager,
             promoCoordinationMode: promoCoordinationMode,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            promoQueueCooldownPolicy: promoQueueCooldownPolicy
         )
     }
 
@@ -290,12 +298,16 @@ final class PromoCoordinationService {
         launchSourceManager: LaunchSourceManaging,
         modalPromptCoordinationManager: ModalPromptCoordinationManaging,
         promoCoordinationMode: PromoCoordinationMode,
-        promoQueueLeaseArbiter: PromoQueueLeaseArbitrating
+        promoQueueLeaseArbiter: PromoQueueLeaseArbitrating,
+        promoQueueCooldownPolicy: PromoQueueCooldownPolicying,
+        dateProvider: @escaping () -> Date = Date.init
     ) {
         self.launchSourceManager = launchSourceManager
         self.modalPromptCoordinationManager = modalPromptCoordinationManager
         self.promoCoordinationMode = promoCoordinationMode
         self.promoQueueLeaseArbiter = promoQueueLeaseArbiter
+        self.promoQueueCooldownPolicy = promoQueueCooldownPolicy
+        self.dateProvider = dateProvider
 
         modalPromptCoordinationManager.setCoordinatedAttemptReleaseHandler { [weak self] in
             guard self?.promoCoordinationMode == .coordinated else {
@@ -395,6 +407,12 @@ final class PromoCoordinationService {
 
         switch promoQueueLeaseArbiter.acquireModalLease() {
         case .acquired(let lease):
+            guard promoQueueCooldownPolicy.evaluateModalAdmission(now: dateProvider()) == .eligible else {
+                lease.release()
+                Logger.modalPrompt.debug("[Promo Queue] - Skipping modal prompt during the fixed RMF-to-modal cooldown.")
+                return
+            }
+
             switch modalPromptCoordinationManager.presentModalPromptIfNeeded(from: viewController, with: lease) {
             case .retained:
                 Logger.modalPrompt.debug("[Modal Prompt Coordination] - The coordinated modal attempt holds the slot.")
@@ -453,8 +471,12 @@ final class PromoCoordinationService {
         }
 
         ownedState.isCurrentPresentationAppearanceReported = true
+        let shouldRecordQueueAppearance = !ownedState.logicalSession.isQueueAppearanceConfirmed
         ownedState.logicalSession.isQueueAppearanceConfirmed = true
         remoteMessageState = .owned(ownedState)
+        if shouldRecordQueueAppearance {
+            promoQueueCooldownPolicy.recordConfirmedRemoteMessageAppearance(at: dateProvider())
+        }
         return .accepted
     }
 
@@ -579,6 +601,15 @@ final class PromoCoordinationService {
         let session = PromoQueueRemoteMessageSession(id: UUID(), messageID: messageID)
         switch promoQueueLeaseArbiter.acquireRemoteMessageLease(for: session) {
         case .acquired(let lease):
+            guard promoQueueCooldownPolicy.evaluateRemoteMessageAdmission(now: dateProvider()) == .eligible else {
+                _ = lease.release()
+                // Reconciliation may have been dirtied when the preceding modal check released a stale modal lease.
+                // A cooldown denial is checkpoint-driven, so do not reacquire in this reconciliation pass.
+                needsRemoteMessageReconciliation = false
+                Logger.modalPrompt.debug("[Promo Queue] - Deferring RMF during the fixed directional cooldown.")
+                return
+            }
+
             let logicalSession = LogicalRemoteMessageSession(identity: session)
             authorizeRemoteMessage(
                 logicalSession: logicalSession,

--- a/iOS/DuckDuckGo/AppServices/PromoCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/PromoCoordinationService.swift
@@ -177,6 +177,7 @@ final class PromoCoordinationService {
     private let launchSourceManager: LaunchSourceManaging
     private let promoQueueLeaseArbiter: PromoQueueLeaseArbitrating
     private let promoQueueCooldownPolicy: PromoQueueCooldownPolicying
+    private let promoQueueCooldownDebugSnapshotProvider: PromoQueueCooldownDebugSnapshotProviding?
     private let dateProvider: () -> Date
     private var remoteMessageRendererRegistrations = [WeakRemoteMessageRendererRegistration]()
     private var nextRemoteMessageRegistrationOrder: UInt64 = 0
@@ -295,6 +296,10 @@ final class PromoCoordinationService {
             modalPresentationStore: presentationStore,
             remoteMessagePresentationStore: remoteMessagePresentationStore
         )
+        let promoQueueCooldownDebugSnapshotProvider = PromoQueueCooldownDebugSnapshotProvider(
+            modalPresentationStore: presentationStore,
+            remoteMessagePresentationStore: remoteMessagePresentationStore
+        )
 
         let modalPromptCoordinationManager = ModalPromptCoordinationManager(
             providers: providers,
@@ -307,7 +312,8 @@ final class PromoCoordinationService {
             modalPromptCoordinationManager: modalPromptCoordinationManager,
             promoCoordinationMode: promoCoordinationMode,
             promoQueueLeaseArbiter: promoQueueLeaseArbiter,
-            promoQueueCooldownPolicy: promoQueueCooldownPolicy
+            promoQueueCooldownPolicy: promoQueueCooldownPolicy,
+            promoQueueCooldownDebugSnapshotProvider: promoQueueCooldownDebugSnapshotProvider
         )
     }
 
@@ -317,6 +323,7 @@ final class PromoCoordinationService {
         promoCoordinationMode: PromoCoordinationMode,
         promoQueueLeaseArbiter: PromoQueueLeaseArbitrating,
         promoQueueCooldownPolicy: PromoQueueCooldownPolicying,
+        promoQueueCooldownDebugSnapshotProvider: PromoQueueCooldownDebugSnapshotProviding? = nil,
         dateProvider: @escaping () -> Date = Date.init
     ) {
         self.launchSourceManager = launchSourceManager
@@ -324,6 +331,7 @@ final class PromoCoordinationService {
         self.promoCoordinationMode = promoCoordinationMode
         self.promoQueueLeaseArbiter = promoQueueLeaseArbiter
         self.promoQueueCooldownPolicy = promoQueueCooldownPolicy
+        self.promoQueueCooldownDebugSnapshotProvider = promoQueueCooldownDebugSnapshotProvider
         self.dateProvider = dateProvider
 
         modalPromptCoordinationManager.setCoordinatedAttemptReleaseHandler { [weak self] in
@@ -955,7 +963,7 @@ extension PromoCoordinationService: PromoQueueDebugSnapshotProviding {
             // The legacy path must not activate either persisted Promo Queue history read.
             cooldownSnapshot = .empty
         case .coordinated:
-            cooldownSnapshot = promoQueueCooldownPolicy.snapshot(now: dateProvider())
+            cooldownSnapshot = promoQueueCooldownDebugSnapshotProvider?.snapshot(now: dateProvider()) ?? .empty
         }
 
         return PromoQueueDebugSnapshot(

--- a/iOS/DuckDuckGo/DebugScreen.swift
+++ b/iOS/DuckDuckGo/DebugScreen.swift
@@ -58,6 +58,7 @@ enum DebugScreen: Identifiable {
         let remoteMessagingDebugHandler: RemoteMessagingDebugHandling
         let webExtensionManager: WebExtensionManaging?
         let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
+        let promoQueueDebugSnapshotProvider: PromoQueueDebugSnapshotProviding?
 
     }
 

--- a/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
@@ -169,7 +169,10 @@ extension DebugScreensViewModel {
                 WinBackOfferDebugView(keyValueStore: d.keyValueStore)
             }),
             .view(title: "Modal Prompt Coordination", { d in
-                ModalPromptCoordinationDebugView(keyValueStore: d.keyValueStore)
+                ModalPromptCoordinationDebugView(
+                    keyValueStore: d.keyValueStore,
+                    promoQueueDebugSnapshotProvider: d.promoQueueDebugSnapshotProvider
+                )
             }),
             .view(title: "What's New", { dependencies in
                 WhatsNewDebugView(keyValueStore: dependencies.keyValueStore, remoteMessagingDebugHandler: dependencies.remoteMessagingDebugHandler)

--- a/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
@@ -168,8 +168,8 @@ extension DebugScreensViewModel {
             .view(title: "Win-back Offer", { d in
                 WinBackOfferDebugView(keyValueStore: d.keyValueStore)
             }),
-            .view(title: "Modal Prompt Coordination", { d in
-                ModalPromptCoordinationDebugView(
+            .view(title: "Prompt Coordination", { d in
+                PromptCoordinationDebugView(
                     keyValueStore: d.keyValueStore,
                     promoQueueDebugSnapshotProvider: d.promoQueueDebugSnapshotProvider
                 )

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -501,7 +501,8 @@ extension MainViewController {
                                                             syncAutoRestoreHandler: syncAutoRestoreHandler,
                                                             freemiumPIRDebugSettings: freemiumPIRDebugSettings,
                                                             freemiumDBPUserStateManager: freemiumDBPUserStateManager,
-                                                            duckAiNativeStorageHandler: duckAiNativeStorageHandler)
+                                                            duckAiNativeStorageHandler: duckAiNativeStorageHandler,
+                                                            promoQueueDebugSnapshotProvider: promoQueueDebugSnapshotProvider)
 
         let aiChatSettings = AIChatSettings(privacyConfigurationManager: privacyConfigurationManager)
         let serpSettingsProvider = SERPSettingsProvider(aiChatProvider: aiChatSettings)
@@ -625,7 +626,8 @@ extension MainViewController {
             subscriptionDataReporter: self.subscriptionDataReporter,
             remoteMessagingDebugHandler: self.remoteMessagingDebugHandler,
             webExtensionManager: self.webExtensionManager,
-            duckAiNativeStorageHandler: self.duckAiNativeStorageHandler))
+            duckAiNativeStorageHandler: self.duckAiNativeStorageHandler,
+            promoQueueDebugSnapshotProvider: self.promoQueueDebugSnapshotProvider))
 
         debug.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: debug, action: #selector(DebugScreensViewController.dismissSelf))
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -356,6 +356,7 @@ class MainViewController: UIViewController {
     let themeManager: ThemeManaging
     let keyValueStore: ThrowingKeyValueStoring
     let newTabPagePromoCoordinator: NewTabPagePromoCoordinating
+    let promoQueueDebugSnapshotProvider: PromoQueueDebugSnapshotProviding?
     let recentModalPromptStatusProvider: RecentModalPromptStatusProviding?
     let systemSettingsPiPTutorialManager: SystemSettingsPiPTutorialManaging
     let onboardingResumeStepStore: any KeyedStoring<OnboardingStoringKeys>
@@ -530,6 +531,7 @@ class MainViewController: UIViewController {
         onboardingResumeStepStore: (any KeyedStoring<OnboardingStoringKeys>)? = nil,
         onboardingManager: OnboardingManaging,
         newTabPagePromoCoordinator: NewTabPagePromoCoordinating,
+        promoQueueDebugSnapshotProvider: PromoQueueDebugSnapshotProviding? = nil,
         recentModalPromptStatusProvider: RecentModalPromptStatusProviding? = nil
     ) {
         self.remoteMessagingActionHandler = remoteMessagingActionHandler
@@ -595,6 +597,7 @@ class MainViewController: UIViewController {
         self.contentScopeExperimentsManager = contentScopeExperimentsManager
         self.keyValueStore = keyValueStore
         self.newTabPagePromoCoordinator = newTabPagePromoCoordinator
+        self.promoQueueDebugSnapshotProvider = promoQueueDebugSnapshotProvider
         self.recentModalPromptStatusProvider = recentModalPromptStatusProvider
         self.onboardingResumeStepStore = if let onboardingResumeStepStore { onboardingResumeStepStore } else { UserDefaults.app.keyedStoring() }
         self.customConfigurationURLProvider = customConfigurationURLProvider

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Arbitration/PromoQueueLeaseArbiter.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Arbitration/PromoQueueLeaseArbiter.swift
@@ -158,16 +158,16 @@ final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
 
     private var activeOwner: ActiveOwner?
 
-    /// Prunes before reading so neither the debug screen nor a caller can observe a lease whose token is already gone.
+    /// Observational projection of the current lease. A record whose weak token has deallocated is reported as idle,
+    /// but reads never mutate arbitration state; the next acquisition performs reclamation.
     var snapshot: PromoQueueLeaseSnapshot {
-        pruneLeasesWithDeallocatedTokens()
         let ownerSnapshot: PromoQueueActiveOwnerSnapshot?
         switch activeOwner {
-        case .modal(let record):
+        case .modal(let record) where record.token != nil:
             ownerSnapshot = .modal(record.attemptIdentity)
-        case .remoteMessage(let record):
+        case .remoteMessage(let record) where record.token != nil:
             ownerSnapshot = .remoteMessage(record.session)
-        case nil:
+        default:
             ownerSnapshot = nil
         }
         return PromoQueueLeaseSnapshot(activeOwner: ownerSnapshot)

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicy.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicy.swift
@@ -1,0 +1,158 @@
+//
+//  PromoQueueCooldownPolicy.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Persistence
+
+struct PromoQueueCooldownSnapshot: Equatable {
+    let lastConfirmedModalAppearance: Date?
+    let lastConfirmedRemoteMessageAppearance: Date?
+    let nextRemoteMessageEligibility: Date?
+    let nextModalEligibility: Date?
+
+    static let empty = PromoQueueCooldownSnapshot(
+        lastConfirmedModalAppearance: nil,
+        lastConfirmedRemoteMessageAppearance: nil,
+        nextRemoteMessageEligibility: nil,
+        nextModalEligibility: nil
+    )
+}
+
+enum PromoQueueCooldownDecision: Equatable {
+    case eligible
+    case blocked(until: Date)
+}
+
+@MainActor
+protocol PromoQueueRemoteMessageCooldownStoring: AnyObject {
+    var lastConfirmedRemoteMessageTimestamp: TimeInterval? { get set }
+}
+
+@MainActor
+final class PromoQueueRemoteMessageCooldownKeyValueFilesStore: PromoQueueRemoteMessageCooldownStoring {
+
+    enum StorageKey {
+        static let lastConfirmedRemoteMessageTimestamp = "com.duckduckgo.promo-queue.last-confirmed-remote-message-timestamp"
+    }
+
+    private enum CachedTimestamp {
+        case unavailable
+        case value(TimeInterval?)
+    }
+
+    private let keyValueStore: ThrowingKeyValueStoring
+    private var lastSuccessfulRead: CachedTimestamp = .unavailable
+    private var locallyWrittenValue: CachedTimestamp = .unavailable
+
+    init(keyValueStore: ThrowingKeyValueStoring) {
+        self.keyValueStore = keyValueStore
+    }
+
+    var lastConfirmedRemoteMessageTimestamp: TimeInterval? {
+        get {
+            if case .value(let timestamp) = locallyWrittenValue {
+                return timestamp
+            }
+
+            do {
+                let timestamp = try keyValueStore.object(forKey: StorageKey.lastConfirmedRemoteMessageTimestamp) as? TimeInterval
+                lastSuccessfulRead = .value(timestamp)
+                return timestamp
+            } catch {
+                Logger.modalPrompt.error("[Promo Queue] - Failed to read the last confirmed RMF timestamp.")
+                guard case .value(let timestamp) = lastSuccessfulRead else {
+                    return nil
+                }
+                return timestamp
+            }
+        }
+        set {
+            // A confirmed appearance must remain authoritative for this process even if persistence is temporarily unavailable.
+            locallyWrittenValue = .value(newValue)
+            lastSuccessfulRead = .value(newValue)
+
+            do {
+                try keyValueStore.set(newValue, forKey: StorageKey.lastConfirmedRemoteMessageTimestamp)
+            } catch {
+                Logger.modalPrompt.error("[Promo Queue] - Failed to write the last confirmed RMF timestamp.")
+            }
+        }
+    }
+}
+
+@MainActor
+protocol PromoQueueCooldownPolicying: AnyObject {
+    func evaluateRemoteMessageAdmission(now: Date) -> PromoQueueCooldownDecision
+    func evaluateModalAdmission(now: Date) -> PromoQueueCooldownDecision
+    func recordConfirmedRemoteMessageAppearance(at date: Date)
+    func snapshot(now: Date) -> PromoQueueCooldownSnapshot
+}
+
+@MainActor
+final class PromoQueueCooldownPolicy: PromoQueueCooldownPolicying {
+    static let remoteMessageTargetInterval: TimeInterval = 10 * 60
+    static let modalAfterRemoteMessageInterval: TimeInterval = 24 * 60 * 60
+
+    private let modalPresentationStore: PromptCooldownStore
+    private let remoteMessagePresentationStore: PromoQueueRemoteMessageCooldownStoring
+
+    init(
+        modalPresentationStore: PromptCooldownStore,
+        remoteMessagePresentationStore: PromoQueueRemoteMessageCooldownStoring
+    ) {
+        self.modalPresentationStore = modalPresentationStore
+        self.remoteMessagePresentationStore = remoteMessagePresentationStore
+    }
+
+    func evaluateRemoteMessageAdmission(now: Date) -> PromoQueueCooldownDecision {
+        let nextEligibility = snapshot(now: now).nextRemoteMessageEligibility
+        return decision(now: now, nextEligibility: nextEligibility)
+    }
+
+    func evaluateModalAdmission(now: Date) -> PromoQueueCooldownDecision {
+        let nextEligibility = snapshot(now: now).nextModalEligibility
+        return decision(now: now, nextEligibility: nextEligibility)
+    }
+
+    func recordConfirmedRemoteMessageAppearance(at date: Date) {
+        remoteMessagePresentationStore.lastConfirmedRemoteMessageTimestamp = date.timeIntervalSince1970
+    }
+
+    func snapshot(now _: Date) -> PromoQueueCooldownSnapshot {
+        let lastModalAppearance = modalPresentationStore.lastPresentationTimestamp.map(Date.init(timeIntervalSince1970:))
+        let lastRemoteMessageAppearance = remoteMessagePresentationStore.lastConfirmedRemoteMessageTimestamp.map(Date.init(timeIntervalSince1970:))
+
+        let remoteMessageBoundaries = [lastModalAppearance, lastRemoteMessageAppearance]
+            .compactMap { $0?.addingTimeInterval(Self.remoteMessageTargetInterval) }
+
+        return PromoQueueCooldownSnapshot(
+            lastConfirmedModalAppearance: lastModalAppearance,
+            lastConfirmedRemoteMessageAppearance: lastRemoteMessageAppearance,
+            nextRemoteMessageEligibility: remoteMessageBoundaries.max(),
+            nextModalEligibility: lastRemoteMessageAppearance?.addingTimeInterval(Self.modalAfterRemoteMessageInterval)
+        )
+    }
+
+    private func decision(now: Date, nextEligibility: Date?) -> PromoQueueCooldownDecision {
+        guard let nextEligibility, now < nextEligibility else {
+            return .eligible
+        }
+        return .blocked(until: nextEligibility)
+    }
+}

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicy.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicy.swift
@@ -99,7 +99,7 @@ final class PromoQueueRemoteMessageCooldownKeyValueFilesStore: PromoQueueRemoteM
     ///
     /// In particular, a successful persistence read made only for diagnostics must not become the fallback for a
     /// later production read failure. Locally confirmed appearances remain authoritative for the current process.
-    func lastConfirmedRemoteMessageTimestampForPromoQueueDiagnostics() -> TimeInterval? {
+    fileprivate func lastConfirmedRemoteMessageTimestampForPromoQueueDiagnostics() -> TimeInterval? {
         if case .value(let timestamp) = locallyWrittenValue {
             return timestamp
         }
@@ -149,7 +149,6 @@ protocol PromoQueueCooldownPolicying: AnyObject {
     func evaluateRemoteMessageAdmission(now: Date) -> PromoQueueCooldownDecision
     func evaluateModalAdmission(now: Date) -> PromoQueueCooldownDecision
     func recordConfirmedRemoteMessageAppearance(at date: Date)
-    func snapshot(now: Date) -> PromoQueueCooldownSnapshot
 }
 
 @MainActor
@@ -169,24 +168,25 @@ final class PromoQueueCooldownPolicy: PromoQueueCooldownPolicying {
     }
 
     func evaluateRemoteMessageAdmission(now: Date) -> PromoQueueCooldownDecision {
-        let nextEligibility = snapshot(now: now).nextRemoteMessageEligibility
+        let lastAppearance = [
+            modalPresentationStore.lastPresentationTimestamp,
+            remoteMessagePresentationStore.lastConfirmedRemoteMessageTimestamp,
+        ]
+            .compactMap { $0 }
+            .map(Date.init(timeIntervalSince1970:))
+            .max()
+        let nextEligibility = lastAppearance?.addingTimeInterval(Self.remoteMessageTargetInterval)
         return decision(now: now, nextEligibility: nextEligibility)
     }
 
     func evaluateModalAdmission(now: Date) -> PromoQueueCooldownDecision {
-        let nextEligibility = snapshot(now: now).nextModalEligibility
+        let nextEligibility = remoteMessagePresentationStore.lastConfirmedRemoteMessageTimestamp
+            .map { Date(timeIntervalSince1970: $0).addingTimeInterval(Self.modalAfterRemoteMessageInterval) }
         return decision(now: now, nextEligibility: nextEligibility)
     }
 
     func recordConfirmedRemoteMessageAppearance(at date: Date) {
         remoteMessagePresentationStore.lastConfirmedRemoteMessageTimestamp = date.timeIntervalSince1970
-    }
-
-    func snapshot(now _: Date) -> PromoQueueCooldownSnapshot {
-        PromoQueueCooldownSnapshot.make(
-            lastModalTimestamp: modalPresentationStore.lastPresentationTimestamp,
-            lastRemoteMessageTimestamp: remoteMessagePresentationStore.lastConfirmedRemoteMessageTimestamp
-        )
     }
 
     private func decision(now: Date, nextEligibility: Date?) -> PromoQueueCooldownDecision {

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicy.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicy.swift
@@ -94,6 +94,54 @@ final class PromoQueueRemoteMessageCooldownKeyValueFilesStore: PromoQueueRemoteM
             }
         }
     }
+
+    /// Returns the timestamp that production admission would currently observe without changing its fallback cache.
+    ///
+    /// In particular, a successful persistence read made only for diagnostics must not become the fallback for a
+    /// later production read failure. Locally confirmed appearances remain authoritative for the current process.
+    func lastConfirmedRemoteMessageTimestampForPromoQueueDiagnostics() -> TimeInterval? {
+        if case .value(let timestamp) = locallyWrittenValue {
+            return timestamp
+        }
+
+        do {
+            return try keyValueStore.object(forKey: StorageKey.lastConfirmedRemoteMessageTimestamp) as? TimeInterval
+        } catch {
+            guard case .value(let timestamp) = lastSuccessfulRead else {
+                return nil
+            }
+            return timestamp
+        }
+    }
+}
+
+@MainActor
+protocol PromoQueueCooldownDebugSnapshotProviding: AnyObject {
+    func snapshot(now: Date) -> PromoQueueCooldownSnapshot
+}
+
+/// Builds the debug cooldown projection through non-reporting, non-mutating reads.
+/// Production admission deliberately continues to use `PromoQueueCooldownPolicy` and its failure semantics.
+@MainActor
+final class PromoQueueCooldownDebugSnapshotProvider: PromoQueueCooldownDebugSnapshotProviding {
+    private let modalPresentationStore: PromptCooldownKeyValueFilesStore
+    private let remoteMessagePresentationStore: PromoQueueRemoteMessageCooldownKeyValueFilesStore
+
+    init(
+        modalPresentationStore: PromptCooldownKeyValueFilesStore,
+        remoteMessagePresentationStore: PromoQueueRemoteMessageCooldownKeyValueFilesStore
+    ) {
+        self.modalPresentationStore = modalPresentationStore
+        self.remoteMessagePresentationStore = remoteMessagePresentationStore
+    }
+
+    func snapshot(now _: Date) -> PromoQueueCooldownSnapshot {
+        PromoQueueCooldownSnapshot.make(
+            lastModalTimestamp: modalPresentationStore.lastPresentationTimestampForPromoQueueDiagnostics(),
+            lastRemoteMessageTimestamp: remoteMessagePresentationStore
+                .lastConfirmedRemoteMessageTimestampForPromoQueueDiagnostics()
+        )
+    }
 }
 
 @MainActor
@@ -135,17 +183,9 @@ final class PromoQueueCooldownPolicy: PromoQueueCooldownPolicying {
     }
 
     func snapshot(now _: Date) -> PromoQueueCooldownSnapshot {
-        let lastModalAppearance = modalPresentationStore.lastPresentationTimestamp.map(Date.init(timeIntervalSince1970:))
-        let lastRemoteMessageAppearance = remoteMessagePresentationStore.lastConfirmedRemoteMessageTimestamp.map(Date.init(timeIntervalSince1970:))
-
-        let remoteMessageBoundaries = [lastModalAppearance, lastRemoteMessageAppearance]
-            .compactMap { $0?.addingTimeInterval(Self.remoteMessageTargetInterval) }
-
-        return PromoQueueCooldownSnapshot(
-            lastConfirmedModalAppearance: lastModalAppearance,
-            lastConfirmedRemoteMessageAppearance: lastRemoteMessageAppearance,
-            nextRemoteMessageEligibility: remoteMessageBoundaries.max(),
-            nextModalEligibility: lastRemoteMessageAppearance?.addingTimeInterval(Self.modalAfterRemoteMessageInterval)
+        PromoQueueCooldownSnapshot.make(
+            lastModalTimestamp: modalPresentationStore.lastPresentationTimestamp,
+            lastRemoteMessageTimestamp: remoteMessagePresentationStore.lastConfirmedRemoteMessageTimestamp
         )
     }
 
@@ -154,5 +194,25 @@ final class PromoQueueCooldownPolicy: PromoQueueCooldownPolicying {
             return .eligible
         }
         return .blocked(until: nextEligibility)
+    }
+}
+
+private extension PromoQueueCooldownSnapshot {
+    @MainActor
+    static func make(
+        lastModalTimestamp: TimeInterval?,
+        lastRemoteMessageTimestamp: TimeInterval?
+    ) -> PromoQueueCooldownSnapshot {
+        let lastModalAppearance = lastModalTimestamp.map(Date.init(timeIntervalSince1970:))
+        let lastRemoteMessageAppearance = lastRemoteMessageTimestamp.map(Date.init(timeIntervalSince1970:))
+        let remoteMessageBoundaries = [lastModalAppearance, lastRemoteMessageAppearance]
+            .compactMap { $0?.addingTimeInterval(PromoQueueCooldownPolicy.remoteMessageTargetInterval) }
+
+        return PromoQueueCooldownSnapshot(
+            lastConfirmedModalAppearance: lastModalAppearance,
+            lastConfirmedRemoteMessageAppearance: lastRemoteMessageAppearance,
+            nextRemoteMessageEligibility: remoteMessageBoundaries.max(),
+            nextModalEligibility: lastRemoteMessageAppearance?.addingTimeInterval(PromoQueueCooldownPolicy.modalAfterRemoteMessageInterval)
+        )
     }
 }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Cooldown/PromptCooldownStore.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Cooldown/PromptCooldownStore.swift
@@ -60,6 +60,18 @@ final class PromptCooldownKeyValueFilesStore: PromptCooldownStore {
         }
     }
 
+    /// Reads persisted modal history for the Promo Queue debug projection without reporting failures.
+    ///
+    /// Debug diagnostics must not add a pixel-firing path. Admission continues to use
+    /// `lastPresentationTimestamp`, which preserves the existing production failure reporting.
+    func lastPresentationTimestampForPromoQueueDiagnostics() -> TimeInterval? {
+        do {
+            return try keyValueStore.object(forKey: StorageKey.lastPromptShownTimestamp) as? TimeInterval
+        } catch {
+            return nil
+        }
+    }
+
 }
 
 extension PromptCooldownKeyValueFilesStore {

--- a/iOS/DuckDuckGo/ModalPromptCoordination/DebugMenu/ModalPromptCoordinationDebugMenu.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/DebugMenu/ModalPromptCoordinationDebugMenu.swift
@@ -24,13 +24,53 @@ import class Common.EventMapping
 struct ModalPromptCoordinationDebugView: View {
     @StateObject private var viewModel: ModalPromptCoordinationDebugViewModel
 
-    init(keyValueStore: ThrowingKeyValueStoring) {
+    init(
+        keyValueStore: ThrowingKeyValueStoring,
+        promoQueueDebugSnapshotProvider: PromoQueueDebugSnapshotProviding? = nil
+    ) {
         let store = PromptCooldownKeyValueFilesStore(keyValueStore: keyValueStore, eventMapper: .init(mapping: { _, _, _, _ in }))
-        self._viewModel = StateObject(wrappedValue: ModalPromptCoordinationDebugViewModel(store: store))
+        self._viewModel = StateObject(
+            wrappedValue: ModalPromptCoordinationDebugViewModel(
+                store: store,
+                promoQueueDebugSnapshotProvider: promoQueueDebugSnapshotProvider
+            )
+        )
     }
 
     var body: some View {
         List {
+            Section {
+                snapshotRow(title: "Process Mode", value: viewModel.formattedPromoQueueMode)
+                snapshotRow(title: "Active Owner", value: viewModel.formattedActiveOwner)
+                snapshotRow(title: "Modal Attempt", value: viewModel.formattedModalAttemptPhase)
+                snapshotRow(title: "Pending Modal", value: viewModel.formattedPendingModalState)
+                snapshotRow(title: "Suppress Other Promos", value: viewModel.formattedSuppressionState)
+                snapshotRow(title: "Application", value: viewModel.formattedApplicationState)
+                snapshotRow(title: "Interaction Readiness", value: viewModel.formattedInteractionReadiness)
+                snapshotRow(title: "RMF Logical State", value: viewModel.formattedRemoteMessageState)
+                snapshotRow(title: "RMF Identity", value: viewModel.formattedRemoteMessageIdentity)
+                snapshotRow(title: "RMF Renderer", value: viewModel.formattedRemoteMessageRenderer)
+                snapshotRow(title: "RMF Presentation", value: viewModel.formattedRemoteMessagePresentation)
+                snapshotRow(title: "RMF Removal", value: viewModel.formattedRemoteMessageRemoval)
+                snapshotRow(title: "RMF Queue Appearance", value: viewModel.formattedRemoteMessageQueueAppearance)
+                snapshotRow(title: "RMF Physical Appearance", value: viewModel.formattedRemoteMessagePhysicalAppearance)
+                snapshotRow(title: "RMF Renderers", value: viewModel.formattedRemoteMessageRendererCounts)
+                snapshotRow(title: "Last Confirmed Modal", value: viewModel.formattedLastConfirmedModalAppearance)
+                snapshotRow(title: "Last Confirmed RMF", value: viewModel.formattedLastConfirmedRemoteMessageAppearance)
+                snapshotRow(title: "Next RMF Eligibility", value: viewModel.formattedNextRemoteMessageEligibility)
+                snapshotRow(title: "Next Modal Eligibility", value: viewModel.formattedNextModalEligibility)
+                Button("Refresh Snapshot") {
+                    viewModel.refresh()
+                }
+            } header: {
+                Text(verbatim: "Promo Queue")
+            } footer: {
+                Text(
+                    verbatim: "Process mode changes require force-quit and relaunch. "
+                        + "Eligibility boundaries are informational and do not schedule work."
+                )
+            }
+
             Section {
                 Text(viewModel.formattedCooldownPeriod)
                 if viewModel.isCooldownPeriodActive {
@@ -48,10 +88,22 @@ struct ModalPromptCoordinationDebugView: View {
             }
         }
     }
+
+    private func snapshotRow(title: String, value: String) -> some View {
+        HStack {
+            Text(verbatim: title)
+            Spacer()
+            Text(verbatim: value)
+                .multilineTextAlignment(.trailing)
+        }
+    }
 }
 
-private final class ModalPromptCoordinationDebugViewModel: ObservableObject {
+@MainActor
+final class ModalPromptCoordinationDebugViewModel: ObservableObject {
     private let store: PromptCooldownStore
+    private let promoQueueDebugSnapshotProvider: PromoQueueDebugSnapshotProviding?
+    private let formatDate: (Date) -> String
 
     private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -63,9 +115,34 @@ private final class ModalPromptCoordinationDebugViewModel: ObservableObject {
 
     @Published private(set) var isCooldownPeriodActive: Bool = false
     @Published private(set) var formattedCooldownPeriod: String = ""
+    @Published private(set) var formattedPromoQueueMode = "Unavailable"
+    @Published private(set) var formattedActiveOwner = "Unavailable"
+    @Published private(set) var formattedModalAttemptPhase = "Unavailable"
+    @Published private(set) var formattedPendingModalState = "Unavailable"
+    @Published private(set) var formattedSuppressionState = "Unavailable"
+    @Published private(set) var formattedApplicationState = "Unavailable"
+    @Published private(set) var formattedInteractionReadiness = "Unavailable"
+    @Published private(set) var formattedRemoteMessageState = "Unavailable"
+    @Published private(set) var formattedRemoteMessageIdentity = "Unavailable"
+    @Published private(set) var formattedRemoteMessageRenderer = "Unavailable"
+    @Published private(set) var formattedRemoteMessagePresentation = "Unavailable"
+    @Published private(set) var formattedRemoteMessageRemoval = "Unavailable"
+    @Published private(set) var formattedRemoteMessageQueueAppearance = "Unavailable"
+    @Published private(set) var formattedRemoteMessagePhysicalAppearance = "Unavailable"
+    @Published private(set) var formattedRemoteMessageRendererCounts = "Unavailable"
+    @Published private(set) var formattedLastConfirmedModalAppearance = "Unavailable"
+    @Published private(set) var formattedLastConfirmedRemoteMessageAppearance = "Unavailable"
+    @Published private(set) var formattedNextRemoteMessageEligibility = "Unavailable"
+    @Published private(set) var formattedNextModalEligibility = "Unavailable"
 
-    init(store: PromptCooldownStore) {
+    init(
+        store: PromptCooldownStore,
+        promoQueueDebugSnapshotProvider: PromoQueueDebugSnapshotProviding?,
+        dateFormatting: ((Date) -> String)? = nil
+    ) {
         self.store = store
+        self.promoQueueDebugSnapshotProvider = promoQueueDebugSnapshotProvider
+        self.formatDate = dateFormatting ?? { Self.dateFormatter.string(from: $0) }
         updateUI()
     }
 
@@ -74,9 +151,14 @@ private final class ModalPromptCoordinationDebugViewModel: ObservableObject {
         updateUI()
     }
 
+    func refresh() {
+        updateUI()
+    }
+
     private func updateUI() {
         isCooldownPeriodActive = isCooldownActive()
         formattedCooldownPeriod = makeFormattedCooldownPeriod()
+        updatePromoQueueSnapshot()
     }
 
     private func isCooldownActive() -> Bool {
@@ -90,5 +172,142 @@ private final class ModalPromptCoordinationDebugViewModel: ObservableObject {
 
         let lastTimeStampDate = Date(timeIntervalSince1970: timestamp)
         return "Modal Prompt shown \(Self.dateFormatter.string(from: lastTimeStampDate))."
+    }
+
+    private func updatePromoQueueSnapshot() {
+        guard let snapshot = promoQueueDebugSnapshotProvider?.promoQueueDebugSnapshot else {
+            return
+        }
+
+        formattedPromoQueueMode = formattedMode(snapshot.mode)
+        formattedActiveOwner = formattedOwner(snapshot.activeOwner)
+        formattedModalAttemptPhase = formattedAttemptPhase(snapshot.modalAttemptPhase)
+        formattedPendingModalState = formattedBoolean(snapshot.hasPendingModalPrompt)
+        formattedSuppressionState = formattedBoolean(snapshot.shouldSuppressOtherSessionPromos)
+        formattedApplicationState = snapshot.isApplicationActive ? "Active" : "Inactive"
+        formattedInteractionReadiness = snapshot.isWaitingForForegroundInteractionReadiness ? "Waiting" : "Ready"
+        updateRemoteMessageSnapshot(snapshot.remoteMessageCoordination)
+        formattedLastConfirmedModalAppearance = formattedDate(snapshot.cooldown.lastConfirmedModalAppearance)
+        formattedLastConfirmedRemoteMessageAppearance = formattedDate(snapshot.cooldown.lastConfirmedRemoteMessageAppearance)
+        formattedNextRemoteMessageEligibility = formattedDate(snapshot.cooldown.nextRemoteMessageEligibility)
+        formattedNextModalEligibility = formattedDate(snapshot.cooldown.nextModalEligibility)
+    }
+
+    private func formattedMode(_ mode: PromoCoordinationMode) -> String {
+        switch mode {
+        case .legacy:
+            return "Legacy"
+        case .coordinated:
+            return "Coordinated"
+        }
+    }
+
+    private func formattedOwner(_ owner: PromoQueueActiveOwnerSnapshot?) -> String {
+        switch owner {
+        case .modal(let identity):
+            return "Modal — \(identity.debugIdentifier)"
+        case .remoteMessage(let session):
+            return "RMF \(session.messageID) — session \(session.id.uuidString)"
+        case nil:
+            return "None"
+        }
+    }
+
+    private func updateRemoteMessageSnapshot(_ snapshot: PromoQueueRemoteMessageCoordinationSnapshot) {
+        formattedRemoteMessageState = formattedRemoteMessageState(snapshot.state)
+        formattedRemoteMessageIdentity = formattedRemoteMessageIdentity(snapshot)
+        formattedRemoteMessageRenderer = formattedRemoteMessageRenderer(snapshot)
+        formattedRemoteMessagePresentation = snapshot.presentationID?.uuidString ?? "None"
+        formattedRemoteMessageRemoval = formattedRemoteMessageRemoval(snapshot)
+        formattedRemoteMessageQueueAppearance = snapshot.isQueueAppearanceConfirmed ? "Confirmed" : "Not Confirmed"
+        formattedRemoteMessagePhysicalAppearance = formattedPhysicalAppearance(snapshot.isPresentationAppearanceReported)
+        formattedRemoteMessageRendererCounts = "\(snapshot.registeredRendererCount) registered — \(snapshot.eligibleRendererCount) eligible"
+    }
+
+    private func formattedRemoteMessageState(_ state: PromoQueueRemoteMessageLogicalStateSnapshot) -> String {
+        switch state {
+        case .idle:
+            return "Idle"
+        case .owned:
+            return "Owned"
+        case .draining:
+            return "Draining"
+        }
+    }
+
+    private func formattedRemoteMessageIdentity(_ snapshot: PromoQueueRemoteMessageCoordinationSnapshot) -> String {
+        guard let messageID = snapshot.messageID, let sessionID = snapshot.sessionID else {
+            return "None"
+        }
+        return "\(messageID) — session \(sessionID.uuidString)"
+    }
+
+    private func formattedRemoteMessageRenderer(_ snapshot: PromoQueueRemoteMessageCoordinationSnapshot) -> String {
+        guard let rendererID = snapshot.rendererID, let generationID = snapshot.registrationGenerationID else {
+            return "None"
+        }
+        return "\(rendererID.uuidString) — generation \(generationID.uuidString)"
+    }
+
+    private func formattedRemoteMessageRemoval(_ snapshot: PromoQueueRemoteMessageCoordinationSnapshot) -> String {
+        guard let removalID = snapshot.removalID else {
+            return "None"
+        }
+
+        let terminal = snapshot.removalTerminal.map(formattedRemovalTerminal) ?? "Pending"
+        let continuation = snapshot.drainContinuation.map(formattedDrainContinuation) ?? "None"
+        return "\(removalID.uuidString) — \(terminal) — \(continuation)"
+    }
+
+    private func formattedRemovalTerminal(_ terminal: PromoQueueRemoteMessageRemovalTerminal) -> String {
+        switch terminal {
+        case .animationCompleted:
+            return "Animation Completed"
+        case .hostDetached:
+            return "Host Detached"
+        case .sourceRemovedWithoutAnimation:
+            return "Source Removed Without Animation"
+        }
+    }
+
+    private func formattedDrainContinuation(_ continuation: PromoQueueRemoteMessageDrainContinuationSnapshot) -> String {
+        switch continuation {
+        case .transferSameMessageIfAvailable:
+            return "Transfer Same Message If Available"
+        case .endSession:
+            return "End Session"
+        }
+    }
+
+    private func formattedPhysicalAppearance(_ appearance: Bool?) -> String {
+        switch appearance {
+        case true:
+            return "Reported"
+        case false:
+            return "Not Reported"
+        case nil:
+            return "None"
+        }
+    }
+
+    private func formattedAttemptPhase(_ phase: ModalPromptAttemptPhase) -> String {
+        switch phase {
+        case .idle:
+            return "Idle"
+        case .evaluating(let identity):
+            return "Evaluating — \(identity.debugIdentifier)"
+        case .committed(let identity):
+            return "Committed — \(identity.debugIdentifier)"
+        case .presentationActive(let identity):
+            return "Presentation Active — \(identity.debugIdentifier)"
+        }
+    }
+
+    private func formattedBoolean(_ value: Bool) -> String {
+        value ? "Yes" : "No"
+    }
+
+    private func formattedDate(_ date: Date?) -> String {
+        date.map(formatDate) ?? "None"
     }
 }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/DebugMenu/PromptCoordinationDebugMenu.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/DebugMenu/PromptCoordinationDebugMenu.swift
@@ -1,5 +1,5 @@
 //
-//  ModalPromptCoordinationDebugMenu.swift
+//  PromptCoordinationDebugMenu.swift
 //  DuckDuckGo
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.
@@ -21,7 +21,7 @@ import SwiftUI
 import Persistence
 import class Common.EventMapping
 
-struct ModalPromptCoordinationDebugView: View {
+struct PromptCoordinationDebugView: View {
     @StateObject private var viewModel: ModalPromptCoordinationDebugViewModel
 
     init(

--- a/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/ModalPromptCoordinationManager.swift
@@ -22,6 +22,8 @@ import UIKit
 @MainActor
 protocol ModalPromptCoordinationManaging {
     var shouldSuppressOtherSessionPromos: Bool { get }
+    var modalAttemptPhase: ModalPromptAttemptPhase { get }
+    var hasPendingModalPrompt: Bool { get }
 
     func setCoordinatedAttemptReleaseHandler(_ handler: (@MainActor () -> Void)?)
     func presentModalPromptIfNeeded(from presenter: ModalPromptPresenter)
@@ -195,6 +197,10 @@ final class ModalPromptCoordinationManager: ModalPromptCoordinationManaging {
             || !legacyActiveAttemptIDs.isEmpty
             || modalAttemptPhase != .idle
             || pendingPreparedItem != nil
+    }
+
+    var hasPendingModalPrompt: Bool {
+        pendingPreparedItem != nil
     }
 
     var modalAttemptPhase: ModalPromptAttemptPhase {

--- a/iOS/DuckDuckGo/NewTabPageMessagesModel.swift
+++ b/iOS/DuckDuckGo/NewTabPageMessagesModel.swift
@@ -72,7 +72,7 @@ final class NewTabPageMessagesModel: ObservableObject {
         return false
     }
 
-    let surfaceID: UUID
+    private let surfaceID: UUID
 
     private struct AuthorizedRemoteMessage {
         let presentation: PromoQueueRemoteMessagePresentation

--- a/iOS/DuckDuckGo/SettingsLegacyViewProvider.swift
+++ b/iOS/DuckDuckGo/SettingsLegacyViewProvider.swift
@@ -63,6 +63,7 @@ class SettingsLegacyViewProvider: ObservableObject {
     let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
     let freemiumPIRDebugSettings: FreemiumPIRDebugSettings
     let freemiumDBPUserStateManager: FreemiumDBPUserStateManaging
+    let promoQueueDebugSnapshotProvider: PromoQueueDebugSnapshotProviding?
 
     init(syncService: any DDGSyncing,
          syncDataProviders: SyncDataProviders,
@@ -85,7 +86,8 @@ class SettingsLegacyViewProvider: ObservableObject {
          syncAutoRestoreHandler: SyncAutoRestoreHandling,
          freemiumPIRDebugSettings: FreemiumPIRDebugSettings,
          freemiumDBPUserStateManager: FreemiumDBPUserStateManaging,
-         duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil) {
+         duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil,
+         promoQueueDebugSnapshotProvider: PromoQueueDebugSnapshotProviding? = nil) {
         self.syncService = syncService
         self.syncDataProviders = syncDataProviders
         self.appSettings = appSettings
@@ -108,6 +110,7 @@ class SettingsLegacyViewProvider: ObservableObject {
         self.duckAiNativeStorageHandler = duckAiNativeStorageHandler
         self.freemiumPIRDebugSettings = freemiumPIRDebugSettings
         self.freemiumDBPUserStateManager = freemiumDBPUserStateManager
+        self.promoQueueDebugSnapshotProvider = promoQueueDebugSnapshotProvider
     }
     
     enum LegacyView {
@@ -164,7 +167,8 @@ class SettingsLegacyViewProvider: ObservableObject {
             subscriptionDataReporter: self.subscriptionDataReporter,
             remoteMessagingDebugHandler: self.remoteMessagingDebugHandler,
             webExtensionManager: self.webExtensionManager,
-            duckAiNativeStorageHandler: self.duckAiNativeStorageHandler))
+            duckAiNativeStorageHandler: self.duckAiNativeStorageHandler,
+            promoQueueDebugSnapshotProvider: self.promoQueueDebugSnapshotProvider))
     }
 
     // Legacy UIKit Views (Pushed unmodified)

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -318,6 +318,7 @@ final class MainCoordinator {
                                         toggleModeStorage: toggleModeStorage,
                                         onboardingManager: onboardingManager,
                                         newTabPagePromoCoordinator: promoCoordinationService,
+                                        promoQueueDebugSnapshotProvider: promoCoordinationService,
                                         recentModalPromptStatusProvider: promoCoordinationService)
 
         setupWebExtensions(privacyConfigurationManager: privacyConfigurationManager)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/UnifiedSuggestionsHost.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Suggestions/UnifiedSuggestionsHost.swift
@@ -42,7 +42,6 @@ final class UnifiedSuggestionsHost {
     /// Built once on first `.favorites` render; NTP has a heavy init, so don't rebuild per body pass.
     private var cachedFavoritesController: NewTabPageViewController?
     private var isSurfaceHostActive = false
-    private var isFavoritesContentResolved = false
 
     /// Single-host path only: the duck.ai surface's source/VM, attached lazily and detached on
     /// disappear (mirrors the legacy per-host lifecycle). Nil on the old single-surface path.
@@ -85,13 +84,8 @@ final class UnifiedSuggestionsHost {
         viewModel.$content
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] content in
+            .sink { [weak self] _ in
                 guard let self else { return }
-                if case .favorites = content {
-                    isFavoritesContentResolved = true
-                } else {
-                    isFavoritesContentResolved = false
-                }
                 updateFavoritesPromoSurfaceActivity()
                 onContentChanged?()
             }
@@ -240,7 +234,7 @@ final class UnifiedSuggestionsHost {
 
     private func updateFavoritesPromoSurfaceActivity() {
         let isActive = isSurfaceHostActive
-            && isFavoritesContentResolved
+            && viewModel.isShowingFavorites
             && !viewModel.isFireTab
 
         cachedFavoritesController?.setPromoSurfaceRenderable(isActive)

--- a/iOS/DuckDuckGoTests/AppServices/PromoCoordinationServicePromoQueueTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/PromoCoordinationServicePromoQueueTests.swift
@@ -33,6 +33,119 @@ final class PromoCoordinationServicePromoQueueTests {
     private var currentDate = Date(timeIntervalSince1970: 1_800_000_000)
     private var sut: PromoCoordinationService!
 
+    // MARK: - Debug Snapshot
+
+    @available(iOS 16, *)
+    @Test("The coordinated debug snapshot projects the service-owned logical RMF lifecycle", .timeLimit(.minutes(1)))
+    func whenDebugSnapshotIsReadThenItProjectsTheLogicalRemoteMessageLifecycle() async {
+        let lastModalAppearance = currentDate.addingTimeInterval(-900)
+        let lastRemoteMessageAppearance = currentDate.addingTimeInterval(-300)
+        let cooldownSnapshot = PromoQueueCooldownSnapshot(
+            lastConfirmedModalAppearance: lastModalAppearance,
+            lastConfirmedRemoteMessageAppearance: lastRemoteMessageAppearance,
+            nextRemoteMessageEligibility: lastRemoteMessageAppearance.addingTimeInterval(600),
+            nextModalEligibility: lastRemoteMessageAppearance.addingTimeInterval(86_400)
+        )
+        promoQueueCooldownPolicy.snapshotToReturn = cooldownSnapshot
+        managerMock.hasPendingModalPrompt = true
+        managerMock.shouldSuppressOtherSessionPromos = true
+        makeSUT()
+
+        let rendererID = UUID()
+        let fixture = registerRenderer(rendererID: rendererID, messageID: "debug-owner")
+        guard let presentation = fixture.renderer.shownPresentations.first else {
+            Issue.record("Expected the service to publish its logical RMF owner")
+            return
+        }
+        #expect(fixture.registration.confirmAppearance(
+            sessionID: presentation.session.id,
+            presentationID: presentation.id,
+            isAttachedToWindow: true
+        ) == .accepted)
+
+        var snapshot = sut.promoQueueDebugSnapshot
+        #expect(snapshot.mode == .coordinated)
+        #expect(snapshot.activeOwner == .remoteMessage(presentation.session))
+        #expect(snapshot.remoteMessageCoordination.state == .owned)
+        #expect(snapshot.remoteMessageCoordination.messageID == presentation.session.messageID)
+        #expect(snapshot.remoteMessageCoordination.sessionID == presentation.session.id)
+        #expect(snapshot.remoteMessageCoordination.rendererID == rendererID)
+        #expect(snapshot.remoteMessageCoordination.registrationGenerationID != nil)
+        #expect(snapshot.remoteMessageCoordination.presentationID == presentation.id)
+        #expect(snapshot.remoteMessageCoordination.isQueueAppearanceConfirmed)
+        #expect(snapshot.remoteMessageCoordination.isPresentationAppearanceReported == true)
+        #expect(snapshot.remoteMessageCoordination.removalID == nil)
+        #expect(snapshot.remoteMessageCoordination.removalTerminal == nil)
+        #expect(snapshot.remoteMessageCoordination.drainContinuation == nil)
+        #expect(snapshot.remoteMessageCoordination.registeredRendererCount == 1)
+        #expect(snapshot.remoteMessageCoordination.eligibleRendererCount == 1)
+        #expect(snapshot.modalAttemptPhase == .idle)
+        #expect(snapshot.hasPendingModalPrompt)
+        #expect(snapshot.shouldSuppressOtherSessionPromos)
+        #expect(snapshot.isApplicationActive)
+        #expect(!snapshot.isWaitingForForegroundInteractionReadiness)
+        #expect(snapshot.cooldown == cooldownSnapshot)
+
+        fixture.registration.update(candidate: .available(messageID: "debug-owner"), isEligible: false)
+
+        snapshot = sut.promoQueueDebugSnapshot
+        #expect(snapshot.activeOwner == .remoteMessage(presentation.session))
+        #expect(snapshot.remoteMessageCoordination.state == .draining)
+        #expect(snapshot.remoteMessageCoordination.sessionID == presentation.session.id)
+        #expect(snapshot.remoteMessageCoordination.presentationID == presentation.id)
+        #expect(snapshot.remoteMessageCoordination.removalID != nil)
+        #expect(snapshot.remoteMessageCoordination.removalTerminal == nil)
+        #expect(snapshot.remoteMessageCoordination.drainContinuation == .transferSameMessageIfAvailable)
+        #expect(snapshot.remoteMessageCoordination.eligibleRendererCount == 0)
+
+        fixture.renderer.isRemoteMessageRendererAttachedToWindow = false
+        fixture.renderer.finishLastRemoval(using: fixture.registration, terminal: .hostDetached)
+
+        snapshot = sut.promoQueueDebugSnapshot
+        #expect(snapshot.remoteMessageCoordination.state == .draining)
+        #expect(snapshot.remoteMessageCoordination.removalTerminal == .hostDetached)
+        #expect(snapshot.activeOwner == .remoteMessage(presentation.session))
+
+        await waitForMainQueueSettlement()
+
+        snapshot = sut.promoQueueDebugSnapshot
+        #expect(snapshot.activeOwner == nil)
+        #expect(snapshot.remoteMessageCoordination.state == .idle)
+        #expect(snapshot.remoteMessageCoordination.registeredRendererCount == 1)
+        #expect(snapshot.remoteMessageCoordination.eligibleRendererCount == 0)
+        #expect(promoQueueCooldownPolicy.snapshotDates == [currentDate, currentDate, currentDate, currentDate])
+        fixture.registration.deregister()
+    }
+
+    @available(iOS 16, *)
+    @Test("The legacy debug snapshot does not read Promo Queue history", .timeLimit(.minutes(1)))
+    func whenLegacyDebugSnapshotIsReadThenCooldownHistoryRemainsUntouched() {
+        promoQueueCooldownPolicy.snapshotToReturn = PromoQueueCooldownSnapshot(
+            lastConfirmedModalAppearance: currentDate,
+            lastConfirmedRemoteMessageAppearance: currentDate,
+            nextRemoteMessageEligibility: currentDate,
+            nextModalEligibility: currentDate
+        )
+        managerMock.hasPendingModalPrompt = true
+        managerMock.shouldSuppressOtherSessionPromos = true
+        makeSUT(mode: .legacy, readyForInteractions: false)
+
+        let snapshot = sut.promoQueueDebugSnapshot
+
+        #expect(snapshot.mode == .legacy)
+        #expect(snapshot.activeOwner == nil)
+        #expect(snapshot.remoteMessageCoordination.state == .idle)
+        #expect(snapshot.remoteMessageCoordination.registeredRendererCount == 0)
+        #expect(snapshot.remoteMessageCoordination.eligibleRendererCount == 0)
+        #expect(snapshot.modalAttemptPhase == .idle)
+        #expect(snapshot.hasPendingModalPrompt)
+        #expect(snapshot.shouldSuppressOtherSessionPromos)
+        #expect(!snapshot.isApplicationActive)
+        #expect(snapshot.isWaitingForForegroundInteractionReadiness)
+        #expect(snapshot.cooldown == .empty)
+        #expect(promoQueueCooldownPolicy.snapshotDates.isEmpty)
+    }
+
     // MARK: - Modal Mutual Exclusion
 
     @available(iOS 16, *)

--- a/iOS/DuckDuckGoTests/AppServices/PromoCoordinationServicePromoQueueTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/PromoCoordinationServicePromoQueueTests.swift
@@ -90,7 +90,6 @@ final class PromoCoordinationServicePromoQueueTests {
         #expect(!snapshot.isWaitingForForegroundInteractionReadiness)
         #expect(snapshot.cooldown == cooldownSnapshot)
         #expect(promoQueueCooldownDebugSnapshotProvider.snapshotDates == [currentDate])
-        #expect(promoQueueCooldownPolicy.snapshotDates.isEmpty)
         #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == remoteMessageAdmissionDates)
         #expect(promoQueueCooldownPolicy.modalAdmissionDates == modalAdmissionDates)
         #expect(promoQueueCooldownPolicy.confirmedRemoteMessageAppearanceDates == confirmedRemoteMessageAppearanceDates)
@@ -128,7 +127,6 @@ final class PromoCoordinationServicePromoQueueTests {
             currentDate,
             currentDate
         ])
-        #expect(promoQueueCooldownPolicy.snapshotDates.isEmpty)
         #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == remoteMessageAdmissionDates)
         #expect(promoQueueCooldownPolicy.modalAdmissionDates == modalAdmissionDates)
         #expect(promoQueueCooldownPolicy.confirmedRemoteMessageAppearanceDates == confirmedRemoteMessageAppearanceDates)
@@ -136,8 +134,9 @@ final class PromoCoordinationServicePromoQueueTests {
     }
 
     @available(iOS 16, *)
-    @Test("The legacy debug snapshot does not read Promo Queue history", .timeLimit(.minutes(1)))
-    func whenLegacyDebugSnapshotIsReadThenCooldownHistoryRemainsUntouched() {
+    @Test("The legacy debug snapshot does not access arbitration or Promo Queue history", .timeLimit(.minutes(1)))
+    func whenLegacyDebugSnapshotIsReadThenCoordinationStateRemainsUntouched() {
+        let snapshotCountingArbiter = SnapshotCountingPromoQueueLeaseArbiter()
         promoQueueCooldownDebugSnapshotProvider.snapshotToReturn = PromoQueueCooldownSnapshot(
             lastConfirmedModalAppearance: currentDate,
             lastConfirmedRemoteMessageAppearance: currentDate,
@@ -146,7 +145,11 @@ final class PromoCoordinationServicePromoQueueTests {
         )
         managerMock.hasPendingModalPrompt = true
         managerMock.shouldSuppressOtherSessionPromos = true
-        makeSUT(mode: .legacy, readyForInteractions: false)
+        makeSUT(
+            mode: .legacy,
+            readyForInteractions: false,
+            leaseArbiter: snapshotCountingArbiter
+        )
 
         let snapshot = sut.promoQueueDebugSnapshot
 
@@ -161,8 +164,8 @@ final class PromoCoordinationServicePromoQueueTests {
         #expect(!snapshot.isApplicationActive)
         #expect(snapshot.isWaitingForForegroundInteractionReadiness)
         #expect(snapshot.cooldown == .empty)
+        #expect(snapshotCountingArbiter.snapshotReadCount == 0)
         #expect(promoQueueCooldownDebugSnapshotProvider.snapshotDates.isEmpty)
-        #expect(promoQueueCooldownPolicy.snapshotDates.isEmpty)
     }
 
     // MARK: - Modal Mutual Exclusion
@@ -190,21 +193,27 @@ final class PromoCoordinationServicePromoQueueTests {
     }
 
     @available(iOS 16, *)
-    @Test("A logical remote-message owner blocks modal evaluation", .timeLimit(.minutes(1)))
-    func whenRemoteMessageOwnsGlobalSlotThenModalManagerIsNotCalled() {
+    @Test("A logical remote-message owner blocks modal and RMF admission after cooldown expiry", .timeLimit(.minutes(1)))
+    func whenRemoteMessageOwnsGlobalSlotAfterCooldownExpiryThenOtherAdmissionsRemainBlocked() {
         launchSourceManagerMock.source = .standard
         presenterMock.presentedViewController = nil
         makeSUT()
         let fixture = registerRenderer(messageID: "owner")
         let presentation = fixture.renderer.shownPresentations.first
+        let remoteMessageAdmissionDates = promoQueueCooldownPolicy.remoteMessageAdmissionDates
         managerMock.resetRecordedInteractions()
 
+        currentDate = currentDate.addingTimeInterval(24 * 60 * 60 + 1)
+        let waitingFixture = registerRenderer(messageID: "waiting")
         presentModalPromptIfNeeded()
 
         #expect(presentation != nil)
+        #expect(waitingFixture.renderer.shownPresentations.isEmpty)
         #expect(!managerMock.didCallPresentModalPromptIfNeeded)
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == remoteMessageAdmissionDates)
+        #expect(promoQueueCooldownPolicy.modalAdmissionDates.isEmpty)
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == presentation.map { .remoteMessage($0.session) })
-        _ = fixture.registration
+        _ = (fixture.registration, waitingFixture.registration)
     }
 
     @available(iOS 16, *)
@@ -281,11 +290,12 @@ final class PromoCoordinationServicePromoQueueTests {
     }
 
     @available(iOS 16, *)
-    @Test("A modal owner blocks all renderer publication", .timeLimit(.minutes(1)))
-    func whenModalOwnsGlobalSlotThenRendererIsNotShown() throws {
+    @Test("A modal owner blocks renderer publication after cooldown expiry", .timeLimit(.minutes(1)))
+    func whenModalOwnsGlobalSlotAfterCooldownExpiryThenRendererIsNotShown() throws {
         makeSUT()
         let modalLease = try acquiredModalLease()
 
+        currentDate = currentDate.addingTimeInterval(10 * 60 + 1)
         let fixture = registerRenderer(messageID: "message")
 
         #expect(fixture.renderer.shownPresentations.isEmpty)
@@ -295,32 +305,54 @@ final class PromoCoordinationServicePromoQueueTests {
     }
 
     @available(iOS 16, *)
-    @Test("Remote-message cooldown denial retains the candidate for a later checkpoint", .timeLimit(.minutes(1)))
-    func whenRemoteMessageCooldownInitiallyBlocksThenAReleaseCheckpointRetriesTheCandidate() {
+    @Test("A confirmed session's cooldown retains a late successor until a checkpoint", .timeLimit(.minutes(1)))
+    func whenConfirmedSessionEndsThenCooldownWaitsForCheckpointBeforeStartingFreshSession() async {
         let initialDate = currentDate
         let eligibilityDate = initialDate.addingTimeInterval(10 * 60)
+        var admissionCount = 0
         promoQueueCooldownPolicy.remoteMessageAdmissionDecisionProvider = { now in
-            now < eligibilityDate ? .blocked(until: eligibilityDate) : .eligible
+            admissionCount += 1
+            return admissionCount == 1 || now >= eligibilityDate ? .eligible : .blocked(until: eligibilityDate)
         }
         makeSUT()
 
-        let fixture = registerRenderer(messageID: "message")
+        let outgoing = registerRenderer(messageID: "message")
+        guard let outgoingPresentation = outgoing.renderer.shownPresentations.first else {
+            Issue.record("Expected the outgoing renderer to own the initial session")
+            return
+        }
+        #expect(outgoing.registration.confirmAppearance(
+            sessionID: outgoingPresentation.session.id,
+            presentationID: outgoingPresentation.id,
+            isAttachedToWindow: true
+        ) == .accepted)
+        outgoing.registration.update(candidate: .none, isEligible: false)
+        outgoing.renderer.finishLastRemoval(using: outgoing.registration)
+        await waitForMainQueueSettlement()
 
-        #expect(fixture.renderer.shownPresentations.isEmpty)
+        let successor = registerRenderer(messageID: "message")
+
+        #expect(successor.renderer.shownPresentations.isEmpty)
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == nil)
-        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == [initialDate])
+        #expect(promoQueueCooldownPolicy.confirmedRemoteMessageAppearanceDates == [initialDate])
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == [initialDate, initialDate])
 
         currentDate = eligibilityDate.addingTimeInterval(1)
 
-        #expect(fixture.renderer.shownPresentations.isEmpty)
-        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == [initialDate])
+        #expect(successor.renderer.shownPresentations.isEmpty)
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == [initialDate, initialDate])
 
         managerMock.coordinatedAttemptReleaseHandler?()
 
-        #expect(fixture.renderer.shownPresentations.count == 1)
-        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == [initialDate, currentDate])
-        #expect(promoQueueLeaseArbiter.snapshot.remoteMessageSession == fixture.renderer.shownPresentations.first?.session)
-        _ = fixture.registration
+        guard let successorPresentation = successor.renderer.shownPresentations.first else {
+            Issue.record("Expected the checkpoint to authorize the retained successor")
+            return
+        }
+        #expect(successorPresentation.session.messageID == outgoingPresentation.session.messageID)
+        #expect(successorPresentation.session.id != outgoingPresentation.session.id)
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == [initialDate, initialDate, currentDate])
+        #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .remoteMessage(successorPresentation.session))
+        _ = (outgoing.registration, successor.registration)
     }
 
     @available(iOS 16, *)
@@ -543,49 +575,6 @@ final class PromoCoordinationServicePromoQueueTests {
         #expect(acceptingSuccessor.renderer.shownPresentations.first?.session == outgoingPresentation.session)
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .remoteMessage(outgoingPresentation.session))
         _ = (outgoing.registration, rejectingSuccessor.registration, acceptingSuccessor.registration)
-    }
-
-    @available(iOS 16, *)
-    @Test("A successor registered after terminal settlement starts a fresh session", .timeLimit(.minutes(1)))
-    func whenMatchingSuccessorRegistersAfterReleaseThenItGetsFreshSession() async {
-        makeSUT()
-        let outgoing = registerRenderer(messageID: "message")
-        guard let outgoingPresentation = outgoing.renderer.shownPresentations.first else {
-            Issue.record("Expected the outgoing renderer to own the session")
-            return
-        }
-        let outgoingConfirmationDate = currentDate
-        #expect(outgoing.registration.confirmAppearance(
-            sessionID: outgoingPresentation.session.id,
-            presentationID: outgoingPresentation.id,
-            isAttachedToWindow: true
-        ) == .accepted)
-
-        outgoing.registration.update(candidate: .available(messageID: "message"), isEligible: false)
-        outgoing.renderer.finishLastRemoval(using: outgoing.registration)
-        await waitForMainQueueSettlement()
-
-        #expect(sut.remoteMessageCoordinationSnapshot.state == .idle)
-        #expect(promoQueueLeaseArbiter.snapshot.activeOwner == nil)
-
-        let successor = registerRenderer(messageID: "message")
-        guard let successorPresentation = successor.renderer.shownPresentations.first else {
-            Issue.record("Expected the late successor to acquire a session")
-            return
-        }
-
-        #expect(successorPresentation.session.messageID == outgoingPresentation.session.messageID)
-        #expect(successorPresentation.session.id != outgoingPresentation.session.id)
-        currentDate = currentDate.addingTimeInterval(60)
-        #expect(successor.registration.confirmAppearance(
-            sessionID: successorPresentation.session.id,
-            presentationID: successorPresentation.id,
-            isAttachedToWindow: true
-        ) == .accepted)
-        #expect(promoQueueCooldownPolicy.confirmedRemoteMessageAppearanceDates == [outgoingConfirmationDate, currentDate])
-        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates.count == 2)
-        #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .remoteMessage(successorPresentation.session))
-        _ = (outgoing.registration, successor.registration)
     }
 
     @available(iOS 16, *)
@@ -1073,12 +1062,16 @@ final class PromoCoordinationServicePromoQueueTests {
 
     // MARK: - Helpers
 
-    private func makeSUT(mode: PromoCoordinationMode = .coordinated, readyForInteractions: Bool = true) {
+    private func makeSUT(
+        mode: PromoCoordinationMode = .coordinated,
+        readyForInteractions: Bool = true,
+        leaseArbiter: PromoQueueLeaseArbitrating? = nil
+    ) {
         sut = PromoCoordinationService(
             launchSourceManager: launchSourceManagerMock,
             modalPromptCoordinationManager: managerMock,
             promoCoordinationMode: mode,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            promoQueueLeaseArbiter: leaseArbiter ?? promoQueueLeaseArbiter,
             promoQueueCooldownPolicy: promoQueueCooldownPolicy,
             promoQueueCooldownDebugSnapshotProvider: promoQueueCooldownDebugSnapshotProvider,
             dateProvider: { [unowned self] in currentDate }
@@ -1140,6 +1133,24 @@ final class PromoCoordinationServicePromoQueueTests {
 private struct RendererFixture {
     let renderer: ControllableRemoteMessageRenderer
     let registration: NewTabPagePromoRendererRegistration
+}
+
+@MainActor
+private final class SnapshotCountingPromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
+    private(set) var snapshotReadCount = 0
+
+    var snapshot: PromoQueueLeaseSnapshot {
+        snapshotReadCount += 1
+        return PromoQueueLeaseSnapshot(activeOwner: nil)
+    }
+
+    func acquireModalLease() -> PromoQueueModalLeaseAcquisitionResult {
+        fatalError("Legacy debug projection must not acquire a modal lease")
+    }
+
+    func acquireRemoteMessageLease(for session: PromoQueueRemoteMessageSession) -> PromoQueueRemoteMessageLeaseAcquisitionResult {
+        fatalError("Legacy debug projection must not acquire a remote-message lease")
+    }
 }
 
 @MainActor

--- a/iOS/DuckDuckGoTests/AppServices/PromoCoordinationServicePromoQueueTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/PromoCoordinationServicePromoQueueTests.swift
@@ -29,6 +29,8 @@ final class PromoCoordinationServicePromoQueueTests {
     private let managerMock = MockModalPromptCoordinationManager()
     private let presenterMock = MockModalPromptPresenter()
     private let promoQueueLeaseArbiter = PromoQueueLeaseArbiter()
+    private let promoQueueCooldownPolicy = MockPromoQueueCooldownPolicy()
+    private var currentDate = Date(timeIntervalSince1970: 1_800_000_000)
     private var sut: PromoCoordinationService!
 
     // MARK: - Modal Mutual Exclusion
@@ -38,6 +40,10 @@ final class PromoCoordinationServicePromoQueueTests {
     func whenModalIsEvaluatedThenManagerReceivesAcquiredLease() {
         launchSourceManagerMock.source = .standard
         presenterMock.presentedViewController = nil
+        var ownerDuringPolicyEvaluation: PromoQueueActiveOwnerSnapshot?
+        promoQueueCooldownPolicy.onEvaluateModalAdmission = { [promoQueueLeaseArbiter] _ in
+            ownerDuringPolicyEvaluation = promoQueueLeaseArbiter.snapshot.activeOwner
+        }
         makeSUT()
 
         presentModalPromptIfNeeded()
@@ -46,6 +52,8 @@ final class PromoCoordinationServicePromoQueueTests {
             Issue.record("Expected the manager to retain the modal lease")
             return
         }
+        #expect(ownerDuringPolicyEvaluation == .modal(lease.attemptIdentity))
+        #expect(promoQueueCooldownPolicy.modalAdmissionDates == [currentDate])
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .modal(lease.attemptIdentity))
     }
 
@@ -79,6 +87,37 @@ final class PromoCoordinationServicePromoQueueTests {
         #expect(managerMock.didCallPresentModalPromptIfNeeded)
         #expect(managerMock.capturedModalLease == nil)
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == nil)
+        #expect(promoQueueCooldownPolicy.modalAdmissionDates.isEmpty)
+    }
+
+    @available(iOS 16, *)
+    @Test("Modal cooldown denial releases the lease and retries only at a later checkpoint", .timeLimit(.minutes(1)))
+    func whenModalCooldownInitiallyBlocksThenASecondEvaluationCanAcquire() {
+        launchSourceManagerMock.source = .standard
+        presenterMock.presentedViewController = nil
+        let initialDate = currentDate
+        let eligibilityDate = initialDate.addingTimeInterval(60)
+        promoQueueCooldownPolicy.modalAdmissionDecisionProvider = { now in
+            now < eligibilityDate ? .blocked(until: eligibilityDate) : .eligible
+        }
+        makeSUT()
+
+        presentModalPromptIfNeeded()
+
+        #expect(!managerMock.didCallPresentModalPromptIfNeeded)
+        #expect(promoQueueLeaseArbiter.snapshot.activeOwner == nil)
+        #expect(promoQueueCooldownPolicy.modalAdmissionDates == [currentDate])
+
+        currentDate = eligibilityDate.addingTimeInterval(1)
+
+        #expect(!managerMock.didCallPresentModalPromptIfNeeded)
+        #expect(promoQueueCooldownPolicy.modalAdmissionDates.count == 1)
+
+        presentModalPromptIfNeeded()
+
+        #expect(managerMock.didCallPresentModalPromptIfNeeded)
+        #expect(managerMock.capturedModalLease != nil)
+        #expect(promoQueueCooldownPolicy.modalAdmissionDates == [initialDate, currentDate])
     }
 
     // MARK: - Selection And Acquisition
@@ -86,6 +125,10 @@ final class PromoCoordinationServicePromoQueueTests {
     @available(iOS 16, *)
     @Test("The service owns the logical lease before renderer publication", .timeLimit(.minutes(1)))
     func whenRendererIsAuthorizedThenLogicalLeaseAlreadyExists() {
+        var ownerDuringPolicyEvaluation: PromoQueueActiveOwnerSnapshot?
+        promoQueueCooldownPolicy.onEvaluateRemoteMessageAdmission = { [promoQueueLeaseArbiter] _ in
+            ownerDuringPolicyEvaluation = promoQueueLeaseArbiter.snapshot.activeOwner
+        }
         makeSUT()
         let renderer = ControllableRemoteMessageRenderer()
         var ownerObservedDuringShow: PromoQueueActiveOwnerSnapshot?
@@ -98,6 +141,8 @@ final class PromoCoordinationServicePromoQueueTests {
             Issue.record("Expected the renderer to be authorized")
             return
         }
+        #expect(ownerDuringPolicyEvaluation == .remoteMessage(presentation.session))
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == [currentDate])
         #expect(ownerObservedDuringShow == .remoteMessage(presentation.session))
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .remoteMessage(presentation.session))
         _ = fixture.registration
@@ -113,6 +158,36 @@ final class PromoCoordinationServicePromoQueueTests {
 
         #expect(fixture.renderer.shownPresentations.isEmpty)
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .modal(modalLease.attemptIdentity))
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates.isEmpty)
+        _ = fixture.registration
+    }
+
+    @available(iOS 16, *)
+    @Test("Remote-message cooldown denial retains the candidate for a later checkpoint", .timeLimit(.minutes(1)))
+    func whenRemoteMessageCooldownInitiallyBlocksThenAReleaseCheckpointRetriesTheCandidate() {
+        let initialDate = currentDate
+        let eligibilityDate = initialDate.addingTimeInterval(10 * 60)
+        promoQueueCooldownPolicy.remoteMessageAdmissionDecisionProvider = { now in
+            now < eligibilityDate ? .blocked(until: eligibilityDate) : .eligible
+        }
+        makeSUT()
+
+        let fixture = registerRenderer(messageID: "message")
+
+        #expect(fixture.renderer.shownPresentations.isEmpty)
+        #expect(promoQueueLeaseArbiter.snapshot.activeOwner == nil)
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == [initialDate])
+
+        currentDate = eligibilityDate.addingTimeInterval(1)
+
+        #expect(fixture.renderer.shownPresentations.isEmpty)
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == [initialDate])
+
+        managerMock.coordinatedAttemptReleaseHandler?()
+
+        #expect(fixture.renderer.shownPresentations.count == 1)
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == [initialDate, currentDate])
+        #expect(promoQueueLeaseArbiter.snapshot.remoteMessageSession == fixture.renderer.shownPresentations.first?.session)
         _ = fixture.registration
     }
 
@@ -147,6 +222,7 @@ final class PromoCoordinationServicePromoQueueTests {
         #expect(first.renderer.shownPresentations.count == 1)
         #expect(second.renderer.shownPresentations.count == 1)
         #expect(first.renderer.shownPresentations.first?.session == second.renderer.shownPresentations.first?.session)
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates.count == 1)
         #expect(promoQueueLeaseArbiter.snapshot.remoteMessageSession == second.renderer.shownPresentations.first?.session)
         _ = (first.registration, second.registration)
     }
@@ -168,6 +244,7 @@ final class PromoCoordinationServicePromoQueueTests {
         #expect(firstRenderer.shownPresentations.count == 1)
         #expect(secondRenderer.shownPresentations.count == 1)
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == nil)
+        #expect(promoQueueCooldownPolicy.confirmedRemoteMessageAppearanceDates.isEmpty)
         _ = (first.registration, second.registration)
     }
 
@@ -210,6 +287,8 @@ final class PromoCoordinationServicePromoQueueTests {
             presentationID: presentation.id,
             isAttachedToWindow: true
         )
+        let confirmationDate = currentDate
+        currentDate = currentDate.addingTimeInterval(60)
         let duplicateResult = fixture.registration.confirmAppearance(
             sessionID: presentation.session.id,
             presentationID: presentation.id,
@@ -218,6 +297,8 @@ final class PromoCoordinationServicePromoQueueTests {
 
         #expect(firstResult == .accepted)
         #expect(duplicateResult == .rejected)
+        #expect(promoQueueCooldownPolicy.confirmedRemoteMessageAppearanceDates == [confirmationDate])
+        #expect(sut.remoteMessageCoordinationSnapshot.isQueueAppearanceConfirmed)
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .remoteMessage(presentation.session))
         _ = fixture.registration
     }
@@ -250,6 +331,7 @@ final class PromoCoordinationServicePromoQueueTests {
             presentationID: presentation.id,
             isAttachedToWindow: true
         ) == .rejected)
+        #expect(promoQueueCooldownPolicy.confirmedRemoteMessageAppearanceDates.isEmpty)
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .remoteMessage(presentation.session))
         _ = fixture.registration
     }
@@ -266,6 +348,12 @@ final class PromoCoordinationServicePromoQueueTests {
             Issue.record("Expected the first renderer to own the session")
             return
         }
+        let firstConfirmationDate = currentDate
+        #expect(first.registration.confirmAppearance(
+            sessionID: outgoingPresentation.session.id,
+            presentationID: outgoingPresentation.id,
+            isAttachedToWindow: true
+        ) == .accepted)
 
         first.registration.update(candidate: .available(messageID: "message"), isEligible: false)
 
@@ -281,6 +369,19 @@ final class PromoCoordinationServicePromoQueueTests {
         #expect(second.renderer.shownPresentations.count == 1)
         #expect(second.renderer.shownPresentations.first?.session == outgoingPresentation.session)
         #expect(second.renderer.shownPresentations.first?.id != outgoingPresentation.id)
+        guard let successorPresentation = second.renderer.shownPresentations.first else {
+            Issue.record("Expected the successor presentation")
+            return
+        }
+        currentDate = currentDate.addingTimeInterval(60)
+        #expect(second.registration.confirmAppearance(
+            sessionID: successorPresentation.session.id,
+            presentationID: successorPresentation.id,
+            isAttachedToWindow: true
+        ) == .accepted)
+        #expect(promoQueueCooldownPolicy.confirmedRemoteMessageAppearanceDates == [firstConfirmationDate])
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates.count == 1)
+        #expect(sut.remoteMessageCoordinationSnapshot.isQueueAppearanceConfirmed)
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .remoteMessage(outgoingPresentation.session))
         _ = (first.registration, second.registration)
     }
@@ -321,6 +422,12 @@ final class PromoCoordinationServicePromoQueueTests {
             Issue.record("Expected the outgoing renderer to own the session")
             return
         }
+        let outgoingConfirmationDate = currentDate
+        #expect(outgoing.registration.confirmAppearance(
+            sessionID: outgoingPresentation.session.id,
+            presentationID: outgoingPresentation.id,
+            isAttachedToWindow: true
+        ) == .accepted)
 
         outgoing.registration.update(candidate: .available(messageID: "message"), isEligible: false)
         outgoing.renderer.finishLastRemoval(using: outgoing.registration)
@@ -337,6 +444,14 @@ final class PromoCoordinationServicePromoQueueTests {
 
         #expect(successorPresentation.session.messageID == outgoingPresentation.session.messageID)
         #expect(successorPresentation.session.id != outgoingPresentation.session.id)
+        currentDate = currentDate.addingTimeInterval(60)
+        #expect(successor.registration.confirmAppearance(
+            sessionID: successorPresentation.session.id,
+            presentationID: successorPresentation.id,
+            isAttachedToWindow: true
+        ) == .accepted)
+        #expect(promoQueueCooldownPolicy.confirmedRemoteMessageAppearanceDates == [outgoingConfirmationDate, currentDate])
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates.count == 2)
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .remoteMessage(successorPresentation.session))
         _ = (outgoing.registration, successor.registration)
     }
@@ -542,6 +657,7 @@ final class PromoCoordinationServicePromoQueueTests {
 
         #expect(sut.remoteMessageCoordinationSnapshot.state == .idle)
         #expect(!sut.remoteMessageCoordinationSnapshot.isQueueAppearanceConfirmed)
+        #expect(promoQueueCooldownPolicy.confirmedRemoteMessageAppearanceDates.isEmpty)
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == nil)
         _ = fixture.registration
     }
@@ -818,6 +934,8 @@ final class PromoCoordinationServicePromoQueueTests {
 
         #expect(fixture.renderer.shownPresentations.isEmpty)
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == nil)
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates.isEmpty)
+        #expect(promoQueueCooldownPolicy.confirmedRemoteMessageAppearanceDates.isEmpty)
         _ = fixture.registration
     }
 
@@ -828,7 +946,9 @@ final class PromoCoordinationServicePromoQueueTests {
             launchSourceManager: launchSourceManagerMock,
             modalPromptCoordinationManager: managerMock,
             promoCoordinationMode: mode,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            promoQueueCooldownPolicy: promoQueueCooldownPolicy,
+            dateProvider: { [unowned self] in currentDate }
         )
 
         guard mode == .coordinated, readyForInteractions else {

--- a/iOS/DuckDuckGoTests/AppServices/PromoCoordinationServicePromoQueueTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/PromoCoordinationServicePromoQueueTests.swift
@@ -30,6 +30,7 @@ final class PromoCoordinationServicePromoQueueTests {
     private let presenterMock = MockModalPromptPresenter()
     private let promoQueueLeaseArbiter = PromoQueueLeaseArbiter()
     private let promoQueueCooldownPolicy = MockPromoQueueCooldownPolicy()
+    private let promoQueueCooldownDebugSnapshotProvider = MockPromoQueueCooldownDebugSnapshotProvider()
     private var currentDate = Date(timeIntervalSince1970: 1_800_000_000)
     private var sut: PromoCoordinationService!
 
@@ -46,7 +47,7 @@ final class PromoCoordinationServicePromoQueueTests {
             nextRemoteMessageEligibility: lastRemoteMessageAppearance.addingTimeInterval(600),
             nextModalEligibility: lastRemoteMessageAppearance.addingTimeInterval(86_400)
         )
-        promoQueueCooldownPolicy.snapshotToReturn = cooldownSnapshot
+        promoQueueCooldownDebugSnapshotProvider.snapshotToReturn = cooldownSnapshot
         managerMock.hasPendingModalPrompt = true
         managerMock.shouldSuppressOtherSessionPromos = true
         makeSUT()
@@ -63,6 +64,9 @@ final class PromoCoordinationServicePromoQueueTests {
             isAttachedToWindow: true
         ) == .accepted)
 
+        let remoteMessageAdmissionDates = promoQueueCooldownPolicy.remoteMessageAdmissionDates
+        let modalAdmissionDates = promoQueueCooldownPolicy.modalAdmissionDates
+        let confirmedRemoteMessageAppearanceDates = promoQueueCooldownPolicy.confirmedRemoteMessageAppearanceDates
         var snapshot = sut.promoQueueDebugSnapshot
         #expect(snapshot.mode == .coordinated)
         #expect(snapshot.activeOwner == .remoteMessage(presentation.session))
@@ -85,6 +89,11 @@ final class PromoCoordinationServicePromoQueueTests {
         #expect(snapshot.isApplicationActive)
         #expect(!snapshot.isWaitingForForegroundInteractionReadiness)
         #expect(snapshot.cooldown == cooldownSnapshot)
+        #expect(promoQueueCooldownDebugSnapshotProvider.snapshotDates == [currentDate])
+        #expect(promoQueueCooldownPolicy.snapshotDates.isEmpty)
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == remoteMessageAdmissionDates)
+        #expect(promoQueueCooldownPolicy.modalAdmissionDates == modalAdmissionDates)
+        #expect(promoQueueCooldownPolicy.confirmedRemoteMessageAppearanceDates == confirmedRemoteMessageAppearanceDates)
 
         fixture.registration.update(candidate: .available(messageID: "debug-owner"), isEligible: false)
 
@@ -113,14 +122,23 @@ final class PromoCoordinationServicePromoQueueTests {
         #expect(snapshot.remoteMessageCoordination.state == .idle)
         #expect(snapshot.remoteMessageCoordination.registeredRendererCount == 1)
         #expect(snapshot.remoteMessageCoordination.eligibleRendererCount == 0)
-        #expect(promoQueueCooldownPolicy.snapshotDates == [currentDate, currentDate, currentDate, currentDate])
+        #expect(promoQueueCooldownDebugSnapshotProvider.snapshotDates == [
+            currentDate,
+            currentDate,
+            currentDate,
+            currentDate
+        ])
+        #expect(promoQueueCooldownPolicy.snapshotDates.isEmpty)
+        #expect(promoQueueCooldownPolicy.remoteMessageAdmissionDates == remoteMessageAdmissionDates)
+        #expect(promoQueueCooldownPolicy.modalAdmissionDates == modalAdmissionDates)
+        #expect(promoQueueCooldownPolicy.confirmedRemoteMessageAppearanceDates == confirmedRemoteMessageAppearanceDates)
         fixture.registration.deregister()
     }
 
     @available(iOS 16, *)
     @Test("The legacy debug snapshot does not read Promo Queue history", .timeLimit(.minutes(1)))
     func whenLegacyDebugSnapshotIsReadThenCooldownHistoryRemainsUntouched() {
-        promoQueueCooldownPolicy.snapshotToReturn = PromoQueueCooldownSnapshot(
+        promoQueueCooldownDebugSnapshotProvider.snapshotToReturn = PromoQueueCooldownSnapshot(
             lastConfirmedModalAppearance: currentDate,
             lastConfirmedRemoteMessageAppearance: currentDate,
             nextRemoteMessageEligibility: currentDate,
@@ -143,6 +161,7 @@ final class PromoCoordinationServicePromoQueueTests {
         #expect(!snapshot.isApplicationActive)
         #expect(snapshot.isWaitingForForegroundInteractionReadiness)
         #expect(snapshot.cooldown == .empty)
+        #expect(promoQueueCooldownDebugSnapshotProvider.snapshotDates.isEmpty)
         #expect(promoQueueCooldownPolicy.snapshotDates.isEmpty)
     }
 
@@ -1061,6 +1080,7 @@ final class PromoCoordinationServicePromoQueueTests {
             promoCoordinationMode: mode,
             promoQueueLeaseArbiter: promoQueueLeaseArbiter,
             promoQueueCooldownPolicy: promoQueueCooldownPolicy,
+            promoQueueCooldownDebugSnapshotProvider: promoQueueCooldownDebugSnapshotProvider,
             dateProvider: { [unowned self] in currentDate }
         )
 
@@ -1120,6 +1140,17 @@ final class PromoCoordinationServicePromoQueueTests {
 private struct RendererFixture {
     let renderer: ControllableRemoteMessageRenderer
     let registration: NewTabPagePromoRendererRegistration
+}
+
+@MainActor
+private final class MockPromoQueueCooldownDebugSnapshotProvider: PromoQueueCooldownDebugSnapshotProviding {
+    var snapshotToReturn: PromoQueueCooldownSnapshot = .empty
+    private(set) var snapshotDates = [Date]()
+
+    func snapshot(now: Date) -> PromoQueueCooldownSnapshot {
+        snapshotDates.append(now)
+        return snapshotToReturn
+    }
 }
 
 @MainActor

--- a/iOS/DuckDuckGoTests/AppServices/PromoCoordinationServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/PromoCoordinationServiceTests.swift
@@ -116,26 +116,6 @@ final class PromoCoordinationServiceTests {
         #expect(!managerMock.didCallPresentModalPromptIfNeeded)
     }
 
-    @Test("Check Modal Is Presented When No Modal Is Currently Presented")
-    func whenNoModalIsPresentedThenModalIsPresented() {
-        // GIVEN
-        launchSourceManagerMock.source = .standard
-        presenterMock.presentedViewController = nil
-        sut = PromoCoordinationService(
-            launchSourceManager: launchSourceManagerMock,
-            modalPromptCoordinationManager: managerMock,
-            promoCoordinationMode: .legacy,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
-            promoQueueCooldownPolicy: MockPromoQueueCooldownPolicy()
-        )
-
-        // WHEN
-        presentModalPromptIfNeeded()
-
-        // THEN
-        #expect(managerMock.didCallPresentModalPromptIfNeeded)
-    }
-
     @Test("Check Modal Is Presented When Presented Modal Is Being Dismissed")
     func whenPresentedModalIsBeingDismissedThenModalIsPresented() {
         // GIVEN
@@ -178,26 +158,6 @@ final class PromoCoordinationServiceTests {
 
         // THEN
         #expect(managerMock.didCallPresentModalPromptIfNeeded)
-    }
-
-    @Test("Check Modal Is Not Presented When Multiple Conditions Fail")
-    func whenMultipleConditionsFailThenModalIsNotPresented() {
-        // GIVEN
-        launchSourceManagerMock.source = .URL
-        presenterMock.presentedViewController = UIViewController()
-        sut = PromoCoordinationService(
-            launchSourceManager: launchSourceManagerMock,
-            modalPromptCoordinationManager: managerMock,
-            promoCoordinationMode: .legacy,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
-            promoQueueCooldownPolicy: MockPromoQueueCooldownPolicy()
-        )
-
-        // WHEN
-        presentModalPromptIfNeeded()
-
-        // THEN
-        #expect(!managerMock.didCallPresentModalPromptIfNeeded)
     }
 
     @Test(

--- a/iOS/DuckDuckGoTests/AppServices/PromoCoordinationServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/PromoCoordinationServiceTests.swift
@@ -61,7 +61,8 @@ final class PromoCoordinationServiceTests {
             launchSourceManager: launchSourceManagerMock,
             modalPromptCoordinationManager: managerMock,
             promoCoordinationMode: .legacy,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            promoQueueCooldownPolicy: MockPromoQueueCooldownPolicy()
         )
 
         // WHEN
@@ -80,7 +81,8 @@ final class PromoCoordinationServiceTests {
             launchSourceManager: launchSourceManagerMock,
             modalPromptCoordinationManager: managerMock,
             promoCoordinationMode: .legacy,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            promoQueueCooldownPolicy: MockPromoQueueCooldownPolicy()
         )
 
         // WHEN
@@ -103,7 +105,8 @@ final class PromoCoordinationServiceTests {
             launchSourceManager: launchSourceManagerMock,
             modalPromptCoordinationManager: managerMock,
             promoCoordinationMode: .legacy,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            promoQueueCooldownPolicy: MockPromoQueueCooldownPolicy()
         )
 
         // WHEN
@@ -122,7 +125,8 @@ final class PromoCoordinationServiceTests {
             launchSourceManager: launchSourceManagerMock,
             modalPromptCoordinationManager: managerMock,
             promoCoordinationMode: .legacy,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            promoQueueCooldownPolicy: MockPromoQueueCooldownPolicy()
         )
 
         // WHEN
@@ -143,7 +147,8 @@ final class PromoCoordinationServiceTests {
             launchSourceManager: launchSourceManagerMock,
             modalPromptCoordinationManager: managerMock,
             promoCoordinationMode: .legacy,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            promoQueueCooldownPolicy: MockPromoQueueCooldownPolicy()
         )
 
         // WHEN
@@ -164,7 +169,8 @@ final class PromoCoordinationServiceTests {
             launchSourceManager: launchSourceManagerMock,
             modalPromptCoordinationManager: managerMock,
             promoCoordinationMode: .legacy,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            promoQueueCooldownPolicy: MockPromoQueueCooldownPolicy()
         )
 
         // WHEN
@@ -183,7 +189,8 @@ final class PromoCoordinationServiceTests {
             launchSourceManager: launchSourceManagerMock,
             modalPromptCoordinationManager: managerMock,
             promoCoordinationMode: .legacy,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            promoQueueCooldownPolicy: MockPromoQueueCooldownPolicy()
         )
 
         // WHEN

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicyTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicyTests.swift
@@ -245,19 +245,71 @@ final class PromoQueueRemoteMessageCooldownStoreTests {
         #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
     }
 
-    @Test("A later read failure returns the last successfully read timestamp")
-    func whenReadFailsAfterSuccessThenCachedTimestampIsReturned() {
-        let keyValueStore = MockKeyValueFileStore(
-            underlyingDict: [
-                PromoQueueRemoteMessageCooldownKeyValueFilesStore.StorageKey.lastConfirmedRemoteMessageTimestamp: referenceTimestamp
-            ]
-        )
+    @Test("A diagnostic read does not warm the production failure fallback")
+    func whenDiagnosticReadSucceedsThenLaterProductionReadFailureHasNoFallback() {
+        let keyValueStore = MockKeyValueFileStore()
+        let persistenceWriter = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        persistenceWriter.lastConfirmedRemoteMessageTimestamp = referenceTimestamp
+        let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+
+        #expect(store.lastConfirmedRemoteMessageTimestampForPromoQueueDiagnostics() == referenceTimestamp)
+
+        keyValueStore.throwOnRead = StoreTestError.read
+        #expect(store.lastConfirmedRemoteMessageTimestamp == nil)
+    }
+
+    @Test("A failed diagnostic read preserves the production failure fallback")
+    func whenProductionCacheExistsThenDiagnosticReadFailureDoesNotChangeIt() {
+        let keyValueStore = MockKeyValueFileStore()
+        let persistenceWriter = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        persistenceWriter.lastConfirmedRemoteMessageTimestamp = referenceTimestamp
         let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
         #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
 
         keyValueStore.throwOnRead = StoreTestError.read
 
+        #expect(store.lastConfirmedRemoteMessageTimestampForPromoQueueDiagnostics() == referenceTimestamp)
         #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
+    }
+
+    @Test("Diagnostics preserve the current-process authoritative RMF value")
+    func whenPersistenceWriteFailsThenDiagnosticReadUsesLocallyConfirmedValue() {
+        let persistedTimestamp = referenceTimestamp - 1
+        let keyValueStore = MockKeyValueFileStore()
+        let persistenceWriter = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        persistenceWriter.lastConfirmedRemoteMessageTimestamp = persistedTimestamp
+        let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        keyValueStore.throwOnSet = StoreTestError.write
+
+        store.lastConfirmedRemoteMessageTimestamp = referenceTimestamp
+
+        #expect(store.lastConfirmedRemoteMessageTimestampForPromoQueueDiagnostics() == referenceTimestamp)
+        keyValueStore.throwOnSet = nil
+        let reconstructedStore = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        #expect(reconstructedStore.lastConfirmedRemoteMessageTimestamp == persistedTimestamp)
+    }
+
+    @Test(
+        "A later read failure returns the last successfully read optional timestamp and recovers",
+        arguments: [nil, 1_775_000_000] as [TimeInterval?]
+    )
+    func whenReadFailsAfterSuccessThenCachedTimestampIsReturned(lastSuccessfulTimestamp: TimeInterval?) {
+        let recoveredTimestamp = referenceTimestamp + 1
+        let keyValueStore = MockKeyValueFileStore()
+        let persistenceWriter = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        persistenceWriter.lastConfirmedRemoteMessageTimestamp = lastSuccessfulTimestamp
+        let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        #expect(store.lastConfirmedRemoteMessageTimestamp == lastSuccessfulTimestamp)
+
+        let persistenceMutator = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        persistenceMutator.lastConfirmedRemoteMessageTimestamp = recoveredTimestamp
+
+        keyValueStore.throwOnRead = StoreTestError.read
+
+        #expect(store.lastConfirmedRemoteMessageTimestamp == lastSuccessfulTimestamp)
+
+        keyValueStore.throwOnRead = nil
+        #expect(store.lastConfirmedRemoteMessageTimestamp == recoveredTimestamp)
     }
 
     @Test("A successful nil read is cached for a later failure")

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicyTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicyTests.swift
@@ -51,13 +51,10 @@ final class PromoQueueCooldownPolicyTests {
         arguments: [
             DirectionalCooldownScenario(direction: .modalToRemoteMessage, elapsed: 599, isEligible: false),
             DirectionalCooldownScenario(direction: .modalToRemoteMessage, elapsed: 600, isEligible: true),
-            DirectionalCooldownScenario(direction: .modalToRemoteMessage, elapsed: 601, isEligible: true),
             DirectionalCooldownScenario(direction: .remoteMessageToRemoteMessage, elapsed: 599, isEligible: false),
             DirectionalCooldownScenario(direction: .remoteMessageToRemoteMessage, elapsed: 600, isEligible: true),
-            DirectionalCooldownScenario(direction: .remoteMessageToRemoteMessage, elapsed: 601, isEligible: true),
             DirectionalCooldownScenario(direction: .remoteMessageToModal, elapsed: 86_399, isEligible: false),
             DirectionalCooldownScenario(direction: .remoteMessageToModal, elapsed: 86_400, isEligible: true),
-            DirectionalCooldownScenario(direction: .remoteMessageToModal, elapsed: 86_401, isEligible: true),
         ]
     )
     func whenEvaluatingDirectionalCooldownBoundaryThenEligibilityIsCorrect(_ scenario: DirectionalCooldownScenario) {
@@ -92,7 +89,6 @@ final class PromoQueueCooldownPolicyTests {
         arguments: [
             (modalOffset: 0, remoteMessageOffset: -300),
             (modalOffset: -300, remoteMessageOffset: 0),
-            (modalOffset: 0, remoteMessageOffset: 0),
         ] as [(TimeInterval, TimeInterval)]
     )
     func whenBothHistoriesExistThenRemoteMessageAdmissionUsesMaximumBoundary(
@@ -107,9 +103,6 @@ final class PromoQueueCooldownPolicyTests {
         let expectedBoundary = max(modalAppearance, remoteMessageAppearance)
             .addingTimeInterval(ApprovedCooldownInterval.remoteMessageTarget)
 
-        let snapshot = policy.snapshot(now: referenceDate)
-
-        #expect(snapshot.nextRemoteMessageEligibility == expectedBoundary)
         #expect(policy.evaluateRemoteMessageAdmission(now: referenceDate) == .blocked(until: expectedBoundary))
     }
 
@@ -120,7 +113,6 @@ final class PromoQueueCooldownPolicyTests {
 
         #expect(policy.evaluateRemoteMessageAdmission(now: referenceDate) == .eligible)
         #expect(policy.evaluateModalAdmission(now: referenceDate) == .eligible)
-        #expect(policy.snapshot(now: referenceDate) == .empty)
     }
 
     @available(iOS 16, *)
@@ -130,6 +122,7 @@ final class PromoQueueCooldownPolicyTests {
         let policy = makePolicy(modalStore: modalStore)
 
         #expect(policy.evaluateModalAdmission(now: referenceDate) == .eligible)
+        #expect(modalStore.readCount == 0)
     }
 
     @available(iOS 16, *)
@@ -163,9 +156,6 @@ final class PromoQueueCooldownPolicyTests {
             modalPresentationStore: PromptCooldownStoreSpy(),
             remoteMessagePresentationStore: PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
         )
-        let snapshot = reconstructedPolicy.snapshot(now: referenceDate.addingTimeInterval(1))
-
-        #expect(snapshot.lastConfirmedRemoteMessageAppearance == referenceDate)
         #expect(
             reconstructedPolicy.evaluateRemoteMessageAdmission(now: referenceDate.addingTimeInterval(1))
                 == .blocked(until: referenceDate.addingTimeInterval(ApprovedCooldownInterval.remoteMessageTarget))
@@ -174,31 +164,6 @@ final class PromoQueueCooldownPolicyTests {
             reconstructedPolicy.evaluateModalAdmission(now: referenceDate.addingTimeInterval(1))
                 == .blocked(until: referenceDate.addingTimeInterval(ApprovedCooldownInterval.modalAfterRemoteMessage))
         )
-    }
-
-    @available(iOS 16, *)
-    @Test("Snapshot derives history and boundaries without writing either store", .timeLimit(.minutes(1)))
-    func whenTakingSnapshotThenValuesAreDerivedWithoutSideEffects() {
-        let modalAppearance = referenceDate.addingTimeInterval(-300)
-        let remoteMessageAppearance = referenceDate.addingTimeInterval(-120)
-        let modalStore = PromptCooldownStoreSpy(timestamp: modalAppearance.timeIntervalSince1970)
-        let remoteMessageStore = RemoteMessageCooldownStoreSpy(timestamp: remoteMessageAppearance.timeIntervalSince1970)
-        let policy = makePolicy(modalStore: modalStore, remoteMessageStore: remoteMessageStore)
-
-        let snapshot = policy.snapshot(now: referenceDate)
-
-        #expect(
-            snapshot == PromoQueueCooldownSnapshot(
-                lastConfirmedModalAppearance: modalAppearance,
-                lastConfirmedRemoteMessageAppearance: remoteMessageAppearance,
-                nextRemoteMessageEligibility: remoteMessageAppearance.addingTimeInterval(ApprovedCooldownInterval.remoteMessageTarget),
-                nextModalEligibility: remoteMessageAppearance.addingTimeInterval(ApprovedCooldownInterval.modalAfterRemoteMessage)
-            )
-        )
-        #expect(modalStore.readCount == 1)
-        #expect(modalStore.writeCount == 0)
-        #expect(remoteMessageStore.readCount == 1)
-        #expect(remoteMessageStore.writeCount == 0)
     }
 
     @available(iOS 16, *)
@@ -261,8 +226,18 @@ final class PromoQueueRemoteMessageCooldownStoreTests {
         let persistenceWriter = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
         persistenceWriter.lastConfirmedRemoteMessageTimestamp = referenceTimestamp
         let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        let debugSnapshotProvider = PromoQueueCooldownDebugSnapshotProvider(
+            modalPresentationStore: PromptCooldownKeyValueFilesStore(
+                keyValueStore: keyValueStore,
+                eventMapper: .init { _, _, _, _ in }
+            ),
+            remoteMessagePresentationStore: store
+        )
 
-        #expect(store.lastConfirmedRemoteMessageTimestampForPromoQueueDiagnostics() == referenceTimestamp)
+        #expect(
+            debugSnapshotProvider.snapshot(now: .distantPast).lastConfirmedRemoteMessageAppearance ==
+                Date(timeIntervalSince1970: referenceTimestamp)
+        )
 
         keyValueStore.throwOnRead = StoreTestError.read
         #expect(store.lastConfirmedRemoteMessageTimestamp == nil)
@@ -275,30 +250,22 @@ final class PromoQueueRemoteMessageCooldownStoreTests {
         let persistenceWriter = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
         persistenceWriter.lastConfirmedRemoteMessageTimestamp = referenceTimestamp
         let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        let debugSnapshotProvider = PromoQueueCooldownDebugSnapshotProvider(
+            modalPresentationStore: PromptCooldownKeyValueFilesStore(
+                keyValueStore: keyValueStore,
+                eventMapper: .init { _, _, _, _ in }
+            ),
+            remoteMessagePresentationStore: store
+        )
         #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
 
         keyValueStore.throwOnRead = StoreTestError.read
 
-        #expect(store.lastConfirmedRemoteMessageTimestampForPromoQueueDiagnostics() == referenceTimestamp)
+        #expect(
+            debugSnapshotProvider.snapshot(now: .distantPast).lastConfirmedRemoteMessageAppearance ==
+                Date(timeIntervalSince1970: referenceTimestamp)
+        )
         #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
-    }
-
-    @available(iOS 16, *)
-    @Test("Diagnostics preserve the current-process authoritative RMF value", .timeLimit(.minutes(1)))
-    func whenPersistenceWriteFailsThenDiagnosticReadUsesLocallyConfirmedValue() {
-        let persistedTimestamp = referenceTimestamp - 1
-        let keyValueStore = MockKeyValueFileStore()
-        let persistenceWriter = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
-        persistenceWriter.lastConfirmedRemoteMessageTimestamp = persistedTimestamp
-        let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
-        keyValueStore.throwOnSet = StoreTestError.write
-
-        store.lastConfirmedRemoteMessageTimestamp = referenceTimestamp
-
-        #expect(store.lastConfirmedRemoteMessageTimestampForPromoQueueDiagnostics() == referenceTimestamp)
-        keyValueStore.throwOnSet = nil
-        let reconstructedStore = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
-        #expect(reconstructedStore.lastConfirmedRemoteMessageTimestamp == persistedTimestamp)
     }
 
     @available(iOS 16, *)
@@ -351,11 +318,22 @@ final class PromoQueueRemoteMessageCooldownStoreTests {
         persistenceWriter.lastConfirmedRemoteMessageTimestamp = persistedTimestamp
         let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
         #expect(store.lastConfirmedRemoteMessageTimestamp == persistedTimestamp)
+        let debugSnapshotProvider = PromoQueueCooldownDebugSnapshotProvider(
+            modalPresentationStore: PromptCooldownKeyValueFilesStore(
+                keyValueStore: keyValueStore,
+                eventMapper: .init { _, _, _, _ in }
+            ),
+            remoteMessagePresentationStore: store
+        )
         keyValueStore.throwOnSet = StoreTestError.write
 
         store.lastConfirmedRemoteMessageTimestamp = referenceTimestamp
 
         #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
+        #expect(
+            debugSnapshotProvider.snapshot(now: .distantPast).lastConfirmedRemoteMessageAppearance ==
+                Date(timeIntervalSince1970: referenceTimestamp)
+        )
 
         keyValueStore.throwOnSet = nil
         let reconstructedStore = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicyTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicyTests.swift
@@ -1,0 +1,374 @@
+//
+//  PromoQueueCooldownPolicyTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import PersistenceTestingUtils
+import Testing
+@testable import DuckDuckGo
+
+@MainActor
+@Suite("Promo Queue - Directional Cooldown Policy")
+final class PromoQueueCooldownPolicyTests {
+    private let referenceDate = Date(timeIntervalSince1970: 1_775_000_000)
+
+    @Test(
+        "Modal to RMF uses an inclusive ten-minute boundary",
+        arguments: [
+            (599, false),
+            (600, true),
+            (601, true),
+        ] as [(TimeInterval, Bool)]
+    )
+    func whenEvaluatingModalToRemoteMessageBoundaryThenEligibilityIsCorrect(elapsed: TimeInterval, isEligible: Bool) {
+        let modalStore = PromptCooldownStoreSpy(timestamp: referenceDate.timeIntervalSince1970)
+        let policy = makePolicy(modalStore: modalStore)
+        let boundary = referenceDate.addingTimeInterval(PromoQueueCooldownPolicy.remoteMessageTargetInterval)
+
+        let decision = policy.evaluateRemoteMessageAdmission(now: referenceDate.addingTimeInterval(elapsed))
+
+        expect(decision, isEligible: isEligible, boundary: boundary)
+    }
+
+    @Test(
+        "RMF to RMF uses an inclusive ten-minute boundary",
+        arguments: [
+            (599, false),
+            (600, true),
+            (601, true),
+        ] as [(TimeInterval, Bool)]
+    )
+    func whenEvaluatingRemoteMessageToRemoteMessageBoundaryThenEligibilityIsCorrect(elapsed: TimeInterval, isEligible: Bool) {
+        let remoteMessageStore = RemoteMessageCooldownStoreSpy(timestamp: referenceDate.timeIntervalSince1970)
+        let policy = makePolicy(remoteMessageStore: remoteMessageStore)
+        let boundary = referenceDate.addingTimeInterval(PromoQueueCooldownPolicy.remoteMessageTargetInterval)
+
+        let decision = policy.evaluateRemoteMessageAdmission(now: referenceDate.addingTimeInterval(elapsed))
+
+        expect(decision, isEligible: isEligible, boundary: boundary)
+    }
+
+    @Test(
+        "RMF to modal uses an inclusive twenty-four-hour boundary",
+        arguments: [
+            (86_399, false),
+            (86_400, true),
+            (86_401, true),
+        ] as [(TimeInterval, Bool)]
+    )
+    func whenEvaluatingRemoteMessageToModalBoundaryThenEligibilityIsCorrect(elapsed: TimeInterval, isEligible: Bool) {
+        let remoteMessageStore = RemoteMessageCooldownStoreSpy(timestamp: referenceDate.timeIntervalSince1970)
+        let policy = makePolicy(remoteMessageStore: remoteMessageStore)
+        let boundary = referenceDate.addingTimeInterval(PromoQueueCooldownPolicy.modalAfterRemoteMessageInterval)
+
+        let decision = policy.evaluateModalAdmission(now: referenceDate.addingTimeInterval(elapsed))
+
+        expect(decision, isEligible: isEligible, boundary: boundary)
+    }
+
+    @Test("RMF admission uses the later modal or RMF boundary")
+    func whenBothHistoriesExistThenRemoteMessageAdmissionUsesMaximumBoundary() {
+        let historyPairs = [
+            (modal: referenceDate, remoteMessage: referenceDate.addingTimeInterval(-300)),
+            (modal: referenceDate.addingTimeInterval(-300), remoteMessage: referenceDate),
+            (modal: referenceDate, remoteMessage: referenceDate),
+        ]
+
+        for histories in historyPairs {
+            let modalStore = PromptCooldownStoreSpy(timestamp: histories.modal.timeIntervalSince1970)
+            let remoteMessageStore = RemoteMessageCooldownStoreSpy(timestamp: histories.remoteMessage.timeIntervalSince1970)
+            let policy = makePolicy(modalStore: modalStore, remoteMessageStore: remoteMessageStore)
+            let expectedBoundary = max(histories.modal, histories.remoteMessage)
+                .addingTimeInterval(PromoQueueCooldownPolicy.remoteMessageTargetInterval)
+
+            let snapshot = policy.snapshot(now: referenceDate)
+
+            #expect(snapshot.nextRemoteMessageEligibility == expectedBoundary)
+            #expect(policy.evaluateRemoteMessageAdmission(now: referenceDate) == .blocked(until: expectedBoundary))
+        }
+    }
+
+    @Test("No confirmed history allows both targets")
+    func whenHistoryIsAbsentThenBothTargetsAreEligible() {
+        let policy = makePolicy()
+
+        #expect(policy.evaluateRemoteMessageAdmission(now: referenceDate) == .eligible)
+        #expect(policy.evaluateModalAdmission(now: referenceDate) == .eligible)
+        #expect(policy.snapshot(now: referenceDate) == .empty)
+    }
+
+    @Test("Modal history is not used for modal admission")
+    func whenOnlyModalHistoryExistsThenModalAdmissionRemainsEligible() {
+        let modalStore = PromptCooldownStoreSpy(timestamp: referenceDate.timeIntervalSince1970)
+        let policy = makePolicy(modalStore: modalStore)
+
+        #expect(policy.evaluateModalAdmission(now: referenceDate) == .eligible)
+    }
+
+    @Test("Future history conservatively extends both cooldowns")
+    func whenClockMovesBackwardThenFutureHistoryExtendsCooldowns() {
+        let futureModalAppearance = referenceDate.addingTimeInterval(300)
+        let futureRemoteMessageAppearance = referenceDate.addingTimeInterval(600)
+        let modalStore = PromptCooldownStoreSpy(timestamp: futureModalAppearance.timeIntervalSince1970)
+        let remoteMessageStore = RemoteMessageCooldownStoreSpy(timestamp: futureRemoteMessageAppearance.timeIntervalSince1970)
+        let policy = makePolicy(modalStore: modalStore, remoteMessageStore: remoteMessageStore)
+        let expectedRemoteMessageBoundary = futureRemoteMessageAppearance
+            .addingTimeInterval(PromoQueueCooldownPolicy.remoteMessageTargetInterval)
+        let expectedModalBoundary = futureRemoteMessageAppearance
+            .addingTimeInterval(PromoQueueCooldownPolicy.modalAfterRemoteMessageInterval)
+
+        #expect(policy.evaluateRemoteMessageAdmission(now: referenceDate) == .blocked(until: expectedRemoteMessageBoundary))
+        #expect(policy.evaluateModalAdmission(now: referenceDate) == .blocked(until: expectedModalBoundary))
+    }
+
+    @Test("Confirmed RMF history persists across policy and store reconstruction")
+    func whenPolicyIsReconstructedThenPersistedRemoteMessageHistoryIsObserved() {
+        let keyValueStore = MockKeyValueFileStore()
+        let firstPolicy = PromoQueueCooldownPolicy(
+            modalPresentationStore: PromptCooldownStoreSpy(),
+            remoteMessagePresentationStore: PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        )
+        firstPolicy.recordConfirmedRemoteMessageAppearance(at: referenceDate)
+
+        let reconstructedPolicy = PromoQueueCooldownPolicy(
+            modalPresentationStore: PromptCooldownStoreSpy(),
+            remoteMessagePresentationStore: PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        )
+        let snapshot = reconstructedPolicy.snapshot(now: referenceDate.addingTimeInterval(1))
+
+        #expect(snapshot.lastConfirmedRemoteMessageAppearance == referenceDate)
+        #expect(
+            reconstructedPolicy.evaluateRemoteMessageAdmission(now: referenceDate.addingTimeInterval(1))
+                == .blocked(until: referenceDate.addingTimeInterval(PromoQueueCooldownPolicy.remoteMessageTargetInterval))
+        )
+        #expect(
+            reconstructedPolicy.evaluateModalAdmission(now: referenceDate.addingTimeInterval(1))
+                == .blocked(until: referenceDate.addingTimeInterval(PromoQueueCooldownPolicy.modalAfterRemoteMessageInterval))
+        )
+    }
+
+    @Test("Snapshot derives history and boundaries without writing either store")
+    func whenTakingSnapshotThenValuesAreDerivedWithoutSideEffects() {
+        let modalAppearance = referenceDate.addingTimeInterval(-300)
+        let remoteMessageAppearance = referenceDate.addingTimeInterval(-120)
+        let modalStore = PromptCooldownStoreSpy(timestamp: modalAppearance.timeIntervalSince1970)
+        let remoteMessageStore = RemoteMessageCooldownStoreSpy(timestamp: remoteMessageAppearance.timeIntervalSince1970)
+        let policy = makePolicy(modalStore: modalStore, remoteMessageStore: remoteMessageStore)
+
+        let snapshot = policy.snapshot(now: referenceDate)
+
+        #expect(
+            snapshot == PromoQueueCooldownSnapshot(
+                lastConfirmedModalAppearance: modalAppearance,
+                lastConfirmedRemoteMessageAppearance: remoteMessageAppearance,
+                nextRemoteMessageEligibility: remoteMessageAppearance.addingTimeInterval(PromoQueueCooldownPolicy.remoteMessageTargetInterval),
+                nextModalEligibility: remoteMessageAppearance.addingTimeInterval(PromoQueueCooldownPolicy.modalAfterRemoteMessageInterval)
+            )
+        )
+        #expect(modalStore.readCount == 1)
+        #expect(modalStore.writeCount == 0)
+        #expect(remoteMessageStore.readCount == 1)
+        #expect(remoteMessageStore.writeCount == 0)
+    }
+
+    @Test("Recording an RMF appearance writes only confirmed RMF history")
+    func whenRecordingRemoteMessageAppearanceThenTimestampIsStored() {
+        let modalStore = PromptCooldownStoreSpy()
+        let remoteMessageStore = RemoteMessageCooldownStoreSpy()
+        let policy = makePolicy(modalStore: modalStore, remoteMessageStore: remoteMessageStore)
+
+        policy.recordConfirmedRemoteMessageAppearance(at: referenceDate)
+
+        #expect(remoteMessageStore.timestamp == referenceDate.timeIntervalSince1970)
+        #expect(remoteMessageStore.writeCount == 1)
+        #expect(modalStore.writeCount == 0)
+    }
+
+    @Test("Iteration-one cooldown intervals are fixed constants")
+    func whenInspectingIntervalsThenTheyMatchTheApprovedPolicy() {
+        #expect(PromoQueueCooldownPolicy.remoteMessageTargetInterval == 10 * 60)
+        #expect(PromoQueueCooldownPolicy.modalAfterRemoteMessageInterval == 24 * 60 * 60)
+    }
+
+    private func makePolicy(
+        modalStore: PromptCooldownStoreSpy? = nil,
+        remoteMessageStore: RemoteMessageCooldownStoreSpy? = nil
+    ) -> PromoQueueCooldownPolicy {
+        PromoQueueCooldownPolicy(
+            modalPresentationStore: modalStore ?? PromptCooldownStoreSpy(),
+            remoteMessagePresentationStore: remoteMessageStore ?? RemoteMessageCooldownStoreSpy()
+        )
+    }
+
+    private func expect(_ decision: PromoQueueCooldownDecision, isEligible: Bool, boundary: Date) {
+        if isEligible {
+            #expect(decision == .eligible)
+        } else {
+            #expect(decision == .blocked(until: boundary))
+        }
+    }
+}
+
+@MainActor
+@Suite("Promo Queue - Confirmed RMF Cooldown Store")
+final class PromoQueueRemoteMessageCooldownStoreTests {
+    private let referenceTimestamp: TimeInterval = 1_775_000_000
+
+    @Test("An initial read failure returns no history and retries later")
+    func whenInitialReadFailsThenLaterReadRetriesPersistence() {
+        let keyValueStore = MockKeyValueFileStore(
+            underlyingDict: [
+                PromoQueueRemoteMessageCooldownKeyValueFilesStore.StorageKey.lastConfirmedRemoteMessageTimestamp: referenceTimestamp
+            ]
+        )
+        keyValueStore.throwOnRead = StoreTestError.read
+        let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+
+        #expect(store.lastConfirmedRemoteMessageTimestamp == nil)
+
+        keyValueStore.throwOnRead = nil
+        #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
+    }
+
+    @Test("A later read failure returns the last successfully read timestamp")
+    func whenReadFailsAfterSuccessThenCachedTimestampIsReturned() {
+        let keyValueStore = MockKeyValueFileStore(
+            underlyingDict: [
+                PromoQueueRemoteMessageCooldownKeyValueFilesStore.StorageKey.lastConfirmedRemoteMessageTimestamp: referenceTimestamp
+            ]
+        )
+        let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
+
+        keyValueStore.throwOnRead = StoreTestError.read
+
+        #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
+    }
+
+    @Test("A successful nil read is cached for a later failure")
+    func whenNilReadSucceedsThenLaterFailureReturnsCachedNil() {
+        let keyValueStore = MockKeyValueFileStore()
+        let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        #expect(store.lastConfirmedRemoteMessageTimestamp == nil)
+
+        keyValueStore.underlyingDict[
+            PromoQueueRemoteMessageCooldownKeyValueFilesStore.StorageKey.lastConfirmedRemoteMessageTimestamp
+        ] = referenceTimestamp
+        keyValueStore.throwOnRead = StoreTestError.read
+
+        #expect(store.lastConfirmedRemoteMessageTimestamp == nil)
+
+        keyValueStore.throwOnRead = nil
+        #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
+    }
+
+    @Test("A successful write updates persistence and current-process memory")
+    func whenWriteSucceedsThenTimestampIsPersistedAndAuthoritativeInMemory() {
+        let key = PromoQueueRemoteMessageCooldownKeyValueFilesStore.StorageKey.lastConfirmedRemoteMessageTimestamp
+        let keyValueStore = MockKeyValueFileStore()
+        let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+
+        store.lastConfirmedRemoteMessageTimestamp = referenceTimestamp
+
+        #expect(keyValueStore.underlyingDict[key] as? TimeInterval == referenceTimestamp)
+        keyValueStore.underlyingDict[key] = referenceTimestamp - 1
+        #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
+    }
+
+    @Test("A failed write remains authoritative only in the current process")
+    func whenWriteFailsThenAttemptedTimestampIsKeptInMemoryButNotReconstructed() {
+        let key = PromoQueueRemoteMessageCooldownKeyValueFilesStore.StorageKey.lastConfirmedRemoteMessageTimestamp
+        let persistedTimestamp = referenceTimestamp - 1
+        let keyValueStore = MockKeyValueFileStore(underlyingDict: [key: persistedTimestamp])
+        let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        #expect(store.lastConfirmedRemoteMessageTimestamp == persistedTimestamp)
+        keyValueStore.throwOnSet = StoreTestError.write
+
+        store.lastConfirmedRemoteMessageTimestamp = referenceTimestamp
+
+        #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
+        #expect(keyValueStore.underlyingDict[key] as? TimeInterval == persistedTimestamp)
+
+        keyValueStore.throwOnSet = nil
+        let reconstructedStore = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        #expect(reconstructedStore.lastConfirmedRemoteMessageTimestamp == persistedTimestamp)
+    }
+
+    @Test("A persisted write is observed after store reconstruction")
+    func whenStoreIsReconstructedThenPersistedTimestampIsObserved() {
+        let keyValueStore = MockKeyValueFileStore()
+        let firstStore = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        firstStore.lastConfirmedRemoteMessageTimestamp = referenceTimestamp
+
+        let reconstructedStore = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+
+        #expect(reconstructedStore.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
+    }
+}
+
+private enum StoreTestError: Error {
+    case read
+    case write
+}
+
+private final class PromptCooldownStoreSpy: PromptCooldownStore {
+    private var storedTimestamp: TimeInterval?
+    private(set) var readCount = 0
+    private(set) var writeCount = 0
+
+    init(timestamp: TimeInterval? = nil) {
+        storedTimestamp = timestamp
+    }
+
+    var lastPresentationTimestamp: TimeInterval? {
+        get {
+            readCount += 1
+            return storedTimestamp
+        }
+        set {
+            writeCount += 1
+            storedTimestamp = newValue
+        }
+    }
+}
+
+@MainActor
+private final class RemoteMessageCooldownStoreSpy: PromoQueueRemoteMessageCooldownStoring {
+    private var storedTimestamp: TimeInterval?
+    private(set) var readCount = 0
+    private(set) var writeCount = 0
+
+    init(timestamp: TimeInterval? = nil) {
+        storedTimestamp = timestamp
+    }
+
+    var timestamp: TimeInterval? {
+        storedTimestamp
+    }
+
+    var lastConfirmedRemoteMessageTimestamp: TimeInterval? {
+        get {
+            readCount += 1
+            return storedTimestamp
+        }
+        set {
+            writeCount += 1
+            storedTimestamp = newValue
+        }
+    }
+}

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicyTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicyTests.swift
@@ -22,88 +22,99 @@ import PersistenceTestingUtils
 import Testing
 @testable import DuckDuckGo
 
+private enum ApprovedCooldownInterval {
+    static let remoteMessageTarget: TimeInterval = 10 * 60
+    static let modalAfterRemoteMessage: TimeInterval = 24 * 60 * 60
+}
+
+enum DirectionalCooldown: Sendable {
+    case modalToRemoteMessage
+    case remoteMessageToRemoteMessage
+    case remoteMessageToModal
+}
+
+struct DirectionalCooldownScenario: Sendable {
+    let direction: DirectionalCooldown
+    let elapsed: TimeInterval
+    let isEligible: Bool
+}
+
 @MainActor
 @Suite("Promo Queue - Directional Cooldown Policy")
 final class PromoQueueCooldownPolicyTests {
     private let referenceDate = Date(timeIntervalSince1970: 1_775_000_000)
 
+    @available(iOS 16, *)
     @Test(
-        "Modal to RMF uses an inclusive ten-minute boundary",
+        "Directional cooldowns use their inclusive approved boundaries",
+        .timeLimit(.minutes(1)),
         arguments: [
-            (599, false),
-            (600, true),
-            (601, true),
-        ] as [(TimeInterval, Bool)]
-    )
-    func whenEvaluatingModalToRemoteMessageBoundaryThenEligibilityIsCorrect(elapsed: TimeInterval, isEligible: Bool) {
-        let modalStore = PromptCooldownStoreSpy(timestamp: referenceDate.timeIntervalSince1970)
-        let policy = makePolicy(modalStore: modalStore)
-        let boundary = referenceDate.addingTimeInterval(PromoQueueCooldownPolicy.remoteMessageTargetInterval)
-
-        let decision = policy.evaluateRemoteMessageAdmission(now: referenceDate.addingTimeInterval(elapsed))
-
-        expect(decision, isEligible: isEligible, boundary: boundary)
-    }
-
-    @Test(
-        "RMF to RMF uses an inclusive ten-minute boundary",
-        arguments: [
-            (599, false),
-            (600, true),
-            (601, true),
-        ] as [(TimeInterval, Bool)]
-    )
-    func whenEvaluatingRemoteMessageToRemoteMessageBoundaryThenEligibilityIsCorrect(elapsed: TimeInterval, isEligible: Bool) {
-        let remoteMessageStore = RemoteMessageCooldownStoreSpy(timestamp: referenceDate.timeIntervalSince1970)
-        let policy = makePolicy(remoteMessageStore: remoteMessageStore)
-        let boundary = referenceDate.addingTimeInterval(PromoQueueCooldownPolicy.remoteMessageTargetInterval)
-
-        let decision = policy.evaluateRemoteMessageAdmission(now: referenceDate.addingTimeInterval(elapsed))
-
-        expect(decision, isEligible: isEligible, boundary: boundary)
-    }
-
-    @Test(
-        "RMF to modal uses an inclusive twenty-four-hour boundary",
-        arguments: [
-            (86_399, false),
-            (86_400, true),
-            (86_401, true),
-        ] as [(TimeInterval, Bool)]
-    )
-    func whenEvaluatingRemoteMessageToModalBoundaryThenEligibilityIsCorrect(elapsed: TimeInterval, isEligible: Bool) {
-        let remoteMessageStore = RemoteMessageCooldownStoreSpy(timestamp: referenceDate.timeIntervalSince1970)
-        let policy = makePolicy(remoteMessageStore: remoteMessageStore)
-        let boundary = referenceDate.addingTimeInterval(PromoQueueCooldownPolicy.modalAfterRemoteMessageInterval)
-
-        let decision = policy.evaluateModalAdmission(now: referenceDate.addingTimeInterval(elapsed))
-
-        expect(decision, isEligible: isEligible, boundary: boundary)
-    }
-
-    @Test("RMF admission uses the later modal or RMF boundary")
-    func whenBothHistoriesExistThenRemoteMessageAdmissionUsesMaximumBoundary() {
-        let historyPairs = [
-            (modal: referenceDate, remoteMessage: referenceDate.addingTimeInterval(-300)),
-            (modal: referenceDate.addingTimeInterval(-300), remoteMessage: referenceDate),
-            (modal: referenceDate, remoteMessage: referenceDate),
+            DirectionalCooldownScenario(direction: .modalToRemoteMessage, elapsed: 599, isEligible: false),
+            DirectionalCooldownScenario(direction: .modalToRemoteMessage, elapsed: 600, isEligible: true),
+            DirectionalCooldownScenario(direction: .modalToRemoteMessage, elapsed: 601, isEligible: true),
+            DirectionalCooldownScenario(direction: .remoteMessageToRemoteMessage, elapsed: 599, isEligible: false),
+            DirectionalCooldownScenario(direction: .remoteMessageToRemoteMessage, elapsed: 600, isEligible: true),
+            DirectionalCooldownScenario(direction: .remoteMessageToRemoteMessage, elapsed: 601, isEligible: true),
+            DirectionalCooldownScenario(direction: .remoteMessageToModal, elapsed: 86_399, isEligible: false),
+            DirectionalCooldownScenario(direction: .remoteMessageToModal, elapsed: 86_400, isEligible: true),
+            DirectionalCooldownScenario(direction: .remoteMessageToModal, elapsed: 86_401, isEligible: true),
         ]
+    )
+    func whenEvaluatingDirectionalCooldownBoundaryThenEligibilityIsCorrect(_ scenario: DirectionalCooldownScenario) {
+        let decision: PromoQueueCooldownDecision
+        let boundary: Date
 
-        for histories in historyPairs {
-            let modalStore = PromptCooldownStoreSpy(timestamp: histories.modal.timeIntervalSince1970)
-            let remoteMessageStore = RemoteMessageCooldownStoreSpy(timestamp: histories.remoteMessage.timeIntervalSince1970)
-            let policy = makePolicy(modalStore: modalStore, remoteMessageStore: remoteMessageStore)
-            let expectedBoundary = max(histories.modal, histories.remoteMessage)
-                .addingTimeInterval(PromoQueueCooldownPolicy.remoteMessageTargetInterval)
-
-            let snapshot = policy.snapshot(now: referenceDate)
-
-            #expect(snapshot.nextRemoteMessageEligibility == expectedBoundary)
-            #expect(policy.evaluateRemoteMessageAdmission(now: referenceDate) == .blocked(until: expectedBoundary))
+        switch scenario.direction {
+        case .modalToRemoteMessage:
+            let modalStore = PromptCooldownStoreSpy(timestamp: referenceDate.timeIntervalSince1970)
+            let policy = makePolicy(modalStore: modalStore)
+            decision = policy.evaluateRemoteMessageAdmission(now: referenceDate.addingTimeInterval(scenario.elapsed))
+            boundary = referenceDate.addingTimeInterval(ApprovedCooldownInterval.remoteMessageTarget)
+        case .remoteMessageToRemoteMessage:
+            let remoteMessageStore = RemoteMessageCooldownStoreSpy(timestamp: referenceDate.timeIntervalSince1970)
+            let policy = makePolicy(remoteMessageStore: remoteMessageStore)
+            decision = policy.evaluateRemoteMessageAdmission(now: referenceDate.addingTimeInterval(scenario.elapsed))
+            boundary = referenceDate.addingTimeInterval(ApprovedCooldownInterval.remoteMessageTarget)
+        case .remoteMessageToModal:
+            let remoteMessageStore = RemoteMessageCooldownStoreSpy(timestamp: referenceDate.timeIntervalSince1970)
+            let policy = makePolicy(remoteMessageStore: remoteMessageStore)
+            decision = policy.evaluateModalAdmission(now: referenceDate.addingTimeInterval(scenario.elapsed))
+            boundary = referenceDate.addingTimeInterval(ApprovedCooldownInterval.modalAfterRemoteMessage)
         }
+
+        expect(decision, isEligible: scenario.isEligible, boundary: boundary)
     }
 
-    @Test("No confirmed history allows both targets")
+    @available(iOS 16, *)
+    @Test(
+        "RMF admission uses the later modal or RMF boundary",
+        .timeLimit(.minutes(1)),
+        arguments: [
+            (modalOffset: 0, remoteMessageOffset: -300),
+            (modalOffset: -300, remoteMessageOffset: 0),
+            (modalOffset: 0, remoteMessageOffset: 0),
+        ] as [(TimeInterval, TimeInterval)]
+    )
+    func whenBothHistoriesExistThenRemoteMessageAdmissionUsesMaximumBoundary(
+        modalOffset: TimeInterval,
+        remoteMessageOffset: TimeInterval
+    ) {
+        let modalAppearance = referenceDate.addingTimeInterval(modalOffset)
+        let remoteMessageAppearance = referenceDate.addingTimeInterval(remoteMessageOffset)
+        let modalStore = PromptCooldownStoreSpy(timestamp: modalAppearance.timeIntervalSince1970)
+        let remoteMessageStore = RemoteMessageCooldownStoreSpy(timestamp: remoteMessageAppearance.timeIntervalSince1970)
+        let policy = makePolicy(modalStore: modalStore, remoteMessageStore: remoteMessageStore)
+        let expectedBoundary = max(modalAppearance, remoteMessageAppearance)
+            .addingTimeInterval(ApprovedCooldownInterval.remoteMessageTarget)
+
+        let snapshot = policy.snapshot(now: referenceDate)
+
+        #expect(snapshot.nextRemoteMessageEligibility == expectedBoundary)
+        #expect(policy.evaluateRemoteMessageAdmission(now: referenceDate) == .blocked(until: expectedBoundary))
+    }
+
+    @available(iOS 16, *)
+    @Test("No confirmed history allows both targets", .timeLimit(.minutes(1)))
     func whenHistoryIsAbsentThenBothTargetsAreEligible() {
         let policy = makePolicy()
 
@@ -112,7 +123,8 @@ final class PromoQueueCooldownPolicyTests {
         #expect(policy.snapshot(now: referenceDate) == .empty)
     }
 
-    @Test("Modal history is not used for modal admission")
+    @available(iOS 16, *)
+    @Test("Modal history is not used for modal admission", .timeLimit(.minutes(1)))
     func whenOnlyModalHistoryExistsThenModalAdmissionRemainsEligible() {
         let modalStore = PromptCooldownStoreSpy(timestamp: referenceDate.timeIntervalSince1970)
         let policy = makePolicy(modalStore: modalStore)
@@ -120,7 +132,8 @@ final class PromoQueueCooldownPolicyTests {
         #expect(policy.evaluateModalAdmission(now: referenceDate) == .eligible)
     }
 
-    @Test("Future history conservatively extends both cooldowns")
+    @available(iOS 16, *)
+    @Test("Future history conservatively extends both cooldowns", .timeLimit(.minutes(1)))
     func whenClockMovesBackwardThenFutureHistoryExtendsCooldowns() {
         let futureModalAppearance = referenceDate.addingTimeInterval(300)
         let futureRemoteMessageAppearance = referenceDate.addingTimeInterval(600)
@@ -128,15 +141,16 @@ final class PromoQueueCooldownPolicyTests {
         let remoteMessageStore = RemoteMessageCooldownStoreSpy(timestamp: futureRemoteMessageAppearance.timeIntervalSince1970)
         let policy = makePolicy(modalStore: modalStore, remoteMessageStore: remoteMessageStore)
         let expectedRemoteMessageBoundary = futureRemoteMessageAppearance
-            .addingTimeInterval(PromoQueueCooldownPolicy.remoteMessageTargetInterval)
+            .addingTimeInterval(ApprovedCooldownInterval.remoteMessageTarget)
         let expectedModalBoundary = futureRemoteMessageAppearance
-            .addingTimeInterval(PromoQueueCooldownPolicy.modalAfterRemoteMessageInterval)
+            .addingTimeInterval(ApprovedCooldownInterval.modalAfterRemoteMessage)
 
         #expect(policy.evaluateRemoteMessageAdmission(now: referenceDate) == .blocked(until: expectedRemoteMessageBoundary))
         #expect(policy.evaluateModalAdmission(now: referenceDate) == .blocked(until: expectedModalBoundary))
     }
 
-    @Test("Confirmed RMF history persists across policy and store reconstruction")
+    @available(iOS 16, *)
+    @Test("Confirmed RMF history persists across policy and store reconstruction", .timeLimit(.minutes(1)))
     func whenPolicyIsReconstructedThenPersistedRemoteMessageHistoryIsObserved() {
         let keyValueStore = MockKeyValueFileStore()
         let firstPolicy = PromoQueueCooldownPolicy(
@@ -154,15 +168,16 @@ final class PromoQueueCooldownPolicyTests {
         #expect(snapshot.lastConfirmedRemoteMessageAppearance == referenceDate)
         #expect(
             reconstructedPolicy.evaluateRemoteMessageAdmission(now: referenceDate.addingTimeInterval(1))
-                == .blocked(until: referenceDate.addingTimeInterval(PromoQueueCooldownPolicy.remoteMessageTargetInterval))
+                == .blocked(until: referenceDate.addingTimeInterval(ApprovedCooldownInterval.remoteMessageTarget))
         )
         #expect(
             reconstructedPolicy.evaluateModalAdmission(now: referenceDate.addingTimeInterval(1))
-                == .blocked(until: referenceDate.addingTimeInterval(PromoQueueCooldownPolicy.modalAfterRemoteMessageInterval))
+                == .blocked(until: referenceDate.addingTimeInterval(ApprovedCooldownInterval.modalAfterRemoteMessage))
         )
     }
 
-    @Test("Snapshot derives history and boundaries without writing either store")
+    @available(iOS 16, *)
+    @Test("Snapshot derives history and boundaries without writing either store", .timeLimit(.minutes(1)))
     func whenTakingSnapshotThenValuesAreDerivedWithoutSideEffects() {
         let modalAppearance = referenceDate.addingTimeInterval(-300)
         let remoteMessageAppearance = referenceDate.addingTimeInterval(-120)
@@ -176,8 +191,8 @@ final class PromoQueueCooldownPolicyTests {
             snapshot == PromoQueueCooldownSnapshot(
                 lastConfirmedModalAppearance: modalAppearance,
                 lastConfirmedRemoteMessageAppearance: remoteMessageAppearance,
-                nextRemoteMessageEligibility: remoteMessageAppearance.addingTimeInterval(PromoQueueCooldownPolicy.remoteMessageTargetInterval),
-                nextModalEligibility: remoteMessageAppearance.addingTimeInterval(PromoQueueCooldownPolicy.modalAfterRemoteMessageInterval)
+                nextRemoteMessageEligibility: remoteMessageAppearance.addingTimeInterval(ApprovedCooldownInterval.remoteMessageTarget),
+                nextModalEligibility: remoteMessageAppearance.addingTimeInterval(ApprovedCooldownInterval.modalAfterRemoteMessage)
             )
         )
         #expect(modalStore.readCount == 1)
@@ -186,7 +201,8 @@ final class PromoQueueCooldownPolicyTests {
         #expect(remoteMessageStore.writeCount == 0)
     }
 
-    @Test("Recording an RMF appearance writes only confirmed RMF history")
+    @available(iOS 16, *)
+    @Test("Recording an RMF appearance writes only confirmed RMF history", .timeLimit(.minutes(1)))
     func whenRecordingRemoteMessageAppearanceThenTimestampIsStored() {
         let modalStore = PromptCooldownStoreSpy()
         let remoteMessageStore = RemoteMessageCooldownStoreSpy()
@@ -197,12 +213,6 @@ final class PromoQueueCooldownPolicyTests {
         #expect(remoteMessageStore.timestamp == referenceDate.timeIntervalSince1970)
         #expect(remoteMessageStore.writeCount == 1)
         #expect(modalStore.writeCount == 0)
-    }
-
-    @Test("Iteration-one cooldown intervals are fixed constants")
-    func whenInspectingIntervalsThenTheyMatchTheApprovedPolicy() {
-        #expect(PromoQueueCooldownPolicy.remoteMessageTargetInterval == 10 * 60)
-        #expect(PromoQueueCooldownPolicy.modalAfterRemoteMessageInterval == 24 * 60 * 60)
     }
 
     private func makePolicy(
@@ -229,13 +239,12 @@ final class PromoQueueCooldownPolicyTests {
 final class PromoQueueRemoteMessageCooldownStoreTests {
     private let referenceTimestamp: TimeInterval = 1_775_000_000
 
-    @Test("An initial read failure returns no history and retries later")
+    @available(iOS 16, *)
+    @Test("An initial read failure returns no history and retries later", .timeLimit(.minutes(1)))
     func whenInitialReadFailsThenLaterReadRetriesPersistence() {
-        let keyValueStore = MockKeyValueFileStore(
-            underlyingDict: [
-                PromoQueueRemoteMessageCooldownKeyValueFilesStore.StorageKey.lastConfirmedRemoteMessageTimestamp: referenceTimestamp
-            ]
-        )
+        let keyValueStore = MockKeyValueFileStore()
+        let persistenceWriter = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        persistenceWriter.lastConfirmedRemoteMessageTimestamp = referenceTimestamp
         keyValueStore.throwOnRead = StoreTestError.read
         let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
 
@@ -245,7 +254,8 @@ final class PromoQueueRemoteMessageCooldownStoreTests {
         #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
     }
 
-    @Test("A diagnostic read does not warm the production failure fallback")
+    @available(iOS 16, *)
+    @Test("A diagnostic read does not warm the production failure fallback", .timeLimit(.minutes(1)))
     func whenDiagnosticReadSucceedsThenLaterProductionReadFailureHasNoFallback() {
         let keyValueStore = MockKeyValueFileStore()
         let persistenceWriter = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
@@ -258,7 +268,8 @@ final class PromoQueueRemoteMessageCooldownStoreTests {
         #expect(store.lastConfirmedRemoteMessageTimestamp == nil)
     }
 
-    @Test("A failed diagnostic read preserves the production failure fallback")
+    @available(iOS 16, *)
+    @Test("A failed diagnostic read preserves the production failure fallback", .timeLimit(.minutes(1)))
     func whenProductionCacheExistsThenDiagnosticReadFailureDoesNotChangeIt() {
         let keyValueStore = MockKeyValueFileStore()
         let persistenceWriter = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
@@ -272,7 +283,8 @@ final class PromoQueueRemoteMessageCooldownStoreTests {
         #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
     }
 
-    @Test("Diagnostics preserve the current-process authoritative RMF value")
+    @available(iOS 16, *)
+    @Test("Diagnostics preserve the current-process authoritative RMF value", .timeLimit(.minutes(1)))
     func whenPersistenceWriteFailsThenDiagnosticReadUsesLocallyConfirmedValue() {
         let persistedTimestamp = referenceTimestamp - 1
         let keyValueStore = MockKeyValueFileStore()
@@ -289,8 +301,10 @@ final class PromoQueueRemoteMessageCooldownStoreTests {
         #expect(reconstructedStore.lastConfirmedRemoteMessageTimestamp == persistedTimestamp)
     }
 
+    @available(iOS 16, *)
     @Test(
         "A later read failure returns the last successfully read optional timestamp and recovers",
+        .timeLimit(.minutes(1)),
         arguments: [nil, 1_775_000_000] as [TimeInterval?]
     )
     func whenReadFailsAfterSuccessThenCachedTimestampIsReturned(lastSuccessfulTimestamp: TimeInterval?) {
@@ -312,41 +326,29 @@ final class PromoQueueRemoteMessageCooldownStoreTests {
         #expect(store.lastConfirmedRemoteMessageTimestamp == recoveredTimestamp)
     }
 
-    @Test("A successful nil read is cached for a later failure")
-    func whenNilReadSucceedsThenLaterFailureReturnsCachedNil() {
-        let keyValueStore = MockKeyValueFileStore()
-        let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
-        #expect(store.lastConfirmedRemoteMessageTimestamp == nil)
-
-        keyValueStore.underlyingDict[
-            PromoQueueRemoteMessageCooldownKeyValueFilesStore.StorageKey.lastConfirmedRemoteMessageTimestamp
-        ] = referenceTimestamp
-        keyValueStore.throwOnRead = StoreTestError.read
-
-        #expect(store.lastConfirmedRemoteMessageTimestamp == nil)
-
-        keyValueStore.throwOnRead = nil
-        #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
-    }
-
-    @Test("A successful write updates persistence and current-process memory")
+    @available(iOS 16, *)
+    @Test("A successful write updates persistence and current-process memory", .timeLimit(.minutes(1)))
     func whenWriteSucceedsThenTimestampIsPersistedAndAuthoritativeInMemory() {
-        let key = PromoQueueRemoteMessageCooldownKeyValueFilesStore.StorageKey.lastConfirmedRemoteMessageTimestamp
         let keyValueStore = MockKeyValueFileStore()
         let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
 
         store.lastConfirmedRemoteMessageTimestamp = referenceTimestamp
 
-        #expect(keyValueStore.underlyingDict[key] as? TimeInterval == referenceTimestamp)
-        keyValueStore.underlyingDict[key] = referenceTimestamp - 1
+        let reconstructedStore = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        #expect(reconstructedStore.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
+
+        let persistenceMutator = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        persistenceMutator.lastConfirmedRemoteMessageTimestamp = referenceTimestamp - 1
         #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
     }
 
-    @Test("A failed write remains authoritative only in the current process")
+    @available(iOS 16, *)
+    @Test("A failed write remains authoritative only in the current process", .timeLimit(.minutes(1)))
     func whenWriteFailsThenAttemptedTimestampIsKeptInMemoryButNotReconstructed() {
-        let key = PromoQueueRemoteMessageCooldownKeyValueFilesStore.StorageKey.lastConfirmedRemoteMessageTimestamp
         let persistedTimestamp = referenceTimestamp - 1
-        let keyValueStore = MockKeyValueFileStore(underlyingDict: [key: persistedTimestamp])
+        let keyValueStore = MockKeyValueFileStore()
+        let persistenceWriter = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
+        persistenceWriter.lastConfirmedRemoteMessageTimestamp = persistedTimestamp
         let store = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
         #expect(store.lastConfirmedRemoteMessageTimestamp == persistedTimestamp)
         keyValueStore.throwOnSet = StoreTestError.write
@@ -354,22 +356,10 @@ final class PromoQueueRemoteMessageCooldownStoreTests {
         store.lastConfirmedRemoteMessageTimestamp = referenceTimestamp
 
         #expect(store.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
-        #expect(keyValueStore.underlyingDict[key] as? TimeInterval == persistedTimestamp)
 
         keyValueStore.throwOnSet = nil
         let reconstructedStore = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
         #expect(reconstructedStore.lastConfirmedRemoteMessageTimestamp == persistedTimestamp)
-    }
-
-    @Test("A persisted write is observed after store reconstruction")
-    func whenStoreIsReconstructedThenPersistedTimestampIsObserved() {
-        let keyValueStore = MockKeyValueFileStore()
-        let firstStore = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
-        firstStore.lastConfirmedRemoteMessageTimestamp = referenceTimestamp
-
-        let reconstructedStore = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
-
-        #expect(reconstructedStore.lastConfirmedRemoteMessageTimestamp == referenceTimestamp)
     }
 }
 

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromptCooldownStoreTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromptCooldownStoreTests.swift
@@ -32,7 +32,8 @@ final class PromptCooldownStoreTests {
         keyValueStoreMock = try MockKeyValueFileStore()
     }
 
-    @Test("Check Last Presentation Timestamp Is Nil When Nothing Is Stored")
+    @available(iOS 16, *)
+    @Test("Check Last Presentation Timestamp Is Nil When Nothing Is Stored", .timeLimit(.minutes(1)))
     func whenNothingStoredThenLastPresentationTimestampIsNil() throws {
         // GIVEN
         var didCallFireEvent = false
@@ -49,16 +50,11 @@ final class PromptCooldownStoreTests {
         #expect(!didCallFireEvent, "Should not fire an event when no error is encountered")
     }
 
-    @Test(
-        "Check Last Presentation Timestamp Returns Stored Value",
-        arguments: [
-            1761091200,  // 22 October 2025 12:00:00 AM GMT
-            1761264000,  // 24 October 2025 12:00:00 AM GMT
-            1761436800,  // 10 October 2025 12:00:00 AM GMT
-        ]
-    )
-    func whenTimestampIsStoredThenLastPresentationTimestampReturnsIt(timestamp: TimeInterval) {
+    @available(iOS 16, *)
+    @Test("Check Last Presentation Timestamp Returns Stored Value", .timeLimit(.minutes(1)))
+    func whenTimestampIsStoredThenLastPresentationTimestampReturnsIt() {
         // GIVEN
+        let timestamp: TimeInterval = 1761091200 // 22 October 2025 12:00:00 AM GMT
         var didCallFireEvent = false
         keyValueStoreMock.underlyingDict = [
             PromptCooldownKeyValueFilesStore.StorageKey.lastPromptShownTimestamp: timestamp
@@ -75,16 +71,11 @@ final class PromptCooldownStoreTests {
         #expect(!didCallFireEvent, "Should not fire an event when no error is encountered")
     }
 
-    @Test(
-        "Check Setting Last Presentation Timestamp Stores Value",
-        arguments: [
-            1761091200,  // 22 October 2025 12:00:00 AM GMT
-            1761264000,  // 24 October 2025 12:00:00 AM GMT
-            1761436800,  // 10 October 2025 12:00:00 AM GMT
-        ]
-    )
-    func whenSettingTimestampThenValueIsStored(timestamp: TimeInterval) throws {
+    @available(iOS 16, *)
+    @Test("Check Setting Last Presentation Timestamp Stores Value", .timeLimit(.minutes(1)))
+    func whenSettingTimestampThenValueIsStored() throws {
         // GIVEN
+        let timestamp: TimeInterval = 1761091200 // 22 October 2025 12:00:00 AM GMT
         var didCallFireEvent = false
         keyValueStoreMock.underlyingDict = [:]
         #expect(keyValueStoreMock.underlyingDict.isEmpty)
@@ -101,7 +92,8 @@ final class PromptCooldownStoreTests {
         #expect(!didCallFireEvent, "Should not fire an event when no error is encountered")
     }
 
-    @Test("Check Setting Timestamp To Nil Removes Value")
+    @available(iOS 16, *)
+    @Test("Check Setting Timestamp To Nil Removes Value", .timeLimit(.minutes(1)))
     func whenSettingTimestampToNilThenValueIsRemoved() throws {
         // GIVEN
         var didCallFireEvent = false
@@ -123,7 +115,8 @@ final class PromptCooldownStoreTests {
         #expect(!didCallFireEvent, "Should not fire an event when no error is encountered")
     }
 
-    @Test("Check Failed Read Triggers Event And Returns Nil")
+    @available(iOS 16, *)
+    @Test("Check Failed Read Triggers Event And Returns Nil", .timeLimit(.minutes(1)))
     func whenReadFailsThenEventIsFiredAndReturnsNil() throws {
         // GIVEN
         var capturedEvent: PromptCooldownKeyValueFilesStore.DebugEvent?
@@ -143,7 +136,8 @@ final class PromptCooldownStoreTests {
         #expect(capturedError != nil)
     }
 
-    @Test("Check Failed Promo Queue Diagnostic Read Does Not Trigger Event")
+    @available(iOS 16, *)
+    @Test("Check Failed Promo Queue Diagnostic Read Does Not Trigger Event", .timeLimit(.minutes(1)))
     func whenPromoQueueDiagnosticReadFailsThenEventIsNotFired() {
         var didCallFireEvent = false
         keyValueStoreMock.throwOnRead = TestError()
@@ -157,7 +151,8 @@ final class PromptCooldownStoreTests {
         #expect(!didCallFireEvent)
     }
 
-    @Test("Check Failed Write Triggers Event")
+    @available(iOS 16, *)
+    @Test("Check Failed Write Triggers Event", .timeLimit(.minutes(1)))
     func whenWriteFailsThenEventIsFired() {
         // GIVEN
         var capturedEvent: PromptCooldownKeyValueFilesStore.DebugEvent?
@@ -176,7 +171,8 @@ final class PromptCooldownStoreTests {
         #expect(capturedError != nil)
     }
 
-    @Test("Check Invalid Type Stored Returns Nil")
+    @available(iOS 16, *)
+    @Test("Check Invalid Type Stored Returns Nil", .timeLimit(.minutes(1)))
     func whenInvalidTypeStoredThenReturnsNil() {
         // GIVEN
         var didCallFireEvent = false

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromptCooldownStoreTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromptCooldownStoreTests.swift
@@ -143,6 +143,20 @@ final class PromptCooldownStoreTests {
         #expect(capturedError != nil)
     }
 
+    @Test("Check Failed Promo Queue Diagnostic Read Does Not Trigger Event")
+    func whenPromoQueueDiagnosticReadFailsThenEventIsNotFired() {
+        var didCallFireEvent = false
+        keyValueStoreMock.throwOnRead = TestError()
+        let sut = PromptCooldownKeyValueFilesStore(keyValueStore: keyValueStoreMock, eventMapper: .init { _, _, _, _ in
+            didCallFireEvent = true
+        })
+
+        let result = sut.lastPresentationTimestampForPromoQueueDiagnostics()
+
+        #expect(result == nil)
+        #expect(!didCallFireEvent)
+    }
+
     @Test("Check Failed Write Triggers Event")
     func whenWriteFailsThenEventIsFired() {
         // GIVEN

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationDebugMenuTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationDebugMenuTests.swift
@@ -1,0 +1,188 @@
+//
+//  ModalPromptCoordinationDebugMenuTests.swift
+//  DuckDuckGoTests
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+@testable import DuckDuckGo
+
+@MainActor
+@Suite("Modal Prompt Coordination Debug Menu")
+final class ModalPromptCoordinationDebugMenuTests {
+
+    @Test("View model formats modal and logical RMF identities without surface state")
+    func whenSnapshotChangesThenViewModelFormatsEveryReadOnlyValue() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+        guard case .acquired(let modalLease) = arbiter.acquireModalLease() else {
+            Issue.record("Expected modal lease acquisition")
+            return
+        }
+        let referenceDate = Date(timeIntervalSince1970: 1_800_000_000)
+        let sessionID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000123"))
+        let rendererID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000234"))
+        let generationID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000345"))
+        let presentationID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000456"))
+        let removalID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000567"))
+        let remoteMessageSession = PromoQueueRemoteMessageSession(id: sessionID, messageID: "debug-promo")
+        let provider = MutablePromoQueueDebugSnapshotProvider(snapshot: PromoQueueDebugSnapshot(
+            mode: .coordinated,
+            activeOwner: .remoteMessage(remoteMessageSession),
+            remoteMessageCoordination: PromoQueueRemoteMessageCoordinationSnapshot(
+                state: .draining,
+                messageID: remoteMessageSession.messageID,
+                sessionID: remoteMessageSession.id,
+                rendererID: rendererID,
+                registrationGenerationID: generationID,
+                presentationID: presentationID,
+                isQueueAppearanceConfirmed: true,
+                isPresentationAppearanceReported: true,
+                removalID: removalID,
+                removalTerminal: .hostDetached,
+                drainContinuation: .transferSameMessageIfAvailable,
+                registeredRendererCount: 3,
+                eligibleRendererCount: 2
+            ),
+            modalAttemptPhase: .committed(modalLease.attemptIdentity),
+            hasPendingModalPrompt: true,
+            shouldSuppressOtherSessionPromos: true,
+            isApplicationActive: true,
+            isWaitingForForegroundInteractionReadiness: false,
+            cooldown: PromoQueueCooldownSnapshot(
+                lastConfirmedModalAppearance: referenceDate,
+                lastConfirmedRemoteMessageAppearance: referenceDate.addingTimeInterval(1),
+                nextRemoteMessageEligibility: referenceDate.addingTimeInterval(600),
+                nextModalEligibility: referenceDate.addingTimeInterval(86_400)
+            )
+        ))
+        let viewModel = ModalPromptCoordinationDebugViewModel(
+            store: MockPromptCooldownStore(),
+            promoQueueDebugSnapshotProvider: provider,
+            dateFormatting: { "timestamp:\(Int($0.timeIntervalSince1970))" }
+        )
+
+        #expect(viewModel.formattedPromoQueueMode == "Coordinated")
+        #expect(viewModel.formattedActiveOwner == "RMF debug-promo — session \(sessionID.uuidString)")
+        #expect(viewModel.formattedModalAttemptPhase == "Committed — \(modalLease.attemptIdentity.debugIdentifier)")
+        #expect(viewModel.formattedPendingModalState == "Yes")
+        #expect(viewModel.formattedSuppressionState == "Yes")
+        #expect(viewModel.formattedApplicationState == "Active")
+        #expect(viewModel.formattedInteractionReadiness == "Ready")
+        #expect(viewModel.formattedRemoteMessageState == "Draining")
+        #expect(viewModel.formattedRemoteMessageIdentity == "debug-promo — session \(sessionID.uuidString)")
+        #expect(viewModel.formattedRemoteMessageRenderer == "\(rendererID.uuidString) — generation \(generationID.uuidString)")
+        #expect(viewModel.formattedRemoteMessagePresentation == presentationID.uuidString)
+        #expect(
+            viewModel.formattedRemoteMessageRemoval
+                == "\(removalID.uuidString) — Host Detached — Transfer Same Message If Available"
+        )
+        #expect(viewModel.formattedRemoteMessageQueueAppearance == "Confirmed")
+        #expect(viewModel.formattedRemoteMessagePhysicalAppearance == "Reported")
+        #expect(viewModel.formattedRemoteMessageRendererCounts == "3 registered — 2 eligible")
+        #expect(viewModel.formattedLastConfirmedModalAppearance == "timestamp:1800000000")
+        #expect(viewModel.formattedLastConfirmedRemoteMessageAppearance == "timestamp:1800000001")
+        #expect(viewModel.formattedNextRemoteMessageEligibility == "timestamp:1800000600")
+        #expect(viewModel.formattedNextModalEligibility == "timestamp:1800086400")
+
+        provider.snapshot = PromoQueueDebugSnapshot(
+            mode: .legacy,
+            activeOwner: .modal(modalLease.attemptIdentity),
+            remoteMessageCoordination: PromoQueueRemoteMessageCoordinationSnapshot(
+                state: .idle,
+                messageID: nil,
+                sessionID: nil,
+                rendererID: nil,
+                registrationGenerationID: nil,
+                presentationID: nil,
+                isQueueAppearanceConfirmed: false,
+                isPresentationAppearanceReported: nil,
+                removalID: nil,
+                removalTerminal: nil,
+                drainContinuation: nil,
+                registeredRendererCount: 0,
+                eligibleRendererCount: 0
+            ),
+            modalAttemptPhase: .idle,
+            hasPendingModalPrompt: false,
+            shouldSuppressOtherSessionPromos: false,
+            isApplicationActive: false,
+            isWaitingForForegroundInteractionReadiness: true,
+            cooldown: .empty
+        )
+
+        viewModel.refresh()
+
+        #expect(provider.snapshotReadCount == 2)
+        #expect(viewModel.formattedPromoQueueMode == "Legacy")
+        #expect(viewModel.formattedActiveOwner == "Modal — \(modalLease.attemptIdentity.debugIdentifier)")
+        #expect(viewModel.formattedModalAttemptPhase == "Idle")
+        #expect(viewModel.formattedPendingModalState == "No")
+        #expect(viewModel.formattedSuppressionState == "No")
+        #expect(viewModel.formattedApplicationState == "Inactive")
+        #expect(viewModel.formattedInteractionReadiness == "Waiting")
+        #expect(viewModel.formattedRemoteMessageState == "Idle")
+        #expect(viewModel.formattedRemoteMessageIdentity == "None")
+        #expect(viewModel.formattedRemoteMessageRenderer == "None")
+        #expect(viewModel.formattedRemoteMessagePresentation == "None")
+        #expect(viewModel.formattedRemoteMessageRemoval == "None")
+        #expect(viewModel.formattedRemoteMessageQueueAppearance == "Not Confirmed")
+        #expect(viewModel.formattedRemoteMessagePhysicalAppearance == "None")
+        #expect(viewModel.formattedRemoteMessageRendererCounts == "0 registered — 0 eligible")
+        #expect(viewModel.formattedLastConfirmedModalAppearance == "None")
+        #expect(viewModel.formattedLastConfirmedRemoteMessageAppearance == "None")
+        #expect(viewModel.formattedNextRemoteMessageEligibility == "None")
+        #expect(viewModel.formattedNextModalEligibility == "None")
+        _ = modalLease
+    }
+
+    @Test("Unavailable Projection Leaves Existing Modal Cooldown Reset Intact")
+    func whenSnapshotProviderIsUnavailableThenOnlyExistingCooldownControlRemainsActive() {
+        let store = MockPromptCooldownStore()
+        store.lastPresentationTimestamp = 1_800_000_000
+        let viewModel = ModalPromptCoordinationDebugViewModel(
+            store: store,
+            promoQueueDebugSnapshotProvider: nil,
+            dateFormatting: { _ in "unused" }
+        )
+
+        #expect(viewModel.formattedPromoQueueMode == "Unavailable")
+        #expect(viewModel.formattedActiveOwner == "Unavailable")
+        #expect(viewModel.isCooldownPeriodActive)
+
+        viewModel.resetCoolDownPeriod()
+
+        #expect(store.lastPresentationTimestamp == nil)
+        #expect(!viewModel.isCooldownPeriodActive)
+        #expect(viewModel.formattedCooldownPeriod == "No Prompt Cooldown active.")
+        #expect(viewModel.formattedPromoQueueMode == "Unavailable")
+    }
+}
+
+@MainActor
+private final class MutablePromoQueueDebugSnapshotProvider: PromoQueueDebugSnapshotProviding {
+    var snapshot: PromoQueueDebugSnapshot
+    private(set) var snapshotReadCount = 0
+
+    init(snapshot: PromoQueueDebugSnapshot) {
+        self.snapshot = snapshot
+    }
+
+    var promoQueueDebugSnapshot: PromoQueueDebugSnapshot {
+        snapshotReadCount += 1
+        return snapshot
+    }
+}

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationDebugMenuTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationDebugMenuTests.swift
@@ -25,7 +25,8 @@ import Testing
 @Suite("Modal Prompt Coordination Debug Menu")
 final class ModalPromptCoordinationDebugMenuTests {
 
-    @Test("View model formats modal and logical RMF identities without surface state")
+    @available(iOS 16, *)
+    @Test("View model formats modal and logical RMF identities without surface state", .timeLimit(.minutes(1)))
     func whenSnapshotChangesThenViewModelFormatsEveryReadOnlyValue() throws {
         let arbiter = PromoQueueLeaseArbiter()
         guard case .acquired(let modalLease) = arbiter.acquireModalLease() else {
@@ -149,7 +150,8 @@ final class ModalPromptCoordinationDebugMenuTests {
         _ = modalLease
     }
 
-    @Test("Unavailable Projection Leaves Existing Modal Cooldown Reset Intact")
+    @available(iOS 16, *)
+    @Test("Unavailable Projection Leaves Existing Modal Cooldown Reset Intact", .timeLimit(.minutes(1)))
     func whenSnapshotProviderIsUnavailableThenOnlyExistingCooldownControlRemainsActive() {
         let store = MockPromptCooldownStore()
         store.lastPresentationTimestamp = 1_800_000_000

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerPromoQueueTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerPromoQueueTests.swift
@@ -160,7 +160,8 @@ final class ModalPromptCoordinationManagerPromoQueueTests {
         #expect(!schedulerMock.didCallSchedule)
     }
 
-    @Test("Modal Prompt Provider Defaults Are Safe")
+    @available(iOS 16, *)
+    @Test("Modal Prompt Provider Defaults Are Safe", .timeLimit(.minutes(1)))
     func modalPromptProviderDefaultsGateOnOnboardingAndPreservePreparedWork() {
         let provider: any ModalPromptProvider = DefaultBehaviorModalPromptProvider()
         let configuration = ModalPromptConfiguration(viewController: UIViewController())

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationManagerTests.swift
@@ -18,7 +18,6 @@
 //
 
 import UIKit
-import Foundation
 import Testing
 @testable import DuckDuckGo
 
@@ -82,6 +81,7 @@ final class ModalPromptCoordinationManagerTests {
         #expect(provider.didCallProvideModalPrompt)
         #expect(schedulerMock.didCallSchedule)
         #expect(schedulerMock.capturedScheduledDelay == 0.1)
+        #expect(!presenterMock.didCallPresent)
 
         // Execute scheduled presentation
         schedulerMock.executeScheduledBlock()
@@ -92,41 +92,15 @@ final class ModalPromptCoordinationManagerTests {
 
     // MARK: - Priority Tests
 
-    @Test("Check First Provider Is Checked First")
-    func whenMultipleProvidersThenFirstProviderIsCheckedFirst() {
-        // GIVEN
-        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
-        let firstProvider = MockModalPromptProvider()
-        let secondProvider = MockModalPromptProvider()
-        sut = ModalPromptCoordinationManager(
-            providers: [firstProvider, secondProvider],
-            cooldownManager: cooldownManagerMock,
-            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
-            modalPromptScheduling: schedulerMock
-        )
-
-        // WHEN
-        sut.presentModalPromptIfNeeded(from: presenterMock)
-
-        // THEN
-        #expect(firstProvider.didCallProvideModalPrompt)
-        #expect(!secondProvider.didCallProvideModalPrompt)
-
-        // Execute scheduled presentation
-        schedulerMock.executeScheduledBlock()
-
-        #expect(firstProvider.didCallDidPresentModal)
-        #expect(!secondProvider.didCallDidPresentModal)
-    }
-
     @Test("Check Second Provider Is Used When First Returns Nil")
     func whenFirstProviderReturnsNilThenSecondProviderIsChecked() {
         // GIVEN
         cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
         let firstProvider = MockModalPromptProvider(shouldReturnPrompt: false)
         let secondProvider = MockModalPromptProvider()
+        let thirdProvider = MockModalPromptProvider()
         sut = ModalPromptCoordinationManager(
-            providers: [firstProvider, secondProvider],
+            providers: [firstProvider, secondProvider, thirdProvider],
             cooldownManager: cooldownManagerMock,
             onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
             modalPromptScheduling: schedulerMock
@@ -138,49 +112,14 @@ final class ModalPromptCoordinationManagerTests {
         // THEN
         #expect(firstProvider.didCallProvideModalPrompt)
         #expect(secondProvider.didCallProvideModalPrompt)
+        #expect(!thirdProvider.didCallProvideModalPrompt)
 
         // Execute scheduled presentation
         schedulerMock.executeScheduledBlock()
 
         #expect(!firstProvider.didCallDidPresentModal)
         #expect(secondProvider.didCallDidPresentModal)
-    }
-
-    @Test("Check The Right Provider Is Used When Others Return Nil")
-    func whenFirstTwoProvidersReturnNilThenThirdProviderIsChecked() {
-        // GIVEN
-        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
-        let firstProvider = MockModalPromptProvider(shouldReturnPrompt: false)
-        let secondProvider = MockModalPromptProvider(shouldReturnPrompt: false)
-        let thirdProvider = MockModalPromptProvider(shouldReturnPrompt: true)
-        let fourthProvider = MockModalPromptProvider(shouldReturnPrompt: false)
-        let fifthProvider = MockModalPromptProvider(shouldReturnPrompt: false)
-
-        sut = ModalPromptCoordinationManager(
-            providers: [firstProvider, secondProvider, thirdProvider, fourthProvider, fifthProvider],
-            cooldownManager: cooldownManagerMock,
-            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
-            modalPromptScheduling: schedulerMock
-        )
-
-        // WHEN
-        sut.presentModalPromptIfNeeded(from: presenterMock)
-
-        // THEN
-        #expect(firstProvider.didCallProvideModalPrompt)
-        #expect(secondProvider.didCallProvideModalPrompt)
-        #expect(thirdProvider.didCallProvideModalPrompt)
-        #expect(!fourthProvider.didCallProvideModalPrompt)
-        #expect(!fifthProvider.didCallProvideModalPrompt)
-
-        // Execute scheduled presentation
-        schedulerMock.executeScheduledBlock()
-
-        #expect(!firstProvider.didCallDidPresentModal)
-        #expect(!secondProvider.didCallDidPresentModal)
-        #expect(thirdProvider.didCallDidPresentModal)
-        #expect(!fourthProvider.didCallDidPresentModal)
-        #expect(!fifthProvider.didCallDidPresentModal)
+        #expect(!thirdProvider.didCallDidPresentModal)
     }
 
     @Test("Check No Modal Is Presented When All Providers Return Nil")
@@ -237,7 +176,7 @@ final class ModalPromptCoordinationManagerTests {
 
         // THEN
         let presentedVC = presenterMock.capturedViewController
-        #expect(presenterMock.capturedViewController === presentedVC)
+        #expect(presenterMock.capturedViewController === viewController)
         #expect(presentedVC?.modalPresentationStyle == .pageSheet)
         #expect(presentedVC?.modalTransitionStyle == .coverVertical)
         #expect(presentedVC?.isModalInPresentation == true)
@@ -269,76 +208,6 @@ final class ModalPromptCoordinationManagerTests {
 
         // THEN
         #expect(presenterMock.capturedAnimated == animated)
-    }
-
-    // MARK: - Scheduler Tests
-
-    @Test("Check Presentation Is Scheduled With Correct Delay")
-    func whenPresentingModalThenSchedulerIsCalledWithCorrectDelay() {
-        // GIVEN
-        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
-        let provider = MockModalPromptProvider()
-        sut = ModalPromptCoordinationManager(
-            providers: [provider],
-            cooldownManager: cooldownManagerMock,
-            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
-            modalPromptScheduling: schedulerMock
-        )
-
-        // WHEN
-        sut.presentModalPromptIfNeeded(from: presenterMock)
-
-        // THEN
-        #expect(schedulerMock.didCallSchedule)
-        #expect(schedulerMock.capturedScheduledDelay == 0.1)
-    }
-
-    @Test("Check Presentation Happens Only After Scheduled Delay")
-    func whenScheduledThenPresentationDoesNotHappenImmediately() {
-        // GIVEN
-        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
-        let provider = MockModalPromptProvider()
-        sut = ModalPromptCoordinationManager(
-            providers: [provider],
-            cooldownManager: cooldownManagerMock,
-            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
-            modalPromptScheduling: schedulerMock
-        )
-
-        // WHEN
-        sut.presentModalPromptIfNeeded(from: presenterMock)
-
-        // THEN (before executing scheduled block)
-        #expect(!presenterMock.didCallPresent)
-
-        // WHEN (executing scheduled block)
-        schedulerMock.executeScheduledBlock()
-
-        // THEN (after executing scheduled block)
-        #expect(presenterMock.didCallPresent)
-    }
-
-    // MARK: - Cooldown Recording Tests
-
-    @Test("Check Cooldown Is Recorded After Successful Presentation")
-    func whenModalIsPresentedThenCooldownIsRecorded() {
-        // GIVEN
-        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
-        let provider = MockModalPromptProvider()
-        sut = ModalPromptCoordinationManager(
-            providers: [provider],
-            cooldownManager: cooldownManagerMock,
-            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
-            modalPromptScheduling: schedulerMock
-        )
-        #expect(!cooldownManagerMock.didCallRecordLastPromptPresentationTimestamp)
-
-        // WHEN
-        sut.presentModalPromptIfNeeded(from: presenterMock)
-        schedulerMock.executeScheduledBlock()
-
-        // THEN
-        #expect(cooldownManagerMock.didCallRecordLastPromptPresentationTimestamp)
     }
 
     @available(iOS 16, *)
@@ -387,46 +256,6 @@ final class ModalPromptCoordinationManagerTests {
 
         // THEN
         #expect(!sut.shouldSuppressOtherSessionPromos)
-    }
-
-    @Test("Check Cooldown Is Not Recorded When No Modal Is Presented")
-    func whenNoModalIsPresentedThenCooldownIsNotRecorded() {
-        // GIVEN
-        cooldownManagerMock.cooldownInfoToReturn = .notInCoolDown
-        let provider = MockModalPromptProvider(shouldReturnPrompt: false)
-        sut = ModalPromptCoordinationManager(
-            providers: [provider],
-            cooldownManager: cooldownManagerMock,
-            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
-            modalPromptScheduling: schedulerMock
-        )
-
-        // WHEN
-        sut.presentModalPromptIfNeeded(from: presenterMock)
-        schedulerMock.executeScheduledBlock()
-
-        // THEN
-        #expect(!cooldownManagerMock.didCallRecordLastPromptPresentationTimestamp)
-    }
-
-    @Test("Check Cooldown Is Not Recorded When Already In Cooldown Period")
-    func whenInCooldownPeriodThenCooldownIsNotRecorded() {
-        // GIVEN
-        cooldownManagerMock.cooldownInfoToReturn = .inCoolDown
-        let provider = MockModalPromptProvider()
-        sut = ModalPromptCoordinationManager(
-            providers: [provider],
-            cooldownManager: cooldownManagerMock,
-            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
-            modalPromptScheduling: schedulerMock
-        )
-
-        // WHEN
-        sut.presentModalPromptIfNeeded(from: presenterMock)
-        schedulerMock.executeScheduledBlock()
-
-        // THEN
-        #expect(!cooldownManagerMock.didCallRecordLastPromptPresentationTimestamp)
     }
 
     // MARK: - OmniBarEditingState Present-On-Top Tests

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationRealUIKitTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationRealUIKitTests.swift
@@ -284,7 +284,8 @@ final class ModalPromptCoordinationRealUIKitTests {
             launchSourceManager: launchSourceManager,
             modalPromptCoordinationManager: manager,
             promoCoordinationMode: .coordinated,
-            promoQueueLeaseArbiter: leaseArbiter
+            promoQueueLeaseArbiter: leaseArbiter,
+            promoQueueCooldownPolicy: MockPromoQueueCooldownPolicy()
         )
         var presentationEvents = [String]()
         let keyboardPresenter = KeyboardPresenter(

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
@@ -185,8 +185,8 @@ struct PromoQueueLeaseArbiterTests {
     }
 
     @available(iOS 16, *)
-    @Test("A dropped remote-message token stops blocking modal acquisition", .timeLimit(.minutes(1)))
-    func droppedRemoteMessageTokenStopsBlockingModalAcquisition() throws {
+    @Test("A dropped remote-message token is observed as idle and reclaimed on modal acquisition", .timeLimit(.minutes(1)))
+    func droppedRemoteMessageTokenIsObservedAsIdleAndReclaimedOnModalAcquisition() throws {
         let arbiter = PromoQueueLeaseArbiter()
         let session = makeRemoteMessageSession()
         do {
@@ -202,8 +202,8 @@ struct PromoQueueLeaseArbiterTests {
     }
 
     @available(iOS 16, *)
-    @Test("A dropped modal token stops blocking remote-message acquisition", .timeLimit(.minutes(1)))
-    func droppedModalTokenStopsBlockingRemoteMessageAcquisition() throws {
+    @Test("A dropped modal token is observed as idle and reclaimed on remote-message acquisition", .timeLimit(.minutes(1)))
+    func droppedModalTokenIsObservedAsIdleAndReclaimedOnRemoteMessageAcquisition() throws {
         let arbiter = PromoQueueLeaseArbiter()
         do {
             let droppedLease = try acquiredLease(from: arbiter.acquireModalLease())
@@ -211,6 +211,7 @@ struct PromoQueueLeaseArbiterTests {
             _ = droppedLease
         }
 
+        #expect(arbiter.snapshot.activeOwner == nil)
         let session = makeRemoteMessageSession()
         let remoteMessageLease = try acquiredLease(from: arbiter.acquireRemoteMessageLease(for: session))
 

--- a/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -606,14 +606,22 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         XCTAssertLessThan(detachedEventIndex, settlementEventIndex)
     }
 
-    func testWhenSynchronousSourceClearIsInjectedThenMountedSourceDisappearsWithoutWaitingForAnimationTerminal() async throws {
+    func testWhenSynchronousRemovalPathRunsThenMountedSourceDisappearsWithoutWaitingForAnimationTerminal() async throws {
         let promoCoordinator = RendererCoordinatorMock(promoCoordinationMode: .coordinated)
         messagesConfiguration.homeMessages = [
             .mockRemote(id: "message-a", withType: .small(titleText: "Title", descriptionText: "Body")),
         ]
+        let removalPath: NewTabPageRemoteMessageRemovalPath
+        if #available(iOS 17, *) {
+            // Exercise the approved old-OS path on current CI without replacing real old-runtime coverage.
+            removalPath = .synchronousSourceClear
+        } else {
+            // On iOS 15/16 this proves production's automatic availability dispatch selects that path.
+            removalPath = .automatic
+        }
         let sut = createSUT(
             promoCoordinator: promoCoordinator,
-            remoteMessageRemovalPath: .synchronousSourceClear
+            remoteMessageRemovalPath: removalPath
         )
         let probe = RemoteMessageWindowAttachmentProbe()
         let mountedHost = mountRemoteMessageRenderHost(model: sut, probe: probe)
@@ -628,7 +636,9 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         let didAttach = expectation(description: "The authorized remote message attached to the test window")
         let didDetach = expectation(description: "The synchronously cleared remote message detached from the test window")
         let didObserveRemovalTransaction = expectation(description: "The mounted host observed the synchronous removal transaction")
+        let didReachSettlement = expectation(description: "The outgoing view detached before service settlement")
         var wasSourceClearedAtTerminal = false
+        var wasProbeDetachedAtSettlement = false
         probe.onAttachmentChanged = { isAttached in
             if isAttached {
                 didAttach.fulfill()
@@ -641,6 +651,10 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         }
         promoCoordinator.onRemovalTerminal = { _ in
             wasSourceClearedAtTerminal = self.coordinatedRenderSession(in: sut) == nil
+            DispatchQueue.main.async {
+                wasProbeDetachedAtSettlement = !probe.isAttachedToWindow
+                didReachSettlement.fulfill()
+            }
         }
 
         sut.load()
@@ -665,7 +679,8 @@ final class NewTabPageMessagesModelTests: XCTestCase {
             )]
         )
 
-        await fulfillment(of: [didObserveRemovalTransaction, didDetach], timeout: 1)
+        await fulfillment(of: [didObserveRemovalTransaction, didDetach, didReachSettlement], timeout: 1)
+        XCTAssertTrue(wasProbeDetachedAtSettlement)
         XCTAssertFalse(probe.isAttachedToWindow)
         XCTAssertEqual(
             probe.removalTransaction,

--- a/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -636,9 +636,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         let didAttach = expectation(description: "The authorized remote message attached to the test window")
         let didDetach = expectation(description: "The synchronously cleared remote message detached from the test window")
         let didObserveRemovalTransaction = expectation(description: "The mounted host observed the synchronous removal transaction")
-        let didReachSettlement = expectation(description: "The outgoing view detached before service settlement")
         var wasSourceClearedAtTerminal = false
-        var wasProbeDetachedAtSettlement = false
         probe.onAttachmentChanged = { isAttached in
             if isAttached {
                 didAttach.fulfill()
@@ -651,10 +649,6 @@ final class NewTabPageMessagesModelTests: XCTestCase {
         }
         promoCoordinator.onRemovalTerminal = { _ in
             wasSourceClearedAtTerminal = self.coordinatedRenderSession(in: sut) == nil
-            DispatchQueue.main.async {
-                wasProbeDetachedAtSettlement = !probe.isAttachedToWindow
-                didReachSettlement.fulfill()
-            }
         }
 
         sut.load()
@@ -679,8 +673,7 @@ final class NewTabPageMessagesModelTests: XCTestCase {
             )]
         )
 
-        await fulfillment(of: [didObserveRemovalTransaction, didDetach, didReachSettlement], timeout: 1)
-        XCTAssertTrue(wasProbeDetachedAtSettlement)
+        await fulfillment(of: [didObserveRemovalTransaction, didDetach], timeout: 1)
         XCTAssertFalse(probe.isAttachedToWindow)
         XCTAssertEqual(
             probe.removalTransaction,

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedInputContentContainerViewControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedInputContentContainerViewControllerTests.swift
@@ -50,7 +50,7 @@ final class UnifiedInputContentContainerViewControllerTests: XCTestCase {
         XCTAssertEqual(delegate.syncSetupRequestCount, 1)
     }
 
-    func testActiveUnifiedFavoritesKeepsCachedNewTabPageEligibleOnlyWhileFavoritesAreExposed() async {
+    func testUnifiedFavoritesUsesCurrentContentForPromoEligibility() async {
         let fixture = PromoHostFixture()
         fixture.appSettings.autocomplete = false
         let switchBarHandler = MockUnifiedInputSwitchBarHandler()
@@ -63,11 +63,7 @@ final class UnifiedInputContentContainerViewControllerTests: XCTestCase {
             featureDiscovery: fixture.featureDiscovery
         )
         sut.suggestionTrayDependencies = fixture.suggestionTrayDependencies
-        let rendererRegistered = expectation(description: "Unified favorites NTP registered as a renderer")
-        fixture.promoCoordinator.onRendererRegistered = { _ in
-            rendererRegistered.fulfill()
-        }
-        let firstSessionStarted = expectation(description: "Unified favorites renderer started a logical session")
+        let firstSessionStarted = expectation(description: "Unified favorites renderer started its session")
         fixture.promoCoordinator.onSessionStarted = { _ in
             firstSessionStarted.fulfill()
         }
@@ -78,80 +74,41 @@ final class UnifiedInputContentContainerViewControllerTests: XCTestCase {
         }
 
         sut.setActive(true)
-        await fulfillment(of: [rendererRegistered, firstSessionStarted], timeout: 3)
+        await fulfillment(of: [firstSessionStarted], timeout: 3)
         fixture.promoCoordinator.onSessionStarted = nil
 
-        let cachedRenderer = fixture.promoCoordinator.registeredRenderer
-        let cachedRendererID = fixture.promoCoordinator.registeredRendererID
-        let firstSession = fixture.promoCoordinator.arbiter.snapshot.remoteMessageSession
-        XCTAssertNotNil(cachedRenderer)
-        XCTAssertNotNil(cachedRendererID)
         XCTAssertTrue(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNotNil(firstSession)
+        XCTAssertEqual(fixture.promoCoordinator.successfulSessionCount, 1)
 
-        let firstRelease = expectation(description: "Query removed the unified favorites card and ended its session")
+        let firstRelease = expectation(description: "Inactive unified input ended the favorites session")
         fixture.promoCoordinator.onSessionReleased = { _ in
             firstRelease.fulfill()
         }
-        sut.setText("query")
+
+        sut.setActive(false)
+        XCTAssertFalse(fixture.promoCoordinator.registeredRendererIsEligible)
         await fulfillment(of: [firstRelease], timeout: 1)
         fixture.promoCoordinator.onSessionReleased = nil
 
-        XCTAssertTrue(fixture.promoCoordinator.registeredRenderer === cachedRenderer)
-        XCTAssertEqual(fixture.promoCoordinator.registeredRendererID, cachedRendererID)
-        XCTAssertFalse(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNil(fixture.promoCoordinator.arbiter.snapshot.activeOwner)
+        XCTAssertFalse(fixture.promoCoordinator.hasActiveSession)
 
-        let secondSessionStarted = expectation(description: "Clearing the query started a fresh unified favorites session")
-        fixture.promoCoordinator.onSessionStarted = { _ in
-            secondSessionStarted.fulfill()
-        }
-        sut.setText("")
-        await fulfillment(of: [secondSessionStarted], timeout: 1)
-        fixture.promoCoordinator.onSessionStarted = nil
+        // Reproduce the activation race in one main-actor turn. The content model resolves the query
+        // synchronously, while its UI notification is deliberately delivered on the next main turn.
+        // Eligibility must use that current model state rather than the prior favorites notification.
+        sut.setText("query")
+        let successfulSessionCount = fixture.promoCoordinator.successfulSessionCount
 
-        let secondSession = fixture.promoCoordinator.arbiter.snapshot.remoteMessageSession
-        XCTAssertTrue(fixture.promoCoordinator.registeredRenderer === cachedRenderer)
-        XCTAssertTrue(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNotNil(secondSession)
-        XCTAssertNotEqual(secondSession?.id, firstSession?.id)
-
-        let secondRelease = expectation(description: "Fire mode removed the unified favorites card and ended its session")
-        fixture.promoCoordinator.onSessionReleased = { _ in
-            secondRelease.fulfill()
-        }
-        sut.refreshFireMode(fireMode: true)
-        await fulfillment(of: [secondRelease], timeout: 1)
-        fixture.promoCoordinator.onSessionReleased = nil
+        sut.setActive(true)
 
         XCTAssertFalse(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNil(fixture.promoCoordinator.arbiter.snapshot.activeOwner)
+        XCTAssertFalse(fixture.promoCoordinator.hasActiveSession)
+        XCTAssertEqual(fixture.promoCoordinator.successfulSessionCount, successfulSessionCount)
 
-        let thirdSessionStarted = expectation(description: "Leaving fire mode started a fresh unified favorites session")
-        fixture.promoCoordinator.onSessionStarted = { _ in
-            thirdSessionStarted.fulfill()
-        }
-        sut.refreshFireMode(fireMode: false)
-        await fulfillment(of: [thirdSessionStarted], timeout: 1)
-        fixture.promoCoordinator.onSessionStarted = nil
-
-        let thirdSession = fixture.promoCoordinator.arbiter.snapshot.remoteMessageSession
-        XCTAssertTrue(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNotNil(thirdSession)
-        XCTAssertNotEqual(thirdSession?.id, secondSession?.id)
-
-        let thirdRelease = expectation(description: "Inactive unified input removed the favorites card and ended its session")
-        fixture.promoCoordinator.onSessionReleased = { _ in
-            thirdRelease.fulfill()
-        }
-        sut.setActive(false)
-        await fulfillment(of: [thirdRelease], timeout: 1)
-        fixture.promoCoordinator.onSessionReleased = nil
+        await nextMainQueueTurn()
 
         XCTAssertFalse(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNil(fixture.promoCoordinator.arbiter.snapshot.activeOwner)
-        XCTAssertEqual(fixture.promoCoordinator.successfulSessionCount, 3)
-        XCTAssertEqual(fixture.promoCoordinator.releaseCount, 3)
+        XCTAssertFalse(fixture.promoCoordinator.hasActiveSession)
+        XCTAssertEqual(fixture.promoCoordinator.successfulSessionCount, successfulSessionCount)
     }
 }
 
@@ -188,34 +145,31 @@ final class NewTabPagePromoHostWiringTests: XCTestCase {
         )
     }
 
-    func testPromoSurfaceHandoffDeactivatesNewTabPageBeforeShowingHostedSurface() {
-        var events = [String]()
+    func testPromoSurfaceHandoffDeactivatesOutgoingSurfaceBeforeActivatingIncomingSurface() {
+        var hostedSurfaceEvents = [String]()
 
         NewTabPagePromoSurfaceHandoff.showHostedSurface(
             deactivateNewTabPage: {
-                events.append("deactivate-standard-ntp")
+                hostedSurfaceEvents.append("deactivate-standard-ntp")
             },
             showHostedSurface: {
-                events.append("show-suggestion-or-unified-host")
+                hostedSurfaceEvents.append("show-suggestion-or-unified-host")
             }
         )
 
-        XCTAssertEqual(events, ["deactivate-standard-ntp", "show-suggestion-or-unified-host"])
-    }
-
-    func testPromoSurfaceHandoffHidesHostedSurfaceBeforeReactivatingNewTabPage() {
-        var events = [String]()
+        var newTabPageEvents = [String]()
 
         NewTabPagePromoSurfaceHandoff.showNewTabPage(
             hideHostedSurface: {
-                events.append("hide-suggestion-or-unified-host")
+                newTabPageEvents.append("hide-suggestion-or-unified-host")
             },
             activateNewTabPage: {
-                events.append("activate-standard-ntp")
+                newTabPageEvents.append("activate-standard-ntp")
             }
         )
 
-        XCTAssertEqual(events, ["hide-suggestion-or-unified-host", "activate-standard-ntp"])
+        XCTAssertEqual(hostedSurfaceEvents, ["deactivate-standard-ntp", "show-suggestion-or-unified-host"])
+        XCTAssertEqual(newTabPageEvents, ["hide-suggestion-or-unified-host", "activate-standard-ntp"])
     }
 
     func testWindowAttachedStandardNewTabPageIsEligibleOnlyWhileOwnerIsActive() async {
@@ -228,7 +182,7 @@ final class NewTabPagePromoHostWiringTests: XCTestCase {
         let renderer = fixture.promoCoordinator.registeredRenderer
         XCTAssertNotNil(renderer)
         XCTAssertFalse(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNil(fixture.promoCoordinator.arbiter.snapshot.activeOwner)
+        XCTAssertFalse(fixture.promoCoordinator.hasActiveSession)
 
         let firstSessionStarted = expectation(description: "Standard NTP started a logical RMF session")
         fixture.promoCoordinator.onSessionStarted = { _ in
@@ -239,8 +193,7 @@ final class NewTabPagePromoHostWiringTests: XCTestCase {
         fixture.promoCoordinator.onSessionStarted = nil
 
         XCTAssertTrue(fixture.promoCoordinator.registeredRendererIsEligible)
-        let firstSession = fixture.promoCoordinator.arbiter.snapshot.remoteMessageSession
-        XCTAssertNotNil(firstSession)
+        XCTAssertTrue(fixture.promoCoordinator.hasActiveSession)
 
         let firstRelease = expectation(description: "Inactive standard NTP completed RMF removal")
         fixture.promoCoordinator.onSessionReleased = { _ in
@@ -249,10 +202,10 @@ final class NewTabPagePromoHostWiringTests: XCTestCase {
         sut.setPromoSurfaceActive(false)
 
         XCTAssertFalse(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertEqual(fixture.promoCoordinator.arbiter.snapshot.remoteMessageSession, firstSession)
+        XCTAssertTrue(fixture.promoCoordinator.hasActiveSession)
         await fulfillment(of: [firstRelease], timeout: 1)
         fixture.promoCoordinator.onSessionReleased = nil
-        XCTAssertNil(fixture.promoCoordinator.arbiter.snapshot.activeOwner)
+        XCTAssertFalse(fixture.promoCoordinator.hasActiveSession)
 
         let secondSessionStarted = expectation(description: "Reactivated standard NTP started a fresh RMF session")
         fixture.promoCoordinator.onSessionStarted = { _ in
@@ -261,9 +214,7 @@ final class NewTabPagePromoHostWiringTests: XCTestCase {
         sut.setPromoSurfaceActive(true)
         await fulfillment(of: [secondSessionStarted], timeout: 1)
         fixture.promoCoordinator.onSessionStarted = nil
-        let secondSession = fixture.promoCoordinator.arbiter.snapshot.remoteMessageSession
-        XCTAssertNotNil(secondSession)
-        XCTAssertNotEqual(secondSession?.id, firstSession?.id)
+        XCTAssertTrue(fixture.promoCoordinator.hasActiveSession)
 
         let secondRelease = expectation(description: "Detached standard NTP completed RMF removal")
         fixture.promoCoordinator.onSessionReleased = { _ in
@@ -273,9 +224,8 @@ final class NewTabPagePromoHostWiringTests: XCTestCase {
         await fulfillment(of: [secondRelease], timeout: 1)
         fixture.promoCoordinator.onSessionReleased = nil
 
-        XCTAssertNil(fixture.promoCoordinator.arbiter.snapshot.activeOwner)
+        XCTAssertFalse(fixture.promoCoordinator.hasActiveSession)
         XCTAssertEqual(fixture.promoCoordinator.successfulSessionCount, 2)
-        XCTAssertEqual(fixture.promoCoordinator.releaseCount, 2)
     }
 
     func testStaleVisibilityCompletionCannotReactivateNewerHiddenStandardNewTabPage() async {
@@ -302,11 +252,11 @@ final class NewTabPagePromoHostWiringTests: XCTestCase {
         await fulfillment(of: [release], timeout: 1)
         fixture.promoCoordinator.onSessionReleased = nil
 
-        let sessionAttemptCountBeforeStaleCompletion = fixture.promoCoordinator.sessionAttemptCount
+        let successfulSessionCountBeforeStaleCompletion = fixture.promoCoordinator.successfulSessionCount
         sut.restorePromoSurfaceVisibility(ifCurrent: staleGeneration)
 
         XCTAssertFalse(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertEqual(fixture.promoCoordinator.sessionAttemptCount, sessionAttemptCountBeforeStaleCompletion)
+        XCTAssertEqual(fixture.promoCoordinator.successfulSessionCount, successfulSessionCountBeforeStaleCompletion)
 
         let secondSessionStarted = expectation(description: "Current completion restored standard NTP visibility")
         fixture.promoCoordinator.onSessionStarted = { _ in
@@ -318,7 +268,7 @@ final class NewTabPagePromoHostWiringTests: XCTestCase {
         XCTAssertTrue(fixture.promoCoordinator.registeredRendererIsEligible)
     }
 
-    func testAutocompleteKeepsCachedTrayNewTabPageInactiveUntilFavoritesReturn() async throws {
+    func testAutocompleteDeactivatesCachedTrayNewTabPageAndDidHideDeregistersIt() async throws {
         try XCTSkipUnless(
             UIDevice.current.userInterfaceIdiom == .phone,
             "The tray caches its NTP below autocomplete only on iPhone"
@@ -341,12 +291,9 @@ final class NewTabPagePromoHostWiringTests: XCTestCase {
         fixture.promoCoordinator.onSessionStarted = nil
 
         let cachedRenderer = fixture.promoCoordinator.registeredRenderer
-        let cachedRendererID = fixture.promoCoordinator.registeredRendererID
-        let firstSession = fixture.promoCoordinator.arbiter.snapshot.remoteMessageSession
         XCTAssertNotNil(cachedRenderer)
-        XCTAssertNotNil(cachedRendererID)
         XCTAssertTrue(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNotNil(firstSession)
+        XCTAssertTrue(fixture.promoCoordinator.hasActiveSession)
 
         let firstRelease = expectation(description: "Tray autocomplete completed cached favorites RMF removal")
         fixture.promoCoordinator.onSessionReleased = { _ in
@@ -356,44 +303,20 @@ final class NewTabPagePromoHostWiringTests: XCTestCase {
 
         XCTAssertTrue(sut.isShowingFavorites)
         XCTAssertTrue(fixture.promoCoordinator.registeredRenderer === cachedRenderer)
-        XCTAssertEqual(fixture.promoCoordinator.registeredRendererID, cachedRendererID)
         XCTAssertFalse(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertEqual(fixture.promoCoordinator.arbiter.snapshot.remoteMessageSession, firstSession)
+        XCTAssertTrue(fixture.promoCoordinator.hasActiveSession)
         await fulfillment(of: [firstRelease], timeout: 1)
         fixture.promoCoordinator.onSessionReleased = nil
-        XCTAssertNil(fixture.promoCoordinator.arbiter.snapshot.activeOwner)
+        XCTAssertFalse(fixture.promoCoordinator.hasActiveSession)
 
-        let secondSessionStarted = expectation(description: "Returning to tray favorites started a fresh RMF session")
-        fixture.promoCoordinator.onSessionStarted = { _ in
-            secondSessionStarted.fulfill()
-        }
-        sut.show(for: .favorites, animated: false)
-        sut.view.layoutIfNeeded()
-        await fulfillment(of: [secondSessionStarted], timeout: 1)
-        fixture.promoCoordinator.onSessionStarted = nil
-
-        let secondSession = fixture.promoCoordinator.arbiter.snapshot.remoteMessageSession
-        XCTAssertTrue(fixture.promoCoordinator.registeredRenderer === cachedRenderer)
-        XCTAssertTrue(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNotNil(secondSession)
-        XCTAssertNotEqual(secondSession?.id, firstSession?.id)
-
-        let secondRelease = expectation(description: "Hidden tray completed favorites RMF removal")
-        fixture.promoCoordinator.onSessionReleased = { _ in
-            secondRelease.fulfill()
-        }
         sut.didHide(animated: false)
-        await fulfillment(of: [secondRelease], timeout: 1)
-        fixture.promoCoordinator.onSessionReleased = nil
 
         XCTAssertFalse(fixture.promoCoordinator.registeredRendererIsEligible)
         XCTAssertNil(fixture.promoCoordinator.registeredRenderer)
-        XCTAssertNil(fixture.promoCoordinator.arbiter.snapshot.activeOwner)
-        XCTAssertEqual(fixture.promoCoordinator.successfulSessionCount, 2)
-        XCTAssertEqual(fixture.promoCoordinator.releaseCount, 2)
+        XCTAssertFalse(fixture.promoCoordinator.hasActiveSession)
     }
 
-    func testDeactivatingTrayKeepsCachedNewTabPageInactiveUntilFavoritesReturn() async {
+    func testDeactivatingTrayKeepsCachedNewTabPageInactive() async {
         let fixture = PromoHostFixture()
         let sut = fixture.makeSuggestionTrayController()
         let window = makeVisibleWindow(rootViewController: sut)
@@ -411,10 +334,9 @@ final class NewTabPagePromoHostWiringTests: XCTestCase {
         fixture.promoCoordinator.onSessionStarted = nil
 
         let cachedRenderer = fixture.promoCoordinator.registeredRenderer
-        let firstSession = fixture.promoCoordinator.arbiter.snapshot.remoteMessageSession
         XCTAssertNotNil(cachedRenderer)
         XCTAssertTrue(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNotNil(firstSession)
+        XCTAssertTrue(fixture.promoCoordinator.hasActiveSession)
 
         let firstRelease = expectation(description: "Hidden tray completed favorites RMF removal")
         fixture.promoCoordinator.onSessionReleased = { _ in
@@ -427,35 +349,7 @@ final class NewTabPagePromoHostWiringTests: XCTestCase {
         XCTAssertTrue(sut.isShowingFavorites, "Hiding the tray must preserve its cached favorites content")
         XCTAssertTrue(fixture.promoCoordinator.registeredRenderer === cachedRenderer)
         XCTAssertFalse(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNil(fixture.promoCoordinator.arbiter.snapshot.activeOwner)
-
-        let secondSessionStarted = expectation(description: "Returning to tray favorites started a fresh RMF session")
-        fixture.promoCoordinator.onSessionStarted = { _ in
-            secondSessionStarted.fulfill()
-        }
-        sut.show(for: .favorites, animated: false)
-        await fulfillment(of: [secondSessionStarted], timeout: 1)
-        fixture.promoCoordinator.onSessionStarted = nil
-
-        let secondSession = fixture.promoCoordinator.arbiter.snapshot.remoteMessageSession
-        XCTAssertTrue(fixture.promoCoordinator.registeredRenderer === cachedRenderer)
-        XCTAssertTrue(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNotNil(secondSession)
-        XCTAssertNotEqual(secondSession?.id, firstSession?.id)
-
-        let secondRelease = expectation(description: "Tray teardown completed favorites RMF removal")
-        fixture.promoCoordinator.onSessionReleased = { _ in
-            secondRelease.fulfill()
-        }
-        sut.teardownPopoverSuggestions()
-        await fulfillment(of: [secondRelease], timeout: 1)
-
-        XCTAssertTrue(sut.isShowingFavorites, "Tray teardown must preserve its cached favorites content")
-        XCTAssertTrue(fixture.promoCoordinator.registeredRenderer === cachedRenderer)
-        XCTAssertFalse(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNil(fixture.promoCoordinator.arbiter.snapshot.activeOwner)
-        XCTAssertEqual(fixture.promoCoordinator.successfulSessionCount, 2)
-        XCTAssertEqual(fixture.promoCoordinator.releaseCount, 2)
+        XCTAssertFalse(fixture.promoCoordinator.hasActiveSession)
     }
 
     func testDeactivatingTrayInvalidatesPendingFavoritesActivation() async {
@@ -482,7 +376,7 @@ final class NewTabPagePromoHostWiringTests: XCTestCase {
 
         XCTAssertTrue(sut.isShowingFavorites, "Hiding during installation must keep the favorites cache")
         XCTAssertFalse(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNil(fixture.promoCoordinator.arbiter.snapshot.activeOwner)
+        XCTAssertFalse(fixture.promoCoordinator.hasActiveSession)
         XCTAssertEqual(fixture.promoCoordinator.successfulSessionCount, 0)
     }
 
@@ -527,7 +421,7 @@ final class NewTabPagePromoHostWiringTests: XCTestCase {
         XCTAssertFalse(autocompleteController.view.isHidden)
         XCTAssertEqual(autocompleteController.view.alpha, 1, accuracy: 0.001)
         XCTAssertFalse(fixture.promoCoordinator.registeredRendererIsEligible)
-        XCTAssertNil(fixture.promoCoordinator.arbiter.snapshot.activeOwner)
+        XCTAssertFalse(fixture.promoCoordinator.hasActiveSession)
     }
 }
 
@@ -552,7 +446,7 @@ private final class PromoHostFixture {
             )
         ]
     )
-    let promoCoordinator = ArbitratingPromoHostCoordinator()
+    let promoCoordinator = PromoHostCoordinatorSpy()
     let tabsModel = TabsModel(desktop: false)
     lazy var bookmarksDatabase = CoreDataDatabase.bookmarksMock
 
@@ -636,12 +530,10 @@ private final class PromoHostFixture {
 }
 
 @MainActor
-private final class ArbitratingPromoHostCoordinator: NewTabPagePromoCoordinating {
+private final class PromoHostCoordinatorSpy: NewTabPagePromoCoordinating {
     private struct SessionState {
         let session: PromoQueueRemoteMessageSession
         let presentation: PromoQueueRemoteMessagePresentation
-        let lease: PromoQueueRemoteMessageLease
-        var appearanceWasConfirmed = false
     }
 
     private struct RemovalState {
@@ -652,15 +544,9 @@ private final class ArbitratingPromoHostCoordinator: NewTabPagePromoCoordinating
         var terminalWasReported = false
     }
 
-    let arbiter = PromoQueueLeaseArbiter()
     let promoCoordinationMode = PromoCoordinationMode.coordinated
 
-    private(set) var sessionAttemptCount = 0
     private(set) var successfulSessionCount = 0
-    private(set) var presentationCount = 0
-    private(set) var appearanceCount = 0
-    private(set) var releaseCount = 0
-    var onRendererRegistered: ((UUID) -> Void)?
     var onSessionStarted: ((PromoQueueRemoteMessageSession) -> Void)?
     var onSessionReleased: ((PromoQueueRemoteMessageSession) -> Void)?
 
@@ -668,16 +554,15 @@ private final class ArbitratingPromoHostCoordinator: NewTabPagePromoCoordinating
         isRendererRegistered ? rendererTarget : nil
     }
 
-    var registeredRendererID: UUID? {
-        isRendererRegistered ? rendererID : nil
-    }
-
     var registeredRendererIsEligible: Bool {
         isRendererRegistered && isRendererEligible
     }
 
+    var hasActiveSession: Bool {
+        sessionState != nil
+    }
+
     private weak var rendererTarget: NewTabPagePromoRendering?
-    private var rendererID: UUID?
     private var registrationID: UUID?
     private var rendererCandidate = PromoQueueRemoteMessageCandidateState.none
     private var isRendererEligible = false
@@ -686,17 +571,15 @@ private final class ArbitratingPromoHostCoordinator: NewTabPagePromoCoordinating
     private var removalState: RemovalState?
 
     func registerRemoteMessageRenderer(
-        id rendererID: UUID,
+        id _: UUID,
         target: NewTabPagePromoRendering
     ) -> NewTabPagePromoRendererRegistration {
         let registrationID = UUID()
-        self.rendererID = rendererID
         self.registrationID = registrationID
         rendererTarget = target
         rendererCandidate = .none
         isRendererEligible = false
         isRendererRegistered = true
-        onRendererRegistered?(rendererID)
 
         return NewTabPagePromoRendererRegistration(
             updateHandler: { [weak self] candidate, isEligible in
@@ -756,17 +639,13 @@ private final class ArbitratingPromoHostCoordinator: NewTabPagePromoCoordinating
               isAttachedToWindow,
               rendererTarget?.isRemoteMessageRendererAttachedToWindow == true,
               removalState == nil,
-              var sessionState,
+              let sessionState,
               sessionState.session.id == sessionID,
               sessionState.presentation.id == presentationID,
-              candidateMessageID == sessionState.session.messageID,
-              !sessionState.appearanceWasConfirmed else {
+              candidateMessageID == sessionState.session.messageID else {
             return .rejected
         }
 
-        sessionState.appearanceWasConfirmed = true
-        self.sessionState = sessionState
-        appearanceCount += 1
         return .accepted
     }
 
@@ -840,28 +719,15 @@ private final class ArbitratingPromoHostCoordinator: NewTabPagePromoCoordinating
     }
 
     private func startSession(messageID: String, renderer: NewTabPagePromoRendering) {
-        sessionAttemptCount += 1
         let session = PromoQueueRemoteMessageSession(id: UUID(), messageID: messageID)
-
-        switch arbiter.acquireRemoteMessageLease(for: session) {
-        case .acquired(let lease):
-            let presentation = PromoQueueRemoteMessagePresentation(id: UUID(), session: session)
-            sessionState = SessionState(
-                session: session,
-                presentation: presentation,
-                lease: lease
-            )
-            guard renderer.showRemoteMessage(presentation) else {
-                sessionState = nil
-                _ = lease.release()
-                return
-            }
-            successfulSessionCount += 1
-            presentationCount += 1
-            onSessionStarted?(session)
-        case .blockedByModal, .blockedByRemoteMessage:
-            break
+        let presentation = PromoQueueRemoteMessagePresentation(id: UUID(), session: session)
+        sessionState = SessionState(session: session, presentation: presentation)
+        guard renderer.showRemoteMessage(presentation) else {
+            sessionState = nil
+            return
         }
+        successfulSessionCount += 1
+        onSessionStarted?(session)
     }
 
     private func shouldKeepShowing(_ sessionState: SessionState) -> Bool {
@@ -911,11 +777,6 @@ private final class ArbitratingPromoHostCoordinator: NewTabPagePromoCoordinating
 
         self.removalState = nil
         self.sessionState = nil
-        guard sessionState.lease.release() else {
-            return
-        }
-
-        releaseCount += 1
         onSessionReleased?(sessionState.session)
         clearRendererIfUnused()
         reconcile()
@@ -935,7 +796,6 @@ private final class ArbitratingPromoHostCoordinator: NewTabPagePromoCoordinating
         }
 
         rendererTarget = nil
-        rendererID = nil
         registrationID = nil
         rendererCandidate = .none
     }

--- a/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
+++ b/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
@@ -63,25 +63,6 @@ final class ModalPromptCoordinationManagerIntegrationTests {
         promoQueueLeaseArbiter = PromoQueueLeaseArbiter()
     }
 
-    @Test("Check Is In Cooldown After Presenting Prompt")
-    func whenPromptIsPresentedThenIsInCooldown() {
-        // GIVEN
-        let provider = MockModalPromptProvider()
-        sut = ModalPromptCoordinationManager(
-            providers: [provider],
-            cooldownManager: cooldownManager,
-            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
-            modalPromptScheduling: schedulerMock
-        )
-        #expect(!cooldownManager.isInCooldownPeriod)
-
-        // WHEN
-        sut.presentModalPromptIfNeeded(from: presenterMock)
-
-        // THEN
-        #expect(cooldownManager.isInCooldownPeriod)
-    }
-
     @Test(
         "Check Modal Is Blocked During Cooldown Period",
         arguments: [1, 6, 12, 18, 23]  // Hours after first presentation

--- a/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
+++ b/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
@@ -533,7 +533,6 @@ final class ModalPromptCoordinationManagerIntegrationTests {
             from: presenterMock,
             readinessToken: service.captureForegroundReadinessToken()
         )
-        promoQueueCooldownPolicy.recordConfirmedRemoteMessageAppearance(at: timeTraveller.getDate())
         let firstSurfaceID = UUID()
         let secondSurfaceID = UUID()
         let messageID = "shared-message"
@@ -561,18 +560,6 @@ final class ModalPromptCoordinationManagerIntegrationTests {
         firstModel.setSurfaceRenderable(true)
         secondModel.setSurfaceRenderable(true)
 
-        #expect(coordinatedRemoteMessageRenderSession(in: firstModel) == nil)
-        #expect(firstModel.homeMessageViewModels.isEmpty)
-        #expect(firstFixture.configuration.appearanceCallCount == 0)
-        #expect(promoQueueLeaseArbiter.snapshot.activeOwner == nil)
-
-        timeTraveller.advanceBy(.minutes(10))
-
-        #expect(coordinatedRemoteMessageRenderSession(in: firstModel) == nil)
-        #expect(firstFixture.configuration.appearanceCallCount == 0)
-
-        firstModel.refresh()
-
         let firstOwnedSnapshot = service.remoteMessageCoordinationSnapshot
         guard let firstSessionID = firstOwnedSnapshot.sessionID,
               let firstPresentationID = firstOwnedSnapshot.presentationID else {
@@ -588,12 +575,8 @@ final class ModalPromptCoordinationManagerIntegrationTests {
         #expect(firstOwnedSnapshot.rendererID == firstSurfaceID)
         #expect(firstRenderSession.presentation.session == logicalSession)
         #expect(firstRenderSession.presentation.id == firstPresentationID)
-        #expect(firstModel.homeMessageViewModels.map(\.messageId) == [messageID])
         #expect(coordinatedRemoteMessageRenderSession(in: secondModel) == nil)
-        #expect(secondModel.homeMessageViewModels.isEmpty)
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .remoteMessage(logicalSession))
-        #expect(firstFixture.configuration.appearanceCallCount == 0)
-        #expect(secondFixture.configuration.appearanceCallCount == 0)
         #expect(!firstOwnedSnapshot.isQueueAppearanceConfirmed)
         #expect(firstOwnedSnapshot.isPresentationAppearanceReported == false)
 
@@ -602,43 +585,24 @@ final class ModalPromptCoordinationManagerIntegrationTests {
         let firstConfirmationDate = timeTraveller.getDate()
         let firstConfirmedSnapshot = service.remoteMessageCoordinationSnapshot
         #expect(firstFixture.configuration.appearanceCallCount == 1)
-        #expect(secondFixture.configuration.appearanceCallCount == 0)
-        #expect(firstConfirmedSnapshot.sessionID == firstSessionID)
-        #expect(firstConfirmedSnapshot.presentationID == firstPresentationID)
         #expect(firstConfirmedSnapshot.isQueueAppearanceConfirmed)
         #expect(firstConfirmedSnapshot.isPresentationAppearanceReported == true)
 
         firstRenderSession.viewModel.onDidAppear()
 
         #expect(firstFixture.configuration.appearanceCallCount == 1)
-        #expect(secondFixture.configuration.appearanceCallCount == 0)
-        #expect(service.remoteMessageCoordinationSnapshot.isQueueAppearanceConfirmed)
-        #expect(
-            promoQueueCooldownPolicy.snapshot(now: firstConfirmationDate).lastConfirmedRemoteMessageAppearance ==
-                firstConfirmationDate
-        )
 
         timeTraveller.advanceBy(.minutes(1))
-        #expect(
-            promoQueueCooldownPolicy.evaluateRemoteMessageAdmission(now: timeTraveller.getDate()) ==
-                .blocked(until: firstConfirmationDate.addingTimeInterval(.minutes(10)))
-        )
 
         firstModel.setSurfaceRenderable(false)
 
         let drainingSnapshot = service.remoteMessageCoordinationSnapshot
         #expect(drainingSnapshot.state == .draining)
         #expect(drainingSnapshot.sessionID == firstSessionID)
-        #expect(drainingSnapshot.presentationID == firstPresentationID)
-        #expect(drainingSnapshot.rendererID == firstSurfaceID)
         #expect(drainingSnapshot.removalID != nil)
         #expect(drainingSnapshot.removalTerminal == .sourceRemovedWithoutAnimation)
-        #expect(drainingSnapshot.isQueueAppearanceConfirmed)
-        #expect(drainingSnapshot.isPresentationAppearanceReported == true)
         #expect(coordinatedRemoteMessageRenderSession(in: firstModel) == nil)
         #expect(coordinatedRemoteMessageRenderSession(in: secondModel) == nil)
-        #expect(firstModel.homeMessageViewModels.isEmpty)
-        #expect(secondModel.homeMessageViewModels.isEmpty)
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .remoteMessage(logicalSession))
 
         await waitForMainQueueSettlement()
@@ -656,9 +620,6 @@ final class ModalPromptCoordinationManagerIntegrationTests {
         #expect(transferredSnapshot.isQueueAppearanceConfirmed)
         #expect(transferredSnapshot.isPresentationAppearanceReported == false)
         #expect(transferredRenderSession.presentation.session == logicalSession)
-        #expect(transferredRenderSession.presentation.id == transferredSnapshot.presentationID)
-        #expect(firstModel.homeMessageViewModels.isEmpty)
-        #expect(secondModel.homeMessageViewModels.map(\.messageId) == [messageID])
         #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .remoteMessage(logicalSession))
 
         transferredRenderSession.viewModel.onDidAppear()
@@ -666,8 +627,6 @@ final class ModalPromptCoordinationManagerIntegrationTests {
         let transferredConfirmedSnapshot = service.remoteMessageCoordinationSnapshot
         #expect(firstFixture.configuration.appearanceCallCount == 1)
         #expect(secondFixture.configuration.appearanceCallCount == 1)
-        #expect(transferredConfirmedSnapshot.sessionID == firstSessionID)
-        #expect(transferredConfirmedSnapshot.presentationID == transferredRenderSession.presentation.id)
         #expect(transferredConfirmedSnapshot.isQueueAppearanceConfirmed)
         #expect(transferredConfirmedSnapshot.isPresentationAppearanceReported == true)
 
@@ -675,92 +634,10 @@ final class ModalPromptCoordinationManagerIntegrationTests {
 
         #expect(firstFixture.configuration.appearanceCallCount == 1)
         #expect(secondFixture.configuration.appearanceCallCount == 1)
-        #expect(service.remoteMessageCoordinationSnapshot.sessionID == firstSessionID)
-        #expect(service.remoteMessageCoordinationSnapshot.isQueueAppearanceConfirmed)
         #expect(
-            promoQueueCooldownPolicy.snapshot(now: timeTraveller.getDate()).lastConfirmedRemoteMessageAppearance ==
-                firstConfirmationDate
+            promoQueueCooldownPolicy.evaluateRemoteMessageAdmission(now: timeTraveller.getDate()) ==
+                .blocked(until: firstConfirmationDate.addingTimeInterval(.minutes(10)))
         )
-    }
-
-    @available(iOS 16, *)
-    @Test("A Different RMF Message Starts A Fresh Logical Session After Removal Settlement", .timeLimit(.minutes(1)))
-    func whenWaitingRendererHasDifferentMessageThenItReceivesAFreshSessionAfterSettlement() async {
-        let manager = ModalPromptCoordinationManager(
-            providers: [],
-            cooldownManager: cooldownManager,
-            onboardingStatusProvider: MockContextualOnboardingStatusProvider(hasSeenOnboarding: true),
-            modalPromptScheduling: schedulerMock
-        )
-        let service = PromoCoordinationService(
-            launchSourceManager: MockLaunchSourceManager(),
-            modalPromptCoordinationManager: manager,
-            promoCoordinationMode: .coordinated,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
-            promoQueueCooldownPolicy: promoQueueCooldownPolicy,
-            dateProvider: timeTraveller.getDate
-        )
-        service.applicationDidBecomeActive()
-        service.presentModalPromptIfNeeded(
-            from: presenterMock,
-            readinessToken: service.captureForegroundReadinessToken()
-        )
-        let firstMessageID = "first-message"
-        let secondMessageID = "second-message"
-        let firstFixture = makeRemoteMessageModel(
-            messageID: firstMessageID,
-            surfaceID: UUID(),
-            coordinator: service
-        )
-        let secondFixture = makeRemoteMessageModel(
-            messageID: secondMessageID,
-            surfaceID: UUID(),
-            coordinator: service
-        )
-        defer {
-            firstFixture.model.tearDown()
-            secondFixture.model.tearDown()
-        }
-
-        firstFixture.model.setSurfaceAttachmentProvider { true }
-        secondFixture.model.setSurfaceAttachmentProvider { true }
-        firstFixture.model.load()
-        secondFixture.model.load()
-        firstFixture.model.setSurfaceRenderable(true)
-        secondFixture.model.setSurfaceRenderable(true)
-
-        guard let firstSessionID = service.remoteMessageCoordinationSnapshot.sessionID else {
-            Issue.record("Expected the first message to own a logical session")
-            return
-        }
-        let firstLogicalSession = PromoQueueRemoteMessageSession(id: firstSessionID, messageID: firstMessageID)
-        #expect(service.remoteMessageCoordinationSnapshot.messageID == firstMessageID)
-        #expect(firstFixture.model.homeMessageViewModels.map(\.messageId) == [firstMessageID])
-        #expect(coordinatedRemoteMessageRenderSession(in: firstFixture.model)?.presentation.session.id == firstSessionID)
-        #expect(secondFixture.model.homeMessageViewModels.isEmpty)
-        #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .remoteMessage(firstLogicalSession))
-
-        firstFixture.model.setSurfaceRenderable(false)
-
-        #expect(service.remoteMessageCoordinationSnapshot.state == .draining)
-        #expect(service.remoteMessageCoordinationSnapshot.sessionID == firstSessionID)
-        #expect(secondFixture.model.homeMessageViewModels.isEmpty)
-        #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .remoteMessage(firstLogicalSession))
-
-        await waitForMainQueueSettlement()
-
-        guard let secondSessionID = service.remoteMessageCoordinationSnapshot.sessionID else {
-            Issue.record("Expected the different message to acquire a fresh logical session")
-            return
-        }
-        let secondLogicalSession = PromoQueueRemoteMessageSession(id: secondSessionID, messageID: secondMessageID)
-        #expect(service.remoteMessageCoordinationSnapshot.state == .owned)
-        #expect(service.remoteMessageCoordinationSnapshot.messageID == secondMessageID)
-        #expect(secondSessionID != firstSessionID)
-        #expect(firstFixture.model.homeMessageViewModels.isEmpty)
-        #expect(secondFixture.model.homeMessageViewModels.map(\.messageId) == [secondMessageID])
-        #expect(coordinatedRemoteMessageRenderSession(in: secondFixture.model)?.presentation.session == secondLogicalSession)
-        #expect(promoQueueLeaseArbiter.snapshot.activeOwner == .remoteMessage(secondLogicalSession))
     }
 
     private func makeRemoteMessageModel(

--- a/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
+++ b/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
@@ -33,6 +33,7 @@ final class ModalPromptCoordinationManagerIntegrationTests {
     private let cooldownStore: PromptCooldownKeyValueFilesStore
     private let cooldownIntervalProvider: MockPromptCooldownIntervalProvider
     private let cooldownManager: PromptCooldownManager
+    private let promoQueueCooldownPolicy: PromoQueueCooldownPolicy
     private let schedulerMock: ImmediateScheduler
     private let presenterMock: MockModalPromptPresenter
     private let promoQueueLeaseArbiter: PromoQueueLeaseArbiter
@@ -46,11 +47,16 @@ final class ModalPromptCoordinationManagerIntegrationTests {
             keyValueStore: keyValueStore,
             eventMapper: .init(mapping: { _, _, _, _ in })
         )
+        let remoteMessageCooldownStore = PromoQueueRemoteMessageCooldownKeyValueFilesStore(keyValueStore: keyValueStore)
         cooldownIntervalProvider = MockPromptCooldownIntervalProvider() // Cooldown Interval 24h
         cooldownManager = PromptCooldownManager(
             presentationStore: cooldownStore,
             cooldownIntervalProvider: cooldownIntervalProvider,
             dateProvider: timeTraveller.getDate
+        )
+        promoQueueCooldownPolicy = PromoQueueCooldownPolicy(
+            modalPresentationStore: cooldownStore,
+            remoteMessagePresentationStore: remoteMessageCooldownStore
         )
         schedulerMock = ImmediateScheduler()
         presenterMock = MockModalPromptPresenter()
@@ -412,7 +418,9 @@ final class ModalPromptCoordinationManagerIntegrationTests {
             launchSourceManager: launchSourceManager,
             modalPromptCoordinationManager: manager,
             promoCoordinationMode: .coordinated,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            promoQueueCooldownPolicy: promoQueueCooldownPolicy,
+            dateProvider: timeTraveller.getDate
         )
 
         service.applicationDidBecomeActive()
@@ -516,13 +524,16 @@ final class ModalPromptCoordinationManagerIntegrationTests {
             launchSourceManager: MockLaunchSourceManager(),
             modalPromptCoordinationManager: manager,
             promoCoordinationMode: .coordinated,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            promoQueueCooldownPolicy: promoQueueCooldownPolicy,
+            dateProvider: timeTraveller.getDate
         )
         service.applicationDidBecomeActive()
         service.presentModalPromptIfNeeded(
             from: presenterMock,
             readinessToken: service.captureForegroundReadinessToken()
         )
+        promoQueueCooldownPolicy.recordConfirmedRemoteMessageAppearance(at: timeTraveller.getDate())
         let firstSurfaceID = UUID()
         let secondSurfaceID = UUID()
         let messageID = "shared-message"
@@ -550,10 +561,22 @@ final class ModalPromptCoordinationManagerIntegrationTests {
         firstModel.setSurfaceRenderable(true)
         secondModel.setSurfaceRenderable(true)
 
+        #expect(coordinatedRemoteMessageRenderSession(in: firstModel) == nil)
+        #expect(firstModel.homeMessageViewModels.isEmpty)
+        #expect(firstFixture.configuration.appearanceCallCount == 0)
+        #expect(promoQueueLeaseArbiter.snapshot.activeOwner == nil)
+
+        timeTraveller.advanceBy(.minutes(10))
+
+        #expect(coordinatedRemoteMessageRenderSession(in: firstModel) == nil)
+        #expect(firstFixture.configuration.appearanceCallCount == 0)
+
+        firstModel.refresh()
+
         let firstOwnedSnapshot = service.remoteMessageCoordinationSnapshot
         guard let firstSessionID = firstOwnedSnapshot.sessionID,
               let firstPresentationID = firstOwnedSnapshot.presentationID else {
-            Issue.record("Expected the first real NTP model to own a remote-message presentation")
+            Issue.record("Expected the first real NTP model to own a remote-message presentation after cooldown")
             return
         }
         let logicalSession = PromoQueueRemoteMessageSession(id: firstSessionID, messageID: messageID)
@@ -576,6 +599,7 @@ final class ModalPromptCoordinationManagerIntegrationTests {
 
         firstRenderSession.viewModel.onDidAppear()
 
+        let firstConfirmationDate = timeTraveller.getDate()
         let firstConfirmedSnapshot = service.remoteMessageCoordinationSnapshot
         #expect(firstFixture.configuration.appearanceCallCount == 1)
         #expect(secondFixture.configuration.appearanceCallCount == 0)
@@ -589,6 +613,16 @@ final class ModalPromptCoordinationManagerIntegrationTests {
         #expect(firstFixture.configuration.appearanceCallCount == 1)
         #expect(secondFixture.configuration.appearanceCallCount == 0)
         #expect(service.remoteMessageCoordinationSnapshot.isQueueAppearanceConfirmed)
+        #expect(
+            promoQueueCooldownPolicy.snapshot(now: firstConfirmationDate).lastConfirmedRemoteMessageAppearance ==
+                firstConfirmationDate
+        )
+
+        timeTraveller.advanceBy(.minutes(1))
+        #expect(
+            promoQueueCooldownPolicy.evaluateRemoteMessageAdmission(now: timeTraveller.getDate()) ==
+                .blocked(until: firstConfirmationDate.addingTimeInterval(.minutes(10)))
+        )
 
         firstModel.setSurfaceRenderable(false)
 
@@ -643,6 +677,10 @@ final class ModalPromptCoordinationManagerIntegrationTests {
         #expect(secondFixture.configuration.appearanceCallCount == 1)
         #expect(service.remoteMessageCoordinationSnapshot.sessionID == firstSessionID)
         #expect(service.remoteMessageCoordinationSnapshot.isQueueAppearanceConfirmed)
+        #expect(
+            promoQueueCooldownPolicy.snapshot(now: timeTraveller.getDate()).lastConfirmedRemoteMessageAppearance ==
+                firstConfirmationDate
+        )
     }
 
     @available(iOS 16, *)
@@ -658,7 +696,9 @@ final class ModalPromptCoordinationManagerIntegrationTests {
             launchSourceManager: MockLaunchSourceManager(),
             modalPromptCoordinationManager: manager,
             promoCoordinationMode: .coordinated,
-            promoQueueLeaseArbiter: promoQueueLeaseArbiter
+            promoQueueLeaseArbiter: promoQueueLeaseArbiter,
+            promoQueueCooldownPolicy: promoQueueCooldownPolicy,
+            dateProvider: timeTraveller.getDate
         )
         service.applicationDidBecomeActive()
         service.presentModalPromptIfNeeded(

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptCoordinationManager.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/MockModalPromptCoordinationManager.swift
@@ -26,6 +26,8 @@ final class MockModalPromptCoordinationManager: ModalPromptCoordinationManaging 
     private(set) var capturedPresenter: ModalPromptPresenter?
     private(set) var callCount = 0
     var shouldSuppressOtherSessionPromos = false
+    var modalAttemptPhase = ModalPromptAttemptPhase.idle
+    var hasPendingModalPrompt = false
     var coordinatedPresentationDisposition = ModalPromptLeaseDisposition.retained
     var reconcilePresentedModalResult = false
     var coordinatedAttemptReleaseHandler: (@MainActor () -> Void)?

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/PromptCooldownMocks.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/PromptCooldownMocks.swift
@@ -50,14 +50,12 @@ final class MockPromoQueueCooldownPolicy: PromoQueueCooldownPolicying {
     var modalAdmissionDecision: PromoQueueCooldownDecision = .eligible
     var remoteMessageAdmissionDecisionProvider: ((Date) -> PromoQueueCooldownDecision)?
     var modalAdmissionDecisionProvider: ((Date) -> PromoQueueCooldownDecision)?
-    var snapshotToReturn: PromoQueueCooldownSnapshot = .empty
     var onEvaluateRemoteMessageAdmission: ((Date) -> Void)?
     var onEvaluateModalAdmission: ((Date) -> Void)?
 
     private(set) var remoteMessageAdmissionDates = [Date]()
     private(set) var modalAdmissionDates = [Date]()
     private(set) var confirmedRemoteMessageAppearanceDates = [Date]()
-    private(set) var snapshotDates = [Date]()
 
     func evaluateRemoteMessageAdmission(now: Date) -> PromoQueueCooldownDecision {
         remoteMessageAdmissionDates.append(now)
@@ -73,11 +71,6 @@ final class MockPromoQueueCooldownPolicy: PromoQueueCooldownPolicying {
 
     func recordConfirmedRemoteMessageAppearance(at date: Date) {
         confirmedRemoteMessageAppearanceDates.append(date)
-    }
-
-    func snapshot(now: Date) -> PromoQueueCooldownSnapshot {
-        snapshotDates.append(now)
-        return snapshotToReturn
     }
 }
 

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/PromptCooldownMocks.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/PromptCooldownMocks.swift
@@ -44,6 +44,43 @@ final class MockPromptCooldownManager: PromptCooldownManaging {
     }
 }
 
+@MainActor
+final class MockPromoQueueCooldownPolicy: PromoQueueCooldownPolicying {
+    var remoteMessageAdmissionDecision: PromoQueueCooldownDecision = .eligible
+    var modalAdmissionDecision: PromoQueueCooldownDecision = .eligible
+    var remoteMessageAdmissionDecisionProvider: ((Date) -> PromoQueueCooldownDecision)?
+    var modalAdmissionDecisionProvider: ((Date) -> PromoQueueCooldownDecision)?
+    var snapshotToReturn: PromoQueueCooldownSnapshot = .empty
+    var onEvaluateRemoteMessageAdmission: ((Date) -> Void)?
+    var onEvaluateModalAdmission: ((Date) -> Void)?
+
+    private(set) var remoteMessageAdmissionDates = [Date]()
+    private(set) var modalAdmissionDates = [Date]()
+    private(set) var confirmedRemoteMessageAppearanceDates = [Date]()
+    private(set) var snapshotDates = [Date]()
+
+    func evaluateRemoteMessageAdmission(now: Date) -> PromoQueueCooldownDecision {
+        remoteMessageAdmissionDates.append(now)
+        onEvaluateRemoteMessageAdmission?(now)
+        return remoteMessageAdmissionDecisionProvider?(now) ?? remoteMessageAdmissionDecision
+    }
+
+    func evaluateModalAdmission(now: Date) -> PromoQueueCooldownDecision {
+        modalAdmissionDates.append(now)
+        onEvaluateModalAdmission?(now)
+        return modalAdmissionDecisionProvider?(now) ?? modalAdmissionDecision
+    }
+
+    func recordConfirmedRemoteMessageAppearance(at date: Date) {
+        confirmedRemoteMessageAppearanceDates.append(date)
+    }
+
+    func snapshot(now: Date) -> PromoQueueCooldownSnapshot {
+        snapshotDates.append(now)
+        return snapshotToReturn
+    }
+}
+
 extension PromptCooldownInfo {
     static let inCoolDown: PromptCooldownInfo = .init(
         isInCooldownPeriod: true,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1217216795122055?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1216624996708289?focus=true
CC:

### Description

PR 3 of 3 in the Promo Queue stack. It is stacked on [PR 6194](https://github.com/duckduckgo/apple-browsers/pull/6194).

This completes the first Promo Queue iteration by adding spacing between confirmed promo appearances and a read-only debug view. The feature remains default-disabled through `promoPresentationCoordination`.

**Directional cooldown decisions**

<img width="889" height="468" alt="Screenshot 2026-08-13 at 01 10 44" src="https://github.com/user-attachments/assets/f221a349-ff2d-4b1f-aafa-1280c71e6b6e" />

<img width="943" height="279" alt="Screenshot 2026-08-13 at 01 11 00" src="https://github.com/user-attachments/assets/0cbf9ecc-012f-4d3a-909d-a031f27c56de" />

### Testing Steps

Check for regressions to current behavior (main) with the promoPresentationCoordination flag off.

<details>
<summary>Common setup</summary>

1. Complete onboarding.
2. Open **Settings → Debug → All debug options → Feature Flags**.
3. Enable **Internal User**.
4. Set `promoPresentationCoordination` explicitly **ON**.
5. Force-quit and relaunch the app. This is required because the flag is process-latched.
6. Confirm **Debug → Prompt Coordination → Process Mode** says `Coordinated`.

</details>

<details>
<summary>Scenario 1: Show an NTP RMF</summary>

Use this URL:

[Verified NTP RMF fixture](https://raw.githubusercontent.com/duckduckgo/apple-browsers/2cedeeb5add3fd62ee4a438ce775fded8442d149/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Resources/remote-messaging-config-metrics.json)

1. Open **Debug → Remote Messaging → Delete All**.
2. Open **Debug → Configuration URLs → Remote Message Framework Config**.
3. Paste the URL above and tap **Override**.
4. Return to **Remote Messaging**. If necessary, tap **Refresh Config**.
5. Confirm message ID `1` says `scheduled`.
6. Close Settings and open a normal new tab.

Expected result:

- A small RMF card appears with title `title` and description `description`.
- The RMF screen changes ID `1` to `shown | scheduled`.
- **Prompt Coordination → Last Confirmed RMF** now contains a timestamp.
- No modal appears over it.

</details>

<details>
<summary>Scenario 2: Show a real queued modal</summary>

Use this URL:

[Verified What’s New modal fixture](https://raw.githubusercontent.com/duckduckgo/apple-browsers/6b117715492a8ca0bdb3135eb65965fa3e0b6f22/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Resources/remote-messaging-config-cards-list-items.json)

1. Start from a fresh install and repeat the common setup.
2. Open **Debug → Remote Messaging → Delete All**.
3. Override the RMF configuration URL with the URL above.
4. Confirm `whats_new_v1` says `scheduled`.
5. Close Settings completely.
6. Background the app, then foreground it again.

Expected result:

- A What’s New modal appears.
- No NTP RMF card appears underneath or alongside it.
- **Last Confirmed Modal** gets a timestamp.
- The What’s New RMF record becomes shown/dismissed when the modal is presented.

The background/foreground step matters: fetching the config schedules the modal, but it does not itself run modal presentation.

</details>

<details>
<summary>Scenario 3: Put an RMF and modal into competition</summary>

0. Start from a fresh install and repeat the common setup.
1. Enable `promoPresentationCoordination` and `showAIChatAddressBarChoiceScreen`, then force-quit and relaunch.
2. Navigate the current tab to a real webpage. This removes the NTP instead of merely covering it.
3. Open Debug and arm the address-picker modal:
    - **Duck.ai Toggle Prompt → Set Install Cooldown Elapsed**
    - **Reset Picker State**
4. Use **Remote Messaging → Delete All**.
5. Override the RMF URL with the metrics fixture.
6. Confirm ID `1` is `not shown | scheduled`.
7. Close Settings. You should return to the webpage with no RMF.
8. Open a new tab. The RMF should now appear visibly.
9. Leave it visible, then fully background and foreground the app.

Expected result:

- The address-picker modal does not overlap the RMF.
- The RMF remains the sole visible promo and queue owner.

</details>

### Impact

Medium — affects promo coordination only when the feature is enabled.

#### What could go wrong?

A promo could appear too soon or release ownership before removal → covered by boundary, lifecycle, and integration tests.

### Quality Considerations

- The disabled path remains unchanged.
- Existing per-presentation RMF accounting remains unchanged.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes promo admission timing and queue ownership when `promoPresentationCoordination` is on; legacy/disabled paths are largely unchanged but coordinated behavior is user-visible and timing-sensitive.
> 
> **Overview**
> Adds **directional spacing** between confirmed promos in coordinated mode: **10 minutes** before another RMF after modal or RMF history, and **24 hours** before a modal after a **confirmed** RMF queue appearance. `PromoCoordinationService` gates modal and RMF lease acquisition through `PromoQueueCooldownPolicy`, records RMF history on first queue appearance confirmation, and defers retries until later checkpoints when blocked.
> 
> Introduces persisted **last confirmed RMF** history (separate from existing modal cooldown storage) plus diagnostic reads that do not alter production failure reporting.
> 
> Expands **Debug → Prompt Coordination** with a read-only **Promo Queue** snapshot (mode, lease owner, modal attempt, RMF lifecycle, cooldown boundaries) wired from `MainViewController` through debug dependencies. Lease arbiter snapshots no longer prune deallocated tokens on read.
> 
> Minor related fixes: favorites promo surface activity follows `viewModel.isShowingFavorites`; coordinated tests and cooldown policy coverage expanded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aedef29dce64245002f33f834168e8f9fb060dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->