### PR TITLE
CI: Print macOS version at the start of every macOS job

### DIFF
--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -49,6 +49,9 @@ jobs:
 
       steps:
 
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Register SSH keys for private repos
         uses: webfactory/ssh-agent@v0.10.0
         with:
@@ -207,6 +210,9 @@ jobs:
         WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
 
       steps:
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Register SSH keys for private repos
         uses: webfactory/ssh-agent@v0.10.0

--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -49,9 +49,6 @@ jobs:
 
       steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Register SSH keys for private repos
         uses: webfactory/ssh-agent@v0.10.0
         with:
@@ -61,6 +58,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Start measuring duration
         id: start-duration-macos
@@ -211,9 +211,6 @@ jobs:
 
       steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Register SSH keys for private repos
         uses: webfactory/ssh-agent@v0.10.0
         with:
@@ -223,6 +220,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Start measuring duration
         id: start-duration-ios

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -49,9 +49,6 @@ jobs:
 
       steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Register SSH keys for private repos
         uses: webfactory/ssh-agent@v0.10.0
         with:
@@ -61,6 +58,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Start measuring duration
         id: start-duration-macos
@@ -193,9 +193,6 @@ jobs:
 
       steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Register SSH keys for private repos
         uses: webfactory/ssh-agent@v0.10.0
         with:
@@ -205,6 +202,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Start measuring duration
         id: start-duration-ios

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -49,6 +49,9 @@ jobs:
 
       steps:
 
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Register SSH keys for private repos
         uses: webfactory/ssh-agent@v0.10.0
         with:
@@ -189,6 +192,9 @@ jobs:
         RUNS_ON: bitrise:macos26-m4 # keep this in sync with runs-on above
 
       steps:
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Register SSH keys for private repos
         uses: webfactory/ssh-agent@v0.10.0

--- a/.github/workflows/ios_adhoc.yml
+++ b/.github/workflows/ios_adhoc.yml
@@ -34,9 +34,6 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Register SSH keys for private repos
         uses: webfactory/ssh-agent@v0.10.0
         with:
@@ -48,6 +45,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Start measuring duration
         id: start-duration

--- a/.github/workflows/ios_adhoc.yml
+++ b/.github/workflows/ios_adhoc.yml
@@ -34,6 +34,9 @@ jobs:
 
     steps:
 
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Register SSH keys for private repos
         uses: webfactory/ssh-agent@v0.10.0
         with:

--- a/.github/workflows/ios_alpha.yml
+++ b/.github/workflows/ios_alpha.yml
@@ -37,13 +37,13 @@ jobs:
       should_skip: ${{ steps.check-upload.outputs.should_skip }}
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Assert main branch
       run: |
@@ -184,13 +184,13 @@ jobs:
       destination: ${{ github.event.inputs.destination || inputs.destination || 'Latest Alpha Group' }}
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Download build artifacts
       uses: actions/download-artifact@v7

--- a/.github/workflows/ios_alpha.yml
+++ b/.github/workflows/ios_alpha.yml
@@ -37,6 +37,9 @@ jobs:
       should_skip: ${{ steps.check-upload.outputs.should_skip }}
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6
       with:
@@ -181,6 +184,9 @@ jobs:
       destination: ${{ github.event.inputs.destination || inputs.destination || 'Latest Alpha Group' }}
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6
       with:

--- a/.github/workflows/ios_build_hotfix_release.yml
+++ b/.github/workflows/ios_build_hotfix_release.yml
@@ -37,6 +37,9 @@ jobs:
       asana_task_id: ${{ steps.task-id.outputs.asana_task_id }}
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
         with:
@@ -81,6 +84,9 @@ jobs:
       commit_sha: ${{ steps.set-commit-sha.outputs.commit_sha }}
 
     steps:
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Check out the code
         uses: actions/checkout@v6

--- a/.github/workflows/ios_build_hotfix_release.yml
+++ b/.github/workflows/ios_build_hotfix_release.yml
@@ -37,13 +37,13 @@ jobs:
       asana_task_id: ${{ steps.task-id.outputs.asana_task_id }}
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Assert hotfix release branch
         run: |
@@ -85,15 +85,15 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history and tags in order to extract Asana task URLs from git log
           ref: ${{ github.ref_name }}
           submodules: recursive
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Set commit SHA output
         id: set-commit-sha

--- a/.github/workflows/ios_bump_internal_release.yml
+++ b/.github/workflows/ios_bump_internal_release.yml
@@ -46,6 +46,9 @@ jobs:
 
     steps:
 
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
         with:
@@ -100,6 +103,9 @@ jobs:
       commit_sha: ${{ steps.increment-build-number.outputs.commit_sha }}
 
     steps:
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Check out the code
         uses: actions/checkout@v6

