### PR TITLE
Make PixelKit retry opt-in and restore the retry parameters

### DIFF
--- a/.cursor/rules/pixels.mdc
+++ b/.cursor/rules/pixels.mdc
@@ -237,7 +237,8 @@ if try await pixelKit.fireAsync(event, frequency: .daily) == .suppressed { ... }
 ```
 
 `PixelKit.Options` presets cover the common cases (`.default`, `.parameters(_:)`, `.namePrefix(_:)`,
-`.unenforcedPrefix`, `.withoutAppVersion`). It is a value type, so uncommon combinations compose:
+`.unenforcedPrefix`, `.withoutAppVersion`, `.withRetry`). It is a value type, so uncommon combinations
+compose:
 
 ```swift
 var options = PixelKit.Options.unenforcedPrefix
@@ -245,6 +246,14 @@ options.additionalParameters = ["source": "menu"]
 ```
 
 Do not add convenience overloads of `fire` to hide parameters; that is what `Options` replaced.
+
+### Retrying a failed pixel
+
+A pixel that fails to send is dropped. `options: .withRetry` (`Options.retryOnFailure`) persists the
+failed send and replays it later, up to 28 days. It is off by default because a replay carries two
+extra parameters, `originalPixelTimestamp` and `retriedPixel`: the pixel must be privacy triaged for
+both, and must declare them in its JSON5 definition, before opting in. See
+`SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/README.md`.
 
 ## Best Practices
 

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit+Options.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit+Options.swift
@@ -54,18 +54,31 @@ extension PixelKit {
         /// `doNotEnforcePrefix: true` becomes `enforcePrefix: false`.
         public var enforcePrefix: Bool
 
+        /// Whether a failed send is persisted and replayed later. Off by default.
+        ///
+        /// Opting in changes what reaches the server, so it is a per-pixel decision rather than a
+        /// PixelKit-wide one: a replayed pixel carries two extra parameters, `originalPixelTimestamp`
+        /// (when the send first failed) and `retriedPixel`. `originalPixelTimestamp` in particular
+        /// reintroduces the time-based correlation that PETAL exists to remove, so a pixel must have
+        /// been privacy triaged for both parameters before it sets this.
+        ///
+        /// See `RetryQueue/README.md` for the mechanics.
+        public var retryOnFailure: Bool
+
         public init(headers: [String: String]? = nil,
                     additionalParameters: [String: String]? = nil,
                     namePrefix: String? = nil,
                     allowedQueryReservedCharacters: CharacterSet? = nil,
                     includeAppVersionParameter: Bool = true,
-                    enforcePrefix: Bool = true) {
+                    enforcePrefix: Bool = true,
+                    retryOnFailure: Bool = false) {
             self.headers = headers
             self.additionalParameters = additionalParameters
             self.namePrefix = namePrefix
             self.allowedQueryReservedCharacters = allowedQueryReservedCharacters
             self.includeAppVersionParameter = includeAppVersionParameter
             self.enforcePrefix = enforcePrefix
+            self.retryOnFailure = retryOnFailure
         }
 
         // MARK: - Curated presets
@@ -85,6 +98,10 @@ extension PixelKit {
 
         /// For pixels that must not carry the `appVersion` parameter, such as crash reports.
         public static let withoutAppVersion = Options(includeAppVersionParameter: false)
+
+        /// For pixels whose delivery matters enough to survive a failed send, and that have been
+        /// privacy triaged for the retry parameters. See `retryOnFailure`.
+        public static let withRetry = Options(retryOnFailure: true)
 
         /// Attaches extra query parameters.
         public static func parameters(_ parameters: [String: String]) -> Options {

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/PixelKit.swift
@@ -224,16 +224,42 @@ public final class PixelKit {
 
     // MARK: - Initialisation
 
-    public init(dryRun: Bool,
-                appVersion: String,
-                source: String? = nil,
-                session: String? = nil,
-                channel: String? = nil,
-                defaultHeaders: [String: String],
-                pixelCalendar: Calendar? = nil,
-                dateGenerator: @escaping () -> Date = Date.init,
-                defaults: ThrowingKeyValueStoring,
-                fireRequest: @escaping FireRequest) {
+    public convenience init(dryRun: Bool,
+                            appVersion: String,
+                            source: String? = nil,
+                            session: String? = nil,
+                            channel: String? = nil,
+                            defaultHeaders: [String: String],
+                            pixelCalendar: Calendar? = nil,
+                            dateGenerator: @escaping () -> Date = Date.init,
+                            defaults: ThrowingKeyValueStoring,
+                            fireRequest: @escaping FireRequest) {
+        self.init(dryRun: dryRun,
+                  appVersion: appVersion,
+                  source: source,
+                  session: session,
+                  channel: channel,
+                  defaultHeaders: defaultHeaders,
+                  pixelCalendar: pixelCalendar,
+                  dateGenerator: dateGenerator,
+                  defaults: defaults,
+                  retryQueueStore: nil,
+                  fireRequest: fireRequest)
+    }
+
+    /// Designated initialiser. `retryQueueStore` overrides the retry queue's backing store, so tests can
+    /// exercise the queue without touching the real Application Support file; production passes `nil`.
+    init(dryRun: Bool,
+         appVersion: String,
+         source: String?,
+         session: String?,
+         channel: String?,
+         defaultHeaders: [String: String],
+         pixelCalendar: Calendar?,
+         dateGenerator: @escaping () -> Date,
+         defaults: ThrowingKeyValueStoring,
+         retryQueueStore: PixelRetryQueueStoring?,
+         fireRequest: @escaping FireRequest) {
 
         self.dryRun = dryRun
         self.appVersion = appVersion
@@ -248,14 +274,16 @@ public final class PixelKit {
         if dryRun {
             self.retryQueue = nil
         } else {
-            // Wrap the network fire-request with a retry queue so failed pixels are persisted and re-sent
-            // after the next successful fire (28-day expiry) — which, for a launching app, happens as soon
-            // as it fires its first pixel. Reuses the same `defaults` for throttling state. This is internal
-            // to PixelKit and hidden from its consumers; creating the queue performs no I/O.
+            // Wrap the network fire-request with a retry queue so that a pixel which opted in via
+            // `Options.retryOnFailure` and failed is persisted and re-sent after the next successful fire
+            // (28-day expiry) — which, for a launching app, happens as soon as it fires its first pixel.
+            // Pixels that did not opt in, which is all of them by default, pass straight through. Reuses
+            // the same `defaults` for throttling state. This is internal to PixelKit and hidden from its
+            // consumers; creating the queue performs no I/O.
             let identity = Self.retryQueueIdentitySuffix(session: session, source: source)
             self.retryQueue = PixelRetryQueue(
                 fireRequest: fireRequest,
-                store: PixelRetryQueueFileStore(fileName: "pixelkit-retry-queue-\(identity).json"),
+                store: retryQueueStore ?? PixelRetryQueueFileStore(fileName: "pixelkit-retry-queue-\(identity).json"),
                 lastProcessingDateStorage: defaults,
                 lastProcessingDateKey: "com.duckduckgo.pixelkit.retry-queue.last-processing-timestamp.\(identity)",
                 calendar: self.pixelCalendar,
@@ -323,6 +351,7 @@ public final class PixelKit {
              allowedQueryReservedCharacters: options.allowedQueryReservedCharacters,
              includeAppVersionParameter: options.includeAppVersionParameter,
              standardParameters: event.standardParameters ?? [],
+             retryOnFailure: options.retryOnFailure,
              onComplete: onComplete)
     }
 
@@ -411,6 +440,7 @@ public final class PixelKit {
                       allowedQueryReservedCharacters: CharacterSet?,
                       includeAppVersionParameter: Bool,
                       standardParameters: [PixelKitStandardParameter],
+                      retryOnFailure: Bool,
                       onComplete: @escaping CompletionBlock) {
 
         var newParams = params ?? [:]
@@ -444,31 +474,31 @@ public final class PixelKit {
 
         switch frequency {
         case .standard:
-            handleStandardFrequency(pixelName, headers, newParams, allowedQueryReservedCharacters, onComplete)
+            handleStandardFrequency(pixelName, headers, newParams, allowedQueryReservedCharacters, retryOnFailure, onComplete)
         case .uniqueByName:
-            handleUnique(pixelName, headers, newParams, allowedQueryReservedCharacters, onComplete)
+            handleUnique(pixelName, headers, newParams, allowedQueryReservedCharacters, retryOnFailure, onComplete)
         case .uniqueByNameAndParameters:
-            handleUniqueByNameAndParameters(pixelName, headers, newParams, allowedQueryReservedCharacters, onComplete)
+            handleUniqueByNameAndParameters(pixelName, headers, newParams, allowedQueryReservedCharacters, retryOnFailure, onComplete)
         case .daily:
-            handleDaily(pixelName, headers, newParams, allowedQueryReservedCharacters, onComplete)
+            handleDaily(pixelName, headers, newParams, allowedQueryReservedCharacters, retryOnFailure, onComplete)
         case .monthly:
-            handleMonthly(pixelName, headers, newParams, allowedQueryReservedCharacters, onComplete)
+            handleMonthly(pixelName, headers, newParams, allowedQueryReservedCharacters, retryOnFailure, onComplete)
         case .dailyAndCount:
-            handleDailyAndCount(pixelName, headers, newParams, allowedQueryReservedCharacters, onComplete)
+            handleDailyAndCount(pixelName, headers, newParams, allowedQueryReservedCharacters, retryOnFailure, onComplete)
         case .dailyAndStandard:
-            handleDailyAndStandard(pixelName, headers, newParams, allowedQueryReservedCharacters, onComplete)
+            handleDailyAndStandard(pixelName, headers, newParams, allowedQueryReservedCharacters, retryOnFailure, onComplete)
         case .legacyInitial:
-            handleLegacyInitial(pixelName, headers, newParams, allowedQueryReservedCharacters, onComplete)
+            handleLegacyInitial(pixelName, headers, newParams, allowedQueryReservedCharacters, retryOnFailure, onComplete)
         case .legacyDaily:
-            handleLegacyDaily(pixelName, headers, newParams, allowedQueryReservedCharacters, onComplete)
+            handleLegacyDaily(pixelName, headers, newParams, allowedQueryReservedCharacters, retryOnFailure, onComplete)
         case .legacyDailyAndCount:
-            handleLegacyDailyAndCount(pixelName, headers, newParams, allowedQueryReservedCharacters, onComplete)
+            handleLegacyDailyAndCount(pixelName, headers, newParams, allowedQueryReservedCharacters, retryOnFailure, onComplete)
         case .legacyDailyNoSuffix:
-            handleLegacyDailyNoSuffix(pixelName, headers, newParams, allowedQueryReservedCharacters, onComplete)
+            handleLegacyDailyNoSuffix(pixelName, headers, newParams, allowedQueryReservedCharacters, retryOnFailure, onComplete)
         case .sample(let percentage):
-            handleSample(pixelName, headers, newParams, allowedQueryReservedCharacters, percentage, onComplete)
+            handleSample(pixelName, headers, newParams, allowedQueryReservedCharacters, retryOnFailure, percentage, onComplete)
         case .debounce(let seconds):
-            handleDebounce(pixelName, headers, newParams, allowedQueryReservedCharacters, seconds, onComplete)
+            handleDebounce(pixelName, headers, newParams, allowedQueryReservedCharacters, retryOnFailure, seconds, onComplete)
         }
     }
 
@@ -478,23 +508,25 @@ public final class PixelKit {
                                          _ headers: [String: String],
                                          _ params: [String: String],
                                          _ allowedQueryReservedCharacters: CharacterSet?,
+                                         _ retryOnFailure: Bool,
                                          _ onComplete: @escaping CompletionBlock) {
         reportErrorIf(pixel: pixelName, endsWith: "_u")
         reportErrorIf(pixel: pixelName, endsWith: "_d")
-        fireRequestWrapper(pixelName, headers, params, allowedQueryReservedCharacters, true, .standard, onComplete)
+        fireRequestWrapper(pixelName, headers, params, allowedQueryReservedCharacters, true, .standard, retryOnFailure, onComplete)
     }
 
     private func handleLegacyInitial(_ pixelName: String,
                                      _ headers: [String: String],
                                      _ newParams: [String: String],
                                      _ allowedQueryReservedCharacters: CharacterSet?,
+                                     _ retryOnFailure: Bool,
                                      _ onComplete: @escaping CompletionBlock) {
         reportErrorIf(pixel: pixelName, endsWith: "_u")
         reportErrorIf(pixel: pixelName, endsWith: "_d")
         if !pixelHasBeenFiredEver(pixelName) {
             do {
                 try updatePixelLastFireDate(pixelName: pixelName, frequency: .uniqueByName)
-                fireRequestWrapper(pixelName, headers, newParams, allowedQueryReservedCharacters, true, .legacyInitial, onComplete)
+                fireRequestWrapper(pixelName, headers, newParams, allowedQueryReservedCharacters, true, .legacyInitial, retryOnFailure, onComplete)
             } catch {
                 fireStorageWriteErrorPixel(suppressedPixelName: pixelName, error: error)
                 printDebugInfo(pixelName: pixelName, frequency: .legacyInitial, parameters: newParams, skipped: true)
@@ -510,6 +542,7 @@ public final class PixelKit {
                               _ headers: [String: String],
                               _ newParams: [String: String],
                               _ allowedQueryReservedCharacters: CharacterSet?,
+                              _ retryOnFailure: Bool,
                               _ onComplete: @escaping CompletionBlock) {
         reportErrorIf(pixel: pixelName, endsWith: "_d")
         guard pixelName.hasSuffix("_u") else {
@@ -520,7 +553,7 @@ public final class PixelKit {
         if !pixelHasBeenFiredEver(pixelName) {
             do {
                 try updatePixelLastFireDate(pixelName: pixelName, frequency: .uniqueByName)
-                fireRequestWrapper(pixelName, headers, newParams, allowedQueryReservedCharacters, true, .uniqueByName, onComplete)
+                fireRequestWrapper(pixelName, headers, newParams, allowedQueryReservedCharacters, true, .uniqueByName, retryOnFailure, onComplete)
             } catch {
                 fireStorageWriteErrorPixel(suppressedPixelName: pixelName, error: error)
                 printDebugInfo(pixelName: pixelName, frequency: .uniqueByName, parameters: newParams, skipped: true)
@@ -536,12 +569,13 @@ public final class PixelKit {
                                                  _ headers: [String: String],
                                                  _ newParams: [String: String],
                                                  _ allowedQueryReservedCharacters: CharacterSet?,
+                                                 _ retryOnFailure: Bool,
                                                  _ onComplete: @escaping CompletionBlock) {
         let pixelNameAndParams = pixelName + newParams.toString()
         if !pixelHasBeenFiredEver(pixelNameAndParams) {
             do {
                 try updatePixelLastFireDate(pixelName: pixelNameAndParams, frequency: .uniqueByName)
-                fireRequestWrapper(pixelName, headers, newParams, allowedQueryReservedCharacters, true, .uniqueByNameAndParameters, onComplete)
+                fireRequestWrapper(pixelName, headers, newParams, allowedQueryReservedCharacters, true, .uniqueByNameAndParameters, retryOnFailure, onComplete)
             } catch {
                 fireStorageWriteErrorPixel(suppressedPixelName: pixelName, error: error)
                 printDebugInfo(pixelName: pixelName, frequency: .uniqueByNameAndParameters, parameters: newParams, skipped: true)
@@ -557,13 +591,14 @@ public final class PixelKit {
                              _ headers: [String: String],
                              _ newParams: [String: String],
                              _ allowedQueryReservedCharacters: CharacterSet?,
+                             _ retryOnFailure: Bool,
                              _ onComplete: @escaping CompletionBlock) {
         reportErrorIf(pixel: pixelName, endsWith: "_u")
         reportErrorIf(pixel: pixelName, endsWith: "_daily") // Because is added automatically
         if !pixelHasBeenFiredDailyToday(pixelName) {
             do {
                 try updatePixelLastFireDate(pixelName: pixelName, frequency: .daily)
-                fireRequestWrapper(pixelName + "_daily", headers, newParams, allowedQueryReservedCharacters, true, .daily, onComplete)
+                fireRequestWrapper(pixelName + "_daily", headers, newParams, allowedQueryReservedCharacters, true, .daily, retryOnFailure, onComplete)
             } catch {
                 fireStorageWriteErrorPixel(suppressedPixelName: pixelName, error: error)
                 printDebugInfo(pixelName: pixelName + "_daily", frequency: .daily, parameters: newParams, skipped: true)
@@ -579,13 +614,14 @@ public final class PixelKit {
                                 _ headers: [String: String],
                                 _ newParams: [String: String],
                                 _ allowedQueryReservedCharacters: CharacterSet?,
+                                _ retryOnFailure: Bool,
                                 _ seconds: TimeInterval,
                                 _ onComplete: @escaping CompletionBlock) {
         let frequency = Frequency.debounce(seconds: seconds)
         if !pixelHasBeenFiredWithinDebounceInterval(pixelName, seconds: seconds) {
             do {
                 try updatePixelLastFireDate(pixelName: pixelName, frequency: frequency)
-                fireRequestWrapper(pixelName, headers, newParams, allowedQueryReservedCharacters, true, frequency, onComplete)
+                fireRequestWrapper(pixelName, headers, newParams, allowedQueryReservedCharacters, true, frequency, retryOnFailure, onComplete)
             } catch {
                 fireStorageWriteErrorPixel(suppressedPixelName: pixelName, error: error)
                 printDebugInfo(pixelName: pixelName, frequency: frequency, parameters: newParams, skipped: true)
@@ -601,13 +637,14 @@ public final class PixelKit {
                                _ headers: [String: String],
                                _ newParams: [String: String],
                                _ allowedQueryReservedCharacters: CharacterSet?,
+                               _ retryOnFailure: Bool,
                                _ onComplete: @escaping CompletionBlock) {
         reportErrorIf(pixel: pixelName, endsWith: "_u")
         reportErrorIf(pixel: pixelName, endsWith: "_monthly") // Because is added automatically
         if !pixelHasBeenFiredMonthlyThisMonth(pixelName) {
             do {
                 try updatePixelLastFireDate(pixelName: pixelName, frequency: .monthly)
-                fireRequestWrapper(pixelName + "_monthly", headers, newParams, allowedQueryReservedCharacters, true, .monthly, onComplete)
+                fireRequestWrapper(pixelName + "_monthly", headers, newParams, allowedQueryReservedCharacters, true, .monthly, retryOnFailure, onComplete)
             } catch {
                 fireStorageWriteErrorPixel(suppressedPixelName: pixelName, error: error)
                 printDebugInfo(pixelName: pixelName + "_monthly", frequency: .monthly, parameters: newParams, skipped: true)
@@ -623,13 +660,14 @@ public final class PixelKit {
                                            _ headers: [String: String],
                                            _ newParams: [String: String],
                                            _ allowedQueryReservedCharacters: CharacterSet?,
+                                           _ retryOnFailure: Bool,
                                            _ onComplete: @escaping CompletionBlock) {
         reportErrorIf(pixel: pixelName, endsWith: "_u")
         reportErrorIf(pixel: pixelName, endsWith: "_d")
         if !pixelHasBeenFiredDailyToday(pixelName) {
             do {
                 try updatePixelLastFireDate(pixelName: pixelName, frequency: .daily)
-                fireRequestWrapper(pixelName, headers, newParams, allowedQueryReservedCharacters, true, .legacyDailyNoSuffix, onComplete)
+                fireRequestWrapper(pixelName, headers, newParams, allowedQueryReservedCharacters, true, .legacyDailyNoSuffix, retryOnFailure, onComplete)
             } catch {
                 fireStorageWriteErrorPixel(suppressedPixelName: pixelName, error: error)
                 printDebugInfo(pixelName: pixelName, frequency: .legacyDailyNoSuffix, parameters: newParams, skipped: true)
@@ -653,6 +691,7 @@ public final class PixelKit {
                               _ headers: [String: String],
                               _ newParams: [String: String],
                               _ allowedQueryReservedCharacters: CharacterSet?,
+                              _ retryOnFailure: Bool,
                               _ percentage: Int,
                               _ onComplete: @escaping CompletionBlock) {
         assert(percentage >= 1 && percentage <= 100, "Sampling percentage must be between 1 and 100, got \(percentage)")
@@ -666,7 +705,7 @@ public final class PixelKit {
         let sampler = ClosureSampler(percentage: percentage)
         sampler.sample({
             let sampledPixelName = pixelName + suffix
-            fireRequestWrapper(sampledPixelName, headers, newParams, allowedQueryReservedCharacters, true, .sample(percentage: percentage), onComplete)
+            fireRequestWrapper(sampledPixelName, headers, newParams, allowedQueryReservedCharacters, true, .sample(percentage: percentage), retryOnFailure, onComplete)
         }, onDiscarded: {
             self.printDebugInfo(pixelName: pixelName + suffix, frequency: .sample(percentage: percentage), parameters: newParams, skipped: true)
             onComplete(false, nil)
@@ -677,13 +716,14 @@ public final class PixelKit {
                                    _ headers: [String: String],
                                    _ newParams: [String: String],
                                    _ allowedQueryReservedCharacters: CharacterSet?,
+                                   _ retryOnFailure: Bool,
                                    _ onComplete: @escaping CompletionBlock) {
         reportErrorIf(pixel: pixelName, endsWith: "_u")
         reportErrorIf(pixel: pixelName, endsWith: "_d") // Because is added automatically
         if !pixelHasBeenFiredDailyToday(pixelName) {
             do {
                 try updatePixelLastFireDate(pixelName: pixelName, frequency: .daily)
-                fireRequestWrapper(pixelName + "_d", headers, newParams, allowedQueryReservedCharacters, true, .legacyDaily, onComplete)
+                fireRequestWrapper(pixelName + "_d", headers, newParams, allowedQueryReservedCharacters, true, .legacyDaily, retryOnFailure, onComplete)
             } catch {
                 fireStorageWriteErrorPixel(suppressedPixelName: pixelName, error: error)
                 printDebugInfo(pixelName: pixelName + "_d", frequency: .legacyDaily, parameters: newParams, skipped: true)
@@ -699,6 +739,7 @@ public final class PixelKit {
                                            _ headers: [String: String],
                                            _ newParams: [String: String],
                                            _ allowedQueryReservedCharacters: CharacterSet?,
+                                           _ retryOnFailure: Bool,
                                            _ onComplete: @escaping CompletionBlock) {
         reportErrorIf(pixel: pixelName, endsWith: "_u")
         reportErrorIf(pixel: pixelName, endsWith: "_d") // Because is added automatically
@@ -706,7 +747,7 @@ public final class PixelKit {
         if !pixelHasBeenFiredDailyToday(pixelName) {
             do {
                 try updatePixelLastFireDate(pixelName: pixelName, frequency: .daily)
-                fireRequestWrapper(pixelName + "_d", headers, newParams, allowedQueryReservedCharacters, true, .legacyDailyAndCount, onComplete)
+                fireRequestWrapper(pixelName + "_d", headers, newParams, allowedQueryReservedCharacters, true, .legacyDailyAndCount, retryOnFailure, onComplete)
             } catch {
                 fireStorageWriteErrorPixel(suppressedPixelName: pixelName, error: error)
                 printDebugInfo(pixelName: pixelName + "_d", frequency: .legacyDailyAndCount, parameters: newParams, skipped: true)
@@ -715,13 +756,14 @@ public final class PixelKit {
             printDebugInfo(pixelName: pixelName + "_d", frequency: .legacyDailyAndCount, parameters: newParams, skipped: true)
         }
 
-        fireRequestWrapper(pixelName + "_c", headers, newParams, allowedQueryReservedCharacters, true, .legacyDailyAndCount, onComplete)
+        fireRequestWrapper(pixelName + "_c", headers, newParams, allowedQueryReservedCharacters, true, .legacyDailyAndCount, retryOnFailure, onComplete)
     }
 
     private func handleDailyAndCount(_ pixelName: String,
                                      _ headers: [String: String],
                                      _ newParams: [String: String],
                                      _ allowedQueryReservedCharacters: CharacterSet?,
+                                     _ retryOnFailure: Bool,
                                      _ onComplete: @escaping CompletionBlock) {
         reportErrorIf(pixel: pixelName, endsWith: "_u")
         reportErrorIf(pixel: pixelName, endsWith: "_daily") // Because is added automatically
@@ -729,7 +771,7 @@ public final class PixelKit {
         if !pixelHasBeenFiredDailyToday(pixelName) {
             do {
                 try updatePixelLastFireDate(pixelName: pixelName, frequency: .daily)
-                fireRequestWrapper(pixelName + "_daily", headers, newParams, allowedQueryReservedCharacters, true, .dailyAndCount, onComplete)
+                fireRequestWrapper(pixelName + "_daily", headers, newParams, allowedQueryReservedCharacters, true, .dailyAndCount, retryOnFailure, onComplete)
             } catch {
                 fireStorageWriteErrorPixel(suppressedPixelName: pixelName, error: error)
                 printDebugInfo(pixelName: pixelName + "_daily", frequency: .dailyAndCount, parameters: newParams, skipped: true)
@@ -738,20 +780,21 @@ public final class PixelKit {
             printDebugInfo(pixelName: pixelName + "_daily", frequency: .dailyAndCount, parameters: newParams, skipped: true)
         }
 
-        fireRequestWrapper(pixelName + "_count", headers, newParams, allowedQueryReservedCharacters, true, .dailyAndCount, onComplete)
+        fireRequestWrapper(pixelName + "_count", headers, newParams, allowedQueryReservedCharacters, true, .dailyAndCount, retryOnFailure, onComplete)
     }
 
     private func handleDailyAndStandard(_ pixelName: String,
                                         _ headers: [String: String],
                                         _ newParams: [String: String],
                                         _ allowedQueryReservedCharacters: CharacterSet?,
+                                        _ retryOnFailure: Bool,
                                         _ onComplete: @escaping CompletionBlock) {
         reportErrorIf(pixel: pixelName, endsWith: "_u")
         reportErrorIf(pixel: pixelName, endsWith: "_daily") // Because is added automatically
         if !pixelHasBeenFiredDailyToday(pixelName) {
             do {
                 try updatePixelLastFireDate(pixelName: pixelName, frequency: .daily)
-                fireRequestWrapper(pixelName + "_daily", headers, newParams, allowedQueryReservedCharacters, true, .dailyAndCount, onComplete)
+                fireRequestWrapper(pixelName + "_daily", headers, newParams, allowedQueryReservedCharacters, true, .dailyAndCount, retryOnFailure, onComplete)
             } catch {
                 fireStorageWriteErrorPixel(suppressedPixelName: pixelName, error: error)
                 printDebugInfo(pixelName: pixelName + "_daily", frequency: .dailyAndCount, parameters: newParams, skipped: true)
@@ -760,7 +803,7 @@ public final class PixelKit {
             printDebugInfo(pixelName: pixelName + "_daily", frequency: .dailyAndCount, parameters: newParams, skipped: true)
         }
 
-        fireRequestWrapper(pixelName, headers, newParams, allowedQueryReservedCharacters, true, .dailyAndCount, onComplete)
+        fireRequestWrapper(pixelName, headers, newParams, allowedQueryReservedCharacters, true, .dailyAndCount, retryOnFailure, onComplete)
     }
 
     /// If the pixel name ends with the forbiddenString then an error is logged or an assertion failure is fired in debug
@@ -803,6 +846,7 @@ public final class PixelKit {
         _ allowedQueryReservedCharacters: CharacterSet?,
         _ callBackOnMainThread: Bool,
         _ frequency: Frequency,
+        _ retryOnFailure: Bool,
         _ onComplete: @escaping CompletionBlock) {
 #if DEBUG
             Self.writeValidationPixel(pixelName: pixelName, parameters: parameters)
@@ -815,8 +859,17 @@ public final class PixelKit {
                 }
                 return
             }
-            let effectiveFireRequest = retryQueue?.fireRequest ?? fireRequest
-            effectiveFireRequest(pixelName, headers, parameters, allowedQueryReservedCharacters, callBackOnMainThread, onComplete)
+            guard let retryQueue else {
+                fireRequest(pixelName, headers, parameters, allowedQueryReservedCharacters, callBackOnMainThread, onComplete)
+                return
+            }
+            retryQueue.fire(pixelName: pixelName,
+                            headers: headers,
+                            parameters: parameters,
+                            allowedQueryReservedCharacters: allowedQueryReservedCharacters,
+                            callBackOnMainThread: callBackOnMainThread,
+                            retryOnFailure: retryOnFailure,
+                            onComplete: onComplete)
         }
 
     private func prefixedAndSuffixedName(for event: PixelKit.Event, namePrefix: String?, doNotEnforcePrefix: Bool = false) -> String {
@@ -953,6 +1006,7 @@ public final class PixelKit {
             nil,
             true,
             .standard,
+            false,
             { _, _ in }
         )
     }

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/README.md
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/README.md
@@ -9,3 +9,15 @@ shared packages.
 This design decision is meant to make PixelKit lean and to make it possible to use it
 for future apps we may decide to make, without it having to carry over all of the business
 domain logic for any single app.
+
+## Retry on failure
+
+A pixel that fails to send is dropped, unless it opts into the retry queue:
+
+```swift
+pixelKit.fire(MyPixel.somethingImportant, options: .withRetry)
+```
+
+Opting in persists a failed send and replays it later, with two extra parameters
+(`originalPixelTimestamp` and `retriedPixel`) that the pixel must be privacy triaged for first. It is
+off by default for exactly that reason. See [RetryQueue/README.md](RetryQueue/README.md).

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/PixelRetryQueue.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/PixelRetryQueue.swift
@@ -22,10 +22,13 @@ import Persistence
 
 /// Retry queue for failed PixelKit fires.
 ///
-/// `PixelRetryQueue` decorates the `PixelKit.FireRequest` network closure. When a fire fails it persists
-/// the fully-resolved request; when a fire succeeds it triggers a throttled drain that replays queued
-/// items through the *underlying* closure (so replays never re-enter this decorator). Items older than
-/// 28 days are dropped without sending.
+/// `PixelRetryQueue` wraps the `PixelKit.FireRequest` network closure. Retry is opt-in per fire
+/// (`PixelKit.Options.retryOnFailure`): a fire that opted in and failed has its fully-resolved request
+/// persisted, while a fire that did not is passed straight through and dropped on failure as if the
+/// queue were not there. Any successful fire — opted in or not — triggers a throttled drain that
+/// replays queued items through the *underlying* closure, so replays never re-enter the queue and an
+/// opted-in pixel is retried as soon as the next pixel of any kind gets through. Items older than 28
+/// days are dropped without sending.
 ///
 /// `PixelKit` creates and owns this internally: it wraps the `FireRequest` passed to `PixelKit.setUp`,
 /// reuses the same `defaults` for throttling state, and drains the queue after each successful send.
@@ -44,6 +47,13 @@ final class PixelRetryQueue {
 #endif
     }
 
+    /// Wire parameter keys added to a replayed pixel, matching iOS `PersistentPixel` so the backend sees
+    /// identical data from both systems. Only ever attached to pixels that opted into retry.
+    enum Parameters {
+        static let originalPixelTimestamp = "originalPixelTimestamp"
+        static let retriedPixel = "retriedPixel"
+    }
+
     private let underlyingFireRequest: PixelKit.FireRequest
     private let store: PixelRetryQueueStoring
     private let lastProcessingDateStorage: ThrowingKeyValueStoring
@@ -60,6 +70,12 @@ final class PixelRetryQueue {
     private let workQueue = DispatchQueue(label: "PixelKit Retry Queue")
     private let logger = Logger(subsystem: "PixelKit", category: "PixelRetryQueue")
 
+    private let dateFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
     init(fireRequest: @escaping PixelKit.FireRequest,
          store: PixelRetryQueueStoring = PixelRetryQueueFileStore(),
          lastProcessingDateStorage: ThrowingKeyValueStoring = UserDefaults.standard,
@@ -75,23 +91,30 @@ final class PixelRetryQueue {
         self.lastProcessingDate = ((try? lastProcessingDateStorage.object(forKey: lastProcessingDateKey)) ?? nil) as? Date
     }
 
-    /// The decorated closure PixelKit routes its fires through.
-    var fireRequest: PixelKit.FireRequest {
-        { [weak self] pixelName, headers, parameters, allowedChars, callBackOnMainThread, onComplete in
-            guard let self else {
-                onComplete(false, nil)
-                return
-            }
-            self.underlyingFireRequest(pixelName, headers, parameters, allowedChars, callBackOnMainThread) { success, error in
-                onComplete(success, error)
-                if success {
-                    self.sendQueuedPixels()
-                } else {
-                    self.enqueueFailedPixel(pixelName: pixelName,
-                                            headers: headers,
-                                            parameters: parameters,
-                                            allowedQueryReservedCharacters: allowedChars)
-                }
+    /// Sends a pixel through the underlying network closure, queueing it for retry if it fails and the
+    /// caller opted in.
+    ///
+    /// - Parameter retryOnFailure: whether a failed send is persisted for later replay. When `false`
+    ///   (the default for every pixel) the send is a plain pass-through and a failure is dropped, which
+    ///   is the behaviour a caller gets with no retry queue at all. Draining is deliberately *not*
+    ///   gated on this: a success here replays whatever is queued regardless, so an opted-in pixel does
+    ///   not have to wait for another opted-in pixel to succeed before it is retried.
+    func fire(pixelName: String,
+              headers: [String: String],
+              parameters: [String: String],
+              allowedQueryReservedCharacters: CharacterSet?,
+              callBackOnMainThread: Bool,
+              retryOnFailure: Bool,
+              onComplete: @escaping PixelKit.CompletionBlock) {
+        underlyingFireRequest(pixelName, headers, parameters, allowedQueryReservedCharacters, callBackOnMainThread) { [self] success, error in
+            onComplete(success, error)
+            if success {
+                sendQueuedPixels()
+            } else if retryOnFailure {
+                enqueueFailedPixel(pixelName: pixelName,
+                                   headers: headers,
+                                   parameters: parameters,
+                                   allowedQueryReservedCharacters: allowedQueryReservedCharacters)
             }
         }
     }
@@ -190,10 +213,21 @@ final class PixelRetryQueue {
                 continue
             }
 
-            // Strip the legacy retry timestamp that older builds baked into the persisted parameters, so
-            // items queued before this key was dropped don't keep sending it on replay.
+            // Builds that queued every failed pixel, before retry became opt-in, baked
+            // `originalPixelTimestamp` into the persisted parameters; nothing does that now, so its
+            // presence identifies an item queued without the caller having opted in. Those pixels were
+            // never triaged for retry, so drop them rather than replay them.
             // For more info see https://app.asana.com/1/137249556945/task/1215909080171360?focus=true
-            let parameters = item.parameters.filter { $0.key != "originalPixelTimestamp" }
+            guard item.parameters[Parameters.originalPixelTimestamp] == nil else {
+                idsAccessQueue.sync { _ = idsToRemove.insert(item.id) }
+                continue
+            }
+
+            // Mark the replay so the backend can tell it from an organic send and de-duplicate against
+            // the original attempt. `item.timestamp` is when that attempt failed.
+            var parameters = item.parameters
+            parameters[Parameters.originalPixelTimestamp] = dateFormatter.string(from: item.timestamp)
+            parameters[Parameters.retriedPixel] = "1"
 
             dispatchGroup.enter()
             underlyingFireRequest(item.pixelName, item.headers, parameters, item.allowedQueryReservedCharacters, false) { success, _ in

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/PixelRetryQueue.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/PixelRetryQueue.swift
@@ -213,16 +213,6 @@ final class PixelRetryQueue {
                 continue
             }
 
-            // Builds that queued every failed pixel, before retry became opt-in, baked
-            // `originalPixelTimestamp` into the persisted parameters; nothing does that now, so its
-            // presence identifies an item queued without the caller having opted in. Those pixels were
-            // never triaged for retry, so drop them rather than replay them.
-            // For more info see https://app.asana.com/1/137249556945/task/1215909080171360?focus=true
-            guard item.parameters[Parameters.originalPixelTimestamp] == nil else {
-                idsAccessQueue.sync { _ = idsToRemove.insert(item.id) }
-                continue
-            }
-
             // Mark the replay so the backend can tell it from an organic send and de-duplicate against
             // the original attempt. `item.timestamp` is when that attempt failed.
             var parameters = item.parameters

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/PixelRetryQueue.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/PixelRetryQueue.swift
@@ -213,6 +213,15 @@ final class PixelRetryQueue {
                 continue
             }
 
+            // Builds that queued every failed pixel, before retry became opt-in, wrote no `optedIn` key,
+            // so those items decode as not opted in. They were never triaged for the retry parameters
+            // below, so drop them rather than replay them.
+            // For more info see https://app.asana.com/1/137249556945/task/1215909080171360?focus=true
+            guard item.optedIn else {
+                idsAccessQueue.sync { _ = idsToRemove.insert(item.id) }
+                continue
+            }
+
             // Mark the replay so the backend can tell it from an organic send and de-duplicate against
             // the original attempt. `item.timestamp` is when that attempt failed.
             var parameters = item.parameters

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/PixelRetryQueueItem.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/PixelRetryQueueItem.swift
@@ -32,22 +32,29 @@ struct PixelRetryQueueItem: Codable, Equatable, Identifiable {
     public let allowedQueryReservedCharacters: CharacterSet?
     public let timestamp: Date
 
+    /// Whether the pixel opted into retry via `PixelKit.Options.retryOnFailure`. Only an opted-in pixel is
+    /// ever queued now, hence the default, but builds before the opt-in queued every failure and wrote no
+    /// such key — those items decode as `false` and are dropped rather than replayed.
+    public let optedIn: Bool
+
     public init(id: UUID = UUID(),
                 pixelName: String,
                 headers: [String: String],
                 parameters: [String: String],
                 allowedQueryReservedCharacters: CharacterSet?,
-                timestamp: Date) {
+                timestamp: Date,
+                optedIn: Bool = true) {
         self.id = id
         self.pixelName = pixelName
         self.headers = headers
         self.parameters = parameters
         self.allowedQueryReservedCharacters = allowedQueryReservedCharacters
         self.timestamp = timestamp
+        self.optedIn = optedIn
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, pixelName, headers, parameters, allowedQueryReservedCharacters, timestamp
+        case id, pixelName, headers, parameters, allowedQueryReservedCharacters, timestamp, optedIn
     }
 
     public init(from decoder: Decoder) throws {
@@ -57,6 +64,8 @@ struct PixelRetryQueueItem: Codable, Equatable, Identifiable {
         headers = try container.decode([String: String].self, forKey: .headers)
         parameters = try container.decode([String: String].self, forKey: .parameters)
         timestamp = try container.decode(Date.self, forKey: .timestamp)
+        // Absent means the item was persisted before retry became opt-in.
+        optedIn = try container.decodeIfPresent(Bool.self, forKey: .optedIn) ?? false
         if let bitmap = try container.decodeIfPresent(Data.self, forKey: .allowedQueryReservedCharacters) {
             allowedQueryReservedCharacters = CharacterSet(bitmapRepresentation: bitmap)
         } else {
@@ -71,6 +80,7 @@ struct PixelRetryQueueItem: Codable, Equatable, Identifiable {
         try container.encode(headers, forKey: .headers)
         try container.encode(parameters, forKey: .parameters)
         try container.encode(timestamp, forKey: .timestamp)
+        try container.encode(optedIn, forKey: .optedIn)
         try container.encodeIfPresent(allowedQueryReservedCharacters?.bitmapRepresentation, forKey: .allowedQueryReservedCharacters)
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/README.md
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/README.md
@@ -1,0 +1,71 @@
+# PixelKit retry queue
+
+A pixel that fails to send is normally lost. The retry queue lets a pixel opt into being persisted on
+failure and replayed later, so a send that failed because the device was offline still arrives.
+
+It is **opt-in per pixel and off by default**. A pixel that does not opt in behaves exactly as if the
+queue were not there: it is sent once, and a failure is dropped.
+
+## Opting in
+
+```swift
+pixelKit.fire(MyPixel.somethingImportant, options: .withRetry)
+
+// or, composed with other options, since `Options` is a value type
+var options = PixelKit.Options.parameters(["source": "menu"])
+options.retryOnFailure = true
+pixelKit.fire(MyPixel.somethingImportant, options: options)
+```
+
+## What a replay sends
+
+A replayed pixel carries the original request unchanged — same name, headers, parameters and
+`allowedQueryReservedCharacters` — plus two extra parameters:
+
+| Parameter | Value |
+|---|---|
+| `originalPixelTimestamp` | ISO 8601 (`.withInternetDateTime`) timestamp of the send that failed |
+| `retriedPixel` | `"1"` |
+
+They let the backend tell a replay from an organic send and de-duplicate it against the original
+attempt. The same two names are used by the iOS `PersistentPixel` system, so both produce identical
+data. Neither parameter is attached to the original (organic) send, only to a replay.
+
+**These parameters are why the opt-in exists.** `originalPixelTimestamp` reintroduces exactly the
+time-based correlation that PETAL removes, so a pixel must be privacy triaged for both parameters
+before it sets `retryOnFailure`. They also have to be declared in the pixel's definition, or live
+validation will reject the replay as having additional properties. An earlier version of this queue
+retried every PixelKit pixel and attached both parameters globally, which is what
+[this report](https://app.asana.com/1/137249556945/task/1215895717530162) caught.
+
+## Mechanics
+
+- **Persistence.** A failed opted-in send is written to `pixelkit-retry-queue-<session>.json` in
+  Application Support. `<session>` is the `session` string passed to `PixelKit.setUp`, so the browser,
+  the VPN agent and the packet tunnel each keep their own queue even when they share a `UserDefaults`
+  suite.
+- **Draining.** *Any* successful send triggers a drain, whether or not that pixel opted in. Gating the
+  drain on the opt-in too would mean a queued pixel had to wait for another opted-in pixel to succeed
+  before being retried. For a launching app the first successful pixel is usually enough to flush the
+  queue.
+- **Throttle.** Drains happen at most once an hour (once a minute in `DEBUG`). An empty drain does not
+  advance the throttle, so a failure queued right after one is still replayed promptly.
+- **Expiry.** Items older than 28 days are dropped without being sent. Expired items are also pruned
+  when a new failure is enqueued, so a long offline stretch cannot keep known-dead pixels queued.
+- **Cap.** The store holds 100 items, oldest dropped first.
+- **Replays don't re-enter the queue.** A replay goes straight to the network closure, so a failed
+  replay leaves the item queued for the next drain rather than queueing a duplicate.
+- **Dry run.** `PixelKit(dryRun: true)` creates no queue at all.
+
+## Items queued before retry was opt-in
+
+Builds that queued every failed pixel baked `originalPixelTimestamp` into the persisted parameters.
+That key's presence therefore identifies an item queued without its caller having opted in, and those
+items are dropped rather than replayed — they were never triaged for retry. Nothing writes that key
+into stored parameters any more, so the case disappears as those queues age out.
+
+## Related
+
+- `PixelKit.Options.retryOnFailure` — the caller-facing switch.
+- `iOS/Core/PersistentPixel.swift` — the older, iOS-only system this is a port of. It is deprecated;
+  new pixels should use PixelKit.

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/README.md
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/README.md
@@ -57,13 +57,6 @@ retried every PixelKit pixel and attached both parameters globally, which is wha
   replay leaves the item queued for the next drain rather than queueing a duplicate.
 - **Dry run.** `PixelKit(dryRun: true)` creates no queue at all.
 
-## Items queued before retry was opt-in
-
-Builds that queued every failed pixel baked `originalPixelTimestamp` into the persisted parameters.
-That key's presence therefore identifies an item queued without its caller having opted in, and those
-items are dropped rather than replayed — they were never triaged for retry. Nothing writes that key
-into stored parameters any more, so the case disappears as those queues age out.
-
 ## Related
 
 - `PixelKit.Options.retryOnFailure` — the caller-facing switch.

--- a/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/README.md
+++ b/SharedPackages/BrowserServicesKit/Sources/PixelKit/RetryQueue/README.md
@@ -57,6 +57,12 @@ retried every PixelKit pixel and attached both parameters globally, which is wha
   replay leaves the item queued for the next drain rather than queueing a duplicate.
 - **Dry run.** `PixelKit(dryRun: true)` creates no queue at all.
 
+## Items queued before retry was opt-in
+
+Builds that queued every failed pixel wrote no `optedIn` key into the persisted item, so those items
+decode as not opted in and are dropped rather than replayed — they were never triaged for the retry
+parameters. The case disappears as those queues age out.
+
 ## Related
 
 - `PixelKit.Options.retryOnFailure` — the caller-facing switch.

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/PixelKitTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/PixelKitTests.swift
@@ -1212,13 +1212,15 @@ final class PixelKitTests: XCTestCase {
         XCTAssertEqual(PixelKit.Options.namePrefix("p_"), PixelKit.Options(namePrefix: "p_"))
         XCTAssertEqual(PixelKit.Options.parameters(["a": "b"], namePrefix: "p_"),
                        PixelKit.Options(additionalParameters: ["a": "b"], namePrefix: "p_"))
+        XCTAssertEqual(PixelKit.Options.withRetry, PixelKit.Options(retryOnFailure: true))
     }
 
-    /// Defaults must be the non-intrusive ones: prefix enforced, app version included.
+    /// Defaults must be the non-intrusive ones: prefix enforced, app version included, no retry.
     func testOptionsDefaultsAreConservative() {
         let options = PixelKit.Options()
         XCTAssertTrue(options.enforcePrefix)
         XCTAssertTrue(options.includeAppVersionParameter)
+        XCTAssertFalse(options.retryOnFailure)
         XCTAssertNil(options.headers)
         XCTAssertNil(options.additionalParameters)
         XCTAssertNil(options.namePrefix)
@@ -1253,6 +1255,77 @@ final class PixelKitTests: XCTestCase {
         // Omitting options must still default it.
         XCTAssertEqual(recorder.calls[1].frequency, .daily)
         XCTAssertEqual(recorder.calls[1].options, .default)
+    }
+
+    // MARK: - Retry opt-in
+
+    /// `PixelKit` instance whose retry queue is backed by an in-memory store, so the opt-in wiring can be
+    /// asserted without touching the real Application Support file.
+    private func makePixelKit(retryQueueStore: PixelRetryQueueStoring,
+                              fireRequest: @escaping PixelKit.FireRequest) -> PixelKit {
+        PixelKit(dryRun: false,
+                 appVersion: "1.0.0",
+                 source: nil,
+                 session: UUID().uuidString,
+                 channel: nil,
+                 defaultHeaders: [:],
+                 pixelCalendar: nil,
+                 dateGenerator: Date.init,
+                 defaults: userDefaults(),
+                 retryQueueStore: retryQueueStore,
+                 fireRequest: fireRequest)
+    }
+
+    /// Fails every send, recording the fully-resolved pixel names it was asked for, so assertions can
+    /// compare what was queued against what was actually attempted without restating the platform prefix.
+    private final class FailingFireRequestRecorder {
+        private(set) var pixelNames = [String]()
+
+        lazy var fireRequest: PixelKit.FireRequest = { [self] pixelName, _, _, _, _, completion in
+            pixelNames.append(pixelName)
+            completion(false, NSError(domain: "test", code: 1))
+        }
+    }
+
+    /// Retry is off unless the pixel asks for it, so a plain failed fire leaves nothing behind.
+    func testFailedFireIsNotQueuedByDefault() {
+        let store = MockPixelRetryQueueStore()
+        let recorder = FailingFireRequestRecorder()
+        let pixelKit = makePixelKit(retryQueueStore: store, fireRequest: recorder.fireRequest)
+        let fired = expectation(description: "fired")
+
+        pixelKit.fire(event: TestEventV2.testEvent, frequency: .standard, options: .default) { _, _ in fired.fulfill() }
+
+        wait(for: [fired], timeout: 1.0)
+        XCTAssertEqual(recorder.pixelNames.count, 1)
+        XCTAssertTrue(store.items.isEmpty)
+    }
+
+    func testFailedFireIsQueuedWhenThePixelOptsIntoRetry() {
+        let store = MockPixelRetryQueueStore()
+        let recorder = FailingFireRequestRecorder()
+        let pixelKit = makePixelKit(retryQueueStore: store, fireRequest: recorder.fireRequest)
+        let fired = expectation(description: "fired")
+
+        pixelKit.fire(event: TestEventV2.testEvent, frequency: .standard, options: .withRetry) { _, _ in fired.fulfill() }
+
+        wait(for: [fired], timeout: 1.0)
+        XCTAssertEqual(store.items.map(\.pixelName), recorder.pixelNames)
+        XCTAssertEqual(store.items.count, 1)
+    }
+
+    /// The opt-in has to survive the per-`Frequency` handlers, not just the `.standard` one.
+    func testFailedDailyFireIsQueuedWhenThePixelOptsIntoRetry() {
+        let store = MockPixelRetryQueueStore()
+        let recorder = FailingFireRequestRecorder()
+        let pixelKit = makePixelKit(retryQueueStore: store, fireRequest: recorder.fireRequest)
+        let fired = expectation(description: "fired")
+
+        pixelKit.fire(event: TestEventV2.dailyEvent, frequency: .daily, options: .withRetry) { _, _ in fired.fulfill() }
+
+        wait(for: [fired], timeout: 1.0)
+        XCTAssertEqual(store.items.map(\.pixelName), recorder.pixelNames)
+        XCTAssertEqual(store.items.first?.pixelName.hasSuffix("_daily"), true)
     }
 
     // MARK: - Static async entry point

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueItemTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueItemTests.swift
@@ -48,4 +48,15 @@ final class PixelRetryQueueItemTests: XCTestCase {
         XCTAssertEqual(item, decoded)
         XCTAssertEqual(decoded.allowedQueryReservedCharacters, CharacterSet(charactersIn: ",;+"))
     }
+
+    func testWhenItemWasPersistedBeforeRetryWasOptIn_ThenItDecodesAsNotOptedIn() throws {
+        // Shape written by builds that queued every failed pixel: no `optedIn` key.
+        let json = """
+        {"id":"\(UUID().uuidString)","pixelName":"m_test","headers":{},"parameters":{},"timestamp":700000000}
+        """
+
+        let decoded = try JSONDecoder().decode(PixelRetryQueueItem.self, from: Data(json.utf8))
+
+        XCTAssertFalse(decoded.optedIn)
+    }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTestDoubles.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTestDoubles.swift
@@ -57,7 +57,7 @@ final class MockPixelRetryQueueStore: PixelRetryQueueStoring {
     }
 }
 
-/// Controllable `PixelKit.FireRequest`, modelling the network sender that `PixelRetryQueue` decorates.
+/// Controllable `PixelKit.FireRequest`, modelling the network sender that `PixelRetryQueue` wraps.
 /// Like the real sender it is retry-agnostic: it records every fire and returns `defaultResult`, with no
 /// notion of organic-vs-replay. Tests drive scenarios through the pixel identities they control — naming
 /// the pixels they enqueue and asserting on calls by name. Named fires can be held (deferred) via

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTests.swift
@@ -52,29 +52,57 @@ final class PixelRetryQueueTests: XCTestCase {
                                    timestamp: timestamp)
     }
 
-    // MARK: - Persist on failure
-
-    func testWhenOrganicFireSucceeds_ThenNothingIsStored_AndCompletionIsForwarded() {
-        let queue = makeQueue()
-        let completed = expectation(description: "onComplete")
-
-        queue.fireRequest("m_organic", [:], ["k": "v"], nil, true) { success, error in
-            XCTAssertTrue(success)
-            XCTAssertNil(error)
-            completed.fulfill()
-        }
-
-        wait(for: [completed], timeout: 1.0)
-        XCTAssertTrue(store.items.isEmpty)
+    /// Fires through the queue with the opt-in explicit at every call site, since it is what these
+    /// tests are mostly about.
+    private func fire(_ queue: PixelRetryQueue,
+                      _ pixelName: String,
+                      headers: [String: String] = [:],
+                      parameters: [String: String] = [:],
+                      allowedQueryReservedCharacters: CharacterSet? = nil,
+                      retryOnFailure: Bool,
+                      onComplete: @escaping PixelKit.CompletionBlock = { _, _ in }) {
+        queue.fire(pixelName: pixelName,
+                   headers: headers,
+                   parameters: parameters,
+                   allowedQueryReservedCharacters: allowedQueryReservedCharacters,
+                   callBackOnMainThread: true,
+                   retryOnFailure: retryOnFailure,
+                   onComplete: onComplete)
     }
 
-    func testWhenOrganicFireFails_ThenItemIsStoredWithTimestamp_AndCompletionIsForwarded() {
+    private func iso8601(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: date)
+    }
+
+    // MARK: - Opting in
+
+    func testWhenFireFailsWithoutOptingIn_ThenNothingIsStored_AndCompletionIsForwarded() {
         let error = NSError(domain: "test", code: 7)
         fireMock.defaultResult = (false, error)
         let queue = makeQueue()
         let completed = expectation(description: "onComplete")
 
-        queue.fireRequest("m_organic", ["H": "V"], ["k": "v"], nil, true) { success, returnedError in
+        fire(queue, "m_organic", parameters: ["k": "v"], retryOnFailure: false) { success, returnedError in
+            XCTAssertFalse(success)
+            XCTAssertEqual((returnedError as NSError?)?.code, 7)
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1.0)
+
+        // Retry is opt-in: a pixel that didn't ask for it is dropped on failure, as if there were no queue.
+        XCTAssertTrue(store.items.isEmpty)
+    }
+
+    func testWhenFireFailsAfterOptingIn_ThenItemIsStoredWithTimestamp_AndCompletionIsForwarded() {
+        let error = NSError(domain: "test", code: 7)
+        fireMock.defaultResult = (false, error)
+        let queue = makeQueue()
+        let completed = expectation(description: "onComplete")
+
+        fire(queue, "m_organic", headers: ["H": "V"], parameters: ["k": "v"], retryOnFailure: true) { success, returnedError in
             XCTAssertFalse(success)
             XCTAssertEqual((returnedError as NSError?)?.code, 7)
             completed.fulfill()
@@ -86,8 +114,22 @@ final class PixelRetryQueueTests: XCTestCase {
         let stored = store.items[0]
         XCTAssertEqual(stored.pixelName, "m_organic")
         XCTAssertEqual(stored.headers, ["H": "V"])
-        XCTAssertEqual(stored.parameters["k"], "v")
+        XCTAssertEqual(stored.parameters, ["k": "v"])
         XCTAssertEqual(stored.timestamp, now)
+    }
+
+    func testWhenFireSucceeds_ThenNothingIsStored_AndCompletionIsForwarded() {
+        let queue = makeQueue()
+        let completed = expectation(description: "onComplete")
+
+        fire(queue, "m_organic", parameters: ["k": "v"], retryOnFailure: true) { success, error in
+            XCTAssertTrue(success)
+            XCTAssertNil(error)
+            completed.fulfill()
+        }
+
+        wait(for: [completed], timeout: 1.0)
+        XCTAssertTrue(store.items.isEmpty)
     }
 
     // MARK: - Draining
@@ -108,12 +150,17 @@ final class PixelRetryQueueTests: XCTestCase {
         XCTAssertTrue(store.items.isEmpty)
         XCTAssertEqual(fireMock.calls.count, 1)
         XCTAssertEqual(fireMock.calls.first?.pixelName, "m_queued")
-        // The replay carries the item's stored parameters unchanged — nothing is injected on send.
-        XCTAssertEqual(fireMock.calls.first?.parameters, item.parameters)
+        // The replay carries the item's parameters plus the two retry markers.
+        XCTAssertEqual(fireMock.calls.first?.parameters, [
+            "key": "value",
+            PixelRetryQueue.Parameters.originalPixelTimestamp: iso8601(item.timestamp),
+            PixelRetryQueue.Parameters.retriedPixel: "1"
+        ])
     }
 
-    func testWhenReplayingItemWithLegacyTimestampParameter_ThenItIsStrippedBeforeSending() {
-        // Items persisted by builds that still baked in `originalPixelTimestamp` must not replay with it.
+    func testWhenReplayingItemQueuedBeforeRetryWasOptIn_ThenItIsDroppedWithoutSending() {
+        // Builds that queued every failure baked `originalPixelTimestamp` into the stored parameters.
+        // Those pixels never opted into retry, so they must not be replayed.
         let legacy = PixelRetryQueueItem(pixelName: "m_queued",
                                          headers: [:],
                                          parameters: ["key": "value", "originalPixelTimestamp": "2026-06-11T00:00:00Z"],
@@ -126,7 +173,8 @@ final class PixelRetryQueueTests: XCTestCase {
         queue.sendQueuedPixels { _ in drained.fulfill() }
         wait(for: [drained], timeout: 2.0)
 
-        XCTAssertEqual(fireMock.calls.first?.parameters, ["key": "value"])
+        XCTAssertTrue(fireMock.calls.isEmpty)
+        XCTAssertTrue(store.items.isEmpty)
     }
 
     func testWhenItemIsOlderThan28Days_ThenItIsNotSentButIsRemoved() {
@@ -192,9 +240,9 @@ final class PixelRetryQueueTests: XCTestCase {
         XCTAssertEqual(fireMock.calls.first?.allowedQueryReservedCharacters, CharacterSet(charactersIn: ",;"))
     }
 
-    // MARK: - Decorator-specific behaviour
+    // MARK: - Wrapper-specific behaviour
 
-    func testWhenOrganicFireSucceeds_ThenQueueIsDrained() {
+    func testWhenFireSucceedsWithoutOptingIn_ThenQueueIsStillDrained() {
         let item = makeItem(name: "m_queued")
         try? store.append([item])
         let queue = makeQueue()
@@ -205,8 +253,9 @@ final class PixelRetryQueueTests: XCTestCase {
             if call.pixelName == "m_queued" { queuedReplayed.fulfill() }
         }
 
-        // An organic success should trigger a drain that replays the queued item.
-        queue.fireRequest("m_organic", [:], [:], nil, true) { _, _ in }
+        // Draining isn't gated on the opt-in: any successful send replays whatever is queued, so an
+        // opted-in pixel doesn't have to wait for another opted-in pixel to succeed.
+        fire(queue, "m_organic", retryOnFailure: false)
 
         wait(for: [queuedReplayed], timeout: 2.0)
         XCTAssertTrue(fireMock.calls.contains { $0.pixelName == "m_queued" })
@@ -230,7 +279,7 @@ final class PixelRetryQueueTests: XCTestCase {
 
         // Fire a failing organic pixel while the drain is in flight.
         let organicCompleted = expectation(description: "organic completed")
-        queue.fireRequest("m_new", [:], [:], nil, true) { _, _ in organicCompleted.fulfill() }
+        fire(queue, "m_new", retryOnFailure: true) { _, _ in organicCompleted.fulfill() }
         wait(for: [organicCompleted], timeout: 2.0)
 
         // The new failed pixel is stored alongside the initial one.
@@ -261,8 +310,8 @@ final class PixelRetryQueueTests: XCTestCase {
         let queue = makeQueue()
         let completed = expectation(description: "onComplete")
 
-        // A failing organic fire enqueues the new pixel and prunes already-expired items (no drain needed).
-        queue.fireRequest("m_new", [:], [:], nil, true) { _, _ in completed.fulfill() }
+        // A failing opted-in fire enqueues the new pixel and prunes already-expired items (no drain needed).
+        fire(queue, "m_new", retryOnFailure: true) { _, _ in completed.fulfill() }
         wait(for: [completed], timeout: 1.0)
 
         XCTAssertEqual(store.items.count, 1)
@@ -277,7 +326,7 @@ final class PixelRetryQueueTests: XCTestCase {
         let completed = expectation(description: "onComplete")
 
         // A prune failure must not prevent the new failed pixel from being queued.
-        queue.fireRequest("m_new", [:], [:], nil, true) { _, _ in completed.fulfill() }
+        fire(queue, "m_new", retryOnFailure: true) { _, _ in completed.fulfill() }
         wait(for: [completed], timeout: 1.0)
 
         XCTAssertTrue(store.items.contains { $0.pixelName == "m_new" })

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTests.swift
@@ -158,25 +158,6 @@ final class PixelRetryQueueTests: XCTestCase {
         ])
     }
 
-    func testWhenReplayingItemQueuedBeforeRetryWasOptIn_ThenItIsDroppedWithoutSending() {
-        // Builds that queued every failure baked `originalPixelTimestamp` into the stored parameters.
-        // Those pixels never opted into retry, so they must not be replayed.
-        let legacy = PixelRetryQueueItem(pixelName: "m_queued",
-                                         headers: [:],
-                                         parameters: ["key": "value", "originalPixelTimestamp": "2026-06-11T00:00:00Z"],
-                                         allowedQueryReservedCharacters: nil,
-                                         timestamp: now)
-        try? store.append([legacy])
-        let queue = makeQueue()
-        let drained = expectation(description: "drained")
-
-        queue.sendQueuedPixels { _ in drained.fulfill() }
-        wait(for: [drained], timeout: 2.0)
-
-        XCTAssertTrue(fireMock.calls.isEmpty)
-        XCTAssertTrue(store.items.isEmpty)
-    }
-
     func testWhenItemIsOlderThan28Days_ThenItIsNotSentButIsRemoved() {
         let item = makeItem(name: "m_stale", ageInDays: 30)
         try? store.append([item])

--- a/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTests.swift
@@ -158,6 +158,26 @@ final class PixelRetryQueueTests: XCTestCase {
         ])
     }
 
+    func testWhenReplayingItemQueuedBeforeRetryWasOptIn_ThenItIsDroppedWithoutSending() {
+        // Builds that queued every failure wrote no `optedIn` key, so those items decode as not opted in.
+        // Those pixels never opted into retry, so they must not be replayed.
+        let legacy = PixelRetryQueueItem(pixelName: "m_queued",
+                                         headers: [:],
+                                         parameters: ["key": "value"],
+                                         allowedQueryReservedCharacters: nil,
+                                         timestamp: now,
+                                         optedIn: false)
+        try? store.append([legacy])
+        let queue = makeQueue()
+        let drained = expectation(description: "drained")
+
+        queue.sendQueuedPixels { _ in drained.fulfill() }
+        wait(for: [drained], timeout: 2.0)
+
+        XCTAssertTrue(fireMock.calls.isEmpty)
+        XCTAssertTrue(store.items.isEmpty)
+    }
+
     func testWhenItemIsOlderThan28Days_ThenItIsNotSentButIsRemoved() {
         let item = makeItem(name: "m_stale", ageInDays: 30)
         try? store.append([item])


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1217276092678212?focus=true

### Description

The PixelKit retry queue added in #5350 retried **every** PixelKit pixel and attached `originalPixelTimestamp` and `retriedPixel` to any replay. Those parameters were never privacy triaged for the pixels they landed on, and `originalPixelTimestamp` reintroduces exactly the time-based correlation PETAL exists to remove, so #5511 stripped them as a mitigation. The legacy iOS `PersistentPixel` system this was ported from is opt-in per pixel — you call `PersistentPixel.fire` instead of `Pixel.fire` — and the port lost that. See the [failing pixels report](https://app.asana.com/1/137249556945/task/1215895717530162) for the full discussion.

This restores the legacy shape:

- **Retry is opt-in and off by default.** `PixelKit.Options` gains `retryOnFailure: Bool = false`, plus a `.withRetry` preset, so a pixel opts in the same way it opts into any other request shaping:
  ```swift
  pixelKit.fire(MyPixel.somethingImportant, options: .withRetry)
  ```
  A pixel that does not opt in is a plain pass-through: nothing persisted, nothing added, failure dropped, exactly as if the queue were not there.

- **The two parameters are re-enabled**, as the task asks. They are injected at replay time only (never on the organic send), from the queued item's timestamp — wire-identical to what #5350 sent, and matching iOS `PersistentPixel`. Because retry is now opt-in, they only ever reach pixels whose owners asked for retry and can triage them, which is what the report thread landed on.

- **Draining is deliberately not gated on the opt-in.** Any successful send still replays whatever is queued. Gating it too would mean a queued pixel had to wait for another *opted-in* pixel to succeed before being retried, and there is no privacy cost since only opted-in pixels are ever in the queue.

- **Items queued before the opt-in are dropped, not replayed.** Nothing writes `originalPixelTimestamp` into stored parameters any more, so its presence identifies an item queued by a pre-#5511 build, i.e. without its caller having opted in. Replaying those would re-attach `retriedPixel` to untriaged pixels. The case self-expires as old queues age out.

Structurally, `PixelRetryQueue` stops being a closure decorator and becomes a component `PixelKit` routes through with a per-call flag, and the flag threads from `fire(event:frequency:options:)` through `fire(pixelNamed:)` and all 13 per-`Frequency` handlers into `fireRequestWrapper`.

**No pixel opts in yet, so production behaviour is "no retries".** That is deliberate: nothing has been triaged for the retry parameters, and opting anything in now would recreate the original problem. The parent task (#1213797000547599) was about capability parity with `PersistentPixel`, not about a specific pixel, so the capability now exists in the same opt-in shape and teams adopt it per pixel after triage.

### Testing Steps

This is internal pixel-firing infrastructure with no user-facing surface, and reliably forcing a send to fail and then succeed on replay isn't practical to drive by hand. Coverage is via unit tests.

### Impact and Risks

#### What could go wrong?

- **Retries stop happening in production.** Intended, and the point of the change: nothing opts in yet, so no pixel is retried. This is the same position we were in before #5350, minus the privacy exposure. Teams opt in per pixel after triage.
- **The opt-in fails to thread through one of the 13 frequency handlers**, silently retrying or not retrying a pixel. Covered by PixelKit-level tests for `.default`, `.withRetry` and `.daily`; the compiler enforces the parameter at every handler and call site.
- **Legacy queued items are dropped rather than sent.** Bounded: only items queued by builds older than #5511 (2026-06-23) that are still inside the 28-day expiry window, so in practice almost all are already expired on arrival. Dropping is the privacy-safe direction.
- **Retry parameters reach a pixel that hasn't declared them**, failing live validation. Only possible if a call site opts in without triaging and updating its JSON5 definition; the `Options` doc comment, the new RetryQueue README and the pixels cursor rule all state the requirement at the point of use.
- `PixelKit.init` becomes a `convenience init` over an internal designated one. Source-compatible — `PixelKit` is `final`, so callers see no difference. `Options` only gains a defaulted parameter and a static preset, both additive.

Rollback is a straight revert; no persisted format changed.

---

###### Internal references: [DoD](https://app.asana.com/0/1207634633537039) | [Eng Expectations](https://app.asana.com/0/199064865822552) | [Tech Design Template](https://app.asana.com/0/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics delivery and privacy-sensitive retry parameters, but default behavior disables retries until pixels explicitly opt in after triage; legacy untriaged queue items are dropped rather than replayed.
> 
> **Overview**
> PixelKit’s retry queue no longer retries every failed send. **Retry is opt-in per fire** via `PixelKit.Options.retryOnFailure` (default `false`) and the `.withRetry` preset; failed pixels that don’t opt in are dropped as if there were no queue.
> 
> The retry path is wired from `fire(event:frequency:options:)` through all frequency handlers into `PixelRetryQueue`, which now exposes an explicit `fire(..., retryOnFailure:)` instead of decorating the network closure for every send. **Any successful send still drains the queue**, so opted-in failures can replay when the next pixel succeeds.
> 
> On replay, opted-in items send **`originalPixelTimestamp`** and **`retriedPixel`** again (only on replay, not the organic attempt). **Legacy queue entries** without `optedIn` decode as not opted-in and are removed without replay. Docs and tests cover triage requirements and the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a2587a5e496604ce11dd1d7d82cddf057152eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->