### PR TITLE
Delete aiChatSyncPromo feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -603,7 +603,6 @@ public enum SyncSubfeature: String, PrivacySubfeature {
     case syncCreditCards
     case syncIdentities
     case aiChatSync
-    case aiChatSyncPromo
     case allowSingleDeviceOnConnectScreen
     case scopedAccessCredentials
     case canUseV2ConnectFlow

--- a/iOS/DuckDuckGo/SyncPromoManager.swift
+++ b/iOS/DuckDuckGo/SyncPromoManager.swift
@@ -127,7 +127,6 @@ final class SyncPromoManager: SyncPromoManaging {
             if syncService.authState == .inactive,
                featureFlagger.isFeatureOn(.sync),
                featureFlagger.isFeatureOn(.aiChatSync),
-               featureFlagger.isFeatureOn(.aiChatSyncPromo),
                privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .duckAiChatHistory),
                syncPromoAIChatDismissed == nil,
                syncPromoAIChatImpressions < Self.aiChatImpressionCap,

--- a/iOS/DuckDuckGoTests/SyncPromoManagerTests.swift
+++ b/iOS/DuckDuckGoTests/SyncPromoManagerTests.swift
@@ -227,7 +227,7 @@ final class SyncPromoManagerTests: XCTestCase {
     // MARK: - AI Chat Tests
 
     func testWhenAllConditionsMetThenShouldPresentPromoForAIChat() {
-        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync])
         syncService.authState = .inactive
 
         let syncPromoManager = SyncPromoManager(syncService: syncService,
@@ -239,7 +239,7 @@ final class SyncPromoManagerTests: XCTestCase {
     }
 
     func testWhenSyncFeatureFlagDisabledThenShouldNotPresentPromoForAIChat() {
-        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.aiChatSync, .aiChatSyncPromo])
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.aiChatSync])
         syncService.authState = .inactive
 
         let syncPromoManager = SyncPromoManager(syncService: syncService,
@@ -251,7 +251,7 @@ final class SyncPromoManagerTests: XCTestCase {
     }
 
     func testWhenAIChatHistoryIsEmptyThenShouldNotPresentPromoForAIChat() {
-        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync])
         syncService.authState = .inactive
 
         let syncPromoManager = SyncPromoManager(syncService: syncService,
@@ -262,20 +262,8 @@ final class SyncPromoManagerTests: XCTestCase {
         XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.aiChat, count: 0))
     }
 
-    func testWhenAIChatSyncPromoFeatureFlagDisabledThenShouldNotPresentPromoForAIChat() {
-        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync])
-        syncService.authState = .inactive
-
-        let syncPromoManager = SyncPromoManager(syncService: syncService,
-                                                featureFlagger: featureFlagger,
-                                                privacyConfigurationManager: makePrivacyConfigManager(historyEnabled: true))
-        syncPromoManager.resetPromos()
-
-        XCTAssertFalse(syncPromoManager.shouldPresentPromoFor(.aiChat, count: 1))
-    }
-
     func testWhenAIChatSyncFeatureFlagDisabledThenShouldNotPresentPromoForAIChat() {
-        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSyncPromo])
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync])
         syncService.authState = .inactive
 
         let syncPromoManager = SyncPromoManager(syncService: syncService,
@@ -287,7 +275,7 @@ final class SyncPromoManagerTests: XCTestCase {
     }
 
     func testWhenAIChatHistoryDisabledThenShouldNotPresentPromoForAIChat() {
-        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync])
         syncService.authState = .inactive
 
         let syncPromoManager = SyncPromoManager(syncService: syncService,
@@ -299,7 +287,7 @@ final class SyncPromoManagerTests: XCTestCase {
     }
 
     func testWhenSyncServiceAuthStateActiveThenShouldNotPresentPromoForAIChat() {
-        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync])
         syncService.authState = .active
 
         let syncPromoManager = SyncPromoManager(syncService: syncService,
@@ -311,7 +299,7 @@ final class SyncPromoManagerTests: XCTestCase {
     }
 
     func testWhenSyncPromoAIChatDismissedThenShouldNotPresentPromoForAIChat() {
-        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync])
         syncService.authState = .inactive
 
         let syncPromoManager = SyncPromoManager(syncService: syncService,
@@ -324,7 +312,7 @@ final class SyncPromoManagerTests: XCTestCase {
     }
 
     func testWhenImpressionsBelowCapThenShouldPresentPromoForAIChat() {
-        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync])
         syncService.authState = .inactive
 
         let syncPromoManager = SyncPromoManager(syncService: syncService,
@@ -339,7 +327,7 @@ final class SyncPromoManagerTests: XCTestCase {
     }
 
     func testWhenImpressionsReachCapThenShouldNotPresentPromoForAIChat() {
-        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync])
         syncService.authState = .inactive
 
         let syncPromoManager = SyncPromoManager(syncService: syncService,
@@ -355,7 +343,7 @@ final class SyncPromoManagerTests: XCTestCase {
     }
 
     func testWhenResetPromosThenAIChatImpressionsAreCleared() {
-        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync])
         syncService.authState = .inactive
 
         let syncPromoManager = SyncPromoManager(syncService: syncService,
@@ -410,7 +398,7 @@ final class SyncPromoManagerTests: XCTestCase {
     }
 
     func testRecordImpressionForAIChatWhenCapReachedFiresDismissedPixelWithImpressionCapReason() {
-        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync, .aiChatSyncPromo])
+        let featureFlagger = createFeatureFlagger(withFeatureFlagsEnabled: [.sync, .aiChatSync])
         syncService.authState = .inactive
 
         let syncPromoManager = SyncPromoManager(syncService: syncService,

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -310,9 +310,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212980785692847?focus=true
     case aiChatSync
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214965000466711?focus=true
-    case aiChatSyncPromo
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1212745919983886?focus=true
     case aiChatSuggestions
 
@@ -787,8 +784,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.multiplePageContexts))
         case .aiChatSync:
             Config(source: .remoteReleasable(SyncSubfeature.aiChatSync))
-        case .aiChatSyncPromo:
-            Config(defaultValue: .enabled, source: .remoteReleasable(SyncSubfeature.aiChatSyncPromo))
         case .aiChatSuggestions:
             Config(defaultValue: .enabled, source: .remoteReleasable(DuckAiChatHistorySubfeature.featureEnabled))
         case .aiChatNativeChatHistory:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1214965000466711

### Description

The `aiChatSyncPromo` flag has been enabled by default (for 7.228.0+) for some time and is safe to remove from the client. Its default value was `true`, so on current/new builds the Duck.ai sync promo is now permanently on. This removes the flag definition, its `SyncSubfeature` entry, the gating check in `SyncPromoManager`, and updates the related tests.

Note: the `aiChatSyncPromo` subfeature is intentionally **kept** in the remote privacy config. Its `minSupportedVersion: 7.228.0` gate is what suppresses the promo on pre-7.228.0 builds (where it previously showed back-to-back with the O-O paid Duck.ai promo). Because the app defaults this flag to enabled when the subfeature is absent, deleting the remote entry would re-enable the promo on those old builds — so the override must remain until pre-7.228.0 usage ages out.

### Testing Steps
1. On a device not signed into Sync, open Duck.ai with at least one recent chat → the "Access your chats across your devices using Sync & Backup." promo card appears above the recent chats list (unchanged behaviour).

### Impact
Low — the flag was already enabled by default on supported builds; this removes client-side dead code without altering remote config.