### PR TITLE
iOS: Add temporary Search Token (Dindex) diagnostic pixels

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -43,10 +43,6 @@ extension Pixel {
         case refreshPressed
         case pullToRefresh
 
-        // Search Token (Dindex) experiment diagnostics — treatment cohort only. See search_token.json5.
-        case searchTokenSerpAttach
-        case searchTokenFetch
-
         // https://app.asana.com/1/137249556945/project/392891325557410/task/1210882421460693?focus=true
         case widgetReport
         case widgetReportFailure
@@ -2136,8 +2132,6 @@ extension Pixel.Event {
         case .appLaunchFromShareExtension: return "m_app-launch_shared-link"
         case .refreshPressed: return "m_r"
         case .pullToRefresh: return "m_pull-to-reload"
-        case .searchTokenSerpAttach: return "m_search-token_serp-attach"
-        case .searchTokenFetch: return "m_search-token_fetch"
         case .widgetReport: return "m_widget-report"
         case .widgetReportFailure: return "m_widget-report-failure"
 

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -43,6 +43,10 @@ extension Pixel {
         case refreshPressed
         case pullToRefresh
 
+        // Search Token (Dindex) experiment diagnostics — treatment cohort only. See search_token.json5.
+        case searchTokenSerpAttach
+        case searchTokenFetch
+
         // https://app.asana.com/1/137249556945/project/392891325557410/task/1210882421460693?focus=true
         case widgetReport
         case widgetReportFailure
@@ -2132,6 +2136,8 @@ extension Pixel.Event {
         case .appLaunchFromShareExtension: return "m_app-launch_shared-link"
         case .refreshPressed: return "m_r"
         case .pullToRefresh: return "m_pull-to-reload"
+        case .searchTokenSerpAttach: return "m_search-token_serp-attach"
+        case .searchTokenFetch: return "m_search-token_fetch"
         case .widgetReport: return "m_widget-report"
         case .widgetReportFailure: return "m_widget-report-failure"
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -430,7 +430,12 @@ class MainViewController: UIViewController {
         let settings = SearchTokenExperimentSettings(privacyConfigurationManager: privacyConfigurationManager)
         return SearchTokenFetcher(requester: SearchTokenRequest(tokenURL: .searchToken),
                                   ttlProvider: { settings.tokenTTL },
-                                  windowProvider: { settings.refreshWindow })
+                                  windowProvider: { settings.refreshWindow },
+                                  onFetchResult: { result in
+            DailyPixel.fireDailyAndCount(pixel: .searchTokenFetch, withAdditionalParameters: [
+                "result": result.rawValue
+            ])
+        })
     }()
 
     /// Whether the ad-blocking rollout's Duck Player default (disable) should be applied at onboarding

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -432,9 +432,7 @@ class MainViewController: UIViewController {
                                   ttlProvider: { settings.tokenTTL },
                                   windowProvider: { settings.refreshWindow },
                                   onFetchResult: { result in
-            DailyPixel.fireDailyAndCount(pixel: .searchTokenFetch, withAdditionalParameters: [
-                "result": result.rawValue
-            ])
+            PixelKit.fire(SearchTokenPixel.fetch(result: result.rawValue), frequency: .dailyAndCount)
         })
     }()
 

--- a/iOS/DuckDuckGo/SearchToken/SearchTokenExperiment.swift
+++ b/iOS/DuckDuckGo/SearchToken/SearchTokenExperiment.swift
@@ -20,8 +20,39 @@
 import BrowserServicesKit
 import Core
 import Foundation
+import PixelKit
 import PrivacyConfig
 import FeatureFlags_iOS
+
+/// Temporary diagnostic pixels for the Search Token (Dindex) experiment (treatment cohort only).
+/// Fired via PixelKit, which appends the `_ios_phone`/`_ios_tablet` platform suffix automatically —
+/// so names are grouped by feature with no `m_` prefix. Both expire 2026-10-12; see search_token.json5.
+enum SearchTokenPixel: PixelKitEvent, PixelKitEventWithCustomPrefix {
+    /// A treatment variant-b SERP navigation the interceptor decorated: whether a token was attached and its length bucket.
+    case serpAttach(outcome: String, tokenLength: String)
+    /// A warm token-fetch attempt and its result.
+    case fetch(result: String)
+
+    var name: String {
+        switch self {
+        case .serpAttach: return "search-token_serp-attach"
+        case .fetch: return "search-token_fetch"
+        }
+    }
+
+    var parameters: [String: String]? {
+        switch self {
+        case .serpAttach(let outcome, let tokenLength):
+            return ["outcome": outcome, "token_length": tokenLength]
+        case .fetch(let result):
+            return ["result": result]
+        }
+    }
+
+    var standardParameters: [PixelKitStandardParameter]? { nil }
+
+    var namePrefix: String { "" }
+}
 
 struct SearchTokenExperiment {
 

--- a/iOS/DuckDuckGo/SearchToken/SearchTokenFetcher.swift
+++ b/iOS/DuckDuckGo/SearchToken/SearchTokenFetcher.swift
@@ -34,7 +34,7 @@ import os.log
 /// else `nil`. Only fetching is UA-aware; retrieval never withholds a live token.
 final class SearchTokenFetcher {
 
-    /// Outcome of a warm fetch, reported to `onFetchResult` for the `m_search-token_fetch` diagnostic pixel.
+    /// Outcome of a warm fetch, reported to `onFetchResult` for the `search-token_fetch` diagnostic pixel.
     enum FetchResult: String {
         case success
         case httpError = "http_error"      // non-2xx status from the token endpoint

--- a/iOS/DuckDuckGo/SearchToken/SearchTokenFetcher.swift
+++ b/iOS/DuckDuckGo/SearchToken/SearchTokenFetcher.swift
@@ -34,10 +34,18 @@ import os.log
 /// else `nil`. Only fetching is UA-aware; retrieval never withholds a live token.
 final class SearchTokenFetcher {
 
+    /// Outcome of a warm fetch, reported to `onFetchResult` for the `m_search-token_fetch` diagnostic pixel.
+    enum FetchResult: String {
+        case success
+        case httpError = "http_error"      // non-2xx status from the token endpoint
+        case transportError = "transport_error"  // no HTTP response (timeout, offline, DNS, …)
+    }
+
     private let requester: SearchTokenRequesting
     private let ttlProvider: () -> TimeInterval
     private let windowProvider: () -> TimeInterval
     private let now: () -> Date
+    private let onFetchResult: (_ result: FetchResult) -> Void
 
     private let lock = NSLock()
     private var cachedToken: String?
@@ -48,11 +56,13 @@ final class SearchTokenFetcher {
     init(requester: SearchTokenRequesting,
          ttlProvider: @escaping () -> TimeInterval = { 300 },
          windowProvider: @escaping () -> TimeInterval = { 120 },
-         now: @escaping () -> Date = Date.init) {
+         now: @escaping () -> Date = Date.init,
+         onFetchResult: @escaping (_ result: FetchResult) -> Void = { _ in }) {
         self.requester = requester
         self.ttlProvider = ttlProvider
         self.windowProvider = windowProvider
         self.now = now
+        self.onFetchResult = onFetchResult
     }
 
     /// The cached token while it is still within its TTL, otherwise `nil`. Synchronous, non-blocking.
@@ -79,8 +89,17 @@ final class SearchTokenFetcher {
         do {
             let token = try await requester.requestToken(userAgent: userAgent)
             cache(token: token, userAgent: userAgent)
+            onFetchResult(.success)
             Logger.general.debug("SearchToken: fetched (len=\(token.count, privacy: .public))")
         } catch {
+            let result: FetchResult
+            if let reqError = error as? SearchTokenRequest.RequestError,
+               case .unexpectedStatusCode = reqError {
+                result = .httpError
+            } else {
+                result = .transportError
+            }
+            onFetchResult(result)
             Logger.general.debug("SearchToken: fetch failed: \(error.localizedDescription, privacy: .public)")
         }
     }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2950,6 +2950,11 @@ extension TabViewController: WKNavigationDelegate {
                                                                            token: token) {
                 modifiedRequest = signalled
                 didModifyRequest = true
+                // Fires only when we mutate the request, i.e. the first pass — the cancel+reload re-enters
+                // with signals already present so `signalledRequest` returns nil, avoiding a double count.
+                if cohort == .treatment {
+                    fireSearchTokenAttachPixel(token: token)
+                }
             }
         }
 
@@ -5219,6 +5224,31 @@ private extension WKProcessTerminationReason {
         case .requestedByClient: return "requested_by_client"
         case .crash: return "crash"
         case .exceededSharedProcessCrashLimit: return "exceeded_shared_process_crash_limit"
+        }
+    }
+}
+
+// MARK: - Search Token (Dindex) experiment diagnostics
+
+private extension TabViewController {
+
+    /// Fires the treatment-only `m_search-token_serp-attach` diagnostic for a SERP navigation the interceptor
+    /// just decorated: whether a token was attached and its length bucket. Daily+count, low-cardinality, no PII.
+    func fireSearchTokenAttachPixel(token: String?) {
+        DailyPixel.fireDailyAndCount(pixel: .searchTokenSerpAttach, withAdditionalParameters: [
+            "outcome": token != nil ? "attached" : "no_token",
+            "token_length": Self.tokenLengthBucket(token?.count ?? 0)
+        ])
+    }
+
+    // A normal token is ~347 chars; buckets bracket that so truncation (1_256) and oversize (513_plus)
+    // stand out from the normal range (257_512).
+    static func tokenLengthBucket(_ length: Int) -> String {
+        switch length {
+        case 0: return "0"
+        case 1...256: return "1_256"
+        case 257...512: return "257_512"
+        default: return "513_plus"
         }
     }
 }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -5232,13 +5232,12 @@ private extension WKProcessTerminationReason {
 
 private extension TabViewController {
 
-    /// Fires the treatment-only `m_search-token_serp-attach` diagnostic for a SERP navigation the interceptor
+    /// Fires the treatment-only `search-token_serp-attach` diagnostic for a SERP navigation the interceptor
     /// just decorated: whether a token was attached and its length bucket. Daily+count, low-cardinality, no PII.
     func fireSearchTokenAttachPixel(token: String?) {
-        DailyPixel.fireDailyAndCount(pixel: .searchTokenSerpAttach, withAdditionalParameters: [
-            "outcome": token != nil ? "attached" : "no_token",
-            "token_length": Self.tokenLengthBucket(token?.count ?? 0)
-        ])
+        PixelKit.fire(SearchTokenPixel.serpAttach(outcome: token != nil ? "attached" : "no_token",
+                                                  tokenLength: Self.tokenLengthBucket(token?.count ?? 0)),
+                      frequency: .dailyAndCount)
     }
 
     // A normal token is ~347 chars; buckets bracket that so truncation (1_256) and oversize (513_plus)

--- a/iOS/PixelDefinitions/pixels/definitions/search_token.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/search_token.json5
@@ -1,0 +1,42 @@
+// Search Token (Dindex) experiment diagnostics — treatment cohort only.
+// Separate from the param-locked experiment_metrics_* pixels so they can carry diagnostic params.
+{
+    "m_search-token_serp-attach": {
+        "description": "Fires once per treatment-cohort variant-b SERP navigation the interceptor decorates, recording whether the client attached an X-DDG-Search-Token header and the token's length bucket. Compare 'attached' against the backend's received-a-header count to separate warming gap from header-stripped-in-transit.",
+        "owners": ["hassaanelgarem"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "outcome",
+                "description": "Whether a live token was attached to the SERP request",
+                "type": "string",
+                "enum": ["attached", "no_token"]
+            },
+            {
+                "key": "token_length",
+                "description": "Bucketed length of the attached token (0 when none attached). A normal token is ~347 chars, so 257_512 is the expected range; 1_256 flags truncation and 513_plus oversize.",
+                "type": "string",
+                "enum": ["0", "1_256", "257_512", "513_plus"]
+            }
+        ],
+        "expires": "2026-10-12"
+    },
+    "m_search-token_fetch": {
+        "description": "Fires on each warm token fetch attempt (treatment cohort), recording the result. Disambiguates whether a warming gap is caused by fetches failing versus warm never triggering.",
+        "owners": ["hassaanelgarem"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "result",
+                "description": "Outcome of the token fetch",
+                "type": "string",
+                "enum": ["success", "http_error", "transport_error"]
+            }
+        ],
+        "expires": "2026-10-12"
+    }
+}

--- a/iOS/PixelDefinitions/pixels/definitions/search_token.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/search_token.json5
@@ -1,11 +1,11 @@
 // Search Token (Dindex) experiment diagnostics — treatment cohort only.
 // Separate from the param-locked experiment_metrics_* pixels so they can carry diagnostic params.
 {
-    "m_search-token_serp-attach": {
+    "search-token_serp-attach": {
         "description": "Fires once per treatment-cohort variant-b SERP navigation the interceptor decorates, recording whether the client attached an X-DDG-Search-Token header and the token's length bucket. Compare 'attached' against the backend's received-a-header count to separate warming gap from header-stripped-in-transit.",
         "owners": ["hassaanelgarem"],
         "triggers": ["other"],
-        "suffixes": ["daily_count", "platform", "form_factor"],
+        "suffixes": ["platform", "form_factor", "daily_count"],
         "parameters": [
             "appVersion",
             {
@@ -23,11 +23,11 @@
         ],
         "expires": "2026-10-12"
     },
-    "m_search-token_fetch": {
+    "search-token_fetch": {
         "description": "Fires on each warm token fetch attempt (treatment cohort), recording the result. Disambiguates whether a warming gap is caused by fetches failing versus warm never triggering.",
         "owners": ["hassaanelgarem"],
         "triggers": ["other"],
-        "suffixes": ["daily_count", "platform", "form_factor"],
+        "suffixes": ["platform", "form_factor", "daily_count"],
         "parameters": [
             "appVersion",
             {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1217367676250922?focus=true

### Description

Adds two temporary, treatment-cohort-only diagnostic pixels to help explain why the Search Token (Dindex) experiment still fails backend validation ~20–30% of the time (the `missing`/`malformed` bucket). Both are daily+count, low-cardinality, and carry no PII. They expire on 2026-10-12.

- **`m_search-token_serp-attach`** — fires once per treatment variant-b SERP navigation the interceptor decorates. Params: `outcome` (`attached`/`no_token`) and `token_length` (bucketed around the normal ~347-char token: `0`/`1_256`/`257_512`/`513_plus`). Comparing the client's `attached` count against the backend's received-a-header count separates a client-side warming gap from a header stripped in transit; the length bucket flags truncation/corruption.
- **`m_search-token_fetch`** — fires on each warm token-fetch attempt. Param: `result` (`success`/`http_error`/`transport_error`). Disambiguates whether a warming gap is caused by fetches failing versus warm never triggering.

### Testing Steps

Diagnostic pixels have no user-facing behavior; verify they fire correctly (pixels appear in the console).

1. Enroll in the Search Token experiment treatment cohort (`searchTokenExperimentV2`).
2. Foreground the app or focus the omnibar to trigger a token warm — confirm **`m_search-token_fetch`** fires with `result=success` (or `http_error`/`transport_error` if the endpoint is unreachable).
3. Perform a search to load a SERP — confirm **`m_search-token_serp-attach`** fires once with `outcome=attached` and `token_length=257_512`.
4. With no live token (e.g. before the first warm completes), perform a search — confirm `m_search-token_serp-attach` fires with `outcome=no_token` and `token_length=0`.
5. Confirm control-cohort users fire neither pixel.

### Impact and Risks

Low. Only adds pixels — no change to behavior. Safe to merge into the release branch.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only change with no impact on token fetch or SERP request behavior. Safe diagnostic instrumentation for an existing experiment.
> 
> **Overview**
> Adds temporary **treatment-cohort-only** diagnostic pixels to explain Search Token (Dindex) backend validation gaps (~20–30% `missing`/`malformed`). Both are daily+count, low-cardinality, expire 2026-10-12, and carry no PII.
> 
> **`search-token_serp-attach`** fires once per decorated SERP navigation with `outcome` (`attached`/`no_token`) and bucketed `token_length`, so client attach rates can be compared against backend receipt and truncation can be spotted.
> 
> **`search-token_fetch`** fires on each warm fetch with `result` (`success`/`http_error`/`transport_error`) via a new `onFetchResult` callback on `SearchTokenFetcher`, separating fetch failures from warm never triggering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a16bc447f17170648f12180e60867e484d0f363f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->