### PR TITLE
[macOS] Collapse Fire Dialog settings after first burn

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1528,7 +1528,9 @@
 		37F636FE3004F5F4007AC9F7 /* FireDialogResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F636FD3004F5F1007AC9F7 /* FireDialogResult.swift */; };
 		37F636FF3004F5F4007AC9F7 /* FireDialogResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F636FD3004F5F1007AC9F7 /* FireDialogResult.swift */; };
 		37F637013004F627007AC9F7 /* FireDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F637003004F627007AC9F7 /* FireDialogView.swift */; };
+		37F637113004F627007AC9F7 /* FireDialogDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F637103004F627007AC9F7 /* FireDialogDebugMenu.swift */; };
 		37F637023004F627007AC9F7 /* FireDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F637003004F627007AC9F7 /* FireDialogView.swift */; };
+		37F637123004F627007AC9F7 /* FireDialogDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F637103004F627007AC9F7 /* FireDialogDebugMenu.swift */; };
 		37F8ABD32CE3EE5B00CB0294 /* FeatureFlagOverridesMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F8ABD22CE3EE5B00CB0294 /* FeatureFlagOverridesMenu.swift */; };
 		37F8ABD42CE3EE5B00CB0294 /* FeatureFlagOverridesMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F8ABD22CE3EE5B00CB0294 /* FeatureFlagOverridesMenu.swift */; };
 		37F9AEB12D131705007FD19B /* NewTabPageLinkOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F9AEB02D1316FE007FD19B /* NewTabPageLinkOpener.swift */; };
@@ -5570,6 +5572,7 @@
 		37F1C1992FACA6B400260FDC /* TrackerProtectionMemoryGuardrailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackerProtectionMemoryGuardrailTests.swift; sourceTree = "<group>"; };
 		37F636FD3004F5F1007AC9F7 /* FireDialogResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireDialogResult.swift; sourceTree = "<group>"; };
 		37F637003004F627007AC9F7 /* FireDialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireDialogView.swift; sourceTree = "<group>"; };
+		37F637103004F627007AC9F7 /* FireDialogDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireDialogDebugMenu.swift; sourceTree = "<group>"; };
 		37F8ABD22CE3EE5B00CB0294 /* FeatureFlagOverridesMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagOverridesMenu.swift; sourceTree = "<group>"; };
 		37F9AEB02D1316FE007FD19B /* NewTabPageLinkOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageLinkOpener.swift; sourceTree = "<group>"; };
 		37FC2A172CF903060048E226 /* MockPrivacyStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPrivacyStats.swift; sourceTree = "<group>"; };
@@ -12232,6 +12235,7 @@
 				37F636FD3004F5F1007AC9F7 /* FireDialogResult.swift */,
 				84796D742E67000C007E6F9F /* LegacyFireDialogView.swift */,
 				37F637003004F627007AC9F7 /* FireDialogView.swift */,
+				37F637103004F627007AC9F7 /* FireDialogDebugMenu.swift */,
 				AAE99B8827088A19008B6BD9 /* FirePopover.swift */,
 				AA6AD95A2704B6DB00159F8A /* FirePopoverViewController.swift */,
 				AAB7320826DD0CD9002FACF9 /* FireViewController.swift */,
@@ -16591,6 +16595,7 @@
 				560EB93A2C789A450080DBC8 /* OnboardingSuggestedSearchesProvider.swift in Sources */,
 				3706FC49293F65D500E42796 /* RoundedSelectionRowView.swift in Sources */,
 				37F637023004F627007AC9F7 /* FireDialogView.swift in Sources */,
+				37F637123004F627007AC9F7 /* FireDialogDebugMenu.swift in Sources */,
 				3706FC4A293F65D500E42796 /* LocalStatisticsStore.swift in Sources */,
 				4B4D60DD2A0C875E00BCD287 /* NetworkProtectionOptionKeyExtension.swift in Sources */,
 				31FC23522DB7A86F00900574 /* AddressBarMenuButton.swift in Sources */,
@@ -18155,6 +18160,7 @@
 				B5C2886C2EC6206100A572F2 /* CASpringAnimationExtension.swift in Sources */,
 				9F6434612BEC82B700D2D8A0 /* AttributionPixelHandler.swift in Sources */,
 				37F637013004F627007AC9F7 /* FireDialogView.swift in Sources */,
