### PR TITLE
[iOS] [Subscription Onboarding] Add Instrumentations (PR 3/3)

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -648,6 +648,7 @@ public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {
     case subscriptionExpirationReminderNotification
     case subscriptionPromoForExistingUsers
     case monthlyFreeTrialExperiment
+    case subscriptionOnboarding
     case onboardingSubscriptionUpsellExperiment
 }
 

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -271,6 +271,9 @@
 		3666D86730017A6800B63F99 /* SubscriptionOnboardingCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3666D86630017A6800B63F99 /* SubscriptionOnboardingCard.swift */; };
 		3666D86D30017B1400B63F99 /* RebrandedPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3666D86B30017B1400B63F99 /* RebrandedPreview.swift */; };
 		3666D8753001917B00B63F99 /* SubscriptionOnboardingChecklistItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3666D8733001917B00B63F99 /* SubscriptionOnboardingChecklistItem.swift */; };
+		36DD9FE5302BB9CE00D12A6A /* SubscriptionOnboardingInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36DD9FE3302BB9CE00D12A6A /* SubscriptionOnboardingInstrumentation.swift */; };
+		36DD9FDE302BB99300D12A6A /* SubscriptionOnboardingInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36DD9FDD302BB99300D12A6A /* SubscriptionOnboardingInstrumentationTests.swift */; };
+		36DD9FE0302BB99D00D12A6A /* SubscriptionOnboardingPostCheckoutTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36DD9FDF302BB99D00D12A6A /* SubscriptionOnboardingPostCheckoutTriggerTests.swift */; };
 		36DD9FD7302B88A600D12A6A /* GraphicLottieRenderer+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36DD9FD6302B88A600D12A6A /* GraphicLottieRenderer+App.swift */; };
 		36DD9FD9302BA75500D12A6A /* SubscriptionOnboardingProtectionOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36DD9FD8302BA75500D12A6A /* SubscriptionOnboardingProtectionOverviewView.swift */; };
 		368349D5302689AC009BDEF7 /* SubscriptionOnboardingFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368349D4302689AC009BDEF7 /* SubscriptionOnboardingFlowView.swift */; };
@@ -3227,6 +3230,9 @@
 		3666D86630017A6800B63F99 /* SubscriptionOnboardingCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingCard.swift; sourceTree = "<group>"; };
 		3666D86B30017B1400B63F99 /* RebrandedPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RebrandedPreview.swift; sourceTree = "<group>"; };
 		3666D8733001917B00B63F99 /* SubscriptionOnboardingChecklistItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingChecklistItem.swift; sourceTree = "<group>"; };
+		36DD9FE3302BB9CE00D12A6A /* SubscriptionOnboardingInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Pixels/SubscriptionOnboardingInstrumentation.swift"; sourceTree = "<group>"; };
+		36DD9FDD302BB99300D12A6A /* SubscriptionOnboardingInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingInstrumentationTests.swift; sourceTree = "<group>"; };
+		36DD9FDF302BB99D00D12A6A /* SubscriptionOnboardingPostCheckoutTriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingPostCheckoutTriggerTests.swift; sourceTree = "<group>"; };
 		36DD9FD6302B88A600D12A6A /* GraphicLottieRenderer+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphicLottieRenderer+App.swift"; sourceTree = "<group>"; };
 		36DD9FD8302BA75500D12A6A /* SubscriptionOnboardingProtectionOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingProtectionOverviewView.swift; sourceTree = "<group>"; };
 		368349D4302689AC009BDEF7 /* SubscriptionOnboardingFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingFlowView.swift; sourceTree = "<group>"; };
@@ -7036,6 +7042,7 @@
 			isa = PBXGroup;
 			children = (
 				3666D878300193DB00B63F99 /* Resources */,
+				36DD9FE3302BB9CE00D12A6A /* SubscriptionOnboardingInstrumentation.swift */,
 				3666D876300193CC00B63F99 /* SubscriptionOnboardingUserText.swift */,
 				3666D8743001917B00B63F99 /* Models */,
 				3666D86C30017B1400B63F99 /* Helpers */,
@@ -7102,6 +7109,8 @@
 				3901A00979D78E26EF811EEA /* SubscriptionOnboardingSectionTests.swift */,
 				368349DE30268B2E009BDEF7 /* SubscriptionOnboardingFlowViewModelTests.swift */,
 				36DD9FE1302BB9A600D12A6A /* SubscriptionOnboardingProgressTests.swift */,
+				36DD9FDD302BB99300D12A6A /* SubscriptionOnboardingInstrumentationTests.swift */,
+				36DD9FDF302BB99D00D12A6A /* SubscriptionOnboardingPostCheckoutTriggerTests.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -13866,6 +13875,7 @@
 				36E8274830264E8300147F78 /* SubscriptionOnboardingOrderConfirmationView.swift in Sources */,
 				36E8274930264E8300147F78 /* SubscriptionOnboardingOrderConfirmationViewModel.swift in Sources */,
 				36E8274D3026508B00147F78 /* SubscriptionOnboardingProgressCardView.swift in Sources */,
+				36DD9FE5302BB9CE00D12A6A /* SubscriptionOnboardingInstrumentation.swift in Sources */,
 				36699A30302CD4F600D1E3EE /* PIRAvailability.swift in Sources */,
 				3677BA07302B78D2004E95E3 /* SubscriptionOnboardingActivationRecorder.swift in Sources */,
 				3677BA08302B78D2004E95E3 /* SubscriptionOnboardingProgress.swift in Sources */,
@@ -14875,6 +14885,8 @@
 				368349DF30268B2E009BDEF7 /* SubscriptionOnboardingFlowViewModelTests.swift in Sources */,
 				36DD9FE2302BB9A600D12A6A /* SubscriptionOnboardingProgressTests.swift in Sources */,
 				36E8274B3026506A00147F78 /* SubscriptionOnboardingOrderConfirmationViewModelTests.swift in Sources */,
+				36DD9FDE302BB99300D12A6A /* SubscriptionOnboardingInstrumentationTests.swift in Sources */,
+				36DD9FE0302BB99D00D12A6A /* SubscriptionOnboardingPostCheckoutTriggerTests.swift in Sources */,
 				CB3B4D4E2D63910B006DAD63 /* LaunchActionHandlerTests.swift in Sources */,
 				CBAD0F1F2D02EE45006267B8 /* IdleReturnEvaluatorTests.swift in Sources */,
 				97D99E642F7420A900EE34E7 /* AIVoiceChatIntentTests.swift in Sources */,

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -533,6 +533,7 @@ extension MainViewController {
                                                   experimentalAIChatManager: ExperimentalAIChatManager(featureFlagger: featureFlagger),
                                                   privacyConfigurationManager: privacyConfigurationManager,
                                                   keyValueStore: keyValueStore,
+                                                  subscriptionOnboardingSession: AppDependencyProvider.shared.subscriptionOnboardingSession,
                                                   contentBlockingAssetsPublisher: contentBlockingAssetsPublisher,
                                                   idleReturnEligibilityManager: idleReturnEligibilityManager,
                                                   afterInactivityOptionAdapter: afterInactivityOptionAdapter,

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -342,6 +342,7 @@ class MainViewController: UIViewController {
                                                   featureDiscovery: featureDiscovery,
                                                   aiChatSettings: aiChatSettings,
                                                   productSurfaceTelemetry: productSurfaceTelemetry,
+                                                  onboardingActivationRecorder: SubscriptionOnboardingActivationRecorder(keyValueStore: keyValueStore),
                                                   duckAiFireModeStorageHandler: duckAiFireModeStorageHandler)
         manager.delegate = self
         manager.isFireModeProvider = { [weak self] in self?.tabManager.currentBrowsingMode == .fire }
@@ -3683,7 +3684,11 @@ class MainViewController: UIViewController {
             internalUserDecider: AppDependencyProvider.shared.internalUserDecider,
             dataBrokerProtectionViewControllerProvider: dbpIOSPublicInterface,
             wideEvent: AppDependencyProvider.shared.wideEvent,
-            featureFlagger: featureFlagger
+            featureFlagger: featureFlagger,
+            onboardingKeyValueStore: keyValueStore,
+            meetsPIRLocaleRequirement: { [weak dbpIOSPublicInterface] in
+                dbpIOSPublicInterface?.meetsLocaleRequirement ?? false
+            }
         ))
         viewController.view.backgroundColor = UIColor(designSystemColor: .surface)
         return viewController

