### PR TITLE
Rename PixelKitEvent to PixelKit.Event

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -12,9 +12,9 @@ When a PR adds or modifies pixel events in Swift, verify that a corresponding pi
 
 A PR introduces a new pixel if it adds or modifies any of the following:
 
-- **iOS:** A new case or changed `name` string in `iOS/Core/PixelEvent.swift`, or in any enum conforming to `PixelKitEvent` under `iOS/`.
-- **macOS:** A new case or changed `name` string in any enum conforming to `PixelKitEvent` under `macOS/` (e.g. `UpdateFlowPixels.swift`, `CrashReportPixels.swift`).
-- **Shared packages:** A new case or changed `name` in any type conforming to `PixelKitEvent` under `SharedPackages/`.
+- **iOS:** A new case or changed `name` string in `iOS/Core/PixelEvent.swift`, or in any enum conforming to `PixelKit.Event` under `iOS/`.
+- **macOS:** A new case or changed `name` string in any enum conforming to `PixelKit.Event` under `macOS/` (e.g. `UpdateFlowPixels.swift`, `CrashReportPixels.swift`).
+- **Shared packages:** A new case or changed `name` in any type conforming to `PixelKit.Event` under `SharedPackages/`.
 
 The pixel name is the string returned by the `name` computed property (e.g. `"m_mac_default-browser"`, `"m_autocomplete_click_phrase"`).
 

--- a/.cursor/rules/pixel-definitions.mdc
+++ b/.cursor/rules/pixel-definitions.mdc
@@ -81,8 +81,8 @@ Check the pixel event's `parameters` computed property in Swift for any addition
 ### Where to Look in Swift
 
 - **iOS:** `iOS/Core/PixelEvent.swift` defines pixel names. `iOS/Core/Pixel.swift` has `PixelParameters` constants. Check the `parameters` and `standardParameters` properties on the pixel event enum.
-- **macOS:** `macOS/DuckDuckGo/Statistics/GeneralPixel.swift` defines many pixel names, parameters, and standard parameters. However, pixel events can also be defined in dedicated files (e.g. `UpdateFlowPixels.swift`, `CrashReportPixels.swift`) — search for types conforming to `PixelKitEvent`.
-- **Shared:** `SharedPackages/BrowserServicesKit/Sources/PixelKit/` contains `PixelKit.swift` (firing logic) and `PixelKitEvent.swift` (protocol).
+- **macOS:** `macOS/DuckDuckGo/Statistics/GeneralPixel.swift` defines many pixel names, parameters, and standard parameters. However, pixel events can also be defined in dedicated files (e.g. `UpdateFlowPixels.swift`, `CrashReportPixels.swift`) — search for types conforming to `PixelKit.Event`.
+- **Shared:** `SharedPackages/BrowserServicesKit/Sources/PixelKit/` contains `PixelKit.swift` (firing logic) and `PixelKit+Event.swift` (the `PixelKit.Event` protocol).
 
 ## Reusing Parameters from the Dictionary
 

--- a/.cursor/rules/pixels.mdc
+++ b/.cursor/rules/pixels.mdc
@@ -130,15 +130,17 @@ case .syncLocalTimestampResolutionTriggered(let feature):
 
 ### macOS Pixels (PixelKit)
 
-macOS uses `PixelKitEvent` protocol, typically in feature-specific files. The implementation of the protocol looks like this:
+macOS uses the `PixelKit.Event` protocol, typically in feature-specific files. The protocol is declared like this:
 
 ```swift
-// SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKitEvent.swift
-public protocol PixelKitEvent {
-    var name: String { get }
-    var standardParameters: [PixelKitStandardParameter]? { get }
-    var parameters: [String: String]? { get }
-    var error: NSError? { get }
+// SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit+Event.swift
+extension PixelKit {
+    public protocol Event {
+        var name: String { get }
+        var standardParameters: [PixelKitStandardParameter]? { get }
+        var parameters: [String: String]? { get }
+        var error: NSError? { get }
+    }
 }
 ```
 