--- a/.github/workflows/ios_bump_internal_release.yml
+++ b/.github/workflows/ios_bump_internal_release.yml
@@ -46,13 +46,13 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Required to compute the git diff during validate_internal_release_bump
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Assert release branch
         run: |
@@ -104,15 +104,15 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history and tags in order to extract Asana task URLs from git log
           ref: ${{ needs.validate_input_conditions.outputs.release-branch }}
           submodules: recursive
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Setup Ruby and dependencies
         uses: ./.github/actions/setup-ruby

--- a/.github/workflows/ios_code_freeze.yml
+++ b/.github/workflows/ios_code_freeze.yml
@@ -58,6 +58,9 @@ jobs:
 
     steps:
 
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/ios_code_freeze.yml
+++ b/.github/workflows/ios_code_freeze.yml
@@ -58,14 +58,14 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: recursive
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Assert main branch
         run: |

--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -37,6 +37,9 @@ jobs:
       RUNS_ON: macos-26 # keep this in sync with runs-on above
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -233,6 +236,9 @@ jobs:
       fail-fast: false
 
     steps:
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Check out the code
       uses: actions/checkout@v6 # Don't need submodules here as this is only for the tests folder

--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -37,9 +37,6 @@ jobs:
       RUNS_ON: macos-26 # keep this in sync with runs-on above
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -49,6 +46,9 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Start measuring duration
       id: start-duration
@@ -237,11 +237,11 @@ jobs:
 
     steps:
 
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6 # Don't need submodules here as this is only for the tests folder
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Start measuring duration
       id: start-duration

--- a/.github/workflows/ios_experimental.yml
+++ b/.github/workflows/ios_experimental.yml
@@ -37,13 +37,13 @@ jobs:
       should_skip: ${{ steps.check-upload.outputs.should_skip }}
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
@@ -173,13 +173,13 @@ jobs:
       destination: ${{ github.event.inputs.destination || inputs.destination || 'Latest Experimental Group' }}
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Download build artifacts
       uses: actions/download-artifact@v7

--- a/.github/workflows/ios_experimental.yml
+++ b/.github/workflows/ios_experimental.yml
@@ -37,6 +37,9 @@ jobs:
       should_skip: ${{ steps.check-upload.outputs.should_skip }}
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6
       with:
@@ -170,6 +173,9 @@ jobs:
       destination: ${{ github.event.inputs.destination || inputs.destination || 'Latest Experimental Group' }}
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6
       with:

--- a/.github/workflows/ios_hotfix.yml
+++ b/.github/workflows/ios_hotfix.yml
@@ -22,15 +22,15 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.GHA_ELEVATED_PERMISSIONS_TOKEN }}
           submodules: recursive
           fetch-depth: 0
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Assert main branch
         run: |

--- a/.github/workflows/ios_hotfix.yml
+++ b/.github/workflows/ios_hotfix.yml
@@ -22,6 +22,9 @@ jobs:
 
     steps:
 
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/ios_nightly.yml
+++ b/.github/workflows/ios_nightly.yml
@@ -65,9 +65,6 @@ jobs:
     continue-on-error: ${{ matrix.user-mode == 'internal' }}
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -77,6 +74,9 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Set cache key hash
       run: |

--- a/.github/workflows/ios_nightly.yml
+++ b/.github/workflows/ios_nightly.yml
@@ -65,6 +65,9 @@ jobs:
     continue-on-error: ${{ matrix.user-mode == 'internal' }}
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -116,6 +116,9 @@ jobs:
 
     steps:
 
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -329,6 +332,9 @@ jobs:
       changed_files: ${{ steps.changed-strings-files.outputs.changed_files }}
 
     steps:
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -116,9 +116,6 @@ jobs:
 
     steps:
 
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -136,6 +133,9 @@ jobs:
       with:
         submodules: recursive
         ref: ${{ inputs.branch || github.ref_name }}
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Start measuring duration
       id: start-duration-tests
@@ -333,9 +333,6 @@ jobs:
 
     steps:
 
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -352,6 +349,9 @@ jobs:
       uses: actions/checkout@v6
       with:
         ref: ${{ inputs.branch || github.ref_name }}
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Start measuring duration
       id: start-duration-release-build

--- a/.github/workflows/ios_promote_testflight.yml
+++ b/.github/workflows/ios_promote_testflight.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: macos-26
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6
       with:

--- a/.github/workflows/ios_promote_testflight.yml
+++ b/.github/workflows/ios_promote_testflight.yml
@@ -17,9 +17,6 @@ jobs:
     runs-on: macos-26
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6
       with:
