### PR TITLE
macOS: Fixes Suggestion Cell Overlap

### DIFF
--- a/macOS/DuckDuckGo/Suggestions/View/SuggestionTableCellView.swift
+++ b/macOS/DuckDuckGo/Suggestions/View/SuggestionTableCellView.swift
@@ -326,29 +326,17 @@ final class SuggestionTableCellView: NSTableCellView {
                 alwaysAnchorToTrailing = false
             }
 
-            if alwaysAnchorToTrailing {
+            let textWidth = calculateTextWidth()
+
+            if alwaysAnchorToTrailing || contentExceedsAvailableWidth(textWidth: textWidth, boxWidth: boxWidth, bounds: bounds) {
                 switchToTabBoxLeadingConstraint.isActive = false
                 switchToTabBoxTrailingConstraint.isActive = true
                 suffixTrailingConstraint.constant = boxWidth + Constants.trailingSpace + Constants.switchToTabSuffixPadding
             } else {
-                var textWidth = attributedString?.boundingRect(with: bounds.size).width ?? 0
-                if textWidth < bounds.width {
-                    textWidth += suffixTextField.attributedStringValue.boundingRect(with: bounds.size).width
-                }
-                if textField!.frame.minX
-                    + textWidth
-                    + Constants.switchToTabSuffixPadding
-                    + boxWidth
-                    + Constants.trailingSpace > bounds.width {
-
-                    switchToTabBoxLeadingConstraint.isActive = false
-                    switchToTabBoxTrailingConstraint.isActive = true
-                } else {
-                    switchToTabBoxTrailingConstraint.isActive = false
-                    switchToTabBoxLeadingConstraint.constant = textField!.frame.minX + textWidth + Constants.switchToTabSuffixPadding
-                    switchToTabBoxLeadingConstraint.isActive = true
-                    suffixTrailingConstraint.constant = Constants.trailingSpace
-                }
+                switchToTabBoxTrailingConstraint.isActive = false
+                switchToTabBoxLeadingConstraint.constant = textField!.frame.minX + textWidth + Constants.switchToTabSuffixPadding
+                switchToTabBoxLeadingConstraint.isActive = true
+                suffixTrailingConstraint.constant = Constants.trailingSpace
             }
         }
 
@@ -369,6 +357,23 @@ final class SuggestionTableCellView: NSTableCellView {
 }
 
 private extension SuggestionTableCellView {
+
+    func contentExceedsAvailableWidth(textWidth: CGFloat, boxWidth: CGFloat, bounds: CGRect) -> Bool {
+        (textField?.frame.minX ?? 0)
+            + textWidth
+            + Constants.switchToTabSuffixPadding
+            + boxWidth
+            + Constants.trailingSpace > bounds.width
+    }
+
+    func calculateTextWidth() -> CGFloat {
+        var textWidth = attributedString?.boundingRect(with: bounds.size).width ?? 0
+        if textWidth < bounds.width {
+            textWidth += suffixTextField.attributedStringValue.boundingRect(with: bounds.size).width
+        }
+
+        return textWidth
+    }
 
     func suggestionsSuffixColor(colorsProvider: ColorsProviding) -> NSColor {
         isSelected


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1217129576969939
Tech Design URL:
CC:

### Description
This PR fixes a layout issue that caused the `Switch to Tab` UI element, present in Suggestions Cells, to overlap with the content.

### Testing Steps
1. Open this URL https://app.asana.com/1/137249556945/project/481882893211075/task/1216951138503975?focus=true
2. Open a new Tab
3. Type `Tech Design`

- [ ] Verify the `Switch to Tab` Box, present in the Suggestions Cells, doesn't overlap with the text

Now | Before
-|-
<img width="400" src="https://github.com/user-attachments/assets/649b0fb2-afe0-4389-a0a8-22549d9de09e" /> | <img width="400" src="https://github.com/user-attachments/assets/bb811de7-be7f-44b2-b206-8b03628c15f3" />

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Worst case scenario, we might have a new layout glitch in the Suggestions cell **(should not happen, though!)**.

### Quality Considerations
Nothing in particular

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout in suggestion cells; risk is minor visual glitches in address bar suggestions, not security or data handling.
> 
> **Overview**
> Fixes **Switch to Tab** overlap in macOS suggestion rows by unifying trailing-anchor layout with the overflow path in `SuggestionTableCellView.layout()`.
> 
> When the box is pinned to the trailing edge (search/AI chat styles) or text plus suffix would collide with the box, the suffix trailing constraint now reserves width for the box (`boxWidth`, trailing space, padding)—behavior that previously only ran in the overflow branch for default/visit styles.
> 
> Text width and overflow checks are moved into `calculateTextWidth()` and `contentExceedsAvailableWidth()` for clarity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de9a427093e1313144a94ba58554921e2fc961ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->