### PR TITLE
Add ScanQRCodeViewV2 snapshot test

### DIFF
--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -189,6 +189,8 @@ jobs:
 
     - name: Build and test
       id: run-unit-tests
+      env:
+        SPM_FORCE_DEBUG_FOR_SNAPSHOTS: "1"
       run: |
         echo "Using iOS simulator: ${{ steps.select-simulator.outputs.ios-version }}"
         echo "Destination: ${{ steps.select-simulator.outputs.destination }}"

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -190,6 +190,9 @@ jobs:
     - name: Build and test
       id: run-unit-tests
       env:
+        # Under CI, SPM builds packages in release configuration (the CI configuration maps to .release),
+        # so `.when(configuration: .debug)` doesn't fire and the DEBUG-only snapshot tests wouldn't compile.
+        # This forces DEBUG on for the package build. Read in SyncUI-iOS/Package.swift.
         SPM_FORCE_DEBUG_FOR_SNAPSHOTS: "1"
       run: |
         echo "Using iOS simulator: ${{ steps.select-simulator.outputs.ios-version }}"

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -277,6 +277,9 @@ jobs:
     - name: Build for testing
       id: build-for-testing
       env:
+        # Under CI, SPM builds packages in release configuration (the CI configuration maps to .release),
+        # so `.when(configuration: .debug)` doesn't fire and the DEBUG-only snapshot tests wouldn't compile.
+        # This forces DEBUG on for the package build. Read in SyncUI-macOS/Package.swift.
         SPM_FORCE_DEBUG_FOR_SNAPSHOTS: "1"
       run: |
         echo "Runner ${RUNNER_NAME} (${RUNNER_TRACKING_ID})"

--- a/SharedPackages/SnapshotTestingSupport/README.md
+++ b/SharedPackages/SnapshotTestingSupport/README.md
@@ -101,6 +101,24 @@ On macOS, device variants don't apply — `.screen`/`.sheet`/`.fixed` all resolv
 
 Default appearance strategy is `.allAppearances` (light + dark). Use `.single(.light)` or `.single(.dark)` to scope, or `.custom([...])` for full control.
 
+## Limitations: `List`, effects, and the host-application requirement
+
+These helpers render through Point-Free's `drawHierarchyInKeyWindow: false` path (`CALayer.render(in:)`), because they are designed to run from **SPM package test targets, which have no host application**. That rasterization path cannot capture UIKit-backed content that needs a live key-window render pass:
+
+- **`List` / `UICollectionView`-backed content renders blank.**
+- **`UIVisualEffect` (blur / "liquid glass") and `UIAppearance` are not applied.**
+- **`NavigationView` on iPad's regular size class renders as a split view** — use `NavigationStack`, or scope the snapshot to iPhone. (Plain `NavigationView` on iPhone, and `VStack` / `ScrollView` content, render fine.)
+
+Point-Free's fix for the first two is `drawHierarchyInKeyWindow: true` (`UIView.drawHierarchy(in:afterScreenUpdates:)` against the real key window). That option **requires a host application and will `fatalError` in a package test target** — see the parameter docs in [`swift-snapshot-testing`](https://github.com/pointfreeco/swift-snapshot-testing) and discussions [#781](https://github.com/pointfreeco/swift-snapshot-testing/discussions/781), [#725](https://github.com/pointfreeco/swift-snapshot-testing/discussions/725), and [#1031](https://github.com/pointfreeco/swift-snapshot-testing/discussions/1031).
+
+**Rule of thumb:** prefer `VStack` / `ScrollView`-based content, which snapshots cleanly from a package test target. A `List`-based settings screen (e.g. `SyncSuccessViewV2`) comes out blank here.
+
+### If you must snapshot a `List` / effect-heavy screen
+
+1. **Run the test from an app-hosted target** (e.g. `iOS/DuckDuckGoTests`), not a package test target — only an Xcode app test target sets `TEST_HOST` / `BUNDLE_LOADER`; SwiftPM package test targets cannot have a host app.
+2. **Keep the `PreviewProvider` / `PreviewSnapshots` in the view's module** and reach it from the test with `@testable import <Module>` (already the pattern for `SyncUI_iOS`).
+3. **Render through the key-window path** (`drawHierarchyInKeyWindow: true`). These helpers currently hardcode `false`; threading it through as an opt-in is not done yet, so until that lands such a screen cannot be image-snapshotted through this wrapper.
+
 ## Environment requirements
 
 Snapshots are pixel-strict, so the test environment is validated before each assertion:

--- a/iOS/LocalPackages/SyncUI-iOS/Package.resolved
+++ b/iOS/LocalPackages/SyncUI-iOS/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dcdfbe4de770641a18834466b4641abdd25fe5da9a88f096bcb1e84d46ba8a6e",
+  "originHash" : "0d36a829615ab743342e75faa2c91fbd51a26dc3c46dc9a5af1808a22110957a",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -29,12 +29,39 @@
       }
     },
     {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "e9c34fd54ece006b491a0e6d23fe9a6024b9a828",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "59a99c458de4d2dee580529b61b4f78dca7b7fa6",
+        "version" : "1.19.4"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
         "version" : "509.1.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version" : "1.11.0"
       }
     }
   ],

--- a/iOS/LocalPackages/SyncUI-iOS/Package.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Package.swift
@@ -18,6 +18,12 @@
 //
 
 import PackageDescription
+import Foundation
+
+// Set by the "Build and test" step in .github/workflows/ios_pr_checks.yml. Under CI the package builds
+// in release configuration (SPM maps the CI configuration to .release), so `.when(configuration: .debug)` below
+// doesn't fire and the DEBUG-only snapshot tests wouldn't compile. This forces DEBUG on for that CI build.
+let forceDebugForSnapshots = ProcessInfo.processInfo.environment["SPM_FORCE_DEBUG_FOR_SNAPSHOTS"] == "1"
 
 let package = Package(
     name: "SyncUI-iOS",
@@ -37,6 +43,7 @@ let package = Package(
         .package(path: "../../../SharedPackages/Infrastructure/DesignResourcesKit"),
         .package(path: "../../../SharedPackages/Infrastructure/MetricBuilder"),
         .package(path: "../../../SharedPackages/UIComponents"),
+        .package(path: "../../../SharedPackages/SnapshotTestingSupport"),
         .package(url: "https://github.com/duckduckgo/apple-toolbox.git", exact: "3.2.1"),
         .package(url: "https://github.com/airbnb/lottie-spm.git", exact: "4.6.1"),
     ],
@@ -49,7 +56,8 @@ let package = Package(
                 .product(name: "DesignResourcesKitIcons", package: "DesignResourcesKitIcons"),
                 .product(name: "MetricBuilder", package: "MetricBuilder"),
                 .product(name: "UIComponents", package: "UIComponents"),
-                .product(name: "Lottie", package: "lottie-spm")
+                .product(name: "Lottie", package: "lottie-spm"),
+                .product(name: "PreviewSnapshots", package: "SnapshotTestingSupport"),
             ],
             resources: [
                 .process("Resources/SyncMedia.xcassets"),
@@ -58,12 +66,13 @@ let package = Package(
             ],
             swiftSettings: [
                 .define("DEBUG", .when(configuration: .debug))
-            ]
+            ] + (forceDebugForSnapshots ? [.define("DEBUG")] : [])
         ),
         .testTarget(
             name: "SyncUI-iOSTests",
             dependencies: [
-                "SyncUI-iOS"
+                "SyncUI-iOS",
+                .product(name: "SnapshotTestingSupport", package: "SnapshotTestingSupport"),
             ]
         )
     ]

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/ScanQRCodeViewV2.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/ScanQRCodeViewV2.swift
@@ -23,6 +23,10 @@ import DuckUI
 import SwiftUI
 import UIComponents
 
