### PR TITLE
Add unified device metadata to Sync account creation

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -19,6 +19,7 @@
 import Foundation
 import DDGSyncCrypto
 import Networking
+import os.log
 
 struct AccountManager: AccountManaging {
 
@@ -215,16 +216,20 @@ struct AccountManager: AccountManaging {
             let keys = try accountInfoKeyFactory.makeProtectedKeys(accountSecretKey: accountSecretKey,
                                                                   thirdPartyMainKey: nil)
             guard let protectedKey = keys.first else {
+                Logger.sync.error("Failed to prepare unified device info for signup: missing account_info protected key")
                 return nil
             }
             let encryptedDeviceInfo = try deviceInfoCodec.encrypt(DeviceInfo(name: name, type: type),
                                                                   using: protectedKey)
-            guard encryptedDeviceInfo.utf8.count <= Signup.maximumDeviceInfoLength else {
+            guard encryptedDeviceInfo.utf8.count <= DeviceInfo.maximumEncryptedLength else {
+                Logger.sync.error("Failed to prepare unified device info for signup: encrypted payload exceeds the maximum length")
                 return nil
             }
             return (keys: keys, deviceInfo: encryptedDeviceInfo)
         } catch {
             // Device info is additive, so local preparation failures must not block legacy signup.
+            let errorType = String(describing: type(of: error))
+            Logger.sync.error("Failed to prepare unified device info for signup: \(errorType, privacy: .public)")
             return nil
         }
     }
@@ -293,8 +298,6 @@ struct AccountManager: AccountManaging {
     }
 
     struct Signup {
-
-        static let maximumDeviceInfoLength = 2_000
 
         struct Result: Decodable {
             let userId: String

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -28,19 +28,28 @@ struct AccountManager: AccountManaging {
     let api: RemoteAPIRequestCreating
     let crypter: CryptingInternal
     let registeredDeviceMapper: any RegisteredDeviceMapping
+    let accountInfoKeyFactory: AccountInfoKeyFactory
+    let deviceInfoCodec: DeviceInfoCoding
     let isScopedAccessCredentialsEnabled: () -> Bool
+    let canWriteUnifiedDeviceList: () -> Bool
 
     init(endpoints: Endpoints,
          api: RemoteAPIRequestCreating,
          crypter: CryptingInternal,
          registeredDeviceMapper: (any RegisteredDeviceMapping)? = nil,
-         isScopedAccessCredentialsEnabled: @escaping () -> Bool) {
+         accountInfoKeyFactory: AccountInfoKeyFactory? = nil,
+         deviceInfoCodec: DeviceInfoCoding = DeviceInfoCodec(),
+         isScopedAccessCredentialsEnabled: @escaping () -> Bool,
+         canWriteUnifiedDeviceList: @escaping () -> Bool = { false }) {
         self.endpoints = endpoints
         self.api = api
         self.crypter = crypter
         self.registeredDeviceMapper = registeredDeviceMapper ?? RegisteredDeviceMapper(crypter: crypter,
                                                                                        isScopedAccessCredentialsEnabled: isScopedAccessCredentialsEnabled)
+        self.accountInfoKeyFactory = accountInfoKeyFactory ?? DefaultAccountInfoKeyFactory(crypter: crypter)
+        self.deviceInfoCodec = deviceInfoCodec
         self.isScopedAccessCredentialsEnabled = isScopedAccessCredentialsEnabled
+        self.canWriteUnifiedDeviceList = canWriteUnifiedDeviceList
     }
 
     func createAccount(deviceName: String, deviceType: String) async throws -> SyncAccount {
@@ -54,6 +63,9 @@ struct AccountManager: AccountManaging {
 
         let hashedPassword = Data(accountKeys.passwordHash).base64EncodedString()
         let protectedEncryptionKey = Data(accountKeys.protectedSecretKey).base64EncodedString()
+        let deviceInfoFields = makeDeviceInfoFieldsForSignup(name: deviceName,
+                                                             type: deviceType,
+                                                             accountSecretKey: Data(accountKeys.secretKey))
 
         let params = Signup.Parameters(
             userId: userId,
@@ -62,7 +74,9 @@ struct AccountManager: AccountManaging {
             deviceId: deviceId,
             deviceName: encryptedDeviceName,
             deviceType: encryptedDeviceType,
-            credentialId: isScopedAccessCredentialsEnabled() ? SyncCredentialID.defaultCredential : nil
+            credentialId: isScopedAccessCredentialsEnabled() ? SyncCredentialID.defaultCredential : nil,
+            keys: deviceInfoFields?.keys,
+            deviceInfo: deviceInfoFields?.deviceInfo
         )
 
         guard let paramJson = try? JSONEncoder.snakeCaseKeys.encode(params) else {
@@ -190,6 +204,31 @@ struct AccountManager: AccountManaging {
         }
     }
 
+    private func makeDeviceInfoFieldsForSignup(name: String,
+                                               type: String,
+                                               accountSecretKey: Data) -> (keys: [ProtectedKey], deviceInfo: String)? {
+        guard canWriteUnifiedDeviceList() else {
+            return nil
+        }
+
+        do {
+            let keys = try accountInfoKeyFactory.makeProtectedKeys(accountSecretKey: accountSecretKey,
+                                                                  thirdPartyMainKey: nil)
+            guard let protectedKey = keys.first else {
+                return nil
+            }
+            let encryptedDeviceInfo = try deviceInfoCodec.encrypt(DeviceInfo(name: name, type: type),
+                                                                  using: protectedKey)
+            guard encryptedDeviceInfo.utf8.count <= Signup.maximumDeviceInfoLength else {
+                return nil
+            }
+            return (keys: keys, deviceInfo: encryptedDeviceInfo)
+        } catch {
+            // Device info is additive, so local preparation failures must not block legacy signup.
+            return nil
+        }
+    }
+
     private func login(_ info: ExtractedLoginInfo,
                        deviceId: String,
                        deviceName: String,
@@ -255,6 +294,8 @@ struct AccountManager: AccountManaging {
 
     struct Signup {
 
+        static let maximumDeviceInfoLength = 2_000
+
         struct Result: Decodable {
             let userId: String
             let token: String
@@ -268,6 +309,8 @@ struct AccountManager: AccountManaging {
             let deviceName: String
             let deviceType: String
             let credentialId: String?
+            let keys: [ProtectedKey]?
+            let deviceInfo: String?
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -216,20 +216,21 @@ struct AccountManager: AccountManaging {
             let keys = try accountInfoKeyFactory.makeProtectedKeys(accountSecretKey: accountSecretKey,
                                                                   thirdPartyMainKey: nil)
             guard let protectedKey = keys.first else {
-                Logger.sync.error("Failed to prepare unified device info for signup: missing account_info protected key")
+                Logger.sync.error("Sync-UnifiedDevices: failed to prepare unified device info for signup: missing account_info protected key")
                 return nil
             }
             let encryptedDeviceInfo = try deviceInfoCodec.encrypt(DeviceInfo(name: name, type: type),
                                                                   using: protectedKey)
             guard encryptedDeviceInfo.utf8.count <= DeviceInfo.maximumEncryptedLength else {
-                Logger.sync.error("Failed to prepare unified device info for signup: encrypted payload exceeds the maximum length")
+                Logger.sync.error("Sync-UnifiedDevices: failed to prepare unified device info for signup: encrypted payload exceeds the maximum length")
                 return nil
             }
+            Logger.sync.debug("Sync-UnifiedDevices: prepared account_info key and device_info for signup")
             return (keys: keys, deviceInfo: encryptedDeviceInfo)
         } catch {
             // Device info is additive, so local preparation failures must not block legacy signup.
             let errorType = String(describing: type(of: error))
-            Logger.sync.error("Failed to prepare unified device info for signup: \(errorType, privacy: .public)")
+            Logger.sync.error("Sync-UnifiedDevices: failed to prepare unified device info for signup: \(errorType)")
             return nil
         }
     }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -64,8 +64,8 @@ struct AccountManager: AccountManaging {
 
         let hashedPassword = Data(accountKeys.passwordHash).base64EncodedString()
         let protectedEncryptionKey = Data(accountKeys.protectedSecretKey).base64EncodedString()
-        let deviceInfoFields = makeDeviceInfoFieldsForSignup(name: deviceName,
-                                                             type: deviceType,
+        let deviceInfoFields = makeDeviceInfoFieldsForSignup(deviceName: deviceName,
+                                                             deviceType: deviceType,
                                                              accountSecretKey: Data(accountKeys.secretKey))
 
         let params = Signup.Parameters(
@@ -205,8 +205,8 @@ struct AccountManager: AccountManaging {
         }
     }
 
-    private func makeDeviceInfoFieldsForSignup(name: String,
-                                               type: String,
+    private func makeDeviceInfoFieldsForSignup(deviceName: String,
+                                               deviceType: String,
                                                accountSecretKey: Data) -> (keys: [ProtectedKey], deviceInfo: String)? {
         guard canWriteUnifiedDeviceList() else {
             return nil
@@ -219,7 +219,7 @@ struct AccountManager: AccountManaging {
                 Logger.sync.error("Sync-UnifiedDevices: failed to prepare unified device info for signup: missing account_info protected key")
                 return nil
             }
-            let encryptedDeviceInfo = try deviceInfoCodec.encrypt(DeviceInfo(name: name, type: type),
+            let encryptedDeviceInfo = try deviceInfoCodec.encrypt(DeviceInfo(name: deviceName, type: deviceType),
                                                                   using: protectedKey)
             guard encryptedDeviceInfo.utf8.count <= DeviceInfo.maximumEncryptedLength else {
                 Logger.sync.error("Sync-UnifiedDevices: failed to prepare unified device info for signup: encrypted payload exceeds the maximum length")
@@ -229,7 +229,7 @@ struct AccountManager: AccountManaging {
             return (keys: keys, deviceInfo: encryptedDeviceInfo)
         } catch {
             // Device info is additive, so local preparation failures must not block legacy signup.
-            let errorType = String(describing: Swift.type(of: error))
+            let errorType = String(describing: type(of: error))
             Logger.sync.error("Sync-UnifiedDevices: failed to prepare unified device info for signup: \(errorType)")
             return nil
         }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -229,7 +229,7 @@ struct AccountManager: AccountManaging {
             return (keys: keys, deviceInfo: encryptedDeviceInfo)
         } catch {
             // Device info is additive, so local preparation failures must not block legacy signup.
-            let errorType = String(describing: type(of: error))
+            let errorType = String(describing: Swift.type(of: error))
             Logger.sync.error("Sync-UnifiedDevices: failed to prepare unified device info for signup: \(errorType)")
             return nil
         }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoCodec.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoCodec.swift
@@ -20,6 +20,8 @@ import Foundation
 import Security
 
 struct DeviceInfo: Codable, Equatable, Sendable {
+    static let maximumEncryptedLength = 2_000
+
     let name: String
     let type: String
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoCodec.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoCodec.swift
@@ -33,8 +33,8 @@ enum DeviceInfoCodecError: Error, Equatable {
 
 protocol DeviceInfoCoding {
     func encrypt(_ deviceInfo: DeviceInfo, using protectedKey: ProtectedKey) throws -> String
-    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKeyMaterial) throws -> String
-    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKeyMaterial) throws -> DeviceInfo
+    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKey) throws -> String
+    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKey) throws -> DeviceInfo
 }
 
 struct DeviceInfoCodec: DeviceInfoCoding {
@@ -53,11 +53,11 @@ struct DeviceInfoCodec: DeviceInfoCoding {
         return try encrypt(deviceInfo, publicKey: publicKey, keyID: protectedKey.kid)
     }
 
-    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKeyMaterial) throws -> String {
+    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKey) throws -> String {
         try encrypt(deviceInfo, publicKey: key.publicKey, keyID: key.kid)
     }
 
-    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKeyMaterial) throws -> DeviceInfo {
+    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKey) throws -> DeviceInfo {
         let payload = try jweCompactCodec.decryptRSAOAEP256(token: encryptedDeviceInfo,
                                                            privateKey: key.privateKey,
                                                            expectedKid: key.kid)

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoCodec.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoCodec.swift
@@ -1,0 +1,78 @@
+//
+//  DeviceInfoCodec.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Security
+
+struct DeviceInfo: Codable, Equatable, Sendable {
+    let name: String
+    let type: String
+}
+
+enum DeviceInfoCodecError: Error, Equatable {
+    case invalidProtectedKey
+    case invalidPayload
+}
+
+protocol DeviceInfoCoding {
+    func encrypt(_ deviceInfo: DeviceInfo, using protectedKey: ProtectedKey) throws -> String
+    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKeyMaterial) throws -> String
+    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKeyMaterial) throws -> DeviceInfo
+}
+
+struct DeviceInfoCodec: DeviceInfoCoding {
+
+    private let jweCompactCodec: JWECompactCodec
+
+    init(jweCompactCodec: JWECompactCodec = JWECompactCodec()) {
+        self.jweCompactCodec = jweCompactCodec
+    }
+
+    func encrypt(_ deviceInfo: DeviceInfo, using protectedKey: ProtectedKey) throws -> String {
+        guard protectedKey.purpose == ProtectedKeyPurpose.accountInfo, !protectedKey.kid.isEmpty else {
+            throw DeviceInfoCodecError.invalidProtectedKey
+        }
+        let publicKey = try RSAKeyImporter.makePublicKey(from: protectedKey.publicKey)
+        return try encrypt(deviceInfo, publicKey: publicKey, keyID: protectedKey.kid)
+    }
+
+    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKeyMaterial) throws -> String {
+        try encrypt(deviceInfo, publicKey: key.publicKey, keyID: key.kid)
+    }
+
+    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKeyMaterial) throws -> DeviceInfo {
+        let payload = try jweCompactCodec.decryptRSAOAEP256(token: encryptedDeviceInfo,
+                                                           privateKey: key.privateKey,
+                                                           expectedKid: key.kid)
+        do {
+            return try JSONDecoder().decode(DeviceInfo.self, from: payload)
+        } catch {
+            throw DeviceInfoCodecError.invalidPayload
+        }
+    }
+
+    private func encrypt(_ deviceInfo: DeviceInfo, publicKey: SecKey, keyID: String) throws -> String {
+        guard !keyID.isEmpty else {
+            throw DeviceInfoCodecError.invalidProtectedKey
+        }
+        let payload = try JSONEncoder().encode(deviceInfo)
+        return try jweCompactCodec.encryptRSAOAEP256(payload: payload,
+                                                     recipientPublicKey: publicKey,
+                                                     kid: keyID)
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoCodec.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoCodec.swift
@@ -33,7 +33,6 @@ enum DeviceInfoCodecError: Error, Equatable {
 
 protocol DeviceInfoCoding {
     func encrypt(_ deviceInfo: DeviceInfo, using protectedKey: ProtectedKey) throws -> String
-    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKey) throws -> String
     func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKey) throws -> DeviceInfo
 }
 
@@ -51,10 +50,6 @@ struct DeviceInfoCodec: DeviceInfoCoding {
         }
         let publicKey = try RSAKeyImporter.makePublicKey(from: protectedKey.publicKey)
         return try encrypt(deviceInfo, publicKey: publicKey, keyID: protectedKey.kid)
-    }
-
-    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKey) throws -> String {
-        try encrypt(deviceInfo, publicKey: key.publicKey, keyID: key.kid)
     }
 
     func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKey) throws -> DeviceInfo {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -89,7 +89,8 @@ struct ProductionDependencies: SyncDependencies {
         let scopedAccess = ScopedAccessCredentialManager(endpoints: endpoints,
                                                          api: api,
                                                          crypter: crypter,
-                                                         accountInfoKeyFactory: accountInfoKeyFactory)
+                                                         accountInfoKeyFactory: accountInfoKeyFactory,
+                                                         canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() })
         accountInfoKeys = AccountInfoKeyManager(secureStore: secureStore,
                                                 scopedAccess: scopedAccess,
                                                 crypter: crypter)
@@ -150,7 +151,8 @@ struct ProductionDependencies: SyncDependencies {
                                             api: api,
                                             crypter: crypter,
                                             scopedAccess: scopedAccess,
-                                            account: account)
+                                            account: account,
+                                            canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() })
     }
 
     func createTokenRescope() -> TokenRescoping {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -85,11 +85,11 @@ struct ProductionDependencies: SyncDependencies {
         payloadCompressor = SyncGzipPayloadCompressor()
 
         crypter = Crypter(secureStore: secureStore)
+        let accountInfoKeyFactory = DefaultAccountInfoKeyFactory(crypter: crypter)
         let scopedAccess = ScopedAccessCredentialManager(endpoints: endpoints,
                                                          api: api,
                                                          crypter: crypter,
-                                                         accountInfoKeyFactory: DefaultAccountInfoKeyFactory(crypter: crypter),
-                                                         canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() })
+                                                         accountInfoKeyFactory: accountInfoKeyFactory)
         accountInfoKeys = AccountInfoKeyManager(secureStore: secureStore,
                                                 scopedAccess: scopedAccess,
                                                 crypter: crypter)
@@ -101,7 +101,9 @@ struct ProductionDependencies: SyncDependencies {
                                  api: api,
                                  crypter: crypter,
                                  registeredDeviceMapper: registeredDeviceMapper,
-                                 isScopedAccessCredentialsEnabled: { syncFeatureFlags.isScopedAccessCredentialsEnabled() })
+                                 accountInfoKeyFactory: accountInfoKeyFactory,
+                                 isScopedAccessCredentialsEnabled: { syncFeatureFlags.isScopedAccessCredentialsEnabled() },
+                                 canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() })
         self.scopedAccess = scopedAccess
         scheduler = SyncScheduler()
     }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -151,8 +151,7 @@ struct ProductionDependencies: SyncDependencies {
                                             api: api,
                                             crypter: crypter,
                                             scopedAccess: scopedAccess,
-                                            account: account,
-                                            canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() })
+                                            account: account)
     }
 
     func createTokenRescope() -> TokenRescoping {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -183,7 +183,7 @@ final class AccountManagerTests: XCTestCase {
         accountInfoKeyFactory.makeProtectedKeysStub = [makeAccountInfoProtectedKey()]
         let deviceInfoCodec = DeviceInfoCodingMock()
         deviceInfoCodec.encryptUsingProtectedKeyStub = String(repeating: "a",
-                                                              count: AccountManager.Signup.maximumDeviceInfoLength + 1)
+                                                              count: DeviceInfo.maximumEncryptedLength + 1)
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: CryptingMock(),

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -750,11 +750,11 @@ private final class DeviceInfoCodingMock: DeviceInfoCoding {
         return encryptUsingProtectedKeyStub
     }
 
-    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKeyMaterial) throws -> String {
+    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKey) throws -> String {
         throw DeviceInfoCodecError.invalidProtectedKey
     }
 
-    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKeyMaterial) throws -> DeviceInfo {
+    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKey) throws -> DeviceInfo {
         throw DeviceInfoCodecError.invalidPayload
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -75,6 +75,138 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertNil(signupBody["credential_id"])
     }
 
