### PR TITLE
Fix Merge snapshots workflow token

### DIFF
--- a/.github/workflows/merge_snapshots.yml
+++ b/.github/workflows/merge_snapshots.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Merge snapshots PR and update pointer
         env:
-          GH_TOKEN: ${{ secrets.GHA_ELEVATED_PERMISSIONS_TOKEN }}
+          GH_TOKEN: ${{ secrets.SNAPSHOTS_REPO_TOKEN }}
           PR_BRANCH: ${{ github.event.pull_request.head.ref }}
         working-directory: pull-request
         run: ../trusted/scripts/merge-snapshots.sh "$PR_BRANCH"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1217448281834622

### Description

The `Shared - Merge Snapshots` workflow was failing to merge the companion PR in the `apple-browsers-snapshots` repo:

```
GraphQL: Resource not accessible by personal access token (mergePullRequest)
```

The merge step used `GHA_ELEVATED_PERMISSIONS_TOKEN`, which is scoped to the monorepo and can't merge in the snapshots repo. This points the merge step at the dedicated `SNAPSHOTS_REPO_TOKEN` (scoped to `apple-browsers-snapshots`). The monorepo push keeps the elevated token.

Because the workflow runs on `pull_request_target`, GitHub executes the workflow file **and** the trusted `scripts/merge-snapshots.sh` (checked out at `github.sha`) from the **base branch**, not from the PR. So this fix is inert until it lands on `main` — it can't be exercised from its own PR. That's why the label kept failing on the combined PR.

### Testing Steps

1. Merge this to `main`.
2. On a PR that has a companion `apple-browsers-snapshots` PR, add the `Merge snapshots` label → the companion PR merges and the submodule pointer updates (previously failed with the token error). This is validated by the snapshot PR that follows this one.

### Impact

None — CI tooling only; no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)