### PR TITLE
iOS: Send search token as URL param and strip it from user-facing URLs

### DIFF
--- a/iOS/Core/AppURLs.swift
+++ b/iOS/Core/AppURLs.swift
@@ -145,7 +145,7 @@ public extension URL {
 
     func removingInternalSearchParameters() -> URL {
         guard isDuckDuckGoSearch else { return self }
-        return removingParameters(named: [Param.atb, Param.source, Param.searchHeader, Param.kbg])
+        return removingParameters(named: [Param.atb, Param.source, Param.searchHeader, Param.kbg, Param.searchToken])
     }
 
     fileprivate enum Param {
@@ -158,6 +158,8 @@ public extension URL {
         static let partialHost = "pv1"
         static let searchHeader = "ko"
         static let kbg = "kbg"
+        // Search Token (Dindex) experiment param. Keep in sync with SerpSearchTokenInterceptor.tokenParam.
+        static let searchToken = "dindextoken"
         static let vertical = "ia"
         static let verticalRewrite = "iar"
         static let verticalMaps = "iaxm"

--- a/iOS/Core/StatisticsLoader.swift
+++ b/iOS/Core/StatisticsLoader.swift
@@ -87,7 +87,6 @@ public class StatisticsLoader {
     /// started with. Drop each experiment as it is cleaned up, and delete this once none remain.
     static func fireLegacySearchRetentionExperimentPixels() {
         let inProgressExperiments = [
-            iOSBrowserConfigSubfeature.searchTokenExperimentV3.rawValue,
             iOSBrowserConfigSubfeature.onboardingFlowByDownloadReasonExperiment.rawValue,
             AutoconsentSubfeature.cookiePopupOptInDialogExperiment.rawValue
         ]

--- a/iOS/Core/StatisticsLoader.swift
+++ b/iOS/Core/StatisticsLoader.swift
@@ -74,7 +74,7 @@ public class StatisticsLoader {
     static func fireSearchTokenExperimentPixels(metric: String) {
         for threshold in [1, 4, 6, 11, 21, 30] {
             PixelKit.fireExperimentPixelIfThresholdReached(
-                for: iOSBrowserConfigSubfeature.searchTokenExperimentV2.rawValue,
+                for: iOSBrowserConfigSubfeature.searchTokenExperimentV3.rawValue,
                 metric: metric,
                 conversionWindowDays: 1...4,
                 threshold: threshold
@@ -87,7 +87,7 @@ public class StatisticsLoader {
     /// started with. Drop each experiment as it is cleaned up, and delete this once none remain.
     static func fireLegacySearchRetentionExperimentPixels() {
         let inProgressExperiments = [
-            iOSBrowserConfigSubfeature.searchTokenExperimentV2.rawValue,
+            iOSBrowserConfigSubfeature.searchTokenExperimentV3.rawValue,
             iOSBrowserConfigSubfeature.onboardingFlowByDownloadReasonExperiment.rawValue,
             AutoconsentSubfeature.cookiePopupOptInDialogExperiment.rawValue
         ]

--- a/iOS/DuckDuckGo/SearchToken/SearchTokenDebugView.swift
+++ b/iOS/DuckDuckGo/SearchToken/SearchTokenDebugView.swift
@@ -37,7 +37,7 @@ struct SearchTokenDebugView: View {
             Section {
                 NavigationLink {
                     ExperimentCohortView(viewModel: FeatureFlagsSettingViewModel(),
-                                         experiment: FeatureFlag.searchTokenExperimentV2)
+                                         experiment: FeatureFlag.searchTokenExperimentV3)
                 } label: {
                     Text(verbatim: "Experiment cohort override")
                 }

--- a/iOS/DuckDuckGo/SearchToken/SearchTokenExperiment.swift
+++ b/iOS/DuckDuckGo/SearchToken/SearchTokenExperiment.swift
@@ -68,11 +68,11 @@ struct SearchTokenExperiment {
     /// Resolves — and thereby enrols — the cohort for an eligible new user. No-op for returning users.
     func enrollIfEligible() {
         guard statisticsStore.variant != VariantIOS.returningUser.name else { return }
-        _ = featureFlagger.resolveCohort(for: FeatureFlag.searchTokenExperimentV2)
+        _ = featureFlagger.resolveCohort(for: FeatureFlag.searchTokenExperimentV3)
     }
 
     /// The assigned cohort, or `nil` when not enrolled.
     var cohort: FeatureFlag.SearchTokenExperimentCohort? {
-        featureFlagger.assignedCohort(for: FeatureFlag.searchTokenExperimentV2) as? FeatureFlag.SearchTokenExperimentCohort
+        featureFlagger.assignedCohort(for: FeatureFlag.searchTokenExperimentV3) as? FeatureFlag.SearchTokenExperimentCohort
     }
 }

--- a/iOS/DuckDuckGo/SearchToken/SearchTokenExperimentSettings.swift
+++ b/iOS/DuckDuckGo/SearchToken/SearchTokenExperimentSettings.swift
@@ -49,7 +49,7 @@ struct SearchTokenExperimentSettings {
     }
 
     private func seconds(forKey key: String) -> TimeInterval? {
-        guard let json = privacyConfigurationManager.privacyConfig.settings(for: iOSBrowserConfigSubfeature.searchTokenExperimentV2),
+        guard let json = privacyConfigurationManager.privacyConfig.settings(for: iOSBrowserConfigSubfeature.searchTokenExperimentV3),
               let data = json.data(using: .utf8),
               let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let value = dict[key] as? NSNumber else {

--- a/iOS/DuckDuckGo/SearchToken/SerpSearchTokenInterceptor.swift
+++ b/iOS/DuckDuckGo/SearchToken/SerpSearchTokenInterceptor.swift
@@ -51,12 +51,8 @@ enum SerpSearchTokenInterceptor {
     /// address bar, bookmarks/favorites, and copied/shared links. The token is experiment plumbing
     /// bound to the live network request only; call this anywhere the current URL is shown to or
     /// persisted for the user.
-    ///
-    /// Gated on `isExperimentActive` (the treatment cohort — the only case where a token can be present)
-    /// so the logic is a no-op for everyone else.
-    static func strippingToken(from url: URL, isExperimentActive: Bool) -> URL {
-        guard isExperimentActive else { return url }
-        return url.getParameter(named: tokenParam) == nil ? url : url.removingParameters(named: [tokenParam])
+    static func strippingToken(from url: URL) -> URL {
+        url.getParameter(named: tokenParam) == nil ? url : url.removingParameters(named: [tokenParam])
     }
 
     /// Returns a copy of `request` with the experiment signals applied, or `nil` when the

--- a/iOS/DuckDuckGo/SearchToken/SerpSearchTokenInterceptor.swift
+++ b/iOS/DuckDuckGo/SearchToken/SerpSearchTokenInterceptor.swift
@@ -40,11 +40,19 @@ extension FeatureFlag.SearchTokenExperimentCohort {
 enum SerpSearchTokenInterceptor {
 
     static let dindexParam = "dindexexp"
-    static let tokenHeader = "X-DDG-Search-Token"
+    static let tokenParam = "dindextoken"
 
     /// A DuckDuckGo search-results URL that is not a Duck AI chat query.
     static func isSerpURL(_ url: URL) -> Bool {
         url.isDuckDuckGoSearch && !url.isDuckAIURL
+    }
+
+    /// Removes the `dindextoken` param so the token never leaks into user-facing surfaces — the
+    /// address bar, bookmarks/favorites, and copied/shared links. The token is experiment plumbing
+    /// bound to the live network request only; call this anywhere the current URL is shown to or
+    /// persisted for the user.
+    static func strippingToken(from url: URL) -> URL {
+        url.getParameter(named: tokenParam) == nil ? url : url.removingParameters(named: [tokenParam])
     }
 
     /// Returns a copy of `request` with the experiment signals applied, or `nil` when the
@@ -52,31 +60,35 @@ enum SerpSearchTokenInterceptor {
     /// lets the navigation proceed unchanged).
     ///
     /// - Parameters:
-    ///   - isTreatment: `true` = treatment arm, `false` = control. Both arms get the param.
-    ///   - token: live search token; used only for the treatment header. `nil`/expired → header skipped.
+    ///   - cohort: `.treatment` / `.control`. Both arms get the `dindexexp` param.
+    ///   - token: live search token; added as the `dindextoken` URL param for treatment only. `nil`/expired → param skipped.
     static func signalledRequest(for request: URLRequest,
                                  cohort: FeatureFlag.SearchTokenExperimentCohort,
                                  token: String?) -> URLRequest? {
         guard let url = request.url, isSerpURL(url) else { return nil }
 
-        var mutated = request
+        var newURL = url
         var changed = false
 
         // dindexexp — both arms: control = a, treatment = b.
         if url.getParameter(named: dindexParam) != cohort.paramValue {
-            mutated.url = url
+            newURL = newURL
                 .removingParameters(named: [dindexParam])
                 .appendingParameter(name: dindexParam, value: cohort.paramValue)
             changed = true
         }
 
-        // X-DDG-Search-Token — treatment only, requires a live token. (Inert until the token is wired in.)
-        if cohort == .treatment, let token, request.value(forHTTPHeaderField: tokenHeader) == nil {
-            mutated.setValue(token, forHTTPHeaderField: tokenHeader)
+        // dindextoken — treatment only, requires a live token.
+        if cohort == .treatment, let token, url.getParameter(named: tokenParam) != token {
+            newURL = newURL
+                .removingParameters(named: [tokenParam])
+                .appendingParameter(name: tokenParam, value: token)
             changed = true
         }
-        
+
         if changed {
+            var mutated = request
+            mutated.url = newURL
             mutated.attribution = .user
             return mutated
         }

--- a/iOS/DuckDuckGo/SearchToken/SerpSearchTokenInterceptor.swift
+++ b/iOS/DuckDuckGo/SearchToken/SerpSearchTokenInterceptor.swift
@@ -51,8 +51,12 @@ enum SerpSearchTokenInterceptor {
     /// address bar, bookmarks/favorites, and copied/shared links. The token is experiment plumbing
     /// bound to the live network request only; call this anywhere the current URL is shown to or
     /// persisted for the user.
-    static func strippingToken(from url: URL) -> URL {
-        url.getParameter(named: tokenParam) == nil ? url : url.removingParameters(named: [tokenParam])
+    ///
+    /// Gated on `isExperimentActive` (the treatment cohort — the only case where a token can be present)
+    /// so the logic is a no-op for everyone else.
+    static func strippingToken(from url: URL, isExperimentActive: Bool) -> URL {
+        guard isExperimentActive else { return url }
+        return url.getParameter(named: tokenParam) == nil ? url : url.removingParameters(named: [tokenParam])
     }
 
     /// Returns a copy of `request` with the experiment signals applied, or `nil` when the

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -34,7 +34,7 @@ protocol TabDelegate: AnyObject {
     func tabWillRequestNewTab(_ tab: TabViewController) -> UIKeyModifierFlags?
 
     /// The current cached search token, or nil if none is live. Used by the SERP interceptor
-    /// to attach `X-DDG-Search-Token` for the treatment cohort of the Search Token experiment.
+    /// to attach the `dindextoken` URL param for the treatment cohort of the Search Token experiment.
     func searchToken(for tab: TabViewController) -> String?
 
     func tabDidRequestNewTab(_ tab: TabViewController)

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -469,7 +469,7 @@ class TabViewController: UIViewController {
     public var link: Core.Link? {
         if isError {
             if let url = url ?? webView.url ?? URL(string: "") {
-                return Link(title: errorText, url: url)
+                return Link(title: errorText, url: SerpSearchTokenInterceptor.strippingToken(from: url))
             }
         }
         
@@ -1146,6 +1146,10 @@ class TabViewController: UIViewController {
     
     func updateTabModel() {
         if let url = url {
+            // Strip the search-token param before it persists into `tabModel.link`, which is read directly
+            // (bypassing the computed `link`) by the tab switcher, autocomplete, and tab restore. Shadow
+            // `url` so the title-preservation comparison below matches the stored (also stripped) URL.
+            let url = SerpSearchTokenInterceptor.strippingToken(from: url)
             let hasTitle = title != nil && !title!.isEmpty
             let previousTitle = (tabModel.link?.url == url) ? tabModel.link?.title : nil
             let link = Link(title: hasTitle ? title : previousTitle, url: url)

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -477,7 +477,9 @@ class TabViewController: UIViewController {
             return tabModel.link
         }
                         
-        let finalURL = duckPlayerNavigationHandler.getDuckURLFor(url)
+        // Strip the search-token param so it never surfaces to the user via this link (address bar,
+        // bookmarks, favorites, copy/share all read `link`). The live network request keeps the token.
+        let finalURL = SerpSearchTokenInterceptor.strippingToken(from: duckPlayerNavigationHandler.getDuckURLFor(url))
         let activeLink = Link(title: title, url: finalURL)
         guard let storedLink = tabModel.link else {
             return activeLink
@@ -3093,7 +3095,7 @@ extension TabViewController: WKNavigationDelegate {
             didModifyRequest = true
         }
 
-        // Attach Search Token experiment signals (dindexexp param + token header) to SERP navigations.
+        // Attach Search Token experiment signals (dindexexp + dindextoken URL params) to SERP navigations.
         // Enrolled devices only, skipping back/forward so we don't wipe forward history.
         if navigationAction.isTargetingMainFrame(),
            navigationAction.navigationType != .backForward,

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -3105,7 +3105,7 @@ extension TabViewController: WKNavigationDelegate {
            navigationAction.navigationType != .backForward,
            let url = navigationAction.request.url,
            SerpSearchTokenInterceptor.isSerpURL(url),
-           let cohort = featureFlagger.assignedCohort(for: FeatureFlag.searchTokenExperimentV2) as? FeatureFlag.SearchTokenExperimentCohort {
+           let cohort = featureFlagger.assignedCohort(for: FeatureFlag.searchTokenExperimentV3) as? FeatureFlag.SearchTokenExperimentCohort {
             // Pin the UA this SERP navigation will send so it can't inherit a stale `customUserAgent`
             // from a prior (non-DDG) navigation. Matches the UA the token was warmed against.
             webView.customUserAgent = userAgentManager.userAgent(isDesktop: tabModel.isDesktop, url: url)

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -466,24 +466,20 @@ class TabViewController: UIViewController {
         return errorMessage.text
     }
     
-    var isSearchTokenExperimentActive: Bool {
-        featureFlagger.isFeatureOn(.searchTokenExperimentV3)
-    }
-
     public var link: Core.Link? {
         if isError {
             if let url = url ?? webView.url ?? URL(string: "") {
-                return Link(title: errorText, url: SerpSearchTokenInterceptor.strippingToken(from: url, isExperimentActive: isSearchTokenExperimentActive))
+                return Link(title: errorText, url: SerpSearchTokenInterceptor.strippingToken(from: url))
             }
         }
-
+        
         guard let url = url else {
             return tabModel.link
         }
-
+                        
         // Strip the search-token param so it never surfaces to the user via this link (address bar,
         // bookmarks, favorites, copy/share all read `link`). The live network request keeps the token.
-        let finalURL = SerpSearchTokenInterceptor.strippingToken(from: duckPlayerNavigationHandler.getDuckURLFor(url), isExperimentActive: isSearchTokenExperimentActive)
+        let finalURL = SerpSearchTokenInterceptor.strippingToken(from: duckPlayerNavigationHandler.getDuckURLFor(url))
         let activeLink = Link(title: title, url: finalURL)
         guard let storedLink = tabModel.link else {
             return activeLink
@@ -1152,7 +1148,7 @@ class TabViewController: UIViewController {
         if let url = url {
             // Strip the search-token param before it persists into `tabModel.link` (read directly by the
             // tab switcher, autocomplete, and tab restore). Shadow `url` so the comparison below matches.
-            let url = SerpSearchTokenInterceptor.strippingToken(from: url, isExperimentActive: isSearchTokenExperimentActive)
+            let url = SerpSearchTokenInterceptor.strippingToken(from: url)
             let hasTitle = title != nil && !title!.isEmpty
             let previousTitle = (tabModel.link?.url == url) ? tabModel.link?.title : nil
             let link = Link(title: hasTitle ? title : previousTitle, url: url)

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1146,9 +1146,8 @@ class TabViewController: UIViewController {
     
     func updateTabModel() {
         if let url = url {
-            // Strip the search-token param before it persists into `tabModel.link`, which is read directly
-            // (bypassing the computed `link`) by the tab switcher, autocomplete, and tab restore. Shadow
-            // `url` so the title-preservation comparison below matches the stored (also stripped) URL.
+            // Strip the search-token param before it persists into `tabModel.link` (read directly by the
+            // tab switcher, autocomplete, and tab restore). Shadow `url` so the comparison below matches.
             let url = SerpSearchTokenInterceptor.strippingToken(from: url)
             let hasTitle = title != nil && !title!.isEmpty
             let previousTitle = (tabModel.link?.url == url) ? tabModel.link?.title : nil

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -466,20 +466,24 @@ class TabViewController: UIViewController {
         return errorMessage.text
     }
     
+    var isSearchTokenExperimentActive: Bool {
+        featureFlagger.isFeatureOn(.searchTokenExperimentV3)
+    }
+
     public var link: Core.Link? {
         if isError {
             if let url = url ?? webView.url ?? URL(string: "") {
-                return Link(title: errorText, url: SerpSearchTokenInterceptor.strippingToken(from: url))
+                return Link(title: errorText, url: SerpSearchTokenInterceptor.strippingToken(from: url, isExperimentActive: isSearchTokenExperimentActive))
             }
         }
-        
+
         guard let url = url else {
             return tabModel.link
         }
-                        
+
         // Strip the search-token param so it never surfaces to the user via this link (address bar,
         // bookmarks, favorites, copy/share all read `link`). The live network request keeps the token.
-        let finalURL = SerpSearchTokenInterceptor.strippingToken(from: duckPlayerNavigationHandler.getDuckURLFor(url))
+        let finalURL = SerpSearchTokenInterceptor.strippingToken(from: duckPlayerNavigationHandler.getDuckURLFor(url), isExperimentActive: isSearchTokenExperimentActive)
         let activeLink = Link(title: title, url: finalURL)
         guard let storedLink = tabModel.link else {
             return activeLink
@@ -1148,7 +1152,7 @@ class TabViewController: UIViewController {
         if let url = url {
             // Strip the search-token param before it persists into `tabModel.link` (read directly by the
             // tab switcher, autocomplete, and tab restore). Shadow `url` so the comparison below matches.
-            let url = SerpSearchTokenInterceptor.strippingToken(from: url)
+            let url = SerpSearchTokenInterceptor.strippingToken(from: url, isExperimentActive: isSearchTokenExperimentActive)
             let hasTitle = title != nil && !title!.isEmpty
             let previousTitle = (tabModel.link?.url == url) ? tabModel.link?.title : nil
             let link = Link(title: hasTitle ? title : previousTitle, url: url)

--- a/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
@@ -413,7 +413,8 @@ extension TabViewController {
         return BrowsingMenuEntry.regular(name: UserText.actionCopy, image: image, action: { [weak self] in
             guard let strongSelf = self else { return }
             if !strongSelf.isError, let url = strongSelf.webView.url {
-                strongSelf.onCopyAction(forUrl: url)
+                // `webView.url` carries the search-token param on SERP navigations; strip it before it hits the pasteboard.
+                strongSelf.onCopyAction(forUrl: SerpSearchTokenInterceptor.strippingToken(from: url))
             } else if let text = self?.chromeDelegate?.omniBar.text {
                 strongSelf.onCopyAction(for: text)
             }

--- a/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
@@ -414,7 +414,7 @@ extension TabViewController {
             guard let strongSelf = self else { return }
             if !strongSelf.isError, let url = strongSelf.webView.url {
                 // `webView.url` carries the search-token param on SERP navigations; strip it before it hits the pasteboard.
-                strongSelf.onCopyAction(forUrl: SerpSearchTokenInterceptor.strippingToken(from: url))
+                strongSelf.onCopyAction(forUrl: SerpSearchTokenInterceptor.strippingToken(from: url, isExperimentActive: strongSelf.isSearchTokenExperimentActive))
             } else if let text = self?.chromeDelegate?.omniBar.text {
                 strongSelf.onCopyAction(for: text)
             }

--- a/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerMenuBuilderExtension.swift
@@ -414,7 +414,7 @@ extension TabViewController {
             guard let strongSelf = self else { return }
             if !strongSelf.isError, let url = strongSelf.webView.url {
                 // `webView.url` carries the search-token param on SERP navigations; strip it before it hits the pasteboard.
-                strongSelf.onCopyAction(forUrl: SerpSearchTokenInterceptor.strippingToken(from: url, isExperimentActive: strongSelf.isSearchTokenExperimentActive))
+                strongSelf.onCopyAction(forUrl: SerpSearchTokenInterceptor.strippingToken(from: url))
             } else if let text = self?.chromeDelegate?.omniBar.text {
                 strongSelf.onCopyAction(for: text)
             }

--- a/iOS/DuckDuckGoTests/AppURLsTests.swift
+++ b/iOS/DuckDuckGoTests/AppURLsTests.swift
@@ -79,6 +79,14 @@ final class AppURLsTests: XCTestCase {
         XCTAssertNil(result.getParameter(named: "ko"))
     }
 
+    func testWhenRemoveInternalSearchParametersThenSearchTokenParamIsRemoved() {
+        let url = URL(string: "https://duckduckgo.com/?q=example&dindexexp=b&dindextoken=abc")!
+        let result = url.removingInternalSearchParameters()
+        XCTAssertNil(result.getParameter(named: "dindextoken"))
+        XCTAssertEqual(result.getParameter(named: "q"), "example")
+        XCTAssertEqual(result.getParameter(named: "dindexexp"), "b")
+    }
+
     func testWhenRemoveInternalSearchParametersFromNonSearchUrlThenUrlIsUnchanged() {
         let example = URL(string: "https://duckduckgo.com?atb=x&t=y&ko=z")!
         let result = example.removingInternalSearchParameters()

--- a/iOS/DuckDuckGoTests/SearchToken/SerpSearchTokenInterceptorTests.swift
+++ b/iOS/DuckDuckGoTests/SearchToken/SerpSearchTokenInterceptorTests.swift
@@ -98,9 +98,9 @@ final class SerpSearchTokenInterceptorTests: XCTestCase {
     
     // MARK: - strippingToken
 
-    func testStrippingToken_removesTokenParam() {
+    func testStrippingToken_removesTokenParam_whenExperimentActive() {
         let url = URL(string: "https://duckduckgo.com/?q=privacy&dindexexp=b&dindextoken=abc")!
-        let out = SerpSearchTokenInterceptor.strippingToken(from: url)
+        let out = SerpSearchTokenInterceptor.strippingToken(from: url, isExperimentActive: true)
         XCTAssertNil(out.getParameter(named: "dindextoken"))
         XCTAssertEqual(out.getParameter(named: "q"), "privacy")
         XCTAssertEqual(out.getParameter(named: "dindexexp"), "b")
@@ -108,7 +108,12 @@ final class SerpSearchTokenInterceptorTests: XCTestCase {
 
     func testStrippingToken_noOpWhenAbsent() {
         let url = URL(string: "https://duckduckgo.com/?q=privacy&dindexexp=b")!
-        XCTAssertEqual(SerpSearchTokenInterceptor.strippingToken(from: url), url)
+        XCTAssertEqual(SerpSearchTokenInterceptor.strippingToken(from: url, isExperimentActive: true), url)
+    }
+
+    func testStrippingToken_noOpWhenExperimentInactive() {
+        let url = URL(string: "https://duckduckgo.com/?q=privacy&dindexexp=b&dindextoken=abc")!
+        XCTAssertEqual(SerpSearchTokenInterceptor.strippingToken(from: url, isExperimentActive: false), url)
     }
 
     // MARK: - Helpers

--- a/iOS/DuckDuckGoTests/SearchToken/SerpSearchTokenInterceptorTests.swift
+++ b/iOS/DuckDuckGoTests/SearchToken/SerpSearchTokenInterceptorTests.swift
@@ -98,9 +98,9 @@ final class SerpSearchTokenInterceptorTests: XCTestCase {
     
     // MARK: - strippingToken
 
-    func testStrippingToken_removesTokenParam_whenExperimentActive() {
+    func testStrippingToken_removesTokenParam() {
         let url = URL(string: "https://duckduckgo.com/?q=privacy&dindexexp=b&dindextoken=abc")!
-        let out = SerpSearchTokenInterceptor.strippingToken(from: url, isExperimentActive: true)
+        let out = SerpSearchTokenInterceptor.strippingToken(from: url)
         XCTAssertNil(out.getParameter(named: "dindextoken"))
         XCTAssertEqual(out.getParameter(named: "q"), "privacy")
         XCTAssertEqual(out.getParameter(named: "dindexexp"), "b")
@@ -108,12 +108,7 @@ final class SerpSearchTokenInterceptorTests: XCTestCase {
 
     func testStrippingToken_noOpWhenAbsent() {
         let url = URL(string: "https://duckduckgo.com/?q=privacy&dindexexp=b")!
-        XCTAssertEqual(SerpSearchTokenInterceptor.strippingToken(from: url, isExperimentActive: true), url)
-    }
-
-    func testStrippingToken_noOpWhenExperimentInactive() {
-        let url = URL(string: "https://duckduckgo.com/?q=privacy&dindexexp=b&dindextoken=abc")!
-        XCTAssertEqual(SerpSearchTokenInterceptor.strippingToken(from: url, isExperimentActive: false), url)
+        XCTAssertEqual(SerpSearchTokenInterceptor.strippingToken(from: url), url)
     }
 
     // MARK: - Helpers

--- a/iOS/DuckDuckGoTests/SearchToken/SerpSearchTokenInterceptorTests.swift
+++ b/iOS/DuckDuckGoTests/SearchToken/SerpSearchTokenInterceptorTests.swift
@@ -67,30 +67,50 @@ final class SerpSearchTokenInterceptorTests: XCTestCase {
         XCTAssertNil(SerpSearchTokenInterceptor.signalledRequest(for: req, cohort: .treatment, token: nil))
     }
     
-    // MARK: - signalledRequest: X-DDG-Search-Token header
+    // MARK: - signalledRequest: dindextoken param
 
-    func testSignalledRequest_setsHeader_forTreatmentWithToken() {
+    func testSignalledRequest_setsTokenParam_forTreatmentWithToken() {
         let out = SerpSearchTokenInterceptor.signalledRequest(for: serpRequest(), cohort: .treatment, token: "abc")
-        XCTAssertEqual(out?.value(forHTTPHeaderField: "X-DDG-Search-Token"), "abc")
+        XCTAssertEqual(out?.url?.getParameter(named: "dindextoken"), "abc")
     }
 
-    func testSignalledRequest_noHeader_forControlEvenWithToken() {
+    func testSignalledRequest_noTokenParam_forControlEvenWithToken() {
         let out = SerpSearchTokenInterceptor.signalledRequest(for: serpRequest(), cohort: .control, token: "abc")
-        XCTAssertNil(out?.value(forHTTPHeaderField: "X-DDG-Search-Token"))
+        XCTAssertNil(out?.url?.getParameter(named: "dindextoken"))
     }
 
-    func testSignalledRequest_noHeader_forTreatmentWithoutToken() {
+    func testSignalledRequest_noTokenParam_forTreatmentWithoutToken() {
         let out = SerpSearchTokenInterceptor.signalledRequest(for: serpRequest(), cohort: .treatment, token: nil)
         XCTAssertEqual(out?.url?.getParameter(named: "dindexexp"), "b")
-        XCTAssertNil(out?.value(forHTTPHeaderField: "X-DDG-Search-Token"))
+        XCTAssertNil(out?.url?.getParameter(named: "dindextoken"))
     }
 
-    func testSignalledRequest_nilWhenParamAndHeaderAlreadyPresent() {
-        var req = serpRequest("https://duckduckgo.com/?q=privacy&dindexexp=b")
-        req.setValue("abc", forHTTPHeaderField: "X-DDG-Search-Token")
+    func testSignalledRequest_nilWhenBothParamsAlreadyPresent() {
+        let req = serpRequest("https://duckduckgo.com/?q=privacy&dindexexp=b&dindextoken=abc")
         XCTAssertNil(SerpSearchTokenInterceptor.signalledRequest(for: req, cohort: .treatment, token: "abc"))
     }
+
+    func testSignalledRequest_replacesStaleTokenParam() {
+        let req = serpRequest("https://duckduckgo.com/?q=privacy&dindexexp=b&dindextoken=old")
+        let out = SerpSearchTokenInterceptor.signalledRequest(for: req, cohort: .treatment, token: "new")
+        XCTAssertEqual(out?.url?.getParameter(named: "dindextoken"), "new")
+    }
     
+    // MARK: - strippingToken
+
+    func testStrippingToken_removesTokenParam() {
+        let url = URL(string: "https://duckduckgo.com/?q=privacy&dindexexp=b&dindextoken=abc")!
+        let out = SerpSearchTokenInterceptor.strippingToken(from: url)
+        XCTAssertNil(out.getParameter(named: "dindextoken"))
+        XCTAssertEqual(out.getParameter(named: "q"), "privacy")
+        XCTAssertEqual(out.getParameter(named: "dindexexp"), "b")
+    }
+
+    func testStrippingToken_noOpWhenAbsent() {
+        let url = URL(string: "https://duckduckgo.com/?q=privacy&dindexexp=b")!
+        XCTAssertEqual(SerpSearchTokenInterceptor.strippingToken(from: url), url)
+    }
+
     // MARK: - Helpers
     
     private func serpRequest(_ string: String = "https://duckduckgo.com/?q=privacy") -> URLRequest {

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -526,7 +526,7 @@ public enum FeatureFlag: String {
 
     /// NA experiment: attach a search token to speed up SERP by combining Index/Deep responses.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216365830146824
-    case searchTokenExperimentV2
+    case searchTokenExperimentV3
 
     /// NA Experiment: tailor the onboarding flow based on the user's download reason.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216491579842691?focus=true
@@ -828,8 +828,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .disabled)
         case .uiTestExperiment:
             Config(source: .disabled, cohortType: UITestExperimentCohort.self)
-        case .searchTokenExperimentV2:
-            Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.searchTokenExperimentV2), cohortType: SearchTokenExperimentCohort.self)
+        case .searchTokenExperimentV3:
+            Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.searchTokenExperimentV3), cohortType: SearchTokenExperimentCohort.self)
         case .onboardingFlowByDownloadReasonExperiment:
             Config(source: .disabled, cohortType: OnboardingFlowByDownloadReasonExperimentCohort.self)
         case .monthlyFreeTrialExperiment2:

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
@@ -125,7 +125,7 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
 
     /// NA experiment: search token to speed up SERP by combining Index/Deep responses.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216365830146824
-    case searchTokenExperimentV2
+    case searchTokenExperimentV3
 
     /// NA Experiment: tailor the onboarding flow based on the user's download reason.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216491579842691?focus=true

--- a/iOS/LocalPackages/FeatureFlags-iOS/Tests/FeatureFlagsTests/FeatureFlagsTests.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Tests/FeatureFlagsTests/FeatureFlagsTests.swift
@@ -46,21 +46,21 @@ final class FeatureFlagsTests: XCTestCase {
     }
 
     func testWhenReadingIOSBrowserConfigSubfeatureThenParentAndRawValueAreStable() {
-        let subfeature = iOSBrowserConfigSubfeature.searchTokenExperimentV2
+        let subfeature = iOSBrowserConfigSubfeature.searchTokenExperimentV3
 
         XCTAssertEqual(subfeature.parent, .iOSBrowserConfig)
-        XCTAssertEqual(subfeature.rawValue, "searchTokenExperimentV2")
+        XCTAssertEqual(subfeature.rawValue, "searchTokenExperimentV3")
     }
 
     func testWhenReadingSearchTokenFeatureFlagThenSourceAndCohortUseSearchTokenConfiguration() {
-        guard case let .remoteReleasable(subfeature) = FeatureFlag.searchTokenExperimentV2.source else {
+        guard case let .remoteReleasable(subfeature) = FeatureFlag.searchTokenExperimentV3.source else {
             XCTFail("Expected remote-releasable source")
             return
         }
 
         XCTAssertEqual((subfeature as? iOSBrowserConfigSubfeature)?.rawValue,
-                       iOSBrowserConfigSubfeature.searchTokenExperimentV2.rawValue)
-        XCTAssertEqual(FeatureFlag.searchTokenExperimentV2.cohortType.map(ObjectIdentifier.init),
+                       iOSBrowserConfigSubfeature.searchTokenExperimentV3.rawValue)
+        XCTAssertEqual(FeatureFlag.searchTokenExperimentV3.cohortType.map(ObjectIdentifier.init),
                        ObjectIdentifier(FeatureFlag.SearchTokenExperimentCohort.self))
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211767540372501/task/1217478732275059?focus=true

### Description

Reworks how the Search Token (Dindex) experiment attaches the token to SERP navigations, moving it from the `X-DDG-Search-Token` request header to a `dindextoken` URL query parameter (treatment cohort only; the `dindexexp` variant param is unchanged).

Because the token now lives in the URL, it could leak into user-facing surfaces. To prevent that, a `SerpSearchTokenInterceptor.strippingToken(from:)` helper removes the `dindextoken` param wherever the current page URL is shown to or persisted for the user:
- `TabViewController.link` — the shared source for the address bar, bookmarks, favorites, and share sheet.
- The browsing-menu **Copy** action, which reads `webView.url` directly and bypasses `link`.

### Testing Steps

**Prerequisite:** Enrol the device in the Search Token experiment **treatment** cohort (Debug menu → Search Token → Experiment cohort override), and ensure a token is being fetched.

1. Run a search on DuckDuckGo. Confirm the SERP loads normally.
2. Verify the request carries `dindextoken` (and `dindexexp=b`) in the URL — e.g. via a proxy.
3. Check the **address bar**: the `dindextoken` param must not be visible to the user.
4. **Bookmark** the SERP page, then edit/inspect the saved bookmark — its URL must not contain `dindextoken`.
5. Save the SERP page as a **favorite** — its URL must not contain `dindextoken`.
6. Open the browsing menu and tap **Copy**, then paste — the copied URL must not contain `dindextoken`.
7. Open the **share sheet**, use **Copy** (or share to Notes), and confirm the shared URL must not contain `dindextoken`.
8. Confirm control-cohort and non-enrolled users see no `dindextoken` at all, and search still works.

### Impact and Risks

**Low.** Scoped to the Search Token experiment's treatment cohort. The token-attach mechanism changes from a header to a URL param, and stripping happens at two well-covered choke points (`link` and the direct Copy action). Worst case if stripping regressed: a short-lived, opaque token could appear in a saved/shared URL — no PII, and the token expires quickly. No change to control-cohort or non-enrolled behavior.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SERP request shaping and tab URL persistence for an active experiment; leakage risk is mitigated at multiple choke points but regressions could expose short-lived tokens in saved or shared links.
> 
> **Overview**
> **Search Token (Dindex) experiment** treatment SERP navigations now attach the live token via the `dindextoken` query parameter instead of the `X-DDG-Search-Token` header; `dindexexp` behavior is unchanged. Enrollment, remote settings, debug UI, and experiment pixels move from `searchTokenExperimentV2` to **`searchTokenExperimentV3`** (V2 is dropped from the legacy search-retention pixel list).
> 
> Because the token lives in the URL, **`SerpSearchTokenInterceptor.strippingToken(from:)`** removes `dindextoken` wherever the page URL is shown or stored: `TabViewController.link`, tab model persistence, and browsing-menu Copy (which reads `webView.url` directly). **`removingInternalSearchParameters()`** also strips `dindextoken` so share/bookmark/copy paths that already clean internal params stay consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35c583421698b0c55234dfb4fafa99155241c84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->