### PR TITLE
Fix a flaky CredentialsProvider test

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/Credentials/CredentialsProviderTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/Credentials/CredentialsProviderTests.swift
@@ -201,15 +201,18 @@ final class CredentialsProviderTests: CredentialsProviderTestsBase {
 
     func testThatInitialSyncClearsModifiedAtFromDeduplicatedCredentialWithAllFieldsNil() async throws {
 
+        let timestamp = Date()
+        let lastModified = timestamp.addingTimeInterval(-10).withMillisecondPrecision
+
         try secureVault.inDatabaseTransaction { database in
-            try self.secureVault.storeSyncableCredentials("1", nullifyOtherFields: true, lastModified: Date().withMillisecondPrecision, in: database)
+            try self.secureVault.storeSyncableCredentials("1", nullifyOtherFields: true, lastModified: lastModified, in: database)
         }
 
         let received: [Syncable] = [
             .credentials(id: "2", nullifyOtherFields: true)
         ]
 
-        try await provider.handleInitialSyncResponse(received: received, clientTimestamp: Date(), serverTimestamp: "1234", crypter: crypter)
+        try await provider.handleInitialSyncResponse(received: received, clientTimestamp: timestamp, serverTimestamp: "1234", crypter: crypter)
 
         let syncableCredentials = try fetchAllSyncableCredentials()
         let credential = try XCTUnwrap(syncableCredentials.first)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1217444116716716?focus=true

### Testing Steps
Verify that CredentialsProviderTests are green.
I also ran that test repeatedly from Xcode and verified that it passes every time.

### Impact
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in CredentialsProviderTests with no production code impact.
> 
> **Overview**
> Fixes flakiness in **`testThatInitialSyncClearsModifiedAtFromDeduplicatedCredentialWithAllFieldsNil`** by tying local **`lastModified`** and **`clientTimestamp`** to one shared **`timestamp`**, with **`lastModified`** set 10 seconds earlier so initial sync logic that clears **`modifiedAt`** when the client time is after local modification always runs deterministically.
> 
> Previously **`Date()`** was called separately for store vs. **`handleInitialSyncResponse`**, so **`clientTimestamp`** could occasionally be before **`lastModified`** and **`XCTAssertNil(credential.metadata.lastModified)`** would fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7266e37c5d7cdd132a468eb5ba96fca4a459656b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->