### PR TITLE
Send New Tab Page session actions only when performed

### DIFF
--- a/iOS/DuckDuckGo/AppLifecycle/NewTabPageSessionWideEventData.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/NewTabPageSessionWideEventData.swift
@@ -204,11 +204,8 @@ extension NewTabPageSessionWideEventData {
         return thresholds.last(where: { $0 <= count }) ?? 0
     }
 
-    /// Reports an action only when it happened, so an absent key reads as "not done".
-    ///
-    /// Most visits touch a handful of the actions at most, and this is the highest volume wide
-    /// event on either platform, so carrying the rest as `false` is most of the payload for none
-    /// of the information. `Dictionary(compacting:)` drops the nils.
+    /// Omits an action that did not happen, since thirty `false` flags per visit are payload
+    /// without information.
     private func whenDone(_ actionOccurred: Bool) -> Bool? {
         actionOccurred ? true : nil
     }

--- a/iOS/DuckDuckGo/AppLifecycle/NewTabPageSessionWideEventData.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/NewTabPageSessionWideEventData.swift
@@ -204,6 +204,15 @@ extension NewTabPageSessionWideEventData {
         return thresholds.last(where: { $0 <= count }) ?? 0
     }
 
+    /// Reports an action only when it happened, so an absent key reads as "not done".
+    ///
+    /// Most visits touch a handful of the actions at most, and this is the highest volume wide
+    /// event on either platform, so carrying the rest as `false` is most of the payload for none
+    /// of the information. `Dictionary(compacting:)` drops the nils.
+    private func whenDone(_ actionOccurred: Bool) -> Bool? {
+        actionOccurred ? true : nil
+    }
+
     func jsonParameters() -> [String: Encodable] {
         let bucket = Self.durationBucket
         return Dictionary(compacting: [
@@ -214,37 +223,37 @@ extension NewTabPageSessionWideEventData {
             (WideEventParameter.NewTabPageSessionFeature.actionCountBucketed, String(Self.actionCountBucket(actionCount))),
             (WideEventParameter.NewTabPageSessionFeature.timeToFirstInteractionMsBucketed, firstInteractionInterval.stringValue(bucket)),
             (WideEventParameter.NewTabPageSessionFeature.sessionDurationMsBucketed, sessionInterval.stringValue(bucket)),
-            (WideEventParameter.NewTabPageSessionFeature.tapInputBar, tapInputBar),
-            (WideEventParameter.NewTabPageSessionFeature.typeInInput, typeInInput),
-            (WideEventParameter.NewTabPageSessionFeature.switchToggleToSearch, switchToggleToSearch),
-            (WideEventParameter.NewTabPageSessionFeature.switchToggleToAiChat, switchToggleToAiChat),
-            (WideEventParameter.NewTabPageSessionFeature.tapDuckaiButton, tapDuckaiButton),
-            (WideEventParameter.NewTabPageSessionFeature.hitSubmit, hitSubmit),
-            (WideEventParameter.NewTabPageSessionFeature.chooseSuggestion, chooseSuggestion),
-            (WideEventParameter.NewTabPageSessionFeature.tapFavorite, tapFavorite),
-            (WideEventParameter.NewTabPageSessionFeature.tapFireButton, tapFireButton),
-            (WideEventParameter.NewTabPageSessionFeature.tapReturnToLast, tapReturnToLast),
-            (WideEventParameter.NewTabPageSessionFeature.tapTabViewerEscapeHatch, tapTabViewerEscapeHatch),
-            (WideEventParameter.NewTabPageSessionFeature.tapTabViewerToolbar, tapTabViewerToolbar),
-            (WideEventParameter.NewTabPageSessionFeature.tapBookmarksToolbarItem, tapBookmarksToolbarItem),
-            (WideEventParameter.NewTabPageSessionFeature.tapPasswordsToolbarItem, tapPasswordsToolbarItem),
-            (WideEventParameter.NewTabPageSessionFeature.openMenu, openMenu),
-            (WideEventParameter.NewTabPageSessionFeature.menuBookmarks, menuBookmarks),
-            (WideEventParameter.NewTabPageSessionFeature.menuPasswords, menuPasswords),
-            (WideEventParameter.NewTabPageSessionFeature.menuChats, menuChats),
-            (WideEventParameter.NewTabPageSessionFeature.menuDownloads, menuDownloads),
-            (WideEventParameter.NewTabPageSessionFeature.menuVpn, menuVpn),
-            (WideEventParameter.NewTabPageSessionFeature.clickMessageCta, clickMessageCta),
-            (WideEventParameter.NewTabPageSessionFeature.clickMessageDismiss, clickMessageDismiss),
-            (WideEventParameter.NewTabPageSessionFeature.dismissKeyboard, dismissKeyboard),
-            (WideEventParameter.NewTabPageSessionFeature.scrollView, scrollView),
-            (WideEventParameter.NewTabPageSessionFeature.utiBackArrow, utiBackArrow),
-            (WideEventParameter.NewTabPageSessionFeature.selectBookmark, selectBookmark),
-            (WideEventParameter.NewTabPageSessionFeature.selectPassword, selectPassword),
-            (WideEventParameter.NewTabPageSessionFeature.selectDownload, selectDownload),
-            (WideEventParameter.NewTabPageSessionFeature.emailCopied, emailCopied),
-            (WideEventParameter.NewTabPageSessionFeature.vpnOn, vpnOn),
-            (WideEventParameter.NewTabPageSessionFeature.vpnOff, vpnOff),
+            (WideEventParameter.NewTabPageSessionFeature.tapInputBar, whenDone(tapInputBar)),
+            (WideEventParameter.NewTabPageSessionFeature.typeInInput, whenDone(typeInInput)),
+            (WideEventParameter.NewTabPageSessionFeature.switchToggleToSearch, whenDone(switchToggleToSearch)),
+            (WideEventParameter.NewTabPageSessionFeature.switchToggleToAiChat, whenDone(switchToggleToAiChat)),
+            (WideEventParameter.NewTabPageSessionFeature.tapDuckaiButton, whenDone(tapDuckaiButton)),
+            (WideEventParameter.NewTabPageSessionFeature.hitSubmit, whenDone(hitSubmit)),
+            (WideEventParameter.NewTabPageSessionFeature.chooseSuggestion, whenDone(chooseSuggestion)),
+            (WideEventParameter.NewTabPageSessionFeature.tapFavorite, whenDone(tapFavorite)),
+            (WideEventParameter.NewTabPageSessionFeature.tapFireButton, whenDone(tapFireButton)),
+            (WideEventParameter.NewTabPageSessionFeature.tapReturnToLast, whenDone(tapReturnToLast)),
+            (WideEventParameter.NewTabPageSessionFeature.tapTabViewerEscapeHatch, whenDone(tapTabViewerEscapeHatch)),
+            (WideEventParameter.NewTabPageSessionFeature.tapTabViewerToolbar, whenDone(tapTabViewerToolbar)),
+            (WideEventParameter.NewTabPageSessionFeature.tapBookmarksToolbarItem, whenDone(tapBookmarksToolbarItem)),
+            (WideEventParameter.NewTabPageSessionFeature.tapPasswordsToolbarItem, whenDone(tapPasswordsToolbarItem)),
+            (WideEventParameter.NewTabPageSessionFeature.openMenu, whenDone(openMenu)),
+            (WideEventParameter.NewTabPageSessionFeature.menuBookmarks, whenDone(menuBookmarks)),
+            (WideEventParameter.NewTabPageSessionFeature.menuPasswords, whenDone(menuPasswords)),
+            (WideEventParameter.NewTabPageSessionFeature.menuChats, whenDone(menuChats)),
+            (WideEventParameter.NewTabPageSessionFeature.menuDownloads, whenDone(menuDownloads)),
+            (WideEventParameter.NewTabPageSessionFeature.menuVpn, whenDone(menuVpn)),
+            (WideEventParameter.NewTabPageSessionFeature.clickMessageCta, whenDone(clickMessageCta)),
+            (WideEventParameter.NewTabPageSessionFeature.clickMessageDismiss, whenDone(clickMessageDismiss)),
+            (WideEventParameter.NewTabPageSessionFeature.dismissKeyboard, whenDone(dismissKeyboard)),
+            (WideEventParameter.NewTabPageSessionFeature.scrollView, whenDone(scrollView)),
+            (WideEventParameter.NewTabPageSessionFeature.utiBackArrow, whenDone(utiBackArrow)),
+            (WideEventParameter.NewTabPageSessionFeature.selectBookmark, whenDone(selectBookmark)),
+            (WideEventParameter.NewTabPageSessionFeature.selectPassword, whenDone(selectPassword)),
+            (WideEventParameter.NewTabPageSessionFeature.selectDownload, whenDone(selectDownload)),
+            (WideEventParameter.NewTabPageSessionFeature.emailCopied, whenDone(emailCopied)),
+            (WideEventParameter.NewTabPageSessionFeature.vpnOn, whenDone(vpnOn)),
+            (WideEventParameter.NewTabPageSessionFeature.vpnOff, whenDone(vpnOff)),
         ])
     }
 }

