### PR TITLE
[iOS] [Subscription Onboarding] Add Feature Flag and Entry Points (3/3)

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -648,6 +648,7 @@ public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {
     case subscriptionExpirationReminderNotification
     case subscriptionPromoForExistingUsers
     case monthlyFreeTrialExperiment
+    case subscriptionOnboarding
     case onboardingSubscriptionUpsellExperiment
 }
 

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		067CACE8BC2AA354D969019F /* NewAddressBarPickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFAB87418082C5BDE38CE4D /* NewAddressBarPickerViewModelTests.swift */; };
 		06D744C1F541FF4F91F7A664 /* DuckAISubscriptionUpsellPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A43FA34A9C65835FF48566 /* DuckAISubscriptionUpsellPresenter.swift */; };
 		0928A567CE4F37AC8E19B215 /* NavigationPixelNavigationResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2870028D8D7FA19512B7FD0 /* NavigationPixelNavigationResponder.swift */; };
+		36DD9FE0302BB99D00D12A6A /* SubscriptionOnboardingPostCheckoutTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36DD9FDF302BB99D00D12A6A /* SubscriptionOnboardingPostCheckoutTriggerTests.swift */; };
 		368349D5302689AC009BDEF7 /* SubscriptionOnboardingFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368349D4302689AC009BDEF7 /* SubscriptionOnboardingFlowView.swift */; };
 		368349DB302689D8009BDEF7 /* SubscriptionOnboardingViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368349DA302689D8009BDEF7 /* SubscriptionOnboardingViewFactory.swift */; };
 		368349DD30268A09009BDEF7 /* SubscriptionOnboardingLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 368349DC30268A09009BDEF7 /* SubscriptionOnboardingLauncher.swift */; };
@@ -5718,6 +5719,7 @@
 		F5B8A4C2A6FBE678C5A92ABF /* SearchTokenFetcherTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchTokenFetcherTests.swift; sourceTree = "<group>"; };
 		F7594859CB2334A38D629EF5 /* SafariRedirectHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariRedirectHandlerTests.swift; sourceTree = "<group>"; };
 		F773BFAFFD82A0D714B8F35D /* SubscriptionOnboardingConnectionInfoService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingConnectionInfoService.swift; sourceTree = "<group>"; };
+		36DD9FDF302BB99D00D12A6A /* SubscriptionOnboardingPostCheckoutTriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingPostCheckoutTriggerTests.swift; sourceTree = "<group>"; };
 		368349D4302689AC009BDEF7 /* SubscriptionOnboardingFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingFlowView.swift; sourceTree = "<group>"; };
 		368349DA302689D8009BDEF7 /* SubscriptionOnboardingViewFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingViewFactory.swift; sourceTree = "<group>"; };
 		368349DC30268A09009BDEF7 /* SubscriptionOnboardingLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingLauncher.swift; sourceTree = "<group>"; };
@@ -7105,6 +7107,7 @@
 			isa = PBXGroup;
 			children = (
 				36DD9FE1302BB9A600D12A6A /* SubscriptionOnboardingProgressTests.swift */,
+				36DD9FDF302BB99D00D12A6A /* SubscriptionOnboardingPostCheckoutTriggerTests.swift */,
 				36DD9FDD302BB99300D12A6A /* SubscriptionOnboardingInstrumentationTests.swift */,
 				368349DE30268B2E009BDEF7 /* SubscriptionOnboardingFlowViewModelTests.swift */,
 				36E8274A3026506A00147F78 /* SubscriptionOnboardingOrderConfirmationViewModelTests.swift */,
@@ -14879,6 +14882,7 @@
 				36DD9FE2302BB9A600D12A6A /* SubscriptionOnboardingProgressTests.swift in Sources */,
 				368349DF30268B2E009BDEF7 /* SubscriptionOnboardingFlowViewModelTests.swift in Sources */,
 				36DD9FDE302BB99300D12A6A /* SubscriptionOnboardingInstrumentationTests.swift in Sources */,