@@ -30,6 +27,9 @@ jobs:
           iOS/Gemfile.lock
           iOS/fastlane
           iOS/scripts
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Setup Ruby and dependencies
       uses: ./.github/actions/setup-ruby

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -75,6 +75,9 @@ jobs:
 
     steps:
 
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6
       with:

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -75,14 +75,14 @@ jobs:
 
     steps:
 
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6
       with:
         submodules: recursive
         ref: ${{ inputs.commit-sha || env.branch }}
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Set destination output
       id: destination

--- a/.github/workflows/ios_sync_end_to_end.yml
+++ b/.github/workflows/ios_sync_end_to_end.yml
@@ -23,6 +23,9 @@ jobs:
       RUNS_ON: macos-26
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -145,6 +148,9 @@ jobs:
     timeout-minutes: 240
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6 # Don't need submodules here as this is only for the tests folder
 
@@ -219,6 +225,9 @@ jobs:
     timeout-minutes: 240
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6 # Don't need submodules here as this is only for the tests folder
 

--- a/.github/workflows/ios_sync_end_to_end.yml
+++ b/.github/workflows/ios_sync_end_to_end.yml
@@ -23,9 +23,6 @@ jobs:
       RUNS_ON: macos-26
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -35,6 +32,9 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Start measuring duration
       id: start-duration
@@ -148,11 +148,11 @@ jobs:
     timeout-minutes: 240
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6 # Don't need submodules here as this is only for the tests folder
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Start measuring duration
       id: start-duration
@@ -225,11 +225,11 @@ jobs:
     timeout-minutes: 240
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6 # Don't need submodules here as this is only for the tests folder
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Start measuring duration
       id: start-duration

--- a/.github/workflows/ios_tag_release.yml
+++ b/.github/workflows/ios_tag_release.yml
@@ -83,15 +83,15 @@ jobs:
 
     steps:
 
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6
       with:
         fetch-depth: 0 # Fetch all history and tags in order to look up tags
         submodules: recursive
         ref: ${{ inputs.commit-sha || env.BRANCH }}
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Assert release branch
       run: |

--- a/.github/workflows/ios_tag_release.yml
+++ b/.github/workflows/ios_tag_release.yml
@@ -83,6 +83,9 @@ jobs:
 
     steps:
 
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6
       with:

--- a/.github/workflows/ios_tag_release_update_asana.yml
+++ b/.github/workflows/ios_tag_release_update_asana.yml
@@ -91,6 +91,9 @@ jobs:
     runs-on: macos-26
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
 
@@ -123,6 +126,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
+
+      - name: Print macOS version
+        run: sw_vers
 
       # Always check out main first, because the release branch might have been deleted (for public releases)
       - name: Check out the code

--- a/.github/workflows/ios_tag_release_update_asana.yml
+++ b/.github/workflows/ios_tag_release_update_asana.yml
@@ -91,11 +91,11 @@ jobs:
     runs-on: macos-26
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Download stop_workflow flag artifact
         id: download-stop-workflow
@@ -127,9 +127,6 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       # Always check out main first, because the release branch might have been deleted (for public releases)
       - name: Check out the code
         uses: actions/checkout@v6
@@ -137,6 +134,9 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           ref: main
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Download tag artifact
         id: download-tag

--- a/.github/workflows/ios_upload_version_metadata.yml
+++ b/.github/workflows/ios_upload_version_metadata.yml
@@ -30,6 +30,9 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/ios_upload_version_metadata.yml
+++ b/.github/workflows/ios_upload_version_metadata.yml
@@ -30,13 +30,13 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Set up Ruby and Bundler
         uses: ./.github/actions/setup-ruby

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -28,13 +28,13 @@ jobs:
       build-number: ${{ steps.update-build-number.outputs.build-number }}
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Assert main branch
       run: |

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -28,6 +28,9 @@ jobs:
       build-number: ${{ steps.update-build-number.outputs.build-number }}
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6
       with:
@@ -115,6 +118,9 @@ jobs:
         working-directory: .
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Download DMG URL artifact
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/macos_build_appstore.yml
+++ b/.github/workflows/macos_build_appstore.yml
@@ -86,14 +86,14 @@ jobs:
 
     steps:
 
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6
       with:
         submodules: recursive
         ref: ${{ inputs.commit-sha || env.branch }}
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Assert release branch
       if: env.destination == 'appstore' || env.destination == 'testflight'
@@ -238,14 +238,14 @@ jobs:
 
     steps:
 
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6
       with:
         submodules: recursive
         ref: ${{ inputs.commit-sha || env.branch }}
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Setup Ruby and dependencies
       uses: ./.github/actions/setup-ruby

--- a/.github/workflows/macos_build_appstore.yml
+++ b/.github/workflows/macos_build_appstore.yml
@@ -86,6 +86,9 @@ jobs:
 
     steps:
 
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6
       with:
