### PR TITLE
Add PixelKit.Options and reshape the fire API around it

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -51,7 +51,7 @@ Check that the `parameters` array accounts for all parameters the pixel includes
 - **Missing `appVersion`.** Many pixels include `appVersion` by default. The definition should list `"appVersion"` unless the Swift call site explicitly opts out of it.
 - **Missing error parameters.** If the pixel event carries an `Error` (via an associated value or the `error` property), the definition must include `"errorCode"` and `"errorDomain"`. If the error may have an underlying error, also include `"underlyingErrorCode"` and `"underlyingErrorDomain"`.
 - **Missing `pixelSource`.** If the pixel event's `standardParameters` property returns `[.pixelSource]`, the definition must include `"pixelSource"`.
-- **Missing custom parameters.** Check the pixel event's `parameters` computed property and any `withAdditionalParameters:` arguments at the call site. Every key that appears in the parameters dictionary must be represented in the definition — either as a reference to the params dictionary or as an inline parameter object.
+- **Missing custom parameters.** Check the pixel event's `parameters` computed property and any extra parameters supplied at the call site. On PixelKit these arrive either as `withAdditionalParameters:` (legacy form) or inside the options argument, as `options: .parameters([...])` or `PixelKit.Options(additionalParameters: [...])`. Every key that appears in the parameters dictionary must be represented in the definition — either as a reference to the params dictionary or as an inline parameter object.
 
 Parameters can be either:
 - A string referencing `params_dictionary.json5` (e.g. `"appVersion"`, `"errorCode"`)

