### PR TITLE
[macOS] Make bookmarksReorderByName a failsafe feature flag

### DIFF
--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -819,7 +819,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .promptBar:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.promptBar), category: .duckAI)
         case .bookmarksReorderByName:
-            Config(defaultValue: .disabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.bookmarksReorderByName))
+            Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.bookmarksReorderByName))
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1217076881156357?focus=true
CC:

### Description

The bookmarks "Reorder by name" action now ships on for everyone instead of being off until we enable it remotely. Its feature flag becomes a failsafe: enabled by default, with no privacy-config entry required to launch it, but still remotely disableable if the action causes problems in the field. Reordering is destructive and permanent, so keeping a remote off-switch is worthwhile even though we expect it to stay on.

### Testing Steps

1. Run macOS on a clean profile with no privacy-config override → right-click a bookmark folder in the bookmarks bar; "Reorder by name" is present and works.
2. Same check in the Bookmarks manager list and its context menu → item is present.
3. Add `bookmarksReorderByName` under `macOSBrowserConfig` with `"state": "disabled"` in a local privacy config → the menu item disappears in both places.
4. As an internal user, toggle the flag off in the internal feature flag debug menu → menu item disappears; toggle back on → it returns.

### Impact

Low — a bookmarks context menu action becomes visible to all users. The reorder itself is unchanged by this PR.

#### What could go wrong?

- Someone adds a colliding `bookmarksReorderByName` key under `macOSBrowserConfig` in privacy-configuration for another purpose and disables it → the action silently switches off. The name is specific and namespaced under the macOS-only parent feature, which keeps the odds low.
- If we do need to kill it, scope the config entry with `minSupportedVersion` so the disable targets the affected builds rather than every version indefinitely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default-value flip for a bookmarks UI gate; reorder logic is unchanged and remote kill switch remains.
> 
> **Overview**
> **Ships the bookmarks “Reorder by name” action on for all macOS users** by changing the `bookmarksReorderByName` feature flag default from **disabled** to **enabled** in `FeatureFlag.swift`.
> 
> The flag stays wired to `MacOSBrowserConfigSubfeature.bookmarksReorderByName`, so privacy config or internal debug overrides can still turn it off remotely. **No change to reorder behavior**—only whether the menu item appears when remote config is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ddc7ca0ef0122e8fa3c9d5c6d8ee7a0abeba889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->