--- a/iOS/DuckDuckGoTests/NewTabPageSessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageSessionWideEventDataTests.swift
@@ -51,6 +51,12 @@ struct NewTabPageSessionWideEventDataTests {
         "feature.data.ext.actions.dismiss_keyboard",
         "feature.data.ext.actions.scroll_view",
         "feature.data.ext.actions.uti_back_arrow",
+        "feature.data.ext.actions.select_bookmark",
+        "feature.data.ext.actions.select_password",
+        "feature.data.ext.actions.select_download",
+        "feature.data.ext.actions.email_copied",
+        "feature.data.ext.actions.vpn_on",
+        "feature.data.ext.actions.vpn_off",
     ]
 
     private func makeData(trigger: NewTabPageSessionWideEventData.Trigger = .appOpen,
@@ -89,6 +95,12 @@ struct NewTabPageSessionWideEventDataTests {
         data.dismissKeyboard = true
         data.scrollView = true
         data.utiBackArrow = true
+        data.selectBookmark = true
+        data.selectPassword = true
+        data.selectDownload = true
+        data.emailCopied = true
+        data.vpnOn = true
+        data.vpnOff = true
     }
 
     // MARK: - Metadata
@@ -165,12 +177,25 @@ struct NewTabPageSessionWideEventDataTests {
     // MARK: - Action flags
 
     @available(iOS 16, *)
-    @Test("Action flags are emitted as false by default", .timeLimit(.minutes(1)))
-    func actionFlagsAreEmittedAsFalseByDefault() {
+    @Test("Actions that did not happen are left out entirely", .timeLimit(.minutes(1)))
+    func actionFlagsAreOmittedWhenNotPerformed() {
         let params = makeData().jsonParameters()
 
         for key in Self.actionKeys {
-            #expect(params[key] as? Bool == false, "Expected \(key) to be emitted as false")
+            #expect(params[key] == nil, "Expected \(key) to be absent")
+        }
+    }
+
+    @available(iOS 16, *)
+    @Test("Only the actions performed are emitted", .timeLimit(.minutes(1)))
+    func onlyPerformedActionsAreEmitted() {
+        let data = makeData()
+        data.tapFavorite = true
+        let params = data.jsonParameters()
+
+        #expect(params[WideEventParameter.NewTabPageSessionFeature.tapFavorite] as? Bool == true)
+        for key in Self.actionKeys where key != WideEventParameter.NewTabPageSessionFeature.tapFavorite {
+            #expect(params[key] == nil, "Expected \(key) to be absent")
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217456666245682
Tech Design URL:
CC:

### Description

Actions on NTP wide event are now reported only if they happen.

### Testing Steps

1. Enable the `newTabPageSessionInstrumentation` feature flag locally, run a debug build
2. On a New Tab Page, open menu, enter bookmarks, return then perform search and load a website.
3. Verify the wide event contains only executed actions in the payload with value `true`.

### Impact and Risks

Low.

#### What could go wrong?

—

### Quality Considerations

Dashboards will be updated to treat missing value properly.

### Notes to Reviewer

--

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics payload shape change only; dashboards must treat absent action keys as “not performed,” as noted in the PR.
> 
> **Overview**
> **New Tab Page session wide events** no longer include every action flag on each visit. Previously each of ~30 boolean action fields was sent as `false` when nothing happened; now only actions the user actually performed appear in the JSON, with value **`true`**.
> 
> A private **`whenDone`** helper maps `false` → `nil` so **`Dictionary(compacting:)`** drops those keys from **`jsonParameters()`**. Performed actions still emit **`true`**.
> 
> Tests were updated to expect **missing keys** instead of **`false`**, plus a case where a single action is set and the rest stay absent. The shared **`actionKeys`** list in tests now includes **`select_bookmark`**, **`select_password`**, **`select_download`**, **`email_copied`**, **`vpn_on`**, and **`vpn_off`** so omission coverage matches the payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64d276b88a751949ba885f84ec6976e6feb3138a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->