### PR TITLE
[macOS] Render snapshot tests at 2x (retina) and re-record references

### DIFF
--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/AppKitImageSnapshots.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/AppKitImageSnapshots.swift
@@ -34,7 +34,7 @@ public func assertImageSnapshot(
     line: UInt = #line,
     column: UInt = #column
 ) {
-    guard !SnapshotSkipMode.isEnabled() else { return }
+    guard !SnapshotSkipMode.skipIfEnabled(testName: testName) else { return }
 
     let configurations = strategy.configurations(for: .macOS, size: size)
     guard assertSnapshotConfigurations(configurations, fileID: fileID, file: file, line: line, column: column) else { return }
@@ -44,7 +44,7 @@ public func assertImageSnapshot(
         view.appearance = configuration.appearance.nsAppearance
         let snapshotSize = resolvedSize(for: view, configuration: configuration, size: size)
 
-        withUnitBackingScale(view, size: snapshotSize) {
+        withFixedBackingScale(view, size: snapshotSize) {
             assertSnapshot(
                 of: view,
                 as: .image(
@@ -102,7 +102,7 @@ public func assertImageSnapshot<Value: SwiftUI.View>(
     line: UInt = #line,
     column: UInt = #column
 ) {
-    guard !SnapshotSkipMode.isEnabled() else { return }
+    guard !SnapshotSkipMode.skipIfEnabled(testName: testName) else { return }
 
     let configurations = strategy.configurations(for: .macOS, size: size)
     guard assertSnapshotConfigurations(configurations, fileID: fileID, file: file, line: line, column: column) else { return }
@@ -128,12 +128,14 @@ public func assertImageSnapshot<Value: SwiftUI.View>(
     }
 }
 
-private final class UnitBackingScaleWindow: NSWindow {
-    override var backingScaleFactor: CGFloat { 1.0 }
+private let macOSSnapshotBackingScaleFactor: CGFloat = 2.0
+
+private final class FixedBackingScaleWindow: NSWindow {
+    override var backingScaleFactor: CGFloat { macOSSnapshotBackingScaleFactor }
 }
 
-private func withUnitBackingScale(_ view: NSView, size: CGSize, perform body: () -> Void) {
-    let window = UnitBackingScaleWindow(
+private func withFixedBackingScale(_ view: NSView, size: CGSize, perform body: () -> Void) {
+    let window = FixedBackingScaleWindow(
         contentRect: CGRect(origin: .zero, size: size),
         styleMask: [],
         backing: .buffered,
@@ -204,7 +206,7 @@ private func assertSwiftUIImageSnapshot<Value: SwiftUI.View>(
     )
     viewController.view.setFrameSize(snapshotSize)
 
-    withUnitBackingScale(viewController.view, size: snapshotSize) {
+    withFixedBackingScale(viewController.view, size: snapshotSize) {
         assertSnapshot(
             of: viewController.view,
             as: .image(

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotSkipMode.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/SnapshotSkipMode.swift
@@ -27,6 +27,12 @@ public enum SnapshotSkipMode {
         isEnabled(environment[environmentVariableName])
     }
 
+    public static func skipIfEnabled(testName: String = #function) -> Bool {
+        guard isEnabled() else { return false }
+        print("⚠️ [SnapshotSkipMode] Skipping snapshot assertion in \(testName) — \(environmentVariableName) is set")
+        return true
+    }
+
     private static func isEnabled(_ value: String?) -> Bool {
         switch value?.lowercased() {
         case "1", "true", "yes":

--- a/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/UIKitImageSnapshots.swift
+++ b/SharedPackages/SnapshotTestingSupport/Sources/SnapshotTestingSupport/UIKitImageSnapshots.swift
@@ -34,7 +34,7 @@ public func assertImageSnapshot(
     line: UInt = #line,
     column: UInt = #column
 ) {
-    guard !SnapshotSkipMode.isEnabled() else { return }
+    guard !SnapshotSkipMode.skipIfEnabled(testName: testName) else { return }
 
     let configurations = strategy.configurations(for: .iOS, size: size)
     guard assertSnapshotConfigurations(configurations, fileID: fileID, file: file, line: line, column: column) else { return }
@@ -76,7 +76,7 @@ public func assertImageSnapshot(
     line: UInt = #line,
     column: UInt = #column
 ) {
-    guard !SnapshotSkipMode.isEnabled() else { return }
+    guard !SnapshotSkipMode.skipIfEnabled(testName: testName) else { return }
 
     let configurations = strategy.configurations(for: .iOS, size: size)
     guard assertSnapshotConfigurations(configurations, fileID: fileID, file: file, line: line, column: column) else { return }
@@ -118,7 +118,7 @@ public func assertImageSnapshot<Value: SwiftUI.View>(
     line: UInt = #line,
     column: UInt = #column
 ) {
-    guard !SnapshotSkipMode.isEnabled() else { return }
+    guard !SnapshotSkipMode.skipIfEnabled(testName: testName) else { return }
 
     let configurations = strategy.configurations(for: .iOS, size: size)
     guard assertSnapshotConfigurations(configurations, fileID: fileID, file: file, line: line, column: column) else { return }

--- a/macOS/LocalPackages/SyncUI-macOS/Tests/SyncUI-macOSTests/ManagementViewTests.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Tests/SyncUI-macOSTests/ManagementViewTests.swift
@@ -22,7 +22,7 @@ import Testing
 @testable import SyncUI_macOS
 
 @MainActor
-@Suite("Management View Tests", .disabled("Snapshot testing is opt-in until the sync automations land"))
+@Suite("Management View Tests")
 final class ManagementViewTests {
 
     @available(macOS 13, *)

--- a/macOS/LocalPackages/SyncUI-macOS/Tests/SyncUI-macOSTests/SyncEnabledViewV2Tests.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Tests/SyncUI-macOSTests/SyncEnabledViewV2Tests.swift
@@ -21,9 +21,8 @@ import SnapshotTestingSupport
 import Testing
 @testable import SyncUI_macOS
 
-#if DEBUG
 @MainActor
-@Suite("Sync Enabled View V2 Tests", .disabled("Snapshot testing is opt-in until the sync automations land"))
+@Suite("Sync Enabled View V2 Tests")
 final class SyncEnabledViewV2Tests {
 
     @available(macOS 13, *)
@@ -35,4 +34,3 @@ final class SyncEnabledViewV2Tests {
         )
     }
 }
-#endif

--- a/macOS/LocalPackages/SyncUI-macOS/Tests/SyncUI-macOSTests/SyncSetupViewV2Tests.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Tests/SyncUI-macOSTests/SyncSetupViewV2Tests.swift
@@ -22,7 +22,7 @@ import Testing
 @testable import SyncUI_macOS
 
 @MainActor
-@Suite("Sync Setup View V2 Tests", .disabled("Snapshot testing is opt-in until the sync automations land"))
+@Suite("Sync Setup View V2 Tests")
 final class SyncSetupViewV2Tests {
 
     @available(macOS 13, *)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1217408440939768

Snapshot references PR: https://github.com/duckduckgo/apple-browsers-snapshots/pull/14

### Description

macOS UI snapshots were rendered at 1x, which looked low-resolution and made small visual differences hard to spot. This raises macOS snapshot rendering to 2x (retina) and re-records all macOS reference images at the new scale. It also enables the SyncUI-macOS snapshot suites and makes the snapshot skip switch log a message whenever it skips an assertion, so a silently-green skipped suite is easy to notice.

The reference images live in the `apple-browsers-snapshots` submodule — see the linked PR above, which must merge before (or together with) this one.

### Testing Steps
1. Run the macOS snapshot suites (SyncUI-macOS `SyncUI-macOS` scheme, and the `URLDragPreviewProvider` / `InfoViews` / `DefaultBrowserAndAddToDockPrompts` tests in the app) against the re-recorded references → all pass.
2. Confirm recorded macOS references are 2x (pixel dimensions are double the point size).

### Impact
None — test infrastructure and reference images only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS snapshot pixel dimensions (needs matching reference images) and turns on previously disabled CI snapshot suites; production code is unaffected.
> 
> **Overview**
> Raises **macOS image snapshot rendering from 1x to 2x** by replacing the unit-scale window helper with a fixed **2.0** backing scale (`FixedBackingScaleWindow` / `withFixedBackingScale`), so reference images match retina pixel density. Expect reference updates in the linked `apple-browsers-snapshots` submodule.
> 
> Snapshot skip behavior is **more visible**: `assertImageSnapshot` entry points on AppKit and UIKit now call `SnapshotSkipMode.skipIfEnabled(testName:)` instead of a silent `isEnabled()` guard, which **prints a warning** naming the test when `SKIP_SNAPSHOT_TESTS` is set.
> 
> **SyncUI-macOS** snapshot suites (`ManagementView`, `SyncEnabledViewV2`, `SyncSetupViewV2`) are **re-enabled** by removing suite `.disabled(...)`; `SyncEnabledViewV2Tests` no longer wraps the suite in `#if DEBUG`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50831232ddf88bced74695abbc5edbf25640ac23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->