--- a/iOS/DuckDuckGo/SettingsRootView.swift
+++ b/iOS/DuckDuckGo/SettingsRootView.swift
@@ -161,7 +161,9 @@ struct SettingsRootView: View {
                                                              internalUserDecider: AppDependencyProvider.shared.internalUserDecider,
                                                              dataBrokerProtectionViewControllerProvider: viewModel.dataBrokerProtectionViewControllerProvider,
                                                              wideEvent: AppDependencyProvider.shared.wideEvent,
-                                                             featureFlagger: viewModel.featureFlagger)
+                                                             featureFlagger: viewModel.featureFlagger,
+                                                             onboardingKeyValueStore: viewModel.keyValueStore,
+                                                             meetsPIRLocaleRequirement: { viewModel.meetsLocaleRequirement })
     }
 
     @ViewBuilder func subscriptionPlanChangeFlowNavigationDestination(redirectURLComponents: URLComponents?) -> some View {

--- a/iOS/DuckDuckGo/Subscription/Onboarding/Navigation/SubscriptionOnboardingFlowViewModel.swift
+++ b/iOS/DuckDuckGo/Subscription/Onboarding/Navigation/SubscriptionOnboardingFlowViewModel.swift
@@ -61,6 +61,15 @@ final class SubscriptionOnboardingFlowViewModel: ObservableObject {
     /// unless `isPIRAvailable`
     let pirScreen: () -> AnyView
 
+    /// Both edges of the PIR sheet, reported from the summary's own observation of `pirLaunch`
+    func reportPIRPresentation(_ isPresenting: Bool) {
+        if isPresenting {
+            instrumentation.stepShown(.pir)
+        } else if progress.completedItems.contains(.pir) {
+            instrumentation.stepCompleted(.pir)
+        }
+    }
+
     // MARK: - Progress
 
     /// The flow writes completion into this and reads it twice — for the step indicator and, once at launch,
@@ -71,6 +80,8 @@ final class SubscriptionOnboardingFlowViewModel: ObservableObject {
 
     /// Screens read cached results from this rather than fetching for themselves.
     let prefetcher: SubscriptionOnboardingPrefetcher
+
+    let instrumentation: SubscriptionOnboardingInstrumenting
 
     private let onFinish: () -> Void
     private let onRequestDuckAIChat: (String?) -> Void
@@ -84,10 +95,12 @@ final class SubscriptionOnboardingFlowViewModel: ObservableObject {
                           onFinish: @escaping () -> Void = {},
                           prefetcher: SubscriptionOnboardingPrefetcher? = nil,
                           onRequestDuckAIChat: ((String?) -> Void)? = nil,
+                          instrumentation: SubscriptionOnboardingInstrumenting? = nil,
                           @ViewBuilder pirScreen: @escaping () -> PIRScreen) {
         self.progress = progress
         self.onFinish = onFinish
         self.prefetcher = prefetcher ?? SubscriptionOnboardingPrefetcher()
+        self.instrumentation = instrumentation ?? SubscriptionOnboardingInstrumentation(entryPoint: entryPoint)
         self.pirScreen = { AnyView(pirScreen()) }
         if let onRequestDuckAIChat {
             self.onRequestDuckAIChat = onRequestDuckAIChat
@@ -102,6 +115,7 @@ final class SubscriptionOnboardingFlowViewModel: ObservableObject {
 
     /// Kicked off when the flow appears.
     func startPrefetching() {
+        instrumentation.flowStarted()
         prefetcher.prefetch(Self.prefetchTargets(for: sequence))
     }
 
@@ -203,10 +217,28 @@ extension SubscriptionOnboardingFlowViewModel: SubscriptionOnboardingSectionDele
             guard !progress.completedItems.contains(item) else { return }
             progress.markComplete(item)
         }
+        instrumentation.stepCompleted(section)
     }
 
     func sectionDidRequestAdvance() {
+        reportSkipIfNeeded()
         proceed()
+    }
+
+    /// The two sections with a skip CTA.
+    private func reportSkipIfNeeded() {
+        switch currentSection {
+        case .vpnActivation:
+            // An incomplete VPN means the customer skipped.
+            if !progress.completedItems.contains(.vpn) {
+                instrumentation.stepSkipped(.vpnActivation)
+            }
+        case .duckAI:
+            // Advancing means user skipped the step
+            instrumentation.stepSkipped(.duckAI)
+        default:
+            break
+        }
     }
 
     func sectionDidRequestDuckAIChat(modelID: String?) {

--- a/iOS/DuckDuckGo/Subscription/Onboarding/Navigation/SubscriptionOnboardingViewFactory.swift
+++ b/iOS/DuckDuckGo/Subscription/Onboarding/Navigation/SubscriptionOnboardingViewFactory.swift
@@ -42,7 +42,8 @@ struct SubscriptionOnboardingViewFactory {
     }
 
     func screen(for section: SubscriptionOnboardingSection) -> AnyView {
-        content(for: section)
+        AnyView(content(for: section)
+            .onFirstAppear { flow.instrumentation.stepShown(section) })
     }
 
     private func content(for section: SubscriptionOnboardingSection) -> AnyView {
@@ -107,6 +108,7 @@ struct SubscriptionOnboardingViewFactory {
                     guard item == .pir else { return }
                     flow.isPresentingPIR = true
                 },
+                onPIRPresentationChanged: { flow.reportPIRPresentation($0) },
                 onNext: { flow.finish() }))
 
         case .pir:

--- a/iOS/DuckDuckGo/Subscription/Onboarding/Pixels/SubscriptionOnboardingInstrumentation.swift
+++ b/iOS/DuckDuckGo/Subscription/Onboarding/Pixels/SubscriptionOnboardingInstrumentation.swift
@@ -1,0 +1,112 @@
+//
+//  SubscriptionOnboardingInstrumentation.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import PixelKit
+import AIChat
+
+/// Reports the onboarding funnel.
+@MainActor
+protocol SubscriptionOnboardingInstrumenting {
+    /// The funnel's denominator, and the only place the Duck.ai-disabled cohort is counted.
+    func flowStarted()
+    func stepShown(_ section: SubscriptionOnboardingSection)
+    func stepCompleted(_ section: SubscriptionOnboardingSection)
+    func stepSkipped(_ section: SubscriptionOnboardingSection)
+}
+
+// MARK: - Pixel vocabulary
+
+/// Step names are their own vocabulary rather than the section case names, so renaming a case cannot
+/// rename a pixel.
+extension SubscriptionOnboardingSection {
+    var pixelStepName: String {
+        switch self {
+        case .orderConfirmation: "intro"
+        case .welcome: "features_summary"
+        case .vpnActivation: "vpn"
+        case .vpnWidget: "vpn_widget"
+        case .idtr: "idtr"
+        case .duckAI: "duck_ai"
+        case .progress: "completion"
+        case .pir: "pir"
+        }
+    }
+}
+
+extension SubscriptionOnboardingEntryPoint {
+    var pixelValue: String {
+        switch self {
+        case .postCheckout: "post_checkout"
+        case .subscriptionSettings: "subscription_settings"
+        }
+    }
+}
+
+// MARK: - Implementation
+
+@MainActor
+struct SubscriptionOnboardingInstrumentation: SubscriptionOnboardingInstrumenting {
+
+    private let entryPoint: SubscriptionOnboardingEntryPoint
+    private let isDuckAIEnabled: () -> Bool
+    private let pixelFiring: PixelFiring?
+
+    init(entryPoint: SubscriptionOnboardingEntryPoint,
+         isDuckAIEnabled: (() -> Bool)? = nil,
+         pixelFiring: PixelFiring? = PixelKit.shared) {
+        self.entryPoint = entryPoint
+        if let isDuckAIEnabled {
+            self.isDuckAIEnabled = isDuckAIEnabled
+        } else {
+            let aiChatSettings = AIChatSettings()
+            self.isDuckAIEnabled = { aiChatSettings.isAIChatEnabled }
+        }
+        self.pixelFiring = pixelFiring
+    }
+
+    func flowStarted() {
+        fire(.subscriptionOnboardingFlowStarted(entryPoint: entryPoint.pixelValue,
+                                                isDuckAIEnabled: isDuckAIEnabled()))
+    }
+
+    func stepShown(_ section: SubscriptionOnboardingSection) {
+        fire(.subscriptionOnboardingStepShown(step: section.pixelStepName, entryPoint: entryPoint.pixelValue))
+    }
+
+    func stepCompleted(_ section: SubscriptionOnboardingSection) {
+        fire(.subscriptionOnboardingStepCompleted(step: section.pixelStepName, entryPoint: entryPoint.pixelValue))
+    }
+
+    func stepSkipped(_ section: SubscriptionOnboardingSection) {
+        fire(.subscriptionOnboardingStepSkipped(step: section.pixelStepName, entryPoint: entryPoint.pixelValue))
+    }
+
+    private func fire(_ pixel: SubscriptionPixel) {
+        pixelFiring?.fire(pixel)
+    }
+}
+
+/// Reports nothing, for previews and tests.
+struct NullSubscriptionOnboardingInstrumentation: SubscriptionOnboardingInstrumenting {
+    func flowStarted() {}
+    func stepShown(_ section: SubscriptionOnboardingSection) {}
+    func stepCompleted(_ section: SubscriptionOnboardingSection) {}
+    func stepSkipped(_ section: SubscriptionOnboardingSection) {}
+}

--- a/iOS/DuckDuckGo/Subscription/Pixels/SubscriptionPixel.swift
+++ b/iOS/DuckDuckGo/Subscription/Pixels/SubscriptionPixel.swift
@@ -45,6 +45,14 @@ enum SubscriptionPixel: PixelKitEvent {
     case subscriptionVPNWidgetClick
     case subscriptionVPNShortcutClick
     case subscriptionVPNNotificationClick
+    // Subscription Onboarding Flow
+    case subscriptionOnboardingFlowStarted(entryPoint: String, isDuckAIEnabled: Bool)
+    case subscriptionOnboardingStepShown(step: String, entryPoint: String)
+    case subscriptionOnboardingStepCompleted(step: String, entryPoint: String)
+    case subscriptionOnboardingStepSkipped(step: String, entryPoint: String)
+    case subscriptionOnboardingConnectionInfoFailure(Error)
+    case subscriptionOnboardingAIModelsFailure(Error)
+    case subscriptionOnboardingSubscriptionFailure(Error)
 
     var name: String {
         switch self {
@@ -69,6 +77,14 @@ enum SubscriptionPixel: PixelKitEvent {
         case .subscriptionVPNWidgetClick: return "subscription_vpn_widget_click"
         case .subscriptionVPNShortcutClick: return "subscription_vpn_shortcut_click"
         case .subscriptionVPNNotificationClick: return "subscription_vpn_notification_click"
+            // Subscription Onboarding Flow
+        case .subscriptionOnboardingFlowStarted: return "subscription_onboarding_flow_started"
+        case .subscriptionOnboardingStepShown(let step, _): return "subscription_onboarding_step_shown_\(step)"
+        case .subscriptionOnboardingStepCompleted(let step, _): return "subscription_onboarding_step_completed_\(step)"
+        case .subscriptionOnboardingStepSkipped(let step, _): return "subscription_onboarding_step_skipped_\(step)"
+        case .subscriptionOnboardingConnectionInfoFailure: return "subscription_onboarding_connection-info_failure"
+        case .subscriptionOnboardingAIModelsFailure: return "subscription_onboarding_ai-models_failure"
+        case .subscriptionOnboardingSubscriptionFailure: return "subscription_onboarding_subscription_failure"
         }
     }
 
@@ -77,6 +93,8 @@ enum SubscriptionPixel: PixelKitEvent {
         static let sourceKey = "source"
         static let platformKey = "platform"
         static let vpnSubscriptionActiveKey = "vpnSubscriptionActive"
+        static let entryPointKey = "entry_point"
+        static let duckAIEnabledKey = "duck_ai_enabled"
     }
 
     private static func vpnSubscriptionActiveValue(_ isSubscriptionActive: Bool?) -> String {
@@ -102,6 +120,13 @@ enum SubscriptionPixel: PixelKitEvent {
         case .subscriptionVPNToolbarImpression(let isSubscriptionActive),
                 .subscriptionVPNAddressBarImpression(let isSubscriptionActive):
             return [SubscriptionPixelsDefaults.vpnSubscriptionActiveKey: Self.vpnSubscriptionActiveValue(isSubscriptionActive)]
+        case .subscriptionOnboardingFlowStarted(let entryPoint, let isDuckAIEnabled):
+            return [SubscriptionPixelsDefaults.entryPointKey: entryPoint,
+                    SubscriptionPixelsDefaults.duckAIEnabledKey: String(isDuckAIEnabled)]
+        case .subscriptionOnboardingStepShown(_, let entryPoint),
+                .subscriptionOnboardingStepCompleted(_, let entryPoint),
+                .subscriptionOnboardingStepSkipped(_, let entryPoint):
+            return [SubscriptionPixelsDefaults.entryPointKey: entryPoint]
         default:
             return nil
         }
@@ -126,7 +151,14 @@ enum SubscriptionPixel: PixelKitEvent {
                 .subscriptionVPNAddressBarClick,
                 .subscriptionVPNWidgetClick,
                 .subscriptionVPNShortcutClick,
-                .subscriptionVPNNotificationClick:
+                .subscriptionVPNNotificationClick,
+                .subscriptionOnboardingFlowStarted,
+                .subscriptionOnboardingStepShown,
+                .subscriptionOnboardingStepCompleted,
+                .subscriptionOnboardingStepSkipped,
+                .subscriptionOnboardingConnectionInfoFailure,
+                .subscriptionOnboardingAIModelsFailure,
+                .subscriptionOnboardingSubscriptionFailure:
             return [.pixelSource]
         }
     }

--- a/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -117,6 +117,7 @@ protocol SubscriptionPagesUseSubscriptionFeature: Subfeature, ObservableObject {
     var onBackToSettings: (() -> Void)? { get set }
     var onFeatureSelected: ((SubscriptionEntitlement) -> Void)? { get set }
     var onActivateSubscription: (() -> Void)? { get set }
+    var onPurchaseCompleted: (() -> Void)? { get set }
 
     func with(broker: UserScriptMessageBroker)
     func handler(forMethodNamed methodName: String) -> Subfeature.Handler?
@@ -221,6 +222,7 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
     var onBackToSettings: (() -> Void)?
     var onFeatureSelected: ((SubscriptionEntitlement) -> Void)?
     var onActivateSubscription: (() -> Void)?
+    var onPurchaseCompleted: (() -> Void)?
 
     struct FeatureSelection: Codable {
         let productFeature: SubscriptionEntitlement
@@ -598,6 +600,7 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
             if let preference = pendingScheduleNotification, let scheduler = expirationReminderScheduler {
                 await scheduler.scheduleReminder(daysBeforeCancel: preference.daysBeforeCancel)
             }
+            onPurchaseCompleted?()
 
         case .failure(let error):
             Logger.subscription.error("App store complete subscription purchase error: \(error, privacy: .public)")
@@ -890,6 +893,7 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
         onSetSubscription = nil
         onActivateSubscription = nil
         onBackToSettings = nil
+        onPurchaseCompleted = nil
     }
 
     private func fireFreemiumUpsellPixel() {

--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionContainerViewModel.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionContainerViewModel.swift
@@ -21,6 +21,7 @@ import Foundation
 import Subscription
 import Combine
 import DataBrokerProtection_iOS
+import Persistence
 
 final class SubscriptionContainerViewModel: ObservableObject {
 
@@ -38,7 +39,9 @@ final class SubscriptionContainerViewModel: ObservableObject {
          userScript: SubscriptionPagesUserScript,
          userScriptsDependencies: DefaultScriptSourceProvider.Dependencies,
          subFeature: any SubscriptionPagesUseSubscriptionFeature,
-         dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?) {
+         dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?,
+         onboardingKeyValueStore: ThrowingKeyValueStoring?,
+         meetsPIRLocaleRequirement: @escaping () -> Bool) {
 
         self.userScript = userScript
 
@@ -52,7 +55,9 @@ final class SubscriptionContainerViewModel: ObservableObject {
                                               userScriptsDependencies: userScriptsDependencies,
                                               subFeature: subFeature,
                                               subscriptionManager: subscriptionManager,
-                                              dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider)
+                                              dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider,
+                                              onboardingKeyValueStore: onboardingKeyValueStore,
+                                              meetsPIRLocaleRequirement: meetsPIRLocaleRequirement)
         self.restore = SubscriptionRestoreViewModel(userScript: userScript,
                                                     subFeature: subFeature)
         self.email = SubscriptionEmailViewModel(isInternalUser: isInternalUser,

--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
@@ -26,6 +26,7 @@ import PrivacyConfig
 import DataBrokerProtection_iOS
 import PixelKit
 import FeatureFlags_iOS
+import Persistence
 
 enum SubscriptionFlowType {
     case firstPurchase
@@ -88,6 +89,7 @@ final class SubscriptionFlowViewModel: ObservableObject {
         var selectedFeature: SelectedFeature = .none
         var viewTitle: String = UserText.subscriptionTitle
         var shouldGoBackToSettings: Bool = false
+        var shouldPresentOnboarding: Bool = false
     }
     
     // Read only View State - Should only be modified from the VM
@@ -95,6 +97,51 @@ final class SubscriptionFlowViewModel: ObservableObject {
 
     var isPIREnabled: Bool {
         featureFlagger.isFeatureOn(.personalInformationRemoval)
+    }
+
+    // MARK: - Post-checkout onboarding
+
+    /// `nil` unless this flow came from `makeSubscribeFlowV2`
+    private let onboardingKeyValueStore: ThrowingKeyValueStoring?
+
+    private let meetsPIRLocaleRequirement: () -> Bool
+
+    private var isPIRAvailable: Bool {
+        PIRAvailability.isAvailable(isPIREnabled: isPIREnabled,
+                                    meetsLocaleRequirement: meetsPIRLocaleRequirement(),
+                                    provider: dataBrokerProtectionViewControllerProvider)
+    }
+
+    /// Latched so a defensive re-invocation of `onPurchaseCompleted` cannot re-offer the flow.
+    private var didRequestOnboarding = false
+
+    var onboardingProgress: SubscriptionOnboardingProgress? {
+        guard let onboardingKeyValueStore else { return nil }
+        return SubscriptionOnboardingProgress(
+            persistor: SubscriptionOnboardingProgressPersistor(keyValueStore: onboardingKeyValueStore),
+            isPIRAvailable: isPIRAvailable)
+    }
+
+    /// A pure rule so it can be tested
+    static func shouldRequestOnboarding(flowType: SubscriptionFlowType,
+                                        hasOnboardingStore: Bool,
+                                        isFeatureEnabled: Bool,
+                                        didAlreadyRequest: Bool) -> Bool {
+        !didAlreadyRequest
+            && flowType == .firstPurchase
+            && hasOnboardingStore
+            && isFeatureEnabled
+    }
+
+    /// Called when the App Store purchase itself completes
+    private func requestOnboardingIfNeeded() {
+        guard Self.shouldRequestOnboarding(
+            flowType: flowType,
+            hasOnboardingStore: onboardingKeyValueStore != nil,
+            isFeatureEnabled: featureFlagger.isFeatureOn(.subscriptionOnboarding),
+            didAlreadyRequest: didRequestOnboarding) else { return }
+        didRequestOnboarding = true
+        state.shouldPresentOnboarding = true
     }
 
     /// Returns the subscription URL type based on the current flow type
@@ -120,7 +167,9 @@ final class SubscriptionFlowViewModel: ObservableObject {
          urlOpener: URLOpener = UIApplication.shared,
          featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
          wideEvent: WideEventManaging = AppDependencyProvider.shared.wideEvent,
-         dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?) {
+         dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?,
+         onboardingKeyValueStore: ThrowingKeyValueStoring?,
+         meetsPIRLocaleRequirement: @escaping () -> Bool) {
         self.initialURL = initialURL
         self.flowType = flowType
         self.userScript = userScript
@@ -131,6 +180,8 @@ final class SubscriptionFlowViewModel: ObservableObject {
         self.featureFlagger = featureFlagger
         self.wideEvent = wideEvent
         self.dataBrokerProtectionViewControllerProvider = dataBrokerProtectionViewControllerProvider
+        self.onboardingKeyValueStore = onboardingKeyValueStore
+        self.meetsPIRLocaleRequirement = meetsPIRLocaleRequirement
         let allowedDomains = AsyncHeadlessWebViewSettings.makeAllowedDomains(baseURL: subscriptionManager.url(for: .baseURL),
                                                                              isInternalUser: isInternalUser)
 
@@ -172,7 +223,13 @@ final class SubscriptionFlowViewModel: ObservableObject {
                 self.setTransactionStatus(.idle)
             }
         }
-        
+
+        subFeature.onPurchaseCompleted = {
+            DispatchQueue.main.async {
+                self.requestOnboardingIfNeeded()
+            }
+        }
+
          subFeature.onFeatureSelected = { feature in
              DispatchQueue.main.async {
                  switch feature {

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
@@ -26,6 +26,7 @@ import PrivacyConfig
 import DataBrokerProtection_iOS
 import PixelKit
 import FeatureFlags_iOS
+import Persistence
 
 enum SubscriptionContainerViewFactory {
 
@@ -64,7 +65,9 @@ enum SubscriptionContainerViewFactory {
                                     internalUserDecider: InternalUserDecider,
                                     dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?,
                                     wideEvent: WideEventManaging,
-                                    featureFlagger: FeatureFlagger) -> some View {
+                                    featureFlagger: FeatureFlagger,
+                                    onboardingKeyValueStore: ThrowingKeyValueStoring?,
+                                    meetsPIRLocaleRequirement: @escaping () -> Bool) -> some View {
 
         let pendingTransactionHandler = DefaultPendingTransactionHandler(userDefaults: subscriptionUserDefaults,
                                                                          pixelHandler: SubscriptionPixelHandler(source: .mainApp, pixelKit: PixelKit.shared))
@@ -111,7 +114,9 @@ enum SubscriptionContainerViewFactory {
                                                                        requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager),
                                                                        expirationReminderScheduler: AppDependencyProvider.shared.subscriptionExpirationReminderScheduler,
                                                                        isExpirationReminderFeatureEnabled: { featureFlagger.isFeatureOn(.subscriptionExpirationReminderNotification) }),
-            dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider
+            dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider,
+            onboardingKeyValueStore: onboardingKeyValueStore,
+            meetsPIRLocaleRequirement: meetsPIRLocaleRequirement
         )
         viewModel.email.setEmailFlowMode(.restoreFlow)
         return SubscriptionContainerView(currentView: .subscribe, viewModel: viewModel, featureFlagger: featureFlagger)
@@ -129,7 +134,9 @@ enum SubscriptionContainerViewFactory {
                                    internalUserDecider: InternalUserDecider,
                                    dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?,
                                    wideEvent: WideEventManaging,
-                                   featureFlagger: FeatureFlagger) -> some View {
+                                   featureFlagger: FeatureFlagger,
+                                   onboardingKeyValueStore: ThrowingKeyValueStoring?,
+                                   meetsPIRLocaleRequirement: @escaping () -> Bool) -> some View {
         if let redirectURLComponents,
            SubscriptionPurchaseFlowPath.isPlansPath(redirectURLComponents.path) {
             makePlansFlowV2(redirectURLComponents: redirectURLComponents,
@@ -152,7 +159,9 @@ enum SubscriptionContainerViewFactory {
                                 internalUserDecider: internalUserDecider,
                                 dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider,
                                 wideEvent: wideEvent,
-                                featureFlagger: featureFlagger)
+                                featureFlagger: featureFlagger,
+                                onboardingKeyValueStore: onboardingKeyValueStore,
+                                meetsPIRLocaleRequirement: meetsPIRLocaleRequirement)
         }
     }
 
@@ -198,7 +207,9 @@ enum SubscriptionContainerViewFactory {
                                                        userScript: SubscriptionPagesUserScript(),
                                                        userScriptsDependencies: userScriptsDependencies,
                                                        subFeature: subscriptionPagesUseSubscriptionFeature,
-                                                       dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider)
+                                                       dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider,
+                                                       onboardingKeyValueStore: nil,
+                                                       meetsPIRLocaleRequirement: { false })
         viewModel.email.setEmailFlowMode(.restoreFlow)
         return SubscriptionContainerView(currentView: .restore, viewModel: viewModel, featureFlagger: featureFlagger)
             .environmentObject(navigationCoordinator)
@@ -262,7 +273,9 @@ enum SubscriptionContainerViewFactory {
                                                                        requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager),
                                                                        expirationReminderScheduler: AppDependencyProvider.shared.subscriptionExpirationReminderScheduler,
                                                                        isExpirationReminderFeatureEnabled: { featureFlagger.isFeatureOn(.subscriptionExpirationReminderNotification) }),
-            dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider
+            dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider,
+            onboardingKeyValueStore: nil,
+            meetsPIRLocaleRequirement: { false }
         )
         return SubscriptionContainerView(currentView: .subscribe, viewModel: viewModel, featureFlagger: featureFlagger)
             .environmentObject(navigationCoordinator)
@@ -310,7 +323,9 @@ enum SubscriptionContainerViewFactory {
                                                                        requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager),
                                                                        expirationReminderScheduler: AppDependencyProvider.shared.subscriptionExpirationReminderScheduler,
                                                                        isExpirationReminderFeatureEnabled: { featureFlagger.isFeatureOn(.subscriptionExpirationReminderNotification) }),
-            dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider
+            dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider,
+            onboardingKeyValueStore: nil,
+            meetsPIRLocaleRequirement: { false }
         )
 
         viewModel.email.setEmailFlowMode(emailFlow)

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionFlowView.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionFlowView.swift
@@ -40,6 +40,11 @@ struct SubscriptionFlowView: View {
     @State private var errorMessageType: SubscriptionTransactionErrorAlert.MessageType = .general
     @State private var isPresentingError: Bool = false
 
+    // MARK: - Onboarding state
+
+    @State private var isShowingOnboarding = false
+    @State private var onboardingFlow: AnyView?
+
     enum Constants {
         static let empty = ""
         static let navButtonPadding: CGFloat = 20.0
@@ -165,6 +170,17 @@ struct SubscriptionFlowView: View {
         .onChange(of: viewModel.state.shouldGoBackToSettings) { _ in
             dismiss()
         }
+
+        .onChange(of: viewModel.state.shouldPresentOnboarding) { shouldPresent in
+            if shouldPresent {
+                startOnboarding()
+            }
+        }
+
+        .sheet(isPresented: $isShowingOnboarding,
+               onDismiss: { onboardingFlow = nil }) {
+            onboardingFlow
+        }
         
         .onFirstAppear {
             setUpAppearances()
@@ -196,6 +212,32 @@ struct SubscriptionFlowView: View {
             if viewModel.state.transactionStatus != .idle {
                 PurchaseInProgressView(status: getTransactionStatus())
             }
+        }
+    }
+
+    // MARK: - Onboarding
+
+    /// Dismisses the onboarding sheet only, leaving the customer on the post-checkout page. The summary's CTA
+    /// is meant to drop them into Subscription Settings, which this container cannot reach — Settings is not
+    /// on the stack beneath a first purchase.
+    private func startOnboarding() {
+        guard let progress = viewModel.onboardingProgress else { return }
+        onboardingFlow = SubscriptionOnboardingLauncher.launch(
+            flow: .postCheckout(progress: progress,
+                                onFinish: { isShowingOnboarding = false },
+                                pirScreen: { pirDestination }))
+        isShowingOnboarding = true
+    }
+
+    /// The same destination the hidden PIR `NavigationLink` above pushes, so the flow's PIR row lands the
+    /// customer in the same place the purchase page's own PIR link would.
+    @ViewBuilder
+    private var pirDestination: some View {
+        if viewModel.isPIREnabled, let provider = viewModel.dataBrokerProtectionViewControllerProvider {
+            DataBrokerProtectionViewControllerRepresentation(dbpViewControllerProvider: provider)
+                .edgesIgnoringSafeArea(.bottom)
+        } else {
+            SubscriptionPIRMoveToDesktopView()
         }
     }
 

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
@@ -27,6 +27,7 @@ import Subscription
 import VPN
 import UIComponents
 import BrowserServicesKit
+import DataBrokerProtection_iOS
 
 enum SubscriptionSettingsViewConfiguration {
     case subscribed
@@ -61,6 +62,12 @@ struct SubscriptionSettingsViewV2: View {
     @State var isShowingUpgradeView = false
     @State var isShowingCancelDowngradeError = false
     @State private var cancelDowngradeErrorMessageType: SubscriptionTransactionErrorAlert.MessageType = .general
+
+    // MARK: - Onboarding state
+
+    @State private var isShowingOnboarding = false
+    /// Built when the customer taps the card.
+    @State private var onboardingFlow: AnyView?
 
     var body: some View {
         optionsView
@@ -453,6 +460,7 @@ struct SubscriptionSettingsViewV2: View {
                 downgradeBanner
                     .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             }
+            onboardingSetupSection
             if viewModel.shouldShowUpgrade {
                 upgradeSection
             }
@@ -466,6 +474,10 @@ struct SubscriptionSettingsViewV2: View {
         .padding(.top, -20)
         .navigationTitle(UserText.settingsPProManageSubscription)
         .applyInsetGroupedListStyle()
+        .sheet(isPresented: $isShowingOnboarding,
+               onDismiss: { onboardingFlow = nil }) {
+            onboardingFlow
+        }
         .onChange(of: viewModel.state.shouldDismissView) { value in
             if value {
                 dismiss()
@@ -648,5 +660,71 @@ private var resubscribeWithWinBackOfferView: some View {
         Text(UserText.winBackCampaignSubscriptionSettingsPageResubscribeSubtitle)
             .daxFootnoteRegular()
             .foregroundColor(Color(designSystemColor: .textSecondary))
+    }
+}
+
+// MARK: - Onboarding
+
+extension SubscriptionSettingsViewV2 {
+
+    /// The "Continue Setup" re-entry card. 
+    ///
+    /// Reaching 100% keeps the card for the rest of the session; it goes on the next launch. It also
+    /// disappears once the subscription expires or the flag is turned off.
+    var onboardingSetupSection: some View {
+        Section {
+            if isOnboardingEnabled {
+                SubscriptionOnboardingSetupCard(visual: .image(Image(.subscription56)),
+                                                progress: onboardingProgress,
+                                                session: settingsViewModel.subscriptionOnboardingSession,
+                                                isPresentingFlow: isShowingOnboarding,
+                                                onContinue: { startOnboarding() })
+            }
+        }
+        .listRowBackground(Color.clear)
+        .listRowInsets(EdgeInsets())
+    }
+
+    func startOnboarding() {
+        onboardingFlow = SubscriptionOnboardingLauncher.launch(
+            flow: .subscriptionSettings(progress: onboardingProgress,
+                                        onFinish: { isShowingOnboarding = false },
+                                        pirScreen: { pirDestination }))
+        isShowingOnboarding = true
+    }
+
+    /// Built fresh on each access; the state it reads lives in the key-value store, not in the value.
+    private var onboardingProgress: SubscriptionOnboardingProgress {
+        SubscriptionOnboardingProgress(
+            persistor: SubscriptionOnboardingProgressPersistor(keyValueStore: settingsViewModel.keyValueStore),
+            isPIRAvailable: isPIRAvailable)
+    }
+
+    /// Checked here rather than inside the card so the flag (and subscription state) also covers `startOnboarding()`.
+    private var isOnboardingEnabled: Bool {
+        settingsViewModel.featureFlagger.isFeatureOn(.subscriptionOnboarding) && hasActiveSubscription
+    }
+
+    /// The card is a re-entry point into an active subscription's onboarding — an expired subscription, or one
+    /// still activating, has nothing left to set up.
+    private var hasActiveSubscription: Bool {
+        configuration == .subscribed || configuration == .trial
+    }
+
+    /// PIR is gated three ways, and a customer who fails any of them is shown a four-item checklist rather
+    /// than a row they could never tick — which also makes their completion ceiling 100% instead of 80%.
+    private var isPIRAvailable: Bool { settingsViewModel.isPIRAvailable }
+
+    /// The PIR screen the flow pushes from its own stack, matching what Settings already pushes from its
+    /// PIR row (`SettingsSubscriptionView`). `LazyView` there is unnecessary — the flow only asks for this
+    /// when it reaches the PIR section.
+    @ViewBuilder
+    private var pirDestination: some View {
+        if let provider = settingsViewModel.dataBrokerProtectionViewControllerProvider {
+            DataBrokerProtectionViewControllerRepresentation(dbpViewControllerProvider: provider)
+                .edgesIgnoringSafeArea(.bottom)
+        } else {
+            SubscriptionPIRMoveToDesktopView()
+        }
     }
 }

--- a/iOS/DuckDuckGoTests/Subscription/Onboarding/SubscriptionOnboardingFlowViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/Onboarding/SubscriptionOnboardingFlowViewModelTests.swift
@@ -278,12 +278,147 @@ final class SubscriptionOnboardingFlowViewModelTests: XCTestCase {
         XCTAssertEqual(requestedModelID, "claude-sonnet-5")
     }
 
+    // MARK: - Funnel reporting
+
+    func testWhenASectionCompletesThenItIsReportedCompleted() {
+        let spy = SpyInstrumentation()
+        let sut = makeSUT(entryPoint: .postCheckout, instrumentation: spy)
+
+        sut.sectionDidComplete(.vpnActivation)
+
+        XCTAssertEqual(spy.completed, [.vpnActivation])
+        XCTAssertTrue(spy.skipped.isEmpty)
+    }
+
+    /// Re-entering an already-completed activation section (e.g. via a navigation quirk) must not re-fire the
+    /// completion pixel.
+    func testWhenAnAlreadyCompletedSectionCompletesAgainThenItIsNotReportedTwice() {
+        let spy = SpyInstrumentation()
+        let sut = makeSUT(entryPoint: .postCheckout, instrumentation: spy)
+
+        sut.sectionDidComplete(.vpnActivation)
+        sut.sectionDidComplete(.vpnActivation)
+
+        XCTAssertEqual(spy.completed, [.vpnActivation])
+    }
+
+    /// The VPN's on-state "Next" and its permission-denied "Skip" share `advance()`, so the skip is derived
+    /// from the item still being incomplete.
+    func testWhenLeavingTheVPNStepWithoutTurningItOnThenItIsReportedSkipped() {
+        let spy = SpyInstrumentation()
+        let sut = makeSUT(entryPoint: .postCheckout, instrumentation: spy)
+        sut.proceed()
+        sut.proceed()
+        XCTAssertEqual(sut.currentSection, .vpnActivation)
+
+        sut.sectionDidRequestAdvance()
+
+        XCTAssertEqual(spy.skipped, [.vpnActivation])
+    }
+
+    func testWhenLeavingTheVPNStepAfterTurningItOnThenNoSkipIsReported() {
+        let spy = SpyInstrumentation()
+        let sut = makeSUT(entryPoint: .postCheckout, instrumentation: spy)
+        sut.proceed()
+        sut.proceed()
+        sut.sectionDidComplete(.vpnActivation)
+
+        sut.sectionDidRequestAdvance()
+
+        XCTAssertTrue(spy.skipped.isEmpty)
+    }
+
+    /// Advancing from Duck.ai is itself the skip: starting a chat shows the interstitial instead of advancing.
+    func testWhenLeavingDuckAIThenItIsReportedSkipped() {
+        let spy = SpyInstrumentation()
+        let sut = makeSUT(entryPoint: .subscriptionSettings,
+                          completed: [.vpn, .widget, .idtr],
+                          instrumentation: spy)
+        XCTAssertEqual(sut.currentSection, .duckAI)
+
+        sut.sectionDidRequestAdvance()
+
+        XCTAssertEqual(spy.skipped, [.duckAI])
+    }
+
+    func testWhenLeavingAStepWithNoSkipCTAThenNoSkipIsReported() {
+        for section in [SubscriptionOnboardingSection.orderConfirmation, .welcome, .vpnWidget, .idtr] {
+            let spy = SpyInstrumentation()
+            let sut = makeSUT(entryPoint: .postCheckout, instrumentation: spy)
+            while sut.currentSection != section, sut.currentSection != nil {
+                sut.proceed()
+            }
+            // Activation steps mark themselves complete before advancing; overviews have no item at all.
+            if case .activation = section.kind {
+                sut.sectionDidComplete(section)
+            }
+
+            sut.sectionDidRequestAdvance()
+
+            XCTAssertTrue(spy.skipped.isEmpty, "\(section) should have no skip CTA to report")
+        }
+    }
+
+    // MARK: - Funnel reporting, PIR sheet
+
+    func testWhenThePIRSheetOpensThenItIsReportedShown() {
+        let spy = SpyInstrumentation()
+        let sut = makeSUT(entryPoint: .postCheckout, instrumentation: spy)
+
+        sut.reportPIRPresentation(true)
+
+        XCTAssertEqual(spy.shown, [.pir])
+        XCTAssertTrue(spy.completed.isEmpty)
+    }
+
+    func testWhenThePIRSheetClosesAfterAProfileIsSavedThenItIsReportedCompleted() {
+        let spy = SpyInstrumentation()
+        let store = MockProgressStore()
+        let sut = makeSUT(entryPoint: .postCheckout, store: store, instrumentation: spy)
+        sut.reportPIRPresentation(true)
+
+        // What saving a Data Broker Protection profile writes, from outside the flow.
+        store.completedItems.insert(.pir)
+        sut.reportPIRPresentation(false)
+
+        XCTAssertEqual(spy.shown, [.pir])
+        XCTAssertEqual(spy.completed, [.pir])
+    }
+
+    /// Closing the sheet is not a skip — PIR has a close button, not a skip CTA.
+    func testWhenThePIRSheetClosesWithoutAProfileThenNothingFurtherIsReported() {
+        let spy = SpyInstrumentation()
+        let sut = makeSUT(entryPoint: .postCheckout, instrumentation: spy)
+        sut.reportPIRPresentation(true)
+
+        sut.reportPIRPresentation(false)
+
+        XCTAssertEqual(spy.shown, [.pir])
+        XCTAssertTrue(spy.completed.isEmpty)
+        XCTAssertTrue(spy.skipped.isEmpty)
+    }
+
+    // MARK: - Funnel reporting, shown
+
+    /// `shown` must come from the screen appearing, never from the factory building it — on iOS 15 a
+    /// `NavigationLink` builds its destination before pushing it.
+    func testWhenAScreenIsBuiltThenItIsNotYetReportedShown() {
+        let spy = SpyInstrumentation()
+        let sut = makeSUT(entryPoint: .postCheckout, instrumentation: spy)
+        let factory = SubscriptionOnboardingViewFactory(flow: sut)
+
+        _ = factory.screen(for: .welcome)
+
+        XCTAssertTrue(spy.shown.isEmpty)
+    }
+
     // MARK: - Helpers
 
     private func makeSUT(entryPoint: SubscriptionOnboardingEntryPoint,
                          completed: Set<SubscriptionOnboardingChecklistItem> = [],
                          isPIRAvailable: Bool = true,
                          store: MockProgressStore? = nil,
+                         instrumentation: SubscriptionOnboardingInstrumenting? = nil,
                          onFinish: @escaping () -> Void = {},
                          onRequestDuckAIChat: @escaping (String?) -> Void = { _ in }) -> SubscriptionOnboardingFlowViewModel {
         let store = store ?? MockProgressStore()
@@ -293,8 +428,23 @@ final class SubscriptionOnboardingFlowViewModelTests: XCTestCase {
                                                   progress: progress,
                                                   onFinish: onFinish,
                                                   onRequestDuckAIChat: onRequestDuckAIChat,
+                                                  instrumentation: instrumentation ?? NullSubscriptionOnboardingInstrumentation(),
                                                   pirScreen: { EmptyView() })
     }
+}
+
+/// Records what the flow reported, so a test can assert the funnel rather than only the pixel names.
+private final class SpyInstrumentation: SubscriptionOnboardingInstrumenting {
+    private(set) var shown: [SubscriptionOnboardingSection] = []
+    private(set) var completed: [SubscriptionOnboardingSection] = []
+    private(set) var skipped: [SubscriptionOnboardingSection] = []
+
+    /// Deliberately unrecorded: asserting it would mean calling `startPrefetching()`, which starts real
+    /// fetches. The flow-start pixel is covered by `SubscriptionOnboardingInstrumentationTests`.
+    func flowStarted() {}
+    func stepShown(_ section: SubscriptionOnboardingSection) { shown.append(section) }
+    func stepCompleted(_ section: SubscriptionOnboardingSection) { completed.append(section) }
+    func stepSkipped(_ section: SubscriptionOnboardingSection) { skipped.append(section) }
 }
 
 /// A reference-typed persistor so a test can observe writes the flow makes through its own copy.

--- a/iOS/DuckDuckGoTests/Subscription/Onboarding/SubscriptionOnboardingInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/Onboarding/SubscriptionOnboardingInstrumentationTests.swift
@@ -1,0 +1,111 @@
+//
+//  SubscriptionOnboardingInstrumentationTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import PixelKit
+import PixelKitTestingUtilities
+@testable import DuckDuckGo
+
+@MainActor
+final class SubscriptionOnboardingInstrumentationTests: XCTestCase {
+
+    private var pixelFiring: PixelKitMock!
+
+    private var fired: [SubscriptionPixel] { pixelFiring.actualFireCalls.compactMap { $0.pixel as? SubscriptionPixel } }
+
+    override func setUp() {
+        super.setUp()
+        pixelFiring = PixelKitMock()
+    }
+
+    override func tearDown() {
+        pixelFiring = nil
+        super.tearDown()
+    }
+
+    private func makeInstrumentation(entryPoint: SubscriptionOnboardingEntryPoint = .postCheckout,
+                                     isDuckAIEnabled: Bool = true) -> SubscriptionOnboardingInstrumentation {
+        SubscriptionOnboardingInstrumentation(entryPoint: entryPoint,
+                                             isDuckAIEnabled: { isDuckAIEnabled },
+                                             pixelFiring: pixelFiring)
+    }
+
+    // MARK: - Step names
+
+    func testWhenEverySectionIsNamedThenTheNamesAreTheAgreedVocabulary() {
+        XCTAssertEqual(SubscriptionOnboardingSection.allCases.map(\.pixelStepName),
+                       ["intro", "features_summary", "vpn", "vpn_widget", "idtr", "duck_ai", "completion", "pir"])
+    }
+
+    func testWhenEntryPointsAreNamedThenTheyMatchThePixelValues() {
+        XCTAssertEqual(SubscriptionOnboardingEntryPoint.postCheckout.pixelValue, "post_checkout")
+        XCTAssertEqual(SubscriptionOnboardingEntryPoint.subscriptionSettings.pixelValue, "subscription_settings")
+    }
+
+    // MARK: - Names on the wire
+
+    /// The step belongs in the name, which is what the definitions' `keyPattern` matches against.
+    func testWhenAStepIsReportedThenTheNameCarriesTheEventAndStep() {
+        let sut = makeInstrumentation()
+
+        sut.stepShown(.vpnActivation)
+        sut.stepCompleted(.duckAI)
+        sut.stepSkipped(.vpnActivation)
+
+        XCTAssertEqual(fired.map(\.name), ["subscription_onboarding_step_shown_vpn",
+                                           "subscription_onboarding_step_completed_duck_ai",
+                                           "subscription_onboarding_step_skipped_vpn"])
+    }
+
+    func testWhenTheFlowStartsThenTheDenominatorIsReported() {
+        let sut = makeInstrumentation()
+
+        sut.flowStarted()
+
+        XCTAssertEqual(fired.map(\.name), ["subscription_onboarding_flow_started"])
+    }
+
+    // MARK: - Parameters
+
+    func testWhenTheFlowStartsThenTheEntryPointAndDuckAIStateAreParameters() {
+        let sut = makeInstrumentation(entryPoint: .subscriptionSettings, isDuckAIEnabled: false)
+
+        sut.flowStarted()
+
+        XCTAssertEqual(fired.first?.parameters?["entry_point"], "subscription_settings")
+        XCTAssertEqual(fired.first?.parameters?["duck_ai_enabled"], "false")
+    }
+
+    func testWhenDuckAIIsEnabledThenTheFlowStartReportsItAsSuch() {
+        let sut = makeInstrumentation(isDuckAIEnabled: true)
+
+        sut.flowStarted()
+
+        XCTAssertEqual(fired.first?.parameters?["duck_ai_enabled"], "true")
+    }
+
+    /// Without this the two entry points share every step pixel, and neither population can be read.
+    func testWhenAStepIsReportedThenTheEntryPointIsAParameter() {
+        let sut = makeInstrumentation(entryPoint: .postCheckout)
+
+        sut.stepShown(.idtr)
+
+        XCTAssertEqual(fired.first?.parameters?["entry_point"], "post_checkout")
+    }
+}

--- a/iOS/DuckDuckGoTests/Subscription/Onboarding/SubscriptionOnboardingPostCheckoutTriggerTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/Onboarding/SubscriptionOnboardingPostCheckoutTriggerTests.swift
@@ -1,0 +1,60 @@
+//
+//  SubscriptionOnboardingPostCheckoutTriggerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+/// The rule deciding whether a purchase flow offers post-checkout onboarding.
+final class SubscriptionOnboardingPostCheckoutTriggerTests: XCTestCase {
+
+    func testWhenAFirstPurchaseCompletesThenOnboardingIsRequested() {
+        XCTAssertTrue(shouldRequest())
+    }
+
+    func testWhenTheFlowIsAPlanUpdateThenOnboardingIsNotRequested() {
+        XCTAssertFalse(shouldRequest(flowType: .planUpdate))
+    }
+
+    /// The restore, email, and plan-update flows are built without a store, which is what keeps them out.
+    func testWhenTheFlowHasNoOnboardingStoreThenOnboardingIsNotRequested() {
+        XCTAssertFalse(shouldRequest(hasOnboardingStore: false))
+    }
+
+    func testWhenTheFeatureIsDisabledThenOnboardingIsNotRequested() {
+        XCTAssertFalse(shouldRequest(isFeatureEnabled: false))
+    }
+
+    /// A defensive re-invocation of the purchase-completed hook must not re-offer the flow.
+    func testWhenOnboardingWasAlreadyRequestedThenItIsNotRequestedAgain() {
+        XCTAssertFalse(shouldRequest(didAlreadyRequest: true))
+    }
+
+    // MARK: - Helper
+
+    /// Defaults describe the one case that should fire, so each test names only the condition it breaks.
+    private func shouldRequest(flowType: SubscriptionFlowType = .firstPurchase,
+                               hasOnboardingStore: Bool = true,
+                               isFeatureEnabled: Bool = true,
+                               didAlreadyRequest: Bool = false) -> Bool {
+        SubscriptionFlowViewModel.shouldRequestOnboarding(flowType: flowType,
+                                                          hasOnboardingStore: hasOnboardingStore,
+                                                          isFeatureEnabled: isFeatureEnabled,
+                                                          didAlreadyRequest: didAlreadyRequest)
+    }
+}

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -161,6 +161,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1214798984829406
     case subscriptionPromoForExistingUsers
 
+    /// https://app.asana.com/1/137249556945/task/1213999582715096
+    case subscriptionOnboarding
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866464085187
     case syncSetupBarcodeIsUrlBased
 
@@ -696,6 +699,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(PrivacyProSubfeature.subscriptionExpirationReminderNotification))
         case .subscriptionPromoForExistingUsers:
             Config(source: .remoteReleasable(PrivacyProSubfeature.subscriptionPromoForExistingUsers))
+        case .subscriptionOnboarding:
+            Config(source: .remoteReleasable(PrivacyProSubfeature.subscriptionOnboarding))
         case .syncSetupBarcodeIsUrlBased:
             Config(source: .remoteReleasable(SyncSubfeature.syncSetupBarcodeIsUrlBased))
         case .canScanUrlBasedSyncSetupBarcodes:

--- a/iOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -909,5 +909,121 @@
                 "enum": ["web_restore", "vpn"]
             }
         ]
+    },
+
+    // Subscription Onboarding Flow
+    "subscription_onboarding_step_shown_": {
+        "description": "Fired when an onboarding step is shown. The step name is the pixel's suffix.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": [
+            {
+                "type": "string",
+                "description": "The onboarding step that was shown",
+                "enum": ["intro", "features_summary", "vpn", "vpn_widget", "idtr", "duck_ai", "pir", "completion"]
+            },
+            "platform",
+            "form_factor"
+        ],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "entry_point",
+                "type": "string",
+                "description": "Which entry point launched this onboarding run",
+                "enum": ["post_checkout", "subscription_settings"]
+            }
+        ]
+    },
+    "subscription_onboarding_step_completed_": {
+        "description": "Fired when an onboarding step is completed — the protection it offers was activated. Only activation steps can complete.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["user_submitted"],
+        "suffixes": [
+            {
+                "type": "string",
+                "description": "The onboarding step that was completed",
+                "enum": ["vpn", "vpn_widget", "idtr", "duck_ai", "pir"]
+            },
+            "platform",
+            "form_factor"
+        ],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "entry_point",
+                "type": "string",
+                "description": "Which entry point launched this onboarding run",
+                "enum": ["post_checkout", "subscription_settings"]
+            }
+        ]
+    },
+    "subscription_onboarding_step_skipped_": {
+        "description": "Fired when the customer leaves an onboarding step via its skip CTA. Only the VPN and Duck.ai steps have one.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["user_submitted"],
+        "suffixes": [
+            {
+                "type": "string",
+                "description": "The onboarding step that was skipped",
+                "enum": ["vpn", "duck_ai"]
+            },
+            "platform",
+            "form_factor"
+        ],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "entry_point",
+                "type": "string",
+                "description": "Which entry point launched this onboarding run",
+                "enum": ["post_checkout", "subscription_settings"]
+            }
+        ]
+    },
+    "subscription_onboarding_flow_started": {
+        "description": "Fired when the flow starts. The funnel's denominator, and the measurement of how many customers enter with Duck.ai disabled.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            {
+                "key": "entry_point",
+                "type": "string",
+                "description": "Which entry point launched this onboarding run",
+                "enum": ["post_checkout", "subscription_settings"]
+            },
+            {
+                "key": "duck_ai_enabled",
+                "type": "boolean",
+                "description": "Whether Duck.ai was enabled in the app when the customer entered the flow"
+            }
+        ]
+    },
+    "subscription_onboarding_connection-info_failure": {
+        "description": "Fired when the public IP and geolocation fetch behind the VPN activation screen fails during onboarding.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+    },
+    "subscription_onboarding_ai-models_failure": {
+        "description": "Fired when the Duck.ai model list fetch fails during onboarding.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
+    },
+    "subscription_onboarding_subscription_failure": {
+        "description": "Fired when the subscription fetch behind the order confirmation screen fails during onboarding.",
+        "owners": ["hanyutang-sandra"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource", "errorDomain", "errorCode"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217384771427832?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1215971357218019?focus=true

### Description
Final of the 3-PR split of the post-checkout subscription onboarding flow (see PR1 and PR2 for the rest). Adds the feature flag that controls this whole feature (off by default, remotely releasable, locally overridable for internal testing), the pixels that measure how customers move through the flow, and the two places customers actually enter it: automatically after finishing a purchase, and via a "Continue Setup" card in Subscription Settings if they didn't finish everything the first time. This is the PR that makes PR1 and PR2's work reachable by real users.

### Testing Steps
1. Enable the subscription onboarding flag locally (internal-user override) with it otherwise off.
2. Complete a purchase → the onboarding sheet should appear automatically after the post-checkout confirmation page.
3. Exit partway through, then open Subscription Settings → confirm the "Continue Setup" card appears and resumes at the first unfinished step.
4. Complete the flow → confirm the funnel pixels fire as expected.
5. Turn the flag back off → confirm neither entry point presents the flow anymore.

### Impact
Medium — could disrupt the post-purchase experience for real subscribers once the flag is turned on, since this is the PR that makes the flow live.

#### What could go wrong?
The post-checkout trigger fires once, off the purchase-completion signal — a bug here could show the onboarding sheet at the wrong time, more than once, or never → mitigated by dedicated trigger tests and the flag defaulting off, so a bad trigger ships dark until explicitly released.

### Quality Considerations
Both entry points and every pixel are gated by the same flag, checked only when the flow is about to be entered rather than continuously — so a remote flag flip mid-flow can't strand a customer partway through.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-purchase and subscription-settings UX for real subscribers once the flag ships; mitigated by remote flag default-off, a one-shot onboarding latch, and trigger/instrumentation tests.
> 
> **Overview**
> Turns on the **subscription onboarding** feature behind a new remotely releasable **`subscriptionOnboarding`** flag and wires **two entry points**: an automatic sheet after a successful **first-purchase** checkout, and a **Continue Setup** card on Subscription Settings for active/trial subscribers.
> 
> Adds **`SubscriptionOnboardingInstrumentation`** and **`SubscriptionPixel`** funnel events (flow started, step shown/completed/skipped with stable step names and `entry_point` / `duck_ai_enabled` params), hooked from the flow VM (including VPN/Duck.ai skip detection and PIR sheet show/complete), **`onFirstAppear`** on each step screen, and matching **`subscription.json5`** definitions. Prefetch/model/order-confirmation failures continue to use the new failure pixel cases elsewhere in onboarding.
> 
> Purchase completion now invokes **`onPurchaseCompleted`**, which latches **`shouldPresentOnboarding`** only when flow type is first purchase, the flag is on, and an onboarding key-value store was passed into **`makeSubscribeFlowV2`** (restore/plan flows pass `nil`). Subscription container/settings factories gain **`onboardingKeyValueStore`** and **`meetsPIRLocaleRequirement`** for PIR-aware progress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39daed3af52c5ca829bc7a7720012399baf27817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->