### PR TITLE
Cap URL length before percent-decoding in canonicalization

### DIFF
--- a/SharedPackages/Infrastructure/SystemFrameworksExtensions/Sources/FoundationExtensions/StringExtension.swift
+++ b/SharedPackages/Infrastructure/SystemFrameworksExtensions/Sources/FoundationExtensions/StringExtension.swift
@@ -167,9 +167,13 @@ public extension String {
         return message
     }
 
+    private static let maxPercentDecodingByteCount = 8192
+
     /// Repeatedly removes percent-encoding until no more percent-escapes remain.
     /// - Returns: The fully unescaped string.
     func fullyRemovingPercentEncoding() -> String {
+        guard utf8.count <= Self.maxPercentDecodingByteCount else { return self }
+
         var currentString = self
         var previousString: String
 

--- a/SharedPackages/Infrastructure/SystemFrameworksExtensions/Tests/FoundationExtensionsTests/StringExtensionTests.swift
+++ b/SharedPackages/Infrastructure/SystemFrameworksExtensions/Tests/FoundationExtensionsTests/StringExtensionTests.swift
@@ -486,4 +486,20 @@ final class StringExtensionTests: XCTestCase {
         XCTAssertEqual(result, "abcde     …    vwxyz")
     }
 
+    func testWhenFullyRemovingPercentEncodingThenEscapesAreDecoded() {
+        XCTAssertEqual("%2525".fullyRemovingPercentEncoding(), "%")
+        XCTAssertEqual("%252520".fullyRemovingPercentEncoding(), " ")
+        XCTAssertEqual("a%20b".fullyRemovingPercentEncoding(), "a b")
+        XCTAssertEqual("%E2%82%AC".fullyRemovingPercentEncoding(), "€")
+        XCTAssertEqual("abc".fullyRemovingPercentEncoding(), "abc")
+    }
+
+    func testWhenInputExceedsDecodingCapThenItIsReturnedUnchanged() {
+        let longInput = "https://a/" + String(repeating: "%25", count: 5_000)
+        XCTAssertEqual(longInput.fullyRemovingPercentEncoding(), longInput)
+
+        let atLimit = String(repeating: "a", count: 4_096)
+        XCTAssertEqual(atLimit.fullyRemovingPercentEncoding(), atLimit)
+    }
+
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1216713034645574
Tech Design URL:
CC:

### Description
Malicious Site Protection canonicalizes every navigated URL, which percent-decodes it via CoreFoundation. On a small number of devices that decode faults *inside* CoreFoundation's percent-decoder (a null-pointer `EXC_BAD_ACCESS`), reached from URL canonicalization while several evaluations run concurrently — most likely under device memory pressure. The crash is low-volume, iOS 26.6 / arm64e, and I could not reproduce it.

As a first, low-risk step this skips percent-decoding for pathologically long inputs (over 8 KB), so a very large allocation is never handed to the system decoder. 8 KB sits well above realistic URL lengths, so canonicalization of real traffic is unchanged.

This is a **mitigation, not a confirmed fix** — the fault is in Apple's CoreFoundation and isn't reproducible. Plan is to ship it and watch whether crash volume drops (and file Feedback with Apple on the unchecked allocation).

### Testing Steps
1. Run the FoundationExtensions unit tests → all pass, including the new length-cap test.

### Impact
Low — only inputs over 8 KB are affected; everything else is unchanged.

#### What could go wrong?
A malicious URL longer than 8 KB would skip percent-decoding and could canonicalize differently → mitigated by the threshold sitting far above realistic URL lengths, so real traffic (including real threats) is unaffected.

### Quality Considerations
- Mitigation only: the crash is a CoreFoundation-internal null deref, not reproducible despite fuzzing the decode + canonicalization path with 3M+ hostile inputs (lone surrogates, overlong/invalid UTF-8, nested/percent-bomb escapes) on macOS and the iOS-26 simulator, under AddressSanitizer and Guard Malloc.
- The decoder logic itself is unchanged; only an input-size guard is added, so no risk of diverging from Foundation's percent-decoding behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to inputs above 8 KB, which is far beyond typical URLs; canonicalization of normal traffic stays the same.
> 
> **Overview**
> Adds an **8 KB UTF-8 byte cap** on inputs to `fullyRemovingPercentEncoding()` so pathologically long strings are returned unchanged instead of being passed into Foundation’s percent decoder (used during Malicious Site Protection URL canonicalization).
> 
> The iterative decode loop is unchanged for normal-sized URLs; only strings over the limit skip decoding. New unit tests cover nested percent escapes and the over-limit unchanged behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2501a9c1ea755f598a8b4cada3594a5ebacbd5d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->