### PR TITLE
[iOS] [MacOS] [Subscription] [Pixels] Followup on Subscription Pixels

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionFreemiumPixels.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionFreemiumPixels.swift
@@ -34,6 +34,7 @@ public class DataBrokerProtectionFreemiumPixelHandler: EventMapping<DataBrokerPr
                     .newTabNoResultsClickCount,
                     .overFlowScanImpressionCount,
                     .overFlowScanCount,
+                    .overFlowResultsImpressionCount,
                     .overFlowResultsCount:
                 PixelKit.fire(event, frequency: .standard)
             default:
@@ -73,6 +74,8 @@ public enum DataBrokerProtectionFreemiumPixels: PixelKitEvent {
     case overFlowScanImpressionCount
     case overFlowScan
     case overFlowScanCount
+    case overFlowResultsImpression
+    case overFlowResultsImpressionCount
     case overFlowResults
     case overFlowResultsCount
     // System notification
@@ -121,6 +124,10 @@ public enum DataBrokerProtectionFreemiumPixels: PixelKitEvent {
             return "dbp-free_overflow_scan_u"
         case .overFlowScanCount:
             return "dbp-free_overflow_scan_c"
+        case .overFlowResultsImpression:
+            return "dbp-free_overflow_results_impression_u"
+        case .overFlowResultsImpressionCount:
+            return "dbp-free_overflow_results_impression_c"
         case .overFlowResults:
             return "dbp-free_overflow_results_u"
         case .overFlowResultsCount:
@@ -157,6 +164,8 @@ public enum DataBrokerProtectionFreemiumPixels: PixelKitEvent {
                 .overFlowScanImpressionCount,
                 .overFlowScan,
                 .overFlowScanCount,
+                .overFlowResultsImpression,
+                .overFlowResultsImpressionCount,
                 .overFlowResults,
                 .overFlowResultsCount,
                 .firstScanCompleteNotificationSent,

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -34,36 +34,36 @@ import VPN
 struct VPNEntryPoint {
     let screenSource: VPNConnectionWideEventData.ScreenSource
     let subscriptionFunnelOrigin: SubscriptionFunnelOrigin
-    let subscriptionFunnelClickPixel: SubscriptionPixel
+    let subscriptionFunnelClickPixel: (_ isSubscriptionActive: Bool?) -> SubscriptionPixel
 
     static let toolbar = VPNEntryPoint(
         screenSource: .toolbar,
         subscriptionFunnelOrigin: .toolbarVPN,
-        subscriptionFunnelClickPixel: .subscriptionVPNToolbarClick)
+        subscriptionFunnelClickPixel: { .subscriptionVPNToolbarClick(isSubscriptionActive: $0) })
 
     static let addressBar = VPNEntryPoint(
         screenSource: .addressBar,
         subscriptionFunnelOrigin: .addressBarVPN,
-        subscriptionFunnelClickPixel: .subscriptionVPNAddressBarClick)
+        subscriptionFunnelClickPixel: { .subscriptionVPNAddressBarClick(isSubscriptionActive: $0) })
 
     static let widget = VPNEntryPoint(
         screenSource: .widget,
         subscriptionFunnelOrigin: .widgetVPN,
-        subscriptionFunnelClickPixel: .subscriptionVPNWidgetClick)
+        subscriptionFunnelClickPixel: { _ in .subscriptionVPNWidgetClick })
 
     static let shortcut = VPNEntryPoint(
         screenSource: .shortcut,
         subscriptionFunnelOrigin: .shortcutVPN,
-        subscriptionFunnelClickPixel: .subscriptionVPNShortcutClick)
+        subscriptionFunnelClickPixel: { _ in .subscriptionVPNShortcutClick })
 
     static let notification = VPNEntryPoint(
         screenSource: .notification,
         subscriptionFunnelOrigin: .notificationVPN,
-        subscriptionFunnelClickPixel: .subscriptionVPNNotificationClick)
+        subscriptionFunnelClickPixel: { _ in .subscriptionVPNNotificationClick })
 
     private init(screenSource: VPNConnectionWideEventData.ScreenSource,
                  subscriptionFunnelOrigin: SubscriptionFunnelOrigin,
-                 subscriptionFunnelClickPixel: SubscriptionPixel) {
+                 subscriptionFunnelClickPixel: @escaping (_ isSubscriptionActive: Bool?) -> SubscriptionPixel) {
         self.screenSource = screenSource
         self.subscriptionFunnelOrigin = subscriptionFunnelOrigin
         self.subscriptionFunnelClickPixel = subscriptionFunnelClickPixel

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1161,7 +1161,8 @@ class MainViewController: UIViewController {
                canShowVPNInUI {
                 segueToVPN(source: entryPoint.screenSource, scrollToStrictRouting: scrollToStrictRouting)
             } else {
-                PixelKit.fire(entryPoint.subscriptionFunnelClickPixel, frequency: .dailyAndCount)
+                let isSubscriptionActive = (try? await subscriptionManager.getSubscription())?.isActive
+                PixelKit.fire(entryPoint.subscriptionFunnelClickPixel(isSubscriptionActive), frequency: .dailyAndCount)
                 segueToDuckDuckGoSubscription(origin: entryPoint.subscriptionFunnelOrigin.rawValue)
             }
         }

--- a/iOS/DuckDuckGo/Subscription/Pixels/SubscriptionPixel.swift
+++ b/iOS/DuckDuckGo/Subscription/Pixels/SubscriptionPixel.swift
@@ -39,9 +39,9 @@ enum SubscriptionPixel: PixelKitEvent {
     case subscriptionKeychainManagerFailedToWriteDataFromBacklog(SubscriptionPixelHandler.Source)
     // VPN Subscription Funnel Entry Points
     case subscriptionVPNToolbarImpression(isSubscriptionActive: Bool?)
-    case subscriptionVPNToolbarClick
+    case subscriptionVPNToolbarClick(isSubscriptionActive: Bool?)
     case subscriptionVPNAddressBarImpression(isSubscriptionActive: Bool?)
-    case subscriptionVPNAddressBarClick
+    case subscriptionVPNAddressBarClick(isSubscriptionActive: Bool?)
     case subscriptionVPNWidgetClick
     case subscriptionVPNShortcutClick
     case subscriptionVPNNotificationClick
@@ -100,7 +100,9 @@ enum SubscriptionPixel: PixelKitEvent {
             return [SubscriptionPixelsDefaults.policyCacheKey: policy.description,
                     SubscriptionPixelsDefaults.sourceKey: source.rawValue]
         case .subscriptionVPNToolbarImpression(let isSubscriptionActive),
-                .subscriptionVPNAddressBarImpression(let isSubscriptionActive):
+                .subscriptionVPNToolbarClick(let isSubscriptionActive),
+                .subscriptionVPNAddressBarImpression(let isSubscriptionActive),
+                .subscriptionVPNAddressBarClick(let isSubscriptionActive):
             return [SubscriptionPixelsDefaults.vpnSubscriptionActiveKey: Self.vpnSubscriptionActiveValue(isSubscriptionActive)]
         default:
             return nil

--- a/iOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -89,7 +89,7 @@
         "owners": ["hanyutang-sandra"],
         "triggers": ["user_submitted"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "vpnSubscriptionActive"]
     },
     "subscription_vpn_address-bar_impression": {
         "description": "Fired when the customizable address-bar VPN button is presented to the user (customization enabled and VPN selected as the address-bar button).",
@@ -103,7 +103,7 @@
         "owners": ["hanyutang-sandra"],
         "triggers": ["user_submitted"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "vpnSubscriptionActive"]
     },
     "subscription_vpn_widget_click": {
         "description": "Fired when a non-subscriber taps the VPN widget entry point and is redirected into the subscription funnel.",

--- a/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/MoreOptionsMenu.swift
@@ -718,8 +718,13 @@ final class MoreOptionsMenu: NSMenu, NSMenuDelegate {
         freemiumDBPItem.target = self
         freemiumDBPItem.action = #selector(openFreemiumDBP(_:))
 
-        dataBrokerProtectionFreemiumPixelHandler.fire(DataBrokerProtectionFreemiumPixels.overFlowScanImpressionCount)
-        dataBrokerProtectionFreemiumPixelHandler.fire(DataBrokerProtectionFreemiumPixels.overFlowScanImpression)
+        if freemiumDBPUserStateManager.didPostFirstProfileSavedNotification {
+            dataBrokerProtectionFreemiumPixelHandler.fire(DataBrokerProtectionFreemiumPixels.overFlowResultsImpressionCount)
+            dataBrokerProtectionFreemiumPixelHandler.fire(DataBrokerProtectionFreemiumPixels.overFlowResultsImpression)
+        } else {
+            dataBrokerProtectionFreemiumPixelHandler.fire(DataBrokerProtectionFreemiumPixels.overFlowScanImpressionCount)
+            dataBrokerProtectionFreemiumPixelHandler.fire(DataBrokerProtectionFreemiumPixels.overFlowScanImpression)
+        }
 
         addItem(freemiumDBPItem)
     }

--- a/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -1173,14 +1173,14 @@
         "parameters": ["appVersion", "pixelSource"]
     },
     "dbp-free_overflow_scan_impression_u": {
-        "description": "Fires once per user when the Personal Information Removal entry is presented in the More Options menu (whenever the freemium DBP feature is available).",
+        "description": "Fires once per user when the Personal Information Removal entry is presented in the More Options menu, before any scan has been completed (pre-scan state).",
         "owners": ["hanyutang-sandra"],
         "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource"]
     },
     "dbp-free_overflow_scan_impression_c": {
-        "description": "Fires every time the Personal Information Removal entry is presented in the More Options menu (whenever the freemium DBP feature is available). Counted variant of dbp-free_overflow_scan_impression_u.",
+        "description": "Fires every time the Personal Information Removal entry is presented in the More Options menu, before any scan has been completed (pre-scan state). Counted variant of dbp-free_overflow_scan_impression_u.",
         "owners": ["hanyutang-sandra"],
         "triggers": ["other"],
         "suffixes": [],
@@ -1197,6 +1197,20 @@
         "description": "Fires every time the user clicks the Personal Information Removal entry in the More Options menu, before any scan has been completed (pre-scan state). Counted variant of dbp-free_overflow_scan_u.",
         "owners": ["hanyutang-sandra"],
         "triggers": ["user_submitted"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "dbp-free_overflow_results_impression_u": {
+        "description": "Fires once per user when the Personal Information Removal entry is presented in the More Options menu, after the first profile has been saved (post-scan state).",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": [],
+        "parameters": ["appVersion", "pixelSource"]
+    },
+    "dbp-free_overflow_results_impression_c": {
+        "description": "Fires every time the Personal Information Removal entry is presented in the More Options menu, after the first profile has been saved (post-scan state). Counted variant of dbp-free_overflow_results_impression_u.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
         "suffixes": [],
         "parameters": ["appVersion", "pixelSource"]
     },

--- a/macOS/UnitTests/Menus/MoreOptionsMenuTests.swift
+++ b/macOS/UnitTests/Menus/MoreOptionsMenuTests.swift
@@ -320,6 +320,55 @@ final class MoreOptionsMenuTests: XCTestCase {
     }
 
     @MainActor
+    func testWhenMoreOptionsMenuBuiltAndFreemiumAvailableThenOnlyScanImpressionPixelsFire() {
+        // Given
+        mockSubscriptionManager.hasAppStoreProductsAvailable = true
+        mockSubscriptionManager.currentEnvironment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .stripe)
+        mockFreemiumDBPFeature.featureAvailable = true
+
+        // When
+        setupMoreOptionsMenu()
+
+        // Then
+        XCTAssertTrue(mockPixelHandler.allFiredEvents.contains(.overFlowScanImpressionCount))
+        XCTAssertTrue(mockPixelHandler.allFiredEvents.contains(.overFlowScanImpression))
+        XCTAssertFalse(mockPixelHandler.allFiredEvents.contains(.overFlowResultsImpressionCount))
+        XCTAssertFalse(mockPixelHandler.allFiredEvents.contains(.overFlowResultsImpression))
+    }
+
+    @MainActor
+    func testWhenMoreOptionsMenuBuiltAndFreemiumActivatedThenOnlyResultsImpressionPixelsFire() {
+        // Given
+        mockFreemiumDBPUserStateManager.didPostFirstProfileSavedNotification = true
+        mockSubscriptionManager.hasAppStoreProductsAvailable = true
+        mockSubscriptionManager.currentEnvironment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .stripe)
+        mockFreemiumDBPFeature.featureAvailable = true
+
+        // When
+        setupMoreOptionsMenu()
+
+        // Then
+        XCTAssertFalse(mockPixelHandler.allFiredEvents.contains(.overFlowScanImpressionCount))
+        XCTAssertFalse(mockPixelHandler.allFiredEvents.contains(.overFlowScanImpression))
+        XCTAssertTrue(mockPixelHandler.allFiredEvents.contains(.overFlowResultsImpressionCount))
+        XCTAssertTrue(mockPixelHandler.allFiredEvents.contains(.overFlowResultsImpression))
+    }
+
+    @MainActor
+    func testWhenMoreOptionsMenuBuiltAndFreemiumUnavailableThenNoImpressionPixelsFire() {
+        // Given
+        mockSubscriptionManager.hasAppStoreProductsAvailable = true
+        mockSubscriptionManager.currentEnvironment = SubscriptionEnvironment(serviceEnvironment: .production, purchasePlatform: .stripe)
+        mockFreemiumDBPFeature.featureAvailable = false
+
+        // When
+        setupMoreOptionsMenu()
+
+        // Then
+        XCTAssertTrue(mockPixelHandler.allFiredEvents.isEmpty)
+    }
+
+    @MainActor
     func testWhenClickingWinBackOfferPurchasePageThenActionDelegateIsCalled() throws {
         // Given
         mockWinBackOfferVisibilityManager.isOfferAvailable = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217411208347240?focus=true

### Description
- Split the macOS freemium DBP overflow-menu impression pixel into pre-scan and post-scan variants, mirroring the existing click-pixel split: `dbp-free_overflow_scan_impression_u/_c` now fires only before a scan completes, and new `dbp-free_overflow_results_impression_u/_c` pixels fire after the first profile is saved.
- Added `vpnSubscriptionActive` parameter to the iOS `subscription_vpn_toolbar_click` and `subscription_vpn_address-bar_click` pixels, matching the parameter already present on their corresponding impression pixels.
- Updated pixel definitions (JSON5) for both platforms, and added macOS unit tests covering pre-scan-only, post-scan-only, and feature-unavailable impression firing.

### Testing Steps
- macOS: Open the More Options menu as a freemium-eligible user before running any scan; confirm `dbp-free_overflow_scan_impression_u/_c` fire (check via pixel debug logging) and `dbp-free_overflow_results_impression_u/_c` do not.
- macOS: Complete a scan/save a profile so `didPostFirstProfileSavedNotification` is true, reopen the More Options menu; confirm the reverse — only `dbp-free_overflow_results_impression_u/_c` fire.
- iOS: As a non-subscriber, tap the VPN entry point in the toolbar and then in the address bar; confirm `subscription_vpn_toolbar_click` / `subscription_vpn_address-bar_click` fire with `vpnSubscriptionActive=no_subscription`.
- iOS: Repeat as an active subscriber with the VPN feature excluded from their plan (if reachable) or simulate; confirm `vpnSubscriptionActive=true`/`false` reflects actual subscription state rather than being omitted.

### Impact and Risks
**Impact Level: Medium**

#### What could go wrong?
- **Pixel volume shift**: `dbp-free_overflow_scan_impression_u/_c` will drop in volume going forward since they no longer fire unconditionally — the post-scan share moves to the new `dbp-free_overflow_results_impression_u/_c` pixels. Any existing dashboards/queries treating `overflow_scan_impression` as "total menu-item impressions" need to sum both scan + results impression pixels after this ships. Mitigated by keeping the split symmetric with the existing, already-understood click-pixel behavior.
- **Extra async call on VPN click path**: fetching `isSubscriptionActive` before firing the toolbar/widget-agnostic click pixel adds one lightweight `getSubscription()` call; low risk since the same call already happens for the impression pixels and for the `isFeatureIncludedInSubscription` check just above it.

### Quality Considerations
- Added macOS unit tests (`MoreOptionsMenuTests`) asserting mutually-exclusive impression firing for pre-scan, post-scan, and feature-unavailable states.
- No new PII collected; `vpnSubscriptionActive` reuses the existing `no_subscription`/`true`/`false` encoding already used by the impression pixels.
- Pixel definitions (JSON5) updated on both iOS and macOS to keep documentation in sync with the new/changed parameters.

### Notes to Reviewer
- Builds on #6102, which originally added the pre-scan DBP impression pixel and the VPN funnel impression/click pixels.
- Flagging for awareness: `dbp-free_overflow_scan_impression_c` daily/weekly counts will drop after this merges as post-scan traffic shifts to the new `dbp-free_overflow_results_impression_c` pixel — worth a heads-up to anyone actively monitoring that specific pixel's trend.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes with tests for menu impression branching; VPN click path adds one subscription state read already used nearby on the same code path.
> 
> **Overview**
> **macOS freemium DBP:** Overflow menu **impression** pixels now mirror the existing click split. Before the first profile save, only `dbp-free_overflow_scan_impression_u/_c` fire; after `didPostFirstProfileSavedNotification`, new **`dbp-free_overflow_results_impression_u/_c`** fire instead. `MoreOptionsMenu.addFreemiumDBPItem()` branches on the same state used for click pixels.
> 
> **iOS VPN subscription funnel:** Toolbar and address-bar **click** pixels (`subscription_vpn_toolbar_click`, `subscription_vpn_address-bar_click`) now carry the **`vpnSubscriptionActive`** parameter, aligned with their impression events. `VPNEntryPoint.subscriptionFunnelClickPixel` is a closure that builds the pixel at fire time; `presentNetworkProtectionStatusSettingsModal` reads subscription active state before firing when routing non-subscribers into the funnel.
> 
> Pixel JSON5 definitions and macOS `MoreOptionsMenuTests` cover the new impression events and mutually exclusive pre/post-scan firing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9ea419b95135106e10f4934111e733243535664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->