### PR TITLE
Add authenticated Sync device metadata PATCH support

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -401,6 +401,7 @@ struct UpdateDevices {
         let id: String
         let name: String?
         let type: String?
+        /// Unlike name and type, nil omits this field and clears any stored device info.
         let info: String?
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -202,6 +202,7 @@ struct AccountManager: AccountManaging {
             throw SyncError.unableToDecodeResponse("Failed to decode devices update")
         }
 
+        Logger.sync.debug("Sync-UnifiedDevices: device update PATCH succeeded")
         return result
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -144,8 +144,7 @@ struct AccountManager: AccountManaging {
             throw SyncError.noToken
         }
 
-        let url = endpoints.syncGet.appendingPathComponent("devices")
-        let request = api.createAuthenticatedGetRequest(url: url, authToken: token)
+        let request = api.createAuthenticatedGetRequest(url: endpoints.devices, authToken: token)
         let result = try await request.execute()
 
         guard let body = result.data else {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -355,6 +355,25 @@ struct AccountManager: AccountManaging {
         }
     }
 
+    struct UpdateDevices {
+
+        struct Parameters: Encodable {
+            let updates: [Update]
+        }
+
+        struct Update: Encodable {
+            let id: String
+            let name: String?
+            let type: String?
+            let info: String?
+        }
+
+        struct Result: Decodable {
+            let devices: [RegisteredDeviceEntry]
+            let devicesV2: [RegisteredDeviceEntry]
+        }
+    }
+
     struct FetchDevicesResult: Decodable {
         struct DeviceWrapper: Decodable {
             var lastModified: String?

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -181,6 +181,30 @@ struct AccountManager: AccountManaging {
         return devices
     }
 
+    func updateDevice(_ update: UpdateDevices.Update, for account: SyncAccount) async throws -> UpdateDevices.Result {
+        guard let token = account.token else {
+            throw SyncError.noToken
+        }
+
+        let parameters = UpdateDevices.Parameters(updates: [update])
+        let requestJSON = try JSONEncoder.snakeCaseKeys.encode(parameters)
+        let request = api.createAuthenticatedJSONRequest(url: endpoints.devices,
+                                                         method: .patch,
+                                                         authToken: token,
+                                                         json: requestJSON)
+        let response = try await request.execute()
+
+        guard let body = response.data else {
+            throw SyncError.noResponseBody
+        }
+
+        guard let result = try? JSONDecoder.snakeCaseKeys.decode(UpdateDevices.Result.self, from: body) else {
+            throw SyncError.unableToDecodeResponse("Failed to decode devices update")
+        }
+
+        return result
+    }
+
     func refreshToken(_ account: SyncAccount, deviceName: String) async throws -> LoginResult {
         let info = try crypter.extractLoginInfo(recoveryKey: SyncCode.RecoveryKey(userId: account.userId,
                                                                                   primaryKey: account.primaryKey))
@@ -355,25 +379,6 @@ struct AccountManager: AccountManaging {
         }
     }
 
-    struct UpdateDevices {
-
-        struct Parameters: Encodable {
-            let updates: [Update]
-        }
-
-        struct Update: Encodable {
-            let id: String
-            let name: String?
-            let type: String?
-            let info: String?
-        }
-
-        struct Result: Decodable {
-            let devices: [RegisteredDeviceEntry]
-            let devicesV2: [RegisteredDeviceEntry]
-        }
-    }
-
     struct FetchDevicesResult: Decodable {
         struct DeviceWrapper: Decodable {
             var lastModified: String?
@@ -382,6 +387,25 @@ struct AccountManager: AccountManaging {
         }
 
         var devices: DeviceWrapper?
+    }
+}
+
+struct UpdateDevices {
+
+    struct Parameters: Encodable {
+        let updates: [Update]
+    }
+
+    struct Update: Encodable {
+        let id: String
+        let name: String?
+        let type: String?
+        let info: String?
+    }
+
+    struct Result: Decodable {
+        let devices: [RegisteredDeviceEntry]
+        let devicesV2: [RegisteredDeviceEntry]
     }
 }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/Endpoints.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/Endpoints.swift
@@ -26,6 +26,7 @@ final class Endpoints {
     private(set) var connect: URL
     private(set) var exchange: URL
     private(set) var aiChats: URL
+    private(set) var devices: URL
     private(set) var tokenRescope: URL
     private(set) var accessCredentials: URL
     private(set) var keys: URL
@@ -61,6 +62,7 @@ final class Endpoints {
         syncPatch = baseURL.appendingPathComponent("sync/data")
         exchange = baseURL.appendingPathComponent("sync/exchange")
         aiChats = baseURL.appendingPathComponent("sync/ai_chats")
+        devices = baseURL.appendingPathComponent("sync/devices")
         tokenRescope = baseURL.appendingPathComponent("sync/token/rescope")
         accessCredentials = baseURL.appendingPathComponent("sync/access-credentials")
         keys = baseURL.appendingPathComponent("sync/keys")
@@ -84,6 +86,7 @@ extension Endpoints {
         syncPatch = baseURL.appendingPathComponent("sync/data")
         exchange = baseURL.appendingPathComponent("sync/exchange")
         aiChats = baseURL.appendingPathComponent("sync/ai_chats")
+        devices = baseURL.appendingPathComponent("sync/devices")
         tokenRescope = baseURL.appendingPathComponent("sync/token/rescope")
         accessCredentials = baseURL.appendingPathComponent("sync/access-credentials")
         keys = baseURL.appendingPathComponent("sync/keys")

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -211,5 +211,6 @@ struct RegisteredDeviceEntry: Decodable {
     let id: String
     let name: String?
     let type: String?
+    let info: String?
     let credentialId: String?
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
@@ -68,6 +68,7 @@ protocol AccountManaging {
     func logout(deviceId: String, token: String) async throws
 
     func fetchDevicesForAccount(_ account: SyncAccount) async throws -> [RegisteredDevice]
+    func updateDevice(_ update: UpdateDevices.Update, for account: SyncAccount) async throws -> UpdateDevices.Result
 }
 
 /// Manages the scoped ("3party") access credential: recovering, creating, and fetching its password and protected keys.

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -782,7 +782,7 @@ final class AccountManagerTests: XCTestCase {
     }
 
     private func devicesURL(for endpoints: Endpoints) -> URL {
-        endpoints.syncGet.appendingPathComponent("devices")
+        endpoints.devices
     }
 
     private func makeSignupBody(from api: RemoteAPIRequestCreatingMock) throws -> [String: Any] {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -613,12 +613,12 @@ final class AccountManagerTests: XCTestCase {
     }
 
     func testWhenEncodingUpdateDevicesParametersThenUsesPatchContractShape() throws {
-        let deviceUpdate = AccountManager.UpdateDevices.Update(
+        let deviceUpdate = UpdateDevices.Update(
             id: "device-1",
             name: "encrypted-name",
             type: "encrypted-type",
             info: "encrypted-info")
-        let parameters = AccountManager.UpdateDevices.Parameters(updates: [deviceUpdate])
+        let parameters = UpdateDevices.Parameters(updates: [deviceUpdate])
 
         let data = try JSONEncoder.snakeCaseKeys.encode(parameters)
         let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
@@ -656,7 +656,7 @@ final class AccountManagerTests: XCTestCase {
         }
         """
 
-        let result = try JSONDecoder.snakeCaseKeys.decode(AccountManager.UpdateDevices.Result.self, from: Data(json.utf8))
+        let result = try JSONDecoder.snakeCaseKeys.decode(UpdateDevices.Result.self, from: Data(json.utf8))
 
         XCTAssertEqual(result.devices.map(\.id), ["device-1"])
         XCTAssertNil(result.devices.first?.info)
@@ -664,6 +664,94 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(result.devicesV2.map(\.id), ["device-1"])
         XCTAssertEqual(result.devicesV2.first?.info, "encrypted-info")
         XCTAssertEqual(result.devicesV2.first?.credentialId, SyncCredentialID.defaultCredential)
+    }
+
+    func testWhenUpdatingDeviceThenUsesAuthenticatedPatchAndDecodesResponse() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            isScopedAccessCredentialsEnabled: { true })
+        api.fakeRequests[endpoints.devices] = makeJSONRequest("""
+        {
+            "devices": [],
+            "devices_v2": [
+                {
+                    "id": "device-1",
+                    "name": "encrypted-name",
+                    "type": "encrypted-type",
+                    "info": "encrypted-info",
+                    "jwt_iat": "2026-06-23T10:00:00Z",
+                    "credential_id": "ddg"
+                }
+            ]
+        }
+        """)
+
+        let result = try await accountManager.updateDevice(makeDeviceUpdate(), for: makeAccount(primaryKey: Data()))
+
+        let requestArguments = try XCTUnwrap(api.createRequestCallArgs.last)
+        let requestBody = try XCTUnwrap(requestArguments.body)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: requestBody) as? [String: Any])
+        let updates = try XCTUnwrap(body["updates"] as? [[String: Any]])
+        XCTAssertEqual(requestArguments.url, endpoints.devices)
+        XCTAssertEqual(requestArguments.method, .patch)
+        XCTAssertEqual(requestArguments.headers["Authorization"], "Bearer token-1")
+        XCTAssertEqual(requestArguments.contentType, "application/json")
+        XCTAssertEqual(updates.first?["id"] as? String, "device-1")
+        XCTAssertEqual(updates.first?["name"] as? String, "encrypted-name")
+        XCTAssertEqual(updates.first?["type"] as? String, "encrypted-type")
+        XCTAssertEqual(updates.first?["info"] as? String, "encrypted-info")
+        XCTAssertEqual(result.devicesV2.map(\.id), ["device-1"])
+    }
+
+    func testWhenUpdatingDeviceWithoutTokenThenThrowsNoToken() async {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            isScopedAccessCredentialsEnabled: { true })
+
+        await assertThrowsError(SyncError.noToken) {
+            try await accountManager.updateDevice(makeDeviceUpdate(),
+                                                  for: makeAccount(primaryKey: Data(), token: nil))
+        }
+
+        XCTAssertTrue(api.createRequestCallArgs.isEmpty)
+    }
+
+    func testWhenUpdatingDeviceResponseHasNoBodyThenThrowsNoResponseBody() async {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            isScopedAccessCredentialsEnabled: { true })
+        api.fakeRequests[endpoints.devices] = HTTPRequestingMock(result: .init(data: nil, response: .init()))
+
+        await assertThrowsError(SyncError.noResponseBody) {
+            try await accountManager.updateDevice(makeDeviceUpdate(), for: makeAccount(primaryKey: Data()))
+        }
+    }
+
+    func testWhenUpdatingDeviceResponseIsInvalidThenThrowsUnableToDecodeResponse() async {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            isScopedAccessCredentialsEnabled: { true })
+        api.fakeRequests[endpoints.devices] = makeJSONRequest("""
+        {
+            "devices": []
+        }
+        """)
+
+        await assertThrowsError(SyncError.unableToDecodeResponse("Failed to decode devices update")) {
+            try await accountManager.updateDevice(makeDeviceUpdate(), for: makeAccount(primaryKey: Data()))
+        }
     }
 
     func testWhenFetchingDevicesWithScopedAccessEnabledThenPrefersEntriesV2OverLegacyEntries() async throws {
@@ -812,14 +900,21 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertTrue(api.createRequestCallArgs.contains { $0.url == endpoints.logoutDevice })
     }
 
-    private func makeAccount(primaryKey: Data) -> SyncAccount {
+    private func makeDeviceUpdate() -> UpdateDevices.Update {
+        UpdateDevices.Update(id: "device-1",
+                             name: "encrypted-name",
+                             type: "encrypted-type",
+                             info: "encrypted-info")
+    }
+
+    private func makeAccount(primaryKey: Data, token: String? = "token-1") -> SyncAccount {
         SyncAccount(deviceId: "device-1",
                     deviceName: "iPhone",
                     deviceType: "ios",
                     userId: "user-1",
                     primaryKey: primaryKey,
                     secretKey: Data(repeating: 0x2, count: 32),
-                    token: "token-1",
+                    token: token,
                     state: .active)
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -612,6 +612,60 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertNil(result.accessCredentials)
     }
 
+    func testWhenEncodingUpdateDevicesParametersThenUsesPatchContractShape() throws {
+        let deviceUpdate = AccountManager.UpdateDevices.Update(
+            id: "device-1",
+            name: "encrypted-name",
+            type: "encrypted-type",
+            info: "encrypted-info")
+        let parameters = AccountManager.UpdateDevices.Parameters(updates: [deviceUpdate])
+
+        let data = try JSONEncoder.snakeCaseKeys.encode(parameters)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let updates = try XCTUnwrap(body["updates"] as? [[String: Any]])
+        let encodedUpdate = try XCTUnwrap(updates.first)
+
+        XCTAssertEqual(updates.count, 1)
+        XCTAssertEqual(encodedUpdate["id"] as? String, "device-1")
+        XCTAssertEqual(encodedUpdate["name"] as? String, "encrypted-name")
+        XCTAssertEqual(encodedUpdate["type"] as? String, "encrypted-type")
+        XCTAssertEqual(encodedUpdate["info"] as? String, "encrypted-info")
+    }
+
+    func testWhenDecodingUpdateDevicesResultThenMapsLegacyAndUnifiedDevices() throws {
+        let json = """
+        {
+            "devices": [
+                {
+                    "id": "device-1",
+                    "name": "encrypted-name",
+                    "type": "encrypted-type",
+                    "jwt_iat": "2026-06-23T10:00:00Z"
+                }
+            ],
+            "devices_v2": [
+                {
+                    "id": "device-1",
+                    "name": "encrypted-name",
+                    "type": "encrypted-type",
+                    "info": "encrypted-info",
+                    "jwt_iat": "2026-06-23T10:00:00Z",
+                    "credential_id": "ddg"
+                }
+            ]
+        }
+        """
+
+        let result = try JSONDecoder.snakeCaseKeys.decode(AccountManager.UpdateDevices.Result.self, from: Data(json.utf8))
+
+        XCTAssertEqual(result.devices.map(\.id), ["device-1"])
+        XCTAssertNil(result.devices.first?.info)
+        XCTAssertNil(result.devices.first?.credentialId)
+        XCTAssertEqual(result.devicesV2.map(\.id), ["device-1"])
+        XCTAssertEqual(result.devicesV2.first?.info, "encrypted-info")
+        XCTAssertEqual(result.devicesV2.first?.credentialId, SyncCredentialID.defaultCredential)
+    }
+
     func testWhenFetchingDevicesWithScopedAccessEnabledThenPrefersEntriesV2OverLegacyEntries() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -632,6 +632,22 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(encodedUpdate["info"] as? String, "encrypted-info")
     }
 
+    func testWhenEncodingUpdateDevicesParametersWithoutInfoThenOmitsInfo() throws {
+        let deviceUpdate = UpdateDevices.Update(
+            id: "device-1",
+            name: "encrypted-name",
+            type: "encrypted-type",
+            info: nil)
+        let parameters = UpdateDevices.Parameters(updates: [deviceUpdate])
+
+        let data = try JSONEncoder.snakeCaseKeys.encode(parameters)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let updates = try XCTUnwrap(body["updates"] as? [[String: Any]])
+        let encodedUpdate = try XCTUnwrap(updates.first)
+
+        XCTAssertEqual(Set(encodedUpdate.keys), ["id", "name", "type"])
+    }
+
     func testWhenDecodingUpdateDevicesResultThenMapsLegacyAndUnifiedDevices() throws {
         let json = """
         {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -115,6 +115,18 @@ class AccountManagingMock: AccountManaging {
     func fetchDevicesForAccount(_ account: SyncAccount) async throws -> [RegisteredDevice] {
         [.mock]
     }
+
+    var updateDeviceCalls: [(update: UpdateDevices.Update, account: SyncAccount)] = []
+    var updateDeviceStub: UpdateDevices.Result?
+    var updateDeviceError: Error?
+    func updateDevice(_ update: UpdateDevices.Update,
+                      for account: SyncAccount) async throws -> UpdateDevices.Result {
+        updateDeviceCalls.append((update: update, account: account))
+        if let updateDeviceError {
+            throw updateDeviceError
+        }
+        return updateDeviceStub ?? UpdateDevices.Result(devices: [], devicesV2: [])
+    }
 }
 
 final class SchedulerMock: SchedulingInternal {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
@@ -28,6 +28,7 @@ final class RegisteredDeviceMapperTests: XCTestCase {
         let entry = RegisteredDeviceEntry(id: "native-device",
                                           name: "encrypted_Mac",
                                           type: "encrypted_desktop",
+                                          info: nil,
                                           credentialId: SyncCredentialID.defaultCredential)
 
         let device = mapper.registeredDevice(fromLegacyEntry: entry, account: makeAccount())
@@ -51,6 +52,7 @@ final class RegisteredDeviceMapperTests: XCTestCase {
             type: try codec.encryptDirect(payload: Data("browser".utf8),
                                           contentEncryptionKey: thirdPartyMainKey,
                                           kid: SyncCredentialID.thirdParty),
+            info: nil,
             credentialId: SyncCredentialID.thirdParty)
         let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
                                             cachedScopedPassword: { scopedPassword },
@@ -78,6 +80,7 @@ final class RegisteredDeviceMapperTests: XCTestCase {
             type: try codec.encryptDirect(payload: Data("browser".utf8),
                                           contentEncryptionKey: thirdPartyMainKey,
                                           kid: SyncCredentialID.thirdParty),
+            info: nil,
             credentialId: SyncCredentialID.thirdParty)
         let accessCredentials = [AccessCredential(id: SyncCredentialID.thirdParty, scope: "sync", encrypted3PartyCredential: "encrypted")]
         let scopedAccess = ScopedAccessCredentialManagingMock()
@@ -113,10 +116,12 @@ final class RegisteredDeviceMapperTests: XCTestCase {
             type: try codec.encryptDirect(payload: Data("browser".utf8),
                                           contentEncryptionKey: thirdPartyMainKey,
                                           kid: SyncCredentialID.thirdParty),
+            info: nil,
             credentialId: SyncCredentialID.thirdParty)
         let undecryptableEntry = RegisteredDeviceEntry(id: "undecryptable-third-party-device",
                                                        name: "not-jwe",
                                                        type: "not-jwe",
+                                                       info: nil,
                                                        credentialId: SyncCredentialID.thirdParty)
         let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
                                             cachedScopedPassword: { scopedPassword },
@@ -141,6 +146,7 @@ final class RegisteredDeviceMapperTests: XCTestCase {
         let entry = RegisteredDeviceEntry(id: "future-device",
                                           name: "encrypted_Future",
                                           type: "encrypted_browser",
+                                          info: nil,
                                           credentialId: "future")
 
         let devices = await mapper.registeredDevices(from: [entry], account: makeAccount())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1216959197715038?focus=true
Tech Design URL:
CC:

### Description
Adds authenticated support for updating a Sync device’s legacy and unified metadata. The response includes both legacy and unified device lists so callers can use the state persisted by the server.

Requests follow the backend’s partial-update contract, including clearing unified device metadata when it is omitted. This PR establishes the transport only; it does not yet trigger device updates during normal app use.

### Testing Steps
No manual testing is required because the new device-update request is not invoked by a user flow in this PR.

1. Confirm CI passes → request construction, authentication, PATCH encoding, optional `info` omission, and response decoding are covered by unit tests.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and URL refactor for device fetch; PATCH is unused in production paths and covered by unit tests.
> 
> **Overview**
> Adds **authenticated PATCH** support for Sync device metadata via a dedicated `sync/devices` endpoint, plus wiring so device **GET** uses that URL instead of `sync/.../devices`.
> 
> `AccountManager` exposes `updateDevice` with `UpdateDevices` request/response types (legacy `devices` and unified `devices_v2`, optional encrypted `info`). Encoding omits `info` when unset to match the server partial-update contract. `RegisteredDeviceEntry` gains optional `info` for decoded payloads.
> 
> `AccountManaging` and test mocks are extended; unit tests cover PATCH auth, encoding, decoding, and error paths. **No app flows call `updateDevice` yet**—transport only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 257106bcd3df8265249f5fd5a3ef2b9b407643a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->