### PR TITLE
Updated CONTRIBUTING.md guidelines for pull requests.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,15 +24,14 @@ If you have encountered a security issue, please reach us through https://hacker
 
 ## Contributing Code
 
-We're always open to contributions from the community! There are different approaches depending on how you wish to contribute:
+We're always open to contributions from the community!
 
-* **For bug fixes**, feel free to open a pull request along with an associated issue. Someone from the team will review your issue/change within a few days.
-* **For new features**, start by logging an issue with a description of your idea. Proposals that fit our product direction and timeline will be added to our backlog and labelled accordingly.
-* If you're looking for a bug to work on, see the [Help Wanted](https://github.com/duckduckgo/apple-browsers/issues?q=is%3Aissue+is%3Aopen+label%3A%22Help+Wanted%22) tag for a list of open issues.
+* **Bug fixes:** Please feel free to open an issue to initiate a discussion before submitting any pull requests. If there's already an associated issue created, please add it to the description. Someone from the team will review your issue/change within a few days.
+* **Refactoring and product/feature changes:** These changes won't be considered and pull requests will be closed.
 
 ### Style Guide
 
-We care about clean code. Refer to our [style guide](styleguide/STYLEGUIDE.md).
+We care about clean code. Refer to our [style guide](iOS/styleguide/STYLEGUIDE.md).
 
 ### Commit Messages
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/38424471409662/task/1217369441445989?focus=true
Tech Design URL:
CC:

### Description

This PR updates our contributing guidelines, bringing the iOS wording closer to Android: product / feature changes from third party contributors will now be closed by default, primarily due to the internal processes we need to go through for big feature changes. I also fixed the link to our style guide.

### Testing Steps

1. Read CONTRIBUTING.md, check it looks good!

### Impact

None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only policy clarification with no runtime or security impact.
> 
> **Overview**
> Updates **contributor expectations** in `CONTRIBUTING.md` to match Android: community PRs are framed around **bug fixes** (discuss via issue first; link existing issues in the PR), while **refactoring and product/feature changes** from third-party contributors are **not accepted** and associated PRs will be closed.
> 
> Removes the prior bullets for new-feature proposals and the Help Wanted issue list. Fixes the style guide link to `iOS/styleguide/STYLEGUIDE.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca1acb7f787f51cff7d2591efb4fb416a6fc56da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->