### PR TITLE
Fix flaky AddressBarSpoof E2E tests (b64_html, pagerewrite)

### DIFF
--- a/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
+++ b/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
@@ -19,6 +19,12 @@ tags:
 # Test
 - tapOn: "Start"
 # This test is expected to do nothing: loading base64 encoded HTML content in a new tab is blocked.
+# Wait for the address bar to settle before reading it; copying too early reads a transient value and flakes (mirrors flows 2 & 6).
+- extendedWaitUntil:
+    visible:
+        id: "searchEntry"
+        text: "privacy-test-pages.site"
+    timeout: 10000
 - copyTextFrom:
     id: "searchEntry"
 - assertTrue: ${maestro.copiedText == "privacy-test-pages.site"}

--- a/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
+++ b/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
@@ -19,6 +19,12 @@ tags:
 # Test
 - tapOn: "Start"
 # Now check the address bar hasn't been updated too early resulting in spoofed content
+# Wait for the address bar to settle before reading it; copying too early reads a transient value and flakes (mirrors flows 2 & 6).
+- extendedWaitUntil:
+    visible:
+        id: "searchEntry"
+        text: "privacy-test-pages.site"
+    timeout: 10000
 - copyTextFrom:
     id: "searchEntry"
 - assertTrue: ${maestro.copiedText == "privacy-test-pages.site"}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1217358467877667?focus=true

### Description

Two `securityTest` Maestro flows — `4_-_AddressBarSpoof,_b64_html` and `7_-_AddressBarSpoof,_pagerewrite` — read the address bar with `copyTextFrom: searchEntry` immediately after tapping **Start**. This leads to test flakiness. The same commit passes and fails across nightly runs, and the spoof mitigation itself is unchanged.

This PR adds an `extendedWaitUntil` settle gate on `searchEntry` before performing the isEqual check.

### Testing Steps

Ensure [CI is green](https://github.com/duckduckgo/apple-browsers/actions/runs/31597590000).

### Impact and Risks

Low.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b9ae4b7759dae6d347e39d8e4b1ec91a04561e9e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->