@@ -234,6 +237,9 @@ jobs:
       branch: ${{ inputs.branch || github.ref_name }}
 
     steps:
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Check out the code
       uses: actions/checkout@v6

--- a/.github/workflows/macos_build_hotfix_release.yml
+++ b/.github/workflows/macos_build_hotfix_release.yml
@@ -38,13 +38,13 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref_name }}
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Assert hotfix release branch
         run: |
@@ -84,15 +84,15 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history and tags in order to extract Asana task URLs from git log
           ref: ${{ github.ref_name }}
           submodules: recursive
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Setup Ruby and dependencies
         uses: ./.github/actions/setup-ruby

--- a/.github/workflows/macos_build_hotfix_release.yml
+++ b/.github/workflows/macos_build_hotfix_release.yml
@@ -38,6 +38,9 @@ jobs:
 
     steps:
 
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
         with:
@@ -80,6 +83,9 @@ jobs:
       commit_sha: ${{ steps.update-asana.outputs.commit_sha }}
 
     steps:
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Check out the code
         uses: actions/checkout@v6

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -110,9 +110,6 @@ jobs:
       branch: ${{ inputs.branch || github.ref_name }}
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -125,6 +122,9 @@ jobs:
       with:
         submodules: recursive
         ref: ${{ inputs.commit-sha || env.branch }}
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Validate architecture selection
       env:
@@ -400,9 +400,6 @@ jobs:
 
     steps:
 
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6
       with:
@@ -418,6 +415,9 @@ jobs:
           macOS/fastlane
           macOS/scripts/assets
           macOS/scripts/validate_release_artifact.sh
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Start measuring duration
       id: start-duration
@@ -594,9 +594,6 @@ jobs:
       failure: ${{ (needs.export-notarized-app.result == 'failure') || (needs.create-dmg.result == 'failure') }}
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
@@ -609,6 +606,9 @@ jobs:
             macOS/Gemfile
             macOS/Gemfile.lock
             macOS/fastlane
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Setup Ruby and dependencies
         uses: ./.github/actions/setup-ruby

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -110,6 +110,9 @@ jobs:
       branch: ${{ inputs.branch || github.ref_name }}
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -397,6 +400,9 @@ jobs:
 
     steps:
 
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6
       with:
@@ -588,6 +594,9 @@ jobs:
       failure: ${{ (needs.export-notarized-app.result == 'failure') || (needs.create-dmg.result == 'failure') }}
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/macos_bump_internal_release.yml
+++ b/.github/workflows/macos_bump_internal_release.yml
@@ -53,6 +53,9 @@ jobs:
       skip-appstore: ${{ steps.prepare-release-bump.outputs.skip_appstore }}
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
         with:
@@ -107,6 +110,9 @@ jobs:
       commit_sha: ${{ steps.increment-build-number.outputs.commit_sha }}
 
     steps:
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Check out the code
         uses: actions/checkout@v6

--- a/.github/workflows/macos_bump_internal_release.yml
+++ b/.github/workflows/macos_bump_internal_release.yml
@@ -53,13 +53,13 @@ jobs:
       skip-appstore: ${{ steps.prepare-release-bump.outputs.skip_appstore }}
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history and tags in order to extract Asana task URLs from git log
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Assert release branch
         run: |
@@ -111,15 +111,15 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history and tags in order to extract Asana task URLs from git log
           ref: ${{ needs.validate_input_conditions.outputs.release-branch }}
           submodules: recursive
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Setup Ruby and dependencies
         uses: ./.github/actions/setup-ruby

--- a/.github/workflows/macos_check_sparkle_update.yml
+++ b/.github/workflows/macos_check_sparkle_update.yml
@@ -16,13 +16,13 @@ jobs:
       # Feature owners (GitHub handles, space-separated). Used for PR reviewers and Asana assignee.
       SPARKLE_OWNERS: "diegoreymendez jotaemepereira"
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Checkout repository
         # Pinned to v5: v6 duplicates the git Authorization header and breaks
         # peter-evans/create-pull-request (Duplicate header: "Authorization", HTTP 400).
         uses: actions/checkout@v5
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Assign SSH keys
         uses: webfactory/ssh-agent@v0.9.1

--- a/.github/workflows/macos_check_sparkle_update.yml
+++ b/.github/workflows/macos_check_sparkle_update.yml
@@ -16,6 +16,9 @@ jobs:
       # Feature owners (GitHub handles, space-separated). Used for PR reviewers and Asana assignee.
       SPARKLE_OWNERS: "diegoreymendez jotaemepereira"
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Checkout repository
         # Pinned to v5: v6 duplicates the git Authorization header and breaks
         # peter-evans/create-pull-request (Duplicate header: "Authorization", HTTP 400).