+    func testWhenCreatingAccountWithUnifiedWriteEnabledThenSignupIncludesKeysAndDeviceInfo() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let protectedKey = makeAccountInfoProtectedKey()
+        accountInfoKeyFactory.makeProtectedKeysStub = [protectedKey]
+        let deviceInfoCodec = DeviceInfoCodingMock()
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            accountInfoKeyFactory: accountInfoKeyFactory,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canWriteUnifiedDeviceList: { true })
+        api.fakeRequests[endpoints.signup] = makeJSONRequest("""
+        {
+            "user_id": "user-1",
+            "token": "token-1"
+        }
+        """)
+
+        _ = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
+
+        let signupBody = try makeSignupBody(from: api)
+        let keys = try XCTUnwrap(signupBody["keys"] as? [[String: Any]])
+        let key = try XCTUnwrap(keys.first)
+        XCTAssertEqual(signupBody["device_info"] as? String, deviceInfoCodec.encryptUsingProtectedKeyStub)
+        XCTAssertEqual(signupBody["device_name"] as? String, "encrypted_iPhone")
+        XCTAssertEqual(signupBody["device_type"] as? String, "encrypted_iOS")
+        XCTAssertEqual(key["kid"] as? String, protectedKey.kid)
+        XCTAssertEqual(key["purpose"] as? String, ProtectedKeyPurpose.accountInfo)
+        XCTAssertEqual(key["encrypted_with"] as? String, SyncCredentialID.defaultCredential)
+        XCTAssertEqual(accountInfoKeyFactory.makeProtectedKeysCalls.count, 1)
+        XCTAssertNil(accountInfoKeyFactory.makeProtectedKeysCalls.first?.thirdPartyMainKey)
+        XCTAssertEqual(deviceInfoCodec.encryptUsingProtectedKeyCalls.first?.deviceInfo,
+                       DeviceInfo(name: "iPhone", type: "iOS"))
+        XCTAssertEqual(deviceInfoCodec.encryptUsingProtectedKeyCalls.first?.protectedKey.kid, protectedKey.kid)
+    }
+
+    func testWhenCreatingAccountWithUnifiedWriteDisabledThenSignupOmitsKeysAndDeviceInfo() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        accountInfoKeyFactory.makeProtectedKeysStub = [makeAccountInfoProtectedKey()]
+        let deviceInfoCodec = DeviceInfoCodingMock()
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            accountInfoKeyFactory: accountInfoKeyFactory,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canWriteUnifiedDeviceList: { false })
+        api.fakeRequests[endpoints.signup] = makeJSONRequest("""
+        {
+            "user_id": "user-1",
+            "token": "token-1"
+        }
+        """)
+
+        _ = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
+
+        let signupBody = try makeSignupBody(from: api)
+        XCTAssertNil(signupBody["keys"])
+        XCTAssertNil(signupBody["device_info"])
+        XCTAssertEqual(signupBody["device_name"] as? String, "encrypted_iPhone")
+        XCTAssertEqual(signupBody["device_type"] as? String, "encrypted_iOS")
+        XCTAssertTrue(accountInfoKeyFactory.makeProtectedKeysCalls.isEmpty)
+        XCTAssertTrue(deviceInfoCodec.encryptUsingProtectedKeyCalls.isEmpty)
+    }
+
+    func testWhenDeviceInfoEncryptionFailsThenSignupFallsBackToLegacyFields() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        accountInfoKeyFactory.makeProtectedKeysStub = [makeAccountInfoProtectedKey()]
+        let deviceInfoCodec = DeviceInfoCodingMock()
+        deviceInfoCodec.encryptUsingProtectedKeyError = DeviceInfoCodecError.invalidPayload
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            accountInfoKeyFactory: accountInfoKeyFactory,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canWriteUnifiedDeviceList: { true })
+        api.fakeRequests[endpoints.signup] = makeJSONRequest("""
+        {
+            "user_id": "user-1",
+            "token": "token-1"
+        }
+        """)
+
+        _ = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
+
+        let signupBody = try makeSignupBody(from: api)
+        XCTAssertNil(signupBody["keys"])
+        XCTAssertNil(signupBody["device_info"])
+        XCTAssertEqual(signupBody["device_name"] as? String, "encrypted_iPhone")
+        XCTAssertEqual(signupBody["device_type"] as? String, "encrypted_iOS")
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.signup])
+    }
+
+    func testWhenDeviceInfoExceedsServerLimitThenSignupFallsBackToLegacyFields() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        accountInfoKeyFactory.makeProtectedKeysStub = [makeAccountInfoProtectedKey()]
+        let deviceInfoCodec = DeviceInfoCodingMock()
+        deviceInfoCodec.encryptUsingProtectedKeyStub = String(repeating: "a",
+                                                              count: AccountManager.Signup.maximumDeviceInfoLength + 1)
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            accountInfoKeyFactory: accountInfoKeyFactory,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canWriteUnifiedDeviceList: { true })
+        api.fakeRequests[endpoints.signup] = makeJSONRequest("""
+        {
+            "user_id": "user-1",
+            "token": "token-1"
+        }
+        """)
+
+        _ = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
+
+        let signupBody = try makeSignupBody(from: api)
+        XCTAssertNil(signupBody["keys"])
+        XCTAssertNil(signupBody["device_info"])
+        XCTAssertEqual(signupBody["device_name"] as? String, "encrypted_iPhone")
+        XCTAssertEqual(signupBody["device_type"] as? String, "encrypted_iOS")
+    }
+
     func testWhenDecodingLoginResultWithoutScopedFieldsThenDecodingSucceeds() throws {
         let json = """
         {
@@ -363,6 +495,40 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertNil(loginBody["scope"])
     }
 
+    func testWhenLoggingInWithUnifiedWriteEnabledThenLoginUsesLegacyMetadataOnly() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        accountInfoKeyFactory.makeProtectedKeysStub = [makeAccountInfoProtectedKey()]
+        let deviceInfoCodec = DeviceInfoCodingMock()
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            accountInfoKeyFactory: accountInfoKeyFactory,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canWriteUnifiedDeviceList: { true })
+        api.fakeRequests[endpoints.login] = makeJSONRequest("""
+        {
+            "devices": [],
+            "token": "token-1",
+            "protected_encryption_key": ""
+        }
+        """)
+
+        _ = try await accountManager.login(.init(userId: "user-1", primaryKey: Data()),
+                                           deviceName: "iPhone",
+                                           deviceType: "iOS")
+
+        let loginBody = try makeLoginBody(from: api)
+        XCTAssertNil(loginBody["keys"])
+        XCTAssertNil(loginBody["device_info"])
+        XCTAssertEqual(loginBody["device_name"] as? String, "encrypted_iPhone")
+        XCTAssertEqual(loginBody["device_type"] as? String, "encrypted_iOS")
+        XCTAssertTrue(accountInfoKeyFactory.makeProtectedKeysCalls.isEmpty)
+        XCTAssertTrue(deviceInfoCodec.encryptUsingProtectedKeyCalls.isEmpty)
+    }
+
     func testWhenRefreshingTokenWithoutAccessCredentialsThenResultAccessCredentialsIsNil() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
@@ -540,6 +706,14 @@ final class AccountManagerTests: XCTestCase {
                     state: .active)
     }
 
+    private func makeAccountInfoProtectedKey() -> ProtectedKey {
+        ProtectedKey(kid: "account-info-key",
+                     encryptedPrivateKey: "encrypted-private-key",
+                     publicKey: .mock,
+                     encryptedWith: SyncCredentialID.defaultCredential,
+                     purpose: ProtectedKeyPurpose.accountInfo)
+    }
+
     private func makeJSONRequest(_ json: String) -> HTTPRequestingMock {
         HTTPRequestingMock(result: .init(data: Data(json.utf8), response: .init()))
     }
@@ -560,6 +734,29 @@ final class AccountManagerTests: XCTestCase {
         return try XCTUnwrap(json as? [String: Any])
     }
 
+}
+
+private final class DeviceInfoCodingMock: DeviceInfoCoding {
+
+    private(set) var encryptUsingProtectedKeyCalls: [(deviceInfo: DeviceInfo, protectedKey: ProtectedKey)] = []
+    var encryptUsingProtectedKeyStub = "encrypted-device-info"
+    var encryptUsingProtectedKeyError: Error?
+
+    func encrypt(_ deviceInfo: DeviceInfo, using protectedKey: ProtectedKey) throws -> String {
+        encryptUsingProtectedKeyCalls.append((deviceInfo: deviceInfo, protectedKey: protectedKey))
+        if let encryptUsingProtectedKeyError {
+            throw encryptUsingProtectedKeyError
+        }
+        return encryptUsingProtectedKeyStub
+    }
+
+    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKeyMaterial) throws -> String {
+        throw DeviceInfoCodecError.invalidProtectedKey
+    }
+
+    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKeyMaterial) throws -> DeviceInfo {
+        throw DeviceInfoCodecError.invalidPayload
+    }
 }
 
 private final class RegisteredDeviceMappingMock: RegisteredDeviceMapping {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -176,6 +176,69 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.signup])
     }
 
+    func testWhenAccountInfoKeyGenerationFailsThenSignupFallsBackToSingleLegacyRequest() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        accountInfoKeyFactory.makeProtectedKeysError = AccountManagerTestError.accountInfoKeyGenerationFailed
+        let deviceInfoCodec = DeviceInfoCodingMock()
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            accountInfoKeyFactory: accountInfoKeyFactory,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canWriteUnifiedDeviceList: { true })
+        api.fakeRequests[endpoints.signup] = makeJSONRequest("""
+        {
+            "user_id": "user-1",
+            "token": "token-1"
+        }
+        """)
+
+        _ = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
+
+        let signupBody = try makeSignupBody(from: api)
+        XCTAssertNil(signupBody["keys"])
+        XCTAssertNil(signupBody["device_info"])
+        XCTAssertEqual(signupBody["device_name"] as? String, "encrypted_iPhone")
+        XCTAssertEqual(signupBody["device_type"] as? String, "encrypted_iOS")
+        XCTAssertEqual(accountInfoKeyFactory.makeProtectedKeysCalls.count, 1)
+        XCTAssertTrue(deviceInfoCodec.encryptUsingProtectedKeyCalls.isEmpty)
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.signup])
+    }
+
+    func testWhenEnrichedSignupRequestFailsThenErrorIsPropagatedWithoutLegacyRetry() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        accountInfoKeyFactory.makeProtectedKeysStub = [makeAccountInfoProtectedKey()]
+        let deviceInfoCodec = DeviceInfoCodingMock()
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            accountInfoKeyFactory: accountInfoKeyFactory,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canWriteUnifiedDeviceList: { true })
+        let signupRequest = HTTPRequestingMock()
+        signupRequest.error = URLError(.timedOut)
+        api.fakeRequests[endpoints.signup] = signupRequest
+
+        do {
+            _ = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
+            XCTFail("Expected signup request failure")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .timedOut)
+        }
+
+        let signupBody = try makeSignupBody(from: api)
+        XCTAssertNotNil(signupBody["keys"])
+        XCTAssertEqual(signupBody["device_info"] as? String, deviceInfoCodec.encryptUsingProtectedKeyStub)
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.signup])
+        XCTAssertEqual(signupRequest.executeCallCount, 1)
+    }
+
     func testWhenDeviceInfoExceedsServerLimitThenSignupFallsBackToLegacyFields() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
@@ -736,6 +799,10 @@ final class AccountManagerTests: XCTestCase {
 
 }
 
+private enum AccountManagerTestError: Error {
+    case accountInfoKeyGenerationFailed
+}
+
 private final class DeviceInfoCodingMock: DeviceInfoCoding {
 
     private(set) var encryptUsingProtectedKeyCalls: [(deviceInfo: DeviceInfo, protectedKey: ProtectedKey)] = []
@@ -748,10 +815,6 @@ private final class DeviceInfoCodingMock: DeviceInfoCoding {
             throw encryptUsingProtectedKeyError
         }
         return encryptUsingProtectedKeyStub
-    }
-
-    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKey) throws -> String {
-        throw DeviceInfoCodecError.invalidProtectedKey
     }
 
     func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKey) throws -> DeviceInfo {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoCodecTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoCodecTests.swift
@@ -31,12 +31,12 @@ final class DeviceInfoCodecTests: XCTestCase {
                 .makeProtectedKeys(accountSecretKey: accountSecretKey)
                 .first
         )
-        let keyMaterial = try makeKeyMaterial(from: protectedKey, crypter: crypter)
+        let accountInfoKey = try makeAccountInfoKey(from: protectedKey, crypter: crypter)
         let deviceInfo = DeviceInfo(name: "Anya's Mac", type: "desktop")
         let codec = DeviceInfoCodec()
 
         let encryptedDeviceInfo = try codec.encrypt(deviceInfo, using: protectedKey)
-        let decryptedDeviceInfo = try codec.decrypt(encryptedDeviceInfo, using: keyMaterial)
+        let decryptedDeviceInfo = try codec.decrypt(encryptedDeviceInfo, using: accountInfoKey)
 
         XCTAssertEqual(decryptedDeviceInfo, deviceInfo)
     }
@@ -62,24 +62,24 @@ final class DeviceInfoCodecTests: XCTestCase {
 
     func testWhenDecryptedPayloadIsNotDeviceInfoThenThrows() throws {
         let keyPair = try RSAKeyPairGenerator.makeKeyPair()
-        let keyMaterial = AccountInfoKeyMaterial(kid: "account-info-key",
-                                                 publicKey: keyPair.publicKey,
-                                                 privateKey: keyPair.privateKey)
+        let accountInfoKey = AccountInfoKey(kid: "account-info-key",
+                                            publicKey: keyPair.publicKey,
+                                            privateKey: keyPair.privateKey)
         let encryptedPayload = try JWECompactCodec().encryptRSAOAEP256(payload: Data("invalid".utf8),
                                                                       recipientPublicKey: keyPair.publicKey,
-                                                                      kid: keyMaterial.kid)
+                                                                      kid: accountInfoKey.kid)
 
-        XCTAssertThrowsError(try DeviceInfoCodec().decrypt(encryptedPayload, using: keyMaterial)) { error in
+        XCTAssertThrowsError(try DeviceInfoCodec().decrypt(encryptedPayload, using: accountInfoKey)) { error in
             XCTAssertEqual(error as? DeviceInfoCodecError, .invalidPayload)
         }
     }
 
-    private func makeKeyMaterial(from protectedKey: ProtectedKey,
-                                 crypter: CryptingInternal) throws -> AccountInfoKeyMaterial {
+    private func makeAccountInfoKey(from protectedKey: ProtectedKey,
+                                    crypter: CryptingInternal) throws -> AccountInfoKey {
         let encryptedPrivateKey = try XCTUnwrap(Base64URL.decode(protectedKey.encryptedPrivateKey))
         let privateKeyPKCS8 = try crypter.decryptData(encryptedPrivateKey, using: accountSecretKey)
-        return AccountInfoKeyMaterial(kid: protectedKey.kid,
-                                      publicKey: try RSAKeyImporter.makePublicKey(from: protectedKey.publicKey),
-                                      privateKey: try RSAKeyImporter.makePrivateKey(fromPKCS8: privateKeyPKCS8))
+        return AccountInfoKey(kid: protectedKey.kid,
+                              publicKey: try RSAKeyImporter.makePublicKey(from: protectedKey.publicKey),
+                              privateKey: try RSAKeyImporter.makePrivateKey(fromPKCS8: privateKeyPKCS8))
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoCodecTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoCodecTests.swift
@@ -1,0 +1,85 @@
+//
+//  DeviceInfoCodecTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+@testable import DDGSync
+
+final class DeviceInfoCodecTests: XCTestCase {
+
+    private let accountSecretKey = Data(repeating: 0x01, count: 32)
+
+    func testWhenEncryptingDeviceInfoWithRSA3072ProtectedKeyThenRoundTripSucceeds() throws {
+        let crypter = CryptingMock()
+        let protectedKey = try XCTUnwrap(
+            DefaultAccountInfoKeyFactory(crypter: crypter)
+                .makeProtectedKeys(accountSecretKey: accountSecretKey)
+                .first
+        )
+        let keyMaterial = try makeKeyMaterial(from: protectedKey, crypter: crypter)
+        let deviceInfo = DeviceInfo(name: "Anya's Mac", type: "desktop")
+        let codec = DeviceInfoCodec()
+
+        let encryptedDeviceInfo = try codec.encrypt(deviceInfo, using: protectedKey)
+        let decryptedDeviceInfo = try codec.decrypt(encryptedDeviceInfo, using: keyMaterial)
+
+        XCTAssertEqual(decryptedDeviceInfo, deviceInfo)
+    }
+
+    func testWhenEncryptingWithProtectedKeyForDifferentPurposeThenThrows() throws {
+        let crypter = CryptingMock()
+        let accountInfoKey = try XCTUnwrap(
+            DefaultAccountInfoKeyFactory(crypter: crypter)
+                .makeProtectedKeys(accountSecretKey: accountSecretKey)
+                .first
+        )
+        let protectedKey = ProtectedKey(kid: accountInfoKey.kid,
+                                        encryptedPrivateKey: accountInfoKey.encryptedPrivateKey,
+                                        publicKey: accountInfoKey.publicKey,
+                                        encryptedWith: accountInfoKey.encryptedWith,
+                                        purpose: "ai_chats")
+
+        XCTAssertThrowsError(try DeviceInfoCodec().encrypt(DeviceInfo(name: "iPhone", type: "mobile"),
+                                                           using: protectedKey)) { error in
+            XCTAssertEqual(error as? DeviceInfoCodecError, .invalidProtectedKey)
+        }
+    }
+
+    func testWhenDecryptedPayloadIsNotDeviceInfoThenThrows() throws {
+        let keyPair = try RSAKeyPairGenerator.makeKeyPair()
+        let keyMaterial = AccountInfoKeyMaterial(kid: "account-info-key",
+                                                 publicKey: keyPair.publicKey,
+                                                 privateKey: keyPair.privateKey)
+        let encryptedPayload = try JWECompactCodec().encryptRSAOAEP256(payload: Data("invalid".utf8),
+                                                                      recipientPublicKey: keyPair.publicKey,
+                                                                      kid: keyMaterial.kid)
+
+        XCTAssertThrowsError(try DeviceInfoCodec().decrypt(encryptedPayload, using: keyMaterial)) { error in
+            XCTAssertEqual(error as? DeviceInfoCodecError, .invalidPayload)
+        }
+    }
+
+    private func makeKeyMaterial(from protectedKey: ProtectedKey,
+                                 crypter: CryptingInternal) throws -> AccountInfoKeyMaterial {
+        let encryptedPrivateKey = try XCTUnwrap(Base64URL.decode(protectedKey.encryptedPrivateKey))
+        let privateKeyPKCS8 = try crypter.decryptData(encryptedPrivateKey, using: accountSecretKey)
+        return AccountInfoKeyMaterial(kid: protectedKey.kid,
+                                      publicKey: try RSAKeyImporter.makePublicKey(from: protectedKey.publicKey),
+                                      privateKey: try RSAKeyImporter.makePrivateKey(fromPKCS8: privateKeyPKCS8))
+    }
+}

--- a/macOS/DuckDuckGo/Sync/SyncDebugMenu.swift
+++ b/macOS/DuckDuckGo/Sync/SyncDebugMenu.swift
@@ -35,6 +35,14 @@ final class SyncDebugMenu: NSMenu {
 
             NSMenuItem(title: "Turn off Sync", action: #selector(turnOffSync), target: self)
                 .withAccessibilityIdentifier("SyncDebugMenu.turnOffSync")
+
+            NSMenuItem.separator()
+            NSMenuItem(title: "Ensure account_info key", action: #selector(ensureAccountInfoKey), target: self)
+                .withAccessibilityIdentifier("SyncDebugMenu.ensureAccountInfoKey")
+            NSMenuItem(title: "Validate account_info key", action: #selector(validateAccountInfoKey), target: self)
+                .withAccessibilityIdentifier("SyncDebugMenu.validateAccountInfoKey")
+            NSMenuItem.separator()
+
             NSMenuItem(title: "Reset Favicons Fetcher Onboarding Dialog", action: #selector(resetFaviconsFetcherOnboardingDialog), target: self)
             NSMenuItem(title: "Populate Stub objects", action: #selector(createStubsForDebug), target: self)
             NSMenuItem(title: "Show Sync With Another Device (Chat Sync)", action: #selector(showSyncWithAnotherDevicePromo), target: self)
@@ -140,6 +148,63 @@ final class SyncDebugMenu: NSMenu {
     @MainActor
     @objc func showSyncWithAnotherDevicePromo(_ sender: NSMenuItem) {
         DeviceSyncCoordinator()?.startDeviceSyncFlow(source: .aiChat, completion: nil)
+    }
+
+    @objc private func ensureAccountInfoKey() {
+        Task { @MainActor [weak self] in
+            guard let self, let syncService = NSApp.delegateTyped.syncService else { return }
+
+            do {
+                let wrapperCount = try await syncService.ensureAccountInfoKeyForDebug()
+                let message: String
+                if wrapperCount == 0 {
+                    message = "No wrappers were returned."
+                } else if wrapperCount == 1 {
+                    message = "Ensured 1 wrapper."
+                } else {
+                    message = "Ensured \(wrapperCount) wrappers."
+                }
+                await showAlert(title: "Account Info Key Ensured", message: message)
+            } catch {
+                await showAlert(title: "Unable to Ensure Account Info Key", message: String(reflecting: error))
+            }
+        }
+    }
+
+    @objc private func validateAccountInfoKey() {
+        Task { @MainActor [weak self] in
+            guard let self, let syncService = NSApp.delegateTyped.syncService else { return }
+
+            do {
+                let result = try await syncService.validateAccountInfoKeyForDebug()
+                guard result.refreshedKeyID == result.reloadedKeyID else {
+                    let message = """
+                    Refreshed key ID: \(result.refreshedKeyID)
+                    Reloaded key ID: \(result.reloadedKeyID)
+                    """
+                    await showAlert(title: "Account Info Key Reload Mismatch", message: message)
+                    return
+                }
+
+                let message = """
+                Key ID: \(result.reloadedKeyID)
+                Key size: \(result.keySizeInBits) bits
+                Cache-first reload: succeeded
+                """
+                await showAlert(title: "Account Info Key Validated", message: message)
+            } catch {
+                await showAlert(title: "Unable to Validate Account Info Key", message: String(reflecting: error))
+            }
+        }
+    }
+
+    @MainActor
+    private func showAlert(title: String, message: String) async {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.addButton(withTitle: "OK")
+        await alert.runModal()
     }
 
     @objc func resetFaviconsFetcherOnboardingDialog(_ sender: NSMenuItem) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1216959071260318?focus=true
Tech Design URL:
CC:

### Description
Creates new Sync accounts with an `account_info` key and encrypted unified device metadata when unified-device writes are enabled. The existing encrypted name and type are still included so older clients remain compatible and the first device is available in both formats from account creation.

If the key or unified metadata cannot be prepared locally, account creation continues using the existing legacy fields. Once a signup request has been sent, any request failure is surfaced without retrying and risking duplicate account creation. With unified-device writes disabled, signup behavior is unchanged.

Adding a device to an existing account remains legacy-only at login in this PR; its authenticated unified metadata update is covered by the later migration work.

### Testing Steps
Prerequisite: Install the PR build on both iOS and macOS. Start with Sync disabled on both platforms.

1. Enable feature flag `syncCanWriteUnifiedDeviceList`
2. In the Xcode console, filter for `Sync-UnifiedDevices`
3. Enable Sync on one Apple device to create a new account → account creation succeeds and the console reports `prepared account_info key and device_info for signup`
4. Open **Debug > Sync** on that device and select **Validate account_info key** without first selecting **Ensure account_info key** → **Account Info Key Validated** reports a 3072-bit key and `Cache-first reload: succeeded`
5. On the other Apple platform, select **Sync with Another Device** and complete pairing → pairing succeeds
6. Open the Sync device list on iOS → both the iOS and macOS devices are shown with the correct names and types
7. Open the Sync device list on macOS → both the iOS and macOS devices are shown with the correct names and types
8. Disable Sync on the device that originally created the account
9. Disable feature flag `syncCanWriteUnifiedDeviceList`
10. Clear the Xcode console
11. Enable Sync to create another new account → account creation succeeds using the legacy path and no unified signup-preparation message appears in the console

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Sync account creation and cryptographic key handling; failures are designed to fall back to legacy signup, but enriched signup errors propagate without retry.
> 
> **Overview**
> When **`syncCanWriteUnifiedDeviceList`** is enabled, **new Sync account signup** can include an **`account_info` protected key** and **encrypted unified `device_info`** (name/type) alongside the existing legacy encrypted `device_name` / `device_type` fields.
> 
> A new **`DeviceInfoCodec`** JWE-encrypts/decrypts `DeviceInfo` with the `account_info` key (with a 2,000-byte cap). **`AccountManager`** prepares these fields only when the flag is on; local key/encryption failures **fall back to legacy signup** without blocking account creation. If an enriched signup request is sent and fails, the error is **not retried** with a stripped payload (avoids duplicate accounts). **Login is unchanged** in this PR (still legacy metadata only).
> 
> **`ProductionDependencies`** shares one `AccountInfoKeyFactory` and passes the unified-write flag into `AccountManager`. **macOS Sync debug menu** adds **Ensure** / **Validate account_info key** helpers for manual testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23963b86d7598d76b5a0f86620e025cc4fb5ed9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->