+				36DD9FE0302BB99D00D12A6A /* SubscriptionOnboardingPostCheckoutTriggerTests.swift in Sources */,
 				39DD82B9D3CC259FF8CF5B13 /* FileLoader.swift in Sources */,
 				80273AB82ED3E22E00EA03A1 /* SpyDownloadManager.swift in Sources */,
 				C10E0A382E5CB269009CAE1B /* URL+QueryParametersTests.swift in Sources */,

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -533,6 +533,7 @@ extension MainViewController {
                                                   experimentalAIChatManager: ExperimentalAIChatManager(featureFlagger: featureFlagger),
                                                   privacyConfigurationManager: privacyConfigurationManager,
                                                   keyValueStore: keyValueStore,
+                                                  subscriptionOnboardingSession: AppDependencyProvider.shared.subscriptionOnboardingSession,
                                                   contentBlockingAssetsPublisher: contentBlockingAssetsPublisher,
                                                   idleReturnEligibilityManager: idleReturnEligibilityManager,
                                                   afterInactivityOptionAdapter: afterInactivityOptionAdapter,

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3684,7 +3684,11 @@ class MainViewController: UIViewController {
             internalUserDecider: AppDependencyProvider.shared.internalUserDecider,
             dataBrokerProtectionViewControllerProvider: dbpIOSPublicInterface,
             wideEvent: AppDependencyProvider.shared.wideEvent,
-            featureFlagger: featureFlagger
+            featureFlagger: featureFlagger,
+            onboardingKeyValueStore: keyValueStore,
+            meetsPIRLocaleRequirement: { [weak dbpIOSPublicInterface] in
+                dbpIOSPublicInterface?.meetsLocaleRequirement ?? false
+            }
         ))
         viewController.view.backgroundColor = UIColor(designSystemColor: .surface)
         return viewController

