### PR TITLE
macOS: Fixes Address Bar Resizing Bug

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -889,7 +889,7 @@ final class AddressBarViewController: NSViewController {
         // update box position on the next pass after text editor layout is updated
         DispatchQueue.main.async {
             self.refreshSwitchToTabVisibility(isHidden: false)
-            self.switchToTabBoxMinXConstraint.constant = editor.textSize.width + Constants.switchToTabMinXPadding
+            self.switchToTabBoxMinXConstraint.constant = targetMinX
         }
     }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -894,10 +894,17 @@ final class AddressBarViewController: NSViewController {
             return nil
         }
 
-        let minX = editor.textSize.width + Constants.switchToTabMinXPadding
-        let requiredWidth = minX + switchToTabBox.fittingSize.width + switchToTabBoxTrailingConstraint.constant
+        let trailingInset = switchToTabBoxTrailingConstraint.constant
+        let switchToWidth = switchToTabBox.fittingSize.width
 
-        return requiredWidth <= view.bounds.width ? minX : nil
+        /// We're placing the `SwitchToTabBox` component at the tail of the Address Bar text.
+        /// But such location is also limited by the actually visible width.
+        let textWidth = min(editor.textSize.width, max(0, addressBarTextField.bounds.width - switchToWidth))
+
+        let switchToMinX = Constants.switchToTabMinXPadding + textWidth
+        let requiredWidth = switchToMinX + switchToWidth + trailingInset
+
+        return requiredWidth <= view.bounds.width ? switchToMinX : nil
     }
 
     private func refreshSwitchToTabVisibility(isHidden: Bool) {

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -124,6 +124,7 @@ final class AddressBarViewController: NSViewController {
     @IBOutlet var buttonsContainerViewLeadingConstraint: NSLayoutConstraint!
     @IBOutlet var buttonsContainerViewTrailingConstraint: NSLayoutConstraint!
     @IBOutlet var switchToTabBoxMinXConstraint: NSLayoutConstraint!
+    @IBOutlet var switchToTabBoxTrailingConstraint: NSLayoutConstraint!
     @IBOutlet var passiveTextFieldMinXConstraint: NSLayoutConstraint!
     @IBOutlet var activeTextFieldMinXConstraint: NSLayoutConstraint!
     @IBOutlet var addressBarTextTrailingConstraint: NSLayoutConstraint!
@@ -872,22 +873,29 @@ final class AddressBarViewController: NSViewController {
 
     private func updateSwitchToTabBoxAppearance() {
         guard case .editing(.openTabSuggestion) = mode,
-              addressBarTextField.isVisible, let editor = addressBarTextField.editor,
-              view.frame.size.width > 280 else {
-            switchToTabBox.isHidden = true
-            switchToTabBox.alphaValue = 0
+              addressBarTextField.isVisible, let editor = addressBarTextField.editor else {
+            refreshSwitchToTabVisibility(isHidden: true)
             return
         }
 
-        if !switchToTabBox.isVisible {
-            switchToTabBox.isShown = true
-            switchToTabBox.alphaValue = 0
+        let targetMinX = editor.textSize.width + Constants.switchToTabMinXPadding
+        let requiredWidth = targetMinX + switchToTabBox.fittingSize.width + switchToTabBoxTrailingConstraint.constant
+
+        guard requiredWidth <= view.bounds.width else {
+            refreshSwitchToTabVisibility(isHidden: true)
+            return
         }
+
         // update box position on the next pass after text editor layout is updated
         DispatchQueue.main.async {
-            self.switchToTabBox.alphaValue = 1
+            self.refreshSwitchToTabVisibility(isHidden: false)
             self.switchToTabBoxMinXConstraint.constant = editor.textSize.width + Constants.switchToTabMinXPadding
         }
+    }
+
+    private func refreshSwitchToTabVisibility(isHidden: Bool) {
+        switchToTabBox.isHidden = isHidden
+        switchToTabBox.alphaValue = isHidden ? 0 : 1
     }
 
     private func updateShadowViewPresence(_ isFirstResponder: Bool) {

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -872,25 +872,32 @@ final class AddressBarViewController: NSViewController {
     }
 
     private func updateSwitchToTabBoxAppearance() {
-        guard case .editing(.openTabSuggestion) = mode,
-              addressBarTextField.isVisible, let editor = addressBarTextField.editor else {
-            refreshSwitchToTabVisibility(isHidden: true)
-            return
-        }
-
-        let targetMinX = editor.textSize.width + Constants.switchToTabMinXPadding
-        let requiredWidth = targetMinX + switchToTabBox.fittingSize.width + switchToTabBoxTrailingConstraint.constant
-
-        guard requiredWidth <= view.bounds.width else {
+        guard let _ = calculateSwitchToTabBoxMinX() else {
             refreshSwitchToTabVisibility(isHidden: true)
             return
         }
 
         // update box position on the next pass after text editor layout is updated
         DispatchQueue.main.async {
+            guard let minX = self.calculateSwitchToTabBoxMinX() else {
+                self.refreshSwitchToTabVisibility(isHidden: true)
+                return
+            }
+
             self.refreshSwitchToTabVisibility(isHidden: false)
-            self.switchToTabBoxMinXConstraint.constant = targetMinX
+            self.switchToTabBoxMinXConstraint.constant = minX
         }
+    }
+
+    private func calculateSwitchToTabBoxMinX() -> CGFloat? {
+        guard case .editing(.openTabSuggestion) = mode, addressBarTextField.isVisible, let editor = addressBarTextField.editor else {
+            return nil
+        }
+
+        let minX = editor.textSize.width + Constants.switchToTabMinXPadding
+        let requiredWidth = minX + switchToTabBox.fittingSize.width + switchToTabBoxTrailingConstraint.constant
+
+        return requiredWidth <= view.bounds.width ? minX : nil
     }
 
     private func refreshSwitchToTabVisibility(isHidden: Bool) {

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -872,7 +872,7 @@ final class AddressBarViewController: NSViewController {
     }
 
     private func updateSwitchToTabBoxAppearance() {
-        guard let _ = calculateSwitchToTabBoxMinX() else {
+        guard calculateSwitchToTabBoxMinX() != nil else {
             refreshSwitchToTabVisibility(isHidden: true)
             return
         }

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
@@ -682,7 +682,7 @@
                             <constraint firstAttribute="trailing" secondItem="ENV-0H-Fcc" secondAttribute="trailing" constant="2" id="Cig-ek-031"/>
                             <constraint firstItem="zaX-wZ-E3D" firstAttribute="height" relation="lessThanOrEqual" secondItem="wj6-L2-5rJ" secondAttribute="height" multiplier="0.55" id="E0Q-AU-qRQ"/>
                             <constraint firstItem="e0p-7S-Gan" firstAttribute="leading" secondItem="wj6-L2-5rJ" secondAttribute="leading" id="E5D-iA-uu3"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="JKb-5c-xaF" secondAttribute="trailing" constant="29" id="F0b-NX-BKL"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="JKb-5c-xaF" secondAttribute="trailing" priority="200" constant="29" id="F0b-NX-BKL"/>
                             <constraint firstItem="ENV-0H-Fcc" firstAttribute="top" secondItem="wj6-L2-5rJ" secondAttribute="top" constant="2" id="HfA-Q8-0Uz"/>
                             <constraint firstItem="zaX-wZ-E3D" firstAttribute="centerY" secondItem="wj6-L2-5rJ" secondAttribute="centerY" id="M2U-b3-Z0t"/>
                             <constraint firstItem="bOl-8Z-hTh" firstAttribute="leading" secondItem="wj6-L2-5rJ" secondAttribute="leading" constant="2" id="OSv-yy-Yz5"/>

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
@@ -740,6 +740,7 @@
                         <outlet property="shadowView" destination="ktI-g4-Uk6" id="v81-tf-DGJ"/>
                         <outlet property="switchToTabBox" destination="JKb-5c-xaF" id="mhx-BL-hG3"/>
                         <outlet property="switchToTabBoxMinXConstraint" destination="9CH-r6-Spp" id="snN-dF-gMm"/>
+                        <outlet property="switchToTabBoxTrailingConstraint" destination="F0b-NX-BKL" id="45A-fo-J8L"/>
                         <outlet property="switchToTabLabel" destination="LBz-Pz-Fw5" id="4bU-BW-M67"/>
                         <outlet property="view" destination="wj6-L2-5rJ" id="bsr-e7-gS7"/>
                     </connections>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213659555956031/task/1217469017538543?focus=true
Tech Design URL:
CC:

### Description
This PR fixed an Autolayout bug that may cause the Address Bar to incorrectly change its size, when moving the mouse over a Suggestion Row that renders the `Switch to Tab` element.

### Testing Steps

#### Scenario: Short Title
1. Open https://www.githubstatus.com/
2. Open a new Tab
3. Type `githubstatus` in the Search Bar
4. Move the mouse over the `github status` Suggestion Row

- [x] Verify the `Switch to Tab` box renders correctly, in the address bar area
- [x] Verify the Address Bar doesn't get resized unexpectedly
- [x] Verify this works as expected with different window sizes

#### Scenario: Long Title + Limited Origin
1. Open https://app.asana.com/1/137249556945/project/481882893211075/task/1216951138503975?focus=true
2. Open a new Tab
3. Type `tech design` in the Search Bar
4. Move the mouse over the `Tech Design` Suggestion Row

- [x] Verify the `Switch to Tab` element renders in the Address Bar area
- [x] Verify the Address Bar doesn't get resized unexpectedly
- [x] Verify this works as expected with different window sizes

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
The `Switch to Tab` UI element could render incorrectly

### Quality Considerations
Nothing in particular!

### Demo

https://github.com/user-attachments/assets/07b7dfe5-3dc6-4831-8968-d87d17515f5a



---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized macOS address bar layout and suggestion UI; no auth, data, or network changes.
> 
> **Overview**
> Fixes an Auto Layout issue where hovering an open-tab suggestion could **resize the address bar** when the **Switch to Tab** chip appeared.
> 
> **Switch to Tab placement** no longer relies on a simple `editor.textSize.width` offset or a fixed minimum bar width. `calculateSwitchToTabBoxMinX()` caps text width to what is actually visible in the field, includes the box width and **trailing inset** from `switchToTabBoxTrailingConstraint`, and only shows the chip when the full layout fits in `view.bounds.width`; otherwise it stays hidden via `refreshSwitchToTabVisibility`.
> 
> In **NavigationBar.storyboard**, the Switch to Tab trailing **≥** constraint priority is lowered to **200** and connected as `switchToTabBoxTrailingConstraint`, so it participates in the fit check without forcing the bar to grow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3efb0323811bcb6e58a1b7fe2dcebb0a27a842f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->