--- a/.cursor/rules/pixels.mdc
+++ b/.cursor/rules/pixels.mdc
@@ -189,6 +189,10 @@ Pixel.fire(pixel: .featureUsed, withAdditionalParameters: [
 
 ## PixelFiring Protocol
 
+There are two unrelated protocols with this name. Pick the one matching the pixel system you are in.
+
+### iOS (`iOS/Core/Pixel`)
+
 For dependency injection and testing, use the `PixelFiring` protocol:
 
 ```swift
@@ -203,6 +207,44 @@ public protocol PixelFiring {
                      withAdditionalParameters params: [String: String])
 }
 ```
+
+### PixelKit (macOS and shared packages)
+
+```swift
+// SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelFiring.swift
+public protocol PixelFiring {
+    func fire(event: PixelKit.Event,
+              frequency: PixelKit.Frequency,
+              options: PixelKit.Options,
+              onComplete: @escaping PixelKit.CompletionBlock)
+}
+```
+
+Conformers implement only that requirement. Callers use one of two entry points, never the
+requirement directly:
+
+```swift
+// Fire and forget. Correct for almost every pixel: telemetry should not make the caller wait.
+pixelKit.fire(SubscriptionPixel.subscriptionActivated, frequency: .uniqueByName)
+
+// Request shaping goes in `options`, not in extra parameters.
+pixelKit.fire(event, options: .parameters(["source": "menu"]))
+pixelKit.fire(event, options: .unenforcedPrefix)     // name already fully qualified
+pixelKit.fire(event, options: .withoutAppVersion)    // e.g. crash reports
+
+// Only when the caller genuinely needs the outcome. This awaits a network round trip.
+if try await pixelKit.fireAsync(event, frequency: .daily) == .suppressed { ... }
+```
+
+`PixelKit.Options` presets cover the common cases (`.default`, `.parameters(_:)`, `.namePrefix(_:)`,
+`.unenforcedPrefix`, `.withoutAppVersion`). It is a value type, so uncommon combinations compose:
+
+```swift
+var options = PixelKit.Options.unenforcedPrefix
+options.additionalParameters = ["source": "menu"]
+```
+
+Do not add convenience overloads of `fire` to hide parameters; that is what `Options` replaced.
 
 ## Best Practices
 

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelFiring+Async.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelFiring+Async.swift
@@ -20,25 +20,26 @@ import Foundation
 
 extension PixelFiring {
 
-    /// Async/await variant of PixelKit `fire`
+    /// Fires a pixel and waits for the request to complete.
     ///
-    /// - Returns: `true` if a request was fired, `false` if it was suppressed by frequency rules.
-    /// - Throws: the underlying error if firing the request failed.
+    /// Prefer the synchronous `fire` unless the caller genuinely needs the outcome: awaiting a
+    /// pixel makes the caller wait on a network round trip.
+    ///
+    /// - Returns: `.sent` if a request was sent, `.suppressed` if the event's frequency rules
+    ///   suppressed it. Suppression is a normal outcome, not a failure.
+    /// - Throws: the underlying error if sending the request failed.
     @discardableResult
     public func fireAsync(_ event: PixelKit.Event,
                           frequency: PixelKit.Frequency = .standard,
-                          includeAppVersionParameter: Bool = true,
-                          withAdditionalParameters parameters: [String: String]? = nil,
-                          withNamePrefix namePrefix: String? = nil,
-                          doNotEnforcePrefix: Bool = false) async throws -> Bool {
+                          options: PixelKit.Options = .default) async throws -> PixelKit.FireResult {
         let firstCompletion = OneTimeFlag()
         return try await withCheckedThrowingContinuation { continuation in
-            fire(event,
+            fire(event: event,
                  frequency: frequency,
-                 includeAppVersionParameter: includeAppVersionParameter,
-                 withAdditionalParameters: parameters,
-                 withNamePrefix: namePrefix,
-                 doNotEnforcePrefix: doNotEnforcePrefix) { fired, error in
+                 options: options) { fired, error in
+                // Multi-request frequencies such as `.dailyAndCount` complete more than once.
+                // Resolve on the first completion and drop the rest, otherwise the second resume
+                // traps.
                 guard firstCompletion.trySet() else { return }
 
                 if let error {
@@ -46,7 +47,7 @@ extension PixelFiring {
                     return
                 }
 
-                continuation.resume(returning: fired)
+                continuation.resume(returning: fired ? .sent : .suppressed)
             }
         }
     }

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelFiring.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelFiring.swift
@@ -17,67 +17,37 @@
 //
 
 /// Protocol to support mocking pixel firing.
+///
+/// This has a single requirement, which is the underlying primitive: fire a pixel and report the
+/// outcome through a completion block. Conformers implement only this. The two public entry points,
+/// `fire` and `fireAsync`, are extension sugar over it, and neither exposes the completion block to
+/// callers.
+///
+/// The requirement carries an `event:` argument label that the sugar deliberately does not. Keeping
+/// the two signatures distinct matters: default argument values are illegal in a protocol
+/// requirement, and an extension method whose signature *matches* the requirement silently becomes
+/// that requirement's default implementation and calls itself, so a conformer that forgot to
+/// implement it would compile cleanly and then recurse forever.
 public protocol PixelFiring {
-    func fire(_ event: PixelKit.Event,
+    func fire(event: PixelKit.Event,
               frequency: PixelKit.Frequency,
-              includeAppVersionParameter: Bool,
-              withAdditionalParameters: [String: String]?,
-              withNamePrefix: String?,
-              doNotEnforcePrefix: Bool,
+              options: PixelKit.Options,
               onComplete: @escaping PixelKit.CompletionBlock)
 }
 
 extension PixelFiring {
-    public func fire(_ event: PixelKit.Event) {
-        fire(event, frequency: .standard, includeAppVersionParameter: true)
-    }
 
+    /// Fires a pixel and returns immediately, without waiting for the request to complete.
+    ///
+    /// This is the right call for almost every pixel: telemetry should not make the caller wait.
+    /// Use `fireAsync` only when the outcome actually matters to the caller.
     public func fire(_ event: PixelKit.Event,
-                     frequency: PixelKit.Frequency) {
-        fire(event, frequency: frequency, includeAppVersionParameter: true, withAdditionalParameters: nil, withNamePrefix: nil, doNotEnforcePrefix: false, onComplete: { _, _ in })
-    }
-
-    public func fire(_ event: PixelKit.Event,
-                     frequency: PixelKit.Frequency,
-                     doNotEnforcePrefix: Bool) {
-        fire(event, frequency: frequency, includeAppVersionParameter: true, withAdditionalParameters: nil, withNamePrefix: nil, doNotEnforcePrefix: doNotEnforcePrefix, onComplete: { _, _ in })
-    }
-
-    public func fire(_ event: PixelKit.Event,
-                     frequency: PixelKit.Frequency,
-                     includeAppVersionParameter: Bool) {
-        fire(event, frequency: frequency, includeAppVersionParameter: includeAppVersionParameter, withAdditionalParameters: nil, withNamePrefix: nil, doNotEnforcePrefix: false, onComplete: { _, _ in })
-    }
-
-    public func fire(_ event: PixelKit.Event,
-                     frequency: PixelKit.Frequency,
-                     onComplete: @escaping PixelKit.CompletionBlock) {
-        fire(event, frequency: frequency, includeAppVersionParameter: true, withAdditionalParameters: nil, withNamePrefix: nil, doNotEnforcePrefix: false, onComplete: onComplete)
-    }
-
-    public func fire(_ event: PixelKit.Event,
-                     frequency: PixelKit.Frequency,
-                     withAdditionalParameters parameters: [String: String]?) {
-        fire(event, frequency: frequency, includeAppVersionParameter: true, withAdditionalParameters: parameters, withNamePrefix: nil, doNotEnforcePrefix: false, onComplete: { _, _ in })
-    }
-
-    public func fire(_ event: PixelKit.Event,
-                     frequency: PixelKit.Frequency,
-                     withAdditionalParameters parameters: [String: String]?,
-                     withNamePrefix namePrefix: String?) {
-        fire(event, frequency: frequency, includeAppVersionParameter: true, withAdditionalParameters: parameters, withNamePrefix: namePrefix, doNotEnforcePrefix: false, onComplete: { _, _ in })
+                     frequency: PixelKit.Frequency = .standard,
+                     options: PixelKit.Options = .default) {
+        fire(event: event, frequency: frequency, options: options, onComplete: { _, _ in })
     }
 }
 
-extension PixelKit: PixelFiring {
-    public func fire(_ event: PixelKit.Event,
-                     frequency: PixelKit.Frequency,
-                     includeAppVersionParameter: Bool,
-                     withAdditionalParameters parameters: [String: String]?,
-                     withNamePrefix namePrefix: String?,
-                     doNotEnforcePrefix: Bool,
-                     onComplete: @escaping PixelKit.CompletionBlock) {
-        fire(event, frequency: frequency, withHeaders: nil, withAdditionalParameters: parameters,
-             withNamePrefix: namePrefix, includeAppVersionParameter: includeAppVersionParameter, doNotEnforcePrefix: doNotEnforcePrefix, onComplete: onComplete)
-    }
-}
+/// `PixelKit` satisfies the requirement with its own `fire(event:frequency:options:onComplete:)`,
+/// so no forwarding shim is needed here.
+extension PixelKit: PixelFiring {}

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit+Options.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit+Options.swift
@@ -27,7 +27,12 @@ extension PixelKit {
     /// call reads `fire(event)` or `fire(event, frequency: .daily)` with no options in sight.
     public struct Options: Equatable, Sendable {
 
-        /// Extra HTTP headers merged over the instance's default headers.
+        /// HTTP headers for the request.
+        ///
+        /// Note this *replaces* the instance's `defaultHeaders` rather than merging with them: see
+        /// `fire(pixelNamed:)`, which does `headers ?? defaultHeaders`. Leave it `nil` (the default)
+        /// to send `defaultHeaders`. Long-standing PixelKit behaviour, preserved here deliberately;
+        /// whether it should merge instead is a separate question from this API reshape.
         public var headers: [String: String]?
 
         /// Extra query parameters merged over the event's own parameters. On key collision the

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit+Options.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit+Options.swift
@@ -1,0 +1,110 @@
+//
+//  PixelKit+Options.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension PixelKit {
+
+    /// How a pixel request is shaped, as opposed to what the pixel *is*.
+    ///
+    /// `event` and `frequency` stay as parameters on `fire` because they describe the telemetry
+    /// itself. Everything here describes the outgoing request, and is defaulted, so the common
+    /// call reads `fire(event)` or `fire(event, frequency: .daily)` with no options in sight.
+    public struct Options: Equatable, Sendable {
+
+        /// Extra HTTP headers merged over the instance's default headers.
+        public var headers: [String: String]?
+
+        /// Extra query parameters merged over the event's own parameters. On key collision the
+        /// value supplied here wins.
+        public var additionalParameters: [String: String]?
+
+        /// Overrides the platform prefix applied to the pixel name.
+        public var namePrefix: String?
+
+        /// Characters left unescaped when building the query string.
+        public var allowedQueryReservedCharacters: CharacterSet?
+
+        /// Whether to append the `appVersion` parameter.
+        public var includeAppVersionParameter: Bool
+
+        /// Whether the platform name prefix is enforced.
+        ///
+        /// Note the polarity: this replaces the previous `doNotEnforcePrefix`, so
+        /// `doNotEnforcePrefix: true` becomes `enforcePrefix: false`.
+        public var enforcePrefix: Bool
+
+        public init(headers: [String: String]? = nil,
+                    additionalParameters: [String: String]? = nil,
+                    namePrefix: String? = nil,
+                    allowedQueryReservedCharacters: CharacterSet? = nil,
+                    includeAppVersionParameter: Bool = true,
+                    enforcePrefix: Bool = true) {
+            self.headers = headers
+            self.additionalParameters = additionalParameters
+            self.namePrefix = namePrefix
+            self.allowedQueryReservedCharacters = allowedQueryReservedCharacters
+            self.includeAppVersionParameter = includeAppVersionParameter
+            self.enforcePrefix = enforcePrefix
+        }
+
+        // MARK: - Curated presets
+        //
+        // Each of these corresponds to a combination that is actually used in the codebase.
+        // Combinations that nobody uses deliberately get no preset: build them with `init`, or
+        // start from a preset and mutate, since this is a value type.
+        //
+        //     var options = PixelKit.Options.unenforcedPrefix
+        //     options.additionalParameters = ["source": "menu"]
+
+        /// Everything default: prefix enforced, app version included, nothing extra.
+        public static let `default` = Options()
+
+        /// For pixels whose names are already fully qualified and must not gain a platform prefix.
+        public static let unenforcedPrefix = Options(enforcePrefix: false)
+
+        /// For pixels that must not carry the `appVersion` parameter, such as crash reports.
+        public static let withoutAppVersion = Options(includeAppVersionParameter: false)
+
+        /// Attaches extra query parameters.
+        public static func parameters(_ parameters: [String: String]) -> Options {
+            Options(additionalParameters: parameters)
+        }
+
+        /// Overrides the platform name prefix, typically with a per-platform value.
+        public static func namePrefix(_ prefix: String) -> Options {
+            Options(namePrefix: prefix)
+        }
+
+        /// Extra parameters plus a name prefix override.
+        public static func parameters(_ parameters: [String: String], namePrefix: String) -> Options {
+            Options(additionalParameters: parameters, namePrefix: namePrefix)
+        }
+    }
+
+    /// Whether a `fire` call actually sent a request.
+    public enum FireResult: Equatable, Sendable {
+
+        /// A request was sent.
+        case sent
+
+        /// No request was sent because the event's `Frequency` rules suppressed it, for example a
+        /// `.daily` pixel already fired today. This is a normal outcome, not a failure.
+        case suppressed
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
@@ -268,18 +268,19 @@ public final class PixelKit {
 
     // MARK: - Public Fire
 
-    /// Main function for firing pixels
-    public func fire(_ event: PixelKit.Event,
-                     frequency: Frequency = .standard,
-                     withHeaders headers: [String: String]? = nil,
-                     withAdditionalParameters params: [String: String]? = nil,
-                     withNamePrefix namePrefix: String? = nil,
-                     allowedQueryReservedCharacters: CharacterSet? = nil,
-                     includeAppVersionParameter: Bool = true,
-                     doNotEnforcePrefix: Bool = false,
-                     onComplete: @escaping CompletionBlock = { _, _ in }) {
+    /// The `PixelFiring` witness, and the single place the real firing logic lives.
+    ///
+    /// Callers should not use this directly. The public entry points are `fire(_:frequency:options:)`
+    /// for fire-and-forget and `fireAsync(_:frequency:options:)` when the outcome matters; both are
+    /// supplied by the `PixelFiring` extension and funnel into here.
+    public func fire(event: PixelKit.Event,
+                     frequency: Frequency,
+                     options: Options,
+                     onComplete: @escaping CompletionBlock) {
 
-        let pixelName = prefixedAndSuffixedName(for: event, namePrefix: namePrefix, doNotEnforcePrefix: doNotEnforcePrefix)
+        let pixelName = prefixedAndSuffixedName(for: event,
+                                                namePrefix: options.namePrefix,
+                                                doNotEnforcePrefix: !options.enforcePrefix)
 
         if !dryRun {
             if frequency == .daily, pixelHasBeenFiredDailyToday(pixelName) {
@@ -295,7 +296,7 @@ public final class PixelKit {
         }
 
         let newParams: [String: String]?
-        switch (event.parameters, params) {
+        switch (event.parameters, options.additionalParameters) {
         case (.some(let parameters), .none):
             newParams = parameters
         case (.none, .some(let parameters)):
@@ -316,15 +317,69 @@ public final class PixelKit {
 
         fire(pixelNamed: pixelName,
              frequency: frequency,
-             withHeaders: headers,
+             withHeaders: options.headers,
              withAdditionalParameters: newParams,
              withError: event.error,
-             allowedQueryReservedCharacters: allowedQueryReservedCharacters,
-             includeAppVersionParameter: includeAppVersionParameter,
+             allowedQueryReservedCharacters: options.allowedQueryReservedCharacters,
+             includeAppVersionParameter: options.includeAppVersionParameter,
              standardParameters: event.standardParameters ?? [],
              onComplete: onComplete)
     }
 
+    /// Legacy wide-parameter entry point.
+    ///
+    /// Superseded by `fire(_:frequency:options:)` and `fireAsync(_:frequency:options:)`. Retained
+    /// only so call sites can migrate incrementally, and removed once they have. Not marked
+    /// deprecated on purpose: Swift resolves a concrete method ahead of a protocol extension
+    /// method, so every unmigrated `fire(event, frequency:)` call still lands here and would
+    /// otherwise emit a deprecation warning.
+    public func fire(_ event: PixelKit.Event,
+                     frequency: Frequency = .standard,
+                     withHeaders headers: [String: String]? = nil,
+                     withAdditionalParameters params: [String: String]? = nil,
+                     withNamePrefix namePrefix: String? = nil,
+                     allowedQueryReservedCharacters: CharacterSet? = nil,
+                     includeAppVersionParameter: Bool = true,
+                     doNotEnforcePrefix: Bool = false,
+                     onComplete: @escaping CompletionBlock = { _, _ in }) {
+
+        fire(event: event,
+             frequency: frequency,
+             options: Options(headers: headers,
+                              additionalParameters: params,
+                              namePrefix: namePrefix,
+                              allowedQueryReservedCharacters: allowedQueryReservedCharacters,
+                              includeAppVersionParameter: includeAppVersionParameter,
+                              enforcePrefix: !doNotEnforcePrefix),
+             onComplete: onComplete)
+    }
+
+    /// Fires a pixel on the shared instance and returns immediately.
+    ///
+    /// No-ops when PixelKit has not been set up, matching the previous behaviour.
+    public static func fire(_ event: PixelKit.Event,
+                            frequency: Frequency = .standard,
+                            options: Options = .default) {
+        Self.shared?.fire(event, frequency: frequency, options: options)
+    }
+
+    /// Fires a pixel on the shared instance and waits for the request to complete.
+    ///
+    /// - Throws: `PixelKitError.notConfigured` if PixelKit has not been set up. The synchronous
+    ///   variant silently no-ops in that case, but a caller that awaited a result cannot honestly
+    ///   be told the pixel was either sent or suppressed.
+    @discardableResult
+    public static func fireAsync(_ event: PixelKit.Event,
+                                 frequency: Frequency = .standard,
+                                 options: Options = .default) async throws -> FireResult {
+        guard let shared = Self.shared else {
+            throw PixelKitError.notConfigured
+        }
+        return try await shared.fireAsync(event, frequency: frequency, options: options)
+    }
+
+    /// Legacy wide-parameter static entry point. See the instance method above for why this is not
+    /// marked deprecated.
     public static func fire(_ event: PixelKit.Event,
                             frequency: Frequency = .standard,
                             withHeaders headers: [String: String] = [:],

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKitError.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKitError.swift
@@ -23,6 +23,10 @@ import FoundationExtensions
 public enum PixelKitError: DDGError {
     case externalError(Error)
 
+    /// `PixelKit.setUp` has not been called, so there is no shared instance to fire through.
+    /// Only surfaced by the async static entry point: the synchronous one silently no-ops.
+    case notConfigured
+
     // MARK: - DDGError Conformance
 
     public static var errorDomain: String { "com.duckduckgo.pixelkit" }
@@ -30,18 +34,21 @@ public enum PixelKitError: DDGError {
     public var errorCode: Int {
         switch self {
         case .externalError: return 0
+        case .notConfigured: return 1
         }
     }
 
     public var underlyingError: Error? {
         switch self {
         case .externalError(let underlyingError): return underlyingError
+        case .notConfigured: return nil
         }
     }
 
     public var description: String {
         switch self {
         case .externalError(let underlyingError): return "An external error occurred: \(underlyingError)"
+        case .notConfigured: return "PixelKit has not been set up"
         }
     }
 
@@ -49,6 +56,10 @@ public enum PixelKitError: DDGError {
         switch (lhs, rhs) {
         case (.externalError(let lhs), .externalError(let rhs)):
             return String(describing: lhs) == String(describing: rhs)
+        case (.notConfigured, .notConfigured):
+            return true
+        default:
+            return false
         }
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKitTestingUtilities/PixelKitMock.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKitTestingUtilities/PixelKitMock.swift
@@ -34,18 +34,16 @@ public final class PixelKitMock: PixelFiring {
         self.expectedFireCalls = expectedFireCalls
     }
 
-    public func fire(_ event: PixelKit.Event,
+    public func fire(event: PixelKit.Event,
                      frequency: PixelKit.Frequency,
-                     includeAppVersionParameter: Bool,
-                     withAdditionalParameters parameters: [String: String]?,
-                     withNamePrefix namePrefix: String?,
-                     doNotEnforcePrefix: Bool,
+                     options: PixelKit.Options,
                      onComplete: @escaping PixelKit.CompletionBlock) {
         let fireCall = ExpectedFireCall(pixel: event,
                                         frequency: frequency,
-                                        additionalParameters: parameters,
-                                        namePrefix: namePrefix,
-                                        includeAppVersionParameter: includeAppVersionParameter)
+                                        additionalParameters: options.additionalParameters,
+                                        namePrefix: options.namePrefix,
+                                        doNotEnforcePrefix: !options.enforcePrefix,
+                                        includeAppVersionParameter: options.includeAppVersionParameter)
         actualFireCalls.append(fireCall)
         onComplete(true, nil)
     }
@@ -84,6 +82,7 @@ public struct ExpectedFireCall: Equatable {
         && lhs.frequency == rhs.frequency
         && lhs.additionalParameters == rhs.additionalParameters
         && lhs.namePrefix == rhs.namePrefix
+        && lhs.doNotEnforcePrefix == rhs.doNotEnforcePrefix
         && lhs.includeAppVersionParameter == rhs.includeAppVersionParameter
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/PixelKitTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/PixelKitTests.swift
@@ -899,12 +899,9 @@ final class PixelKitTests: XCTestCase {
             self.completions = completions
         }
 
-        func fire(_ event: PixelKit.Event,
+        func fire(event: PixelKit.Event,
                   frequency: PixelKit.Frequency,
-                  includeAppVersionParameter: Bool,
-                  withAdditionalParameters parameters: [String: String]?,
-                  withNamePrefix namePrefix: String?,
-                  doNotEnforcePrefix: Bool,
+                  options: PixelKit.Options,
                   onComplete: @escaping PixelKit.CompletionBlock) {
             for completion in completions {
                 onComplete(completion.fired, completion.error)
@@ -924,36 +921,36 @@ final class PixelKitTests: XCTestCase {
                  fireRequest: fireRequest)
     }
 
-    /// `await fire` returns `true` and resolves once the underlying request reports success.
-    func testAsyncFireReturnsTrueWhenRequestSucceeds() async throws {
+    /// `fireAsync` returns `.sent` and resolves once the underlying request reports success.
+    func testAsyncFireReturnsSentWhenRequestSucceeds() async throws {
         let pixelKit = makePixelKit()
 
-        let fired = try await pixelKit.fireAsync(TestEventV2.testEvent)
+        let result = try await pixelKit.fireAsync(TestEventV2.testEvent)
 
-        XCTAssertTrue(fired)
+        XCTAssertEqual(result, .sent)
     }
 
-    /// `await fire` returns `false` (without throwing) when a daily pixel is suppressed by frequency rules.
-    func testAsyncFireReturnsFalseWhenSuppressedByDailyFrequency() async throws {
+    /// `fireAsync` returns `.suppressed` (without throwing) when a daily pixel is suppressed by frequency rules.
+    func testAsyncFireReturnsSuppressedWhenSuppressedByDailyFrequency() async throws {
         let pixelKit = makePixelKit()
 
         let firstFire = try await pixelKit.fireAsync(TestEventV2.dailyEvent, frequency: .daily)
         let secondFire = try await pixelKit.fireAsync(TestEventV2.dailyEvent, frequency: .daily)
 
-        XCTAssertTrue(firstFire)
-        XCTAssertFalse(secondFire)
+        XCTAssertEqual(firstFire, .sent)
+        XCTAssertEqual(secondFire, .suppressed)
     }
 
     /// Legacy frequencies are suppressed inside their handlers (not the early frequency pre-checks);
     /// before those handlers reported suppression to the completion, this second `await` hung forever.
-    func testAsyncFireReturnsFalseWhenSuppressedByLegacyDailyFrequency() async throws {
+    func testAsyncFireReturnsSuppressedWhenSuppressedByLegacyDailyFrequency() async throws {
         let pixelKit = makePixelKit()
 
         let firstFire = try await pixelKit.fireAsync(TestEventV2.dailyEvent, frequency: .legacyDaily)
         let secondFire = try await pixelKit.fireAsync(TestEventV2.dailyEvent, frequency: .legacyDaily)
 
-        XCTAssertTrue(firstFire)
-        XCTAssertFalse(secondFire)
+        XCTAssertEqual(firstFire, .sent)
+        XCTAssertEqual(secondFire, .suppressed)
     }
 
     /// `.dailyAndCount` fires two requests (`_daily` and `_count`), completing once per request:
@@ -974,10 +971,10 @@ final class PixelKitTests: XCTestCase {
             bothRequestsFired.fulfill()
         }
 
-        let fired = try await pixelKit.fireAsync(TestEventV2.dailyEvent, frequency: .dailyAndCount)
+        let result = try await pixelKit.fireAsync(TestEventV2.dailyEvent, frequency: .dailyAndCount)
         await fulfillment(of: [bothRequestsFired], timeout: 1)
 
-        XCTAssertTrue(fired)
+        XCTAssertEqual(result, .sent)
         namesLock.lock()
         let names = firedPixelNames
         namesLock.unlock()
@@ -991,9 +988,9 @@ final class PixelKitTests: XCTestCase {
         let pixelFiring = StubPixelFiring(completions: [(fired: true, error: nil),
                                                         (fired: false, error: AsyncFireSampleError())])
 
-        let fired = try await pixelFiring.fireAsync(TestEventV2.testEvent)
+        let result = try await pixelFiring.fireAsync(TestEventV2.testEvent)
 
-        XCTAssertTrue(fired)
+        XCTAssertEqual(result, .sent)
     }
 
     /// `fireAsync` rethrows the error reported by the underlying completion handler.
@@ -1009,6 +1006,185 @@ final class PixelKitTests: XCTestCase {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
+    }
+
+    // MARK: - Options parity
+
+    /// Fires `event` through both the legacy wide-parameter entry point and the new `options:` one,
+    /// and returns the resulting (pixelName, parameters) pair from each.
+    private func firedNameAndParameters(
+        legacy: (PixelKit) -> Void,
+        options: (PixelKit) -> Void
+    ) -> (legacy: (String, [String: String]), options: (String, [String: String])) {
+        var captured = [(String, [String: String])]()
+        let lock = NSLock()
+        let pixelKit = makePixelKit { pixelName, _, parameters, _, _, completion in
+            lock.lock()
+            captured.append((pixelName, parameters))
+            lock.unlock()
+            completion(true, nil)
+        }
+
+        legacy(pixelKit)
+        options(pixelKit)
+
+        lock.lock()
+        defer { lock.unlock() }
+        XCTAssertEqual(captured.count, 2, "Expected exactly one request from each entry point")
+        return (captured[0], captured[1])
+    }
+
+    /// The `options:` entry point must produce byte-identical pixel names and parameters to the
+    /// legacy wide-parameter one. This is what makes the `doNotEnforcePrefix` -> `enforcePrefix`
+    /// polarity inversion safe: pixel names are contractual, so a botched translation would
+    /// silently rename production pixels.
+    func testOptionsPathMatchesLegacyPathForDefaults() {
+        let result = firedNameAndParameters(
+            legacy: { $0.fire(TestEventV2.testEventWithoutParameters) },
+            options: { $0.fire(TestEventV2.testEventWithoutParameters, options: .default) }
+        )
+        XCTAssertEqual(result.legacy.0, result.options.0)
+        XCTAssertEqual(result.legacy.1, result.options.1)
+    }
+
+    func testOptionsPathMatchesLegacyPathForUnenforcedPrefix() {
+        let result = firedNameAndParameters(
+            legacy: { $0.fire(TestEventV2.testEventWithoutParameters, doNotEnforcePrefix: true) },
+            options: { $0.fire(TestEventV2.testEventWithoutParameters, options: .unenforcedPrefix) }
+        )
+        XCTAssertEqual(result.legacy.0, result.options.0,
+                       "enforcePrefix: false must produce the same pixel name as doNotEnforcePrefix: true")
+        XCTAssertEqual(result.legacy.1, result.options.1)
+    }
+
+    func testOptionsPathMatchesLegacyPathForNamePrefix() {
+        let result = firedNameAndParameters(
+            legacy: { $0.fire(TestEventV2.testEventWithoutParameters, withNamePrefix: "custom_") },
+            options: { $0.fire(TestEventV2.testEventWithoutParameters, options: .namePrefix("custom_")) }
+        )
+        XCTAssertEqual(result.legacy.0, result.options.0)
+        XCTAssertEqual(result.legacy.1, result.options.1)
+    }
+
+    func testOptionsPathMatchesLegacyPathWithoutAppVersion() {
+        let result = firedNameAndParameters(
+            legacy: { $0.fire(TestEventV2.testEventWithoutParameters, includeAppVersionParameter: false) },
+            options: { $0.fire(TestEventV2.testEventWithoutParameters, options: .withoutAppVersion) }
+        )
+        XCTAssertEqual(result.legacy.0, result.options.0)
+        XCTAssertEqual(result.legacy.1, result.options.1)
+        XCTAssertNil(result.options.1["appVersion"], "withoutAppVersion must drop the appVersion parameter")
+    }
+
+    func testOptionsPathMatchesLegacyPathForAdditionalParameters() {
+        let extra = ["source": "menu", "eventParam1": "overridden"]
+        let result = firedNameAndParameters(
+            legacy: { $0.fire(TestEventV2.testEvent, withAdditionalParameters: extra) },
+            options: { $0.fire(TestEventV2.testEvent, options: .parameters(extra)) }
+        )
+        XCTAssertEqual(result.legacy.0, result.options.0)
+        XCTAssertEqual(result.legacy.1, result.options.1)
+        XCTAssertEqual(result.options.1["eventParam1"], "overridden",
+                       "additionalParameters must win over the event's own parameters")
+    }
+
+    /// namePrefix and enforcePrefix interact, so cover them together rather than only in isolation.
+    func testOptionsPathMatchesLegacyPathForNamePrefixWithUnenforcedPrefix() {
+        let result = firedNameAndParameters(
+            legacy: { $0.fire(TestEventV2.testEventWithoutParameters, withNamePrefix: "custom_", doNotEnforcePrefix: true) },
+            options: { $0.fire(TestEventV2.testEventWithoutParameters,
+                               options: PixelKit.Options(namePrefix: "custom_", enforcePrefix: false)) }
+        )
+        XCTAssertEqual(result.legacy.0, result.options.0)
+        XCTAssertEqual(result.legacy.1, result.options.1)
+    }
+
+    // MARK: - Options presets
+
+    func testOptionsPresetsMatchTheirMemberwiseEquivalents() {
+        XCTAssertEqual(PixelKit.Options.default, PixelKit.Options())
+        XCTAssertEqual(PixelKit.Options.unenforcedPrefix, PixelKit.Options(enforcePrefix: false))
+        XCTAssertEqual(PixelKit.Options.withoutAppVersion, PixelKit.Options(includeAppVersionParameter: false))
+        XCTAssertEqual(PixelKit.Options.parameters(["a": "b"]),
+                       PixelKit.Options(additionalParameters: ["a": "b"]))
+        XCTAssertEqual(PixelKit.Options.namePrefix("p_"), PixelKit.Options(namePrefix: "p_"))
+        XCTAssertEqual(PixelKit.Options.parameters(["a": "b"], namePrefix: "p_"),
+                       PixelKit.Options(additionalParameters: ["a": "b"], namePrefix: "p_"))
+    }
+
+    /// Defaults must be the non-intrusive ones: prefix enforced, app version included.
+    func testOptionsDefaultsAreConservative() {
+        let options = PixelKit.Options()
+        XCTAssertTrue(options.enforcePrefix)
+        XCTAssertTrue(options.includeAppVersionParameter)
+        XCTAssertNil(options.headers)
+        XCTAssertNil(options.additionalParameters)
+        XCTAssertNil(options.namePrefix)
+        XCTAssertNil(options.allowedQueryReservedCharacters)
+    }
+
+    // MARK: - Sugar forwarding
+
+    /// The defaulted `fire(_:frequency:options:)` sugar must reach the conformer's witness with the
+    /// documented defaults applied. This guards the argument-label indirection between the protocol
+    /// requirement and the entry point.
+    func testSugarForwardsDefaultsToWitness() {
+        let recorder = RecordingPixelFiring()
+
+        recorder.fire(TestEventV2.testEvent)
+
+        XCTAssertEqual(recorder.calls.count, 1)
+        XCTAssertEqual(recorder.calls.first?.frequency, .standard)
+        XCTAssertEqual(recorder.calls.first?.options, .default)
+    }
+
+    func testSugarForwardsExplicitArgumentsToWitness() {
+        let recorder = RecordingPixelFiring()
+
+        recorder.fire(TestEventV2.testEvent, options: .unenforcedPrefix)
+        recorder.fire(TestEventV2.testEvent, frequency: .daily)
+
+        XCTAssertEqual(recorder.calls.count, 2)
+        // Skipping the middle parameter must still default frequency.
+        XCTAssertEqual(recorder.calls[0].frequency, .standard)
+        XCTAssertEqual(recorder.calls[0].options, .unenforcedPrefix)
+        // Omitting options must still default it.
+        XCTAssertEqual(recorder.calls[1].frequency, .daily)
+        XCTAssertEqual(recorder.calls[1].options, .default)
+    }
+
+    // MARK: - Static async entry point
+
+    func testStaticFireAsyncThrowsWhenPixelKitNotConfigured() async {
+        PixelKit.tearDown()
+
+        do {
+            _ = try await PixelKit.fireAsync(TestEventV2.testEvent)
+            XCTFail("Expected fireAsync to throw when PixelKit is not set up")
+        } catch let error as PixelKitError {
+            XCTAssertEqual(error, .notConfigured)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}
+
+/// Records what the `PixelFiring` sugar forwards to the single protocol requirement.
+private final class RecordingPixelFiring: PixelFiring {
+    struct Call {
+        let event: PixelKit.Event
+        let frequency: PixelKit.Frequency
+        let options: PixelKit.Options
+    }
+
+    private(set) var calls = [Call]()
+
+    func fire(event: PixelKit.Event,
+              frequency: PixelKit.Frequency,
+              options: PixelKit.Options,
+              onComplete: @escaping PixelKit.CompletionBlock) {
+        calls.append(Call(event: event, frequency: frequency, options: options))
+        onComplete(true, nil)
     }
 }
 

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/PixelKitTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/PixelKitTests.swift
@@ -1012,15 +1012,20 @@ final class PixelKitTests: XCTestCase {
 
     /// Fires `event` through both the legacy wide-parameter entry point and the new `options:` one,
     /// and returns the resulting (pixelName, parameters) pair from each.
+    ///
+    /// Headers are captured too. An earlier version of this helper ignored them, which let a
+    /// headers-only behaviour difference slip through unnoticed.
     private func firedNameAndParameters(
         legacy: (PixelKit) -> Void,
         options: (PixelKit) -> Void
     ) -> (legacy: (String, [String: String]), options: (String, [String: String])) {
         var captured = [(String, [String: String])]()
+        var capturedHeaders = [[String: String]]()
         let lock = NSLock()
-        let pixelKit = makePixelKit { pixelName, _, parameters, _, _, completion in
+        let pixelKit = makePixelKit { pixelName, headers, parameters, _, _, completion in
             lock.lock()
             captured.append((pixelName, parameters))
+            capturedHeaders.append(headers)
             lock.unlock()
             completion(true, nil)
         }
@@ -1031,6 +1036,9 @@ final class PixelKitTests: XCTestCase {
         lock.lock()
         defer { lock.unlock() }
         XCTAssertEqual(captured.count, 2, "Expected exactly one request from each entry point")
+        XCTAssertEqual(capturedHeaders.count, 2)
+        XCTAssertEqual(capturedHeaders[0], capturedHeaders[1],
+                       "Legacy and options paths must send identical headers")
         return (captured[0], captured[1])
     }
 
@@ -1097,6 +1105,100 @@ final class PixelKitTests: XCTestCase {
         )
         XCTAssertEqual(result.legacy.0, result.options.0)
         XCTAssertEqual(result.legacy.1, result.options.1)
+    }
+
+    // MARK: - Header semantics
+
+    /// Captures the headers of a single fired request.
+    private func firedHeaders(defaultHeaders: [String: String],
+                              _ fire: (PixelKit) -> Void) -> [String: String] {
+        var captured = [String: String]()
+        let lock = NSLock()
+        let pixelKit = PixelKit(dryRun: false,
+                                appVersion: "1.0.0",
+                                session: UUID().uuidString,
+                                defaultHeaders: defaultHeaders,
+                                pixelCalendar: nil,
+                                defaults: userDefaults()) { _, headers, _, _, _, completion in
+            lock.lock()
+            captured = headers
+            lock.unlock()
+            completion(true, nil)
+        }
+        fire(pixelKit)
+        lock.lock()
+        defer { lock.unlock() }
+        return captured
+    }
+
+    /// Omitting headers sends the instance's `defaultHeaders`.
+    func testOmittingHeadersSendsDefaultHeaders() {
+        let headers = firedHeaders(defaultHeaders: ["X-Default": "yes"]) {
+            $0.fire(TestEventV2.testEventWithoutParameters)
+        }
+        XCTAssertEqual(headers["X-Default"], "yes")
+    }
+
+    /// Supplying headers *replaces* `defaultHeaders`, it does not merge with them.
+    ///
+    /// This is long-standing PixelKit behaviour (`headers ?? defaultHeaders` in `fire(pixelNamed:)`)
+    /// and is easy to misread as merging. Pinned here so the semantics are explicit, and so that
+    /// changing it later is a deliberate decision with a failing test rather than a silent shift in
+    /// what every custom-header pixel puts on the wire.
+    func testSupplyingHeadersReplacesDefaultHeaders() {
+        let headers = firedHeaders(defaultHeaders: ["X-Default": "yes"]) {
+            $0.fire(TestEventV2.testEventWithoutParameters, options: .init(headers: ["X-Custom": "1"]))
+        }
+        XCTAssertEqual(headers["X-Custom"], "1")
+        XCTAssertNil(headers["X-Default"], "Supplied headers replace defaultHeaders rather than merging")
+    }
+
+    /// The options path must treat headers exactly as the legacy path did.
+    func testOptionsHeadersMatchLegacyHeaders() {
+        let viaLegacy = firedHeaders(defaultHeaders: ["X-Default": "yes"]) {
+            $0.fire(TestEventV2.testEventWithoutParameters, withHeaders: ["X-Custom": "1"])
+        }
+        let viaOptions = firedHeaders(defaultHeaders: ["X-Default": "yes"]) {
+            $0.fire(TestEventV2.testEventWithoutParameters, options: .init(headers: ["X-Custom": "1"]))
+        }
+        XCTAssertEqual(viaLegacy, viaOptions)
+    }
+
+    /// The static entry point must send the same headers as the instance one.
+    ///
+    /// These used to disagree: the legacy static defaulted `withHeaders` to `[:]` while the instance
+    /// defaulted to `nil`, and since `fire(pixelNamed:)` does `headers ?? defaultHeaders`, a
+    /// non-nil `[:]` meant static calls dropped `defaultHeaders` entirely. The options-based static
+    /// passes `nil`, so both now behave the same. Only observable where `defaultHeaders` is
+    /// non-empty, which today is just the macOS VPN packet tunnel.
+    func testStaticFireSendsSameHeadersAsInstanceFire() {
+        defer { PixelKit.tearDown() }
+
+        let viaInstance = firedHeaders(defaultHeaders: ["X-Default": "yes"]) {
+            $0.fire(TestEventV2.testEventWithoutParameters)
+        }
+
+        var viaStatic = [String: String]()
+        let lock = NSLock()
+        PixelKit.setUp(dryRun: false,
+                       appVersion: "1.0.0",
+                       session: UUID().uuidString,
+                       defaultHeaders: ["X-Default": "yes"],
+                       defaults: userDefaults()) { _, headers, _, _, _, completion in
+            lock.lock()
+            viaStatic = headers
+            lock.unlock()
+            completion(true, nil)
+        }
+        PixelKit.fire(TestEventV2.testEventWithoutParameters)
+
+        lock.lock()
+        let staticHeaders = viaStatic
+        lock.unlock()
+
+        XCTAssertEqual(staticHeaders["X-Default"], "yes",
+                       "The static entry point must not drop defaultHeaders")
+        XCTAssertEqual(staticHeaders, viaInstance)
     }
 
     // MARK: - Options presets

--- a/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
@@ -165,8 +165,7 @@ final public class OnboardingSharedPixelHandler: OnboardingSharedPixelHandling {
 
         pixelFiring?.fire(event,
                           frequency: .uniqueByNameAndParameters,
-                          withAdditionalParameters: additionalParameters,
-                          withNamePrefix: platform.pixelPrefix)
+                          options: .parameters(additionalParameters, namePrefix: platform.pixelPrefix))
     }
 
 }

--- a/iOS/DuckDuckGoTests/TabTerminationErrorPageTests.swift
+++ b/iOS/DuckDuckGoTests/TabTerminationErrorPageTests.swift
@@ -198,12 +198,9 @@ private final class MockTabTerminationErrorPagePixelFiring: PixelFiring {
 
     private(set) var calls: [Call] = []
 
-    func fire(_ event: PixelKit.Event,
+    func fire(event: PixelKit.Event,
               frequency: PixelKit.Frequency,
-              includeAppVersionParameter: Bool,
-              withAdditionalParameters: [String: String]?,
-              withNamePrefix: String?,
-              doNotEnforcePrefix: Bool,
+              options: PixelKit.Options,
               onComplete: @escaping PixelKit.CompletionBlock) {
         calls.append(.init(event: event, frequency: frequency))
         onComplete(true, nil)

--- a/iOS/DuckDuckGoTests/TabTerminationTelemetryTests.swift
+++ b/iOS/DuckDuckGoTests/TabTerminationTelemetryTests.swift
@@ -237,12 +237,9 @@ private final class MockTabTerminationPixelFiring: PixelFiring {
 
     private(set) var calls: [Call] = []
 
-    func fire(_ event: PixelKit.Event,
+    func fire(event: PixelKit.Event,
               frequency: PixelKit.Frequency,
-              includeAppVersionParameter: Bool,
-              withAdditionalParameters: [String: String]?,
-              withNamePrefix: String?,
-              doNotEnforcePrefix: Bool,
+              options: PixelKit.Options,
               onComplete: @escaping PixelKit.CompletionBlock) {
         calls.append(.init(event: event, frequency: frequency))
         onComplete(true, nil)

--- a/macOS/DuckDuckGo/Application/AutoClearHandler.swift
+++ b/macOS/DuckDuckGo/Application/AutoClearHandler.swift
@@ -134,8 +134,8 @@ final class AutoClearHandler: ApplicationTerminationDecider {
                 await aiChatSyncCleaner?.recordLocalClear(date: Date())
             }
         }
-        pixelFiring?.fire(FireDialogPixel.fireStarted, frequency: .dailyAndCount, doNotEnforcePrefix: true)
-        pixelFiring?.fire(FireDialogPixel.fireStartedOnExit, frequency: .dailyAndCount, doNotEnforcePrefix: true)
+        pixelFiring?.fire(FireDialogPixel.fireStarted, frequency: .dailyAndCount, options: .unenforcedPrefix)
+        pixelFiring?.fire(FireDialogPixel.fireStartedOnExit, frequency: .dailyAndCount, options: .unenforcedPrefix)
         await fireViewModel.fire.burnAll(isBurnOnExit: true,
                                          includeChatHistory: dataClearingPreferences.isAutoClearAIChatHistoryEnabled,
                                          isAutoClear: true,
@@ -155,8 +155,8 @@ final class AutoClearHandler: ApplicationTerminationDecider {
         let shouldBurnOnStart = dataClearingPreferences.isAutoClearEnabled && !appTerminationHandledCorrectly
         guard shouldBurnOnStart else { return false }
 
-        pixelFiring?.fire(FireDialogPixel.fireStarted, frequency: .dailyAndCount, doNotEnforcePrefix: true)
-        pixelFiring?.fire(FireDialogPixel.fireStartedOnStartup, frequency: .dailyAndCount, doNotEnforcePrefix: true)
+        pixelFiring?.fire(FireDialogPixel.fireStarted, frequency: .dailyAndCount, options: .unenforcedPrefix)
+        pixelFiring?.fire(FireDialogPixel.fireStartedOnStartup, frequency: .dailyAndCount, options: .unenforcedPrefix)
         fireViewModel.fire.burnAll(includeChatHistory: dataClearingPreferences.isAutoClearAIChatHistoryEnabled,
                                    isAutoClear: true,
                                    dataClearingWideEventService: dataClearingWideEventService)

--- a/macOS/DuckDuckGo/Application/WarnBeforeQuitManager.swift
+++ b/macOS/DuckDuckGo/Application/WarnBeforeQuitManager.swift
@@ -681,7 +681,7 @@ extension PixelFiring {
     func fireAndWait(_ event: PixelKit.Event, frequency: PixelKit.Frequency, timeout: TimeInterval = 1) async {
         try? await withTimeout(timeout) {
             await withCancellableContinuation { resume, _ in
-                fire(event, frequency: frequency) { _, _ in
+                fire(event: event, frequency: frequency, options: .default) { _, _ in
                     DispatchQueue.main.asyncOrNow {
                         resume(())
                     }

--- a/macOS/DuckDuckGo/Fire/View/FireCoordinator.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireCoordinator.swift
@@ -124,7 +124,7 @@ final class FireCoordinator {
                     showIndividualSitesLink: config.showIndividualSitesLink,
                     onConfirm: { response in
                         if case .noAction = response {
-                            pixelFiring?.fire(FireDialogPixel.fireDialogCancel, frequency: .dailyAndCount, doNotEnforcePrefix: true)
+                            pixelFiring?.fire(FireDialogPixel.fireDialogCancel, frequency: .dailyAndCount, options: .unenforcedPrefix)
                         }
                         config.onConfirm(response)
                     }
@@ -135,7 +135,7 @@ final class FireCoordinator {
                 viewModel: config.viewModel,
                 onConfirm: { response in
                     if case .noAction = response {
-                        pixelFiring?.fire(FireDialogPixel.fireDialogCancel, frequency: .dailyAndCount, doNotEnforcePrefix: true)
+                        pixelFiring?.fire(FireDialogPixel.fireDialogCancel, frequency: .dailyAndCount, options: .unenforcedPrefix)
                     }
                     config.onConfirm(response)
                 }
@@ -363,7 +363,7 @@ extension FireCoordinator {
                     )
                 ),
                 frequency: .dailyAndCount,
-                doNotEnforcePrefix: true
+                options: .unenforcedPrefix
             )
 
             let entity = Fire.BurningEntity.tab(tabViewModel: tabViewModel,
@@ -396,7 +396,7 @@ extension FireCoordinator {
                     )
                 ),
                 frequency: .dailyAndCount,
-                doNotEnforcePrefix: true
+                options: .unenforcedPrefix
             )
 
             let entity = Fire.BurningEntity.window(tabCollectionViewModel: tabCollectionViewModel,
@@ -424,7 +424,7 @@ extension FireCoordinator {
                     )
                 ),
                 frequency: .dailyAndCount,
-                doNotEnforcePrefix: true
+                options: .unenforcedPrefix
             )
 
             // "All" implies history too; respect includeHistory by routing via burnAll or burnEntity
@@ -459,8 +459,8 @@ extension FireCoordinator {
         }
 
         pixelFiring?.fire(GeneralPixel.fireButtonFirstBurn, frequency: .legacyDailyNoSuffix)
-        pixelFiring?.fire(FireDialogPixel.fireStarted, frequency: .dailyAndCount, doNotEnforcePrefix: true)
-        pixelFiring?.fire(FireDialogPixel.fireStartedInSession, frequency: .dailyAndCount, doNotEnforcePrefix: true)
+        pixelFiring?.fire(FireDialogPixel.fireStarted, frequency: .dailyAndCount, options: .unenforcedPrefix)
+        pixelFiring?.fire(FireDialogPixel.fireStartedInSession, frequency: .dailyAndCount, options: .unenforcedPrefix)
 
         // Complete wide event tracking
         dataClearingWideEventService?.complete()

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -243,7 +243,7 @@ final class FireDialogViewModel: ObservableObject {
         didSet {
             updateItems(for: clearingOption)
             settings.lastSelectedClearingOption = clearingOption
-            pixelFiring?.fire(FireDialogPixel.fireDialogToggleMode, frequency: .dailyAndCount, doNotEnforcePrefix: true)
+            pixelFiring?.fire(FireDialogPixel.fireDialogToggleMode, frequency: .dailyAndCount, options: .unenforcedPrefix)
         }
     }
 
@@ -251,24 +251,24 @@ final class FireDialogViewModel: ObservableObject {
     @Published var includeTabsAndWindows: Bool {
         didSet {
             settings.lastIncludeTabsAndWindowsState = includeTabsAndWindows
-            pixelFiring?.fire(FireDialogPixel.fireDialogChangeSettings, frequency: .uniqueByName, doNotEnforcePrefix: true)
-            pixelFiring?.fire(FireDialogPixel.fireDialogToggleCloseTabs, frequency: .dailyAndCount, doNotEnforcePrefix: true)
+            pixelFiring?.fire(FireDialogPixel.fireDialogChangeSettings, frequency: .uniqueByName, options: .unenforcedPrefix)
+            pixelFiring?.fire(FireDialogPixel.fireDialogToggleCloseTabs, frequency: .dailyAndCount, options: .unenforcedPrefix)
         }
     }
     /// when true, history is cleared for the selected scope.
     @Published var includeHistory: Bool {
         didSet {
             settings.lastIncludeHistoryState = includeHistory
-            pixelFiring?.fire(FireDialogPixel.fireDialogChangeSettings, frequency: .uniqueByName, doNotEnforcePrefix: true)
-            pixelFiring?.fire(FireDialogPixel.fireDialogToggleClearHistory, frequency: .dailyAndCount, doNotEnforcePrefix: true)
+            pixelFiring?.fire(FireDialogPixel.fireDialogChangeSettings, frequency: .uniqueByName, options: .unenforcedPrefix)
+            pixelFiring?.fire(FireDialogPixel.fireDialogToggleClearHistory, frequency: .dailyAndCount, options: .unenforcedPrefix)
         }
     }
     /// when true, cookies/site data are cleared for the selected (non-fireproof) domains in scope.
     @Published var includeCookiesAndSiteData: Bool {
         didSet {
             settings.lastIncludeCookiesAndSiteDataState = includeCookiesAndSiteData
-            pixelFiring?.fire(FireDialogPixel.fireDialogChangeSettings, frequency: .uniqueByName, doNotEnforcePrefix: true)
-            pixelFiring?.fire(FireDialogPixel.fireDialogToggleClearSiteData, frequency: .dailyAndCount, doNotEnforcePrefix: true)
+            pixelFiring?.fire(FireDialogPixel.fireDialogChangeSettings, frequency: .uniqueByName, options: .unenforcedPrefix)
+            pixelFiring?.fire(FireDialogPixel.fireDialogToggleClearSiteData, frequency: .dailyAndCount, options: .unenforcedPrefix)
         }
     }
     /// When true, all Duck.ai chat history is cleared.
@@ -281,8 +281,8 @@ final class FireDialogViewModel: ObservableObject {
     @Published var includeChatHistorySetting: Bool {
         didSet {
             settings.lastIncludeChatHistoryState = includeChatHistorySetting
-            pixelFiring?.fire(FireDialogPixel.fireDialogChangeSettings, frequency: .uniqueByName, doNotEnforcePrefix: true)
-            pixelFiring?.fire(FireDialogPixel.fireDialogToggleClearAIChats, frequency: .dailyAndCount, doNotEnforcePrefix: true)
+            pixelFiring?.fire(FireDialogPixel.fireDialogChangeSettings, frequency: .uniqueByName, options: .unenforcedPrefix)
+            pixelFiring?.fire(FireDialogPixel.fireDialogToggleClearAIChats, frequency: .dailyAndCount, options: .unenforcedPrefix)
         }
     }
 
@@ -473,7 +473,7 @@ final class FireDialogViewModel: ObservableObject {
 
     /// Presents the Manage Fireproof Sites dialog stacked above the Fire dialog, then refreshes the scope.
     func showManageFireproofSites() {
-        pixelFiring?.fire(FireDialogPixel.fireDialogManageFireproofedSites, frequency: .dailyAndCount, doNotEnforcePrefix: true)
+        pixelFiring?.fire(FireDialogPixel.fireDialogManageFireproofedSites, frequency: .dailyAndCount, options: .unenforcedPrefix)
         Task { @MainActor in
             await dataClearingPreferences.presentManageFireproofSitesDialog()
             // Refresh selectable/fireproofed lists in case fireproofing changed.
@@ -483,7 +483,7 @@ final class FireDialogViewModel: ObservableObject {
 
     /// Dismisses the dialog and opens the per-site history/deletion view.
     func deleteIndividualSites() {
-        pixelFiring?.fire(FireDialogPixel.fireDialogDeleteIndividualSitesClicked, frequency: .dailyAndCount, doNotEnforcePrefix: true)
+        pixelFiring?.fire(FireDialogPixel.fireDialogDeleteIndividualSitesClicked, frequency: .dailyAndCount, options: .unenforcedPrefix)
         dismissDialog()
         windowControllersManager.lastKeyMainWindowController?
             .mainViewController

--- a/macOS/DuckDuckGo/Preferences/Model/DockPreferencesModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/DockPreferencesModel.swift
@@ -55,11 +55,11 @@ final class DockPreferencesModel: ObservableObject {
         case .defaultBrowser:
             pixelFiring?.fire(GeneralPixel.userAddedToDockFromDefaultBrowserSection,
                               frequency: .standard,
-                              includeAppVersionParameter: false)
+                              options: .withoutAppVersion)
         case .general:
             pixelFiring?.fire(GeneralPixel.userAddedToDockFromSettings,
                              frequency: .standard,
-                             includeAppVersionParameter: false)
+                             options: .withoutAppVersion)
         default:
             break
         }

--- a/macOS/DuckDuckGo/Preferences/Model/PreferencesSidebarModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/PreferencesSidebarModel.swift
@@ -63,7 +63,7 @@ final class PreferencesSidebarModel: ObservableObject {
                 pixelFiring?.fire(
                     SettingsPixel.settingsPaneOpened(selectedPane),
                     frequency: .dailyAndStandard,
-                    withAdditionalParameters: ["subscribed": String(subscriptionManager.isUserAuthenticated)]
+                    options: .parameters(["subscribed": String(subscriptionManager.isUserAuthenticated)])
                 )
             default:
                 pixelFiring?.fire(SettingsPixel.settingsPaneOpened(selectedPane), frequency: .daily)

--- a/macOS/DuckDuckGo/Tab/TabExtensions/NavigationPixelNavigationResponder.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/NavigationPixelNavigationResponder.swift
@@ -185,6 +185,6 @@ extension NavigationPixelNavigationResponder: NavigationResponder {
             firstMeaningfulPaintMs: firstMeaningfulPaintMs,
             documentCompleteMs: documentCompleteMs,
             allResourcesCompleteMs: allResourcesCompleteMs
-        ), frequency: .standard, withAdditionalParameters: additionalParams)
+        ), frequency: .standard, options: .parameters(additionalParams))
     }
 }

--- a/macOS/LocalPackages/AddressBarPerformance/Sources/AddressBarPerformance/AddressBarPerformanceCoordinator.swift
+++ b/macOS/LocalPackages/AddressBarPerformance/Sources/AddressBarPerformance/AddressBarPerformanceCoordinator.swift
@@ -204,7 +204,7 @@ public final class AddressBarPerformanceCoordinator {
 
         let firing = pixelFiring
         let work = DispatchWorkItem {
-            firing?.fire(pixel, frequency: .standard, includeAppVersionParameter: true)
+            firing?.fire(pixel, frequency: .standard)
         }
         DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + deferredEmitDelay, execute: work)
     }

--- a/macOS/LocalPackages/AddressBarPerformance/Tests/AddressBarPerformanceTests/AddressBarPerformanceCoordinatorTests.swift
+++ b/macOS/LocalPackages/AddressBarPerformance/Tests/AddressBarPerformanceTests/AddressBarPerformanceCoordinatorTests.swift
@@ -33,11 +33,9 @@ final class AddressBarPerformanceCoordinatorTests: XCTestCase {
         private let lock = NSLock()
         private var pixels: [AddressBarPerformancePixel] = []
 
-        func fire(_ event: PixelKit.Event,
+        func fire(event: PixelKit.Event,
                   frequency: PixelKit.Frequency,
-                  includeAppVersionParameter: Bool,
-                  withAdditionalParameters: [String: String]?,
-                  withNamePrefix: String?,
+                  options: PixelKit.Options,
                   onComplete: @escaping PixelKit.CompletionBlock) {
             guard let pixel = event as? AddressBarPerformancePixel else {
                 XCTFail("Unexpected event type: \(type(of: event))")

--- a/macOS/LocalPackages/AppUpdater/Tests/SparkleAppUpdaterTests/ReleaseNotesUserScriptTests.swift
+++ b/macOS/LocalPackages/AppUpdater/Tests/SparkleAppUpdaterTests/ReleaseNotesUserScriptTests.swift
@@ -274,12 +274,9 @@ private final class StubSparkleUpdateController: NSObject, SparkleUpdateControll
 private final class CapturingPixelFiring: PixelFiring {
     var firedEvents: [PixelKit.Event] = []
 
-    func fire(_ event: PixelKit.Event,
+    func fire(event: PixelKit.Event,
               frequency: PixelKit.Frequency,
-              includeAppVersionParameter: Bool,
-              withAdditionalParameters: [String: String]?,
-              withNamePrefix: String?,
-              doNotEnforcePrefix: Bool,
+              options: PixelKit.Options,
               onComplete: @escaping PixelKit.CompletionBlock) {
         firedEvents.append(event)
     }

--- a/macOS/UnitTests/TabBar/ViewModel/TabSuspensionServiceTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabSuspensionServiceTests.swift
@@ -366,15 +366,10 @@ private final class MockSuspensionPixelFiring: PixelFiring {
 
     var fireCalls = [FireCall]()
 
-    func fire(_ event: PixelKit.Event) {
-        fire(event, frequency: .standard)
-    }
-
-    func fire(_ event: PixelKit.Event, frequency: PixelKit.Frequency) {
-        fire(event, frequency: frequency, includeAppVersionParameter: true, withAdditionalParameters: nil, withNamePrefix: nil, doNotEnforcePrefix: false, onComplete: { _, _ in })
-    }
-
-    func fire(_ event: PixelKit.Event, frequency: PixelKit.Frequency, includeAppVersionParameter: Bool, withAdditionalParameters: [String: String]?, withNamePrefix: String?, doNotEnforcePrefix: Bool, onComplete: @escaping PixelKit.CompletionBlock) {
+    func fire(event: PixelKit.Event,
+              frequency: PixelKit.Frequency,
+              options: PixelKit.Options,
+              onComplete: @escaping PixelKit.CompletionBlock) {
         fireCalls.append(FireCall(pixel: event, frequency: frequency))
         onComplete(true, nil)
     }

--- a/macOS/UnitTests/WarnBeforeQuit/WarnBeforeQuitManagerTests.swift
+++ b/macOS/UnitTests/WarnBeforeQuit/WarnBeforeQuitManagerTests.swift
@@ -2967,12 +2967,9 @@ final class WarnBeforeQuitManagerTests: XCTestCase, Sendable {
                 self.fireExpectation = fireExpectation
                 self.completionExpectation = completionExpectation
             }
-            public func fire(_ event: PixelKit.Event,
+            public func fire(event: PixelKit.Event,
                              frequency: PixelKit.Frequency,
-                             includeAppVersionParameter: Bool,
-                             withAdditionalParameters: [String: String]?,
-                             withNamePrefix: String?,
-                             doNotEnforcePrefix: Bool,
+                             options: PixelKit.Options,
                              onComplete: @escaping PixelKit.CompletionBlock) {
                 fireExpectation.fulfill()
                 // Never call completion handler - simulates timeout


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1217419466538070?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1217412374194171
CC:

### Description

Replaces PixelKit's eight-parameter `fire` with two entry points over a single protocol requirement.

```swift
pixelKit.fire(event, frequency: .daily)                      // fire and forget, as today
pixelKit.fire(event, options: .parameters(["source": "x"]))  // when the request needs shaping
try await pixelKit.fireAsync(event, frequency: .daily)       // when the outcome matters
```

The six parameters that describe *how the request is shaped* collapse into `PixelKit.Options`. The two that describe *what the pixel is*, event and frequency, stay where they are. `options` is defaulted, so the majority of call sites, the ones passing only an event and a frequency, are untouched by this PR and read exactly as before.

`Options` ships presets derived from measured usage rather than from what is theoretically expressible: `.unenforcedPrefix` (133 sites), `.parameters(_:)`, `.namePrefix(_:)` (17 sites, all DBP), `.withoutAppVersion` (19 sites). Combinations nobody uses deliberately get no preset; it is a value type, so those compose.

Top of a 2-PR stack, on top of the `PixelKit.Event` rename.

**Call sites that reach PixelKit through the `PixelFiring` protocol are migrated here** (28 sites across 8 files), because removing the 8 convenience overloads leaves them no other way to pass those parameters. Call sites using a concrete `PixelKit` or the static `PixelKit.fire` are untouched: each keeps its own legacy method, so they migrate later.

### Testing Steps

No user-facing behaviour to exercise. Pixels must fire exactly as before. CI must be green.

### Impact

Medium. Nothing user-facing changes, but pixel names and parameters are contractual, and this PR moves every pixel through a rewritten code path.

#### What could go wrong?

- `doNotEnforcePrefix: false` becomes `enforcePrefix: true`, and a botched polarity inversion would silently rename production pixels → mitigated by 6 parity tests asserting the legacy and options paths produce byte-identical names and parameters. These were checked by mutation: deliberately inverting the polarity turns 0 failures into 18, so they hold the invariant rather than passing vacuously.
- A conformer could fail to implement the new requirement and silently recurse forever → mitigated by giving the requirement an `event:` label the sugar does not have. A same-signature extension method would otherwise become the requirement's own default implementation. Omitting it is now a compile error naming the expected labels.
- `fireAsync` could resume its continuation twice under `.dailyAndCount` / `.dailyAndStandard`, which complete more than once → mitigated by the existing single-resume latch, with a regression test.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> All pixels flow through a rewritten path where wrong `enforcePrefix` polarity or header handling could change contractual names or wire payloads; parity tests and the distinct protocol witness mitigate this, but telemetry regressions would be silent until validated.
> 
> **Overview**
> **PixelKit firing is reshaped** so request-shaping knobs live in **`PixelKit.Options`** while **`event`** and **`frequency`** stay on **`fire`**. Callers use **`fire(_:frequency:options:)`** for fire-and-forget or **`fireAsync`** when they need the outcome; **`fireAsync`** now returns **`FireResult`** (`.sent` / `.suppressed`) instead of a boolean.
> 
> The **`PixelFiring`** protocol has one requirement, **`fire(event:frequency:options:onComplete:)`** (the **`event:`** label avoids accidental infinite recursion via protocol extensions). The old eight-parameter overloads on the extension are removed; **`PixelKitMock`** and protocol call sites are updated to **`options:`** presets such as **`.unenforcedPrefix`**, **`.parameters(_:)`**, and **`.withoutAppVersion`**.
> 
> **Legacy wide-parameter `fire` on `PixelKit`** remains as a forwarding shim for unmigrated concrete/static call sites. **`PixelKit.fireAsync`** on the shared instance throws **`PixelKitError.notConfigured`** when **`setUp`** was not called. Docs (**`pixels.mdc`**, **`BUGBOT.md`**) describe the two **`PixelFiring`** protocols and how extra parameters appear in **`options`**.
> 
> Tests add **legacy vs options parity** (names, parameters, headers), **`fireAsync`** multi-completion handling, and static/instance header behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 006f52afabd8e1ea80312db9fbb167be4b96e4bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->