--- a/iOS/DuckDuckGo/SettingsRootView.swift
+++ b/iOS/DuckDuckGo/SettingsRootView.swift
@@ -161,7 +161,9 @@ struct SettingsRootView: View {
                                                              internalUserDecider: AppDependencyProvider.shared.internalUserDecider,
                                                              dataBrokerProtectionViewControllerProvider: viewModel.dataBrokerProtectionViewControllerProvider,
                                                              wideEvent: AppDependencyProvider.shared.wideEvent,
-                                                             featureFlagger: viewModel.featureFlagger)
+                                                             featureFlagger: viewModel.featureFlagger,
+                                                             onboardingKeyValueStore: viewModel.keyValueStore,
+                                                             meetsPIRLocaleRequirement: { viewModel.meetsLocaleRequirement })
     }
 
     @ViewBuilder func subscriptionPlanChangeFlowNavigationDestination(redirectURLComponents: URLComponents?) -> some View {

--- a/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
+++ b/iOS/DuckDuckGo/Subscription/UserScripts/SubscriptionPagesUseSubscriptionFeature.swift
@@ -117,6 +117,7 @@ protocol SubscriptionPagesUseSubscriptionFeature: Subfeature, ObservableObject {
     var onBackToSettings: (() -> Void)? { get set }
     var onFeatureSelected: ((SubscriptionEntitlement) -> Void)? { get set }
     var onActivateSubscription: (() -> Void)? { get set }
+    var onPurchaseCompleted: (() -> Void)? { get set }
 
     func with(broker: UserScriptMessageBroker)
     func handler(forMethodNamed methodName: String) -> Subfeature.Handler?
@@ -221,6 +222,7 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
     var onBackToSettings: (() -> Void)?
     var onFeatureSelected: ((SubscriptionEntitlement) -> Void)?
     var onActivateSubscription: (() -> Void)?
+    var onPurchaseCompleted: (() -> Void)?
 
     struct FeatureSelection: Codable {
         let productFeature: SubscriptionEntitlement
@@ -598,6 +600,7 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
             if let preference = pendingScheduleNotification, let scheduler = expirationReminderScheduler {
                 await scheduler.scheduleReminder(daysBeforeCancel: preference.daysBeforeCancel)
             }
+            onPurchaseCompleted?()
 
         case .failure(let error):
             Logger.subscription.error("App store complete subscription purchase error: \(error, privacy: .public)")
@@ -890,6 +893,7 @@ final class DefaultSubscriptionPagesUseSubscriptionFeature: SubscriptionPagesUse
         onSetSubscription = nil
         onActivateSubscription = nil
         onBackToSettings = nil
+        onPurchaseCompleted = nil
     }
 
     private func fireFreemiumUpsellPixel() {

--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionContainerViewModel.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionContainerViewModel.swift
@@ -21,6 +21,7 @@ import Foundation
 import Subscription
 import Combine
 import DataBrokerProtection_iOS
+import Persistence
 
 final class SubscriptionContainerViewModel: ObservableObject {
 
@@ -38,7 +39,9 @@ final class SubscriptionContainerViewModel: ObservableObject {
          userScript: SubscriptionPagesUserScript,
          userScriptsDependencies: DefaultScriptSourceProvider.Dependencies,
          subFeature: any SubscriptionPagesUseSubscriptionFeature,
-         dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?) {
+         dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?,
+         onboardingKeyValueStore: ThrowingKeyValueStoring?,
+         meetsPIRLocaleRequirement: @escaping () -> Bool) {
 
         self.userScript = userScript
 
@@ -52,7 +55,9 @@ final class SubscriptionContainerViewModel: ObservableObject {
                                               userScriptsDependencies: userScriptsDependencies,
                                               subFeature: subFeature,
                                               subscriptionManager: subscriptionManager,
-                                              dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider)
+                                              dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider,
+                                              onboardingKeyValueStore: onboardingKeyValueStore,
+                                              meetsPIRLocaleRequirement: meetsPIRLocaleRequirement)
         self.restore = SubscriptionRestoreViewModel(userScript: userScript,
                                                     subFeature: subFeature)
         self.email = SubscriptionEmailViewModel(isInternalUser: isInternalUser,

--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
@@ -26,6 +26,7 @@ import PrivacyConfig
 import DataBrokerProtection_iOS
 import PixelKit
 import FeatureFlags_iOS
+import Persistence
 
 enum SubscriptionFlowType {
     case firstPurchase
@@ -88,6 +89,7 @@ final class SubscriptionFlowViewModel: ObservableObject {
         var selectedFeature: SelectedFeature = .none
         var viewTitle: String = UserText.subscriptionTitle
         var shouldGoBackToSettings: Bool = false
+        var shouldPresentOnboarding: Bool = false
     }
     
     // Read only View State - Should only be modified from the VM
@@ -95,6 +97,51 @@ final class SubscriptionFlowViewModel: ObservableObject {
 
     var isPIREnabled: Bool {
         featureFlagger.isFeatureOn(.personalInformationRemoval)
+    }
+
+    // MARK: - Post-checkout onboarding
+
+    /// `nil` unless this flow came from `makeSubscribeFlowV2`
+    private let onboardingKeyValueStore: ThrowingKeyValueStoring?
+
+    private let meetsPIRLocaleRequirement: () -> Bool
+
+    private var isPIRAvailable: Bool {
+        PIRAvailability.isAvailable(isPIREnabled: isPIREnabled,
+                                    meetsLocaleRequirement: meetsPIRLocaleRequirement(),
+                                    provider: dataBrokerProtectionViewControllerProvider)
+    }
+
+    /// Latched so a defensive re-invocation of `onPurchaseCompleted` cannot re-offer the flow.
+    private var didRequestOnboarding = false
+
+    var onboardingProgress: SubscriptionOnboardingProgress? {
+        guard let onboardingKeyValueStore else { return nil }
+        return SubscriptionOnboardingProgress(
+            persistor: SubscriptionOnboardingProgressPersistor(keyValueStore: onboardingKeyValueStore),
+            isPIRAvailable: isPIRAvailable)
+    }
+
+    /// A pure rule so it can be tested
+    static func shouldRequestOnboarding(flowType: SubscriptionFlowType,
+                                        hasOnboardingStore: Bool,
+                                        isFeatureEnabled: Bool,
+                                        didAlreadyRequest: Bool) -> Bool {
+        !didAlreadyRequest
+            && flowType == .firstPurchase
+            && hasOnboardingStore
+            && isFeatureEnabled
+    }
+
+    /// Called when the App Store purchase itself completes
+    private func requestOnboardingIfNeeded() {
+        guard Self.shouldRequestOnboarding(
+            flowType: flowType,
+            hasOnboardingStore: onboardingKeyValueStore != nil,
+            isFeatureEnabled: featureFlagger.isFeatureOn(.subscriptionOnboarding),
+            didAlreadyRequest: didRequestOnboarding) else { return }
+        didRequestOnboarding = true
+        state.shouldPresentOnboarding = true
     }
 
     /// Returns the subscription URL type based on the current flow type
@@ -120,7 +167,9 @@ final class SubscriptionFlowViewModel: ObservableObject {
          urlOpener: URLOpener = UIApplication.shared,
          featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
          wideEvent: WideEventManaging = AppDependencyProvider.shared.wideEvent,
-         dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?) {
+         dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?,
+         onboardingKeyValueStore: ThrowingKeyValueStoring?,
+         meetsPIRLocaleRequirement: @escaping () -> Bool) {
         self.initialURL = initialURL
         self.flowType = flowType
         self.userScript = userScript
@@ -131,6 +180,8 @@ final class SubscriptionFlowViewModel: ObservableObject {
         self.featureFlagger = featureFlagger
         self.wideEvent = wideEvent
         self.dataBrokerProtectionViewControllerProvider = dataBrokerProtectionViewControllerProvider
+        self.onboardingKeyValueStore = onboardingKeyValueStore
+        self.meetsPIRLocaleRequirement = meetsPIRLocaleRequirement
         let allowedDomains = AsyncHeadlessWebViewSettings.makeAllowedDomains(baseURL: subscriptionManager.url(for: .baseURL),
                                                                              isInternalUser: isInternalUser)
 
@@ -172,7 +223,13 @@ final class SubscriptionFlowViewModel: ObservableObject {
                 self.setTransactionStatus(.idle)
             }
         }
-        
+
+        subFeature.onPurchaseCompleted = {
+            DispatchQueue.main.async {
+                self.requestOnboardingIfNeeded()
+            }
+        }
+
          subFeature.onFeatureSelected = { feature in
              DispatchQueue.main.async {
                  switch feature {

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
@@ -26,6 +26,7 @@ import PrivacyConfig
 import DataBrokerProtection_iOS
 import PixelKit
 import FeatureFlags_iOS
+import Persistence
 
 enum SubscriptionContainerViewFactory {
 
@@ -64,7 +65,9 @@ enum SubscriptionContainerViewFactory {
                                     internalUserDecider: InternalUserDecider,
                                     dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?,
                                     wideEvent: WideEventManaging,
-                                    featureFlagger: FeatureFlagger) -> some View {
+                                    featureFlagger: FeatureFlagger,
+                                    onboardingKeyValueStore: ThrowingKeyValueStoring?,
+                                    meetsPIRLocaleRequirement: @escaping () -> Bool) -> some View {
 
         let pendingTransactionHandler = DefaultPendingTransactionHandler(userDefaults: subscriptionUserDefaults,
                                                                          pixelHandler: SubscriptionPixelHandler(source: .mainApp, pixelKit: PixelKit.shared))
@@ -111,7 +114,9 @@ enum SubscriptionContainerViewFactory {
                                                                        requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager),
                                                                        expirationReminderScheduler: AppDependencyProvider.shared.subscriptionExpirationReminderScheduler,
                                                                        isExpirationReminderFeatureEnabled: { featureFlagger.isFeatureOn(.subscriptionExpirationReminderNotification) }),
-            dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider
+            dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider,
+            onboardingKeyValueStore: onboardingKeyValueStore,
+            meetsPIRLocaleRequirement: meetsPIRLocaleRequirement
         )
         viewModel.email.setEmailFlowMode(.restoreFlow)
         return SubscriptionContainerView(currentView: .subscribe, viewModel: viewModel, featureFlagger: featureFlagger)
@@ -129,7 +134,9 @@ enum SubscriptionContainerViewFactory {
                                    internalUserDecider: InternalUserDecider,
                                    dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?,
                                    wideEvent: WideEventManaging,
-                                   featureFlagger: FeatureFlagger) -> some View {
+                                   featureFlagger: FeatureFlagger,
+                                   onboardingKeyValueStore: ThrowingKeyValueStoring?,
+                                   meetsPIRLocaleRequirement: @escaping () -> Bool) -> some View {
         if let redirectURLComponents,
            SubscriptionPurchaseFlowPath.isPlansPath(redirectURLComponents.path) {
             makePlansFlowV2(redirectURLComponents: redirectURLComponents,
@@ -152,7 +159,9 @@ enum SubscriptionContainerViewFactory {
                                 internalUserDecider: internalUserDecider,
                                 dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider,
                                 wideEvent: wideEvent,
-                                featureFlagger: featureFlagger)
+                                featureFlagger: featureFlagger,
+                                onboardingKeyValueStore: onboardingKeyValueStore,
+                                meetsPIRLocaleRequirement: meetsPIRLocaleRequirement)
         }
     }
 
@@ -198,7 +207,9 @@ enum SubscriptionContainerViewFactory {
                                                        userScript: SubscriptionPagesUserScript(),
                                                        userScriptsDependencies: userScriptsDependencies,
                                                        subFeature: subscriptionPagesUseSubscriptionFeature,
-                                                       dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider)
+                                                       dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider,
+                                                       onboardingKeyValueStore: nil,
+                                                       meetsPIRLocaleRequirement: { false })
         viewModel.email.setEmailFlowMode(.restoreFlow)
         return SubscriptionContainerView(currentView: .restore, viewModel: viewModel, featureFlagger: featureFlagger)
             .environmentObject(navigationCoordinator)
@@ -262,7 +273,9 @@ enum SubscriptionContainerViewFactory {
                                                                        requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager),
                                                                        expirationReminderScheduler: AppDependencyProvider.shared.subscriptionExpirationReminderScheduler,
                                                                        isExpirationReminderFeatureEnabled: { featureFlagger.isFeatureOn(.subscriptionExpirationReminderNotification) }),
-            dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider
+            dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider,
+            onboardingKeyValueStore: nil,
+            meetsPIRLocaleRequirement: { false }
         )
         return SubscriptionContainerView(currentView: .subscribe, viewModel: viewModel, featureFlagger: featureFlagger)
             .environmentObject(navigationCoordinator)
@@ -310,7 +323,9 @@ enum SubscriptionContainerViewFactory {
                                                                        requestValidator: DefaultScriptRequestValidator(subscriptionManager: subscriptionManager),
                                                                        expirationReminderScheduler: AppDependencyProvider.shared.subscriptionExpirationReminderScheduler,
                                                                        isExpirationReminderFeatureEnabled: { featureFlagger.isFeatureOn(.subscriptionExpirationReminderNotification) }),
-            dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider
+            dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider,
+            onboardingKeyValueStore: nil,
+            meetsPIRLocaleRequirement: { false }
         )
 
         viewModel.email.setEmailFlowMode(emailFlow)

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionFlowView.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionFlowView.swift
@@ -40,6 +40,11 @@ struct SubscriptionFlowView: View {
     @State private var errorMessageType: SubscriptionTransactionErrorAlert.MessageType = .general
     @State private var isPresentingError: Bool = false
 
+    // MARK: - Onboarding state
+
+    @State private var isShowingOnboarding = false
+    @State private var onboardingFlow: AnyView?
+
     enum Constants {
         static let empty = ""
         static let navButtonPadding: CGFloat = 20.0
@@ -165,6 +170,17 @@ struct SubscriptionFlowView: View {
         .onChange(of: viewModel.state.shouldGoBackToSettings) { _ in
             dismiss()
         }
+
+        .onChange(of: viewModel.state.shouldPresentOnboarding) { shouldPresent in
+            if shouldPresent {
+                startOnboarding()
+            }
+        }
+
+        .sheet(isPresented: $isShowingOnboarding,
+               onDismiss: { onboardingFlow = nil }) {
+            onboardingFlow
+        }
         
         .onFirstAppear {
             setUpAppearances()
@@ -196,6 +212,32 @@ struct SubscriptionFlowView: View {
             if viewModel.state.transactionStatus != .idle {
                 PurchaseInProgressView(status: getTransactionStatus())
             }
+        }
+    }
+
+    // MARK: - Onboarding
+
+    /// Dismisses the onboarding sheet only, leaving the customer on the post-checkout page. The summary's CTA
+    /// is meant to drop them into Subscription Settings, which this container cannot reach — Settings is not
+    /// on the stack beneath a first purchase.
+    private func startOnboarding() {
+        guard let progress = viewModel.onboardingProgress else { return }
+        onboardingFlow = SubscriptionOnboardingLauncher.launch(
+            flow: .postCheckout(progress: progress,
+                                onFinish: { isShowingOnboarding = false },
+                                pirScreen: { pirDestination }))
+        isShowingOnboarding = true
+    }
+
+    /// The same destination the hidden PIR `NavigationLink` above pushes, so the flow's PIR row lands the
+    /// customer in the same place the purchase page's own PIR link would.
+    @ViewBuilder
+    private var pirDestination: some View {
+        if viewModel.isPIREnabled, let provider = viewModel.dataBrokerProtectionViewControllerProvider {
+            DataBrokerProtectionViewControllerRepresentation(dbpViewControllerProvider: provider)
+                .edgesIgnoringSafeArea(.bottom)
+        } else {
+            SubscriptionPIRMoveToDesktopView()
         }
     }
 

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionSettingsView.swift
@@ -27,6 +27,7 @@ import Subscription
 import VPN
 import UIComponents
 import BrowserServicesKit
+import DataBrokerProtection_iOS
 
 enum SubscriptionSettingsViewConfiguration {
     case subscribed
@@ -61,6 +62,12 @@ struct SubscriptionSettingsViewV2: View {
     @State var isShowingUpgradeView = false
     @State var isShowingCancelDowngradeError = false
     @State private var cancelDowngradeErrorMessageType: SubscriptionTransactionErrorAlert.MessageType = .general
+
+    // MARK: - Onboarding state
+
+    @State private var isShowingOnboarding = false
+    /// Built when the customer taps the card.
+    @State private var onboardingFlow: AnyView?
 
     var body: some View {
         optionsView
@@ -453,6 +460,9 @@ struct SubscriptionSettingsViewV2: View {
                 downgradeBanner
                     .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
             }
+            if isOnboardingEnabled {
+                onboardingSetupSection
+            }
             if viewModel.shouldShowUpgrade {
                 upgradeSection
             }
@@ -466,6 +476,10 @@ struct SubscriptionSettingsViewV2: View {
         .padding(.top, -20)
         .navigationTitle(UserText.settingsPProManageSubscription)
         .applyInsetGroupedListStyle()
+        .sheet(isPresented: $isShowingOnboarding,
+               onDismiss: { onboardingFlow = nil }) {
+            onboardingFlow
+        }
         .onChange(of: viewModel.state.shouldDismissView) { value in
             if value {
                 dismiss()
@@ -648,5 +662,69 @@ private var resubscribeWithWinBackOfferView: some View {
         Text(UserText.winBackCampaignSubscriptionSettingsPageResubscribeSubtitle)
             .daxFootnoteRegular()
             .foregroundColor(Color(designSystemColor: .textSecondary))
+    }
+}
+
+// MARK: - Onboarding
+
+extension SubscriptionSettingsViewV2 {
+
+    /// The "Continue Setup" re-entry card. 
+    ///
+    /// Reaching 100% keeps the card for the rest of the session; it goes on the next launch. It also
+    /// disappears once the subscription expires or the flag is turned off.
+    var onboardingSetupSection: some View {
+        Section {
+            SubscriptionOnboardingSetupCard(visual: .image(Image(.subscription56)),
+                                            progress: onboardingProgress,
+                                            session: settingsViewModel.subscriptionOnboardingSession,
+                                            isPresentingFlow: isShowingOnboarding,
+                                            onContinue: { startOnboarding() })
+        }
+        .listRowBackground(Color.clear)
+        .listRowInsets(EdgeInsets())
+    }
+
+    func startOnboarding() {
+        onboardingFlow = SubscriptionOnboardingLauncher.launch(
+            flow: .subscriptionSettings(progress: onboardingProgress,
+                                        onFinish: { isShowingOnboarding = false },
+                                        pirScreen: { pirDestination }))
+        isShowingOnboarding = true
+    }
+
+    /// Built fresh on each access; the state it reads lives in the key-value store, not in the value.
+    private var onboardingProgress: SubscriptionOnboardingProgress {
+        SubscriptionOnboardingProgress(
+            persistor: SubscriptionOnboardingProgressPersistor(keyValueStore: settingsViewModel.keyValueStore),
+            isPIRAvailable: isPIRAvailable)
+    }
+
+    /// Checked here rather than inside the card so the flag (and subscription state) also covers `startOnboarding()`.
+    private var isOnboardingEnabled: Bool {
+        settingsViewModel.featureFlagger.isFeatureOn(.subscriptionOnboarding) && hasActiveSubscription
+    }
+
+    /// The card is a re-entry point into an active subscription's onboarding — an expired subscription, or one
+    /// still activating, has nothing left to set up.
+    private var hasActiveSubscription: Bool {
+        configuration == .subscribed || configuration == .trial
+    }
+
+    /// PIR is gated three ways, and a customer who fails any of them is shown a four-item checklist rather
+    /// than a row they could never tick — which also makes their completion ceiling 100% instead of 80%.
+    private var isPIRAvailable: Bool { settingsViewModel.isPIRAvailable }
+
+    /// The PIR screen the flow pushes from its own stack, matching what Settings already pushes from its
+    /// PIR row (`SettingsSubscriptionView`). `LazyView` there is unnecessary — the flow only asks for this
+    /// when it reaches the PIR section.
+    @ViewBuilder
+    private var pirDestination: some View {
+        if let provider = settingsViewModel.dataBrokerProtectionViewControllerProvider {
+            DataBrokerProtectionViewControllerRepresentation(dbpViewControllerProvider: provider)
+                .edgesIgnoringSafeArea(.bottom)
+        } else {
+            SubscriptionPIRMoveToDesktopView()
+        }
     }
 }

--- a/iOS/DuckDuckGoTests/Subscription/Onboarding/SubscriptionOnboardingPostCheckoutTriggerTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/Onboarding/SubscriptionOnboardingPostCheckoutTriggerTests.swift
@@ -1,0 +1,60 @@
+//
+//  SubscriptionOnboardingPostCheckoutTriggerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+/// The rule deciding whether a purchase flow offers post-checkout onboarding.
+final class SubscriptionOnboardingPostCheckoutTriggerTests: XCTestCase {
+
+    func testWhenAFirstPurchaseCompletesThenOnboardingIsRequested() {
+        XCTAssertTrue(shouldRequest())
+    }
+
+    func testWhenTheFlowIsAPlanUpdateThenOnboardingIsNotRequested() {
+        XCTAssertFalse(shouldRequest(flowType: .planUpdate))
+    }
+
+    /// The restore, email, and plan-update flows are built without a store, which is what keeps them out.
+    func testWhenTheFlowHasNoOnboardingStoreThenOnboardingIsNotRequested() {
+        XCTAssertFalse(shouldRequest(hasOnboardingStore: false))
+    }
+
+    func testWhenTheFeatureIsDisabledThenOnboardingIsNotRequested() {
+        XCTAssertFalse(shouldRequest(isFeatureEnabled: false))
+    }
+
+    /// A defensive re-invocation of the purchase-completed hook must not re-offer the flow.
+    func testWhenOnboardingWasAlreadyRequestedThenItIsNotRequestedAgain() {
+        XCTAssertFalse(shouldRequest(didAlreadyRequest: true))
+    }
+
+    // MARK: - Helper
+
+    /// Defaults describe the one case that should fire, so each test names only the condition it breaks.
+    private func shouldRequest(flowType: SubscriptionFlowType = .firstPurchase,
+                               hasOnboardingStore: Bool = true,
+                               isFeatureEnabled: Bool = true,
+                               didAlreadyRequest: Bool = false) -> Bool {
+        SubscriptionFlowViewModel.shouldRequestOnboarding(flowType: flowType,
+                                                          hasOnboardingStore: hasOnboardingStore,
+                                                          isFeatureEnabled: isFeatureEnabled,
+                                                          didAlreadyRequest: didAlreadyRequest)
+    }
+}

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -161,6 +161,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1214798984829406
     case subscriptionPromoForExistingUsers
 
+    /// https://app.asana.com/1/137249556945/task/1213999582715096
+    case subscriptionOnboarding
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866464085187
     case syncSetupBarcodeIsUrlBased
 
@@ -696,6 +699,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(PrivacyProSubfeature.subscriptionExpirationReminderNotification))
         case .subscriptionPromoForExistingUsers:
             Config(source: .remoteReleasable(PrivacyProSubfeature.subscriptionPromoForExistingUsers))
+        case .subscriptionOnboarding:
+            Config(source: .remoteReleasable(PrivacyProSubfeature.subscriptionOnboarding))
         case .syncSetupBarcodeIsUrlBased:
             Config(source: .remoteReleasable(SyncSubfeature.syncSetupBarcodeIsUrlBased))
         case .canScanUrlBasedSyncSetupBarcodes:


### PR DESCRIPTION
Task/Issue URL:
Tech Design URL:
CC:

### Description
Final of a 3-PR split of the post-checkout subscription onboarding flow (see PR 1 and PR 2 for the rest). Adds the feature flag that controls this whole feature (off by default, remotely releasable, locally overridable for internal testing), and the two places customers actually enter it: automatically after finishing a purchase, and via a "Continue Setup" card in Subscription Settings if they didn't finish everything the first time. This is the PR that makes PR 1 and PR 2's work reachable by real users.

### Testing Steps
1. Enable the subscription onboarding flag locally (internal-user override) with it otherwise off.
2. Complete a purchase → the onboarding sheet should appear automatically after the post-checkout confirmation page.
3. Exit partway through, then open Subscription Settings → confirm the "Continue Setup" card appears and resumes at the first unfinished step.
4. Complete the flow → confirm the onboarding-flow pixels fire as expected (added in PR 2, wired to real usage here).
5. Turn the flag back off → confirm neither entry point presents the flow anymore.

### Impact
Medium — could disrupt the post-purchase experience for real subscribers once the flag is turned on, since this is the PR that makes the flow live.

#### What could go wrong?
The post-checkout trigger fires once, off the purchase-completion signal — a bug here could show the onboarding sheet at the wrong time, more than once, or never → mitigated by dedicated trigger tests and the flag defaulting off, so a bad trigger ships dark until explicitly released.

### Quality Considerations
Both entry points are gated by the same flag, checked only when the flow is about to be entered rather than continuously — so a remote flag flip mid-flow can't strand a customer partway through.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the post-purchase path for new subscribers once the flag is released; mitigated by remote flag default-off, restore/plan flows excluded, and latch/tests on the one-shot trigger.
> 
> **Overview**
> Introduces the **`subscriptionOnboarding`** privacy/feature flag (remote releasable on iOS and Privacy Pro config) and wires the post-checkout onboarding flow into two user-facing entry points when the flag is on.
> 
> **After a first purchase**, purchase completion now invokes a new **`onPurchaseCompleted`** hook on the subscription web user script. `SubscriptionFlowViewModel` applies a gated rule (first-purchase flow, onboarding key-value store present, flag enabled, single latch) and presents the onboarding flow in a sheet over the purchase web view, using persisted progress and PIR availability from the injected store and locale callback.
> 
> **In Subscription Settings**, subscribed/trial customers see a **Continue Setup** card that re-opens the same onboarding via `SubscriptionOnboardingLauncher`, gated by the same flag and active subscription state.
> 
> Subscribe/purchase factory paths pass **`onboardingKeyValueStore`** and **`meetsPIRLocaleRequirement`**; restore, plans, and email flows pass `nil`/`false` so they never auto-trigger onboarding. Settings receives **`subscriptionOnboardingSession`** for the setup card. Unit tests cover the post-checkout trigger rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7017100ff703fa5d56a3d31906d34546b6a44fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->