### PR TITLE
Migrate existing Sync devices to unified device info

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -265,6 +265,10 @@ public class DDGSync: DDGSyncing {
             try dependencies.secureStore.persistAccount(result.account)
             persistRecoveredThirdPartyScopedPasswordIfAvailable(from: result.accessCredentials, account: result.account)
             updateProtectedKeysCache(with: result.keys)
+            if dependencies.syncFeatureFlags.canWriteUnifiedDeviceList() {
+                // The legacy rename leaves device_info stale, so allow migration to write the new name.
+                deviceInfoMigrationCoordinator.reset()
+            }
             scheduleDeviceInfoMigration(for: result.account)
             return result.devices
         } catch {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -85,6 +85,7 @@ public class DDGSync: DDGSyncing {
 
     public weak var dataProvidersSource: DataProvidersSource?
     private var customOperations: [any SyncCustomOperation] = []
+    private let deviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating
 
     /// This is the constructor intended for use by app clients.
     public convenience init(dataProvidersSource: DataProvidersSource,
@@ -112,6 +113,7 @@ public class DDGSync: DDGSyncing {
 
         let account = try await dependencies.account.createAccount(deviceName: deviceName, deviceType: deviceType)
         try updateAccount(account)
+        scheduleDeviceInfoMigration(for: account)
         scheduler.requestSyncImmediately()
     }
 
@@ -123,8 +125,8 @@ public class DDGSync: DDGSyncing {
         let result = try await dependencies.account.login(recoveryKey, deviceName: deviceName, deviceType: deviceType)
         try updateAccount(result.account)
         persistRecoveredThirdPartyScopedPasswordIfAvailable(from: result.accessCredentials, account: result.account)
-        let accountInfoKeys = await ensureAccountInfoProtectedKeysIfNeeded(for: result.account)
-        updateProtectedKeysCache(with: (result.keys ?? []) + accountInfoKeys)
+        updateProtectedKeysCache(with: result.keys)
+        scheduleDeviceInfoMigration(for: result.account)
         scheduler.requestSyncImmediately()
         return result.devices
     }
@@ -349,6 +351,7 @@ public class DDGSync: DDGSyncing {
             }
             cacheScopedPasswordInBackground(result.scopedPassword)
             updateProtectedKeysCache(with: result.protectedKeys)
+            scheduleDeviceInfoMigration(for: result.account)
             scheduler.requestSyncImmediately()
             return result.devices
         } catch {
@@ -396,6 +399,7 @@ public class DDGSync: DDGSyncing {
     init(dataProvidersSource: DataProvidersSource, dependencies: SyncDependencies) {
         self.dataProvidersSource = dataProvidersSource
         self.dependencies = dependencies
+        self.deviceInfoMigrationCoordinator = dependencies.createDeviceInfoMigrationCoordinator()
 
         featureFlagsCancellable = Publishers.Merge(
             self.dependencies.privacyConfigurationManager.updatesPublisher,
@@ -498,6 +502,9 @@ public class DDGSync: DDGSyncing {
 
         do {
             try updateAccount(account)
+            if isSyncEngineReady {
+                scheduleDeviceInfoMigration(for: account)
+            }
         } catch {
             dependencies.errorEvents.fire(.failedToSetupEngine, error: error)
         }
@@ -655,6 +662,16 @@ public class DDGSync: DDGSyncing {
         }
     }
 
+    private func scheduleDeviceInfoMigration(for account: SyncAccount) {
+        guard deviceInfoMigrationTask == nil else {
+            return
+        }
+        let deviceInfoMigrationCoordinator = deviceInfoMigrationCoordinator
+        deviceInfoMigrationTask = Task {
+            await deviceInfoMigrationCoordinator.migrateCurrentDeviceIfNeeded(for: account)
+        }
+    }
+
     private func persistRecoveredThirdPartyScopedPasswordIfAvailable(from accessCredentials: [AccessCredential]?, account: SyncAccount) {
         guard dependencies.syncFeatureFlags.isScopedAccessCredentialsEnabled() else {
             return
@@ -768,4 +785,5 @@ public class DDGSync: DDGSyncing {
     private var syncQueueCancellable: AnyCancellable?
     private var syncDidFinishCancellable: AnyCancellable?
     private var syncQueueRequestErrorCancellable: AnyCancellable?
+    private var deviceInfoMigrationTask: Task<Void, Never>?
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -254,6 +254,8 @@ public class DDGSync: DDGSyncing {
     }
 
     public func updateDeviceName(_ name: String) async throws -> [RegisteredDevice] {
+        await cancelDeviceInfoMigrationAndWait()
+
         guard let account = try dependencies.secureStore.account() else {
             throw SyncError.accountNotFound
         }
@@ -263,6 +265,7 @@ public class DDGSync: DDGSyncing {
             try dependencies.secureStore.persistAccount(result.account)
             persistRecoveredThirdPartyScopedPasswordIfAvailable(from: result.accessCredentials, account: result.account)
             updateProtectedKeysCache(with: result.keys)
+            scheduleDeviceInfoMigration(for: result.account)
             return result.devices
         } catch {
             throw handleUnauthenticatedAndMap(error)
@@ -673,6 +676,15 @@ public class DDGSync: DDGSyncing {
         deviceInfoMigrationTask = Task {
             await deviceInfoMigrationCoordinator.migrateCurrentDeviceIfNeeded(for: account)
         }
+    }
+
+    private func cancelDeviceInfoMigrationAndWait() async {
+        guard let deviceInfoMigrationTask else {
+            return
+        }
+        deviceInfoMigrationTask.cancel()
+        await deviceInfoMigrationTask.value
+        self.deviceInfoMigrationTask = nil
     }
 
     private func persistRecoveredThirdPartyScopedPasswordIfAvailable(from accessCredentials: [AccessCredential]?, account: SyncAccount) {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -330,8 +330,21 @@ public class DDGSync: DDGSyncing {
         guard let account = try dependencies.secureStore.account() else {
             throw SyncError.accountNotFound
         }
+
+        // Let an automatic migration finish before starting the explicit debug run.
+        if let migrationTask = deviceInfoMigrationTask,
+           let migrationTaskID = deviceInfoMigrationTaskID {
+            await migrationTask.value
+            clearCompletedDeviceInfoMigrationTask(withID: migrationTaskID)
+        }
+
         scheduleDeviceInfoMigration(for: account)
-        await deviceInfoMigrationTask?.value
+        let migrationTask = deviceInfoMigrationTask
+        let migrationTaskID = deviceInfoMigrationTaskID
+        await migrationTask?.value
+        if let migrationTaskID {
+            clearCompletedDeviceInfoMigrationTask(withID: migrationTaskID)
+        }
     }
 
     public func resetDeviceInfoMigrationForDebug() {
@@ -492,6 +505,7 @@ public class DDGSync: DDGSyncing {
             do {
                 deviceInfoMigrationTask?.cancel()
                 deviceInfoMigrationTask = nil
+                deviceInfoMigrationTaskID = nil
                 try dependencies.secureStore.removeAccount()
                 deviceInfoMigrationCoordinator.reset()
                 didRemoveAccount = true
@@ -673,28 +687,29 @@ public class DDGSync: DDGSyncing {
         return (try? JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: data)) ?? []
     }
 
-    private func ensureAccountInfoProtectedKeysIfNeeded(for account: SyncAccount) async -> [ProtectedKey] {
-        guard dependencies.syncFeatureFlags.canWriteUnifiedDeviceList() else {
-            return []
-        }
-
-        do {
-            return try await dependencies.scopedAccess.ensureAccountInfoProtectedKeys(for: account)
-        } catch {
-            let errorType = String(describing: Swift.type(of: error))
-            Logger.sync.error("Sync-UnifiedDevices: failed to ensure account_info protected keys after login: \(errorType)")
-            return []
-        }
-    }
-
     private func scheduleDeviceInfoMigration(for account: SyncAccount) {
         guard deviceInfoMigrationTask == nil else {
             return
         }
         let deviceInfoMigrationCoordinator = deviceInfoMigrationCoordinator
-        deviceInfoMigrationTask = Task {
+        let taskID = UUID()
+        deviceInfoMigrationTaskID = taskID
+        let task = Task {
             await deviceInfoMigrationCoordinator.migrateCurrentDeviceIfNeeded(for: account)
         }
+        deviceInfoMigrationTask = task
+        Task { [weak self] in
+            await task.value
+            self?.clearCompletedDeviceInfoMigrationTask(withID: taskID)
+        }
+    }
+
+    private func clearCompletedDeviceInfoMigrationTask(withID taskID: UUID) {
+        guard deviceInfoMigrationTaskID == taskID else {
+            return
+        }
+        deviceInfoMigrationTask = nil
+        deviceInfoMigrationTaskID = nil
     }
 
     private func cancelDeviceInfoMigrationAndWait() async {
@@ -704,6 +719,7 @@ public class DDGSync: DDGSyncing {
         deviceInfoMigrationTask.cancel()
         await deviceInfoMigrationTask.value
         self.deviceInfoMigrationTask = nil
+        deviceInfoMigrationTaskID = nil
     }
 
     private func persistRecoveredThirdPartyScopedPasswordIfAvailable(from accessCredentials: [AccessCredential]?, account: SyncAccount) {
@@ -768,6 +784,7 @@ public class DDGSync: DDGSyncing {
     private func removeAccount(reason: SyncError.AccountRemovedReason) throws {
         deviceInfoMigrationTask?.cancel()
         deviceInfoMigrationTask = nil
+        deviceInfoMigrationTaskID = nil
         dependencies.scheduler.isEnabled = false
         startSyncCancellable?.cancel()
         syncQueueCancellable?.cancel()
@@ -823,4 +840,5 @@ public class DDGSync: DDGSyncing {
     private var syncDidFinishCancellable: AnyCancellable?
     private var syncQueueRequestErrorCancellable: AnyCancellable?
     private var deviceInfoMigrationTask: Task<Void, Never>?
+    private var deviceInfoMigrationTaskID: UUID?
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -468,7 +468,10 @@ public class DDGSync: DDGSyncing {
 
             var didRemoveAccount = false
             do {
+                deviceInfoMigrationTask?.cancel()
+                deviceInfoMigrationTask = nil
                 try dependencies.secureStore.removeAccount()
+                deviceInfoMigrationCoordinator.reset()
                 didRemoveAccount = true
             } catch {
                 dependencies.errorEvents.fire(.failedToRemoveAccount, error: error)
@@ -732,6 +735,8 @@ public class DDGSync: DDGSyncing {
     }
 
     private func removeAccount(reason: SyncError.AccountRemovedReason) throws {
+        deviceInfoMigrationTask?.cancel()
+        deviceInfoMigrationTask = nil
         dependencies.scheduler.isEnabled = false
         startSyncCancellable?.cancel()
         syncQueueCancellable?.cancel()
@@ -746,6 +751,7 @@ public class DDGSync: DDGSyncing {
         syncQueue = nil
         authState = .inactive
         try dependencies.secureStore.removeAccount()
+        deviceInfoMigrationCoordinator.reset()
         try dependencies.keyValueStore.set(nil, forKey: Constants.syncEnabledKey)
         dependencies.errorEvents.fire(.accountRemoved(reason))
     }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -319,6 +319,25 @@ public class DDGSync: DDGSyncing {
                 keySizeInBits: SecKeyGetBlockSize(reloadedKey.publicKey) * 8)
     }
 
+    public func isDeviceInfoMigrationCompleteForDebug() throws -> Bool {
+        guard let account = try dependencies.secureStore.account() else {
+            throw SyncError.accountNotFound
+        }
+        return deviceInfoMigrationCoordinator.hasCompletedMigration(for: account)
+    }
+
+    public func runDeviceInfoMigrationForDebug() async throws {
+        guard let account = try dependencies.secureStore.account() else {
+            throw SyncError.accountNotFound
+        }
+        scheduleDeviceInfoMigration(for: account)
+        await deviceInfoMigrationTask?.value
+    }
+
+    public func resetDeviceInfoMigrationForDebug() {
+        deviceInfoMigrationCoordinator.reset()
+    }
+
     public func prepareThirdPartyRecoveryCode(purpose: String) async throws -> String {
         guard let account else {
             throw SyncError.accountNotFound

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSyncing.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSyncing.swift
@@ -289,6 +289,9 @@ public protocol DDGSyncingDebuggingSupport {
     func ensureAccountInfoKeyForDebug() async throws -> Int
     /// Refreshes the account_info key and returns metadata from a subsequent cache-first reload.
     func validateAccountInfoKeyForDebug() async throws -> (refreshedKeyID: String, reloadedKeyID: String, keySizeInBits: Int)
+    func isDeviceInfoMigrationCompleteForDebug() throws -> Bool
+    func runDeviceInfoMigrationForDebug() async throws
+    func resetDeviceInfoMigrationForDebug()
 }
 
 public extension DDGSyncingDebuggingSupport {
@@ -299,6 +302,16 @@ public extension DDGSyncingDebuggingSupport {
     func validateAccountInfoKeyForDebug() async throws -> (refreshedKeyID: String, reloadedKeyID: String, keySizeInBits: Int) {
         throw SyncError.accountNotFound
     }
+
+    func isDeviceInfoMigrationCompleteForDebug() throws -> Bool {
+        throw SyncError.accountNotFound
+    }
+
+    func runDeviceInfoMigrationForDebug() async throws {
+        throw SyncError.accountNotFound
+    }
+
+    func resetDeviceInfoMigrationForDebug() {}
 }
 
 public enum ServerEnvironment: LosslessStringConvertible {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
@@ -82,6 +82,7 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
               !Task.isCancelled else {
             return
         }
+        Logger.sync.debug("Sync-UnifiedDevices: migrating current device_info")
 
         do {
             let protectedKey = try await prepareAccountInfoProtectedKey(for: account,
@@ -114,6 +115,7 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
                 return
             }
             markMigrationComplete(for: currentAccount)
+            Logger.sync.debug("Sync-UnifiedDevices: current device_info update complete")
         } catch is CancellationError {
             return
         } catch {
@@ -121,7 +123,7 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
                 return
             }
             let errorType = String(describing: type(of: error))
-            Logger.sync.error("Failed to migrate current device info: \(errorType, privacy: .public)")
+            Logger.sync.error("Sync-UnifiedDevices: failed to migrate current device_info: \(errorType)")
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
@@ -22,6 +22,7 @@ import Persistence
 
 protocol DeviceInfoMigrationCoordinating {
     func migrateCurrentDeviceIfNeeded(for account: SyncAccount) async
+    func hasCompletedMigration(for account: SyncAccount) -> Bool
     func reset()
 }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
@@ -1,0 +1,182 @@
+//
+//  DeviceInfoMigrationCoordinator.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import os.log
+import Persistence
+
+protocol DeviceInfoMigrationCoordinating {
+    func migrateCurrentDeviceIfNeeded(for account: SyncAccount) async
+    func reset()
+}
+
+private struct DeviceInfoMigrationIdentity: Hashable {
+    let userID: String
+    let deviceID: String
+
+    init(account: SyncAccount) {
+        userID = account.userId
+        deviceID = account.deviceId
+    }
+
+    var persistedValue: String {
+        "\(userID):\(deviceID)"
+    }
+}
+
+enum DeviceInfoMigrationError: Error, Equatable {
+    case missingAccountInfoProtectedKey
+    case encryptedDeviceInfoTooLarge
+}
+
+struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
+
+    private enum Key: String {
+        case completedAccountDevice = "com.duckduckgo.sync.device-info-migration.completed-account-device"
+    }
+
+    private let accountManager: AccountManaging
+    private let scopedAccess: ScopedAccessCredentialManaging
+    private let crypter: CryptingInternal
+    private let deviceInfoCodec: DeviceInfoCoding
+    private let secureStore: SecureStoring
+    private let keyValueStore: ThrowingKeyValueStoring
+    private let canWriteUnifiedDeviceList: () -> Bool
+
+    init(accountManager: AccountManaging,
+         scopedAccess: ScopedAccessCredentialManaging,
+         crypter: CryptingInternal,
+         deviceInfoCodec: DeviceInfoCoding = DeviceInfoCodec(),
+         secureStore: SecureStoring,
+         keyValueStore: ThrowingKeyValueStoring,
+         canWriteUnifiedDeviceList: @escaping () -> Bool) {
+        self.accountManager = accountManager
+        self.scopedAccess = scopedAccess
+        self.crypter = crypter
+        self.deviceInfoCodec = deviceInfoCodec
+        self.secureStore = secureStore
+        self.keyValueStore = keyValueStore
+        self.canWriteUnifiedDeviceList = canWriteUnifiedDeviceList
+    }
+
+    func migrateCurrentDeviceIfNeeded(for account: SyncAccount) async {
+        let identity = DeviceInfoMigrationIdentity(account: account)
+        guard canWriteUnifiedDeviceList(),
+              !hasCompletedMigration(for: account),
+              currentAccount(matching: identity) != nil,
+              !Task.isCancelled else {
+            return
+        }
+
+        do {
+            let protectedKey = try await prepareAccountInfoProtectedKey(for: account,
+                                                                        identity: identity)
+            guard !Task.isCancelled,
+                  let currentAccount = currentAccount(matching: identity) else {
+                return
+            }
+
+            let encryptedDeviceInfo = try deviceInfoCodec.encrypt(
+                DeviceInfo(name: currentAccount.deviceName, type: currentAccount.deviceType),
+                using: protectedKey)
+            guard encryptedDeviceInfo.utf8.count <= DeviceInfo.maximumEncryptedLength else {
+                throw DeviceInfoMigrationError.encryptedDeviceInfoTooLarge
+            }
+
+            let update = UpdateDevices.Update(
+                id: currentAccount.deviceId,
+                name: try crypter.encryptAndBase64Encode(currentAccount.deviceName, using: currentAccount.primaryKey),
+                type: try crypter.encryptAndBase64Encode(currentAccount.deviceType, using: currentAccount.primaryKey),
+                info: encryptedDeviceInfo)
+            guard !Task.isCancelled,
+                  isCurrentAccountSnapshot(currentAccount, identity: identity) else {
+                return
+            }
+            _ = try await accountManager.updateDevice(update, for: currentAccount)
+
+            guard !Task.isCancelled,
+                  isCurrentAccountSnapshot(currentAccount, identity: identity) else {
+                return
+            }
+            markMigrationComplete(for: currentAccount)
+        } catch is CancellationError {
+            return
+        } catch {
+            guard !Task.isCancelled else {
+                return
+            }
+            let errorType = String(describing: type(of: error))
+            Logger.sync.error("Failed to migrate current device info: \(errorType, privacy: .public)")
+        }
+    }
+
+    func reset() {
+        try? keyValueStore.removeObject(forKey: Key.completedAccountDevice.rawValue)
+    }
+
+    func hasCompletedMigration(for account: SyncAccount) -> Bool {
+        guard let storedValue = try? keyValueStore.object(forKey: Key.completedAccountDevice.rawValue) else {
+            return false
+        }
+        return storedValue as? String == DeviceInfoMigrationIdentity(account: account).persistedValue
+    }
+
+    private func markMigrationComplete(for account: SyncAccount) {
+        try? keyValueStore.set(DeviceInfoMigrationIdentity(account: account).persistedValue,
+                               forKey: Key.completedAccountDevice.rawValue)
+    }
+
+    private func prepareAccountInfoProtectedKey(for account: SyncAccount,
+                                                identity: DeviceInfoMigrationIdentity) async throws -> ProtectedKey {
+        let protectedKeys = try await scopedAccess.ensureAccountInfoProtectedKeys(for: account)
+        guard let protectedKey = protectedKeys.first(where: { $0.purpose == ProtectedKeyPurpose.accountInfo }) else {
+            throw DeviceInfoMigrationError.missingAccountInfoProtectedKey
+        }
+        guard !Task.isCancelled,
+              currentAccount(matching: identity) != nil else {
+            throw CancellationError()
+        }
+        return protectedKey
+    }
+
+    private func currentAccount(matching identity: DeviceInfoMigrationIdentity) -> SyncAccount? {
+        do {
+            guard let currentAccount = try secureStore.account() else {
+                return nil
+            }
+            guard DeviceInfoMigrationIdentity(account: currentAccount) == identity else {
+                return nil
+            }
+            return currentAccount
+        } catch {
+            return nil
+        }
+    }
+
+    private func isCurrentAccountSnapshot(_ account: SyncAccount,
+                                          identity: DeviceInfoMigrationIdentity) -> Bool {
+        guard let currentAccount = currentAccount(matching: identity) else {
+            return false
+        }
+        return currentAccount.deviceName == account.deviceName
+            && currentAccount.deviceType == account.deviceType
+            && currentAccount.primaryKey == account.primaryKey
+            && currentAccount.secretKey == account.secretKey
+            && currentAccount.token == account.token
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -154,6 +154,15 @@ struct ProductionDependencies: SyncDependencies {
                                             account: account)
     }
 
+    func createDeviceInfoMigrationCoordinator() -> DeviceInfoMigrationCoordinating {
+        DeviceInfoMigrationCoordinator(accountManager: account,
+                                       scopedAccess: scopedAccess,
+                                       crypter: crypter,
+                                       secureStore: secureStore,
+                                       keyValueStore: keyValueStore,
+                                       canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() })
+    }
+
     func createTokenRescope() -> TokenRescoping {
         return TokenRescope(api: api, endpoints: endpoints)
     }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
@@ -53,6 +53,7 @@ protocol SyncDependencies: SyncDependenciesDebuggingSupport {
     func createExchangeRecoveryKeyTransmitter(exchangeMessage: ExchangeMessage) throws -> ExchangeRecoveryKeyTransmitting
     func createPairingV2MessageExchanger() -> PairingV2MessageExchanging
     func createThirdPartyAccountUpgradeCoordinator() -> ThirdPartyAccountUpgradeCoordinating
+    func createDeviceInfoMigrationCoordinator() -> DeviceInfoMigrationCoordinating
     func createTokenRescope() -> TokenRescoping
     func createAIChats() -> AIChatsHandling
 }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncLifecycleTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncLifecycleTests.swift
@@ -72,6 +72,43 @@ final class DDGSyncLifecycleTests: XCTestCase {
         XCTAssertEqual(mockErrorHandler.handledErrors, [])
     }
 
+    func testWhenInitializingActiveAccountThenCurrentDeviceMigrationIsScheduled() async throws {
+        secureStorageStub.theAccount = .mock
+        try dependencies.keyValueStore.set(true, forKey: DDGSync.Constants.syncEnabledKey)
+        let migrationScheduled = expectation(description: "Device info migration scheduled")
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.migrateCurrentDeviceHandler = {
+            migrationScheduled.fulfill()
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        syncService.initializeIfNeeded()
+        await fulfillment(of: [migrationScheduled], timeout: 1)
+
+        let migrationCall = try XCTUnwrap(migrationCoordinator.calls.first)
+        XCTAssertEqual(migrationCall.account.deviceId, SyncAccount.mock.deviceId)
+    }
+
+    func testWhenInitializingInactiveAccountThenCurrentDeviceMigrationIsNotScheduled() async throws {
+        secureStorageStub.theAccount = .mock.updatingState(.inactive)
+        try dependencies.keyValueStore.set(true, forKey: DDGSync.Constants.syncEnabledKey)
+        let migrationScheduled = expectation(description: "Device info migration not scheduled")
+        migrationScheduled.isInverted = true
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.migrateCurrentDeviceHandler = {
+            migrationScheduled.fulfill()
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        syncService.initializeIfNeeded()
+        await fulfillment(of: [migrationScheduled], timeout: 0.1)
+
+        XCTAssertTrue(migrationCoordinator.calls.isEmpty)
+        XCTAssertEqual(syncService.authState, .inactive)
+    }
+
     func testWhenInitializingAndAfterReinstallThenStateIsInactive() {
         secureStorageStub.theAccount = .mock
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncLifecycleTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncLifecycleTests.swift
@@ -111,12 +111,15 @@ final class DDGSyncLifecycleTests: XCTestCase {
 
     func testWhenInitializingAndAfterReinstallThenStateIsInactive() {
         secureStorageStub.theAccount = .mock
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
 
         let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
         XCTAssertEqual(syncService.authState, .initializing)
         syncService.initializeIfNeeded()
         XCTAssertEqual(syncService.authState, .inactive)
         XCTAssertNil(secureStorageStub.theAccount)
+        XCTAssertEqual(migrationCoordinator.resetCallCount, 1)
         XCTAssertEqual(mockErrorHandler.handledErrors, [.accountRemoved(.syncEnabledNotSetOnKeyValueStore)])
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -764,6 +764,47 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(scopedAccess.recoverScopedPasswordCalls.count, 1)
     }
 
+    func testWhenRenamingDeviceDuringMigrationThenMigrationIsCancelledBeforeRenameAndRescheduled() async throws {
+        let migrationStarted = expectation(description: "Device info migration started")
+        let migrationFinished = expectation(description: "Device info migration finished")
+        let migrationRescheduled = expectation(description: "Device info migration rescheduled")
+        let (migrationCancellationGate, migrationCancellationContinuation) = AsyncStream<Void>.makeStream()
+        defer { migrationCancellationContinuation.finish() }
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.migrateCurrentDeviceHandler = {
+            guard migrationCoordinator.calls.count == 1 else {
+                migrationRescheduled.fulfill()
+                return
+            }
+            migrationStarted.fulfill()
+            for await _ in migrationCancellationGate {}
+            migrationFinished.fulfill()
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let renamedAccount = SyncAccount(
+            deviceId: SyncAccount.mock.deviceId,
+            deviceName: "Renamed Device",
+            deviceType: SyncAccount.mock.deviceType,
+            userId: SyncAccount.mock.userId,
+            primaryKey: SyncAccount.mock.primaryKey,
+            secretKey: SyncAccount.mock.secretKey,
+            token: SyncAccount.mock.token,
+            state: .active)
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        accountManager.refreshTokenStub = LoginResult(account: renamedAccount, devices: [.mock])
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+        syncService.initializeIfNeeded()
+        await fulfillment(of: [migrationStarted], timeout: 1)
+
+        _ = try await syncService.updateDeviceName(renamedAccount.deviceName)
+        await fulfillment(of: [migrationFinished, migrationRescheduled], timeout: 1)
+
+        XCTAssertTrue(accountManager.refreshTokenCalled)
+        XCTAssertEqual((dependencies.secureStore as? SecureStorageStub)?.theAccount?.deviceName, renamedAccount.deviceName)
+        XCTAssertEqual(migrationCoordinator.calls.count, 2)
+        XCTAssertEqual(migrationCoordinator.calls.last?.account.deviceName, renamedAccount.deviceName)
+    }
+
     func testWhenRefreshResponseContainsRecoverableScopedPasswordThenScopedPasswordIsCached() async throws {
         let scopedPassword = Data(repeating: 7, count: 32)
         (dependencies.account as? AccountManagingMock)?.refreshTokenStub = LoginResult(

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -644,62 +644,21 @@ final class DDGSyncTests: XCTestCase {
                                         deviceType: "iOS")
         await fulfillment(of: [migrationScheduled], timeout: 1)
 
-        let cachedProtectedKeysData = try XCTUnwrap((dependencies.secureStore as? SecureStorageStub)?.theProtectedKeysData)
-        let cachedProtectedKeys = try JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: cachedProtectedKeysData)
-
-        XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.map(\.userId), [SyncAccount.mock.userId])
-        XCTAssertEqual(Set(cachedProtectedKeys.map(\.kid)), Set(["ai-chat-key", "account-info-key"]))
-        XCTAssertEqual(cachedProtectedKeys.count, 2)
         let migrationCall = try XCTUnwrap(migrationCoordinator.calls.first)
         XCTAssertEqual(migrationCall.account.deviceId, SyncAccount.mock.deviceId)
     }
 
-    func testWhenUnifiedDeviceListWritingIsDisabledThenLoginDoesNotEnsureAccountInfoKeys() async throws {
-        dependencies.canWriteUnifiedDeviceList = { false }
-        (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil
-        let loginKey = makeProtectedKey(kid: "ai-chat-key", encryptedWith: "ddg", purpose: "ai_chats")
-        (dependencies.account as? AccountManagingMock)?.loginStub = LoginResult(account: .mock,
-                                                                                devices: [],
-                                                                                keys: [loginKey])
-        let scopedAccess = try XCTUnwrap(dependencies.scopedAccess as? ScopedAccessCredentialManagingMock)
-        scopedAccess.ensureAccountInfoProtectedKeysStub = [
-            makeProtectedKey(kid: "account-info-key", encryptedWith: "ddg", purpose: "account_info")
-        ]
+    func testWhenDebugMigrationIsResetThenItCanRunAgain() async throws {
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
         let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
 
-        _ = try await syncService.login(.init(userId: "userId", primaryKey: Data()),
-                                        deviceName: "iPhone",
-                                        deviceType: "iOS")
+        try await syncService.runDeviceInfoMigrationForDebug()
+        syncService.resetDeviceInfoMigrationForDebug()
+        try await syncService.runDeviceInfoMigrationForDebug()
 
-        let cachedProtectedKeysData = try XCTUnwrap((dependencies.secureStore as? SecureStorageStub)?.theProtectedKeysData)
-        let cachedProtectedKeys = try JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: cachedProtectedKeysData)
-
-        XCTAssertTrue(scopedAccess.ensureAccountInfoProtectedKeysCalls.isEmpty)
-        XCTAssertEqual(cachedProtectedKeys.map(\.kid), ["ai-chat-key"])
-    }
-
-    func testWhenEnsuringAccountInfoKeysFailsThenLoginStillSucceedsAndResponseKeysAreCached() async throws {
-        dependencies.canWriteUnifiedDeviceList = { true }
-        (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil
-        let loginKey = makeProtectedKey(kid: "ai-chat-key", encryptedWith: "ddg", purpose: "ai_chats")
-        (dependencies.account as? AccountManagingMock)?.loginStub = LoginResult(account: .mock,
-                                                                                devices: [.mock],
-                                                                                keys: [loginKey])
-        let scopedAccess = try XCTUnwrap(dependencies.scopedAccess as? ScopedAccessCredentialManagingMock)
-        scopedAccess.ensureAccountInfoProtectedKeysError = SyncError.invalidDataInResponse("account_info registration failed")
-        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
-
-        let devices = try await syncService.login(.init(userId: "userId", primaryKey: Data()),
-                                                  deviceName: "iPhone",
-                                                  deviceType: "iOS")
-
-        let cachedProtectedKeysData = try XCTUnwrap((dependencies.secureStore as? SecureStorageStub)?.theProtectedKeysData)
-        let cachedProtectedKeys = try JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: cachedProtectedKeysData)
-
-        XCTAssertEqual(devices.map(\.id), [RegisteredDevice.mock.id])
-        XCTAssertNotNil((dependencies.secureStore as? SecureStorageStub)?.theAccount)
-        XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.count, 1)
-        XCTAssertEqual(cachedProtectedKeys.map(\.kid), ["ai-chat-key"])
+        XCTAssertEqual(migrationCoordinator.calls.count, 2)
+        XCTAssertEqual(migrationCoordinator.resetCallCount, 1)
     }
 
     func testWhenScopedPasswordRecoveryFailsDuringLoginThenNativeLoginStillSucceeds() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -724,6 +724,7 @@ final class DDGSyncTests: XCTestCase {
     }
 
     func testWhenRenamingDeviceDuringMigrationThenMigrationIsCancelledBeforeRenameAndRescheduled() async throws {
+        dependencies.canWriteUnifiedDeviceList = { true }
         let migrationStarted = expectation(description: "Device info migration started")
         let migrationFinished = expectation(description: "Device info migration finished")
         let migrationRescheduled = expectation(description: "Device info migration rescheduled")
@@ -762,6 +763,54 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual((dependencies.secureStore as? SecureStorageStub)?.theAccount?.deviceName, renamedAccount.deviceName)
         XCTAssertEqual(migrationCoordinator.calls.count, 2)
         XCTAssertEqual(migrationCoordinator.calls.last?.account.deviceName, renamedAccount.deviceName)
+        XCTAssertEqual(migrationCoordinator.resetCallCount, 1)
+    }
+
+    func testWhenRenamingDeviceWithUnifiedWritesDisabledThenMigrationStateIsPreserved() async throws {
+        dependencies.canWriteUnifiedDeviceList = { false }
+        let migrationScheduled = expectation(description: "Device info migration scheduled")
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.migrateCurrentDeviceHandler = {
+            migrationScheduled.fulfill()
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let renamedAccount = SyncAccount(
+            deviceId: SyncAccount.mock.deviceId,
+            deviceName: "Renamed Device",
+            deviceType: SyncAccount.mock.deviceType,
+            userId: SyncAccount.mock.userId,
+            primaryKey: SyncAccount.mock.primaryKey,
+            secretKey: SyncAccount.mock.secretKey,
+            token: SyncAccount.mock.token,
+            state: .active)
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        accountManager.refreshTokenStub = LoginResult(account: renamedAccount, devices: [.mock])
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        _ = try await syncService.updateDeviceName(renamedAccount.deviceName)
+        await fulfillment(of: [migrationScheduled], timeout: 1)
+
+        XCTAssertEqual(migrationCoordinator.resetCallCount, 0)
+    }
+
+    func testWhenRenamingDeviceFailsWithUnifiedWritesEnabledThenMigrationStateIsPreserved() async throws {
+        dependencies.canWriteUnifiedDeviceList = { true }
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        accountManager.refreshTokenError = SyncError.noResponseBody
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        do {
+            _ = try await syncService.updateDeviceName("Renamed Device")
+            XCTFail("Expected device rename to fail")
+        } catch SyncError.noResponseBody {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(migrationCoordinator.resetCallCount, 0)
+        XCTAssertTrue(migrationCoordinator.calls.isEmpty)
     }
 
     func testWhenRefreshResponseContainsRecoverableScopedPasswordThenScopedPasswordIsCached() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -787,6 +787,8 @@ final class DDGSyncTests: XCTestCase {
         (dependencies.secureStore as? SecureStorageStub)?.theAccount = .mock
         (dependencies.secureStore as? SecureStorageStub)?.theScopedPassword = Data(repeating: 6, count: 32)
         (dependencies.secureStore as? SecureStorageStub)?.theProtectedKeysData = protectedKeysData
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
         let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
 
         try await syncService.disconnect()
@@ -794,6 +796,7 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertNil((dependencies.secureStore as? SecureStorageStub)?.theAccount)
         XCTAssertNil((dependencies.secureStore as? SecureStorageStub)?.theScopedPassword)
         XCTAssertNil((dependencies.secureStore as? SecureStorageStub)?.theProtectedKeysData)
+        XCTAssertEqual(migrationCoordinator.resetCallCount, 1)
     }
 
     func testWhenPreparingThirdPartyRecoveryCodeAndCredentialExistsThenRecoveredScopedPasswordIsUsed() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -611,21 +611,38 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(cachedProtectedKeys.count, 3)
     }
 
-    func testWhenUnifiedDeviceListWritingIsEnabledThenLoginEnsuresAndCachesAccountInfoKeys() async throws {
-        dependencies.canWriteUnifiedDeviceList = { true }
+    func testWhenAccountCreationSucceedsThenCurrentDeviceMigrationIsScheduled() async throws {
         (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil
-        let loginKey = makeProtectedKey(kid: "ai-chat-key", encryptedWith: "ddg", purpose: "ai_chats")
-        let accountInfoKey = makeProtectedKey(kid: "account-info-key", encryptedWith: "ddg", purpose: "account_info")
-        (dependencies.account as? AccountManagingMock)?.loginStub = LoginResult(account: .mock,
-                                                                                devices: [],
-                                                                                keys: [loginKey])
-        let scopedAccess = try XCTUnwrap(dependencies.scopedAccess as? ScopedAccessCredentialManagingMock)
-        scopedAccess.ensureAccountInfoProtectedKeysStub = [accountInfoKey]
+        let migrationScheduled = expectation(description: "Device info migration scheduled")
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.migrateCurrentDeviceHandler = {
+            migrationScheduled.fulfill()
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        try await syncService.createAccount(deviceName: "iPhone", deviceType: "iOS")
+        await fulfillment(of: [migrationScheduled], timeout: 1)
+
+        let migrationCall = try XCTUnwrap(migrationCoordinator.calls.first)
+        XCTAssertEqual(migrationCall.account.deviceId, SyncAccount.mock.deviceId)
+    }
+
+    func testWhenLoginSucceedsThenCurrentDeviceMigrationIsScheduled() async throws {
+        (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil
+        (dependencies.account as? AccountManagingMock)?.loginStub = LoginResult(account: .mock, devices: [])
+        let migrationScheduled = expectation(description: "Device info migration scheduled")
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.migrateCurrentDeviceHandler = {
+            migrationScheduled.fulfill()
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
         let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
 
         _ = try await syncService.login(.init(userId: "userId", primaryKey: Data()),
                                         deviceName: "iPhone",
                                         deviceType: "iOS")
+        await fulfillment(of: [migrationScheduled], timeout: 1)
 
         let cachedProtectedKeysData = try XCTUnwrap((dependencies.secureStore as? SecureStorageStub)?.theProtectedKeysData)
         let cachedProtectedKeys = try JSONDecoder.snakeCaseKeys.decode([ProtectedKey].self, from: cachedProtectedKeysData)
@@ -633,6 +650,8 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.map(\.userId), [SyncAccount.mock.userId])
         XCTAssertEqual(Set(cachedProtectedKeys.map(\.kid)), Set(["ai-chat-key", "account-info-key"]))
         XCTAssertEqual(cachedProtectedKeys.count, 2)
+        let migrationCall = try XCTUnwrap(migrationCoordinator.calls.first)
+        XCTAssertEqual(migrationCall.account.deviceId, SyncAccount.mock.deviceId)
     }
 
     func testWhenUnifiedDeviceListWritingIsDisabledThenLoginDoesNotEnsureAccountInfoKeys() async throws {
@@ -922,6 +941,27 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(upgradeCoordinator.upgradeThirdPartyAccountCalls.map(\.recoveryCode), ["third-party-recovery-code"])
         XCTAssertEqual(devices.map(\.id), [RegisteredDevice.mock.id])
         XCTAssertEqual((dependencies.secureStore as? SecureStorageStub)?.theAccount?.userId, SyncAccount.mock.userId)
+    }
+
+    func testWhenThirdPartyUpgradeSucceedsThenCurrentDeviceMigrationIsScheduled() async throws {
+        (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil
+        let upgradeCoordinator = ThirdPartyAccountUpgradeCoordinatingMock()
+        dependencies.createThirdPartyAccountUpgradeCoordinatorStub = upgradeCoordinator
+        let migrationScheduled = expectation(description: "Device info migration scheduled")
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.migrateCurrentDeviceHandler = {
+            migrationScheduled.fulfill()
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        _ = try await syncService.upgradeThirdPartyAccountToDefaultCredential("third-party-recovery-code",
+                                                                             deviceName: "Mac",
+                                                                             deviceType: "desktop")
+        await fulfillment(of: [migrationScheduled], timeout: 1)
+
+        let migrationCall = try XCTUnwrap(migrationCoordinator.calls.first)
+        XCTAssertEqual(migrationCall.account.deviceId, SyncAccount.mock.deviceId)
     }
 
     func testWhenGeneratingThirdPartyRecoveryCodeThenPayloadMatchesV2Spec() throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
@@ -1,0 +1,317 @@
+//
+//  DeviceInfoMigrationCoordinatorTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import PersistenceTestingUtils
+import XCTest
+
+@testable import DDGSync
+
+final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
+
+    private var accountManager: AccountManagingMock!
+    private var scopedAccess: ScopedAccessCredentialManagingMock!
+    private var deviceInfoCodec: DeviceInfoMigrationCodingMock!
+    private var secureStore: SecureStorageStub!
+    private var keyValueStore: MockKeyValueFileStore!
+    private var coordinator: DeviceInfoMigrationCoordinator!
+    private var canWriteUnifiedDeviceList: Bool!
+    private var accountInfoProtectedKey: ProtectedKey!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        accountManager = AccountManagingMock()
+        scopedAccess = ScopedAccessCredentialManagingMock()
+        deviceInfoCodec = DeviceInfoMigrationCodingMock()
+        secureStore = SecureStorageStub()
+        secureStore.theAccount = .mock
+        keyValueStore = try MockKeyValueFileStore()
+        canWriteUnifiedDeviceList = true
+        accountInfoProtectedKey = ProtectedKey(
+            kid: "account-info-key",
+            encryptedPrivateKey: "encrypted-private-key",
+            publicKey: .mock,
+            encryptedWith: SyncCredentialID.defaultCredential,
+            purpose: ProtectedKeyPurpose.accountInfo)
+        scopedAccess.ensureAccountInfoProtectedKeysStub = [accountInfoProtectedKey]
+        coordinator = makeCoordinator()
+    }
+
+    override func tearDown() {
+        accountManager = nil
+        scopedAccess = nil
+        deviceInfoCodec = nil
+        secureStore = nil
+        keyValueStore = nil
+        coordinator = nil
+        canWriteUnifiedDeviceList = nil
+        accountInfoProtectedKey = nil
+
+        super.tearDown()
+    }
+
+    func testWhenWriteFlagIsDisabledThenMigrationIsSkipped() async {
+        canWriteUnifiedDeviceList = false
+
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+
+        XCTAssertTrue(scopedAccess.ensureAccountInfoProtectedKeysCalls.isEmpty)
+        XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+    }
+
+    func testWhenMigrationSucceedsThenCurrentDeviceIsPatchedInBothFormatsAndMarkedComplete() async throws {
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+
+        XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.map(\.deviceId), [SyncAccount.mock.deviceId])
+        XCTAssertEqual(deviceInfoCodec.encryptCalls.map(\.deviceInfo), [
+            DeviceInfo(name: SyncAccount.mock.deviceName, type: SyncAccount.mock.deviceType)
+        ])
+        let call = try XCTUnwrap(accountManager.updateDeviceCalls.first)
+        XCTAssertEqual(call.account.deviceId, SyncAccount.mock.deviceId)
+        XCTAssertEqual(call.update.id, SyncAccount.mock.deviceId)
+        XCTAssertEqual(call.update.name, "encrypted_\(SyncAccount.mock.deviceName)")
+        XCTAssertEqual(call.update.type, "encrypted_\(SyncAccount.mock.deviceType)")
+        XCTAssertEqual(call.update.info, deviceInfoCodec.encryptStub)
+        XCTAssertTrue(coordinator.hasCompletedMigration(for: .mock))
+    }
+
+    func testWhenMigrationRunsTwiceThenCurrentDeviceIsPatchedOnce() async {
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+
+        XCTAssertEqual(accountManager.updateDeviceCalls.count, 1)
+        XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.count, 1)
+    }
+
+    func testWhenMigrationStateIsResetThenCurrentDeviceCanMigrateAgain() async {
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+        coordinator.reset()
+
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+
+        XCTAssertEqual(accountManager.updateDeviceCalls.count, 2)
+    }
+
+    func testWhenAccountIsRemovedDuringKeyPreparationThenMigrationStops() async throws {
+        let keyPreparationStarted = expectation(description: "Key preparation started")
+        let gate = AsyncGate()
+        let accountInfoProtectedKey = try XCTUnwrap(accountInfoProtectedKey)
+        scopedAccess.ensureAccountInfoProtectedKeysHandler = { [accountInfoProtectedKey] _ in
+            keyPreparationStarted.fulfill()
+            await gate.wait()
+            return [accountInfoProtectedKey]
+        }
+        let migration = Task {
+            await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+        }
+        await fulfillment(of: [keyPreparationStarted], timeout: 1)
+
+        secureStore.theAccount = nil
+        await gate.open()
+        await migration.value
+
+        XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+    }
+
+    func testWhenAccountIsRemovedWhilePatchIsInFlightThenMigrationIsNotMarkedComplete() async throws {
+        let patchStarted = expectation(description: "Patch started")
+        let gate = AsyncGate()
+        accountManager.updateDeviceHandler = { _, _ in
+            patchStarted.fulfill()
+            await gate.wait()
+            return UpdateDevices.Result(devices: [], devicesV2: [])
+        }
+        let migration = Task {
+            await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+        }
+        await fulfillment(of: [patchStarted], timeout: 1)
+
+        try secureStore.removeAccount()
+        coordinator.reset()
+        await gate.open()
+        await migration.value
+
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+    }
+
+    func testWhenDeviceNameChangesDuringKeyPreparationThenLatestNameIsMigrated() async throws {
+        let keyPreparationStarted = expectation(description: "Key preparation started")
+        let gate = AsyncGate()
+        let accountInfoProtectedKey = try XCTUnwrap(accountInfoProtectedKey)
+        scopedAccess.ensureAccountInfoProtectedKeysHandler = { [accountInfoProtectedKey] _ in
+            keyPreparationStarted.fulfill()
+            await gate.wait()
+            return [accountInfoProtectedKey]
+        }
+        let migration = Task {
+            await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+        }
+        await fulfillment(of: [keyPreparationStarted], timeout: 1)
+        let renamedAccount = SyncAccount(
+            deviceId: SyncAccount.mock.deviceId,
+            deviceName: "Renamed Device",
+            deviceType: SyncAccount.mock.deviceType,
+            userId: SyncAccount.mock.userId,
+            primaryKey: SyncAccount.mock.primaryKey,
+            secretKey: SyncAccount.mock.secretKey,
+            token: SyncAccount.mock.token,
+            state: .active)
+        secureStore.theAccount = renamedAccount
+
+        await gate.open()
+        await migration.value
+
+        let update = try XCTUnwrap(accountManager.updateDeviceCalls.first?.update)
+        XCTAssertEqual(update.name, "encrypted_Renamed Device")
+        XCTAssertEqual(deviceInfoCodec.encryptCalls.first?.deviceInfo.name, renamedAccount.deviceName)
+        XCTAssertTrue(coordinator.hasCompletedMigration(for: renamedAccount))
+    }
+
+    func testWhenEnsuringAccountInfoKeysFailsThenLaterAttemptRetries() async {
+        scopedAccess.ensureAccountInfoProtectedKeysError = TestError.expected
+
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+
+        XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+
+        scopedAccess.ensureAccountInfoProtectedKeysError = nil
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+
+        XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.count, 2)
+        XCTAssertEqual(accountManager.updateDeviceCalls.count, 1)
+        XCTAssertTrue(coordinator.hasCompletedMigration(for: .mock))
+    }
+
+    func testWhenPatchFailsThenLaterAttemptRetries() async {
+        accountManager.updateDeviceError = SyncError.unexpectedStatusCode(500)
+
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+
+        XCTAssertEqual(accountManager.updateDeviceCalls.count, 1)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+
+        accountManager.updateDeviceError = nil
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+
+        XCTAssertEqual(accountManager.updateDeviceCalls.count, 2)
+        XCTAssertTrue(coordinator.hasCompletedMigration(for: .mock))
+    }
+
+    func testWhenPatchIsUnauthorizedThenAccountIsPreservedAndMigrationIsNotMarkedComplete() async {
+        accountManager.updateDeviceError = SyncError.unexpectedStatusCode(401)
+
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+
+        XCTAssertNotNil(secureStore.theAccount)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+    }
+
+    func testWhenEncryptedDeviceInfoExceedsServerLimitThenMigrationIsNotPatchedOrMarkedComplete() async {
+        deviceInfoCodec.encryptStub = String(repeating: "a", count: DeviceInfo.maximumEncryptedLength + 1)
+
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+
+        XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+    }
+
+    func testWhenAccountChangesThenCompletedMigrationDoesNotSkipNewDevice() async {
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+        let replacementAccount = SyncAccount(
+            deviceId: "replacement-device",
+            deviceName: SyncAccount.mock.deviceName,
+            deviceType: SyncAccount.mock.deviceType,
+            userId: SyncAccount.mock.userId,
+            primaryKey: SyncAccount.mock.primaryKey,
+            secretKey: SyncAccount.mock.secretKey,
+            token: SyncAccount.mock.token,
+            state: .active)
+        secureStore.theAccount = replacementAccount
+
+        await coordinator.migrateCurrentDeviceIfNeeded(for: replacementAccount)
+
+        XCTAssertEqual(accountManager.updateDeviceCalls.map(\.update.id), [SyncAccount.mock.deviceId, replacementAccount.deviceId])
+        XCTAssertTrue(coordinator.hasCompletedMigration(for: replacementAccount))
+    }
+
+    private func makeCoordinator() -> DeviceInfoMigrationCoordinator {
+        DeviceInfoMigrationCoordinator(
+            accountManager: accountManager,
+            scopedAccess: scopedAccess,
+            crypter: CryptingMock(),
+            deviceInfoCodec: deviceInfoCodec,
+            secureStore: secureStore,
+            keyValueStore: keyValueStore,
+            canWriteUnifiedDeviceList: { [weak self] in self?.canWriteUnifiedDeviceList == true })
+    }
+}
+
+private enum TestError: Error {
+    case expected
+}
+
+private actor AsyncGate {
+    private var isOpen = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func open() {
+        isOpen = true
+        continuations.forEach { $0.resume() }
+        continuations.removeAll()
+    }
+}
+
+private final class DeviceInfoMigrationCodingMock: DeviceInfoCoding {
+
+    struct EncryptCall {
+        let deviceInfo: DeviceInfo
+        let keyID: String
+    }
+
+    private(set) var encryptCalls: [EncryptCall] = []
+    var encryptStub = "encrypted-device-info"
+    var encryptError: Error?
+
+    func encrypt(_ deviceInfo: DeviceInfo, using protectedKey: ProtectedKey) throws -> String {
+        encryptCalls.append(EncryptCall(deviceInfo: deviceInfo, keyID: protectedKey.kid))
+        if let encryptError {
+            throw encryptError
+        }
+        return encryptStub
+    }
+
+    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKeyMaterial) throws -> String {
+        throw DeviceInfoCodecError.invalidProtectedKey
+    }
+
+    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKeyMaterial) throws -> DeviceInfo {
+        throw DeviceInfoCodecError.invalidPayload
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
@@ -16,7 +16,7 @@
 //  limitations under the License.
 //
 
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 
 @testable import DDGSync

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
@@ -307,11 +307,11 @@ private final class DeviceInfoMigrationCodingMock: DeviceInfoCoding {
         return encryptStub
     }
 
-    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKeyMaterial) throws -> String {
+    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKey) throws -> String {
         throw DeviceInfoCodecError.invalidProtectedKey
     }
 
-    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKeyMaterial) throws -> DeviceInfo {
+    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKey) throws -> DeviceInfo {
         throw DeviceInfoCodecError.invalidPayload
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
@@ -99,13 +99,27 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.count, 1)
     }
 
-    func testWhenMigrationStateIsResetThenCurrentDeviceCanMigrateAgain() async {
+    func testWhenCompletedMigrationIsResetAfterRenameThenCurrentDeviceIsPatchedAgainWithLatestName() async throws {
         await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+        let renamedAccount = SyncAccount(
+            deviceId: SyncAccount.mock.deviceId,
+            deviceName: "Renamed Device",
+            deviceType: SyncAccount.mock.deviceType,
+            userId: SyncAccount.mock.userId,
+            primaryKey: SyncAccount.mock.primaryKey,
+            secretKey: SyncAccount.mock.secretKey,
+            token: SyncAccount.mock.token,
+            state: .active)
+        secureStore.theAccount = renamedAccount
         coordinator.reset()
 
-        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+        await coordinator.migrateCurrentDeviceIfNeeded(for: renamedAccount)
 
         XCTAssertEqual(accountManager.updateDeviceCalls.count, 2)
+        let latestUpdate = try XCTUnwrap(accountManager.updateDeviceCalls.last?.update)
+        XCTAssertEqual(latestUpdate.name, "encrypted_\(renamedAccount.deviceName)")
+        XCTAssertEqual(deviceInfoCodec.encryptCalls.last?.deviceInfo.name, renamedAccount.deviceName)
+        XCTAssertTrue(coordinator.hasCompletedMigration(for: renamedAccount))
     }
 
     func testWhenAccountIsRemovedDuringKeyPreparationThenMigrationStops() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -565,6 +565,7 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
     private let lock = NSLock()
     private var recordedCalls: [Call] = []
     private var recordedResetCallCount = 0
+    var hasCompletedMigrationStub = false
     var calls: [Call] {
         lock.lock()
         defer { lock.unlock() }
@@ -580,6 +581,10 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
     func migrateCurrentDeviceIfNeeded(for account: SyncAccount) async {
         let handler = record(Call(account: account))
         await handler?()
+    }
+
+    func hasCompletedMigration(for account: SyncAccount) -> Bool {
+        hasCompletedMigrationStub
     }
 
     func reset() {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -119,9 +119,13 @@ class AccountManagingMock: AccountManaging {
     var updateDeviceCalls: [(update: UpdateDevices.Update, account: SyncAccount)] = []
     var updateDeviceStub: UpdateDevices.Result?
     var updateDeviceError: Error?
+    var updateDeviceHandler: ((UpdateDevices.Update, SyncAccount) async throws -> UpdateDevices.Result)?
     func updateDevice(_ update: UpdateDevices.Update,
                       for account: SyncAccount) async throws -> UpdateDevices.Result {
         updateDeviceCalls.append((update: update, account: account))
+        if let updateDeviceHandler {
+            return try await updateDeviceHandler(update, account)
+        }
         if let updateDeviceError {
             throw updateDeviceError
         }
@@ -324,6 +328,11 @@ final class MockSyncDependencies: SyncDependencies, SyncDependenciesDebuggingSup
         createThirdPartyAccountUpgradeCoordinatorStub ?? ThirdPartyAccountUpgradeCoordinatingMock()
     }
 
+    var createDeviceInfoMigrationCoordinatorStub: DeviceInfoMigrationCoordinating?
+    func createDeviceInfoMigrationCoordinator() -> DeviceInfoMigrationCoordinating {
+        createDeviceInfoMigrationCoordinatorStub ?? DeviceInfoMigrationCoordinatingMock()
+    }
+
     func updateServerEnvironment(_ serverEnvironment: ServerEnvironment) {}
 
     var createTokenRescopeStub: TokenRescoping?
@@ -460,8 +469,12 @@ final class ScopedAccessCredentialManagingMock: ScopedAccessCredentialManaging {
     var ensureAccountInfoProtectedKeysCalls: [SyncAccount] = []
     var ensureAccountInfoProtectedKeysStub: [ProtectedKey] = []
     var ensureAccountInfoProtectedKeysError: Error?
+    var ensureAccountInfoProtectedKeysHandler: ((SyncAccount) async throws -> [ProtectedKey])?
     func ensureAccountInfoProtectedKeys(for account: SyncAccount) async throws -> [ProtectedKey] {
         ensureAccountInfoProtectedKeysCalls.append(account)
+        if let ensureAccountInfoProtectedKeysHandler {
+            return try await ensureAccountInfoProtectedKeysHandler(account)
+        }
         if let ensureAccountInfoProtectedKeysError {
             throw ensureAccountInfoProtectedKeysError
         }
@@ -540,6 +553,47 @@ final class ThirdPartyAccountUpgradeCoordinatingMock: ThirdPartyAccountUpgradeCo
             throw upgradeThirdPartyAccountError
         }
         return upgradeThirdPartyAccountStub
+    }
+}
+
+final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating {
+
+    struct Call {
+        let account: SyncAccount
+    }
+
+    private let lock = NSLock()
+    private var recordedCalls: [Call] = []
+    private var recordedResetCallCount = 0
+    var calls: [Call] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedCalls
+    }
+    var resetCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedResetCallCount
+    }
+    var migrateCurrentDeviceHandler: (() async -> Void)?
+
+    func migrateCurrentDeviceIfNeeded(for account: SyncAccount) async {
+        let handler = record(Call(account: account))
+        await handler?()
+    }
+
+    func reset() {
+        lock.lock()
+        recordedResetCallCount += 1
+        lock.unlock()
+    }
+
+    private func record(_ call: Call) -> (() async -> Void)? {
+        lock.lock()
+        recordedCalls.append(call)
+        let handler = migrateCurrentDeviceHandler
+        lock.unlock()
+        return handler
     }
 }
 

--- a/iOS/DuckDuckGo/SyncDebugViewController.swift
+++ b/iOS/DuckDuckGo/SyncDebugViewController.swift
@@ -28,6 +28,8 @@ class SyncDebugViewController: UITableViewController {
 
     private let titles = [
         Sections.info: "Info",
+        Sections.unifiedDevices: "Unified Devices",
+        Sections.testActions: "Test Actions",
         Sections.models: "Models",
         Sections.environment: "Environment"
     ]
@@ -35,6 +37,8 @@ class SyncDebugViewController: UITableViewController {
     enum Sections: Int, CaseIterable {
 
         case info
+        case unifiedDevices
+        case testActions
         case models
         case environment
 
@@ -43,13 +47,26 @@ class SyncDebugViewController: UITableViewController {
     enum InfoRows: Int, CaseIterable {
 
         case syncNow
-        case ensureAccountInfoKey
-        case validateAccountInfoKey
         case logOut
         case toggleFavoritesDisplayMode
         case resetFaviconsFetcherOnboardingDialog
         case getRecoveryCode
         case resetSyncAnotherDevicePrompt
+
+    }
+
+    enum UnifiedDeviceRows: Int, CaseIterable {
+
+        case accountInfoKey
+        case migration
+
+    }
+
+    enum TestActionRows: Int, CaseIterable {
+
+        case ensureAccountInfoKey
+        case runMigration
+        case resetMigrationMarker
 
     }
 
@@ -69,6 +86,8 @@ class SyncDebugViewController: UITableViewController {
 
     private let bookmarksDatabase: CoreDataDatabase
     private let sync: DDGSyncing
+    private var accountInfoKeyStatus = "Not checked"
+    private var migrationStatus = "Not checked"
 
     var syncCancellable: Cancellable?
 
@@ -92,6 +111,11 @@ class SyncDebugViewController: UITableViewController {
         fatalError("Not implemented")
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        refreshMigrationStatus()
+    }
+
     override func numberOfSections(in tableView: UITableView) -> Int {
         return Sections.allCases.count
     }
@@ -104,7 +128,9 @@ class SyncDebugViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
 
+        cell.textLabel?.text = nil
         cell.detailTextLabel?.text = nil
+        cell.accessoryType = .none
         cell.accessoryView = nil
         cell.selectionStyle = .default
         
@@ -114,10 +140,6 @@ class SyncDebugViewController: UITableViewController {
             switch InfoRows(rawValue: indexPath.row) {
             case .syncNow:
                 cell.textLabel?.text = "Sync now"
-            case .ensureAccountInfoKey:
-                cell.textLabel?.text = "Ensure account_info key"
-            case .validateAccountInfoKey:
-                cell.textLabel?.text = "Validate account_info key"
             case .logOut:
                 cell.textLabel?.text = "Log out of sync in 10 seconds"
             case .toggleFavoritesDisplayMode:
@@ -128,6 +150,32 @@ class SyncDebugViewController: UITableViewController {
                 cell.textLabel?.text = "Paste and Copy Recovery Code"
             case .resetSyncAnotherDevicePrompt:
                 cell.textLabel?.text = "Reset Sync Another Device prompt"
+            case .none:
+                break
+            }
+
+        case .unifiedDevices:
+            switch UnifiedDeviceRows(rawValue: indexPath.row) {
+            case .accountInfoKey:
+                cell.textLabel?.text = "Account info key"
+                cell.detailTextLabel?.text = accountInfoKeyStatus
+                cell.accessoryType = .disclosureIndicator
+            case .migration:
+                cell.textLabel?.text = "Migration"
+                cell.detailTextLabel?.text = migrationStatus
+                cell.selectionStyle = .none
+            case .none:
+                break
+            }
+
+        case .testActions:
+            switch TestActionRows(rawValue: indexPath.row) {
+            case .ensureAccountInfoKey:
+                cell.textLabel?.text = "Ensure/repair account_info key"
+            case .runMigration:
+                cell.textLabel?.text = "Run device_info migration"
+            case .resetMigrationMarker:
+                cell.textLabel?.text = "Reset migration marker"
             case .none:
                 break
             }
@@ -187,6 +235,8 @@ class SyncDebugViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch Sections(rawValue: section) {
         case .info: return InfoRows.allCases.count
+        case .unifiedDevices: return UnifiedDeviceRows.allCases.count
+        case .testActions: return TestActionRows.allCases.count
         case .models: return ModelRows.allCases.count
         case .environment: return EnvironmentRows.allCases.count
         case .none: return 0
@@ -199,10 +249,6 @@ class SyncDebugViewController: UITableViewController {
             switch InfoRows(rawValue: indexPath.row) {
             case .syncNow:
                 sync.scheduler.requestSyncImmediately()
-            case .ensureAccountInfoKey:
-                ensureAccountInfoKey()
-            case .validateAccountInfoKey:
-                validateAccountInfoKey()
             case .logOut:
                 Task {
                     try await Task.sleep(nanoseconds: UInt64(10e9))
@@ -228,6 +274,24 @@ class SyncDebugViewController: UITableViewController {
             case .resetSyncAnotherDevicePrompt:
                 UserDefaults.standard.removeObject(forKey: "sync.simplified.sync-another-device-prompt.shown")
             default: break
+            }
+        case .unifiedDevices:
+            switch UnifiedDeviceRows(rawValue: indexPath.row) {
+            case .accountInfoKey:
+                validateAccountInfoKey()
+            case .migration, .none:
+                break
+            }
+        case .testActions:
+            switch TestActionRows(rawValue: indexPath.row) {
+            case .ensureAccountInfoKey:
+                ensureAccountInfoKey()
+            case .runMigration:
+                runDeviceInfoMigration()
+            case .resetMigrationMarker:
+                confirmResetMigrationMarker()
+            case .none:
+                break
             }
         case .models:
             switch ModelRows(rawValue: indexPath.row) {
@@ -283,6 +347,8 @@ class SyncDebugViewController: UITableViewController {
                 } else {
                     message = "Ensured \(wrapperCount) wrappers."
                 }
+                accountInfoKeyStatus = message
+                reloadUnifiedDevicesSection()
                 showAlert(title: "Account Info Key Ensured", message: message)
             } catch {
                 showAlert(title: "Unable to Ensure Account Info Key", message: String(reflecting: error))
@@ -301,10 +367,14 @@ class SyncDebugViewController: UITableViewController {
                     Refreshed key ID: \(result.refreshedKeyID)
                     Reloaded key ID: \(result.reloadedKeyID)
                     """
+                    accountInfoKeyStatus = "Reload mismatch"
+                    reloadUnifiedDevicesSection()
                     showAlert(title: "Account Info Key Reload Mismatch", message: message)
                     return
                 }
 
+                accountInfoKeyStatus = "\(abbreviatedKeyID(result.reloadedKeyID)) • \(result.keySizeInBits)-bit"
+                reloadUnifiedDevicesSection()
                 let message = """
                 Key ID: \(result.reloadedKeyID)
                 Key size: \(result.keySizeInBits) bits
@@ -315,6 +385,55 @@ class SyncDebugViewController: UITableViewController {
                 showAlert(title: "Unable to Validate Account Info Key", message: String(reflecting: error))
             }
         }
+    }
+
+    private func refreshMigrationStatus() {
+        do {
+            migrationStatus = try sync.isDeviceInfoMigrationCompleteForDebug() ? "Complete" : "Not complete"
+        } catch {
+            migrationStatus = "Unavailable"
+        }
+        reloadUnifiedDevicesSection()
+    }
+
+    private func runDeviceInfoMigration() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            do {
+                try await sync.runDeviceInfoMigrationForDebug()
+                refreshMigrationStatus()
+                let isComplete = try sync.isDeviceInfoMigrationCompleteForDebug()
+                let message = isComplete ? "Migration is complete." : "Migration did not complete. Check the Sync logs for details."
+                showAlert(title: "Device Info Migration", message: message)
+            } catch {
+                showAlert(title: "Unable to Run Migration", message: String(reflecting: error))
+            }
+        }
+    }
+
+    private func confirmResetMigrationMarker() {
+        let alertController = UIAlertController(
+            title: "Reset Migration Marker?",
+            message: "The next migration run will attempt to write device_info again.",
+            preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alertController.addAction(UIAlertAction(title: "Reset", style: .destructive) { [weak self] _ in
+            guard let self else { return }
+            sync.resetDeviceInfoMigrationForDebug()
+            refreshMigrationStatus()
+        })
+        present(alertController, animated: true)
+    }
+
+    private func abbreviatedKeyID(_ keyID: String) -> String {
+        guard keyID.count > 12 else { return keyID }
+        return "…\(keyID.suffix(12))"
+    }
+
+    private func reloadUnifiedDevicesSection() {
+        guard isViewLoaded else { return }
+        tableView.reloadSections(IndexSet(integer: Sections.unifiedDevices.rawValue), with: .automatic)
     }
 
     private func showAlert(title: String, message: String) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1216959197715041?focus=true
Tech Design URL:
CC:

### Description
Unified device lists use encrypted `device_info` so all clients, including FE, can share a device’s name and type. New Sync accounts are prepared for this during account setup, but devices already signed in before this support was added would otherwise never upload the new metadata.

This PR backfills the current device for those existing accounts when unified-device writes (flag `canWriteUnifiedDeviceList`) are enabled. It ensures the account has the shared encryption key, then updates the current device with:
- encrypted device_info for unified-device-list clients; and
- the existing legacy name and type fields for older clients.

Only the current device is migrated. Completion is recorded per Sync account and device so successful work is not repeated. The migration runs in the background: failures do not interrupt account setup or sign the user out, and remain eligible to retry later.

Adds iOS debug controls for reviewers to inspect the migration status, run it on demand, and reset its completion marker.

### Testing Steps
Prerequisite: Test on iOS because this PR adds migration controls to the iOS Sync debug screen; the underlying Sync functionality is shared with macOS. Start with Sync disabled.

1. Ensure feature flag `syncCanWriteUnifiedDeviceList` is disabled
2. Enable Sync to create a new account → account creation succeeds
3. Open **Debug > Sync** → **Migration** reports **Not complete**
4. In the Xcode console, filter for `Sync-UnifiedDevices`
5. Enable feature flag `syncCanWriteUnifiedDeviceList`
6. Terminate and relaunch the app → the console reports that the current `device_info` migration completed
7. Open **Debug > Sync** → **Migration** reports **Complete**
8. Tap **Reset migration marker**, then confirm **Reset** → **Migration** reports **Not complete**
9. Tap **Run device_info migration** → the alert reports **Migration is complete** and the status returns to **Complete**
10. Tap **Run device_info migration** again without resetting → the status remains **Complete** and the console does not report another metadata update
11. On macOS, pair with iOS, and open its Sync device list → the migrated device is still displayed with its correct name and type



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Sync login protected-key caching and issues server device updates in the background; behavior is flag-gated and non-blocking, but touches account lifecycle and device metadata consistency.
> 
> **Overview**
> Adds a **background migration** that backfills encrypted `device_info` for the **current Sync device** when `canWriteUnifiedDeviceList` is enabled, so older sign-ins get unified device metadata without blocking account setup.
> 
> **`DeviceInfoMigrationCoordinator`** ensures `account_info` protected keys, patches the device with unified `device_info` plus legacy encrypted name/type, and records completion per user/device in the key-value store. Failures log and can retry; cancellation and account-snapshot checks avoid marking complete after renames or logout.
> 
> **`DDGSync`** schedules migration after create/login/third-party upgrade and on init when the engine is ready; **login no longer** calls `ensureAccountInfoProtectedKeys` inline—only caches login response keys. **Rename** cancels in-flight migration, resets the completion marker when unified writes are on, and reschedules. Logout/account removal cancels tasks and resets migration state. **Debug APIs** and iOS **Sync debug** UI expose migration status, manual run, and marker reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46d8e3f6545918c1d47ec1338b7a0af0d87dfd0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->