@@ -146,7 +148,7 @@ An example implementation of this protocol is:
 
 ```swift
 // macOS/DuckDuckGo/Statistics/SubscriptionPixel.swift
-enum SubscriptionPixel: PixelKitEvent {
+enum SubscriptionPixel: PixelKit.Event {
     case subscriptionActive(AuthVersion)
     case subscriptionPurchaseAttempt
     case subscriptionPurchaseSuccess

--- a/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricPixel.swift
+++ b/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricPixel.swift
@@ -38,7 +38,7 @@ enum AttributedMetricPixelName: String {
 /// - Appending app/OS version in the User-Agent header
 /// - Send default suffixes such as [phone|tablet]  or [store|direct]
 /// See https://app.asana.com/1/137249556945/project/72649045549333/task/1210849966244847?focus=true
-enum AttributedMetricPixel: PixelKitEvent {
+enum AttributedMetricPixel: PixelKit.Event {
 
     // Metrics
     case userRetentionWeek(origin: String?, installDate: String?, defaultBrowser: Bool, count: Int, bucketVersion: Int)

--- a/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Model/Event.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/Model/Event.swift
@@ -36,7 +36,7 @@ public extension PixelKit {
     }
 }
 
-public enum Event: PixelKitEvent {
+public enum Event: PixelKit.Event {
     case errorPageShown(category: ThreatKind, clientSideHit: Bool?)
     case visitSite(category: ThreatKind)
     case leaveSite(category: ThreatKind)

--- a/SharedPackages/BrowserServicesKit/Sources/PixelExperimentKit/PixelExperimentKit.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelExperimentKit/PixelExperimentKit.swift
@@ -23,7 +23,7 @@ import Foundation
 public typealias ConversionWindow = ClosedRange<Int>
 public typealias NumberOfCalls = Int
 
-struct ExperimentEvent: PixelKitEvent {
+struct ExperimentEvent: PixelKit.Event {
     var name: String
     var parameters: [String: String]?
     var standardParameters: [PixelKitStandardParameter]? {
@@ -48,7 +48,7 @@ extension PixelKit {
     struct ExperimentConfig {
         static var featureFlagger: FeatureFlagger?
         static var eventTracker: ExperimentEventTracking = ExperimentEventTracker()
-        static var fireFunction: (PixelKitEvent, PixelKit.Frequency, Bool) -> Void = { event, frequency, includeAppVersion in
+        static var fireFunction: (PixelKit.Event, PixelKit.Frequency, Bool) -> Void = { event, frequency, includeAppVersion in
             fire(event, frequency: frequency, includeAppVersionParameter: includeAppVersion)
         }
     }
@@ -57,7 +57,7 @@ extension PixelKit {
     public static func configureExperimentKit(
         featureFlagger: FeatureFlagger,
         eventTracker: ExperimentEventTracking = ExperimentEventTracker(),
-        fire: @escaping (PixelKitEvent, PixelKit.Frequency, Bool) -> Void = { event, frequency, includeAppVersion in
+        fire: @escaping (PixelKit.Event, PixelKit.Frequency, Bool) -> Void = { event, frequency, includeAppVersion in
             fire(event, frequency: frequency, includeAppVersionParameter: includeAppVersion)
         }
     ) {

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/DebugEvent.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/DebugEvent.swift
@@ -20,11 +20,11 @@ import Common
 import FoundationExtensions
 import Foundation
 
-/// Implementation of ``PixelKitEvent`` with specific logic for debug events.
-public final class DebugEvent: PixelKitEvent {
+/// Implementation of ``PixelKit.Event`` with specific logic for debug events.
+public final class DebugEvent: PixelKit.Event {
     public enum EventType {
         case assertionFailure(message: String, file: StaticString, line: UInt)
-        case custom(_ event: PixelKitEvent)
+        case custom(_ event: PixelKit.Event)
     }
 
     public let eventType: EventType
@@ -37,7 +37,7 @@ public final class DebugEvent: PixelKitEvent {
         self.standardParameters = standardParameters
     }
 
-    public init(_ event: PixelKitEvent, error: Error? = nil) {
+    public init(_ event: PixelKit.Event, error: Error? = nil) {
         self.eventType = .custom(event)
         self.error = error
         self.standardParameters = event.standardParameters

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/OSDistributionPixel.swift
@@ -26,7 +26,7 @@ import Common
 /// "low monthly search traffic" metric counts total search + AI-query *traffic*, not active users.
 ///
 /// Tech design: https://app.asana.com/1/137249556945/project/1208546505108826/task/1214950124367783?focus=true
-public struct OSDistributionPixel: PixelKitEvent {
+public struct OSDistributionPixel: PixelKit.Event {
 
     public enum Metric: String {
         case client

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelFiring+Async.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelFiring+Async.swift
@@ -25,7 +25,7 @@ extension PixelFiring {
     /// - Returns: `true` if a request was fired, `false` if it was suppressed by frequency rules.
     /// - Throws: the underlying error if firing the request failed.
     @discardableResult
-    public func fireAsync(_ event: PixelKitEvent,
+    public func fireAsync(_ event: PixelKit.Event,
                           frequency: PixelKit.Frequency = .standard,
                           includeAppVersionParameter: Bool = true,
                           withAdditionalParameters parameters: [String: String]? = nil,

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelFiring.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelFiring.swift
@@ -18,7 +18,7 @@
 
 /// Protocol to support mocking pixel firing.
 public protocol PixelFiring {
-    func fire(_ event: PixelKitEvent,
+    func fire(_ event: PixelKit.Event,
               frequency: PixelKit.Frequency,
               includeAppVersionParameter: Bool,
               withAdditionalParameters: [String: String]?,
@@ -28,40 +28,40 @@ public protocol PixelFiring {
 }
 
 extension PixelFiring {
-    public func fire(_ event: PixelKitEvent) {
+    public func fire(_ event: PixelKit.Event) {
         fire(event, frequency: .standard, includeAppVersionParameter: true)
     }
 
-    public func fire(_ event: PixelKitEvent,
+    public func fire(_ event: PixelKit.Event,
                      frequency: PixelKit.Frequency) {
         fire(event, frequency: frequency, includeAppVersionParameter: true, withAdditionalParameters: nil, withNamePrefix: nil, doNotEnforcePrefix: false, onComplete: { _, _ in })
     }
 
-    public func fire(_ event: PixelKitEvent,
+    public func fire(_ event: PixelKit.Event,
                      frequency: PixelKit.Frequency,
                      doNotEnforcePrefix: Bool) {
         fire(event, frequency: frequency, includeAppVersionParameter: true, withAdditionalParameters: nil, withNamePrefix: nil, doNotEnforcePrefix: doNotEnforcePrefix, onComplete: { _, _ in })
     }
 
-    public func fire(_ event: PixelKitEvent,
+    public func fire(_ event: PixelKit.Event,
                      frequency: PixelKit.Frequency,
                      includeAppVersionParameter: Bool) {
         fire(event, frequency: frequency, includeAppVersionParameter: includeAppVersionParameter, withAdditionalParameters: nil, withNamePrefix: nil, doNotEnforcePrefix: false, onComplete: { _, _ in })
     }
 
-    public func fire(_ event: PixelKitEvent,
+    public func fire(_ event: PixelKit.Event,
                      frequency: PixelKit.Frequency,
                      onComplete: @escaping PixelKit.CompletionBlock) {
         fire(event, frequency: frequency, includeAppVersionParameter: true, withAdditionalParameters: nil, withNamePrefix: nil, doNotEnforcePrefix: false, onComplete: onComplete)
     }
 
-    public func fire(_ event: PixelKitEvent,
+    public func fire(_ event: PixelKit.Event,
                      frequency: PixelKit.Frequency,
                      withAdditionalParameters parameters: [String: String]?) {
         fire(event, frequency: frequency, includeAppVersionParameter: true, withAdditionalParameters: parameters, withNamePrefix: nil, doNotEnforcePrefix: false, onComplete: { _, _ in })
     }
 
-    public func fire(_ event: PixelKitEvent,
+    public func fire(_ event: PixelKit.Event,
                      frequency: PixelKit.Frequency,
                      withAdditionalParameters parameters: [String: String]?,
                      withNamePrefix namePrefix: String?) {
@@ -70,7 +70,7 @@ extension PixelFiring {
 }
 
 extension PixelKit: PixelFiring {
-    public func fire(_ event: PixelKitEvent,
+    public func fire(_ event: PixelKit.Event,
                      frequency: PixelKit.Frequency,
                      includeAppVersionParameter: Bool,
                      withAdditionalParameters parameters: [String: String]?,

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit+Event.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit+Event.swift
@@ -1,5 +1,5 @@
 //
-//  PixelKitEvent.swift
+//  PixelKit.Event.swift
 //
 //  Copyright © 2023 DuckDuckGo. All rights reserved.
 //
@@ -24,17 +24,25 @@ public enum PixelKitStandardParameter {
     case pixelSource
 }
 
-/// An event that can be fired using PixelKit.
-public protocol PixelKitEvent {
-    var name: String { get }
-    var standardParameters: [PixelKitStandardParameter]? { get }
-    var parameters: [String: String]? { get }
-    /// Automatically implemented by the below extension using reflection, please implement the error, if needed as enum parameter
-    var error: NSError? { get }
+extension PixelKit {
+
+    /// An event that can be fired using PixelKit.
+    public protocol Event {
+        var name: String { get }
+        var standardParameters: [PixelKitStandardParameter]? { get }
+        var parameters: [String: String]? { get }
+        /// Automatically implemented by the below extension using reflection, please implement the error, if needed as enum parameter
+        var error: NSError? { get }
+    }
 }
 
-/// Extract Error parameter from the PixelKitEvent, only one error is supported, if multiple errors are found we assert
-public extension PixelKitEvent {
+/// Compatibility alias for the pre-rename spelling. Retained so out-of-tree conformances keep
+/// compiling; every in-tree conformance uses `PixelKit.Event`. Removed once the migration lands.
+@available(*, deprecated, renamed: "PixelKit.Event")
+public typealias PixelKitEvent = PixelKit.Event
+
+/// Extract Error parameter from the PixelKit.Event, only one error is supported, if multiple errors are found we assert
+public extension PixelKit.Event {
 
     var error: NSError? {
         let mirror = Mirror(reflecting: self)
@@ -51,7 +59,7 @@ public extension PixelKitEvent {
             for child in associatedMirror.children {
                 if let error = child.value as? NSError {
                     guard resultError == nil else {
-                        assertionFailure("Multiple errors found in PixelKitEvent, only one error is supported")
+                        assertionFailure("Multiple errors found in PixelKit.Event, only one error is supported")
                         return resultError
                     }
                     resultError = error

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit+Event.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit+Event.swift
@@ -36,11 +36,6 @@ extension PixelKit {
     }
 }
 
-/// Compatibility alias for the pre-rename spelling. Retained so out-of-tree conformances keep
-/// compiling; every in-tree conformance uses `PixelKit.Event`. Removed once the migration lands.
-@available(*, deprecated, renamed: "PixelKit.Event")
-public typealias PixelKitEvent = PixelKit.Event
-
 /// Extract Error parameter from the PixelKit.Event, only one error is supported, if multiple errors are found we assert
 public extension PixelKit.Event {
 

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit+Event.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit+Event.swift
@@ -1,5 +1,5 @@
 //
-//  PixelKit.Event.swift
+//  PixelKit+Event.swift
 //
 //  Copyright © 2023 DuckDuckGo. All rights reserved.
 //

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
@@ -269,7 +269,7 @@ public final class PixelKit {
     // MARK: - Public Fire
 
     /// Main function for firing pixels
-    public func fire(_ event: PixelKitEvent,
+    public func fire(_ event: PixelKit.Event,
                      frequency: Frequency = .standard,
                      withHeaders headers: [String: String]? = nil,
                      withAdditionalParameters params: [String: String]? = nil,
@@ -325,7 +325,7 @@ public final class PixelKit {
              onComplete: onComplete)
     }
 
-    public static func fire(_ event: PixelKitEvent,
+    public static func fire(_ event: PixelKit.Event,
                             frequency: Frequency = .standard,
                             withHeaders headers: [String: String] = [:],
                             withAdditionalParameters parameters: [String: String]? = nil,
@@ -764,7 +764,7 @@ public final class PixelKit {
             effectiveFireRequest(pixelName, headers, parameters, allowedQueryReservedCharacters, callBackOnMainThread, onComplete)
         }
 
-    private func prefixedAndSuffixedName(for event: PixelKitEvent, namePrefix: String?, doNotEnforcePrefix: Bool = false) -> String {
+    private func prefixedAndSuffixedName(for event: PixelKit.Event, namePrefix: String?, doNotEnforcePrefix: Bool = false) -> String {
 
         if let pixelWithCustomPrefix = event as? PixelKitEventWithCustomPrefix {
             return pixelWithCustomPrefix.namePrefix + event.name + platformSuffix
@@ -843,11 +843,11 @@ public final class PixelKit {
         Self.shared?.cohort(from: cohortLocalDate, dateGenerator: dateGenerator) ?? ""
     }
 
-    public static func pixelLastFireDate(event: PixelKitEvent, frequency: Frequency, namePrefix: String? = nil) throws -> Date? {
+    public static func pixelLastFireDate(event: PixelKit.Event, frequency: Frequency, namePrefix: String? = nil) throws -> Date? {
         try Self.shared?.pixelLastFireDate(event: event, frequency: frequency, namePrefix: namePrefix)
     }
 
-    public func pixelLastFireDate(event: PixelKitEvent, frequency: Frequency, namePrefix: String? = nil) throws -> Date? {
+    public func pixelLastFireDate(event: PixelKit.Event, frequency: Frequency, namePrefix: String? = nil) throws -> Date? {
         try pixelLastFireDate(pixelName: prefixedAndSuffixedName(for: event, namePrefix: namePrefix), frequency: frequency)
     }
 
@@ -967,7 +967,7 @@ public final class PixelKit {
         }
     }
 
-    public func clearFrequencyHistoryFor(pixel: PixelKitEvent) {
+    public func clearFrequencyHistoryFor(pixel: PixelKit.Event) {
         guard let name = Self.shared?.userDefaultsKeyName(forPixelName: pixel.name) else {
             return
         }

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKitEventWithCustomPrefix.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKitEventWithCustomPrefix.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-/// New version of this protocol that allows us to maintain backwards-compatibility with PixelKitEvent
+/// New version of this protocol that allows us to maintain backwards-compatibility with PixelKit.Event
 ///
 /// This allows us to introduce support for new features without having to immediately migrate every other pixel to it.
 ///

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/WideEvent/WideEvent.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/WideEvent/WideEvent.swift
@@ -283,7 +283,7 @@ public final class WideEvent: WideEventManaging {
     }
 }
 
-public struct WideEventPixelKitEvent: PixelKitEvent {
+public struct WideEventPixelKitEvent: PixelKit.Event {
     public let name: String
     public let parameters: [String: String]?
     public let standardParameters: [PixelKitStandardParameter]?

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/WideEvent/WideEventFailureEvent.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/WideEvent/WideEventFailureEvent.swift
@@ -32,7 +32,7 @@ public enum WideEventFailureEvent {
     case discardFailed(pixelName: String, error: Error)
 }
 
-extension WideEventFailureEvent: PixelKitEvent, PixelKitEventWithCustomPrefix {
+extension WideEventFailureEvent: PixelKit.Event, PixelKitEventWithCustomPrefix {
     public var namePrefix: String {
 #if os(macOS)
         return "m_mac_"

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKitTestingUtilities/PixelKitMock.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKitTestingUtilities/PixelKitMock.swift
@@ -34,7 +34,7 @@ public final class PixelKitMock: PixelFiring {
         self.expectedFireCalls = expectedFireCalls
     }
 
-    public func fire(_ event: PixelKitEvent,
+    public func fire(_ event: PixelKit.Event,
                      frequency: PixelKit.Frequency,
                      includeAppVersionParameter: Bool,
                      withAdditionalParameters parameters: [String: String]?,
@@ -56,14 +56,14 @@ public final class PixelKitMock: PixelFiring {
 }
 
 public struct ExpectedFireCall: Equatable {
-    public let pixel: PixelKitEvent
+    public let pixel: PixelKit.Event
     public let frequency: PixelKit.Frequency
     public let additionalParameters: [String: String]?
     public let namePrefix: String?
     public let doNotEnforcePrefix: Bool
     public let includeAppVersionParameter: Bool
 
-    public init(pixel: PixelKitEvent,
+    public init(pixel: PixelKit.Event,
                 frequency: PixelKit.Frequency,
                 additionalParameters: [String: String]? = nil,
                 namePrefix: String? = nil,

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKitTestingUtilities/XCTestCase+PixelKit.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKitTestingUtilities/XCTestCase+PixelKit.swift
@@ -57,7 +57,7 @@ public extension XCTestCase {
     /// They're not a complete list of parameters for the event, as the fire call may contain extra information
     /// that results in additional parameters.  Ideally we want most (if not all) that information to eventually
     /// make part of the pixel definition.
-    func knownExpectedParameters(for event: PixelKitEvent) -> [String: String] {
+    func knownExpectedParameters(for event: PixelKit.Event) -> [String: String] {
         var expectedParameters = [String: String]()
 
         if let error = event.error {
@@ -89,7 +89,7 @@ public extension XCTestCase {
 
     // MARK: - Pixel Firing Expectations
 
-    func fire(_ event: PixelKitEvent,
+    func fire(_ event: PixelKit.Event,
               frequency: PixelKit.Frequency,
               doNotEnforcePrefix: Bool = false,
               and expectations: PixelFireExpectations,
@@ -105,7 +105,7 @@ public extension XCTestCase {
     /// Provides some snapshot of a fired pixel so that external libraries can validate all the expected info is included.
     ///
     /// This method also checks that there is internal consistency in the expected fields.
-    func verifyThat(_ event: PixelKitEvent,
+    func verifyThat(_ event: PixelKit.Event,
                     frequency: PixelKit.Frequency,
                     doNotEnforcePrefix: Bool = false,
                     meets expectations: PixelFireExpectations,

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/SiteLoadingPerformancePixel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/SiteLoadingPerformancePixel.swift
@@ -20,7 +20,7 @@ import Foundation
 import PixelKit
 
 /// Tracks site loading performance metrics received via push notifications from Content Scope Scripts
-enum SiteLoadingPerformancePixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+enum SiteLoadingPerformancePixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
 
     // MARK: - Parameter Names
 

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/SiteLoadingPerformanceSubfeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/SiteLoadingPerformanceSubfeature.swift
@@ -36,10 +36,10 @@ public final class SiteLoadingPerformanceSubfeature: Subfeature {
     public weak var broker: UserScriptMessageBroker?
 
     private let samplePercentage: Int
-    private let pixelFire: (PixelKitEvent, PixelKit.Frequency) -> Void
+    private let pixelFire: (PixelKit.Event, PixelKit.Frequency) -> Void
 
     public init(samplePercentage: Int = 2,
-                pixelFire: @escaping (PixelKitEvent, PixelKit.Frequency) -> Void = { event, frequency in
+                pixelFire: @escaping (PixelKit.Event, PixelKit.Frequency) -> Void = { event, frequency in
                     PixelKit.fire(event, frequency: frequency)
                 }) {
         self.samplePercentage = samplePercentage

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/SiteLoadingPixel.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyDashboard/BrokenSiteReporting/SiteLoadingPixel.swift
@@ -25,7 +25,7 @@ import PixelKit
 ///
 /// The `.siteLoadingTiming` case is sourced from `WKPageLoadTiming` via the BSK `Navigation` library and
 /// is therefore only fired on macOS today; iOS only fires`.siteLoadingSuccess` / `.siteLoadingFailure`.
-public enum SiteLoadingPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+public enum SiteLoadingPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
 
     /// Pixels are not sent on each fire for privacy reasons, and to avoid overwhelming the pipeline with too much data
     public static let samplePercentage: Int = 2

--- a/SharedPackages/BrowserServicesKit/Tests/PixelExperimentKitTests/PixelExperimentKitTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelExperimentKitTests/PixelExperimentKitTests.swift
@@ -28,7 +28,7 @@ final class PixelExperimentKitTests: XCTestCase {
     var mockPixelStore: MockExperimentActionPixelStore!
     var mockFeatureFlagger: MockFeatureFlagger!
     var firedEventSet = Set<String>()
-    var firedEvent = [PixelKitEvent]()
+    var firedEvent = [PixelKit.Event]()
     var firedFrequency = [PixelKit.Frequency]()
     var firedIncludeAppVersion = [Bool]()
 

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/DDGErrorPixelComparisonTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/DDGErrorPixelComparisonTests.swift
@@ -96,14 +96,14 @@ final class DDGErrorPixelComparisonTests: XCTestCase {
 
     // MARK: - Test Events
 
-    private struct TestEventWithDDGError: PixelKitEvent {
+    private struct TestEventWithDDGError: PixelKit.Event {
         let name = "test_ddg_error_event"
         let error: Error?
         var parameters: [String: String]? { nil }
         var standardParameters: [PixelKitStandardParameter]? { [.pixelSource] }
     }
 
-    private struct TestEventWithStandardError: PixelKitEvent {
+    private struct TestEventWithStandardError: PixelKit.Event {
         let name = "test_standard_error_event"
         let error: Error?
         var parameters: [String: String]? { nil }

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/PixelKitEventWithCustomPrefixTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/PixelKitEventWithCustomPrefixTests.swift
@@ -22,7 +22,7 @@ import os.log
 
 final class PixelKitEventWithCustomPrefixTests: XCTestCase {
 
-    enum TestEvent: String, PixelKitEvent, PixelKitEventWithCustomPrefix {
+    enum TestEvent: String, PixelKit.Event, PixelKitEventWithCustomPrefix {
         /// Both test events are the same but the macOS one adds the "mac" prefix, since prefixes aren't
         /// centrally managed anymore.
         case macEvent

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/PixelKitParametersTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/PixelKitParametersTests.swift
@@ -24,7 +24,7 @@ final class PixelKitParametersTests: XCTestCase {
 
     /// Test events for convenience
     ///
-    private enum TestEvent: PixelKitEvent {
+    private enum TestEvent: PixelKit.Event {
         case errorEvent(error: Error)
 
         var name: String {

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/PixelKitTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/PixelKitTests.swift
@@ -28,7 +28,7 @@ final class PixelKitTests: XCTestCase {
 
     /// Test events for convenience
 
-    private enum TestEvent: String, PixelKitEvent {
+    private enum TestEvent: String, PixelKit.Event {
 
         case testEventPrefixed = "m_mac_testEventPrefixed"
         case testEvent
@@ -51,7 +51,7 @@ final class PixelKitTests: XCTestCase {
 
     }
 
-    private enum TestEventV2: String, PixelKitEvent {
+    private enum TestEventV2: String, PixelKit.Event {
 
         case testEvent
         case testEventWithoutParameters
@@ -899,7 +899,7 @@ final class PixelKitTests: XCTestCase {
             self.completions = completions
         }
 
-        func fire(_ event: PixelKitEvent,
+        func fire(_ event: PixelKit.Event,
                   frequency: PixelKit.Frequency,
                   includeAppVersionParameter: Bool,
                   withAdditionalParameters parameters: [String: String]?,

--- a/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/SiteLoadingPerformanceSubfeatureTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/SiteLoadingPerformanceSubfeatureTests.swift
@@ -25,7 +25,7 @@ import BrowserServicesKitTestsUtils
 final class SiteLoadingPerformanceSubfeatureTests: XCTestCase {
 
     private struct FiredPixel {
-        let event: PixelKitEvent
+        let event: PixelKit.Event
         let frequency: PixelKit.Frequency
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Managers/SubscriptionManagerTests.swift
@@ -897,7 +897,7 @@ private final class MockSubscriptionPixelHandler: SubscriptionPixelHandling {
     }
 }
 
-private struct SubscriptionPixelEvent: PixelKitEvent {
+private struct SubscriptionPixelEvent: PixelKit.Event {
     let name: String
     let parameters: [String: String]?
     let standardParameters: [PixelKitStandardParameter]? = [.pixelSource]

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionFreemiumPixels.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionFreemiumPixels.swift
@@ -48,7 +48,7 @@ public class DataBrokerProtectionFreemiumPixelHandler: EventMapping<DataBrokerPr
     }
 }
 
-public enum DataBrokerProtectionFreemiumPixels: PixelKitEvent {
+public enum DataBrokerProtectionFreemiumPixels: PixelKit.Event {
 
     // Before the first scan
     case newTabScanImpression

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionSharedPixels.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionSharedPixels.swift
@@ -220,7 +220,7 @@ public enum DataBrokerProtectionSharedPixels {
     case updateDataBrokersFailure(dataBrokerFileName: String, removedAt: Int64?, isFreeScan: Bool?, error: Error)
 }
 
-extension DataBrokerProtectionSharedPixels: PixelKitEvent {
+extension DataBrokerProtectionSharedPixels: PixelKit.Event {
     public var name: String {
         switch self {
         case .parentChildMatches: return "dbp_parent-child-broker-matches"

--- a/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
@@ -171,7 +171,7 @@ final public class OnboardingSharedPixelHandler: OnboardingSharedPixelHandling {
 
 }
 
-public enum OnboardingSharedPixelEvent: PixelKitEvent, Equatable {
+public enum OnboardingSharedPixelEvent: PixelKit.Event, Equatable {
     // Linear onboarding events
     case welcome(EngagementEvent)
     case skipOnboarding(EngagementEvent) // iOS only

--- a/SharedPackages/VPN/Sources/VPN/Subscription/VPNSubscriptionClientCheckPixel.swift
+++ b/SharedPackages/VPN/Sources/VPN/Subscription/VPNSubscriptionClientCheckPixel.swift
@@ -19,7 +19,7 @@
 import PixelKit
 import Subscription
 
-public enum VPNSubscriptionClientCheckPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+public enum VPNSubscriptionClientCheckPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
     case vpnFeatureEnabled(isSubscriptionActive: Bool?,
                            trigger: Trigger)
     case vpnFeatureDisabled(isSubscriptionActive: Bool?,

--- a/SharedPackages/VPN/Sources/VPN/Subscription/VPNSubscriptionStatusPixel.swift
+++ b/SharedPackages/VPN/Sources/VPN/Subscription/VPNSubscriptionStatusPixel.swift
@@ -19,7 +19,7 @@
 import PixelKit
 import Subscription
 
-public enum VPNSubscriptionStatusPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+public enum VPNSubscriptionStatusPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
     case vpnFeatureEnabled(isSubscriptionActive: Bool?,
                     sourceObject: Any?)
     case vpnFeatureDisabled(isSubscriptionActive: Bool?,

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -4187,7 +4187,7 @@ extension Pixel.Event {
 
 // This is a temporary mapper from PixelKit to Pixel events for MaliciousSiteProtection
 // Malicious Site Protection BSK library depends on PixelKit which is not ready yet to be ported to iOS.
-// The below code maps between `PixelKitEvent` to `Pixel.Event` in order to use `Pixel.fire` on the client.
+// The below code maps between `PixelKit.Event` to `Pixel.Event` in order to use `Pixel.fire` on the client.
 public extension Pixel.Event {
 
     enum MaliciousSiteProtectionEvent: Equatable {
@@ -4232,7 +4232,7 @@ public extension Pixel.Event {
             }
         }
 
-        private var event: PixelKitEvent {
+        private var event: PixelKit.Event {
             switch self {
             case .errorPageShown(let category, let clientSideHit):
                 return MaliciousSiteProtection.Event.errorPageShown(category: category, clientSideHit: clientSideHit)

--- a/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
@@ -20,7 +20,7 @@
 import Foundation
 import PixelKit
 
-enum AppReturnPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+enum AppReturnPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
 
     case appReturn
 

--- a/iOS/DuckDuckGo/AppServices/LaunchTimeMetrics/LaunchTimeMetricsSubscriber.swift
+++ b/iOS/DuckDuckGo/AppServices/LaunchTimeMetrics/LaunchTimeMetricsSubscriber.swift
@@ -126,7 +126,7 @@ final class LaunchTimeMetricsSubscriber: NSObject, MXMetricManagerSubscriber {
     }
 }
 
-enum LaunchTimeMetricsPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+enum LaunchTimeMetricsPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
     case firstDraw(minMs: Int, maxMs: Int)
     case resume(minMs: Int, maxMs: Int)
     case optimizedFirstDraw(minMs: Int, maxMs: Int)

--- a/iOS/DuckDuckGo/Autoconsent/AutoconsentPixels.swift
+++ b/iOS/DuckDuckGo/Autoconsent/AutoconsentPixels.swift
@@ -20,7 +20,7 @@
 import PixelKit
 import UIKit
 
-enum AutoconsentPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+enum AutoconsentPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
 
     case acInit
     case errorMultiplePopups

--- a/iOS/DuckDuckGo/EventHub/IOSEventHubPixelFiring.swift
+++ b/iOS/DuckDuckGo/EventHub/IOSEventHubPixelFiring.swift
@@ -26,12 +26,12 @@ import PixelKit
 /// The PixelKit event shape shared by both EventHub pixel paths on iOS — telemetry and the failure events
 /// below. See `IOSEventHubPixelFiring`'s doc comment for why the empty `namePrefix` is what produces the
 /// names `event_hub.json5` declares.
-private struct EventHubPixelKitEvent: PixelKitEvent, PixelKitEventWithCustomPrefix {
+private struct EventHubPixelKitEvent: PixelKit.Event, PixelKitEventWithCustomPrefix {
     let namePrefix = ""
     let name: String
     let parameters: [String: String]?
     let standardParameters: [PixelKitStandardParameter]? = nil
-    /// Declared explicitly rather than left to `PixelKitEvent`'s reflection-based default, which would
+    /// Declared explicitly rather than left to `PixelKit.Event`'s reflection-based default, which would
     /// find nothing on a struct whose error is not an associated value.
     let error: NSError?
 }

--- a/iOS/DuckDuckGo/Fire/Statistics/DataClearingPixels.swift
+++ b/iOS/DuckDuckGo/Fire/Statistics/DataClearingPixels.swift
@@ -29,9 +29,9 @@ enum DataClearingPixels {
     case userActionBeforeCompletion
 }
 
-// MARK: - PixelKitEvent Protocol
+// MARK: - PixelKit.Event Protocol
 
-extension DataClearingPixels: PixelKitEvent {
+extension DataClearingPixels: PixelKit.Event {
 
     var name: String {
         switch self {

--- a/iOS/DuckDuckGo/SERP/SERPSettingsEventHandler.swift
+++ b/iOS/DuckDuckGo/SERP/SERPSettingsEventHandler.swift
@@ -24,7 +24,7 @@ import FoundationExtensions
 import PixelKit
 import SERPSettings
 
-enum SERPSettingsPixel: PixelKitEvent {
+enum SERPSettingsPixel: PixelKit.Event {
     case serpSettingsSerializationFailed
     case serpSettingsKeyValueStoreReadError
     case serpSettingsKeyValueStoreWriteError

--- a/iOS/DuckDuckGo/SafariRedirectHandler.swift
+++ b/iOS/DuckDuckGo/SafariRedirectHandler.swift
@@ -48,7 +48,7 @@ enum SafariRedirectPixel {
     var countPixel: SafariRedirectScheduledPixel { SafariRedirectScheduledPixel(name: name + "_count") }
 }
 
-struct SafariRedirectScheduledPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+struct SafariRedirectScheduledPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
     let name: String
 
     var parameters: [String: String]? { nil }

--- a/iOS/DuckDuckGo/SearchToken/SearchTokenExperiment.swift
+++ b/iOS/DuckDuckGo/SearchToken/SearchTokenExperiment.swift
@@ -27,7 +27,7 @@ import FeatureFlags_iOS
 /// Temporary diagnostic pixels for the Search Token (Dindex) experiment (treatment cohort only).
 /// Fired via PixelKit, which appends the `_ios_phone`/`_ios_tablet` platform suffix automatically —
 /// so names are grouped by feature with no `m_` prefix. Both expire 2026-10-12; see search_token.json5.
-enum SearchTokenPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+enum SearchTokenPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
     /// A treatment variant-b SERP navigation the interceptor decorated: whether a token was attached and its length bucket.
     case serpAttach(outcome: String, tokenLength: String)
     /// A warm token-fetch attempt and its result.

--- a/iOS/DuckDuckGo/Subscription/Pixels/SubscriptionPixel.swift
+++ b/iOS/DuckDuckGo/Subscription/Pixels/SubscriptionPixel.swift
@@ -21,7 +21,7 @@ import Foundation
 import PixelKit
 import Networking
 
-enum SubscriptionPixel: PixelKitEvent {
+enum SubscriptionPixel: PixelKit.Event {
     // Subscription
     case subscriptionActive
     // Auth

--- a/iOS/DuckDuckGo/TabTerminationErrorPage.swift
+++ b/iOS/DuckDuckGo/TabTerminationErrorPage.swift
@@ -50,7 +50,7 @@ final class DefaultTabTerminationErrorPageInstrumentation: TabTerminationErrorPa
     }
 }
 
-enum TabTerminationErrorPagePixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+enum TabTerminationErrorPagePixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
     case shown
     case reload
     case sendFeedback

--- a/iOS/DuckDuckGo/TabTerminationTelemetry.swift
+++ b/iOS/DuckDuckGo/TabTerminationTelemetry.swift
@@ -187,7 +187,7 @@ final class TabTerminationTelemetryOccurrenceStore {
     }
 }
 
-enum TabTerminationTelemetryPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+enum TabTerminationTelemetryPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
     case interactionStateFailedToRestore
     case interactionStateFailedToRestoreDaily
     case foreground

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
@@ -41,7 +41,7 @@ struct UTIPixelFiring {
         daily.fireDailyAndCount(event, error: nil, withAdditionalParameters: parameters)
     }
 
-    func fire(_ event: PixelKitEvent, frequency: PixelKit.Frequency) {
+    func fire(_ event: PixelKit.Event, frequency: PixelKit.Frequency) {
         pixelKit()?.fire(event, frequency: frequency)
     }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
@@ -25,7 +25,7 @@ import Subscription
 
 /// The schedule suffix is part of the name, fired with frequencies that append nothing, so PixelKit's
 /// platform suffix lands after it and the wire name stays `..._daily_ios_phone` as the legacy pixel reports it.
-enum ExperimentalOmnibarPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+enum ExperimentalOmnibarPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
 
     /// `isToggleVisible`: whether the Search/Duck.ai toggle was on screen when the surface appeared.
     case omnibarShownDaily(isToggleVisible: Bool)

--- a/iOS/DuckDuckGoTests/TabTerminationErrorPageTests.swift
+++ b/iOS/DuckDuckGoTests/TabTerminationErrorPageTests.swift
@@ -192,13 +192,13 @@ private struct MockTabTerminationErrorPageSettings: TabTerminationErrorPageSetti
 private final class MockTabTerminationErrorPagePixelFiring: PixelFiring {
 
     struct Call {
-        let event: PixelKitEvent
+        let event: PixelKit.Event
         let frequency: PixelKit.Frequency
     }
 
     private(set) var calls: [Call] = []
 
-    func fire(_ event: PixelKitEvent,
+    func fire(_ event: PixelKit.Event,
               frequency: PixelKit.Frequency,
               includeAppVersionParameter: Bool,
               withAdditionalParameters: [String: String]?,

--- a/iOS/DuckDuckGoTests/TabTerminationTelemetryTests.swift
+++ b/iOS/DuckDuckGoTests/TabTerminationTelemetryTests.swift
@@ -231,13 +231,13 @@ final class TabTerminationTelemetryTests: XCTestCase {
 private final class MockTabTerminationPixelFiring: PixelFiring {
 
     struct Call {
-        let event: PixelKitEvent
+        let event: PixelKit.Event
         let frequency: PixelKit.Frequency
     }
 
     private(set) var calls: [Call] = []
 
-    func fire(_ event: PixelKitEvent,
+    func fire(_ event: PixelKit.Event,
               frequency: PixelKit.Frequency,
               includeAppVersionParameter: Bool,
               withAdditionalParameters: [String: String]?,

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/Notifications/DataBrokerProtectionNotificationPixel.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/Notifications/DataBrokerProtectionNotificationPixel.swift
@@ -31,7 +31,7 @@ public enum DataBrokerProtectionNotificationPixel {
     case notificationSentGoToMarketFirstScan
 }
 
-extension DataBrokerProtectionNotificationPixel: PixelKitEvent {
+extension DataBrokerProtectionNotificationPixel: PixelKit.Event {
     public var name: String {
         switch self {
         case .notificationSentFirstScanComplete:

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/Pixels/IOSPixels.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Sources/DataBrokerProtection-iOS/Pixels/IOSPixels.swift
@@ -39,7 +39,7 @@ public enum IOSPixels {
     }
 }
 
-extension IOSPixels: PixelKitEvent {
+extension IOSPixels: PixelKit.Event {
     public var name: String {
         switch self {
         case .backgroundTaskStarted: return "m_ios_dbp_background-task_started"

--- a/macOS/DuckDuckGo/AIChat/AIChatDeleter.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatDeleter.swift
@@ -40,12 +40,12 @@ final class AIChatDeleter: AIChatDeleting {
     private let historyCleaner: PhasedAIChatHistoryCleaning
     private let syncCleaner: () -> AIChatSyncCleaning?
     private let recordsSyncDeletion: Bool
-    private let firePixel: (PixelKitEvent) -> Void
+    private let firePixel: (PixelKit.Event) -> Void
 
     init(historyCleaner: PhasedAIChatHistoryCleaning,
          syncCleaner: @escaping () -> AIChatSyncCleaning? = { Application.appDelegate.aiChatSyncCleaner },
          recordsSyncDeletion: Bool = true,
-         firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .dailyAndCount) }) {
+         firePixel: @escaping (PixelKit.Event) -> Void = { PixelKit.fire($0, frequency: .dailyAndCount) }) {
         self.historyCleaner = historyCleaner
         self.syncCleaner = syncCleaner
         self.recordsSyncDeletion = recordsSyncDeletion

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -26,7 +26,7 @@ import PixelKit
 /// [Sidebar Pixel Triage](https://app.asana.com/1/137249556945/project/1209671977594486/task/1210676151750614)
 /// [Summarization Pixel Triage](https://app.asana.com/1/137249556945/project/69071770703008/task/1210636012460969?focus=true)
 
-enum AIChatPixel: PixelKitEvent {
+enum AIChatPixel: PixelKit.Event {
 
     /// Event Trigger: AI Chat is opened via the ... Menu -> New Duck.ai Chat
     case aichatApplicationMenuAppClicked

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -652,7 +652,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             return nil
         }
         hasAttachedPageContext = payload.enabled
-        let pixel: PixelKitEvent = {
+        let pixel: PixelKit.Event = {
             if payload.enabled {
                 return AIChatPixel.aiChatPageContextAdded(automaticEnabled: storage.shouldAutomaticallySendPageContext)
             }
@@ -934,7 +934,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     }
 
     @MainActor
-    private func fireSyncDailyAndStandardPixel(_ pixel: PixelKitEvent) {
+    private func fireSyncDailyAndStandardPixel(_ pixel: PixelKit.Event) {
         pixelFiring?.fire(pixel, frequency: .dailyAndStandard)
     }
 

--- a/macOS/DuckDuckGo/AppHealth/HangPixel.swift
+++ b/macOS/DuckDuckGo/AppHealth/HangPixel.swift
@@ -18,7 +18,7 @@
 
 import PixelKit
 
-enum HangPixel: PixelKitEvent {
+enum HangPixel: PixelKit.Event {
 
     /// A recovered hang is one that has ended by the time we report it.
     case uiHangRecovered(durationSeconds: Int, inForeground: Bool?, anyWindowVisible: Bool?, batteryPower: BatteryPower?, openBrowserWindowCount: Int?, openBrowserTabCount: Int?, stackTrace: String?)

--- a/macOS/DuckDuckGo/AppHealth/MemoryPressureReporter.swift
+++ b/macOS/DuckDuckGo/AppHealth/MemoryPressureReporter.swift
@@ -28,7 +28,7 @@ enum MemoryPressureNotification {
     static let contextKey = "memoryReportingContext"
 }
 
-enum MemoryPressurePixel: PixelKitEvent {
+enum MemoryPressurePixel: PixelKit.Event {
     /// Fired when the system reports critical level memory pressure, with context about browser state.
     case memoryPressureCritical(context: MemoryReportingContext)
 

--- a/macOS/DuckDuckGo/AppHealth/MemoryUsageIntervalPixel.swift
+++ b/macOS/DuckDuckGo/AppHealth/MemoryUsageIntervalPixel.swift
@@ -26,7 +26,7 @@ import Foundation
 /// Context parameters include bucketed memory usage, window count, standard/pinned tab counts,
 /// architecture, and allocation usage.
 ///
-enum MemoryUsageIntervalPixel: PixelKitEvent {
+enum MemoryUsageIntervalPixel: PixelKit.Event {
 
     case memoryUsage(trigger: Trigger, context: MemoryReportingContext)
 

--- a/macOS/DuckDuckGo/AppHealth/MemoryUsagePixel.swift
+++ b/macOS/DuckDuckGo/AppHealth/MemoryUsagePixel.swift
@@ -19,7 +19,7 @@
 import PixelKit
 
 /// Threshold memory usage pixels that fire once daily when memory enters a specific bucket.
-enum MemoryUsagePixel: PixelKitEvent {
+enum MemoryUsagePixel: PixelKit.Event {
 
     // swiftlint:disable identifier_name
     enum Threshold {

--- a/macOS/DuckDuckGo/AppHealth/MemoryUsageThresholdReporter.swift
+++ b/macOS/DuckDuckGo/AppHealth/MemoryUsageThresholdReporter.swift
@@ -177,7 +177,7 @@ final class MemoryUsageThresholdReporter {
         }
     }
 
-    private func fireIfNeeded(_ pixel: some PixelKitEvent, logLabel: String, logValue: Double) {
+    private func fireIfNeeded(_ pixel: some PixelKit.Event, logLabel: String, logValue: Double) {
         let shouldFire: Bool = lock.withLock {
             let now = Date()
             if !Calendar.current.isDate(now, inSameDayAs: lastCheckDate) {

--- a/macOS/DuckDuckGo/AppHealth/StartupMetricsPixel.swift
+++ b/macOS/DuckDuckGo/AppHealth/StartupMetricsPixel.swift
@@ -21,7 +21,7 @@ import PixelKit
 
 // MARK: - StartupMetricsPixel
 
-struct StartupMetricsPixel: PixelKitEvent {
+struct StartupMetricsPixel: PixelKit.Event {
 
     // MARK: - System
 

--- a/macOS/DuckDuckGo/AppHealth/WebViewMemoryUsagePixel.swift
+++ b/macOS/DuckDuckGo/AppHealth/WebViewMemoryUsagePixel.swift
@@ -20,7 +20,7 @@ import PixelKit
 
 /// Threshold WebContent process memory usage pixels that fire once daily when
 /// total WebContent memory enters a specific bucket.
-enum WebViewMemoryUsagePixel: PixelKitEvent {
+enum WebViewMemoryUsagePixel: PixelKit.Event {
 
     // swiftlint:disable identifier_name
     enum Threshold {

--- a/macOS/DuckDuckGo/Application/WarnBeforeQuitManager.swift
+++ b/macOS/DuckDuckGo/Application/WarnBeforeQuitManager.swift
@@ -678,7 +678,7 @@ final class WarnBeforeQuitManager: ApplicationTerminationDecider {
 
 extension PixelFiring {
     /// Fire a pixel and wait for completion asynchronously (with timeout)
-    func fireAndWait(_ event: PixelKitEvent, frequency: PixelKit.Frequency, timeout: TimeInterval = 1) async {
+    func fireAndWait(_ event: PixelKit.Event, frequency: PixelKit.Frequency, timeout: TimeInterval = 1) async {
         try? await withTimeout(timeout) {
             await withCancellableContinuation { resume, _ in
                 fire(event, frequency: frequency) { _, _ in

--- a/macOS/DuckDuckGo/Autoconsent/AutoconsentPixels.swift
+++ b/macOS/DuckDuckGo/Autoconsent/AutoconsentPixels.swift
@@ -18,7 +18,7 @@
 
 import PixelKit
 
-enum AutoconsentPixel: PixelKitEvent {
+enum AutoconsentPixel: PixelKit.Event {
 
     case acInit
     case errorMultiplePopups

--- a/macOS/DuckDuckGo/Autoconsent/OptInDialog/CookiePopupProtectionOptInPixel.swift
+++ b/macOS/DuckDuckGo/Autoconsent/OptInDialog/CookiePopupProtectionOptInPixel.swift
@@ -22,7 +22,7 @@ import WebExtensions
 
 /// Telemetry for the Cookie Pop-up Protection opt-in dialog.
 /// `autoconsentEnabled` is the feature state at the moment the dialog was shown.
-enum CookiePopupProtectionOptInPixel: PixelKitEvent {
+enum CookiePopupProtectionOptInPixel: PixelKit.Event {
     /// The dialog was shown on launch for the first time (once per install).
     case shownFirst(autoconsentEnabled: Bool)
     /// The dialog was shown on launch again (any presentation after the first).

--- a/macOS/DuckDuckGo/Autofill/AutofillPixelEvent.swift
+++ b/macOS/DuckDuckGo/Autofill/AutofillPixelEvent.swift
@@ -19,7 +19,7 @@
 import Foundation
 import PixelKit
 
-enum AutofillPixelKitEvent: PixelKitEvent {
+enum AutofillPixelKitEvent: PixelKit.Event {
     enum Parameter {
         static let lastUsed = "last_used"
     }

--- a/macOS/DuckDuckGo/Bookmarks/Model/BookmarksPixel.swift
+++ b/macOS/DuckDuckGo/Bookmarks/Model/BookmarksPixel.swift
@@ -21,7 +21,7 @@ import PixelKit
 /**
  * This enum keeps pixels related to Bookmarks.
  */
-enum BookmarksPixel: PixelKitEvent {
+enum BookmarksPixel: PixelKit.Event {
     /**
      * Event Trigger: Bookmark data finishes loading successfully.
      *

--- a/macOS/DuckDuckGo/Common/Attribution/AttributionPixelHandler.swift
+++ b/macOS/DuckDuckGo/Common/Attribution/AttributionPixelHandler.swift
@@ -24,7 +24,7 @@ import FoundationExtensions
 // A type that send pixels that needs attributions parameters.
 protocol AttributionPixelHandler {
     func fireAttributionPixel(
-        event: PixelKitEvent,
+        event: PixelKit.Event,
         frequency: PixelKit.Frequency,
         origin: String?,
         additionalParameters: [String: String]?
@@ -54,7 +54,7 @@ final class GenericAttributionPixelHandler: AttributionPixelHandler {
     }
 
     func fireAttributionPixel(
-        event: PixelKitEvent,
+        event: PixelKit.Event,
         frequency: PixelKit.Frequency,
         origin: String?,
         additionalParameters: [String: String]?
@@ -90,7 +90,7 @@ private extension GenericAttributionPixelHandler {
 
 extension GenericAttributionPixelHandler {
     typealias FireRequest = (
-        _ event: PixelKitEvent,
+        _ event: PixelKit.Event,
         _ frequency: PixelKit.Frequency,
         _ headers: [String: String],
         _ parameters: [String: String]?,

--- a/macOS/DuckDuckGo/Common/Database/Database.swift
+++ b/macOS/DuckDuckGo/Common/Database/Database.swift
@@ -89,7 +89,7 @@ final class Database {
 
 extension NSManagedObjectContext {
 
-    func save(onErrorFire event: PixelKitEvent) throws {
+    func save(onErrorFire event: PixelKit.Event) throws {
         do {
             try save()
         } catch {

--- a/macOS/DuckDuckGo/DBP/DataBrokerProtectionLoginItemPixels.swift
+++ b/macOS/DuckDuckGo/DBP/DataBrokerProtectionLoginItemPixels.swift
@@ -21,7 +21,7 @@ import PixelKit
 
 struct DataBrokerProtectionLoginItemPixels {
 
-    static func fire(pixel: PixelKitEvent, frequency: PixelKit.Frequency) {
+    static func fire(pixel: PixelKit.Event, frequency: PixelKit.Frequency) {
 
         DispatchQueue.main.async { // delegateTyped needs to be called in the main thread
             let isInternalUser = NSApp.delegateTyped.internalUserDecider.isInternalUser

--- a/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptPixelEvent.swift
+++ b/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptPixelEvent.swift
@@ -23,7 +23,7 @@ import PixelKit
 /// > Related links:
 /// [Pixel Definition](https://app.asana.com/1/137249556945/project/1206329551987282/task/1210257532277820)
 /// [Pixel Privacy Triage](https://app.asana.com/1/137249556945/project/69071770703008/task/1210341343812872)
-enum DefaultBrowserAndDockPromptPixelEvent: PixelKitEvent, Hashable {
+enum DefaultBrowserAndDockPromptPixelEvent: PixelKit.Event, Hashable {
     private enum ParameterKey {
         static let contentType = "contentType"
         static let numberOfBannersShown = "numberOfBannersShown"
@@ -136,7 +136,7 @@ enum DefaultBrowserAndDockPromptPixelEvent: PixelKitEvent, Hashable {
 /// > Related links:
 /// [Pixel Definition](https://app.asana.com/1/137249556945/project/1206329551987282/task/1210257532277820)
 /// [Pixel Privacy Triage](https://app.asana.com/1/137249556945/project/69071770703008/task/1210341343812872)
-enum DefaultBrowserAndDockPromptDebugPixelEvent: PixelKitEvent {
+enum DefaultBrowserAndDockPromptDebugPixelEvent: PixelKit.Event {
     /// Trigger Event: The popover seen date fails to save.
     case failedToSavePopoverSeenDate
     /// Trigger Event: The popover seen date fails to retrieve.

--- a/macOS/DuckDuckGo/EventHub/MacOSEventHubPixelFiring.swift
+++ b/macOS/DuckDuckGo/EventHub/MacOSEventHubPixelFiring.swift
@@ -28,11 +28,11 @@ private let macOSSuffix = "_macos"
 /// The PixelKit event shape shared by both EventHub pixel paths on macOS — telemetry and the failure
 /// events below. Deliberately *not* wrapped in `DebugEvent` for the failure path: PixelKit rewrites an
 /// unprefixed `DebugEvent` to `m_mac_debug_<name>`, which would undo the naming these pixels need.
-private struct EventHubPixelKitEvent: PixelKitEvent {
+private struct EventHubPixelKitEvent: PixelKit.Event {
     let name: String
     let parameters: [String: String]?
     let standardParameters: [PixelKitStandardParameter]? = nil
-    /// Declared explicitly rather than left to `PixelKitEvent`'s reflection-based default, which would
+    /// Declared explicitly rather than left to `PixelKit.Event`'s reflection-based default, which would
     /// find nothing on a struct whose error is not an associated value.
     let error: NSError?
 }

--- a/macOS/DuckDuckGo/Fire/Statistics/DataClearingPixels.swift
+++ b/macOS/DuckDuckGo/Fire/Statistics/DataClearingPixels.swift
@@ -25,9 +25,9 @@ enum DataClearingPixels {
     case retriggerIn20s
 }
 
-// MARK: - PixelKitEvent Protocol
+// MARK: - PixelKit.Event Protocol
 
-extension DataClearingPixels: PixelKitEvent {
+extension DataClearingPixels: PixelKit.Event {
 
     var name: String {
         switch self {

--- a/macOS/DuckDuckGo/HomePage/View/VPNSubscriptionPromo/SubscriptionPromoPixel.swift
+++ b/macOS/DuckDuckGo/HomePage/View/VPNSubscriptionPromo/SubscriptionPromoPixel.swift
@@ -19,7 +19,7 @@
 import Foundation
 import PixelKit
 
-enum SubscriptionPromoPixel: PixelKitEvent {
+enum SubscriptionPromoPixel: PixelKit.Event {
     case promoDisplayed(isEligibleForFreeTrial: Bool)
     case promoViewed(isEligibleForFreeTrial: Bool)
     case promoCtaActioned(isEligibleForFreeTrial: Bool)

--- a/macOS/DuckDuckGo/NetworkProtection/AppAndExtensionAndAgentTargets/NetworkProtectionPixelEvent.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppAndExtensionAndAgentTargets/NetworkProtectionPixelEvent.swift
@@ -21,7 +21,7 @@ import PixelKit
 import VPN
 import Configuration
 
-enum NetworkProtectionPixelEvent: PixelKitEvent {
+enum NetworkProtectionPixelEvent: PixelKit.Event {
     static let vpnErrorDomain = "com.duckduckgo.vpn.errorDomain"
 
     case networkProtectionActiveUser

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNAppEventsHandler.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/VPNAppEventsHandler.swift
@@ -79,7 +79,7 @@ final class VPNAppEventsHandler {
 
     // MARK: - Login Item Control Checkpoints
 
-    private enum LoginItemsControlCheckpointPixel: PixelKitEvent {
+    private enum LoginItemsControlCheckpointPixel: PixelKit.Event {
         case cannotStopVPN(_ error: Error)
 
         var name: String {

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionIPCTunnelController.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/DeveloperIDTarget/NetworkProtectionIPCTunnelController.swift
@@ -242,7 +242,7 @@ extension NetworkProtectionIPCTunnelController: TunnelController {
 
 extension NetworkProtectionIPCTunnelController {
 
-    enum StartAttempt: PixelKitEvent {
+    enum StartAttempt: PixelKit.Event {
         case begin
         case success
         case failure(_ error: Error)
@@ -280,7 +280,7 @@ extension NetworkProtectionIPCTunnelController {
 
 extension NetworkProtectionIPCTunnelController {
 
-    enum StopAttempt: PixelKitEvent {
+    enum StopAttempt: PixelKit.Event {
         case begin
         case success
         case failure(_ error: Error)

--- a/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/Pixels/VPNFailureRecoveryPixel.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/NetworkExtensionTargets/NetworkExtensionTargets/Pixels/VPNFailureRecoveryPixel.swift
@@ -23,7 +23,7 @@ import PixelKit
 ///
 /// Ref: https://app.asana.com/0/0/1206939413299475/f
 ///
-public enum VPNFailureRecoveryPixel: PixelKitEvent {
+public enum VPNFailureRecoveryPixel: PixelKit.Event {
 
     /// This pixel is emitted when the last handshake diff is greater than n minutes and an attempt to recover is made (/register is called with failureRecovery)
     ///

--- a/macOS/DuckDuckGo/NewTabPage/Features/Customization/NewTabPageCustomizationModel.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/Customization/NewTabPageCustomizationModel.swift
@@ -37,7 +37,7 @@ final class NewTabPageCustomizationModel: ObservableObject {
 
     let appearancePreferences: AppearancePreferences
     let customImagesManager: UserBackgroundImagesManaging?
-    let sendPixel: (PixelKitEvent) -> Void
+    let sendPixel: (PixelKit.Event) -> Void
     let openFilePanel: () -> URL?
     let showAddImageFailedAlert: () -> Void
     let customizerOpener = NewTabPageCustomizerOpener()
@@ -76,7 +76,7 @@ final class NewTabPageCustomizationModel: ObservableObject {
     init(
         appearancePreferences: AppearancePreferences,
         userBackgroundImagesManager: UserBackgroundImagesManaging?,
-        sendPixel: @escaping (PixelKitEvent) -> Void,
+        sendPixel: @escaping (PixelKit.Event) -> Void,
         openFilePanel: @escaping () -> URL?,
         showAddImageFailedAlert: @escaping () -> Void
     ) {

--- a/macOS/DuckDuckGo/NewTabPage/Features/Customization/UserBackgroundImagesManager.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/Customization/UserBackgroundImagesManager.swift
@@ -50,7 +50,7 @@ final class UserBackgroundImagesManager: UserBackgroundImagesManaging {
     let maximumNumberOfImages: Int
     let storageLocation: URL
     let thumbnailsStorageLocation: URL
-    private let sendPixel: (PixelKitEvent) -> Void
+    private let sendPixel: (PixelKit.Event) -> Void
     private let imageProcessor: ImageProcessing
     private var availableImagesSortedByAccessTime: [UserBackgroundImage] = []
 
@@ -87,7 +87,7 @@ final class UserBackgroundImagesManager: UserBackgroundImagesManaging {
         maximumNumberOfImages: Int,
         applicationSupportDirectory: URL,
         imageProcessor: ImageProcessing = ImageProcessor(),
-        sendPixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0) }
+        sendPixel: @escaping (PixelKit.Event) -> Void = { PixelKit.fire($0) }
     ) {
         assert(maximumNumberOfImages > 0, "maximumNumberOfImages must be greater than 0")
         self.maximumNumberOfImages = maximumNumberOfImages

--- a/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsCardsPixelHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/Features/NextSteps/NewTabPageNextStepsCardsPixelHandler.swift
@@ -53,7 +53,7 @@ protocol NewTabPageNextStepsCardsPixelHandling {
 }
 
 final class NewTabPageNextStepsCardsPixelHandler: NewTabPageNextStepsCardsPixelHandling {
-    private let pixelHandler: (PixelKitEvent, PixelKit.Frequency, Bool) -> Void
+    private let pixelHandler: (PixelKit.Event, PixelKit.Frequency, Bool) -> Void
     private let persistor: NewTabPageNextStepsCardsPersisting
     private let appearancePreferences: AppearancePreferences
     private let daysSinceInstallProvider: () -> Int?
@@ -61,7 +61,7 @@ final class NewTabPageNextStepsCardsPixelHandler: NewTabPageNextStepsCardsPixelH
     init(persistor: NewTabPageNextStepsCardsPersisting,
          appearancePreferences: AppearancePreferences,
          installDateProvider: @escaping () -> Date?,
-         pixelHandler: @escaping (PixelKitEvent, PixelKit.Frequency, Bool) -> Void = { PixelKit.fire($0, frequency: $1, includeAppVersionParameter: $2) }) {
+         pixelHandler: @escaping (PixelKit.Event, PixelKit.Frequency, Bool) -> Void = { PixelKit.fire($0, frequency: $1, includeAppVersionParameter: $2) }) {
         self.pixelHandler = pixelHandler
         self.persistor = persistor
         self.appearancePreferences = appearancePreferences

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageCoordinator.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageCoordinator.swift
@@ -73,7 +73,7 @@ final class NewTabPageCoordinator {
         duckPlayerPreferences: DuckPlayerPreferencesPersistor,
         syncService: DDGSyncing?,
         pinningManager: PinningManager,
-        fireDailyPixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .legacyDaily) },
+        fireDailyPixel: @escaping (PixelKit.Event) -> Void = { PixelKit.fire($0, frequency: .legacyDaily) },
         promoService: PromoService? = nil,
         dockCustomization: DockCustomization
     ) {

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageLoadMetrics.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageLoadMetrics.swift
@@ -30,9 +30,9 @@ final class NewTabPageLoadMetrics {
     private var ntpStartTime: Date?
     private var ntpShownTime: Date?
     private var state: NTPState = .notLoading
-    private let firePixel: (PixelKitEvent) -> Void
+    private let firePixel: (PixelKit.Event) -> Void
 
-    init(firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .standard) }) {
+    init(firePixel: @escaping (PixelKit.Event) -> Void = { PixelKit.fire($0, frequency: .standard) }) {
         self.firePixel = firePixel
     }
 

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
@@ -35,9 +35,9 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
     private let aiChatDeleter: AIChatDeleting
     private let isShiftPressed: () -> Bool
     private let isCommandPressed: () -> Bool
-    private let firePixel: (PixelKitEvent) -> Void
+    private let firePixel: (PixelKit.Event) -> Void
     /// Deletion-flow pixels fire at `.dailyAndCount`, matching the address-bar delete pixels.
-    private let fireDailyCountPixel: (PixelKitEvent) -> Void
+    private let fireDailyCountPixel: (PixelKit.Event) -> Void
     private let presentDeleteConfirmation: @MainActor (String, NSWindow?) async -> Bool
 
     /// Called after the Customize Responses modal closes or the toggle is set, so the NTP config
@@ -54,8 +54,8 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
          aiChatDeleter: AIChatDeleting,
          isShiftPressed: @escaping () -> Bool = { NSApp?.isShiftPressed ?? false },
          isCommandPressed: @escaping () -> Bool = { NSApp?.isCommandPressed ?? false },
-         firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) },
-         fireDailyCountPixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .dailyAndCount, includeAppVersionParameter: true) },
+         firePixel: @escaping (PixelKit.Event) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) },
+         fireDailyCountPixel: @escaping (PixelKit.Event) -> Void = { PixelKit.fire($0, frequency: .dailyAndCount, includeAppVersionParameter: true) },
          presentDeleteConfirmation: @escaping @MainActor (String, NSWindow?) async -> Bool = NewTabPageOmnibarActionsHandler.presentNativeDeleteConfirmation) {
         self.promptHandler = promptHandler
         self.windowControllersManager = windowControllersManager

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -94,7 +94,7 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     private let keyValueStore: ThrowingKeyValueStoring
     private let aiChatShortcutSettingProvider: NewTabPageAIChatShortcutSettingProviding
     private let featureFlagger: FeatureFlagger
-    private let firePixel: (PixelKitEvent) -> Void
+    private let firePixel: (PixelKit.Event) -> Void
     private var aiChatPreferencesPersistor: AIChatPreferencesPersisting
     private let searchPreferences: SearchPreferences
     private let windowControllersManager: WindowControllersManagerProtocol?
@@ -111,7 +111,7 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
          aiChatPreferencesPersistor: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),
          searchPreferences: SearchPreferences,
          windowControllersManager: WindowControllersManagerProtocol? = nil,
-         firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) }) {
+         firePixel: @escaping (PixelKit.Event) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) }) {
         self.keyValueStore = keyValueStore
         self.aiChatShortcutSettingProvider = aiChatShortcutSettingProvider
         self.featureFlagger = featureFlagger

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageShownPixelSender.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageShownPixelSender.swift
@@ -36,7 +36,7 @@ final class NewTabPageShownPixelSender {
         appearancePreferences: AppearancePreferences,
         protectionsReportVisibleFeedProvider: NewTabPageProtectionsReportVisibleFeedProviding,
         customizationModel: NewTabPageCustomizationModel,
-        fireDailyPixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .legacyDaily) }
+        fireDailyPixel: @escaping (PixelKit.Event) -> Void = { PixelKit.fire($0, frequency: .legacyDaily) }
     ) {
         self.appearancePreferences = appearancePreferences
         self.protectionsReportVisibleFeedProvider = protectionsReportVisibleFeedProvider
@@ -88,5 +88,5 @@ final class NewTabPageShownPixelSender {
     let appearancePreferences: AppearancePreferences
     let protectionsReportVisibleFeedProvider: NewTabPageProtectionsReportVisibleFeedProviding
     let customizationModel: NewTabPageCustomizationModel
-    private let fireDailyPixel: (PixelKitEvent) -> Void
+    private let fireDailyPixel: (PixelKit.Event) -> Void
 }

--- a/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/OnboardingPixelReporter.swift
+++ b/macOS/DuckDuckGo/Onboarding/ContextualOnboarding/OnboardingPixelReporter.swift
@@ -47,14 +47,14 @@ protocol OnboardingFireReporting: AnyObject {
 final class OnboardingPixelReporter {
 
     private weak var onboardingStateProvider: (ContextualOnboardingDialogTypeProviding & ContextualOnboardingStateUpdater)?
-    private let fire: (PixelKitEvent, PixelKit.Frequency) -> Void
+    private let fire: (PixelKit.Event, PixelKit.Frequency) -> Void
     private let userDefaults: UserDefaults
     private let sharedPixelHandler: OnboardingSharedPixelHandling
 
     init(onboardingStateProvider: ContextualOnboardingDialogTypeProviding & ContextualOnboardingStateUpdater
  = Application.appDelegate.onboardingContextualDialogsManager,
          userDefaults: UserDefaults = UserDefaults.standard,
-         fireAction: @escaping (PixelKitEvent, PixelKit.Frequency) -> Void = { event, frequency in PixelKit.fire(event, frequency: frequency) },
+         fireAction: @escaping (PixelKit.Event, PixelKit.Frequency) -> Void = { event, frequency in PixelKit.fire(event, frequency: frequency) },
          onboardingSharedPixelHandler: OnboardingSharedPixelHandling = OnboardingSharedPixelHandler(
             platform: .macOS,
             installTypeProvider: {

--- a/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ChromeExtensionInstaller.swift
+++ b/macOS/DuckDuckGo/Onboarding/ThirdPartyBrowserExtensions/ChromeExtensionInstaller.swift
@@ -21,7 +21,7 @@ import PixelKit
 import PrivacyConfig
 import os.log
 
-enum ChromeExtensionInstallerPixelEvent: PixelKitEvent {
+enum ChromeExtensionInstallerPixelEvent: PixelKit.Event {
     case detectionFailed
     case installFailed
 

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixel.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixel.swift
@@ -25,7 +25,7 @@ import PixelKit
 /// `LIKE 'm_mac_aichat_promptbar%'`. The mirrored cases keep the tail of their `aichat_addressbar_*`
 /// counterpart, so the two surfaces compare token for token — see `PromptBarPixelHandler` for the
 /// mapping and the events the Prompt Bar deliberately can't produce.
-enum PromptBarPixel: PixelKitEvent {
+enum PromptBarPixel: PixelKit.Event {
 
     // MARK: - Mirrored from the address bar
 

--- a/macOS/DuckDuckGo/QuitSurvey/QuitSurveyPixels.swift
+++ b/macOS/DuckDuckGo/QuitSurvey/QuitSurveyPixels.swift
@@ -28,7 +28,7 @@ enum QuitSurveyPixelName: String {
 
 }
 
-enum QuitSurveyPixels: PixelKitEvent {
+enum QuitSurveyPixels: PixelKit.Event {
     private static let reasonsKey = "reasons"
     private static let affectedDomainsKey = "affected_domains"
 

--- a/macOS/DuckDuckGo/SecureVault/View/SaveCredentialsViewController.swift
+++ b/macOS/DuckDuckGo/SecureVault/View/SaveCredentialsViewController.swift
@@ -587,7 +587,7 @@ final class SaveCredentialsViewController: NSViewController {
         }
     }
 
-    private func firePixel(for action: Action, confirmedPixel: PixelKitEvent, dismissedPixel: PixelKitEvent, backfilled: Bool) {
+    private func firePixel(for action: Action, confirmedPixel: PixelKit.Event, dismissedPixel: PixelKit.Event, backfilled: Bool) {
         let pixel = action == .confirmed ? confirmedPixel : dismissedPixel
         PixelKit.fire(pixel, withAdditionalParameters: [backfilledKey: String(describing: backfilled)])
     }

--- a/macOS/DuckDuckGo/Statistics/AutoplayPromoPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/AutoplayPromoPixel.swift
@@ -20,14 +20,14 @@ import PixelKit
 
 /// Pixels for the Autoplay Discoverability Promo, which auto-opens the Permission Center the first time a page displays the autoplay policy.
 /// - Note: The promo runs at most once per install, so plain standard pixels are enough to bound their volume.
-enum AutoplayPromoPixel: PixelKitEvent, Equatable {
+enum AutoplayPromoPixel: PixelKit.Event, Equatable {
 
     case shown
     case engaged
     case autoDismissed
     case settingsLinkClicked
 
-    // MARK: - PixelKitEvent
+    // MARK: - PixelKit.Event
 
     var name: String {
         switch self {

--- a/macOS/DuckDuckGo/Statistics/ContextualOnboardingPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/ContextualOnboardingPixel.swift
@@ -26,7 +26,7 @@ import PixelKit
  * [Privacy Triage]()
  * [Detailed Pixels description](https://app.asana.com/0/1201621853593513/1208114308034584/f)
  */
-enum ContextualOnboardingPixel: PixelKitEvent {
+enum ContextualOnboardingPixel: PixelKit.Event {
     /**
      * Event Trigger: User types into the address bar when the search suggestions dialog is shown during the contextual onboarding
      *

--- a/macOS/DuckDuckGo/Statistics/ErrorPagePixel.swift
+++ b/macOS/DuckDuckGo/Statistics/ErrorPagePixel.swift
@@ -20,7 +20,7 @@ import Foundation
 import PixelKit
 import WebKit
 
-enum ErrorPagePixel: PixelKitEvent {
+enum ErrorPagePixel: PixelKit.Event {
     case errorPageShownOther(error: WKError)
     case errorPageShownWebkitTermination
 

--- a/macOS/DuckDuckGo/Statistics/FireButtonPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/FireButtonPixel.swift
@@ -23,7 +23,7 @@ import PixelKit
 typealias FireDialogPixel = FireButtonPixel
 
 /// This enum keeps pixels related to Fire Button and Fire Dialog.
-enum FireButtonPixel: PixelKitEvent {
+enum FireButtonPixel: PixelKit.Event {
     case fireStarted
     case fireStartedInSession
     case fireStartedOnExit

--- a/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/GeneralPixel.swift
@@ -33,7 +33,7 @@ enum AppStateRestorationTrigger {
     case appUpdate
 }
 
-enum GeneralPixel: PixelKitEvent {
+enum GeneralPixel: PixelKit.Event {
 
     case crash(appIdentifier: CrashPixelAppIdentifier?)
     case crashOnCrashHandlersSetUp

--- a/macOS/DuckDuckGo/Statistics/HistoryViewPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/HistoryViewPixel.swift
@@ -32,7 +32,7 @@ import PixelKit
  * Anomaly Investigation:
  * - Unless otherwise specified, anomaly in all the pixels will be related to an increase/drop in app use.
  */
-enum HistoryViewPixel: PixelKitEvent {
+enum HistoryViewPixel: PixelKit.Event {
 
     // MARK: - Permanent Pixels
 

--- a/macOS/DuckDuckGo/Statistics/MoreOptionsMenuPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/MoreOptionsMenuPixel.swift
@@ -31,7 +31,7 @@ import PixelKit
  * Anomaly Investigation:
  * - Anomaly in these pixels may mean an increase/drop in app use.
  */
-enum MoreOptionsMenuPixel: PixelKitEvent {
+enum MoreOptionsMenuPixel: PixelKit.Event {
 
     /// Event Trigger: Feedback or Subscription feedback menu action is clicked
     case feedbackActionClicked

--- a/macOS/DuckDuckGo/Statistics/NavigationBarPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/NavigationBarPixel.swift
@@ -22,7 +22,7 @@ import PixelKit
 /**
  * This enum keeps pixels related to the navigation bar.
  */
-enum NavigationBarPixel: PixelKitEvent {
+enum NavigationBarPixel: PixelKit.Event {
 
     /**
      * Event Trigger: Home toolbar button clicked.

--- a/macOS/DuckDuckGo/Statistics/NavigationEngagementPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/NavigationEngagementPixel.swift
@@ -55,7 +55,7 @@ enum NavigationEngagementPixel {
     }
 }
 
-extension NavigationEngagementPixel: PixelKitEvent {
+extension NavigationEngagementPixel: PixelKit.Event {
 
     var name: String {
         switch self {

--- a/macOS/DuckDuckGo/Statistics/NewTabBackgroundPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/NewTabBackgroundPixel.swift
@@ -26,7 +26,7 @@ import PixelKit
  * [Privacy Triage](https://app.asana.com/0/69071770703008/1208146890364172/f)
  * [Detailed Pixels description](https://app.asana.com/0/1201621708115095/1207983904350396/f)
  */
-enum NewTabBackgroundPixel: PixelKitEvent {
+enum NewTabBackgroundPixel: PixelKit.Event {
 
     /**
      * Event Trigger: User selects gradient as custom NTP background.

--- a/macOS/DuckDuckGo/Statistics/NewTabPagePixel.swift
+++ b/macOS/DuckDuckGo/Statistics/NewTabPagePixel.swift
@@ -22,7 +22,7 @@ import PixelKit
 /**
  * This enum keeps pixels related to HTML New Tab Page.
  */
-enum NewTabPagePixel: PixelKitEvent {
+enum NewTabPagePixel: PixelKit.Event {
 
     /**
      * Event Trigger: New Tab Page is displayed to user.

--- a/macOS/DuckDuckGo/Statistics/NonStandardPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/NonStandardPixel.swift
@@ -23,7 +23,7 @@ import DDGSync
 import Configuration
 
 /// These pixels deliberately omit the `m_mac_` prefix in order to format these pixel the same way as other platforms, they are sent unchanged
-enum NonStandardPixel: PixelKitEvent {
+enum NonStandardPixel: PixelKit.Event {
 
     case brokenSiteReport
     case brokenSiteReportShown

--- a/macOS/DuckDuckGo/Statistics/PermissionPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/PermissionPixel.swift
@@ -21,7 +21,7 @@ import PixelKit
 /**
  * This enum keeps pixels related to permissions management.
  */
-enum PermissionPixel: PixelKitEvent {
+enum PermissionPixel: PixelKit.Event {
 
     // MARK: - Authorization Flow
 
@@ -64,7 +64,7 @@ enum PermissionPixel: PixelKitEvent {
      */
     case systemPreferencesOpened(permissionType: PermissionType)
 
-    // MARK: - PixelKitEvent
+    // MARK: - PixelKit.Event
 
     var name: String {
         switch self {

--- a/macOS/DuckDuckGo/Statistics/PinnedTabsPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/PinnedTabsPixel.swift
@@ -21,7 +21,7 @@ import PixelKit
 /**
  * This enum keeps pixels related to pinned tabs
  */
-enum PinnedTabsPixel: PixelKitEvent {
+enum PinnedTabsPixel: PixelKit.Event {
 
     case userPinnedTab
     case userUnpinnedTab

--- a/macOS/DuckDuckGo/Statistics/SessionRestorePromptPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/SessionRestorePromptPixel.swift
@@ -34,7 +34,7 @@ enum UncleanExitRestartSource: String {
  *
  * See macOS/PixelDefinitions/pixels/session_restore_prompt_pixels.json5 for more details.
  */
-enum SessionRestorePromptPixel: PixelKitEvent {
+enum SessionRestorePromptPixel: PixelKit.Event {
     case unexpectedAppTerminationDetected(reason: UncleanExitRestartSource)
     case promptShown
     case promptDismissedWithoutRestore

--- a/macOS/DuckDuckGo/Statistics/SettingsPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/SettingsPixel.swift
@@ -22,7 +22,7 @@ import PixelKit
 /**
  * This enum keeps pixels related to Settings Page.
  */
-enum SettingsPixel: PixelKitEvent {
+enum SettingsPixel: PixelKit.Event {
 
     /**
      * Event Trigger: Settings pane with a specified identifier is opened.

--- a/macOS/DuckDuckGo/Statistics/SubscriptionPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/SubscriptionPixel.swift
@@ -31,7 +31,7 @@ enum SubscriptionAppMenuEntryStatus: String {
     case freeIneligible = "free-ineligible"
 }
 
-enum SubscriptionPixel: PixelKitEvent {
+enum SubscriptionPixel: PixelKit.Event {
     // Subscription
     case subscriptionActive(AuthVersion)
     case subscriptionOfferScreenImpression(origin: String?)
@@ -406,7 +406,7 @@ enum SubscriptionPixel: PixelKitEvent {
 
 }
 
-enum SubscriptionErrorPixel: PixelKitEvent {
+enum SubscriptionErrorPixel: PixelKit.Event {
 
     case subscriptionKeychainAccessError(accessType: AccountKeychainAccessType,
                                        accessError: AccountKeychainAccessError,

--- a/macOS/DuckDuckGo/Statistics/WebNotificationPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/WebNotificationPixel.swift
@@ -25,7 +25,7 @@ import PixelKit
 /// - **Engagement** (`shown`, `clicked`, `error`): track what happens after a notification is posted.
 /// - **System authorization** (`systemAuthorizationRequested`, `systemAuthorizationGranted`): track the
 ///   macOS system prompt. The difference `requested − granted` gives the deny/dismiss rate.
-enum WebNotificationPixel: PixelKitEvent {
+enum WebNotificationPixel: PixelKit.Event {
 
     // MARK: Engagement
 

--- a/macOS/DuckDuckGo/Statistics/WebViewZoomPixel.swift
+++ b/macOS/DuckDuckGo/Statistics/WebViewZoomPixel.swift
@@ -33,7 +33,7 @@ enum WebViewZoomEntryPoint: String {
     }
 }
 
-enum WebViewZoomPixel: PixelKitEvent {
+enum WebViewZoomPixel: PixelKit.Event {
 
     /// Fired on each page zoom action (zoom in, zoom out, or actual size).
     case zoomChanged(entryPoint: WebViewZoomEntryPoint)

--- a/macOS/DuckDuckGo/Sync/Promotion/SyncPromoPixelKitEvent.swift
+++ b/macOS/DuckDuckGo/Sync/Promotion/SyncPromoPixelKitEvent.swift
@@ -19,7 +19,7 @@
 import Foundation
 import PixelKit
 
-enum SyncPromoPixelKitEvent: PixelKitEvent {
+enum SyncPromoPixelKitEvent: PixelKit.Event {
     case syncPromoDisplayed
     case syncPromoConfirmed
     case syncPromoDismissed

--- a/macOS/DuckDuckGo/Sync/SyncPixels.swift
+++ b/macOS/DuckDuckGo/Sync/SyncPixels.swift
@@ -19,7 +19,7 @@
 import PixelKit
 import DDGSync
 
-enum SyncFeatureUsagePixels: PixelKitEvent {
+enum SyncFeatureUsagePixels: PixelKit.Event {
     private enum ParameterKeys {
         static let connectedDevices = "connected_devices"
     }
@@ -52,7 +52,7 @@ enum SyncFeatureUsagePixels: PixelKitEvent {
     }
 }
 
-enum SyncSwitchAccountPixelKitEvent: PixelKitEvent {
+enum SyncSwitchAccountPixelKitEvent: PixelKit.Event {
     case syncAskUserToSwitchAccount
     case syncUserAcceptedSwitchingAccount
     case syncUserCancelledSwitchingAccount
@@ -88,7 +88,7 @@ enum SyncSwitchAccountPixelKitEvent: PixelKitEvent {
     }
 }
 
-enum SyncSetupPixelKitEvent: PixelKitEvent {
+enum SyncSetupPixelKitEvent: PixelKit.Event {
 
     enum ParameterKey {
         static let source = "source"

--- a/macOS/DuckDuckGo/Tab/Model/TabCrashIndicatorModel.swift
+++ b/macOS/DuckDuckGo/Tab/Model/TabCrashIndicatorModel.swift
@@ -42,7 +42,7 @@ final class TabCrashIndicatorModel: ObservableObject {
     /// in order to simplify unit testing.
     init(
         maxPresentationDuration: RunLoop.SchedulerTimeType.Stride = Const.maxIndicatorPresentationDuration,
-        firePixel: @escaping (PixelKitEvent) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) }
+        firePixel: @escaping (PixelKit.Event) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) }
     ) {
         self.maxPresentationDuration = maxPresentationDuration
         self.firePixel = firePixel
@@ -81,6 +81,6 @@ final class TabCrashIndicatorModel: ObservableObject {
     }
 
     private let maxPresentationDuration: RunLoop.SchedulerTimeType.Stride
-    private let firePixel: (PixelKitEvent) -> Void
+    private let firePixel: (PixelKit.Event) -> Void
     private var cancellables: Set<AnyCancellable> = []
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/TabCrashRecoveryExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/TabCrashRecoveryExtension.swift
@@ -83,7 +83,7 @@ final class TabCrashRecoveryExtension {
 
     private let featureFlagger: FeatureFlagger
     private let crashLoopDetector: TabCrashLoopDetecting
-    private let firePixel: (PixelKitEvent, [String: String]) -> Void
+    private let firePixel: (PixelKit.Event, [String: String]) -> Void
     private let tabCrashAggregator: TabCrashAggregator
 
     private var cancellables = Set<AnyCancellable>()
@@ -95,7 +95,7 @@ final class TabCrashRecoveryExtension {
         webViewPublisher: some Publisher<WKWebView, Never>,
         webViewErrorPublisher: some Publisher<WKError?, Never>,
         crashLoopDetector: TabCrashLoopDetecting = TabCrashLoopDetector(),
-        firePixel: @escaping (PixelKitEvent, [String: String]) -> Void = { event, parameters in
+        firePixel: @escaping (PixelKit.Event, [String: String]) -> Void = { event, parameters in
             PixelKit.fire(event, frequency: .dailyAndStandard, withAdditionalParameters: parameters)
         },
         tabCrashAggregator: TabCrashAggregator

--- a/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionEventReporter.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/Subscription/SubscriptionEventReporter.swift
@@ -69,7 +69,7 @@ enum SubscriptionError: LocalizedError {
 
 protocol SubscriptionEventReporter {
     func report(subscriptionActivationError: SubscriptionError)
-    func report(subscriptionTierOptionEvent: PixelKitEvent)
+    func report(subscriptionTierOptionEvent: PixelKit.Event)
 }
 
 struct DefaultSubscriptionEventReporter: SubscriptionEventReporter {
@@ -105,7 +105,7 @@ struct DefaultSubscriptionEventReporter: SubscriptionEventReporter {
         }
     }
 
-    func report(subscriptionTierOptionEvent: PixelKitEvent) {
+    func report(subscriptionTierOptionEvent: PixelKit.Event) {
         PixelKit.fire(subscriptionTierOptionEvent)
     }
 }

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabSuspensionService.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabSuspensionService.swift
@@ -25,7 +25,7 @@ import Persistence
 import PixelKit
 import PrivacyConfig
 
-enum TabSuspensionPixel: PixelKitEvent {
+enum TabSuspensionPixel: PixelKit.Event {
 
     enum Trigger: String {
         case criticalMemoryPressure = "critical_memory_pressure"

--- a/macOS/DuckDuckGo/UnifiedFeedbackForm/UnifiedFeedbackSender.swift
+++ b/macOS/DuckDuckGo/UnifiedFeedbackForm/UnifiedFeedbackSender.swift
@@ -49,7 +49,7 @@ protocol UnifiedFeedbackSender {
 }
 
 extension UnifiedFeedbackSender {
-    func sendStandardPixel(_ pixel: PixelKitEvent) async throws {
+    func sendStandardPixel(_ pixel: PixelKit.Event) async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             PixelKit.fire(pixel, frequency: .standard) { _, error in
                 if let error {

--- a/macOS/DuckDuckGo/UserChurn/UserChurnPixel.swift
+++ b/macOS/DuckDuckGo/UserChurn/UserChurnPixel.swift
@@ -19,7 +19,7 @@
 import Foundation
 import PixelKit
 
-enum UserChurnPixel: PixelKitEvent {
+enum UserChurnPixel: PixelKit.Event {
 
     case unsetAsDefault(newDefaultBrowserBundleId: String?, atb: String?)
 

--- a/macOS/DuckDuckGo/VisualRefresh/ThemePixels.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/ThemePixels.swift
@@ -23,7 +23,7 @@ private enum ThemePixelName: String {
     case themeNameDaily = "m_mac_theme_name"
 }
 
-enum ThemePixels: PixelKitEvent {
+enum ThemePixels: PixelKit.Event {
 
     case themeNameDaily(themeName: ThemeName)
 

--- a/macOS/DuckDuckGo/Waitlist/VPNUninstaller.swift
+++ b/macOS/DuckDuckGo/Waitlist/VPNUninstaller.swift
@@ -77,7 +77,7 @@ final class VPNUninstaller: VPNUninstalling {
         }
     }
 
-    enum IPCUninstallAttempt: PixelKitEvent {
+    enum IPCUninstallAttempt: PixelKit.Event {
         case prevented
         case begin
         case cancelled(_ reason: UninstallCancellationReason)

--- a/macOS/DuckDuckGo/WebExtensions/Pixels/MacOSWebExtensionPixelFiring.swift
+++ b/macOS/DuckDuckGo/WebExtensions/Pixels/MacOSWebExtensionPixelFiring.swift
@@ -19,7 +19,7 @@
 import PixelKit
 import WebExtensions
 
-enum WebExtensionPixel: PixelKitEvent {
+enum WebExtensionPixel: PixelKit.Event {
 
     // MARK: - Installation
 
@@ -87,7 +87,7 @@ enum WebExtensionPixel: PixelKitEvent {
 
     case dailyAdBlockingState(isEnabled: Bool, analyticsEnabled: Bool)
 
-    // MARK: - PixelKitEvent
+    // MARK: - PixelKit.Event
 
     var name: String {
         switch self {

--- a/macOS/DuckDuckGo/YoutubePlayer/DuckPlayerOverlayPixels.swift
+++ b/macOS/DuckDuckGo/YoutubePlayer/DuckPlayerOverlayPixels.swift
@@ -107,7 +107,7 @@ final class DuckPlayerOverlayUsagePixels: NSObject, DuckPlayerOverlayPixelFiring
         }
     }
 
-    private func firePixelIfNeeded(_ pixel: PixelKitEvent, url: URL?) {
+    private func firePixelIfNeeded(_ pixel: PixelKit.Event, url: URL?) {
         if let url, url.isYoutubeWatch, duckPlayerMode == .alwaysAsk {
             pixelFiring?.fire(pixel)
         }

--- a/macOS/DuckDuckGoVPN/TunnelControllerIPCService.swift
+++ b/macOS/DuckDuckGoVPN/TunnelControllerIPCService.swift
@@ -51,7 +51,7 @@ final class TunnelControllerIPCService {
         }
     }
 
-    enum UDSError: PixelKitEvent {
+    enum UDSError: PixelKit.Event {
         case udsServerStartFailure(_ error: Error)
 
         var name: String {

--- a/macOS/DuckDuckGoVPN/VPNUninstaller.swift
+++ b/macOS/DuckDuckGoVPN/VPNUninstaller.swift
@@ -113,7 +113,7 @@ extension VPNUninstaller {
         case sysexInstallationRequiresAuthorization
     }
 
-    enum VPNUninstallAttempt: PixelKitEvent {
+    enum VPNUninstallAttempt: PixelKit.Event {
         case begin
         case cancelled(_ reason: UninstallCancellationReason)
         case success

--- a/macOS/LocalPackages/AddressBarPerformance/Sources/AddressBarPerformance/AddressBarPerformancePixel.swift
+++ b/macOS/LocalPackages/AddressBarPerformance/Sources/AddressBarPerformance/AddressBarPerformancePixel.swift
@@ -30,7 +30,7 @@ import PixelKit
 /// macOS divergence is intentional — both stages share trigger, snapshot, and deferred dispatch,
 /// so a single pixel halves the network traffic in the case where both stages have data.
 /// Backend aggregation accommodates the divergence via a macOS-specific Prefect case.
-struct AddressBarPerformancePixel: PixelKitEvent {
+struct AddressBarPerformancePixel: PixelKit.Event {
 
     /// Names which halves of the pixel carry real data. A pixel is only emitted when at least one
     /// stage has samples, so a "neither" case is never sent.

--- a/macOS/LocalPackages/AddressBarPerformance/Tests/AddressBarPerformanceTests/AddressBarPerformanceCoordinatorTests.swift
+++ b/macOS/LocalPackages/AddressBarPerformance/Tests/AddressBarPerformanceTests/AddressBarPerformanceCoordinatorTests.swift
@@ -33,7 +33,7 @@ final class AddressBarPerformanceCoordinatorTests: XCTestCase {
         private let lock = NSLock()
         private var pixels: [AddressBarPerformancePixel] = []
 
-        func fire(_ event: PixelKitEvent,
+        func fire(_ event: PixelKit.Event,
                   frequency: PixelKit.Frequency,
                   includeAppVersionParameter: Bool,
                   withAdditionalParameters: [String: String]?,

--- a/macOS/LocalPackages/AppUpdater/Sources/AppUpdaterShared/UpdateFlowPixels.swift
+++ b/macOS/LocalPackages/AppUpdater/Sources/AppUpdaterShared/UpdateFlowPixels.swift
@@ -17,7 +17,7 @@
 //
 import PixelKit
 
-public enum UpdateFlowPixels: PixelKitEvent {
+public enum UpdateFlowPixels: PixelKit.Event {
 
     /**
      * Event Trigger: Update notification is shown to user

--- a/macOS/LocalPackages/AppUpdater/Tests/SparkleAppUpdaterTests/ReleaseNotesUserScriptTests.swift
+++ b/macOS/LocalPackages/AppUpdater/Tests/SparkleAppUpdaterTests/ReleaseNotesUserScriptTests.swift
@@ -272,9 +272,9 @@ private final class StubSparkleUpdateController: NSObject, SparkleUpdateControll
 }
 
 private final class CapturingPixelFiring: PixelFiring {
-    var firedEvents: [PixelKitEvent] = []
+    var firedEvents: [PixelKit.Event] = []
 
-    func fire(_ event: PixelKitEvent,
+    func fire(_ event: PixelKit.Event,
               frequency: PixelKit.Frequency,
               includeAppVersionParameter: Bool,
               withAdditionalParameters: [String: String]?,

--- a/macOS/LocalPackages/BWIntegration/Sources/BWManagement/BWManagementPixels.swift
+++ b/macOS/LocalPackages/BWIntegration/Sources/BWManagement/BWManagementPixels.swift
@@ -18,7 +18,7 @@
 
 import PixelKit
 
-enum BWManagementPixels: PixelKitEvent {
+enum BWManagementPixels: PixelKit.Event {
 
     case bitwardenNotResponding
     case bitwardenRespondedCannotDecrypt

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/Pixels/DataBrokerProtectionMacOSPixels.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/Pixels/DataBrokerProtectionMacOSPixels.swift
@@ -83,7 +83,7 @@ public enum DataBrokerProtectionMacOSPixels {
     case failedToParsePrivacyConfig(Error)
 }
 
-extension DataBrokerProtectionMacOSPixels: PixelKitEvent {
+extension DataBrokerProtectionMacOSPixels: PixelKit.Event {
     public var name: String {
         switch self {
 

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Controller/TransparentProxyController.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Controller/TransparentProxyController.swift
@@ -285,7 +285,7 @@ extension TransparentProxyController {
         case stopped
     }
 
-    public enum StartAttemptStep: PixelKitEvent {
+    public enum StartAttemptStep: PixelKit.Event {
         /// Abnormal attempt to start the proxy when it wasn't needed
         case prevented(_ error: Error)
 

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/TransparentProxyProvider.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/NetworkProtectionProxy/Provider/TransparentProxyProvider.swift
@@ -636,7 +636,7 @@ extension TransparentProxyProvider {
         }
     }
 
-    public struct OrphanedEvent: PixelKitEvent {
+    public struct OrphanedEvent: PixelKit.Event {
         public let heartbeatAge: HeartbeatAgeBucket
         public let proxyAge: ProxyAgeBucket
 
@@ -656,7 +656,7 @@ extension TransparentProxyProvider {
         }
     }
 
-    public enum StartAttemptStep: PixelKitEvent {
+    public enum StartAttemptStep: PixelKit.Event {
         /// Attempt to start the proxy begins
         case begin
 

--- a/macOS/LocalPackages/NetworkProtectionMac/Sources/VPNPixels/VPNPixel.swift
+++ b/macOS/LocalPackages/NetworkProtectionMac/Sources/VPNPixels/VPNPixel.swift
@@ -23,7 +23,7 @@ import PixelKit
 ///
 let vpnPixelModulePrefix = "vpn"
 
-public protocol VPNPixel: PixelKitEvent {
+public protocol VPNPixel: PixelKit.Event {
 
     /// The name of the pixel without the module prefix.
     ///

--- a/macOS/LocalPackages/PixelKit/Sources/PixelKitTestingUtilities/PixelKitMock.swift
+++ b/macOS/LocalPackages/PixelKit/Sources/PixelKitTestingUtilities/PixelKitMock.swift
@@ -34,15 +34,15 @@ public final class PixelKitMock: PixelFiring {
         self.expectedFireCalls = expectedFireCalls
     }
 
-    public func fire(_ event: PixelKitEvent) {
+    public func fire(_ event: PixelKit.Event) {
         fire(event, frequency: .standard)
     }
 
-    public func fire(_ event: PixelKitEvent, frequency: PixelKit.Frequency) {
+    public func fire(_ event: PixelKit.Event, frequency: PixelKit.Frequency) {
         fire(event, frequency: frequency, includeAppVersionParameter: true, withAdditionalParameters: nil, onComplete: { _, _ in })
     }
 
-    public func fire(_ event: PixelKitEvent,
+    public func fire(_ event: PixelKit.Event,
                      frequency: PixelKit.Frequency,
                      includeAppVersionParameter: Bool,
                      withAdditionalParameters parameters: [String: String]?,
@@ -58,11 +58,11 @@ public final class PixelKitMock: PixelFiring {
 }
 
 public struct ExpectedFireCall: Equatable {
-    let pixel: PixelKitEvent
+    let pixel: PixelKit.Event
     let frequency: PixelKit.Frequency
     let includeAppVersionParameter: Bool
 
-    public init(pixel: PixelKitEvent, frequency: PixelKit.Frequency, includeAppVersionParameter: Bool = true) {
+    public init(pixel: PixelKit.Event, frequency: PixelKit.Frequency, includeAppVersionParameter: Bool = true) {
         self.pixel = pixel
         self.frequency = frequency
         self.includeAppVersionParameter = includeAppVersionParameter

--- a/macOS/UnitTests/Common/Pixel/PixelCapturedParameters.swift
+++ b/macOS/UnitTests/Common/Pixel/PixelCapturedParameters.swift
@@ -20,7 +20,7 @@ import Foundation
 import PixelKit
 
 struct PixelCapturedParameters {
-    var event: PixelKitEvent?
+    var event: PixelKit.Event?
     var frequency: PixelKit.Frequency = .standard
     var headers: [String: String] = [:]
     var parameters: [String: String]?

--- a/macOS/UnitTests/HomePage/HomePageSettingsModelTests.swift
+++ b/macOS/UnitTests/HomePage/HomePageSettingsModelTests.swift
@@ -31,7 +31,7 @@ final class NewTabPageCustomizationModelTests: XCTestCase {
     var storageLocation: URL!
     var appearancePreferences: AppearancePreferences!
     var userBackgroundImagesManager: CapturingUserBackgroundImagesManager!
-    var sendPixelEvents: [PixelKitEvent] = []
+    var sendPixelEvents: [PixelKit.Event] = []
     var openFilePanel: () -> URL? = { return "file:///sample.jpg".url! }
     var openFilePanelCallCount = 0
     var showImageFailedAlertCallCount = 0

--- a/macOS/UnitTests/HomePage/UserBackgroundImagesManagerTests.swift
+++ b/macOS/UnitTests/HomePage/UserBackgroundImagesManagerTests.swift
@@ -26,7 +26,7 @@ final class UserBackgroundImagesManagerTests: XCTestCase {
     var manager: UserBackgroundImagesManager!
     var storageLocation: URL!
     var imageProcessor: ImageProcessorMock!
-    var sendPixelEvents: [PixelKitEvent] = []
+    var sendPixelEvents: [PixelKit.Event] = []
 
     override func setUp() async throws {
         storageLocation = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)

--- a/macOS/UnitTests/NewTabPage/NewTabPageCoordinatorTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageCoordinatorTests.swift
@@ -74,7 +74,7 @@ final class NewTabPageCoordinatorTests: XCTestCase {
     var customizationModel: NewTabPageCustomizationModel!
     var notificationCenter: NotificationCenter!
     var keyValueStore: MockKeyValueFileStore!
-    var firePixelCalls: [PixelKitEvent] = []
+    var firePixelCalls: [PixelKit.Event] = []
     var featureFlagger: FeatureFlagger!
     var windowControllersManager: (WindowControllersManagerProtocol & AIChatTabManaging)!
     var tabsPreferences: TabsPreferences!

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsCardsPixelHandlerTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsCardsPixelHandlerTests.swift
@@ -25,7 +25,7 @@ import XCTest
 
 final class NewTabPageNextStepsCardsPixelHandlerTests: XCTestCase {
     private var pixelHandler: NewTabPageNextStepsCardsPixelHandler!
-    private var firedPixels: [(event: PixelKitEvent, frequency: PixelKit.Frequency, includesAppVersionParameter: Bool)] = []
+    private var firedPixels: [(event: PixelKit.Event, frequency: PixelKit.Frequency, includesAppVersionParameter: Bool)] = []
     private var persistor: MockNewTabPageNextStepsCardsPersistor!
     private var appearancePrefsPersistor: MockAppearancePreferencesPersistor!
 
@@ -406,7 +406,7 @@ final class NewTabPageNextStepsCardsPixelHandlerTests: XCTestCase {
 }
 
 private extension NewTabPageNextStepsCardsPixelHandlerTests {
-    func setUpExpectedClickedEvent(for card: NewTabPageDataModel.CardID) -> PixelKitEvent {
+    func setUpExpectedClickedEvent(for card: NewTabPageDataModel.CardID) -> PixelKit.Event {
         persistor.setTimesShown(expectedCardImpressions, for: card)
         return NewTabPagePixel.nextStepsCardClicked(card.rawValue,
                                                     cardImpressionCount: expectedCardImpressions,
@@ -415,7 +415,7 @@ private extension NewTabPageNextStepsCardsPixelHandlerTests {
                                                     activeUsageDays: expectedNextStepsActiveUsageDays)
     }
 
-    func setUpExpectedDismissedEvent(for card: NewTabPageDataModel.CardID) -> PixelKitEvent {
+    func setUpExpectedDismissedEvent(for card: NewTabPageDataModel.CardID) -> PixelKit.Event {
         persistor.setTimesShown(expectedCardImpressions, for: card)
         return NewTabPagePixel.nextStepsCardDismissed(card.rawValue,
                                                       cardImpressionCount: expectedCardImpressions,

--- a/macOS/UnitTests/NewTabPage/NewTabPageShownPixelSenderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageShownPixelSenderTests.swift
@@ -37,7 +37,7 @@ final class NewTabPageShownPixelSenderTests: XCTestCase {
     var customizationModel: NewTabPageCustomizationModel!
     var handler: NewTabPageShownPixelSender!
     var keyValueStore: MockKeyValueStore!
-    var firePixelCalls: [PixelKitEvent] = []
+    var firePixelCalls: [PixelKit.Event] = []
 
     @MainActor
     override func setUp() async throws {

--- a/macOS/UnitTests/Onboarding/ContextualOnboarding/OnboardingPixelReporterTests.swift
+++ b/macOS/UnitTests/Onboarding/ContextualOnboarding/OnboardingPixelReporterTests.swift
@@ -27,7 +27,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
 
     var reporter: OnboardingPixelReporter!
     var onboardingState: MockContextualOnboardingState!
-    var eventSent: PixelKitEvent?
+    var eventSent: PixelKit.Event?
     var frequency: PixelKit.Frequency?
     var userDefaults: UserDefaults?
     private var sharedPixelHandler: MockOnboardingSharedPixelHandler!

--- a/macOS/UnitTests/Onboarding/ContextualOnboarding/OnboardingSubscriptionUpsellMetricsTests.swift
+++ b/macOS/UnitTests/Onboarding/ContextualOnboarding/OnboardingSubscriptionUpsellMetricsTests.swift
@@ -27,7 +27,7 @@ import XCTest
 
 final class OnboardingSubscriptionUpsellMetricsTests: XCTestCase {
 
-    private var firedEvents: [PixelKitEvent]!
+    private var firedEvents: [PixelKit.Event]!
     private let subfeatureID = PrivacyProSubfeature.onboardingSubscriptionUpsellExperiment.rawValue
 
     override func setUp() {

--- a/macOS/UnitTests/Onboarding/OnboardingChromeExtensionExperimentTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingChromeExtensionExperimentTests.swift
@@ -26,7 +26,7 @@ import XCTest
 
 final class OnboardingChromeExtensionExperimentTests: XCTestCase {
 
-    private var firedEvents: [PixelKitEvent]!
+    private var firedEvents: [PixelKit.Event]!
 
     override func setUp() {
         firedEvents = []

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -503,7 +503,7 @@ class OnboardingManagerTests: XCTestCase {
 
     func testSetDefaultCompletedExperimentMetricFiredWhenEnrolled() {
         // Given
-        var firedEvents: [PixelKitEvent] = []
+        var firedEvents: [PixelKit.Event] = []
         let featureFlagger = makeFeatureFlagger(cohort: .control)
         let subfeatureID = MacOSBrowserConfigSubfeature.onboardingChromeExtension.rawValue
         featureFlagger.allActiveExperiments = [
@@ -530,7 +530,7 @@ class OnboardingManagerTests: XCTestCase {
 
     func testSetDefaultCompletedExperimentMetricNotFiredWhenNotEnrolled() {
         // Given
-        var firedEvents: [PixelKitEvent] = []
+        var firedEvents: [PixelKit.Event] = []
         PixelKit.configureExperimentKit(
             featureFlagger: MockFeatureFlagger(),
             eventTracker: ExperimentEventTracker(store: MockExperimentActionPixelStore()),

--- a/macOS/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
+++ b/macOS/UnitTests/Subscription/SubscriptionPagesUseSubscriptionFeatureTests.swift
@@ -1234,7 +1234,7 @@ final class MockSubscriptionEventReporter: SubscriptionEventReporter {
         reportedActivationErrors.append(subscriptionActivationError)
     }
 
-    func report(subscriptionTierOptionEvent: PixelKitEvent) {
+    func report(subscriptionTierOptionEvent: PixelKit.Event) {
         reportedTierOptionEvents.append(TierOptionEventRecord(eventName: subscriptionTierOptionEvent.name))
     }
 }

--- a/macOS/UnitTests/Tab/Model/TabCrashIndicatorModelTests.swift
+++ b/macOS/UnitTests/Tab/Model/TabCrashIndicatorModelTests.swift
@@ -29,7 +29,7 @@ final class TabCrashIndicatorModelTests: XCTestCase {
     var cancellables: Set<AnyCancellable> = []
 
     var firePixelCallCount: Int = 0
-    var firePixelHandler: (PixelKitEvent) -> Void = { _ in }
+    var firePixelHandler: (PixelKit.Event) -> Void = { _ in }
 
     override func setUp() async throws {
         crashPublisher = PassthroughSubject()

--- a/macOS/UnitTests/TabBar/ViewModel/TabSuspensionServiceTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabSuspensionServiceTests.swift
@@ -360,21 +360,21 @@ final class TabSuspensionServiceTests: XCTestCase {
 
 private final class MockSuspensionPixelFiring: PixelFiring {
     struct FireCall {
-        let pixel: PixelKitEvent
+        let pixel: PixelKit.Event
         let frequency: PixelKit.Frequency
     }
 
     var fireCalls = [FireCall]()
 
-    func fire(_ event: PixelKitEvent) {
+    func fire(_ event: PixelKit.Event) {
         fire(event, frequency: .standard)
     }
 
-    func fire(_ event: PixelKitEvent, frequency: PixelKit.Frequency) {
+    func fire(_ event: PixelKit.Event, frequency: PixelKit.Frequency) {
         fire(event, frequency: frequency, includeAppVersionParameter: true, withAdditionalParameters: nil, withNamePrefix: nil, doNotEnforcePrefix: false, onComplete: { _, _ in })
     }
 
-    func fire(_ event: PixelKitEvent, frequency: PixelKit.Frequency, includeAppVersionParameter: Bool, withAdditionalParameters: [String: String]?, withNamePrefix: String?, doNotEnforcePrefix: Bool, onComplete: @escaping PixelKit.CompletionBlock) {
+    func fire(_ event: PixelKit.Event, frequency: PixelKit.Frequency, includeAppVersionParameter: Bool, withAdditionalParameters: [String: String]?, withNamePrefix: String?, doNotEnforcePrefix: Bool, onComplete: @escaping PixelKit.CompletionBlock) {
         fireCalls.append(FireCall(pixel: event, frequency: frequency))
         onComplete(true, nil)
     }

--- a/macOS/UnitTests/TabExtensionsTests/TabCrashRecoveryExtensionTests.swift
+++ b/macOS/UnitTests/TabExtensionsTests/TabCrashRecoveryExtensionTests.swift
@@ -73,7 +73,7 @@ final class TabCrashRecoveryExtensionTests: XCTestCase {
     var cancellables: Set<AnyCancellable> = []
 
     var firePixelCallCount: Int = 0
-    var firePixelHandler: (PixelKitEvent, [String: String]) -> Void = { _, _ in }
+    var firePixelHandler: (PixelKit.Event, [String: String]) -> Void = { _, _ in }
 
     @MainActor
     override func setUp() async throws {

--- a/macOS/UnitTests/WarnBeforeQuit/WarnBeforeQuitManagerTests.swift
+++ b/macOS/UnitTests/WarnBeforeQuit/WarnBeforeQuitManagerTests.swift
@@ -2967,7 +2967,7 @@ final class WarnBeforeQuitManagerTests: XCTestCase, Sendable {
                 self.fireExpectation = fireExpectation
                 self.completionExpectation = completionExpectation
             }
-            public func fire(_ event: PixelKitEvent,
+            public func fire(_ event: PixelKit.Event,
                              frequency: PixelKit.Frequency,
                              includeAppVersionParameter: Bool,
                              withAdditionalParameters: [String: String]?,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1217419466538070?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1217412374194171
CC:

### Description

Renames the pixel event protocol from `PixelKitEvent` to `PixelKit.Event`, so it reads consistently with the other types nested in PixelKit and with the `Options`/`FireResult` types added in the next PR of this stack.

This is a pure rename. No behaviour changes, no pixel names change, nothing is added or removed from the API surface.

Bottom of a 2-PR stack. Reviewing this one first makes the next PR's diff much easier to read, since otherwise the same declaration lines would be touched twice.

### Testing Steps

No user-facing behaviour to exercise. Verification is that it compiles and the existing suite is unchanged:

1. Build BrowserServicesKit → succeeds with no new warnings
2. Run `PixelKitTests` → 138 tests pass, same as before this PR
3. Build the macOS and iOS apps → succeed

### Impact

None. Internal refactor with no runtime behaviour change.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical type rename with no logic changes to pixel firing or telemetry; compile-time and test coverage are the main verification surface.
> 
> **Overview**
> Renames the pixel event protocol from **`PixelKitEvent`** to **`PixelKit.Event`**, nesting it under `PixelKit` like other kit types and aligning naming with follow-up work in the same stack.
> 
> The declaration moves from a top-level `PixelKitEvent` protocol in `PixelKitEvent.swift` to `extension PixelKit { public protocol Event }` in **`PixelKit+Event.swift`**. **`PixelFiring`**, **`PixelKit.fire`**, mocks, and test helpers now take **`PixelKit.Event`** instead of **`PixelKitEvent`**. Every pixel enum across iOS, macOS, shared packages, and tests updates its conformance and closure types accordingly; **`PixelKitEventWithCustomPrefix`** stays a separate protocol and is unchanged.
> 
> Internal docs (**`.cursor/BUGBOT.md`**, **`pixels.mdc`**, **`pixel-definitions.mdc`**) are updated so pixel-review guidance refers to **`PixelKit.Event`**. No pixel names, firing behavior, or public API beyond the type rename change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0c583fa0ff64993ce27d57143f19b244b48fe74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->