### PR TITLE
[macOS] Fix DuckPlayer UI tests

### DIFF
--- a/macOS/UITests/DuckPlayerTests.swift
+++ b/macOS/UITests/DuckPlayerTests.swift
@@ -22,6 +22,7 @@ class DuckPlayerTests: UITestCase {
     private var addressBarTextField: XCUIElement!
 
     private static let searchURL = "https://duckduckgo.com/?q=%22DuckDuckGo+vs+Google%3A+5+Reasons+You+Should+Switch%E2%80%9D+site%3Ayoutube.com&atb=v469-1-wb&ia=web"
+    private static let videoSearchURL = "https://duckduckgo.com/?q=%22DuckDuckGo+vs+Google%3A+5+Reasons+You+Should+Switch%E2%80%9D+site%3Ayoutube.com&atb=v469-1-wb&ia=videos&iax=videos"
     private static let youtubeVideoTitle = "DuckDuckGo vs Google: 5 Reasons You Should Switch"
     private static let organicVideoTitle = "DuckDuckGo vs Google: 5 Reasons You Should Switch - YouTube"
     private static let duckPlayerTabPreffix = "Duck Player - "
@@ -276,8 +277,8 @@ class DuckPlayerTests: UITestCase {
         selectAskOpenInDuckPlayer()
         app.closeCurrentTab()
 
-        // Search
-        openURL(url: Self.searchURL)
+        // Search Videos - regular search stopped showing a video thumbnail
+        openURL(url: Self.videoSearchURL)
 
         // Click Link - check both possible title formats
         let organicVideo = findOrganicVideoLink()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1217486021518135?focus=true

### Description
Update SERP-dependent UI test to work with Videos vertical to ensure it displays a video thumbnail.

### Testing Steps
Verify that [this UI tests workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/31801289090) is green

### Impact
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code impact.
> 
> **Overview**
> Updates **`test_DuckPlayer_AskMode_ShowsOverlay_FromSERPAndOpensInDuckPlayer`** so it matches the current Duck Player ask-mode UI.
> 
> After opening a YouTube video from the SERP, the test may tap **`AddressBarButtonsViewController.youTubeAdBlockButton`** when present, then waits for and taps a link labeled **"Turn On Duck Player"** (`turnOnDuckPlayer`) instead of **"Watch in Duck Player"** (`watchOnDuckPlayerLink`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 500e18804fc20418334dd17cc64815487d875caf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->