### PR TITLE
[iOS] merge feature flags for internal release of floating ui

### DIFF
--- a/iOS/DuckDuckGo/FloatingUI/FloatingUIManager.swift
+++ b/iOS/DuckDuckGo/FloatingUI/FloatingUIManager.swift
@@ -25,6 +25,7 @@ import FeatureFlags_iOS
 
 protocol FloatingUIManaging {
     var isFloatingUIEnabled: Bool { get }
+    var isFloatingTabSwitcherEnabled: Bool { get }
 }
 
 final class FloatingUIManager: FloatingUIManaging {
@@ -33,20 +34,27 @@ final class FloatingUIManager: FloatingUIManaging {
     private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
     private let isPad: () -> Bool
     private let isSupportedOS: () -> Bool
+    private let isTabSwitcherSupportedOS: () -> Bool
 
     init(featureFlagger: any FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
          isPadProvider: @escaping () -> Bool = { DevicePlatform.isIpad },
          isSupportedOSProvider: @escaping () -> Bool = { if #available(iOS 26, *) { true } else { false } },
+         isTabSwitcherSupportedOSProvider: @escaping () -> Bool = { if #available(iOS 18, *) { true } else { false } },
          unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature()) {
         self.featureFlagger = featureFlagger
         self.isPad = isPadProvider
         self.isSupportedOS = isSupportedOSProvider
+        self.isTabSwitcherSupportedOS = isTabSwitcherSupportedOSProvider
         self.unifiedToggleInputFeature = unifiedToggleInputFeature
     }
 
     var isFloatingUIEnabled: Bool {
         // iPhone-only, iOS 26+ (for obscuredContentInsets), and requires Unified Toggle Input.
-        guard featureFlagger.isFeatureOn(.floatingUI), !isPad(), isSupportedOS() else { return false }
+        guard featureFlagger.isFeatureOn(.floatingUIAugust2026), !isPad(), isSupportedOS() else { return false }
         return unifiedToggleInputFeature.isAvailable
+    }
+
+    var isFloatingTabSwitcherEnabled: Bool {
+        featureFlagger.isFeatureOn(.floatingUIAugust2026) && !isPad() && isTabSwitcherSupportedOS()
     }
 }

--- a/iOS/DuckDuckGo/TabSwitcherChrome.swift
+++ b/iOS/DuckDuckGo/TabSwitcherChrome.swift
@@ -92,9 +92,9 @@ extension TabSwitcherChrome {
 enum TabSwitcherChromeFactory {
 
     @MainActor
-    static func makeChrome(isTabSwitcherJuly2026Enabled: Bool,
+    static func makeChrome(isFloatingTabSwitcherEnabled: Bool,
                            appSettings: AppSettings) -> TabSwitcherChrome {
-        if isTabSwitcherJuly2026Enabled {
+        if isFloatingTabSwitcherEnabled {
             return FloatingTabSwitcherChrome()
         }
         return LegacyTabSwitcherChrome(appSettings: appSettings)

--- a/iOS/DuckDuckGo/TabSwitcherPageViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherPageViewController.swift
@@ -67,7 +67,7 @@ class TabSwitcherPageViewController: UIViewController {
     private weak var previewsSource: TabPreviewsSource?
     private let tabSwitcherSettings: TabSwitcherSettings
     private var isFireModeEnabled: Bool
-    private let isTabSwitcherJuly2026Enabled: Bool
+    private let isFloatingTabSwitcherEnabled: Bool
     private var tabObserverCancellable: AnyCancellable?
     private var trackerCountViewModel: TabSwitcherTrackerCountViewModel?
     private var trackerCountCancellable: AnyCancellable?
@@ -90,7 +90,7 @@ class TabSwitcherPageViewController: UIViewController {
          tabSwitcherSettings: TabSwitcherSettings,
          trackerCountViewModel: TabSwitcherTrackerCountViewModel?,
          isFireModeEnabled: Bool,
-         isTabSwitcherJuly2026Enabled: Bool = false,
+         isFloatingTabSwitcherEnabled: Bool = false,
          duckAIGridContentProvider: DuckAIGridContentProviding?,
          duckAIVoiceSessionTracker: DuckAIVoiceSessionTracking?) {
         self.browsingMode = browsingMode
@@ -99,7 +99,7 @@ class TabSwitcherPageViewController: UIViewController {
         self.tabSwitcherSettings = tabSwitcherSettings
         self.trackerCountViewModel = trackerCountViewModel
         self.isFireModeEnabled = isFireModeEnabled
-        self.isTabSwitcherJuly2026Enabled = isTabSwitcherJuly2026Enabled
+        self.isFloatingTabSwitcherEnabled = isFloatingTabSwitcherEnabled
         self.currentSelection = tabsModel.currentIndex
         self.duckAIGridContentProvider = duckAIGridContentProvider
         self.duckAIVoiceSessionTracker = duckAIVoiceSessionTracker
@@ -201,7 +201,7 @@ class TabSwitcherPageViewController: UIViewController {
         view.addSubview(hostingController.view)
         hostingController.didMove(toParent: self)
 
-        let topConstraint = isTabSwitcherJuly2026Enabled
+        let topConstraint = isFloatingTabSwitcherEnabled
             ? hostingController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor,
                                                           constant: FireModeEmptyStateMetrics.floatingNavigationBarClearance)
             : hostingController.view.topAnchor.constraint(equalTo: view.topAnchor)

--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -22,7 +22,6 @@ import BrowserServicesKit
 import Core
 import Bookmarks
 import DesignResourcesKit
-import FeatureFlags_iOS
 
 // MARK: Source agnostic action implementations
 extension TabSwitcherViewController {
@@ -301,7 +300,7 @@ extension TabSwitcherViewController {
     func createMultiSelectionMenu() -> UIMenu {
         let selectedIndexPaths = selectedTabs
         let selectedTabObjects = selectedIndexPaths.map { tabsModel.get(tabAt: $0.row) }.compactMap { $0 }
-        let shouldShowSelectionToggleActions = !featureFlagger.isFeatureOn(.tabSwitcherJuly2026) || UIDevice.current.userInterfaceIdiom != .phone
+        let shouldShowSelectionToggleActions = !floatingUIManager.isFloatingTabSwitcherEnabled
         let state = TabSwitcherMultiSelectMenuState(
             selectedCount: selectedTabObjects.count,
             totalCount: tabsModel.count,

--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -145,6 +145,7 @@ class TabSwitcherViewController: UIViewController {
     var canShowSelectionMenu = false
     var menuBuilder: TabSwitcherMenuBuilding = DefaultTabSwitcherMenuBuilder()
 
+    let floatingUIManager: FloatingUIManaging
     let featureFlagger: FeatureFlagger
     let tabManager: TabManager
     let historyManager: HistoryManaging
@@ -197,10 +198,12 @@ class TabSwitcherViewController: UIViewController {
          daxDialogsManager: DaxDialogsManaging,
          initialTrackerCountState: TabSwitcherTrackerCountViewModel.State,
          duckAIGridContentProvider: DuckAIGridContentProviding?,
-         duckAIVoiceSessionTracker: DuckAIVoiceSessionTracking?) {
+         duckAIVoiceSessionTracker: DuckAIVoiceSessionTracking?,
+         floatingUIManager: FloatingUIManaging? = nil) {
         self.bookmarksDatabase = bookmarksDatabase
         self.syncService = syncService
         self.featureFlagger = featureFlagger
+        self.floatingUIManager = floatingUIManager ?? FloatingUIManager(featureFlagger: featureFlagger)
         self.keyValueStore = keyValueStore
         self.favicons = favicons
         self.tabManager = tabManager
@@ -296,13 +299,13 @@ class TabSwitcherViewController: UIViewController {
 
     private func makeChrome() -> TabSwitcherChrome {
         TabSwitcherChromeFactory.makeChrome(
-            isTabSwitcherJuly2026Enabled: featureFlagger.isFeatureOn(.tabSwitcherJuly2026),
+            isFloatingTabSwitcherEnabled: floatingUIManager.isFloatingTabSwitcherEnabled,
             appSettings: appSettings)
     }
 
     private func setupPagingScrollView() {
         let isFireModeEnabled = fireModeCapability.isFireModeEnabled
-        let isTabSwitcherJuly2026Enabled = featureFlagger.isFeatureOn(.tabSwitcherJuly2026)
+        let isFloatingTabSwitcherEnabled = floatingUIManager.isFloatingTabSwitcherEnabled
 
         pagingScrollView = UIScrollView()
         pagingScrollView.isPagingEnabled = isFireModeEnabled
@@ -364,7 +367,7 @@ class TabSwitcherViewController: UIViewController {
                 tabSwitcherSettings: tabSwitcherSettings,
                 trackerCountViewModel: nil,
                 isFireModeEnabled: isFireModeEnabled,
-                isTabSwitcherJuly2026Enabled: isTabSwitcherJuly2026Enabled,
+                isFloatingTabSwitcherEnabled: isFloatingTabSwitcherEnabled,
                 duckAIGridContentProvider: duckAIGridContentProvider,
                 duckAIVoiceSessionTracker: duckAIVoiceSessionTracker)
             firePageController?.pageDelegate = self

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -26,7 +26,7 @@ final class FloatingUIManagerTests: XCTestCase {
 
     func testWhenFloatingUIAndUnifiedToggleInputAreEnabledOnIPhoneThenFloatingUIIsEnabled() {
         let manager = FloatingUIManager(
-            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.floatingUI]),
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.floatingUIAugust2026]),
             isPadProvider: { false },
             isSupportedOSProvider: { true },
             unifiedToggleInputFeature: MockUnifiedToggleInputFeatureProvider(isAvailable: true)
@@ -37,7 +37,7 @@ final class FloatingUIManagerTests: XCTestCase {
 
     func testWhenFloatingUIIsEnabledButUnifiedToggleInputIsUnavailableThenFloatingUIIsDisabled() {
         let manager = FloatingUIManager(
-            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.floatingUI]),
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.floatingUIAugust2026]),
             isPadProvider: { false },
             isSupportedOSProvider: { true },
             unifiedToggleInputFeature: MockUnifiedToggleInputFeatureProvider(isAvailable: false)
@@ -59,7 +59,7 @@ final class FloatingUIManagerTests: XCTestCase {
 
     func testWhenFloatingUIAndUnifiedToggleInputAreEnabledOnIPadThenFloatingUIIsDisabled() {
         let manager = FloatingUIManager(
-            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.floatingUI]),
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.floatingUIAugust2026]),
             isPadProvider: { true },
             isSupportedOSProvider: { true },
             unifiedToggleInputFeature: MockUnifiedToggleInputFeatureProvider(isAvailable: true)
@@ -70,13 +70,56 @@ final class FloatingUIManagerTests: XCTestCase {
 
     func testWhenOSIsUnsupportedThenFloatingUIIsDisabled() {
         let manager = FloatingUIManager(
-            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.floatingUI]),
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.floatingUIAugust2026]),
             isPadProvider: { false },
             isSupportedOSProvider: { false },
             unifiedToggleInputFeature: MockUnifiedToggleInputFeatureProvider(isAvailable: true)
         )
 
         XCTAssertFalse(manager.isFloatingUIEnabled)
+    }
+
+    func testWhenAugustFlagIsEnabledOnSupportedIPhoneThenFloatingTabSwitcherIsEnabled() {
+        let manager = FloatingUIManager(
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.floatingUIAugust2026]),
+            isPadProvider: { false },
+            isSupportedOSProvider: { false },
+            isTabSwitcherSupportedOSProvider: { true },
+            unifiedToggleInputFeature: MockUnifiedToggleInputFeatureProvider(isAvailable: false)
+        )
+
+        XCTAssertFalse(manager.isFloatingUIEnabled)
+        XCTAssertTrue(manager.isFloatingTabSwitcherEnabled)
+    }
+
+    func testWhenAugustFlagIsDisabledThenFloatingTabSwitcherIsDisabled() {
+        let manager = FloatingUIManager(
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: []),
+            isPadProvider: { false },
+            isTabSwitcherSupportedOSProvider: { true }
+        )
+
+        XCTAssertFalse(manager.isFloatingTabSwitcherEnabled)
+    }
+
+    func testWhenAugustFlagIsEnabledOnIPadThenFloatingTabSwitcherIsDisabled() {
+        let manager = FloatingUIManager(
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.floatingUIAugust2026]),
+            isPadProvider: { true },
+            isTabSwitcherSupportedOSProvider: { true }
+        )
+
+        XCTAssertFalse(manager.isFloatingTabSwitcherEnabled)
+    }
+
+    func testWhenTabSwitcherOSIsUnsupportedThenFloatingTabSwitcherIsDisabled() {
+        let manager = FloatingUIManager(
+            featureFlagger: MockFeatureFlagger(enabledFeatureFlags: [.floatingUIAugust2026]),
+            isPadProvider: { false },
+            isTabSwitcherSupportedOSProvider: { false }
+        )
+
+        XCTAssertFalse(manager.isFloatingTabSwitcherEnabled)
     }
 
 }

--- a/iOS/DuckDuckGoTests/TabSwitcherChromeFactoryTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherChromeFactoryTests.swift
@@ -23,14 +23,14 @@ import XCTest
 @MainActor
 final class TabSwitcherChromeFactoryTests: XCTestCase {
 
-    func testWhenTabSwitcherJuly2026EnabledThenFloatingChromeIsCreated() {
-        let chrome = TabSwitcherChromeFactory.makeChrome(isTabSwitcherJuly2026Enabled: true,
+    func testWhenFloatingTabSwitcherEnabledThenFloatingChromeIsCreated() {
+        let chrome = TabSwitcherChromeFactory.makeChrome(isFloatingTabSwitcherEnabled: true,
                                                          appSettings: AppSettingsMock())
         XCTAssertTrue(chrome is FloatingTabSwitcherChrome)
     }
 
-    func testWhenTabSwitcherJuly2026DisabledThenLegacyChromeIsCreated() {
-        let chrome = TabSwitcherChromeFactory.makeChrome(isTabSwitcherJuly2026Enabled: false,
+    func testWhenFloatingTabSwitcherDisabledThenLegacyChromeIsCreated() {
+        let chrome = TabSwitcherChromeFactory.makeChrome(isFloatingTabSwitcherEnabled: false,
                                                          appSettings: AppSettingsMock())
         XCTAssertTrue(chrome is LegacyTabSwitcherChrome)
     }

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -493,10 +493,7 @@ public enum FeatureFlag: String {
     case iPadDuckAIBarControls
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215359554019438?focus=true
-    case floatingUI
-
-    /// https://app.asana.com/1/137249556945/project/392891325557410/task/1216807388526023
-    case tabSwitcherJuly2026
+    case floatingUIAugust2026
 
     /// https://app.asana.com/1/137249556945/project/1211150618152277/task/1213745858492635?focus=true
     case removeChatHistory
@@ -904,10 +901,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.walletPassDownload))
         case .aiChatChromeShortcutIPad:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.iPadChromeShortcut))
-        case .floatingUI:
-            Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.floatingUI))
-        case .tabSwitcherJuly2026:
-            Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.tabSwitcherJuly2026))
+        case .floatingUIAugust2026:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(iOSBrowserConfigSubfeature.floatingUIAugust2026))
         case .removeChatHistory:
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.removeChatHistory))
         case .aiChatTabSwitcherRichCard:

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
@@ -115,10 +115,7 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     case walletPassDownload
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215359554019438?focus=true
-    case floatingUI
-
-    /// https://app.asana.com/1/137249556945/project/392891325557410/task/1216807388526023?focus=true
-    case tabSwitcherJuly2026
+    case floatingUIAugust2026
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215385432113040?focus=true
     case removeChatHistory


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1217417169996190?focus=true
Tech Design URL:
CC:

### Description
Consolidates the floating browser UI and updated tab switcher rollout behind a single `floatingUIAugust2026` feature flag. The new flag defaults to internal users while preserving the existing device and OS eligibility requirements.

### Testing Steps
1. Enable floatingUIAugust2026 on an iOS 26 iPhone with Unified Toggle Input available → floating browser chrome appears.
2. Open the tab switcher → updated floating controls appear.
3. Enter tab-selection mode → the updated selection controls and menu appear.
4. Disable floatingUIAugust2026 and relaunch the app → legacy browser chrome and tab-switcher controls appear.
5. Enable floatingUIAugust2026 on an iOS 18 iPhone → the updated tab switcher appears while browser chrome remains unchanged.
6. Enable floatingUIAugust2026 on an iPad → existing browser chrome and tab-switcher controls remain unchanged.

### Impact
Medium: Could disrupt the browser chrome or tab-switcher experience for internal users.

#### What could go wrong?
* Floating UI could appear on an unsupported device or OS → mitigated by preserved eligibility guards and focused unit tests.
*  The browser chrome and tab switcher could disagree about the rollout state → mitigated by routing both experiences through one central gate.

### Quality Considerations
* The browser UI remains limited to iPhone, iOS 26+, and Unified Toggle Input availability. 
* The updated tab switcher remains limited to iPhone and iOS 18+. 
* The change does not affect user data, privacy, networking, or performance.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches feature-flag gating for browser chrome and tab switcher UI, so a misconfigured flag or eligibility check could show the wrong chrome for internal users. Existing device/OS guards and unit tests limit blast radius.
> 
> **Overview**
> Consolidates the floating browser chrome and floating tab switcher rollouts behind a single **`floatingUIAugust2026`** flag (internal-only by default), replacing the separate `floatingUI` and `tabSwitcherJuly2026` flags.
> 
> **`FloatingUIManager`** now owns both gates: browser chrome still requires iPhone + iOS 26+ + Unified Toggle Input, while the new `isFloatingTabSwitcherEnabled` path allows iPhone + iOS 18+. Tab switcher chrome selection, empty-state layout, and multi-select menu behavior now all read from that central manager instead of checking a dedicated flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57b851dd162239fe3f69179c87ec4dff4ba1e903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->