--- a/.github/workflows/macos_code_freeze.yml
+++ b/.github/workflows/macos_code_freeze.yml
@@ -45,14 +45,14 @@ jobs:
       asana_task_url: ${{ steps.make_release_branch.outputs.asana_task_url }}
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history and tags in order to extract Asana task URLs from git log
           submodules: recursive
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Assert main branch
         run: |
@@ -112,14 +112,14 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           submodules: recursive
           ref: ${{ needs.create_release_branch.outputs.release_branch_name }}
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Setup Ruby and dependencies
         uses: ./.github/actions/setup-ruby

--- a/.github/workflows/macos_code_freeze.yml
+++ b/.github/workflows/macos_code_freeze.yml
@@ -45,6 +45,9 @@ jobs:
       asana_task_url: ${{ steps.make_release_branch.outputs.asana_task_url }}
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
         with:
@@ -108,6 +111,9 @@ jobs:
       commit_sha: ${{ steps.increment-build-number.outputs.commit_sha }}
 
     steps:
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Check out the code
         uses: actions/checkout@v6

--- a/.github/workflows/macos_create_variant.yml
+++ b/.github/workflows/macos_create_variant.yml
@@ -66,6 +66,9 @@ jobs:
 
     steps:
 
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6
       with:

--- a/.github/workflows/macos_create_variant.yml
+++ b/.github/workflows/macos_create_variant.yml
@@ -66,15 +66,15 @@ jobs:
 
     steps:
 
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6
       with:
         sparse-checkout: |
           .github
           macOS/scripts
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Download DMG artifact
       id: download-dmg-artifact

--- a/.github/workflows/macos_create_variants.yml
+++ b/.github/workflows/macos_create_variants.yml
@@ -42,11 +42,11 @@ jobs:
       build-variants-2: ${{ steps.get-build-variants.outputs.build-variants-2 }}
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out repository
         uses: actions/checkout@v6
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Fetch Build Variants
         id: get-build-variants
@@ -65,9 +65,6 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
@@ -77,6 +74,9 @@ jobs:
             macOS/Gemfile.lock
             macOS/fastlane
             macOS/scripts
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Download release app
         env:
@@ -130,9 +130,6 @@ jobs:
       failure: ${{ needs.create-variants-1.result == 'failure' || needs.create-variants-2.result == 'failure' }}
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         if: ${{ env.success || env.failure }} # Don't execute when cancelled
         uses: actions/checkout@v6
@@ -143,6 +140,10 @@ jobs:
             macOS/Gemfile.lock
             macOS/fastlane
             macOS/scripts
+
+      - name: Print macOS version
+        if: ${{ env.success || env.failure }} # Don't execute when cancelled
+        run: sw_vers
 
       - name: Setup Ruby and dependencies
         if: ${{ env.success || env.failure }} # Don't execute when cancelled

--- a/.github/workflows/macos_create_variants.yml
+++ b/.github/workflows/macos_create_variants.yml
@@ -42,6 +42,9 @@ jobs:
       build-variants-2: ${{ steps.get-build-variants.outputs.build-variants-2 }}
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out repository
         uses: actions/checkout@v6
 
@@ -61,6 +64,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Check out the code
         uses: actions/checkout@v6
@@ -124,6 +130,9 @@ jobs:
       failure: ${{ needs.create-variants-1.result == 'failure' || needs.create-variants-2.result == 'failure' }}
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         if: ${{ env.success || env.failure }} # Don't execute when cancelled
         uses: actions/checkout@v6

--- a/.github/workflows/macos_crossbench_chrome.yml
+++ b/.github/workflows/macos_crossbench_chrome.yml
@@ -247,9 +247,6 @@ jobs:
     runs-on: [ self-hosted, apple ]
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Download ClickHouse rows TSV
         # A cancelled or early-failed benchmark job may never have uploaded this;
         # that is not a reason to skip the attempts insert below.

--- a/.github/workflows/macos_crossbench_chrome.yml
+++ b/.github/workflows/macos_crossbench_chrome.yml
@@ -79,6 +79,9 @@ jobs:
     timeout-minutes: 200
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
         with:
@@ -244,6 +247,9 @@ jobs:
     runs-on: [ self-hosted, apple ]
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Download ClickHouse rows TSV
         # A cancelled or early-failed benchmark job may never have uploaded this;
         # that is not a reason to skip the attempts insert below.

--- a/.github/workflows/macos_crossbench_chrome.yml
+++ b/.github/workflows/macos_crossbench_chrome.yml
@@ -79,13 +79,13 @@ jobs:
     timeout-minutes: 200
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Download validated WPR archives
         uses: actions/download-artifact@v7

--- a/.github/workflows/macos_crossbench_safari.yml
+++ b/.github/workflows/macos_crossbench_safari.yml
@@ -75,6 +75,9 @@ jobs:
     timeout-minutes: 200
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
         with:
@@ -260,6 +263,9 @@ jobs:
     runs-on: [ self-hosted, apple ]
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Download ClickHouse rows TSV
         # A cancelled or early-failed benchmark job may never have uploaded this;
         # that is not a reason to skip the attempts insert below.

--- a/.github/workflows/macos_crossbench_safari.yml
+++ b/.github/workflows/macos_crossbench_safari.yml
@@ -75,13 +75,13 @@ jobs:
     timeout-minutes: 200
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Download validated WPR archives
         uses: actions/download-artifact@v7

--- a/.github/workflows/macos_crossbench_safari.yml
+++ b/.github/workflows/macos_crossbench_safari.yml
@@ -263,9 +263,6 @@ jobs:
     runs-on: [ self-hosted, apple ]
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Download ClickHouse rows TSV
         # A cancelled or early-failed benchmark job may never have uploaded this;
         # that is not a reason to skip the attempts insert below.

--- a/.github/workflows/macos_hotfix.yml
+++ b/.github/workflows/macos_hotfix.yml
@@ -22,15 +22,15 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.GHA_ELEVATED_PERMISSIONS_TOKEN }}
           submodules: recursive
           fetch-depth: 0 # Fetch all history and tags in order to extract Asana task URLs from git log
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Assert main branch
         run: |

--- a/.github/workflows/macos_hotfix.yml
+++ b/.github/workflows/macos_hotfix.yml
@@ -22,6 +22,9 @@ jobs:
 
     steps:
 
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/macos_performance_tests.yml
+++ b/.github/workflows/macos_performance_tests.yml
@@ -391,9 +391,6 @@ jobs:
     runs-on: [ self-hosted, apple ]
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Download startup metrics
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/macos_performance_tests.yml
+++ b/.github/workflows/macos_performance_tests.yml
@@ -58,6 +58,9 @@ jobs:
     timeout-minutes: 60
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -388,6 +391,9 @@ jobs:
     runs-on: [ self-hosted, apple ]
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Download startup metrics
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/macos_performance_tests.yml
+++ b/.github/workflows/macos_performance_tests.yml
@@ -58,9 +58,6 @@ jobs:
     timeout-minutes: 60
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -73,6 +70,9 @@ jobs:
       with:
         submodules: recursive
         ref: ${{ inputs.branch || github.sha }}
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Start measuring duration
       id: start-duration

--- a/.github/workflows/macos_pir_end_to_end_tests.yml
+++ b/.github/workflows/macos_pir_end_to_end_tests.yml
@@ -50,9 +50,6 @@ jobs:
 
     timeout-minutes: 32
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -65,6 +62,9 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Start measuring duration
       id: start-duration

--- a/.github/workflows/macos_pir_end_to_end_tests.yml
+++ b/.github/workflows/macos_pir_end_to_end_tests.yml
@@ -50,6 +50,9 @@ jobs:
 
     timeout-minutes: 32
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -178,6 +178,9 @@ jobs:
       pr_reviewers: ${{ steps.fetch_commit_author.outputs.pr_reviewers }}
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -540,6 +543,9 @@ jobs:
       changed_files: ${{ steps.changed-strings-files.outputs.changed_files }}
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -178,9 +178,6 @@ jobs:
       pr_reviewers: ${{ steps.fetch_commit_author.outputs.pr_reviewers }}
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -200,6 +197,9 @@ jobs:
       with:
         submodules: recursive
         ref: ${{ inputs.branch || github.ref_name }}
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Start measuring duration
       id: start-duration-tests
@@ -543,9 +543,6 @@ jobs:
       changed_files: ${{ steps.changed-strings-files.outputs.changed_files }}
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -557,6 +554,9 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Start measuring duration
       id: start-duration-release-build

--- a/.github/workflows/macos_promote_testflight.yml
+++ b/.github/workflows/macos_promote_testflight.yml
@@ -17,9 +17,6 @@ jobs:
     runs-on: macos-26
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6
       with:
@@ -30,6 +27,9 @@ jobs:
           macOS/Gemfile.lock
           macOS/fastlane
           macOS/scripts
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Setup Ruby and dependencies
       uses: ./.github/actions/setup-ruby

--- a/.github/workflows/macos_promote_testflight.yml
+++ b/.github/workflows/macos_promote_testflight.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: macos-26
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6
       with:

--- a/.github/workflows/macos_publish_dmg_release.yml
+++ b/.github/workflows/macos_publish_dmg_release.yml
@@ -85,11 +85,11 @@ jobs:
     runs-on: macos-26
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Download stop_workflow flag artifact
         id: download-stop-workflow
@@ -123,9 +123,6 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       # Always check out main first, because the release branch might have been deleted (for public releases)
       - name: Check out the code
         uses: actions/checkout@v6
