### PR TITLE
iOS: Replace monthly free trial experiment, gate enrollment on trial eligibility

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -634,7 +634,7 @@ public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {
     case subscriptionPromoForReinstallers
     case subscriptionExpirationReminderNotification
     case subscriptionPromoForExistingUsers
-    case monthlyFreeTrialExperiment
+    case monthlyFreeTrialExperiment2
 }
 
 public enum DuckPlayerSubfeature: String, PrivacySubfeature {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
@@ -227,9 +227,9 @@ extension URL {
         }
 
         if let queryItems = components.queryItems, !queryItems.isEmpty {
-            // `experiment_mobileannualtrials_ios` is the monthly free-trial experiment cohort param;
+            // `experiment_mobileannualtrials2_ios` is the monthly free-trial experiment cohort param;
             // like `origin` it's appended to loaded URLs and must be ignored when matching screens.
-            components.queryItems = queryItems.filter { !["environment", "origin", "using", "experiment_mobileannualtrials_ios"].contains($0.name) }
+            components.queryItems = queryItems.filter { !["environment", "origin", "using", "experiment_mobileannualtrials2_ios"].contains($0.name) }
             if components.queryItems?.isEmpty ?? true {
                 components.queryItems = nil
             }

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
@@ -244,7 +244,7 @@ final class SubscriptionURLTests: XCTestCase {
     }
 
     func testURLForComparisonRemovesMonthlyFreeTrialExperimentCohort() throws {
-        let url = URL(string: "https://duckduckgo.com/subscriptions?experiment_mobileannualtrials_ios=control")!
+        let url = URL(string: "https://duckduckgo.com/subscriptions?experiment_mobileannualtrials2_ios=control")!
         let expectedURL = URL(string: "https://duckduckgo.com/subscriptions")!
 
         XCTAssertEqual(url.forComparison(), expectedURL)

--- a/iOS/Core/StatisticsLoader.swift
+++ b/iOS/Core/StatisticsLoader.swift
@@ -89,7 +89,6 @@ public class StatisticsLoader {
         let inProgressExperiments = [
             iOSBrowserConfigSubfeature.searchTokenExperimentV2.rawValue,
             iOSBrowserConfigSubfeature.onboardingFlowByDownloadReasonExperiment.rawValue,
-            PrivacyProSubfeature.monthlyFreeTrialExperiment.rawValue,
             AutoconsentSubfeature.cookiePopupOptInDialogExperiment.rawValue
         ]
         for subfeatureID in inProgressExperiments {

--- a/iOS/DuckDuckGo/Subscription/IOSMonthlyFreeTrialDecider.swift
+++ b/iOS/DuckDuckGo/Subscription/IOSMonthlyFreeTrialDecider.swift
@@ -31,7 +31,7 @@ struct IOSMonthlyFreeTrialDecider: MonthlyFreeTrialDeciding {
     }
 
     func shouldOfferMonthlyFreeTrial() -> Bool {
-        let cohort = featureFlagger.assignedCohort(for: FeatureFlag.monthlyFreeTrialExperiment) as? FeatureFlag.MonthlyFreeTrialExperimentCohort
+        let cohort = featureFlagger.assignedCohort(for: FeatureFlag.monthlyFreeTrialExperiment2) as? FeatureFlag.MonthlyFreeTrialExperimentCohort
 
         // Do not offer free monthly trial for users in the treatment group.
         switch cohort {

--- a/iOS/DuckDuckGo/Subscription/MonthlyFreeTrialExperiment.swift
+++ b/iOS/DuckDuckGo/Subscription/MonthlyFreeTrialExperiment.swift
@@ -24,10 +24,17 @@ import PrivacyConfig
 import FeatureFlags_iOS
 
 enum MonthlyFreeTrialExperiment {
-    static let cohortParameterName = "experiment_mobileannualtrials_ios"
+    static let cohortParameterName = "experiment_mobileannualtrials2_ios"
 
-    static func appendingCohortParameter(to url: URL, resolvedBy featureFlagger: FeatureFlagger) -> URL {
-        guard let cohort = featureFlagger.resolveCohort(for: FeatureFlag.monthlyFreeTrialExperiment)
+    /// Enrols the user in the experiment and appends the resolved cohort to `url`.
+    ///
+    /// Users who are not eligible for a free trial are never enrolled.
+    static func appendingCohortParameter(to url: URL,
+                                         resolvedBy featureFlagger: FeatureFlagger,
+                                         isEligibleForFreeTrial: Bool) -> URL {
+        guard isEligibleForFreeTrial else { return url }
+
+        guard let cohort = featureFlagger.resolveCohort(for: FeatureFlag.monthlyFreeTrialExperiment2)
             as? FeatureFlag.MonthlyFreeTrialExperimentCohort else {
             return url
         }

--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
@@ -380,7 +380,11 @@ final class SubscriptionFlowViewModel: ObservableObject {
         if webViewModel.url != subscriptionManager.url(for: currentSubscriptionURL).forComparison() {
             // Only enroll users into experiment for initial purchase offer.
             let urlToLoad = isInitialPurchaseOfferScreen
-                ? MonthlyFreeTrialExperiment.appendingCohortParameter(to: initialURL, resolvedBy: featureFlagger)
+                ? MonthlyFreeTrialExperiment.appendingCohortParameter(
+                    to: initialURL,
+                    resolvedBy: featureFlagger,
+                    isEligibleForFreeTrial: subscriptionManager.isUserEligibleForFreeTrial()
+                  )
                 : initialURL
             self.webViewModel.navigationCoordinator.navigateTo(url: urlToLoad)
         }

--- a/iOS/DuckDuckGoTests/MonthlyFreeTrialExperimentTests.swift
+++ b/iOS/DuckDuckGoTests/MonthlyFreeTrialExperimentTests.swift
@@ -32,26 +32,30 @@ struct MonthlyFreeTrialExperimentTests {
     private func cohortValue(in url: URL) -> String? {
         URLComponents(url: url, resolvingAgainstBaseURL: false)?
             .queryItems?
-            .first { $0.name == "experiment_mobileannualtrials_ios" }?
+            .first { $0.name == "experiment_mobileannualtrials2_ios" }?
             .value
     }
 
     @available(iOS 16, *)
-    @Test("Control cohort is appended as experiment_mobileannualtrials_ios=control", .timeLimit(.minutes(1)))
+    @Test("Control cohort is appended as experiment_mobileannualtrials2_ios=control", .timeLimit(.minutes(1)))
     func controlCohortAppendedToURL() {
         let featureFlagger = PrivacyConfig.MockFeatureFlagger(resolveCohortStub: FeatureFlag.MonthlyFreeTrialExperimentCohort.control)
 
-        let result = MonthlyFreeTrialExperiment.appendingCohortParameter(to: baseURL, resolvedBy: featureFlagger)
+        let result = MonthlyFreeTrialExperiment.appendingCohortParameter(to: baseURL,
+                                                                        resolvedBy: featureFlagger,
+                                                                        isEligibleForFreeTrial: true)
 
         #expect(cohortValue(in: result) == "control")
     }
 
     @available(iOS 16, *)
-    @Test("Treatment cohort is appended as experiment_mobileannualtrials_ios=treatment", .timeLimit(.minutes(1)))
+    @Test("Treatment cohort is appended as experiment_mobileannualtrials2_ios=treatment", .timeLimit(.minutes(1)))
     func treatmentCohortAppendedToURL() {
         let featureFlagger = PrivacyConfig.MockFeatureFlagger(resolveCohortStub: FeatureFlag.MonthlyFreeTrialExperimentCohort.treatment)
 
-        let result = MonthlyFreeTrialExperiment.appendingCohortParameter(to: baseURL, resolvedBy: featureFlagger)
+        let result = MonthlyFreeTrialExperiment.appendingCohortParameter(to: baseURL,
+                                                                        resolvedBy: featureFlagger,
+                                                                        isEligibleForFreeTrial: true)
 
         #expect(cohortValue(in: result) == "treatment")
     }
@@ -61,8 +65,24 @@ struct MonthlyFreeTrialExperimentTests {
     func unenrolledUserLeavesURLUnchanged() {
         let featureFlagger = PrivacyConfig.MockFeatureFlagger(resolveCohortStub: nil)
 
-        let result = MonthlyFreeTrialExperiment.appendingCohortParameter(to: baseURL, resolvedBy: featureFlagger)
+        let result = MonthlyFreeTrialExperiment.appendingCohortParameter(to: baseURL,
+                                                                        resolvedBy: featureFlagger,
+                                                                        isEligibleForFreeTrial: true)
 
+        #expect(cohortValue(in: result) == nil)
+        #expect(result == baseURL)
+    }
+
+    @available(iOS 16, *)
+    @Test("A user who is not eligible for a free trial is not enrolled and the URL is unchanged", .timeLimit(.minutes(1)))
+    func ineligibleUserIsNotEnrolled() {
+        let featureFlagger = PrivacyConfig.MockFeatureFlagger(resolveCohortStub: FeatureFlag.MonthlyFreeTrialExperimentCohort.treatment)
+
+        let result = MonthlyFreeTrialExperiment.appendingCohortParameter(to: baseURL,
+                                                                        resolvedBy: featureFlagger,
+                                                                        isEligibleForFreeTrial: false)
+
+        #expect(featureFlagger.didCallResolveCohort == false)
         #expect(cohortValue(in: result) == nil)
         #expect(result == baseURL)
     }

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -513,9 +513,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216629730083154?focus=true
     case systemFindInPage
 
-    /// Experiment for removing monthly free trials
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216851336490252
-    case monthlyFreeTrialExperiment
+    /// Experiment for removing monthly free trials — second run, enrolling only free-trial eligible users.
+    /// https://app.asana.com/1/137249556945/task/1217334233390728
+    case monthlyFreeTrialExperiment2
 
     /// Moves the iPad tabs bar up into the system window controls row (iOS 26+ resizable windows).
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217015452646368?focus=true
@@ -803,8 +803,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.searchTokenExperimentV2), cohortType: SearchTokenExperimentCohort.self)
         case .onboardingFlowByDownloadReasonExperiment:
             Config(source: .disabled, cohortType: OnboardingFlowByDownloadReasonExperimentCohort.self)
-        case .monthlyFreeTrialExperiment:
-            Config(source: .remoteReleasable(PrivacyProSubfeature.monthlyFreeTrialExperiment), cohortType: MonthlyFreeTrialExperimentCohort.self)
+        case .monthlyFreeTrialExperiment2:
+            Config(source: .remoteReleasable(PrivacyProSubfeature.monthlyFreeTrialExperiment2), cohortType: MonthlyFreeTrialExperimentCohort.self)
         case .genericBackgroundTask:
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.genericBackgroundTask))
         case .crashCollectionLimitCallStackTreeDepth:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217334233390728

### Description
Replaces the stopped `monthlyFreeTrialExperiment` with a new experiment, `monthlyFreeTrialExperiment2`, so the second run's data is separate from the first. Cohorts stay `control` / `treatment`; the purchase URL parameter becomes `experiment_mobileannualtrials2_ios`.

Users who are not eligible for a free trial are no longer enrolled — both cohorts look identical to them, so enrolling them only dilutes the results.

Requires a privacy config update adding the `monthlyFreeTrialExperiment2` subfeature. The FE needs to accept the new URL parameter.

### Testing Steps
1. Debug menu → Feature Flags Overrides → set `monthlyFreeTrialExperiment2` to `treatment`.
2. Settings → Privacy Pro → open the subscription purchase screen → the monthly plan shows no free trial.
3. Repeat with `control` → the monthly plan shows the free trial.
4. Sign in to an Apple ID that has already used the trial and reopen the purchase screen → no `experiment_mobileannualtrials2_ios` parameter is appended to the URL.

### Impact
Low

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped experiment rename and enrollment gating on subscription purchase URLs; requires privacy config and FE support for the new query parameter.
> 
> **Overview**
> Replaces the stopped **`monthlyFreeTrialExperiment`** with **`monthlyFreeTrialExperiment2`** so the second run’s analytics stay separate from the first. Cohorts remain `control` / `treatment`; the subscription purchase URL cohort query param is now **`experiment_mobileannualtrials2_ios`**. Privacy config, iOS feature flags, `IOSMonthlyFreeTrialDecider`, and `URL.forComparison()` filtering are updated accordingly.
> 
> **Enrollment is limited to users who can actually get a monthly free trial.** `MonthlyFreeTrialExperiment.appendingCohortParameter` now takes `isEligibleForFreeTrial`; when false it returns the URL unchanged and does not call `resolveCohort`. `SubscriptionFlowViewModel` passes `subscriptionManager.isUserEligibleForFreeTrial()` on the initial purchase offer screen only.
> 
> The first experiment is removed from legacy search-retention experiment pixels in `StatisticsLoader`. Tests cover the new param name and ineligible-user behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19cb42314087aff80a990f3c9c6cd187f3a1fe57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->