### PR TITLE
Restore ⌘-click on the Ask Duck.ai pill to start a new chat

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -1000,9 +1000,10 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
     }
 
     @objc private func duckAITitlebarButtonAction(_ sender: NSButton) {
-        // Menu-button layout: left-click opens the dropdown; middle-click opens a new Duck.ai tab directly.
+        // Menu-button layout: left-click opens the dropdown; middle-click and ⌘-click skip it and start a
+        // new chat right away, preserving the one-click access the split button used to offer.
         if isMenuButtonLayout {
-            if NSApp.currentEvent?.type == .otherMouseUp {
+            if NSApp.currentEvent?.type == .otherMouseUp || NSApp.isCommandPressed {
                 duckAIMenuNewChatAction()
             } else {
                 presentDuckAIMenuButtonMenu(from: sender)

--- a/macOS/UITests/AIChatMenuButtonTests.swift
+++ b/macOS/UITests/AIChatMenuButtonTests.swift
@@ -158,6 +158,23 @@ class AIChatMenuButtonTests: UITestCase {
                        "Clicking 'New Chat' should open a new Duck.ai tab")
     }
 
+    /// ⌘-click skips the dropdown and starts a new chat directly, as clicking the split button used to.
+    func test_pillCommandClick_opensNewChatTab_withoutDropdown() {
+        addressBarTextField.typeURL(UITests.simpleServedPage(titled: "Command Click Test"))
+        XCTAssertTrue(pillButton.waitForExistence(timeout: UITests.Timeouts.elementExistence))
+
+        let tabsBefore = app.tabGroups.matching(identifier: "Tabs").radioButtons.count
+
+        XCUIElement.perform(withKeyModifiers: [.command]) {
+            pillButton.click()
+        }
+
+        let tabsAfter = app.tabGroups.matching(identifier: "Tabs").radioButtons.count
+        XCTAssertEqual(tabsAfter, tabsBefore + 1,
+                       "⌘-clicking the pill should open a new Duck.ai tab")
+        XCTAssertFalse(newChatMenuItem.exists, "⌘-click should not present the dropdown")
+    }
+
     // MARK: - Close Sidebar
 
     /// With a chat already presented the sidebar item becomes "Close Sidebar" and closes it.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1217453137554172?focus=true

### Description
The old split button opened a new Duck.ai tab on a plain click, so ⌘-click landed there too. The single "Ask Duck.ai" pill only presents its dropdown on a left click, which turned a one-click flow into two clicks and read as a regression (reported internally).

⌘-click now starts a new chat directly, the same as middle-click and the dropdown's New Chat item. Plain click still opens the dropdown, and the split-button layout is untouched.

### Testing Steps
1. Enable the `aiChatChromeSidebar` and `aiChatChromeMenuButton` feature flags in debug settings.
2. Open any website, then ⌘-click "Ask Duck.ai" in the tab bar → a new Duck.ai tab opens and no dropdown appears.
3. Plain-click "Ask Duck.ai" → the dropdown appears with New Chat and the sidebar item, as before.
4. Middle-click "Ask Duck.ai" → a new Duck.ai tab opens, as before.
5. On the new tab page, ⌘-click "Ask Duck.ai" → the current tab becomes the Duck.ai chat (matches New Chat / middle-click).
6. Turn `aiChatChromeMenuButton` off → the split button behaves as before.

### Impact
Low: restores a shortcut on an existing tab-bar button; the default left-click path is unchanged.

#### What could go wrong?
⌘-click could swallow a click the dropdown was expected to handle → the branch only triggers on ⌘ or middle-click, and `AIChatMenuButtonTests` covers both the ⌘-click path and the plain-click dropdown.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small branch in tab-bar click handling for a feature-flagged layout; plain click unchanged and covered by UI tests.
> 
> **Overview**
> Restores **one-click new chat** on the single **Ask Duck.ai** tab-bar pill when the menu-button layout is enabled (`aiChatChromeMenuButton`). A plain left click still opens the dropdown; **middle-click** and **⌘-click** now both call the same **New Chat** path as the dropdown item (`duckAIMenuNewChatAction` / `openNewDuckAIChatTab`), matching behavior users had with the old split button.
> 
> The split-button layout and non-menu-button code path are unchanged.
> 
> **Testing:** `AIChatMenuButtonTests` adds `test_pillCommandClick_opensNewChatTab_withoutDropdown`, asserting a new tab and that the New Chat menu item never appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da0cc68dba70a8777eb99504b2371f4027a640f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->