@@ -133,6 +130,9 @@ jobs:
           fetch-depth: 0 # Fetch all history and tags in order to extract Asana task URLs from git log
           submodules: recursive
           ref: main
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Download tag artifact
         id: download-tag

--- a/.github/workflows/macos_publish_dmg_release.yml
+++ b/.github/workflows/macos_publish_dmg_release.yml
@@ -85,6 +85,9 @@ jobs:
     runs-on: macos-26
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
 
@@ -120,6 +123,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       # Always check out main first, because the release branch might have been deleted (for public releases)
       - name: Check out the code
         uses: actions/checkout@v6

--- a/.github/workflows/macos_replay_harness_tests.yml
+++ b/.github/workflows/macos_replay_harness_tests.yml
@@ -16,6 +16,9 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/macos_replay_harness_tests.yml
+++ b/.github/workflows/macos_replay_harness_tests.yml
@@ -16,13 +16,13 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Run replay harness tests
         working-directory: macOS/scripts/crossbench

--- a/.github/workflows/macos_run_ui_test.yml
+++ b/.github/workflows/macos_run_ui_test.yml
@@ -70,6 +70,9 @@ jobs:
       extra-xcargs: ${{ inputs.build-type == 'appstore' && 'UI_TESTS_TARGET_APP=sandbox' || '' }}
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:

--- a/.github/workflows/macos_run_ui_test.yml
+++ b/.github/workflows/macos_run_ui_test.yml
@@ -70,9 +70,6 @@ jobs:
       extra-xcargs: ${{ inputs.build-type == 'appstore' && 'UI_TESTS_TARGET_APP=sandbox' || '' }}
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -84,6 +81,9 @@ jobs:
       uses: actions/checkout@v6
       with:
         ref: ${{ inputs.branch }}
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Initialize submodules with retry
       run: |

--- a/.github/workflows/macos_sync_end_to_end.yml
+++ b/.github/workflows/macos_sync_end_to_end.yml
@@ -46,9 +46,6 @@ jobs:
     timeout-minutes: 60
 
     steps:
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -60,6 +57,9 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Start measuring duration
       id: start-duration

--- a/.github/workflows/macos_sync_end_to_end.yml
+++ b/.github/workflows/macos_sync_end_to_end.yml
@@ -46,6 +46,9 @@ jobs:
     timeout-minutes: 60
 
     steps:
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:

--- a/.github/workflows/macos_tag_release.yml
+++ b/.github/workflows/macos_tag_release.yml
@@ -89,15 +89,15 @@ jobs:
 
     steps:
 
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Check out the code
       uses: actions/checkout@v6
       with:
         fetch-depth: 0 # Fetch all history and tags in order to look up tags
         submodules: recursive
         ref: ${{ inputs.commit-sha || env.BRANCH }}
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Assert release branch
       run: |

--- a/.github/workflows/macos_tag_release.yml
+++ b/.github/workflows/macos_tag_release.yml
@@ -89,6 +89,9 @@ jobs:
 
     steps:
 
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Check out the code
       uses: actions/checkout@v6
       with:

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -118,13 +118,13 @@ jobs:
       run-production: ${{ steps.define-user-modes.outputs.run-production }}
       run-internal: ${{ steps.define-user-modes.outputs.run-internal }}
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out repository
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.sha }}
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Start measuring duration
         id: start-duration

--- a/.github/workflows/macos_ui_tests.yml
+++ b/.github/workflows/macos_ui_tests.yml
@@ -118,6 +118,9 @@ jobs:
       run-production: ${{ steps.define-user-modes.outputs.run-production }}
       run-internal: ${{ steps.define-user-modes.outputs.run-internal }}
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/macos_upload_version_metadata.yml
+++ b/.github/workflows/macos_upload_version_metadata.yml
@@ -44,13 +44,13 @@ jobs:
       CDN_PATH: ${{ vars.DMG_URL_ROOT }}
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Check out the code
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Set up Ruby and Bundler
         uses: ./.github/actions/setup-ruby

--- a/.github/workflows/macos_upload_version_metadata.yml
+++ b/.github/workflows/macos_upload_version_metadata.yml
@@ -44,6 +44,9 @@ jobs:
       CDN_PATH: ${{ vars.DMG_URL_ROOT }}
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Check out the code
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/report_failed_release_workflow.yml
+++ b/.github/workflows/report_failed_release_workflow.yml
@@ -35,9 +35,6 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Set working directory
         id: set-working-directory
         run: |
@@ -59,6 +56,9 @@ jobs:
         with:
           submodules: recursive
           ref: ${{ inputs.branch }}
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Setup Ruby and dependencies
         uses: ./.github/actions/setup-ruby