+#if DEBUG
+import PreviewSnapshots
+#endif
+
 public struct ScanQRCodeViewV2: View {
 
     enum Tab {
@@ -96,28 +100,30 @@ public struct ScanQRCodeViewV2: View {
 }
 
 #if DEBUG
-#Preview {
-    let sampleCode = "https://duckduckgo.com/sync/pairing/#&code2=eyJ2ZXJzaW9uIjoiMiIsImNoYW5uZWxJZCI6IjY4MEQ0NUI1LTVFNkUtNDM0Ny05QzQ0LUI2RkJFODBGQzRBNyIsInB1YmxpY0tleSI6IkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaIn0"
+struct ScanQRCodeViewV2_Previews: PreviewProvider {
 
-    return NavigationView {
-        RebrandedPreview(isRebranded: true) {
-            ScanQRCodeViewV2(
-                model: ScanOrPasteCodeViewModel(codeForDisplayOrPasting: sampleCode, qrCodeString: sampleCode, source: .connect)
-            )
-        }
+    static let sampleCode = "https://duckduckgo.com/sync/pairing/#&code2=eyJ2ZXJzaW9uIjoiMiIsImNoYW5uZWxJZCI6IjY4MEQ0NUI1LTVFNkUtNDM0Ny05QzQ0LUI2RkJFODBGQzRBNyIsInB1YmxpY0tleSI6IkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaIn0"
+
+    static var previews: some View {
+        snapshots.previews
     }
-}
 
-#Preview("Enter Code") {
-    let sampleCode = "https://duckduckgo.com/sync/pairing/#&code2=eyJ2ZXJzaW9uIjoiMiIsImNoYW5uZWxJZCI6IjY4MEQ0NUI1LTVFNkUtNDM0Ny05QzQ0LUI2RkJFODBGQzRBNyIsInB1YmxpY0tleSI6IkFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaIn0"
-
-    return NavigationView {
-        RebrandedPreview(isRebranded: true) {
-            ScanQRCodeViewV2(
-                model: ScanOrPasteCodeViewModel(codeForDisplayOrPasting: sampleCode, qrCodeString: sampleCode, source: .connect),
-                selectedTab: .enterCode
-            )
+    static let snapshots = PreviewSnapshots<ScanQRCodeViewV2.Tab>(
+        configurations: [
+            .init(name: "Scan QR Code", state: .scanQRCode),
+            .init(name: "Enter Code", state: .enterCode)
+        ],
+        configure: { tab in
+            NavigationView {
+                RebrandedPreview(isRebranded: true) {
+                    ScanQRCodeViewV2(
+                        model: ScanOrPasteCodeViewModel(codeForDisplayOrPasting: sampleCode, qrCodeString: sampleCode, source: .connect),
+                        selectedTab: tab
+                    )
+                }
+            }
+            .navigationViewStyle(.stack)
         }
-    }
+    )
 }
 #endif

--- a/iOS/LocalPackages/SyncUI-iOS/Tests/SyncUI-iOSTests/ScanQRCodeViewV2Tests.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Tests/SyncUI-iOSTests/ScanQRCodeViewV2Tests.swift
@@ -1,0 +1,37 @@
+//
+//  ScanQRCodeViewV2Tests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SnapshotTestingSupport
+import Testing
+@testable import SyncUI_iOS
+
+@MainActor
+@Suite("Scan QR Code View V2 Tests")
+final class ScanQRCodeViewV2Tests {
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1)))
+    func testScanQRCodeViewV2iPhoneScreenSnapshots() {
+        assertImageSnapshots(
+            ScanQRCodeViewV2_Previews.snapshots,
+            strategy: .custom([SnapshotImageConfiguration(appearance: .dark, device: .iPhoneDefault)]),
+            size: .screen
+        )
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1217448281834622

### Description

Adds an iOS image snapshot test for the Sync "Scan QR / Enter Code" screen (`ScanQRCodeViewV2`):

- Converts the previews to a `PreviewProvider` backed by `PreviewSnapshots`, snapshotting both tab states on iPhone (`.screen`, dark).
- Wires the `SyncUI-iOS` package to `SnapshotTestingSupport` and adds the CI `SPM_FORCE_DEBUG_FOR_SNAPSHOTS` shim so the DEBUG-only preview compiles under CI.
- Adds a "Limitations" section to the `SnapshotTestingSupport` README explaining when a view can/can't be image-snapshotted (`List` / `UIVisualEffect` need `drawHierarchyInKeyWindow: true` + a host application, which SPM package test targets can't provide).

Companion reference images: duckduckgo/apple-browsers-snapshots#15

> Depends on #6355 (the Merge snapshots token fix). That must land on `main` first, because the `Merge snapshots` workflow runs from the base branch under `pull_request_target` — so the label can only be exercised on this PR once #6355 is merged.

### Testing Steps

1. After #6355 is on `main`, add the `Merge snapshots` label to this PR → the companion snapshots PR merges and `SnapshotReferences` repoints to snapshots `main`.
2. Run the `ScanQRCodeViewV2Tests` suite in the `SyncUI-iOS` package → passes. (Image-snapshot assertions are currently globally skipped via `SKIP_SNAPSHOT_TESTS` pinned in the app schemes.)

### Impact

Low — a new test plus package/CI wiring; no user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and CI/package wiring with no production behavior changes; minor risk if DEBUG forcing in CI affects unrelated debug-only code paths in SyncUI-iOS.
> 
> **Overview**
> Adds an **image snapshot test** for Sync **`ScanQRCodeViewV2`**, covering the Scan QR and Enter Code tabs on iPhone (dark, `.screen`).
> 
> **`ScanQRCodeViewV2`** previews move from `#Preview` to a DEBUG **`PreviewProvider`** backed by **`PreviewSnapshots`**, with stacked **`NavigationView`** styling so iPad split-view doesn’t affect captures.
> 
> **`SyncUI-iOS`** now depends on **`SnapshotTestingSupport`** (including **`PreviewSnapshots`** on the library target) and **`Package.resolved`** picks up the snapshot-testing transitive pins. **`Package.swift`** reads **`SPM_FORCE_DEBUG_FOR_SNAPSHOTS`** so CI can define **`DEBUG`** when SPM builds packages as release under the CI configuration.
> 
> **iOS PR checks** set that env var on the unit-test **`xcodebuild`** step (macOS build-for-testing already documents the same shim). **`SnapshotTestingSupport` README** gains a **Limitations** section on SPM package tests vs **`List`**, effects, and key-window rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dd4eb83805fe18ee8c1ee54264870fc4575e239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->