### PR TITLE
Read Duck.ai usage limits from native storage on input activation

### DIFF
--- a/SharedPackages/AIChat/Package.resolved
+++ b/SharedPackages/AIChat/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "92cf14f5ae4b969e996b4bd4ac6f837afe73197d05c766cfac0cbb731962bc32",
+  "originHash" : "72300bfa05f9665e6bc01dcb47146afe0ddf8e2d072bc4dd9b0678ca1c141899",
   "pins" : [
     {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "5735b061ee14708ca17bc5b72b8eb9d21eb7f830",
-        "version" : "15.3.0"
+        "revision" : "d35665e13add70752e51c2442529a2a2d32bd318",
+        "version" : "16.6.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/duckduckgo-autofill.git",
       "state" : {
-        "revision" : "84b5e3019b2c7b3c90e8d296f30fcfd53768bcd8",
-        "version" : "19.1.0"
+        "revision" : "34eb540473a90d25e11942e9c72a18c2430d4f50",
+        "version" : "19.2.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/privacy-dashboard",
       "state" : {
-        "revision" : "40a8c752fb73a15738899dc0edb5e17e33302a37",
-        "version" : "9.10.1"
+        "revision" : "88a028fe9e4aa53941cb49dfc93bbcf62bd46f3b",
+        "version" : "9.10.2"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/TrackerRadarKit.git",
       "state" : {
-        "revision" : "6d2db2a50cbd6d0a33d40864953bbef523489b28",
-        "version" : "3.1.0"
+        "revision" : "6ae7e79e77a4deb03fb5f21a73d701cae4132281",
+        "version" : "4.0.0"
       }
     }
   ],

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageKeys.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageKeys.swift
@@ -31,9 +31,15 @@ public struct DuckAiNativeStorageSettings: StoringKeys {
     public let settings = StorageKey<Data>(DuckAiNativeStorageKeyNames.settings)
 }
 
-/// Well-known entry keys that carry a contract with the Duck.ai web app, which reads them over the storage userscript bridge via `getEntry`.
+/// Well-known entry keys that carry a contract with the Duck.ai web app over the storage userscript bridge.
+/// The direction differs per key — see each case.
 public enum DuckAiNativeStorageReservedEntryKeys: String {
-    /// Entry holding the JSON array of chat IDs deleted on the native side.
-    /// The web app reads it to reconcile deletions it did not itself initiate. Value: `[String]`.
+    /// Native-written, web-read via `getEntry`. Entry holding the JSON array of chat IDs deleted on the
+    /// native side; the web app reads it to reconcile deletions it did not itself initiate. Value: `[String]`.
     case locallyDeletedChatIds
+
+    /// Web-written via `putEntry`, native-read. Entry holding the Duck.ai usage-limit snapshot, rewritten by
+    /// the web app on every usage-state update while it is running. Value: a JSON-encoded `String` of
+    /// `{ daily?, weekly? }`, each window `{ percentUsed, resetsAt }`. Decode with `DuckAiUsageLimits.make`.
+    case usageLimits
 }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageKeys.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeStorageKeys.swift
@@ -31,15 +31,11 @@ public struct DuckAiNativeStorageSettings: StoringKeys {
     public let settings = StorageKey<Data>(DuckAiNativeStorageKeyNames.settings)
 }
 
-/// Well-known entry keys that carry a contract with the Duck.ai web app over the storage userscript bridge.
-/// The direction differs per key — see each case.
+/// Well-known entry keys that carry a contract with the Duck.ai web app. The direction differs per key.
 public enum DuckAiNativeStorageReservedEntryKeys: String {
-    /// Native-written, web-read via `getEntry`. Entry holding the JSON array of chat IDs deleted on the
-    /// native side; the web app reads it to reconcile deletions it did not itself initiate. Value: `[String]`.
+    /// Native-written, web-read: the web app reconciles deletions it did not itself initiate. Value: `[String]`.
     case locallyDeletedChatIds
 
-    /// Web-written via `putEntry`, native-read. Entry holding the Duck.ai usage-limit snapshot, rewritten by
-    /// the web app on every usage-state update while it is running. Value: a JSON-encoded `String` of
-    /// `{ daily?, weekly? }`, each window `{ percentUsed, resetsAt }`. Decode with `DuckAiUsageLimits.make`.
+    /// Web-written, native-read. Value: JSON-encoded `String`; decode with `DuckAiUsageLimits.make`.
     case usageLimits
 }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageLimits.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageLimits.swift
@@ -1,0 +1,119 @@
+//
+//  DuckAiUsageLimits.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// One metering window from the Duck.ai usage snapshot.
+public struct DuckAiUsageLimitWindow: Equatable {
+
+    /// Percentage of the user's limit consumed, 0–100. Already clamped by the web app; fractional values are normal.
+    /// The underlying used/limit counts are deliberately never exposed, so they can't be derived from this.
+    public let percentUsed: Double
+
+    /// The UTC instant at which this window resets. Always in the future — expired windows are dropped at decode time.
+    public let resetsAt: Date
+
+    public init(percentUsed: Double, resetsAt: Date) {
+        self.percentUsed = percentUsed
+        self.resetsAt = resetsAt
+    }
+}
+
+/// Privacy-safe projection of the user's Duck.ai usage, written by the web app into the reserved
+/// `usageLimits` native-storage entry and read on demand by native.
+///
+/// Both windows are optional and independent: a missing window means "no data for this window", never zero usage.
+/// The snapshot is only refreshed while the Duck.ai web app is running, so a window may well be stale — `resetsAt`
+/// is the only staleness signal there is, and `make(entryValue:now:)` uses it to drop windows that have already reset.
+public struct DuckAiUsageLimits: Equatable {
+
+    /// The backend's `day` window.
+    public let daily: DuckAiUsageLimitWindow?
+
+    /// The backend's `iso_week` window — a week starting Monday on UTC boundaries, not a rolling 7 days.
+    public let weekly: DuckAiUsageLimitWindow?
+
+    /// No usable usage information. Produced by an absent key, an empty snapshot (`"{}"`), a value that
+    /// doesn't parse, and by every window having expired. All of those mean the same thing to a caller:
+    /// we don't know the user's usage, so don't warn.
+    public static let noData = DuckAiUsageLimits(daily: nil, weekly: nil)
+
+    public var hasData: Bool { daily != nil || weekly != nil }
+
+    public init(daily: DuckAiUsageLimitWindow?, weekly: DuckAiUsageLimitWindow?) {
+        self.daily = daily
+        self.weekly = weekly
+    }
+
+    /// Decodes the raw `usageLimits` entry value. Never throws — anything unexpected degrades to no-data rather
+    /// than to an error, because a malformed snapshot must not be distinguishable from an absent one at the call site.
+    ///
+    /// The entries namespace mirrors the web app's `localStorage`, so the stored value is a JSON-encoded `String`.
+    /// A dictionary is accepted too, defensively, in case a future writer stores the object directly.
+    ///
+    /// Windows are decoded independently: one malformed window doesn't discard the other. A window whose `resetsAt`
+    /// is at or before `now` is dropped — a window that has already reset has unknown current usage, and reporting
+    /// its last-seen percentage would show a stale "you're at your limit" long after the limit lifted.
+    public static func make(entryValue: Any?, now: Date) -> DuckAiUsageLimits {
+        guard let root = rootObject(from: entryValue) else { return .noData }
+        return DuckAiUsageLimits(daily: window(from: root["daily"], now: now),
+                                 weekly: window(from: root["weekly"], now: now))
+    }
+
+    private static func rootObject(from value: Any?) -> [String: Any]? {
+        switch value {
+        case let json as String:
+            guard !json.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  let data = json.data(using: .utf8) else { return nil }
+            return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        case let object as [String: Any]:
+            return object
+        default:
+            return nil
+        }
+    }
+
+    private static func window(from value: Any?, now: Date) -> DuckAiUsageLimitWindow? {
+        guard let object = value as? [String: Any],
+              let percentUsed = percentUsed(from: object["percentUsed"]),
+              let resetsAt = date(from: object["resetsAt"]),
+              resetsAt > now else { return nil }
+        return DuckAiUsageLimitWindow(percentUsed: percentUsed, resetsAt: resetsAt)
+    }
+
+    /// Read through `NSNumber` so both integer- and double-encoded percentages decode. Clamped defensively:
+    /// the web app clamps already, but a value we can't render sensibly is worse than a slightly wrong one.
+    /// The `CFBoolean` check rejects `true`/`false`, which would otherwise bridge to `1`/`0`.
+    private static func percentUsed(from value: Any?) -> Double? {
+        guard let number = value as? NSNumber, CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
+        let percent = number.doubleValue
+        guard percent.isFinite else { return nil }
+        return min(max(percent, 0), 100)
+    }
+
+    /// The web app writes `Date.toISOString()`, so fractional seconds are always present. The plain
+    /// internet-date-time fallback costs nothing and keeps a hand-seeded or future timestamp from being dropped.
+    private static func date(from value: Any?) -> Date? {
+        guard let text = value as? String else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: text) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: text)
+    }
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageLimits.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageLimits.swift
@@ -18,14 +18,11 @@
 
 import Foundation
 
-/// One metering window from the Duck.ai usage snapshot.
 public struct DuckAiUsageLimitWindow: Equatable {
 
-    /// Percentage of the user's limit consumed, 0–100. Already clamped by the web app; fractional values are normal.
-    /// The underlying used/limit counts are deliberately never exposed, so they can't be derived from this.
+    /// 0–100, clamped web-side. The underlying counts are deliberately never exposed.
     public let percentUsed: Double
 
-    /// The UTC instant at which this window resets. Always in the future — expired windows are dropped at decode time.
     public let resetsAt: Date
 
     public init(percentUsed: Double, resetsAt: Date) {
@@ -34,23 +31,15 @@ public struct DuckAiUsageLimitWindow: Equatable {
     }
 }
 
-/// Privacy-safe projection of the user's Duck.ai usage, written by the web app into the reserved
-/// `usageLimits` native-storage entry and read on demand by native.
-///
-/// Both windows are optional and independent: a missing window means "no data for this window", never zero usage.
-/// The snapshot is only refreshed while the Duck.ai web app is running, so a window may well be stale — `resetsAt`
-/// is the only staleness signal there is, and `make(entryValue:now:)` uses it to drop windows that have already reset.
+/// Usage snapshot the Duck.ai web app writes into the reserved `usageLimits` entry.
+/// A missing window means "no data for this window", never zero usage.
 public struct DuckAiUsageLimits: Equatable {
 
-    /// The backend's `day` window.
     public let daily: DuckAiUsageLimitWindow?
 
-    /// The backend's `iso_week` window — a week starting Monday on UTC boundaries, not a rolling 7 days.
+    /// The backend's `iso_week` window: Monday-start, UTC boundaries, not a rolling 7 days.
     public let weekly: DuckAiUsageLimitWindow?
 
-    /// No usable usage information. Produced by an absent key, an empty snapshot (`"{}"`), a value that
-    /// doesn't parse, and by every window having expired. All of those mean the same thing to a caller:
-    /// we don't know the user's usage, so don't warn.
     public static let noData = DuckAiUsageLimits(daily: nil, weekly: nil)
 
     public var hasData: Bool { daily != nil || weekly != nil }
@@ -60,21 +49,16 @@ public struct DuckAiUsageLimits: Equatable {
         self.weekly = weekly
     }
 
-    /// Decodes the raw `usageLimits` entry value. Never throws — anything unexpected degrades to no-data rather
-    /// than to an error, because a malformed snapshot must not be distinguishable from an absent one at the call site.
-    ///
-    /// The entries namespace mirrors the web app's `localStorage`, so the stored value is a JSON-encoded `String`.
-    /// A dictionary is accepted too, defensively, in case a future writer stores the object directly.
-    ///
-    /// Windows are decoded independently: one malformed window doesn't discard the other. A window whose `resetsAt`
-    /// is at or before `now` is dropped — a window that has already reset has unknown current usage, and reporting
-    /// its last-seen percentage would show a stale "you're at your limit" long after the limit lifted.
+    /// Anything unexpected degrades to no-data, so a malformed snapshot can't be told apart from an absent one.
+    /// A window past its reset is dropped: its last-seen percentage would warn long after the limit lifted.
     public static func make(entryValue: Any?, now: Date) -> DuckAiUsageLimits {
         guard let root = rootObject(from: entryValue) else { return .noData }
         return DuckAiUsageLimits(daily: window(from: root["daily"], now: now),
                                  weekly: window(from: root["weekly"], now: now))
     }
 
+    /// The entries namespace mirrors the web app's `localStorage`, so the value is a JSON-encoded string.
+    /// A dictionary is accepted defensively, in case a future writer stores the object directly.
     private static func rootObject(from value: Any?) -> [String: Any]? {
         switch value {
         case let json as String:
@@ -96,8 +80,7 @@ public struct DuckAiUsageLimits: Equatable {
         return DuckAiUsageLimitWindow(percentUsed: percentUsed, resetsAt: resetsAt)
     }
 
-    /// `NSNumber` so integer- and double-encoded percentages both decode; the `CFBoolean` check rejects
-    /// `true`/`false`, which would otherwise bridge to `1`/`0`.
+    /// The `CFBoolean` check rejects `true`/`false`, which would otherwise bridge to `1`/`0`.
     private static func percentUsed(from value: Any?) -> Double? {
         guard let number = value as? NSNumber, CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
         let percent = number.doubleValue
@@ -105,8 +88,7 @@ public struct DuckAiUsageLimits: Equatable {
         return min(max(percent, 0), 100)
     }
 
-    /// `Date.toISOString()` always carries fractional seconds; the plain fallback keeps a hand-seeded
-    /// timestamp from being dropped.
+    /// `Date.toISOString()` always carries fractional seconds; the fallback covers hand-seeded timestamps.
     private static func date(from value: Any?) -> Date? {
         guard let text = value as? String else { return nil }
         let formatter = ISO8601DateFormatter()

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageLimits.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageLimits.swift
@@ -96,9 +96,8 @@ public struct DuckAiUsageLimits: Equatable {
         return DuckAiUsageLimitWindow(percentUsed: percentUsed, resetsAt: resetsAt)
     }
 
-    /// Read through `NSNumber` so both integer- and double-encoded percentages decode. Clamped defensively:
-    /// the web app clamps already, but a value we can't render sensibly is worse than a slightly wrong one.
-    /// The `CFBoolean` check rejects `true`/`false`, which would otherwise bridge to `1`/`0`.
+    /// `NSNumber` so integer- and double-encoded percentages both decode; the `CFBoolean` check rejects
+    /// `true`/`false`, which would otherwise bridge to `1`/`0`.
     private static func percentUsed(from value: Any?) -> Double? {
         guard let number = value as? NSNumber, CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
         let percent = number.doubleValue
@@ -106,8 +105,8 @@ public struct DuckAiUsageLimits: Equatable {
         return min(max(percent, 0), 100)
     }
 
-    /// The web app writes `Date.toISOString()`, so fractional seconds are always present. The plain
-    /// internet-date-time fallback costs nothing and keeps a hand-seeded or future timestamp from being dropped.
+    /// `Date.toISOString()` always carries fractional seconds; the plain fallback keeps a hand-seeded
+    /// timestamp from being dropped.
     private static func date(from value: Any?) -> Date? {
         guard let text = value as? String else { return nil }
         let formatter = ISO8601DateFormatter()

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageLimitsProviding.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageLimitsProviding.swift
@@ -18,12 +18,8 @@
 
 import Foundation
 
-/// Reads the Duck.ai usage-limit snapshot the web app writes into native storage.
 public protocol DuckAiUsageLimitsProviding {
-    /// Returns the last snapshot the Duck.ai web app wrote, with already-reset windows dropped.
-    ///
-    /// Returns `.noData` — never an error — when the key is absent, the value doesn't parse, or every window has
-    /// expired. Reads are cheap and intended to be made on demand; there is no subscription or polling to set up.
+    /// `.noData` rather than an error when the key is absent, unparseable, or every window has expired.
     func currentUsageLimits() -> DuckAiUsageLimits
 }
 
@@ -51,8 +47,7 @@ public struct DuckAiUsageLimitsProvider: DuckAiUsageLimitsProviding {
             pixelFiring.fire(.settingsGetError(error))
             return .noData
         }
-        // A value that fails to decode is not reported: per the storage contract it's an ordinary
-        // "nothing to show" state, indistinguishable to the user from an absent key.
+        // No pixel for a value that fails to decode: per the contract that's an ordinary "nothing to show" state.
         return DuckAiUsageLimits.make(entryValue: value, now: dateProvider())
     }
 }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageLimitsProviding.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageLimitsProviding.swift
@@ -1,0 +1,58 @@
+//
+//  DuckAiUsageLimitsProviding.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Reads the Duck.ai usage-limit snapshot the web app writes into native storage.
+public protocol DuckAiUsageLimitsProviding {
+    /// Returns the last snapshot the Duck.ai web app wrote, with already-reset windows dropped.
+    ///
+    /// Returns `.noData` — never an error — when the key is absent, the value doesn't parse, or every window has
+    /// expired. Reads are cheap and intended to be made on demand; there is no subscription or polling to set up.
+    func currentUsageLimits() -> DuckAiUsageLimits
+}
+
+public struct DuckAiUsageLimitsProvider: DuckAiUsageLimitsProviding {
+
+    private let storage: DuckAiNativeStorageHandling
+    private let pixelFiring: DuckAiNativeStoragePixelFiring
+    private let dateProvider: () -> Date
+
+    public init(
+        storage: DuckAiNativeStorageHandling,
+        pixelFiring: DuckAiNativeStoragePixelFiring = NullDuckAiNativeStoragePixelFiring(),
+        dateProvider: @escaping () -> Date = Date.init
+    ) {
+        self.storage = storage
+        self.pixelFiring = pixelFiring
+        self.dateProvider = dateProvider
+    }
+
+    public func currentUsageLimits() -> DuckAiUsageLimits {
+        let value: Any?
+        do {
+            value = try storage.getEntry(key: DuckAiNativeStorageReservedEntryKeys.usageLimits.rawValue)
+        } catch {
+            pixelFiring.fire(.settingsGetError(error))
+            return .noData
+        }
+        // A value that fails to decode is not reported: per the storage contract it's an ordinary
+        // "nothing to show" state, indistinguishable to the user from an absent key.
+        return DuckAiUsageLimits.make(entryValue: value, now: dateProvider())
+    }
+}

--- a/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiUsageLimitsTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiUsageLimitsTests.swift
@@ -54,8 +54,7 @@ final class DuckAiUsageLimitsTests: XCTestCase {
         XCTAssertNil(limits.daily)
     }
 
-    /// The web app writes a snapshot on every usage-state update, so a field it adds later must not
-    /// take the whole payload down with it.
+    /// A field the web app adds later must not take the whole payload down with it.
     func testWhenPayloadCarriesUnknownFieldsThenTheyAreIgnored() {
         let limits = decode(#"{"schemaVersion":2,"monthly":{"percentUsed":1,"resetsAt":"\#(future)"},"daily":{"percentUsed":5,"resetsAt":"\#(future)","used":12,"limit":240}}"#)
 
@@ -70,8 +69,7 @@ final class DuckAiUsageLimitsTests: XCTestCase {
 
     // MARK: - No-data inputs
 
-    /// The web app writes `"{}"` deliberately rather than deleting the key, so a stale snapshot can't
-    /// outlive a sign-out or a server response that dropped usage.
+    /// The web app writes `"{}"` rather than deleting the key, so a stale snapshot can't outlive a sign-out.
     func testWhenSnapshotIsEmptyObjectThenNoData() {
         XCTAssertEqual(decode("{}"), .noData)
     }
@@ -107,8 +105,7 @@ final class DuckAiUsageLimitsTests: XCTestCase {
 
     // MARK: - Freshness
 
-    /// The snapshot isn't updated while Duck.ai isn't running, so a window past its reset has unknown
-    /// usage — reporting its last-seen percentage would keep warning long after the limit lifted.
+    /// A window past its reset has unknown usage; its last-seen percentage would warn forever.
     func testWhenWindowHasAlreadyResetThenItIsDropped() {
         let limits = decode(#"{"daily":{"percentUsed":100,"resetsAt":"\#(past)"},"weekly":{"percentUsed":80,"resetsAt":"\#(future)"}}"#)
 

--- a/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiUsageLimitsTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiUsageLimitsTests.swift
@@ -1,0 +1,251 @@
+//
+//  DuckAiUsageLimitsTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DuckAiDataStore
+import XCTest
+@testable import AIChat
+
+final class DuckAiUsageLimitsTests: XCTestCase {
+
+    /// Fixed "now" for every case, so the future/past timestamps below read unambiguously.
+    private let now = Date(timeIntervalSince1970: 1_755_000_000) // 2025-08-12T12:00:00Z
+    private let future = "2026-08-14T00:00:00.000Z"
+    private let alsoFuture = "2026-08-17T00:00:00.000Z"
+    private let past = "2024-01-01T00:00:00.000Z"
+
+    // MARK: - Well-formed payloads
+
+    func testWhenBothWindowsPresentThenBothDecode() {
+        let limits = decode(#"{"daily":{"percentUsed":42.5,"resetsAt":"\#(future)"},"weekly":{"percentUsed":63,"resetsAt":"\#(alsoFuture)"}}"#)
+
+        XCTAssertEqual(limits.daily?.percentUsed, 42.5)
+        XCTAssertEqual(limits.daily?.resetsAt, date(future))
+        XCTAssertEqual(limits.weekly?.percentUsed, 63)
+        XCTAssertEqual(limits.weekly?.resetsAt, date(alsoFuture))
+        XCTAssertTrue(limits.hasData)
+    }
+
+    func testWhenOnlyDailyPresentThenWeeklyIsNilRatherThanZero() {
+        let limits = decode(#"{"daily":{"percentUsed":10,"resetsAt":"\#(future)"}}"#)
+
+        XCTAssertEqual(limits.daily?.percentUsed, 10)
+        XCTAssertNil(limits.weekly)
+    }
+
+    func testWhenOnlyWeeklyPresentThenDailyIsNilRatherThanZero() {
+        let limits = decode(#"{"weekly":{"percentUsed":10,"resetsAt":"\#(future)"}}"#)
+
+        XCTAssertEqual(limits.weekly?.percentUsed, 10)
+        XCTAssertNil(limits.daily)
+    }
+
+    /// The web app writes a snapshot on every usage-state update, so a field it adds later must not
+    /// take the whole payload down with it.
+    func testWhenPayloadCarriesUnknownFieldsThenTheyAreIgnored() {
+        let limits = decode(#"{"schemaVersion":2,"monthly":{"percentUsed":1,"resetsAt":"\#(future)"},"daily":{"percentUsed":5,"resetsAt":"\#(future)","used":12,"limit":240}}"#)
+
+        XCTAssertEqual(limits.daily?.percentUsed, 5)
+    }
+
+    func testWhenResetsAtHasNoFractionalSecondsThenItStillParses() {
+        let limits = decode(#"{"daily":{"percentUsed":5,"resetsAt":"2026-08-14T00:00:00Z"}}"#)
+
+        XCTAssertNotNil(limits.daily)
+    }
+
+    // MARK: - No-data inputs
+
+    /// The web app writes `"{}"` deliberately rather than deleting the key, so a stale snapshot can't
+    /// outlive a sign-out or a server response that dropped usage.
+    func testWhenSnapshotIsEmptyObjectThenNoData() {
+        XCTAssertEqual(decode("{}"), .noData)
+    }
+
+    func testWhenKeyIsAbsentThenNoData() {
+        XCTAssertEqual(DuckAiUsageLimits.make(entryValue: nil, now: now), .noData)
+    }
+
+    func testWhenValueIsNotAStringThenNoData() {
+        for value in [42, true, ["a", "b"], NSNull()] as [Any] {
+            XCTAssertEqual(DuckAiUsageLimits.make(entryValue: value, now: now), .noData, "unexpected decode of \(value)")
+        }
+    }
+
+    func testWhenStringIsNotJSONThenNoData() {
+        for json in ["", "   ", "not json", "{oops", #"{"daily":}"#] {
+            XCTAssertEqual(decode(json), .noData, "unexpected decode of \(json)")
+        }
+    }
+
+    func testWhenJSONIsNotAnObjectThenNoData() {
+        for json in ["[1,2]", "\"x\"", "12"] {
+            XCTAssertEqual(decode(json), .noData, "unexpected decode of \(json)")
+        }
+    }
+
+    /// Defensive: the entries namespace stores strings today, but a dictionary shouldn't be rejected.
+    func testWhenValueIsADictionaryThenItDecodes() {
+        let value: [String: Any] = ["daily": ["percentUsed": 20, "resetsAt": future]]
+
+        XCTAssertEqual(DuckAiUsageLimits.make(entryValue: value, now: now).daily?.percentUsed, 20)
+    }
+
+    // MARK: - Freshness
+
+    /// The snapshot isn't updated while Duck.ai isn't running, so a window past its reset has unknown
+    /// usage — reporting its last-seen percentage would keep warning long after the limit lifted.
+    func testWhenWindowHasAlreadyResetThenItIsDropped() {
+        let limits = decode(#"{"daily":{"percentUsed":100,"resetsAt":"\#(past)"},"weekly":{"percentUsed":80,"resetsAt":"\#(future)"}}"#)
+
+        XCTAssertNil(limits.daily)
+        XCTAssertEqual(limits.weekly?.percentUsed, 80)
+    }
+
+    func testWhenEveryWindowHasResetThenNoData() {
+        XCTAssertEqual(decode(#"{"daily":{"percentUsed":100,"resetsAt":"\#(past)"},"weekly":{"percentUsed":100,"resetsAt":"\#(past)"}}"#), .noData)
+    }
+
+    func testWhenResetsAtEqualsNowThenWindowIsDropped() {
+        let atNow = ISO8601DateFormatter.testFormatter.string(from: now)
+
+        XCTAssertNil(decode(#"{"daily":{"percentUsed":50,"resetsAt":"\#(atNow)"}}"#).daily)
+    }
+
+    // MARK: - Malformed windows
+
+    func testWhenWindowIsMalformedThenOnlyThatWindowIsDropped() {
+        let malformedDaily = [
+            #"{"percentUsed":50}"#,                                    // no resetsAt
+            #"{"resetsAt":"\#(future)"}"#,                             // no percentUsed
+            #"{"percentUsed":50,"resetsAt":"whenever"}"#,              // unparseable date
+            #"{"percentUsed":50,"resetsAt":123}"#,                     // non-string date
+            #"{"percentUsed":"50","resetsAt":"\#(future)"}"#,          // string percentage
+            #"{"percentUsed":true,"resetsAt":"\#(future)"}"#,          // bool percentage
+            "42"                                                       // not an object
+        ]
+
+        for daily in malformedDaily {
+            let limits = decode(#"{"daily":\#(daily),"weekly":{"percentUsed":63,"resetsAt":"\#(future)"}}"#)
+            XCTAssertNil(limits.daily, "unexpectedly decoded \(daily)")
+            XCTAssertEqual(limits.weekly?.percentUsed, 63, "sibling window lost for \(daily)")
+        }
+    }
+
+    // MARK: - percentUsed
+
+    func testPercentUsedBoundaries() {
+        XCTAssertEqual(decode(#"{"daily":{"percentUsed":0,"resetsAt":"\#(future)"}}"#).daily?.percentUsed, 0)
+        XCTAssertEqual(decode(#"{"daily":{"percentUsed":100,"resetsAt":"\#(future)"}}"#).daily?.percentUsed, 100)
+        XCTAssertEqual(decode(#"{"daily":{"percentUsed":0.001,"resetsAt":"\#(future)"}}"#).daily?.percentUsed, 0.001)
+    }
+
+    /// The web app clamps already; this only guards against a contract change reaching the UI unclamped.
+    func testWhenPercentUsedIsOutOfRangeThenItIsClamped() {
+        XCTAssertEqual(decode(#"{"daily":{"percentUsed":140,"resetsAt":"\#(future)"}}"#).daily?.percentUsed, 100)
+        XCTAssertEqual(decode(#"{"daily":{"percentUsed":-5,"resetsAt":"\#(future)"}}"#).daily?.percentUsed, 0)
+    }
+
+    // MARK: - Provider
+
+    func testProviderReadsWhatTheBridgeWrote() throws {
+        let storage = try DuckAiNativeStorageHandler(.memory())
+        try storage.putEntry(key: DuckAiNativeStorageReservedEntryKeys.usageLimits.rawValue,
+                             value: #"{"daily":{"percentUsed":42.5,"resetsAt":"\#(future)"}}"#)
+        let sut = DuckAiUsageLimitsProvider(storage: storage, dateProvider: { self.now })
+
+        XCTAssertEqual(sut.currentUsageLimits().daily?.percentUsed, 42.5)
+    }
+
+    func testProviderReturnsNoDataWhenKeyWasNeverWritten() throws {
+        let storage = try DuckAiNativeStorageHandler(.memory())
+        let sut = DuckAiUsageLimitsProvider(storage: storage, dateProvider: { self.now })
+
+        XCTAssertEqual(sut.currentUsageLimits(), .noData)
+    }
+
+    func testProviderReturnsNoDataAndFiresPixelWhenStorageThrows() {
+        struct StorageError: Error {}
+        let storage = ThrowingStorageHandler(error: StorageError())
+        let pixelFiring = MockDuckAiNativeStoragePixelFiring()
+        let sut = DuckAiUsageLimitsProvider(storage: storage, pixelFiring: pixelFiring, dateProvider: { self.now })
+
+        XCTAssertEqual(sut.currentUsageLimits(), .noData)
+        XCTAssertEqual(pixelFiring.firedEvents.count, 1)
+        guard case .settingsGetError = pixelFiring.firedEvents[0] else {
+            return XCTFail("Expected settingsGetError pixel, got \(pixelFiring.firedEvents[0])")
+        }
+    }
+
+    /// A snapshot that doesn't parse is an ordinary no-data state, not something to report.
+    func testProviderDoesNotFirePixelForUnparseableSnapshot() throws {
+        let storage = try DuckAiNativeStorageHandler(.memory())
+        try storage.putEntry(key: DuckAiNativeStorageReservedEntryKeys.usageLimits.rawValue, value: "{oops")
+        let pixelFiring = MockDuckAiNativeStoragePixelFiring()
+        let sut = DuckAiUsageLimitsProvider(storage: storage, pixelFiring: pixelFiring, dateProvider: { self.now })
+
+        XCTAssertEqual(sut.currentUsageLimits(), .noData)
+        XCTAssertTrue(pixelFiring.firedEvents.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func decode(_ json: String) -> DuckAiUsageLimits {
+        DuckAiUsageLimits.make(entryValue: json, now: now)
+    }
+
+    private func date(_ iso: String) -> Date? {
+        ISO8601DateFormatter.testFormatter.date(from: iso)
+    }
+}
+
+private extension ISO8601DateFormatter {
+    static let testFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+}
+
+/// Only the entries read matters here; everything else is inert.
+private final class ThrowingStorageHandler: DuckAiNativeStorageHandling {
+    private let error: Error
+
+    init(error: Error) { self.error = error }
+
+    func putEntry(key: String, value: Any) throws {}
+    func getEntry(key: String) throws -> Any? { throw error }
+    func getAllEntries() throws -> [String: Any] { [:] }
+    func deleteEntry(key: String) throws {}
+    func deleteAllEntries() throws {}
+    func replaceAllEntries(_ entries: [String: Any]) throws {}
+    func putChat(chatId: String, data: Data) throws {}
+    func putChats(_ chats: [DuckAiChatRecord]) throws {}
+    func getChat(chatId: String) throws -> DuckAiChatRecord? { nil }
+    func getAllChats() throws -> [DuckAiChatRecord] { [] }
+    func deleteChat(chatId: String) throws {}
+    func deleteAllChats() throws {}
+    func putFile(uuid: String, chatId: String, data: Data) throws {}
+    func getFile(uuid: String) throws -> DuckAiFileContent? { nil }
+    func listFiles() throws -> [DuckAiFileMetadata] { [] }
+    func deleteFile(uuid: String) throws {}
+    func deleteFiles(chatId: String) throws {}
+    func deleteAllFiles() throws {}
+    func isMigrationDone() throws -> Bool { false }
+    func isMigrationDone(key: String) throws -> Bool { false }
+    func markMigrationDone(key: String) throws {}
+}

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -523,6 +523,10 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
 
     /// Supports Duck.ai edit prompt from the native input field.
     case nativePromptEditing
+
+    /// Warns users as they approach their daily/weekly Duck.ai limits, using the usage snapshot the
+    /// web app writes into the reserved `usageLimits` native-storage entry.
+    case usageWarnings
 }
 
 public enum HtmlNewTabPageSubfeature: String, Equatable, PrivacySubfeature {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -4054,6 +4054,8 @@
 		CA57DE500000000000000022 /* CustomizeResponsesModalController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000020 /* CustomizeResponsesModalController.swift */; };
 		CA57DE500000000000000031 /* CustomizeResponsesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000030 /* CustomizeResponsesStore.swift */; };
 		CA57DE500000000000000032 /* CustomizeResponsesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000030 /* CustomizeResponsesStore.swift */; };
+		CA57DE500000000000000041 /* DuckAiUsageLimitsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000040 /* DuckAiUsageLimitsStore.swift */; };
+		CA57DE500000000000000042 /* DuckAiUsageLimitsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA57DE500000000000000040 /* DuckAiUsageLimitsStore.swift */; };
 		CB24F70C29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB24F70B29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift */; };
 		CB24F70D29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB24F70B29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift */; };
 		CB63DECB2CDC0BBE0097986A /* PageRefreshMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB63DECA2CDC0BB80097986A /* PageRefreshMonitor.swift */; };
@@ -7009,6 +7011,7 @@
 		CA57DE500000000000000010 /* CustomizeResponsesMenuRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeResponsesMenuRowView.swift; sourceTree = "<group>"; };
 		CA57DE500000000000000020 /* CustomizeResponsesModalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeResponsesModalController.swift; sourceTree = "<group>"; };
 		CA57DE500000000000000030 /* CustomizeResponsesStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeResponsesStore.swift; sourceTree = "<group>"; };
+		CA57DE500000000000000040 /* DuckAiUsageLimitsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAiUsageLimitsStore.swift; sourceTree = "<group>"; };
 		CAAA013D5BF54C0C260E784E /* WebViewUserAgentProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewUserAgentProvider.swift; sourceTree = "<group>"; };
 		CB24F70B29A3D9CB006DCC58 /* AppConfigurationURLProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigurationURLProvider.swift; sourceTree = "<group>"; };
 		CB63DECA2CDC0BB80097986A /* PageRefreshMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageRefreshMonitor.swift; sourceTree = "<group>"; };
@@ -8128,6 +8131,7 @@
 				CA57DE500000000000000010 /* CustomizeResponsesMenuRowView.swift */,
 				CA57DE500000000000000020 /* CustomizeResponsesModalController.swift */,
 				CA57DE500000000000000030 /* CustomizeResponsesStore.swift */,
+				CA57DE500000000000000040 /* DuckAiUsageLimitsStore.swift */,
 				31BFDB6F2ECA46DD00ADFABD /* AIChatOmnibarTextContainerViewController.swift */,
 				31E3FD712CE39C4600A392C8 /* Debug */,
 				1E4EDA262DE9ED1C0019B6E8 /* Sidebar */,
@@ -15713,6 +15717,7 @@
 				CA57DE500000000000000011 /* CustomizeResponsesMenuRowView.swift in Sources */,
 				CA57DE500000000000000021 /* CustomizeResponsesModalController.swift in Sources */,
 				CA57DE500000000000000031 /* CustomizeResponsesStore.swift in Sources */,
+				CA57DE500000000000000041 /* DuckAiUsageLimitsStore.swift in Sources */,
 				4D5E6F708192A3B4C5D6E7F8 /* BookmarksBarMenuCustomPopover.swift in Sources */,
 				2B3C4D5E6F708192A3B4C5D6 /* BookmarksBarMenuPopoverPresenting.swift in Sources */,
 				7380BFFD4A203C992E79AD0B /* BookmarksBarMenuWindow.swift in Sources */,
@@ -18355,6 +18360,7 @@
 				CA57DE500000000000000012 /* CustomizeResponsesMenuRowView.swift in Sources */,
 				CA57DE500000000000000022 /* CustomizeResponsesModalController.swift in Sources */,
 				CA57DE500000000000000032 /* CustomizeResponsesStore.swift in Sources */,
+				CA57DE500000000000000042 /* DuckAiUsageLimitsStore.swift in Sources */,
 				BDD13E222D8BD47A00FBC383 /* VPNBypassServiceExtensions.swift in Sources */,
 				EE1886532EB3BA4900A46272 /* NewImportSummaryView.swift in Sources */,
 				B6F41031264D2B23003DA42C /* ProgressExtension.swift in Sources */,

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -102,7 +102,6 @@ final class AIChatOmnibarController {
     /// Shared 4-view cap across both pickers (reuses `FreeTrialBadgePersistor`, separately keyed).
     /// Past the cap the badge mutes instead of hiding — it's the only entry point to the upsell.
     private let badgeImpressionPersistor: FreeTrialBadgePersisting
-    /// `nil` for surfaces built without a native-storage handler (and in tests).
     private let usageLimitsStore: DuckAiUsageLimitsStore?
     private lazy var attachedTabsTracker = AIChatAttachedTabsTracker(
         origin: origin,
@@ -135,9 +134,7 @@ final class AIChatOmnibarController {
     /// omits the block — callers fall back to the previously shipped defaults in that case.
     private(set) var attachmentLimits: AIChatAttachmentTierLimits?
 
-    /// The Duck.ai usage snapshot as of the last activation. `nil` when the usage-warnings feature isn't
-    /// active for this user, which is not the same as `.noData` (active, but nothing worth warning about).
-    /// Refreshed on every activation and cleared on cleanup, so it never outlives the panel that read it.
+    /// `nil` when the usage-warnings feature isn't active, which is not the same as `.noData`.
     @Published private(set) var usageLimits: DuckAiUsageLimits?
 
     /// Called after a successful submit so the container VC can cancel any in-flight image
@@ -409,9 +406,8 @@ final class AIChatOmnibarController {
         }
     }
 
-    /// Reads the usage snapshot the Duck.ai web app last wrote. Synchronous and cheap — it's a lookup in the
-    /// already-loaded entries blob, the same read `CustomizeResponsesStore` does on the tools-menu path — so it
-    /// doesn't need the async treatment `fetchModels()` gets for its network call.
+    /// Synchronous: a lookup in the already-loaded entries blob, so it doesn't need the async treatment
+    /// `fetchModels()` gets for its network call.
     private func refreshUsageLimits() {
         usageLimits = usageLimitsStore?.currentLimits()
     }

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -102,6 +102,8 @@ final class AIChatOmnibarController {
     /// Shared 4-view cap across both pickers (reuses `FreeTrialBadgePersistor`, separately keyed).
     /// Past the cap the badge mutes instead of hiding — it's the only entry point to the upsell.
     private let badgeImpressionPersistor: FreeTrialBadgePersisting
+    /// `nil` for surfaces built without a native-storage handler (and in tests).
+    private let usageLimitsStore: DuckAiUsageLimitsStore?
     private lazy var attachedTabsTracker = AIChatAttachedTabsTracker(
         origin: origin,
         windowControllersManager: Application.appDelegate.windowControllersManager
@@ -132,6 +134,11 @@ final class AIChatOmnibarController {
     /// models endpoint, resolved to the user's tier. `nil` until fetched, or when the endpoint
     /// omits the block — callers fall back to the previously shipped defaults in that case.
     private(set) var attachmentLimits: AIChatAttachmentTierLimits?
+
+    /// The Duck.ai usage snapshot as of the last activation. `nil` when the usage-warnings feature isn't
+    /// active for this user, which is not the same as `.noData` (active, but nothing worth warning about).
+    /// Refreshed on every activation and cleared on cleanup, so it never outlives the panel that read it.
+    @Published private(set) var usageLimits: DuckAiUsageLimits?
 
     /// Called after a successful submit so the container VC can cancel any in-flight image
     /// resize tasks (data is cleared via `persistAttachmentsToActiveTab([])`).
@@ -286,7 +293,8 @@ final class AIChatOmnibarController {
         // are both @MainActor-isolated; a default *parameter value* is evaluated in a nonisolated
         // context even though this initializer's body is not, so the real default is resolved below.
         subscriptionUpsellPresenter: AIChatOmnibarSubscriptionUpselling? = nil,
-        badgeImpressionPersistor: FreeTrialBadgePersisting = FreeTrialBadgePersistor(keyValueStore: UserDefaults.standard, keyPrefix: "aichat-omnibar")
+        badgeImpressionPersistor: FreeTrialBadgePersisting = FreeTrialBadgePersistor(keyValueStore: UserDefaults.standard, keyPrefix: "aichat-omnibar"),
+        usageLimitsStore: DuckAiUsageLimitsStore? = nil
     ) {
         self.aiChatTabOpener = aiChatTabOpener
         self.surface = surface
@@ -305,6 +313,7 @@ final class AIChatOmnibarController {
         self.subscriptionUpsellPresenter = subscriptionUpsellPresenter
             ?? AIChatOmnibarSubscriptionUpsellPresenter(coordinator: Application.appDelegate.subscriptionNavigationCoordinator)
         self.badgeImpressionPersistor = badgeImpressionPersistor
+        self.usageLimitsStore = usageLimitsStore
         self.suggestionsViewModel = AIChatSuggestionsViewModel(
             maxSuggestions: suggestionsReader?.maxHistoryCount ?? AIChatSuggestionsViewModel.defaultMaxSuggestions
         )
@@ -387,6 +396,7 @@ final class AIChatOmnibarController {
         }
 
         fetchModels()
+        refreshUsageLimits()
 
         // If feature is disabled, clear any existing suggestions and don't fetch
         if !isSuggestionsEnabled {
@@ -397,6 +407,13 @@ final class AIChatOmnibarController {
         if shouldFetchSuggestions {
             fetchSuggestionsIfNeeded(query: currentText)
         }
+    }
+
+    /// Reads the usage snapshot the Duck.ai web app last wrote. Synchronous and cheap — it's a lookup in the
+    /// already-loaded entries blob, the same read `CustomizeResponsesStore` does on the tools-menu path — so it
+    /// doesn't need the async treatment `fetchModels()` gets for its network call.
+    private func refreshUsageLimits() {
+        usageLimits = usageLimitsStore?.currentLimits()
     }
 
     private func fetchModels() {
@@ -1061,6 +1078,7 @@ final class AIChatOmnibarController {
         activeToolMode = nil
         hasImageAttachments = false
         hasBeenActivated = false
+        usageLimits = nil
         suggestionsViewModel.clearAllChats()
         currentFetchTask?.cancel()
         currentFetchTask = nil

--- a/macOS/DuckDuckGo/AIChat/DuckAiUsageLimitsStore.swift
+++ b/macOS/DuckDuckGo/AIChat/DuckAiUsageLimitsStore.swift
@@ -42,11 +42,17 @@ final class DuckAiUsageLimitsStore {
     func currentLimits() -> DuckAiUsageLimits? {
         guard featureFlagger.isFeatureOn(.aiChatUsageWarnings), let provider else { return nil }
         let limits = provider.currentUsageLimits()
-        // Presence only: enough to verify the read, and keeps the user's percentages out of the log.
+        // Marked private so the percentages are redacted wherever redaction applies; local debug builds
+        // still show them, which is what makes a read verifiable while testing.
         Logger.aiChat.debug("""
-            Duck.ai usage limits read: daily=\(limits.daily == nil ? "none" : "present", privacy: .public) \
-            weekly=\(limits.weekly == nil ? "none" : "present", privacy: .public)
+            Duck.ai usage limits read: daily=\(Self.describe(limits.daily), privacy: .private) \
+            weekly=\(Self.describe(limits.weekly), privacy: .private)
             """)
         return limits
+    }
+
+    private static func describe(_ window: DuckAiUsageLimitWindow?) -> String {
+        guard let window else { return "none" }
+        return "\(window.percentUsed)% resets \(window.resetsAt)"
     }
 }

--- a/macOS/DuckDuckGo/AIChat/DuckAiUsageLimitsStore.swift
+++ b/macOS/DuckDuckGo/AIChat/DuckAiUsageLimitsStore.swift
@@ -22,12 +22,8 @@ import FeatureFlags_macOS
 import os.log
 import PrivacyConfig
 
-/// Reads the Duck.ai usage-limit snapshot from the native-storage bridge for the Duck.ai input surfaces
-/// (address bar omnibar, Prompt Bar, New Tab Page omnibar), gated on the usage-warnings feature flag.
-///
-/// Mirrors `CustomizeResponsesStore`: the shared reader stays flag-agnostic and this owns the app-side gating,
-/// so call sites don't repeat it. The store is cheap to build — construct it with a burner-aware handler at the
-/// surface's construction site, the same way `CustomizeResponsesStore` is.
+/// Owns the app-side flag gating so the shared reader stays flag-agnostic and call sites don't repeat it.
+/// Mirrors `CustomizeResponsesStore`: cheap to build, constructed with a burner-aware handler per surface.
 final class DuckAiUsageLimitsStore {
 
     private let provider: DuckAiUsageLimitsProviding?
@@ -41,15 +37,12 @@ final class DuckAiUsageLimitsStore {
         self.featureFlagger = featureFlagger
     }
 
-    /// `nil` when there is nothing to read at all: the feature flag is off, or native storage is unavailable
-    /// (flag off, outside the `nativeStorage` rollout, bridge never installed). `.noData` when the read happened
-    /// but produced no usable window. Callers must keep the two apart — the first means "feature inactive",
-    /// the second means "active, but we don't know this user's usage".
+    /// `nil` means the feature is inactive (flag off, or no storage bridge); `.noData` means active but nothing
+    /// worth warning about. Callers must keep the two apart.
     func currentLimits() -> DuckAiUsageLimits? {
         guard featureFlagger.isFeatureOn(.aiChatUsageWarnings), let provider else { return nil }
         let limits = provider.currentUsageLimits()
-        // Which windows we got is public so the read is verifiable from Console; the percentages themselves
-        // are the user's usage and stay redacted.
+        // Window presence is public so the read is verifiable from Console; the percentages stay redacted.
         Logger.aiChat.debug("""
             Duck.ai usage limits read: daily=\(limits.daily == nil ? "none" : "present", privacy: .public) \
             weekly=\(limits.weekly == nil ? "none" : "present", privacy: .public) \

--- a/macOS/DuckDuckGo/AIChat/DuckAiUsageLimitsStore.swift
+++ b/macOS/DuckDuckGo/AIChat/DuckAiUsageLimitsStore.swift
@@ -42,11 +42,10 @@ final class DuckAiUsageLimitsStore {
     func currentLimits() -> DuckAiUsageLimits? {
         guard featureFlagger.isFeatureOn(.aiChatUsageWarnings), let provider else { return nil }
         let limits = provider.currentUsageLimits()
-        // Window presence is public so the read is verifiable from Console; the percentages stay redacted.
+        // Presence only: enough to verify the read, and keeps the user's percentages out of the log.
         Logger.aiChat.debug("""
             Duck.ai usage limits read: daily=\(limits.daily == nil ? "none" : "present", privacy: .public) \
-            weekly=\(limits.weekly == nil ? "none" : "present", privacy: .public) \
-            values=[\(limits.daily?.percentUsed ?? -1, privacy: .private), \(limits.weekly?.percentUsed ?? -1, privacy: .private)]
+            weekly=\(limits.weekly == nil ? "none" : "present", privacy: .public)
             """)
         return limits
     }

--- a/macOS/DuckDuckGo/AIChat/DuckAiUsageLimitsStore.swift
+++ b/macOS/DuckDuckGo/AIChat/DuckAiUsageLimitsStore.swift
@@ -35,7 +35,9 @@ final class DuckAiUsageLimitsStore {
 
     init(storageHandler: DuckAiNativeStorageHandling?,
          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger) {
-        self.provider = storageHandler.map { DuckAiUsageLimitsProvider(storage: $0) }
+        self.provider = storageHandler.map {
+            DuckAiUsageLimitsProvider(storage: $0, pixelFiring: DuckAiNativeStoragePixelAdapter())
+        }
         self.featureFlagger = featureFlagger
     }
 

--- a/macOS/DuckDuckGo/AIChat/DuckAiUsageLimitsStore.swift
+++ b/macOS/DuckDuckGo/AIChat/DuckAiUsageLimitsStore.swift
@@ -1,0 +1,58 @@
+//
+//  DuckAiUsageLimitsStore.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import AppKit
+import FeatureFlags_macOS
+import os.log
+import PrivacyConfig
+
+/// Reads the Duck.ai usage-limit snapshot from the native-storage bridge for the Duck.ai input surfaces
+/// (address bar omnibar, Prompt Bar, New Tab Page omnibar), gated on the usage-warnings feature flag.
+///
+/// Mirrors `CustomizeResponsesStore`: the shared reader stays flag-agnostic and this owns the app-side gating,
+/// so call sites don't repeat it. The store is cheap to build — construct it with a burner-aware handler at the
+/// surface's construction site, the same way `CustomizeResponsesStore` is.
+final class DuckAiUsageLimitsStore {
+
+    private let provider: DuckAiUsageLimitsProviding?
+    private let featureFlagger: FeatureFlagger
+
+    init(storageHandler: DuckAiNativeStorageHandling?,
+         featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger) {
+        self.provider = storageHandler.map { DuckAiUsageLimitsProvider(storage: $0) }
+        self.featureFlagger = featureFlagger
+    }
+
+    /// `nil` when there is nothing to read at all: the feature flag is off, or native storage is unavailable
+    /// (flag off, outside the `nativeStorage` rollout, bridge never installed). `.noData` when the read happened
+    /// but produced no usable window. Callers must keep the two apart — the first means "feature inactive",
+    /// the second means "active, but we don't know this user's usage".
+    func currentLimits() -> DuckAiUsageLimits? {
+        guard featureFlagger.isFeatureOn(.aiChatUsageWarnings), let provider else { return nil }
+        let limits = provider.currentUsageLimits()
+        // Which windows we got is public so the read is verifiable from Console; the percentages themselves
+        // are the user's usage and stay redacted.
+        Logger.aiChat.debug("""
+            Duck.ai usage limits read: daily=\(limits.daily == nil ? "none" : "present", privacy: .public) \
+            weekly=\(limits.weekly == nil ? "none" : "present", privacy: .public) \
+            values=[\(limits.daily?.percentUsed ?? -1, privacy: .private), \(limits.weekly?.percentUsed ?? -1, privacy: .private)]
+            """)
+        return limits
+    }
+}

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -328,6 +328,10 @@ final class MainViewController: NSViewController {
             ),
             historySettings: AIChatHistorySettings(privacyConfig: contentBlocking.privacyConfigurationManager)
         )
+        // Fire Windows resolve to their own isolated handler, so a burner omnibar reads none of the
+        // regular session's Duck.ai storage.
+        let duckAiNativeStorageHandler = NSApp.delegateTyped.burnerDuckAiStorageRegistry?.handler(for: tabCollectionViewModel.burnerMode)
+            ?? NSApp.delegateTyped.duckAiNativeStorageHandler
         let aiChatOmnibarController = AIChatOmnibarController(
             aiChatTabOpener: aiChatTabOpener,
             surface: .addressBar,
@@ -338,14 +342,14 @@ final class MainViewController: NSViewController {
             // Fire Windows run an isolated Duck.ai session; persisted chat-history suggestions
             // from the regular session can't be opened here, so suppress them.
             isBurner: tabCollectionViewModel.isBurner,
-            preferences: NSApp.delegateTyped.aiChatPreferencesPersistor
+            preferences: NSApp.delegateTyped.aiChatPreferencesPersistor,
+            usageLimitsStore: DuckAiUsageLimitsStore(storageHandler: duckAiNativeStorageHandler)
         )
 
         aiChatOmnibarContainerViewController = AIChatOmnibarContainerViewController(
             themeManager: themeManager,
             omnibarController: aiChatOmnibarController,
-            duckAiNativeStorageHandler: NSApp.delegateTyped.burnerDuckAiStorageRegistry?.handler(for: tabCollectionViewModel.burnerMode)
-                ?? NSApp.delegateTyped.duckAiNativeStorageHandler,
+            duckAiNativeStorageHandler: duckAiNativeStorageHandler,
             burnerMode: tabCollectionViewModel.burnerMode
         )
         aiChatOmnibarTextContainerViewController = AIChatOmnibarTextContainerViewController(

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageActionsManagerExtension.swift
@@ -131,7 +131,11 @@ extension NewTabPageActionsManager {
             featureFlagger: featureFlagger,
             aiChatPreferencesPersistor: NSApp.delegateTyped.aiChatPreferencesPersistor,
             searchPreferences: NSApp.delegateTyped.searchPreferences,
-            windowControllersManager: windowControllersManager
+            windowControllersManager: windowControllersManager,
+            duckAiStorageHandlerProvider: { burnerMode in
+                NSApp.delegateTyped.burnerDuckAiStorageRegistry?.handler(for: burnerMode)
+                    ?? NSApp.delegateTyped.duckAiNativeStorageHandler
+            }
         )
         omnibarActionHandler.onCustomizeResponsesChanged = { [weak omnibarConfigProvider] in
             omnibarConfigProvider?.notifyCustomizeResponsesChanged()

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -276,9 +276,7 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
         customizeResponsesChangedSubject.eraseToAnyPublisher()
     }
 
-    /// The Duck.ai usage snapshot as of the last time this NTP entered Duck.ai mode. `nil` when the
-    /// usage-warnings feature isn't active for this user — distinct from `.noData`, which means the read
-    /// happened and there's nothing worth warning about.
+    /// `nil` when the usage-warnings feature isn't active, which is not the same as `.noData`.
     private(set) var usageLimits: DuckAiUsageLimits?
 
     @MainActor

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -98,6 +98,9 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     private var aiChatPreferencesPersistor: AIChatPreferencesPersisting
     private let searchPreferences: SearchPreferences
     private let windowControllersManager: WindowControllersManagerProtocol?
+    /// Resolves the Duck.ai storage handler for a burner mode. Defaults to no storage, which reads as
+    /// "usage warnings inactive"; the app passes the burner-aware resolver at composition.
+    private let duckAiStorageHandlerProvider: (BurnerMode) -> DuckAiNativeStorageHandling?
     private let showCustomizePopoverSubject = PassthroughSubject<Bool, Never>()
     private let modeSubject = PassthroughSubject<NewTabPageDataModel.OmnibarMode, Never>()
     private let customizeResponsesChangedSubject = PassthroughSubject<Void, Never>()
@@ -111,6 +114,7 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
          aiChatPreferencesPersistor: AIChatPreferencesPersisting = AIChatPreferencesPersistor(),
          searchPreferences: SearchPreferences,
          windowControllersManager: WindowControllersManagerProtocol? = nil,
+         duckAiStorageHandlerProvider: @escaping (BurnerMode) -> DuckAiNativeStorageHandling? = { _ in nil },
          firePixel: @escaping (PixelKit.Event) -> Void = { PixelKit.fire($0, frequency: .dailyAndStandard) }) {
         self.keyValueStore = keyValueStore
         self.aiChatShortcutSettingProvider = aiChatShortcutSettingProvider
@@ -118,6 +122,7 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
         self.aiChatPreferencesPersistor = aiChatPreferencesPersistor
         self.searchPreferences = searchPreferences
         self.windowControllersManager = windowControllersManager
+        self.duckAiStorageHandlerProvider = duckAiStorageHandlerProvider
         self.firePixel = firePixel
 
         Self.migrateLegacySelectedModelIdIfNeeded(from: keyValueStore, into: &self.aiChatPreferencesPersistor)
@@ -267,8 +272,7 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     func customizeResponsesState(requestingWebView: WKWebView?) -> NewTabPageDataModel.OmnibarCustomizeResponsesState {
         guard let windowControllersManager else { return .none }
         let burnerMode = AIChatTabPickerSource.originTabCollectionViewModel(for: requestingWebView, in: windowControllersManager)?.burnerMode ?? .regular
-        let handler = NSApp.delegateTyped.burnerDuckAiStorageRegistry?.handler(for: burnerMode) ?? NSApp.delegateTyped.duckAiNativeStorageHandler
-        let state = CustomizeResponsesStore(storageHandler: handler).currentState()
+        let state = CustomizeResponsesStore(storageHandler: duckAiStorageHandlerProvider(burnerMode)).currentState()
         return NewTabPageDataModel.OmnibarCustomizeResponsesState(subLabel: state.subLabel, hasCustomization: state.hasCustomization, active: state.isActive)
     }
 
@@ -283,8 +287,8 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     func refreshUsageLimits(requestingWebView: WKWebView?) {
         guard let windowControllersManager else { return }
         let burnerMode = AIChatTabPickerSource.originTabCollectionViewModel(for: requestingWebView, in: windowControllersManager)?.burnerMode ?? .regular
-        let handler = NSApp.delegateTyped.burnerDuckAiStorageRegistry?.handler(for: burnerMode) ?? NSApp.delegateTyped.duckAiNativeStorageHandler
-        usageLimits = DuckAiUsageLimitsStore(storageHandler: handler).currentLimits()
+        usageLimits = DuckAiUsageLimitsStore(storageHandler: duckAiStorageHandlerProvider(burnerMode),
+                                             featureFlagger: featureFlagger).currentLimits()
     }
 
     func notifyCustomizeResponsesChanged() {

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -276,6 +276,19 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
         customizeResponsesChangedSubject.eraseToAnyPublisher()
     }
 
+    /// The Duck.ai usage snapshot as of the last time this NTP entered Duck.ai mode. `nil` when the
+    /// usage-warnings feature isn't active for this user — distinct from `.noData`, which means the read
+    /// happened and there's nothing worth warning about.
+    private(set) var usageLimits: DuckAiUsageLimits?
+
+    @MainActor
+    func refreshUsageLimits(requestingWebView: WKWebView?) {
+        guard let windowControllersManager else { return }
+        let burnerMode = AIChatTabPickerSource.originTabCollectionViewModel(for: requestingWebView, in: windowControllersManager)?.burnerMode ?? .regular
+        let handler = NSApp.delegateTyped.burnerDuckAiStorageRegistry?.handler(for: burnerMode) ?? NSApp.delegateTyped.duckAiNativeStorageHandler
+        usageLimits = DuckAiUsageLimitsStore(storageHandler: handler).currentLimits()
+    }
+
     func notifyCustomizeResponsesChanged() {
         customizeResponsesChangedSubject.send(())
     }

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -98,8 +98,6 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     private var aiChatPreferencesPersistor: AIChatPreferencesPersisting
     private let searchPreferences: SearchPreferences
     private let windowControllersManager: WindowControllersManagerProtocol?
-    /// Resolves the Duck.ai storage handler for a burner mode. Defaults to no storage, which reads as
-    /// "usage warnings inactive"; the app passes the burner-aware resolver at composition.
     private let duckAiStorageHandlerProvider: (BurnerMode) -> DuckAiNativeStorageHandling?
     private let showCustomizePopoverSubject = PassthroughSubject<Bool, Never>()
     private let modeSubject = PassthroughSubject<NewTabPageDataModel.OmnibarMode, Never>()

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarContentFactory.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarContentFactory.swift
@@ -39,7 +39,8 @@ enum PromptBarContentFactory {
             origin: nil,
             pixelHandler: PromptBarPixelHandler(),
             suggestionsReader: nil,
-            preferences: preferences
+            preferences: preferences,
+            usageLimitsStore: DuckAiUsageLimitsStore(storageHandler: duckAiNativeStorageHandler)
         )
 
         let containerViewController = AIChatOmnibarContainerViewController(

--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -489,6 +489,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217076881156357?focus=true
     case bookmarksReorderByName
 
+    /// Gates reading the Duck.ai usage-limit snapshot from native storage on Duck.ai input activation,
+    /// and the warnings that will be built on top of it. Internal-only while the UI is in development.
+    case aiChatUsageWarnings
+
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -820,6 +824,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.promptBar), category: .duckAI)
         case .bookmarksReorderByName:
             Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.bookmarksReorderByName))
+        case .aiChatUsageWarnings:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.usageWarnings), category: .duckAI)
         }
     }
 

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
@@ -135,6 +135,10 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
     private func getConfig(params: Any, original: WKScriptMessage) async throws -> Encodable? {
         let aiModelSections = await modelsProvider?.fetchAIModelSections()
         let customize = configProvider.customizeResponsesState(requestingWebView: original.webView)
+        // An NTP that loads already in Duck.ai mode never sends `setConfig`, so it needs its own read.
+        if configProvider.mode == .ai {
+            configProvider.refreshUsageLimits(requestingWebView: original.webView)
+        }
         return NewTabPageDataModel.OmnibarConfig(
             mode: configProvider.mode,
             enableAi: configProvider.isAIChatShortcutEnabled,
@@ -168,6 +172,9 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             return nil
         }
         configProvider.mode = config.mode
+        if config.mode == .ai {
+            configProvider.refreshUsageLimits(requestingWebView: original.webView)
+        }
         configProvider.isAIChatShortcutEnabled = config.enableAi
         if let showCustomizePopover = config.showCustomizePopover {
             configProvider.showCustomizePopover = showCustomizePopover

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
@@ -55,6 +55,12 @@ public protocol NewTabPageOmnibarConfigProviding: AnyObject {
     /// Fires when the stored response customization changes, so the client re-pushes the config.
     var customizeResponsesStatePublisher: AnyPublisher<Void, Never> { get }
 
+    /// Re-reads the Duck.ai usage-limit snapshot for the window hosting `requestingWebView`; pass `nil` to
+    /// resolve the current key window. Called when the NTP omnibar enters Duck.ai mode — the web omnibar has
+    /// no focus message, so mode entry is the closest available "the user is about to prompt" signal.
+    @MainActor
+    func refreshUsageLimits(requestingWebView: WKWebView?)
+
     /// Whether the attach-tabs (and files) affordance is enabled. Driven by the
     /// `aiChatNtpAttachMoreTabs` feature flag. Published so the client can push an
     /// `omnibar_onConfigUpdate` when the flag flips at runtime, keeping an open NTP in sync.

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
@@ -55,9 +55,8 @@ public protocol NewTabPageOmnibarConfigProviding: AnyObject {
     /// Fires when the stored response customization changes, so the client re-pushes the config.
     var customizeResponsesStatePublisher: AnyPublisher<Void, Never> { get }
 
-    /// Re-reads the Duck.ai usage-limit snapshot for the window hosting `requestingWebView`; pass `nil` to
-    /// resolve the current key window. Called when the NTP omnibar enters Duck.ai mode — the web omnibar has
-    /// no focus message, so mode entry is the closest available "the user is about to prompt" signal.
+    /// Called on entry into Duck.ai mode: the web omnibar sends no focus message, so that's the closest
+    /// "user is about to prompt" signal. `requestingWebView` resolves burner mode; `nil` uses the key window.
     @MainActor
     func refreshUsageLimits(requestingWebView: WKWebView?)
 

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
@@ -70,6 +70,12 @@ final class MockNewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProvidin
         customizeResponsesStateSubject.eraseToAnyPublisher()
     }
 
+    var refreshUsageLimitsCallCount = 0
+    @MainActor
+    func refreshUsageLimits(requestingWebView: WKWebView?) {
+        refreshUsageLimitsCallCount += 1
+    }
+
     @Published var isAttachTabsEnabled: Bool = false
 
     var isAttachTabsEnabledPublisher: AnyPublisher<Bool, Never> {

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
@@ -96,6 +96,20 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         XCTAssertEqual(config.isEligibleForFreeTrial, true)
     }
 
+    /// The web omnibar sends no focus message, so entering Duck.ai mode is the read trigger.
+    @MainActor
+    func testUsageLimitsAreReadOnlyWhenTheOmnibarIsInDuckAiMode() async throws {
+        configProvider.mode = .search
+        var config: NewTabPageDataModel.OmnibarConfig = try await messageHelper.handleMessage(named: .getConfig)
+        XCTAssertEqual(config.mode, .search)
+        XCTAssertEqual(configProvider.refreshUsageLimitsCallCount, 0)
+
+        configProvider.mode = .ai
+        config = try await messageHelper.handleMessage(named: .getConfig)
+        XCTAssertEqual(config.mode, .ai)
+        XCTAssertEqual(configProvider.refreshUsageLimitsCallCount, 1)
+    }
+
     /// NTP reuses one webview per window rather than a fresh one per "new tab", so an already-open
     /// tab relies on this refetch to notice a subscription purchase completing.
     @MainActor
@@ -117,6 +131,8 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         XCTAssertEqual(configProvider.mode, .ai)
         XCTAssertEqual(configProvider.isAIChatShortcutEnabled, false)
         XCTAssertEqual(configProvider.isAIChatSettingVisible, true)
+        // Switching into Duck.ai mode is the NTP's "user is about to prompt" signal.
+        XCTAssertEqual(configProvider.refreshUsageLimitsCallCount, 1)
     }
 
     @MainActor

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
@@ -131,7 +131,6 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         XCTAssertEqual(configProvider.mode, .ai)
         XCTAssertEqual(configProvider.isAIChatShortcutEnabled, false)
         XCTAssertEqual(configProvider.isAIChatSettingVisible, true)
-        // Switching into Duck.ai mode is the NTP's "user is about to prompt" signal.
         XCTAssertEqual(configProvider.refreshUsageLimitsCallCount, 1)
     }
 

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
@@ -348,6 +348,8 @@ private final class MockAiChatsConfigProvider: NewTabPageOmnibarConfigProviding 
     @MainActor
     func customizeResponsesState(requestingWebView: WKWebView?) -> NewTabPageDataModel.OmnibarCustomizeResponsesState { .none }
     var customizeResponsesStatePublisher: AnyPublisher<Void, Never> { Empty<Void, Never>().eraseToAnyPublisher() }
+    @MainActor
+    func refreshUsageLimits(requestingWebView: WKWebView?) {}
     var isAttachTabsEnabled: Bool = false
     var isAttachTabsEnabledPublisher: AnyPublisher<Bool, Never> { Just(false).eraseToAnyPublisher() }
     var selectedModelId: String?


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217449069234918?focus=true
Tech Design: https://app.asana.com/1/137249556945/project/481882893211075/task/1216355483179556

### Description

Duck.ai enforces daily and weekly limits per tier. The native app had no access to that data, so it can't warn users as they approach a limit.

The web app now writes a privacy-safe usage snapshot — percentage used and reset time, per window — into the existing Duck.ai native storage. This adds the native side that reads it, on demand, when the user activates a Duck.ai input: the address bar, the Prompt Bar, and the New Tab Page omnibar.

**No UI yet.** The warning design isn't final, so this lands behind `aiChatUsageWarnings` (internal-only) with nothing user-visible

### Testing Steps

**Setup:**

1. In a terminal, monitor for reading logs:
   `log stream --level debug --predicate 'subsystem == "com.duckduckgo.macos.browser.debug" AND category == "AIChat" AND (eventMessage CONTAINS "usage limits read")'`
10. Run the app, 
11. Focus the address bar
12. Verify the app read the usage from native storage.
13. Make sure the value is same in Duck.ai Settings -> Usage
14. Submit a duck.ai prompt (ideally with extended reasoning or something that moves the usage)
15. Open a new tab, and focus the address bar
16. Verify the app read the usage from native storage again
13. Make sure the value is same in Duck.ai Settings -> Usage

_Note: Fire Windows currently don't read the usage value. I'll be adding support for them in a follow-up PR_

### Impact

Low — internal-only flag, no UI, and nothing consumes the value yet.

### Known gaps, worth a reviewer's eye

1. **Free-tier users will almost always see an empty snapshot.** The backend withholds usage data until a window is already blocked, so an "approaching your limit" warning effectively cannot fire for them. Harmless while there's no UI, but it needs a product answer before the warning is built.
2. **After sign-in the snapshot updates on the next status refresh, not immediately.** Pre-existing web-side behaviour; the next input activation picks it up.
3. **When the storage bridge isn't available we show nothing** — indistinguishable from "no usage data", by design.

Note: `Run unit tests (macOS)` and `BSK Test Report (macOS)` are red, with 79 `NavigationTests` failures. The identical 79 fail on `main`, so they're pre-existing and unrelated to this change.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only, flag-gated plumbing with defensive parsing and no shipped UI; limited exposure until warnings ship.
> 
> **Overview**
> Adds native support for the Duck.ai web app’s **usage limit snapshot** (daily/weekly percent used and reset times) written to the reserved `usageLimits` native-storage entry, so macOS can later warn users before they hit limits.
> 
> **Shared AIChat:** New `DuckAiUsageLimits` decoding (JSON string or dict), expiry handling, and `DuckAiUsageLimitsProvider` reading via `getEntry`; documents the new reserved key alongside `locallyDeletedChatIds`. **Privacy config:** `AIChatSubfeature.usageWarnings`. **macOS:** Internal-only `aiChatUsageWarnings` flag; `DuckAiUsageLimitsStore` gates reads and logs debug output. **Activation reads:** Address bar and Prompt Bar omnibar controllers refresh `@Published usageLimits` on activation; NTP omnibar refreshes when `getConfig`/`setConfig` is in Duck.ai mode, with burner-aware storage handler wiring aligned to Customize Responses.
> 
> **No user-visible UI yet**—values are stored for upcoming warnings. SPM pins are bumped in AIChat’s `Package.resolved`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a31646d0c445f82aa1b746343795d921dcca5c5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->