--- a/.github/workflows/report_failed_release_workflow.yml
+++ b/.github/workflows/report_failed_release_workflow.yml
@@ -35,6 +35,9 @@ jobs:
 
     steps:
 
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Set working directory
         id: set-working-directory
         run: |

--- a/.github/workflows/shared_web_tests.yml
+++ b/.github/workflows/shared_web_tests.yml
@@ -45,6 +45,9 @@ jobs:
     timeout-minutes: 30
     steps:
 
+    - name: Print macOS version
+      run: sw_vers
+
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -117,6 +120,9 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 30
     steps:
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0

--- a/.github/workflows/shared_web_tests.yml
+++ b/.github/workflows/shared_web_tests.yml
@@ -45,9 +45,6 @@ jobs:
     timeout-minutes: 30
     steps:
 
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -57,6 +54,9 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Select Xcode
       uses: ./.github/actions/select-xcode-version
@@ -121,9 +121,6 @@ jobs:
     timeout-minutes: 30
     steps:
 
-    - name: Print macOS version
-      run: sw_vers
-
     - name: Register SSH keys for private repos
       uses: webfactory/ssh-agent@v0.10.0
       with:
@@ -133,6 +130,9 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Print macOS version
+      run: sw_vers
 
     - name: Select Xcode
       uses: ./.github/actions/select-xcode-version

--- a/.github/workflows/smartling.yml
+++ b/.github/workflows/smartling.yml
@@ -51,6 +51,9 @@ jobs:
 
     steps:
 
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Determine trigger and parameters
         id: params
         env:

--- a/.github/workflows/smartling.yml
+++ b/.github/workflows/smartling.yml
@@ -51,9 +51,6 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Determine trigger and parameters
         id: params
         env:
@@ -122,6 +119,9 @@ jobs:
           submodules: recursive
           ref: ${{ steps.params.outputs.branch }}
           persist-credentials: true
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Parse job details from PR comments
         if: steps.params.outputs.needs_comment_parsing == 'true'

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -17,6 +17,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Checkout Code
         uses: actions/checkout@v6
 

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Checkout Code
         uses: actions/checkout@v6
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Cache Mint packages
         uses: actions/cache@v5

--- a/.github/workflows/update_code_signing.yml
+++ b/.github/workflows/update_code_signing.yml
@@ -25,6 +25,9 @@ jobs:
 
     steps:
 
+      - name: Print macOS version
+        run: sw_vers
+
       - name: Register SSH keys for access to certificates
         uses: webfactory/ssh-agent@v0.10.0
         with:

--- a/.github/workflows/update_code_signing.yml
+++ b/.github/workflows/update_code_signing.yml
@@ -25,9 +25,6 @@ jobs:
 
     steps:
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Register SSH keys for access to certificates
         uses: webfactory/ssh-agent@v0.10.0
         with:
@@ -35,6 +32,9 @@ jobs:
 
       - name: Check out the code
         uses: actions/checkout@v6
+
+      - name: Print macOS version
+        run: sw_vers
 
       - name: Setup Ruby and dependencies for iOS
         if: startsWith(inputs.target, 'ios')


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1217455483209825?focus=true

### Description

Every CI job that runs on a macOS machine now prints the OS version of that machine, so the logs show which macOS version a build or test actually ran on. Until now you had to infer it from the runner label, which is not reliable — labels like `macos-latest` move over time, and the self-hosted and Bitrise machines can be updated without any change in this repository.

The step runs directly after the checkout step. It cannot run before it: most of these workflows set `defaults.run.working-directory` to `macOS` or `iOS`, and that directory does not exist until the repository is checked out, so bash cannot start there.

### Testing Steps
1. Verify that logs show macOS version being used by the runner.

### Impact

None — this is internal tooling. The new step only prints information. It does not change how the apps are built, signed or tested, and it does not touch app code.

### Quality Considerations

- The change is only insertions: 208 added lines, no deleted lines. Nothing that exists today was moved or re-indented.
- `actionlint -shellcheck=` — the same command the `Actionlint` workflow runs — passes on all workflow files.
- I checked every job of every workflow, not only the ones with a `macos-*` label. The runner is given indirectly in five jobs, through `matrix.runner`, `matrix.runs-on` or `inputs.runner`; every value those can take is a macOS runner.
- Three jobs check out twice under mutually exclusive conditions (`pull_request`/`push` against everything else). The step goes after the second checkout in those jobs, so it runs after whichever one applied.
- The Mattermost job of the variants workflow checks out only when the jobs it needs did not cancel. The step carries that same condition, like every other step of that job, so a cancelled run does not fail on it.
- One job has no checkout and sets `working-directory: .`, which always exists, so its step stays at the top.
- Seven jobs use a sparse checkout. Each sparse list includes paths below that job's working directory, so the directory is created.
- `sw_vers` needs no network and no credentials, and it adds well under a second per job.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
