### PR TITLE
Remove fireButtonSingleTabDeleteAll feature flag

### DIFF
--- a/iOS/DuckDuckGo/Fire/DataClearingCapability.swift
+++ b/iOS/DuckDuckGo/Fire/DataClearingCapability.swift
@@ -24,10 +24,6 @@ import FeatureFlags_iOS
 
 protocol DataClearingCapable {
     var isFireButtonRefinementsEnabled: Bool { get }
-
-    /// When enabled, the fire confirmation collapses to a single "Delete All" button
-    /// if only one non-Duck.ai tab is open, since burning that tab equals burning all.
-    var isSingleTabDeleteAllEnabled: Bool { get }
 }
 
 enum DataClearingCapability {
@@ -56,9 +52,5 @@ struct DataClearingDefaultCapability: DataClearingCapable {
             // but the refinements should still apply independently.
             featureFlagger.isFeatureOn(for: FeatureFlag.fireButtonRefinements)
         }
-    }
-
-    var isSingleTabDeleteAllEnabled: Bool {
-        featureFlagger.isFeatureOn(for: FeatureFlag.fireButtonSingleTabDeleteAll)
     }
 }

--- a/iOS/DuckDuckGo/Fire/ScopedFireConfirmationView.swift
+++ b/iOS/DuckDuckGo/Fire/ScopedFireConfirmationView.swift
@@ -151,7 +151,6 @@ private extension ScopedFireConfirmationView {
 #if DEBUG
 private struct PreviewDataClearingCapability: DataClearingCapable {
     var isFireButtonRefinementsEnabled: Bool { false }
-    var isSingleTabDeleteAllEnabled: Bool { false }
 }
 
 private final class PreviewDownloadManager: DownloadManaging {

--- a/iOS/DuckDuckGo/Fire/ScopedFireConfirmationViewModel.swift
+++ b/iOS/DuckDuckGo/Fire/ScopedFireConfirmationViewModel.swift
@@ -101,8 +101,7 @@ final class ScopedFireConfirmationViewModel: ObservableObject {
         let showDeleteAllOnlyForSingleTab = Self.showDeleteAllOnlyForSingleTab(fireContext: fireContext,
                                                                                isSingleTab: isSingleTab,
                                                                                isSingleChatConfirmation: isSingleChatConfirmation,
-                                                                               tabViewModel: tabViewModel,
-                                                                               dataClearingCapability: dataClearingCapability)
+                                                                               tabViewModel: tabViewModel)
 
         self.headerTitle = Self.computeHeaderTitle(fireContext: fireContext,
                                                    isSingleChatConfirmation: isSingleChatConfirmation,
@@ -157,14 +156,13 @@ final class ScopedFireConfirmationViewModel: ObservableObject {
 
     /// Returns `true` when only one non-Duck.ai tab is open and the standard fire button is used.
     /// In that case "Delete This Tab" is equivalent to "Delete All", so the choice is dropped and
-    /// only "Delete All" is shown. Gated behind the `fireButtonSingleTabDeleteAll` flag.
+    /// only "Delete All" is shown.
     private static func showDeleteAllOnlyForSingleTab(fireContext: FireContext,
                                                       isSingleTab: Bool,
                                                       isSingleChatConfirmation: Bool,
-                                                      tabViewModel: TabViewModel?,
-                                                      dataClearingCapability: DataClearingCapable) -> Bool {
+                                                      tabViewModel: TabViewModel?) -> Bool {
         guard case .default = fireContext else { return false }
-        guard dataClearingCapability.isSingleTabDeleteAllEnabled, isSingleTab else { return false }
+        guard isSingleTab else { return false }
         // Never override the Duck.ai single-chat confirmation.
         return !isSingleChatConfirmation && tabViewModel?.tab.isAITab != true
     }

--- a/iOS/DuckDuckGoTests/Fire/DataClearingSettingsViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/DataClearingSettingsViewModelTests.swift
@@ -24,7 +24,6 @@ import AIChat
 
 final class MockDataClearingCapability: DataClearingCapable {
     var isFireButtonRefinementsEnabled: Bool = false
-    var isSingleTabDeleteAllEnabled: Bool = false
 }
 
 @MainActor

--- a/iOS/DuckDuckGoTests/Fire/ScopedFireConfirmationViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/ScopedFireConfirmationViewModelTests.swift
@@ -515,10 +515,9 @@ final class ScopedFireConfirmationViewModelTests: XCTestCase {
 
     // MARK: - Single Tab "Delete All" Only Tests
 
-    func testWhenSingleTabAndFlagEnabledThenOnlyDeleteAllShown() {
+    func testWhenSingleTabThenOnlyDeleteAllShown() {
         // Given
         mockDataClearingCapability.isFireButtonRefinementsEnabled = true
-        mockDataClearingCapability.isSingleTabDeleteAllEnabled = true
 
         // When
         let sut = makeSUT(tabViewModel: createTabViewModel(), isSingleTab: true)
@@ -529,10 +528,9 @@ final class ScopedFireConfirmationViewModelTests: XCTestCase {
         XCTAssertEqual(sut.buttons[0].style, .primary)
     }
 
-    func testWhenSingleTabAndFlagEnabledWithRefinementsDisabledThenOnlyDeleteAllShown() {
+    func testWhenSingleTabWithRefinementsDisabledThenOnlyDeleteAllShown() {
         // Given
         mockDataClearingCapability.isFireButtonRefinementsEnabled = false
-        mockDataClearingCapability.isSingleTabDeleteAllEnabled = true
 
         // When
         let sut = makeSUT(tabViewModel: createTabViewModel(), isSingleTab: true)
@@ -543,24 +541,9 @@ final class ScopedFireConfirmationViewModelTests: XCTestCase {
         XCTAssertEqual(sut.buttons[0].style, .primary)
     }
 
-    func testWhenSingleTabButFlagDisabledThenNormalButtons() {
+    func testWhenMultipleTabsThenNormalButtons() {
         // Given
         mockDataClearingCapability.isFireButtonRefinementsEnabled = true
-        mockDataClearingCapability.isSingleTabDeleteAllEnabled = false
-
-        // When
-        let sut = makeSUT(tabViewModel: createTabViewModel(), isSingleTab: true)
-
-        // Then
-        XCTAssertEqual(sut.buttons.count, 2)
-        XCTAssertEqual(sut.buttons[0].title, UserText.scopedFireConfirmationDeleteThisTabButton)
-        XCTAssertEqual(sut.buttons[1].title, UserText.scopedFireConfirmationDeleteAllButton)
-    }
-
-    func testWhenMultipleTabsAndFlagEnabledThenNormalButtons() {
-        // Given
-        mockDataClearingCapability.isFireButtonRefinementsEnabled = true
-        mockDataClearingCapability.isSingleTabDeleteAllEnabled = true
 
         // When
         let sut = makeSUT(tabViewModel: createTabViewModel(), isSingleTab: false)
@@ -571,10 +554,9 @@ final class ScopedFireConfirmationViewModelTests: XCTestCase {
         XCTAssertEqual(sut.buttons[1].title, UserText.scopedFireConfirmationDeleteAllButton)
     }
 
-    func testWhenSingleAITabAndFlagEnabledThenChatConfirmationUnaffected() {
+    func testWhenSingleAITabThenChatConfirmationUnaffected() {
         // Given
         mockDataClearingCapability.isFireButtonRefinementsEnabled = true
-        mockDataClearingCapability.isSingleTabDeleteAllEnabled = true
 
         // When
         let sut = makeSUT(tabViewModel: createAITabViewModel(), isSingleTab: true)
@@ -587,7 +569,6 @@ final class ScopedFireConfirmationViewModelTests: XCTestCase {
     func testWhenSingleTabDeleteAllShownThenTitleIsSingular() {
         // Given
         mockDataClearingCapability.isFireButtonRefinementsEnabled = true
-        mockDataClearingCapability.isSingleTabDeleteAllEnabled = true
 
         // When
         let sut = makeSUT(tabViewModel: createTabViewModel(), isSingleTab: true)
@@ -600,7 +581,6 @@ final class ScopedFireConfirmationViewModelTests: XCTestCase {
         // Given
         var capturedRequest: FireRequest?
         mockDataClearingCapability.isFireButtonRefinementsEnabled = true
-        mockDataClearingCapability.isSingleTabDeleteAllEnabled = true
         let sut = makeSUT(tabViewModel: createTabViewModel(),
                           isSingleTab: true,
                           onConfirm: { capturedRequest = $0 })

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -441,9 +441,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213965646075290
     case fireButtonRefinements
 
-    /// https://app.asana.com/1/137249556945/project/1214749231578703/task/1213613180881406
-    case fireButtonSingleTabDeleteAll
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213728968355833?focus=true
     case aiChatOmnibarDefaultPosition
 
@@ -872,8 +869,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.fireMode))
         case .fireButtonRefinements:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.fireButtonRefinements))
-        case .fireButtonSingleTabDeleteAll:
-            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.fireButtonSingleTabDeleteAll))
         case .aiChatOmnibarDefaultPosition:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.omnibarDefaultPosition))
         case .duckAIVoiceShortcut:

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
@@ -96,9 +96,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213965646075290
     case fireButtonRefinements
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216535350078652
-    case fireButtonSingleTabDeleteAll
-
     /// https://app.asana.com/1/137249556945/project/392891325557410/task/1212828713075939?focus=true
     case omniBarLongPressMenu
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1217486389734280?focus=true
Tech Design URL:
CC:

### Description
Removes the temporary `fireButtonSingleTabDeleteAll` feature flag, keeping the enabled behaviour.

The fire confirmation now always collapses to a single "Delete All" button when only one non-Duck.ai tab is open and the standard fire button is used.

### Testing Steps
1. Open the app with a single regular tab, no Duck.ai chat.
2. Tap the fire button, verify the confirmation shows only "Delete All", no "Delete This Tab" option.
3. Open a second tab, tap the fire button, verify both "Delete This Tab" and "Delete All" are shown.
4. Open a Duck.ai chat as the only tab, tap the fire button, verify the single chat confirmation is unchanged.

### Impact and Risks
Low. Flag was already defaulted to enabled and rolled out.

#### What could go wrong?
--

### Quality Considerations
--

### Notes to Reviewer
--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag was already default-enabled; this is rollout cleanup with no new burn logic, only removal of a remote kill switch.
> 
> **Overview**
> Removes the temporary **`fireButtonSingleTabDeleteAll`** feature flag and makes its behavior unconditional.
> 
> When the standard fire confirmation is shown with **only one non-Duck.ai tab**, **`ScopedFireConfirmationViewModel`** now always collapses the sheet to a single **Delete All** action (and the singular header title), without checking **`DataClearingCapable`**. Duck.ai single-chat confirmation and multi-tab flows are unchanged.
> 
> Cleanup touches **`DataClearingCapability`**, preview/test mocks, **`FeatureFlag`** / **`iOSBrowserConfigSubfeature`**, and unit tests (flag toggles removed; one test for “flag disabled + single tab” dropped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f39f8bd14798c139fd9592b4f54e765ee850d0b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->