+				37F637113004F627007AC9F7 /* FireDialogDebugMenu.swift in Sources */,
 				37D0469F2C7D0EDD00AEAA50 /* CustomBackground.swift in Sources */,
 				B684592225C93BE000DC17B6 /* Publisher.asVoid.swift in Sources */,
 				BB9BDD4A2D09BAA80069E9EF /* TabBarRemoteMessageViewModel.swift in Sources */,

--- a/macOS/DuckDuckGo/Fire/View/FireDialogDebugMenu.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogDebugMenu.swift
@@ -1,0 +1,55 @@
+//
+//  FireDialogDebugMenu.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AppKit
+import Persistence
+
+@MainActor
+final class FireDialogDebugMenu: NSMenuItem {
+
+    private var settings: any KeyedStoring<FireDialogViewSettings> {
+        UserDefaults.standard.keyedStoring()
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public init() {
+        super.init(title: "Fire Dialog", action: nil, keyEquivalent: "")
+        self.submenu = makeSubmenu()
+    }
+
+    private func makeSubmenu() -> NSMenu {
+        let menu = NSMenu(title: "")
+        menu.addItem(NSMenuItem(title: "Reset Fire Dialog Settings", action: #selector(resetSettings), target: self))
+        return menu
+    }
+
+    /// Removes all stored `FireDialogViewSettings` values, so that the dialog opens in its default state.
+    ///
+    /// Add new `FireDialogViewSettings` keys here.
+    @objc private func resetSettings() {
+        settings.removeValue(for: \.lastSelectedClearingOption)
+        settings.removeValue(for: \.lastIncludeTabsAndWindowsState)
+        settings.removeValue(for: \.lastIncludeHistoryState)
+        settings.removeValue(for: \.lastIncludeCookiesAndSiteDataState)
+        settings.removeValue(for: \.lastIncludeChatHistoryState)
+        settings.removeValue(for: \.lastSectionsExpandedState)
+    }
+}

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -1005,6 +1005,7 @@ struct FireDialogView: ModalView {
                         selectedCookieDomains: viewModel.selectedCookieDomainsForScope,
                         selectedVisits: viewModel.historyVisits
                     )
+                    viewModel.didConfirmDataClearing()
                     onConfirm?(.burn(options: result))
                     dismiss()
                 } label: {

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -192,7 +192,7 @@ final class FireDialogViewModel: ObservableObject {
         self.includeHistory = includeHistory ?? self.settings.lastIncludeHistoryState ?? true
         self.includeCookiesAndSiteData = includeCookiesAndSiteData ?? self.settings.lastIncludeCookiesAndSiteDataState ?? true
         self.includeChatHistorySetting = includeChatHistory ?? self.settings.lastIncludeChatHistoryState ?? false
-        self.isSectionsExpanded = sectionsExpanded ?? self.settings.lastSectionsExpandedState ?? false
+        self.isSectionsExpanded = sectionsExpanded ?? self.settings.lastSectionsExpandedState ?? true
 
         updateLastSelectedClearingOptionIfNeeded()
 
@@ -287,10 +287,23 @@ final class FireDialogViewModel: ObservableObject {
     }
 
     /// Whether the "Choose what to delete" sections are expanded.
+    ///
+    /// The sections are expanded until the first data clearing, then collapsed. Setting this property
+    /// stores the user choice, which all later dialogs use instead of the default.
     @Published var isSectionsExpanded: Bool {
         didSet {
             settings.lastSectionsExpandedState = isSectionsExpanded
         }
+    }
+
+    /// Collapses the "Choose what to delete" sections for all later dialogs, if the user did not
+    /// choose the expanded state themselves.
+    ///
+    /// Call this when the user starts data clearing from the dialog. Only the expand/collapse button
+    /// also stores this state, so a missing stored state means that the user made no choice yet.
+    func didConfirmDataClearing() {
+        guard settings.lastSectionsExpandedState == nil else { return }
+        settings.lastSectionsExpandedState = false
     }
 
     @Published private(set) var selectable: [Item] = []

--- a/macOS/DuckDuckGo/Menus/MainMenu.swift
+++ b/macOS/DuckDuckGo/Menus/MainMenu.swift
@@ -1038,6 +1038,7 @@ final class MainMenu: NSMenu {
             FreemiumDebugMenu()
             SubscriptionPromoDebugMenu()
             AdBlockingDebugMenu()
+            FireDialogDebugMenu()
 
             if case .normal = AppVersion.runType {
                 NSMenuItem(title: "VPN")

--- a/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
+++ b/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
@@ -115,6 +115,8 @@ final class FireDialogViewModelTests: XCTestCase {
         tabCollectionVM = nil
         historyCoordinator = nil
         aiChatHistoryCleaner = nil
+        dataClearingPreferences = nil
+        pixelFiringMock = nil
     }
 
     @MainActor func testOnBurn_OnboardingContextualDialogsManagerFireButtonUsedCalled() {
@@ -2102,6 +2104,109 @@ final class FireDialogViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.includeHistory, "Default includeHistory should be true")
         XCTAssertTrue(viewModel.includeCookiesAndSiteData, "Default includeCookiesAndSiteData should be true")
         XCTAssertFalse(viewModel.includeChatHistorySetting, "Default includeChatHistorySetting should be false")
+        XCTAssertTrue(viewModel.isSectionsExpanded, "Default isSectionsExpanded should be true")
+    }
+
+    // MARK: - Sections expanded state
+
+    @MainActor func testWhenNoPersistedSectionsExpandedState_ThenSectionsAreExpanded() {
+        // Scenario: The user never used the expand/collapse button and never cleared data.
+        // Action: Create ViewModel with empty mock settings.
+        // Expectation: Sections are expanded, and nothing is stored yet.
+
+        let mockSettings = MockFireDialogViewSettings()
+
+        let viewModel = makeViewModel(settings: mockSettings)
+
+        XCTAssertTrue(viewModel.isSectionsExpanded, "Sections should be expanded by default")
+        XCTAssertNil(mockSettings.lastSectionsExpandedState, "Initialization should not store the default state")
+    }
+
+    @MainActor func testWhenSectionsExpandedChanged_ThenSettingIsPersistedAndUsedByNextDialog() {
+        // Scenario: The user collapses the sections, then expands them again.
+        // Action: Change isSectionsExpanded, creating a new ViewModel after each change.
+        // Expectation: Mock settings hold the last value, and the next ViewModel uses it.
+
+        let mockSettings = MockFireDialogViewSettings()
+
+        let viewModel1 = makeViewModel(settings: mockSettings)
+        viewModel1.isSectionsExpanded = false
+
+        XCTAssertEqual(mockSettings.lastSectionsExpandedState, false, "Mock settings should be updated")
+
+        let viewModel2 = makeViewModel(settings: mockSettings)
+
+        XCTAssertFalse(viewModel2.isSectionsExpanded, "isSectionsExpanded should be loaded from mock settings")
+
+        viewModel2.isSectionsExpanded = true
+
+        XCTAssertEqual(mockSettings.lastSectionsExpandedState, true, "Mock settings should reflect new value")
+
+        let viewModel3 = makeViewModel(settings: mockSettings)
+
+        XCTAssertTrue(viewModel3.isSectionsExpanded, "Updated isSectionsExpanded should persist in mock settings")
+    }
+
+    @MainActor func testWhenDataClearingConfirmedAndUserNeverChangedSectionsState_ThenSectionsCollapseForNextDialog() {
+        // Scenario: The user clears data for the first time without using the expand/collapse button.
+        // Action: Confirm data clearing on a ViewModel with empty mock settings.
+        // Expectation: The collapsed state is stored, and the next ViewModel is collapsed.
+
+        let mockSettings = MockFireDialogViewSettings()
+
+        let viewModel1 = makeViewModel(settings: mockSettings)
+        XCTAssertTrue(viewModel1.isSectionsExpanded, "First dialog should be expanded")
+
+        viewModel1.didConfirmDataClearing()
+
+        XCTAssertEqual(mockSettings.lastSectionsExpandedState, false, "First data clearing should store the collapsed state")
+
+        let viewModel2 = makeViewModel(settings: mockSettings)
+
+        XCTAssertFalse(viewModel2.isSectionsExpanded, "Dialogs after the first data clearing should be collapsed")
+    }
+
+    @MainActor func testWhenDataClearingConfirmedAndUserExpandedSections_ThenExpandedStateIsKept() {
+        // Scenario: The user keeps the sections expanded with the expand/collapse button, then clears data.
+        // Action: Set isSectionsExpanded to true, then confirm data clearing.
+        // Expectation: The user choice remains, and the next ViewModel is expanded.
+
+        let mockSettings = MockFireDialogViewSettings()
+
+        let viewModel1 = makeViewModel(settings: mockSettings)
+        viewModel1.isSectionsExpanded = false
+        viewModel1.isSectionsExpanded = true
+
+        viewModel1.didConfirmDataClearing()
+
+        XCTAssertEqual(mockSettings.lastSectionsExpandedState, true, "Data clearing should not overwrite the user choice")
+
+        let viewModel2 = makeViewModel(settings: mockSettings)
+
+        XCTAssertTrue(viewModel2.isSectionsExpanded, "Dialogs should keep the expanded state chosen by the user")
+    }
+
+    @MainActor func testWhenDataClearingConfirmedRepeatedlyAfterUserExpandedSections_ThenExpandedStateIsKept() {
+        // Scenario: The user expands the sections after the first data clearing, then clears data again.
+        // Action: Confirm data clearing, expand the sections, then confirm data clearing again.
+        // Expectation: Later data clearings never overwrite the user choice.
+
+        let mockSettings = MockFireDialogViewSettings()
+
+        let viewModel1 = makeViewModel(settings: mockSettings)
+        viewModel1.didConfirmDataClearing()
+
+        let viewModel2 = makeViewModel(settings: mockSettings)
+        XCTAssertFalse(viewModel2.isSectionsExpanded, "Second dialog should be collapsed")
+
+        viewModel2.isSectionsExpanded = true
+        viewModel2.didConfirmDataClearing()
+
+        XCTAssertEqual(mockSettings.lastSectionsExpandedState, true, "Data clearing should not overwrite the user choice")
+
+        let viewModel3 = makeViewModel(settings: mockSettings)
+
+        XCTAssertTrue(viewModel3.isSectionsExpanded, "Third dialog should be expanded")
     }
 
     // MARK: - Simplified Fire Dialog: currentWindow folding
@@ -2255,6 +2360,24 @@ final class FireDialogViewModelTests: XCTestCase {
             featureFlagger: MockFeatureFlagger(),
             clearingOption: clearingOption,
             scopeCookieDomains: scopeCookieDomains,
+            tld: TLD(),
+            windowControllersManager: windowControllersManager,
+            dataClearingPreferences: dataClearingPreferences,
+            pixelFiring: pixelFiringMock
+        )
+    }
+
+    @MainActor
+    private func makeViewModel(settings: any KeyedStoring<FireDialogViewSettings>) -> FireDialogViewModel {
+        FireDialogViewModel(
+            fireViewModel: .init(fire: fire),
+            tabCollectionViewModel: tabCollectionVM,
+            historyCoordinating: historyCoordinator,
+            aiChatHistoryCleaner: MockAIChatHistoryCleaner(showCleanOption: true),
+            fireproofDomains: fireproofDomains,
+            faviconManagement: fire.faviconManagement,
+            featureFlagger: MockFeatureFlagger(),
+            settings: settings,
             tld: TLD(),
             windowControllersManager: windowControllersManager,
             dataClearingPreferences: dataClearingPreferences,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217444116716709?focus=true

### Description
Present Fire Dialog expanded, until the user collapses it or performs a burn.

### Testing Steps
1. Enable `fireDialogSimplified` feature flag
2. Select Debug Menu -> Fire Dialog -> Reset Fire Dialog settings
3. Open Fire Dialog, verify it's expanded
4. Close and show again, verify that it's expanded
5. Now burn data
6. Open Fire Dialog, verify it's collapsed.
7. Reset Settings again.
9. Open Fire Dialog, verify it's expanded, collapse it manually.
10. Close and reopen, verify it's collapsed.
11. Reset Settings again.
12. Open Fire Dialog, verify it's expanded, collapse and expand it.
13. Close and reopen, verify it's expanded.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only preference persistence for the Fire dialog disclosure state; no changes to data clearing logic or security-sensitive paths.
> 
> **Overview**
> Changes how the macOS Fire dialog shows the **“Choose what to delete”** section: it now **opens expanded** until the user collapses it manually or completes a burn.
> 
> **`FireDialogViewModel`** defaults `isSectionsExpanded` to **true** when nothing is stored (was false). Toggling the disclosure still persists via `lastSectionsExpandedState`. **`didConfirmDataClearing()`** runs on delete/burn: if the user never changed the disclosure, it stores **collapsed** so later opens stay collapsed; explicit expand/collapse choices are **not** overwritten.
> 
> **`FireDialogView`** calls `didConfirmDataClearing()` on the burn button before confirming. A debug **`FireDialogDebugMenu`** (“Reset Fire Dialog Settings”) is added under the Debug menu, clearing persisted Fire dialog keys including sections state. Unit tests cover defaults, persistence, and burn vs. user-toggle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd224cdaae8739bc5bf0b2797254a7ace7a6cdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->