### PR TITLE
Update errorActionButton appearance for rebrand

### DIFF
--- a/iOS/LocalPackages/DuckUI/Package.swift
+++ b/iOS/LocalPackages/DuckUI/Package.swift
@@ -33,7 +33,6 @@ let package = Package(
     dependencies: [
         .package(path: "../../../SharedPackages/Infrastructure/DesignResourcesKit"),
         .package(path: "../../../SharedPackages/Infrastructure/DesignResourcesKitIcons"),
-        .package(path: "../../../SharedPackages/Infrastructure/MetricBuilder"),
         .package(path: "../../../SharedPackages/UIComponents"),
     ],
     targets: [
@@ -42,7 +41,6 @@ let package = Package(
             dependencies: [
                 "DesignResourcesKit",
                 "DesignResourcesKitIcons",
-                "MetricBuilder",
                 "UIComponents",
             ],
             swiftSettings: [

--- a/iOS/LocalPackages/DuckUI/Sources/DuckUI/Button+UIKit.swift
+++ b/iOS/LocalPackages/DuckUI/Sources/DuckUI/Button+UIKit.swift
@@ -17,7 +17,6 @@
 //  limitations under the License.
 //
 
-import MetricBuilder
 import SwiftUI
 import UIKit
 
@@ -43,7 +42,7 @@ private extension UIButton {
     func applyFilledStyle(colors: PrimaryButtonColors, compact: Bool) {
         var buttonConfiguration = UIButton.Configuration.filled()
         buttonConfiguration.contentInsets = compact ? ButtonAppearanceConstants.compactContentInsets : ButtonAppearanceConstants.contentInsets
-        buttonConfiguration.background.cornerRadius = ContainerMetrics.cornerRadius
+        buttonConfiguration.cornerStyle = .capsule
 
         configuration = buttonConfiguration
         configurationUpdateHandler = { button in
@@ -52,7 +51,7 @@ private extension UIButton {
             let background: UIColor
             let foreground: UIColor
             if !button.isEnabled {
-                background = UIColor(colors.disabled)
+                background = UIColor(colors.disabled).withDisabledOpacity
                 foreground = UIColor(colors.textDisabled)
             } else if button.isHighlighted {
                 background = UIColor(colors.pressed)
@@ -62,12 +61,14 @@ private extension UIButton {
                 foreground = UIColor(colors.text)
             }
 
+            let titleFont = ButtonAppearanceConstants.titleFont(compact: compact, traits: button.traitCollection)
+
             // Set resolved color rather than baseBackgroundColor, so UIKit doesn't apply extra dimming
             configuration.background.backgroundColor = background
             configuration.baseForegroundColor = foreground
             configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
                 var transformed = incoming
-                transformed.font = compact ? ButtonAppearanceConstants.compactTitleFont : ButtonAppearanceConstants.titleFont
+                transformed.font = titleFont
                 transformed.foregroundColor = foreground
                 return transformed
             }
@@ -77,9 +78,26 @@ private extension UIButton {
     }
 }
 
+private extension UIColor {
+    var withDisabledOpacity: UIColor {
+        UIColor { [self] traits in
+            resolvedColor(with: traits).withAlphaComponent(Consts.disabledOpacity)
+        }
+    }
+}
+
 private enum ButtonAppearanceConstants {
     static let compactContentInsets: NSDirectionalEdgeInsets = NSDirectionalEdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16)
     static let contentInsets: NSDirectionalEdgeInsets = NSDirectionalEdgeInsets(top: 16, leading: 24, bottom: 16, trailing: 24)
-    static let compactTitleFont: UIFont = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .subheadline) .pointSize, weight: .medium)
-    static let titleFont: UIFont = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize, weight: .medium)
+
+    /// The UIKit equivalent of the SwiftUI styles' `ddgButtonDynamicTypeCap()`, capping the font size at `DynamicTypeSize.accessibility3`
+    static let maximumContentSizeCategory: UIContentSizeCategory = .accessibilityExtraLarge
+
+    static func titleFont(compact: Bool, traits: UITraitCollection) -> UIFont {
+        let textStyle: UIFont.TextStyle = compact ? .subheadline : .body
+        let maximumTraits = UITraitCollection(preferredContentSizeCategory: maximumContentSizeCategory)
+        let pointSize = min(UIFont.preferredFont(forTextStyle: textStyle, compatibleWith: traits).pointSize,
+                            UIFont.preferredFont(forTextStyle: textStyle, compatibleWith: maximumTraits).pointSize)
+        return .systemFont(ofSize: pointSize, weight: .medium)
+    }
 }

--- a/iOS/LocalPackages/DuckUI/Sources/DuckUI/Button.swift
+++ b/iOS/LocalPackages/DuckUI/Sources/DuckUI/Button.swift
@@ -24,7 +24,7 @@ import UIComponents
 
 // MARK: - Shared colors
 
-internal struct PrimaryButtonColors {
+struct PrimaryButtonColors {
     let standard: Color
     let pressed: Color
     let disabled: Color
@@ -792,7 +792,7 @@ public struct GhostAltButtonStyle: ButtonStyle {
 
 // MARK: - Constants
 
-private enum Consts {
+enum Consts {
     static let legacyCornerRadius: CGFloat = 12
     static let legacyHeight: CGFloat = 50
     static let rebrandedHeightLarge: CGFloat = 50


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214749231578703/task/1217244101759297?focus=true
Tech Design URL:
CC:

### Description

This PR simply updates the errorActionButton on the webview error screen to use a new rebranded appearance.

| Light | Dark |
|--------|--------|
| <img alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-12 at 10 49 52" src="https://github.com/user-attachments/assets/846151cf-83a8-4a54-ac77-01f3c882fd00" /> | <img alt="simulator_screenshot_83AC35F7-E17A-457F-BE8F-943A1611A775" src="https://github.com/user-attachments/assets/ca40cbd8-c05b-4291-aa9e-3e47c48ebbba" /> |

### Testing Steps

1. In `TabTerminationErrorPage.swift` override `var terminationCount: Int` to just return `1`.
2. Build and run on iOS
3. Load a webpage in the DDG browser
4. In your terminal, run `pgrep -lf WebContent` – look for the simulator's webcontent processes, and run `kill -9 {pid}` to kill it / them.
5. You should see the error in your browser. Check the button appearance in both light and dark mode.

Note: I kept the old appearance around, but I plan to remove the non-rebranded / legacy code from the iOS app very soon.


### Impact

Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only button styling updates in DuckUI with no auth, data, or security impact.
> 
> **Overview**
> Aligns **UIKit** filled button styles in `DuckUI` with the rebranded SwiftUI look used by screens like the webview error action button.
> 
> Switches corners to **capsule**, applies the shared disabled opacity, and caps Dynamic Type for title fonts to match `ddgButtonDynamicTypeCap()`. Removes the `MetricBuilder` dependency (previously used for corner radius) and widens `PrimaryButtonColors` / `Consts` visibility so UIKit can reuse them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 642392b07b9e1c844cc16c7d7325f1d4a1ea1371. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->