### PR TITLE
[macOS] Small Fire Dialog for History View

### DIFF
--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -47,7 +47,7 @@ struct UserText {
     static let fireDialogCloseAllTabsWindowsAfterDeleting = NotLocalizedString("fire.dialog.close.all.windows.after.deleting", value: "Close all windows after deleting, except pinned tabs.", comment: "Checkbox caption for when the data clearing scope is ‘Everything’. Means: all browser tabs and windows will be closed, unless they contain pinned tabs in which case all regular tabs from a window will be closed and pinned tabs reloaeded.")
 
     static func fireDialogHistoryItemsTitle(_ count: Int) -> String {
-        let template = NSLocalizedString(
+        let template = NotLocalizedString(
             "fire.dialog.history.items.title",
             value: "Delete %d History items?",
             comment: "Dialog title. Shows the exact number of browsing history entries that will be deleted in this operation, using plural substitutions for the count and noun (%d)."

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -39,11 +39,21 @@ struct UserText {
     static let fireDialogHistoryTitle = NSLocalizedString("fire.dialog.history.title", value: "History", comment: "Section title. Toggle that controls whether browsing history entries are deleted.")
     static let cookiesAndSiteDataTitle = NSLocalizedString("fire.dialog.cookies.title", value: "Cookies and site data", comment: "Section title. Toggle that controls whether website cookies and storage (site data) are deleted.")
     static let fireDialogCookiesAndOtherData = NotLocalizedString("fire.dialog.cookies.and.other.data.title", value: "Cookies & other data", comment: "Section title. Toggle that controls whether website cookies and storage (site data) are deleted.")
+    static let fireDialogIncludeCookiesAndOtherData = NotLocalizedString("fire.dialog.include.cookies.and.other.data.title", value: "Include cookies & other data?", comment: "Section title. Toggle that controls whether website cookies and storage (site data) are deleted.")
     static let fireDialogCloseThisTab = NSLocalizedString("fire.dialog.close.this.tab", value: "Close this tab.", comment: "Subtitle shown under the Tabs and windows row when scope is ‘Tab’. Means: the currently active tab will be closed.")
     static let fireDialogCloseThisWindow = NSLocalizedString("fire.dialog.close.this.window", value: "Close this window.", comment: "Subtitle shown under the Tabs and windows row when scope is ‘Window’. Means: the current browser window (all tabs inside it) will be closed.")
     static let fireDialogCloseAllTabsWindows = NSLocalizedString("fire.dialog.close.all.tabs.windows", value: "Close all tabs and windows.", comment: "Subtitle shown under the Tabs and windows row when scope is ‘Everything’. Means: all browser tabs and windows will be closed.")
     static let fireDialogCloseThisTabAfterDeleting = NotLocalizedString("fire.dialog.close.this.tab.after.deleting", value: "Close this tab after deleting, except if it's pinned.", comment: "Checkbox caption for when the data clearing scope is ‘Tab’. Means: the currently active tab will be closed, unless it's pinned.")
     static let fireDialogCloseAllTabsWindowsAfterDeleting = NotLocalizedString("fire.dialog.close.all.windows.after.deleting", value: "Close all windows after deleting, except pinned tabs.", comment: "Checkbox caption for when the data clearing scope is ‘Everything’. Means: all browser tabs and windows will be closed, unless they contain pinned tabs in which case all regular tabs from a window will be closed and pinned tabs reloaeded.")
+
+    static func fireDialogHistoryItemsTitle(_ count: Int) -> String {
+        let template = NSLocalizedString(
+            "fire.dialog.history.items.title",
+            value: "Delete %d History items?",
+            comment: "Dialog title. Shows the exact number of browsing history entries that will be deleted in this operation, using plural substitutions for the count and noun (%d)."
+        )
+        return String.localizedStringWithFormat(template, count)
+    }
 
     static func fireDialogHistoryItemsSubtitle(_ count: Int) -> String {
         let template = NSLocalizedString(

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -113,14 +113,6 @@ struct FireDialogView: ModalView {
         self.onConfirm = onConfirm
     }
 
-    private var isIncludeHistoryEnabled: Bool {
-        viewModel.historyItemsCountForCurrentScope > 0
-    }
-
-    private var isIncludeCookiesAndSiteDataEnabled: Bool {
-        viewModel.cookiesSitesCountForCurrentScope > 0
-    }
-
     private var isIncludeChatHistoryEnabled: Bool {
         viewModel.chatsCountForCurrentScope > 0
     }
@@ -140,12 +132,6 @@ struct FireDialogView: ModalView {
         return count > 0 ? UserText.fireDialogChatsCountDetail(count) : UserText.none
     }
 
-    private var isDeleteEnabled: Bool {
-        (viewModel.mode.shouldShowCloseTabsToggle && viewModel.includeTabsAndWindows)
-        || (viewModel.includeHistory && isIncludeHistoryEnabled)
-        || (viewModel.includeCookiesAndSiteData && isIncludeCookiesAndSiteDataEnabled)
-        || viewModel.includeChatHistory
-    }
 
     var body: some View {
         ZStack {
@@ -417,15 +403,15 @@ struct FireDialogView: ModalView {
                     title: UserText.fireDialogHistoryTitle,
                     detail: historyDetail,
                     isOn: Binding {
-                        viewModel.includeHistory && isIncludeHistoryEnabled
+                        viewModel.includeHistory && viewModel.hasHistoryItemsInScope
                     } set: {
                         viewModel.includeHistory = $0
                     },
                     // the history items list isn't supported for the (deprecated, pending removal) Window scope
-                    detailAction: (isIncludeHistoryEnabled && viewModel.clearingOption != .currentWindow) ? { isShowingHistoryOverlay = true } : nil,
+                    detailAction: (viewModel.hasHistoryItemsInScope && viewModel.clearingOption != .currentWindow) ? { isShowingHistoryOverlay = true } : nil,
                     detailActionEnabled: viewModel.includeHistory,
                     detailAccessibilityIdentifier: "FireDialogView.historyDetailButton",
-                    isEnabled: isIncludeHistoryEnabled,
+                    isEnabled: viewModel.hasHistoryItemsInScope,
                     toggleId: "FireDialogView.historyToggle"
                 )
                 .accessibilityHidden(isShowingAnyOverlay)
@@ -438,15 +424,15 @@ struct FireDialogView: ModalView {
                 title: viewModel.mode.shouldShowVisitsToggle ? UserText.fireDialogCookiesAndOtherData : UserText.fireDialogIncludeCookiesAndOtherData,
                 subtitle: UserText.fireDialogCookiesSignOutWarning,
                 detail: cookiesDetail,
-                isOn: Binding { viewModel.includeCookiesAndSiteData && isIncludeCookiesAndSiteDataEnabled } set: { viewModel.includeCookiesAndSiteData = $0 },
+                isOn: Binding { viewModel.includeCookiesAndSiteData && viewModel.hasCookiesAndSiteDataInScope } set: { viewModel.includeCookiesAndSiteData = $0 },
                 // don‘t make the detail label clickable when there‘s no site data in scope
-                detailAction: isIncludeCookiesAndSiteDataEnabled ? { isShowingSitesOverlay = true } : nil,
+                detailAction: viewModel.hasCookiesAndSiteDataInScope ? { isShowingSitesOverlay = true } : nil,
                 // grey-out the detail label when the toggle is Off
                 detailActionEnabled: viewModel.includeCookiesAndSiteData,
-                isEnabled: isIncludeCookiesAndSiteDataEnabled,
+                isEnabled: viewModel.hasCookiesAndSiteDataInScope,
                 toggleId: "FireDialogView.cookiesToggle"
             )
-            .disabled(!isIncludeCookiesAndSiteDataEnabled)
+            .disabled(!viewModel.hasCookiesAndSiteDataInScope)
             .accessibilityHidden(isShowingAnyOverlay)
             .padding(.top, viewModel.mode.shouldShowVisitsToggle ? 0 : -13)
 
@@ -1026,7 +1012,7 @@ struct FireDialogView: ModalView {
                 }
                 .buttonStyle(
                     DestructiveActionButtonStyle(
-                        enabled: isDeleteEnabled,
+                        enabled: viewModel.isDeleteEnabled,
                         topPadding: 0,
                         bottomPadding: 0,
                         background: deleteButtonBackground,
@@ -1034,7 +1020,7 @@ struct FireDialogView: ModalView {
                         pillShape: true
                     )
                 )
-                .disabled(!isDeleteEnabled)
+                .disabled(!viewModel.isDeleteEnabled)
                 .accessibilityLabel(viewModel.includeTabsAndWindows ? UserText.fireDialogDeleteAndClose : UserText.delete)
                 .keyboardShortcut(.defaultAction)
                 .accessibilityIdentifier("FireDialogView.burnButton")

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -1005,7 +1005,7 @@ struct FireDialogView: ModalView {
                 Button {
                     let result = FireDialogResult(
                         clearingOption: viewModel.clearingOption,
-                        includeHistory: viewModel.includeHistory,
+                        includeHistory: viewModel.shouldDeleteHistory,
                         includeTabsAndWindows: viewModel.includeTabsAndWindows,
                         includeCookiesAndSiteData: viewModel.includeCookiesAndSiteData,
                         includeChatHistory: viewModel.includeChatHistory,

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -47,6 +47,8 @@ struct FireDialogView: ModalView {
         static var sectionRowWidth: CGFloat { viewSize.width - 2 * horizontalPadding - 2 * boxContentPadding }
         static let historyOverlayMaxVisibleItems = 100
         static let overlayAnimationDuration: TimeInterval = 0.2
+        static let overlayTopSpacing: CGFloat = 167
+        static let overlayTopSpacingShort: CGFloat = 48
     }
 
     @State private var viewHeight: CGFloat = Constants.viewSize.height
@@ -159,19 +161,21 @@ struct FireDialogView: ModalView {
                                 .accessibilityHidden(isShowingAnyOverlay)
                         }
                         VStack(spacing: 0) {
-                            detailsDisclosureView
-                                .accessibilityHidden(isShowingAnyOverlay)
+                            if viewModel.mode.shouldShowDetailsDisclosure {
+                                detailsDisclosureView
+                                    .accessibilityHidden(isShowingAnyOverlay)
+                            }
                             ZStack(alignment: .top) {
-                                if viewModel.isSectionsExpanded {
+                                if viewModel.shouldShowSectionsExpanded {
                                     sectionsView
                                         .transition(.opacity)
                                 }
                             }
                             .frame(width: Constants.sectionRowWidth)
                             .clipped()
-                            .allowsHitTesting(viewModel.isSectionsExpanded)
-                            .accessibilityHidden(!viewModel.isSectionsExpanded)
-                            .padding(.bottom, viewModel.isSectionsExpanded ? -10 : 0)
+                            .allowsHitTesting(viewModel.shouldShowSectionsExpanded)
+                            .accessibilityHidden(!viewModel.shouldShowSectionsExpanded)
+                            .padding(.bottom, viewModel.shouldShowSectionsExpanded ? -10 : 0)
                         }
                     }
                     .padding(Constants.boxContentPadding)
@@ -209,7 +213,7 @@ struct FireDialogView: ModalView {
                     .zIndex(9)
 
                 VStack(spacing: 0) {
-                    Spacer(minLength: 167)
+                    Spacer(minLength: viewModel.mode.shouldShowDetailsDisclosure ? Constants.overlayTopSpacing : Constants.overlayTopSpacingShort)
                     sitesOverlay
                 }
                 .zIndex(11)
@@ -223,7 +227,7 @@ struct FireDialogView: ModalView {
                     .zIndex(9)
 
                 VStack(spacing: 0) {
-                    Spacer(minLength: 167)
+                    Spacer(minLength: viewModel.mode.shouldShowDetailsDisclosure ? Constants.overlayTopSpacing : Constants.overlayTopSpacingShort)
                     chatsOverlay
                 }
                 .zIndex(11)
@@ -237,7 +241,7 @@ struct FireDialogView: ModalView {
                     .zIndex(9)
 
                 VStack(spacing: 0) {
-                    Spacer(minLength: 167)
+                    Spacer(minLength: viewModel.mode.shouldShowDetailsDisclosure ? Constants.overlayTopSpacing : Constants.overlayTopSpacingShort)
                     historyOverlay
                 }
                 .zIndex(11)
@@ -403,30 +407,32 @@ struct FireDialogView: ModalView {
 
     private var sectionsView: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Row 1: History
-            sectionRow(
-                icon: DesignSystemImages.Glyphs.Size16.history,
-                title: UserText.fireDialogHistoryTitle,
-                detail: historyDetail,
-                isOn: Binding {
-                    viewModel.includeHistory && isIncludeHistoryEnabled
-                } set: {
-                    viewModel.includeHistory = $0
-                },
-                // the history items list isn't supported for the (deprecated, pending removal) Window scope
-                detailAction: (isIncludeHistoryEnabled && viewModel.clearingOption != .currentWindow) ? { isShowingHistoryOverlay = true } : nil,
-                detailActionEnabled: viewModel.includeHistory,
-                detailAccessibilityIdentifier: "FireDialogView.historyDetailButton",
-                isEnabled: isIncludeHistoryEnabled,
-                toggleId: "FireDialogView.historyToggle"
-            )
-            .accessibilityHidden(isShowingAnyOverlay)
-            sectionDivider()
+            if viewModel.mode.shouldShowVisitsToggle {
+                // Row 1: History
+                sectionRow(
+                    icon: DesignSystemImages.Glyphs.Size16.history,
+                    title: UserText.fireDialogHistoryTitle,
+                    detail: historyDetail,
+                    isOn: Binding {
+                        viewModel.includeHistory && isIncludeHistoryEnabled
+                    } set: {
+                        viewModel.includeHistory = $0
+                    },
+                    // the history items list isn't supported for the (deprecated, pending removal) Window scope
+                    detailAction: (isIncludeHistoryEnabled && viewModel.clearingOption != .currentWindow) ? { isShowingHistoryOverlay = true } : nil,
+                    detailActionEnabled: viewModel.includeHistory,
+                    detailAccessibilityIdentifier: "FireDialogView.historyDetailButton",
+                    isEnabled: isIncludeHistoryEnabled,
+                    toggleId: "FireDialogView.historyToggle"
+                )
+                .accessibilityHidden(isShowingAnyOverlay)
+                sectionDivider()
+            }
 
             // Row 2: Cookies and Site Data
             sectionRow(
                 icon: DesignSystemImages.Glyphs.Size16.cookie,
-                title: UserText.fireDialogCookiesAndOtherData,
+                title: viewModel.mode.shouldShowVisitsToggle ? UserText.fireDialogCookiesAndOtherData : UserText.fireDialogIncludeCookiesAndOtherData,
                 subtitle: UserText.fireDialogCookiesSignOutWarning,
                 detail: cookiesDetail,
                 isOn: Binding { viewModel.includeCookiesAndSiteData && isIncludeCookiesAndSiteDataEnabled } set: { viewModel.includeCookiesAndSiteData = $0 },
@@ -439,6 +445,7 @@ struct FireDialogView: ModalView {
             )
             .disabled(!isIncludeCookiesAndSiteDataEnabled)
             .accessibilityHidden(isShowingAnyOverlay)
+            .padding(.top, viewModel.mode.shouldShowVisitsToggle ? 0 : -13)
 
             if viewModel.shouldShowChatHistoryToggle {
                 sectionDivider()

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -1006,7 +1006,7 @@ struct FireDialogView: ModalView {
                     let result = FireDialogResult(
                         clearingOption: viewModel.clearingOption,
                         includeHistory: viewModel.shouldDeleteHistory,
-                        includeTabsAndWindows: viewModel.includeTabsAndWindows,
+                        includeTabsAndWindows: viewModel.shouldCloseTabsAndWindows,
                         includeCookiesAndSiteData: viewModel.includeCookiesAndSiteData,
                         includeChatHistory: viewModel.includeChatHistory,
                         selectedCookieDomains: viewModel.selectedCookieDomainsForScope,

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -132,7 +132,6 @@ struct FireDialogView: ModalView {
         return count > 0 ? UserText.fireDialogChatsCountDetail(count) : UserText.none
     }
 
-
     var body: some View {
         ZStack {
             VStack(spacing: 24) {

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -253,7 +253,7 @@ struct FireDialogView: ModalView {
         .frame(width: Constants.viewSize.width, height: viewHeight, alignment: .top)
         .background(Color(designSystemColor: .surfacePrimary, palette: themeManager.designColorPalette))
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(viewModel.mode.dialogTitle)
+        .accessibilityLabel(viewModel.dialogTitle)
     }
 
     private var moreOptionsMenuDotsIcon: some View {
@@ -351,7 +351,7 @@ struct FireDialogView: ModalView {
                 .frame(width: 72, height: 72)
                 .padding(.top, 8)
 
-            Text(viewModel.mode.dialogTitle)
+            Text(viewModel.dialogTitle)
                 .multilineText()
                 .multilineTextAlignment(.center)
                 .font(.system(size: 15).weight(.semibold))

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -368,7 +368,10 @@ struct FireDialogView: ModalView {
                 set: { viewModel.clearingOption = FireDialogViewModel.ClearingOption(rawValue: $0) ?? .allData }
             ),
             tabs: [
-                FireDialogTabItem(id: FireDialogViewModel.ClearingOption.currentTab.rawValue, title: UserText.fireDialogModeFromThisTab, image: Image(nsImage: DesignSystemImages.Glyphs.Size16.tabDesktop)),
+                FireDialogTabItem(id: FireDialogViewModel.ClearingOption.currentTab.rawValue,
+                                  title: UserText.fireDialogModeFromThisTab,
+                                  image: Image(nsImage: DesignSystemImages.Glyphs.Size16.tabDesktop),
+                                  isEnabled: viewModel.isCurrentTabOptionEnabled),
                 FireDialogTabItem(id: FireDialogViewModel.ClearingOption.allData.rawValue, title: UserText.fireDialogModeAllData, image: Image(nsImage: DesignSystemImages.Glyphs.Size16.browser))
             ]
         )
@@ -1083,6 +1086,7 @@ private struct FireDialogTabItem: Identifiable {
     let id: Int
     let title: String
     let image: Image
+    var isEnabled: Bool = true
 }
 
 private struct FireDialogTabsContainer: View {
@@ -1136,6 +1140,8 @@ private struct FireDialogTabButton: View {
             )
         }
         .buttonStyle(.plain)
+        .disabled(!tab.isEnabled)
+        .opacity(tab.isEnabled ? 1 : 0.4)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(tab.title)
         .accessibilityValue(isSelected ? UserText.fireDialogAccessibilitySelected : "")

--- a/macOS/DuckDuckGo/Fire/View/FireViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireViewController.swift
@@ -56,7 +56,7 @@ final class FireViewController: NSViewController {
     private let tabCollectionViewModel: TabCollectionViewModel
     private let featureFlagger: FeatureFlagger
 
-    private let themeManager: ThemeManaging
+    private let themeManager: ThemeManager
     private var theme: ThemeStyleProviding {
         themeManager.theme
     }
@@ -87,7 +87,7 @@ final class FireViewController: NSViewController {
     }()
 
     private lazy var progressIndicatorBackgroundView: ColorView = {
-        let view = ColorView(frame: .zero, backgroundColor: .newTabPageBackground)
+        let view = ColorView(frame: .zero, backgroundColor: .init(designSystemColor: .surfacePrimary, palette: themeManager.designColorPalette))
         view.translatesAutoresizingMaskIntoConstraints = false
         view.cornerRadius = featureFlagger.isFeatureOn(.fireDialogSimplified) ? 24 : 8
         return view
@@ -152,7 +152,7 @@ final class FireViewController: NSViewController {
     @MainActor
     init(tabCollectionViewModel: TabCollectionViewModel,
          fireViewModel: FireViewModel,
-         themeManager: ThemeManaging? = nil,
+         themeManager: ThemeManager? = nil,
          visualizeFireAnimationDecider: VisualizeFireSettingsDecider,
          featureFlagger: FeatureFlagger) {
         self.tabCollectionViewModel = tabCollectionViewModel

--- a/macOS/DuckDuckGo/Fire/View/FireViewController.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireViewController.swift
@@ -87,7 +87,11 @@ final class FireViewController: NSViewController {
     }()
 
     private lazy var progressIndicatorBackgroundView: ColorView = {
-        let view = ColorView(frame: .zero, backgroundColor: .init(designSystemColor: .surfacePrimary, palette: themeManager.designColorPalette))
+        // The legacy dialog keeps its fixed background color, which its design was made for.
+        let backgroundColor: NSColor = featureFlagger.isFeatureOn(.fireDialogSimplified)
+            ? .init(designSystemColor: .surfacePrimary, palette: themeManager.designColorPalette)
+            : .newTabPageBackground
+        let view = ColorView(frame: .zero, backgroundColor: backgroundColor)
         view.translatesAutoresizingMaskIntoConstraints = false
         view.cornerRadius = featureFlagger.isFeatureOn(.fireDialogSimplified) ? 24 : 8
         return view

--- a/macOS/DuckDuckGo/Fire/View/LegacyFireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/LegacyFireDialogView.swift
@@ -178,7 +178,7 @@ struct LegacyFireDialogView: ModalView {
         .frame(width: Constants.viewSize.width, height: viewHeight, alignment: .top)
         .background(Color(designSystemColor: .surfaceSecondary))
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(viewModel.mode.dialogTitle)
+        .accessibilityLabel(viewModel.dialogTitle)
     }
 
     private var headerView: some View {
@@ -187,7 +187,7 @@ struct LegacyFireDialogView: ModalView {
                 .frame(width: 72, height: 72)
                 .padding(.top, 8)
 
-            Text(viewModel.mode.dialogTitle)
+            Text(viewModel.dialogTitle)
                 .multilineText()
                 .multilineTextAlignment(.center)
                 .font(.system(size: 15).weight(.semibold))

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -171,6 +171,7 @@ final class FireDialogViewModel: ObservableObject {
          includeCookiesAndSiteData: Bool? = nil,
          includeChatHistory: Bool? = nil,
          sectionsExpanded: Bool? = nil,
+         isCurrentTabOptionEnabled: Bool? = nil,
          mode: Mode = .fireButton,
          settings: (any KeyedStoring<FireDialogViewSettings>)? = nil,
          scopeCookieDomains: Set<String>? = nil,
@@ -201,7 +202,19 @@ final class FireDialogViewModel: ObservableObject {
         self.scopeCookieDomains = scopeCookieDomains
 
         self.settings = if let settings { settings } else { UserDefaults.standard.keyedStoring() }
-        self.clearingOption = clearingOption ?? self.settings.lastSelectedClearingOption ?? .currentTab
+
+        // Disabling the current tab scope belongs to the new dialog only.
+        let currentTabOptionEnabled = if featureFlagger.isFeatureOn(.fireDialogSimplified) {
+            isCurrentTabOptionEnabled ?? Self.isCurrentTabOptionEnabled(for: tabCollectionViewModel.selectedTab)
+        } else {
+            true
+        }
+        self.isCurrentTabOptionEnabled = currentTabOptionEnabled
+
+        // Fall back to All Data when the current tab holds nothing to delete. This is set here,
+        // and not after initialization, to keep the last selected clearing option untouched.
+        let selectedClearingOption = clearingOption ?? self.settings.lastSelectedClearingOption ?? .currentTab
+        self.clearingOption = (selectedClearingOption == .currentTab && !currentTabOptionEnabled) ? .allData : selectedClearingOption
         self.includeTabsAndWindows = includeTabsAndWindows ?? self.settings.lastIncludeTabsAndWindowsState ?? true
         self.includeHistory = includeHistory ?? self.settings.lastIncludeHistoryState ?? true
         self.includeCookiesAndSiteData = includeCookiesAndSiteData ?? self.settings.lastIncludeCookiesAndSiteDataState ?? true
@@ -215,6 +228,17 @@ final class FireDialogViewModel: ObservableObject {
 
         // Duck.ai chats aren't scoped by tab/window, so fetch them once
         self.chats = aiChatHistoryCleaner.allChats()
+    }
+
+    /// Whether the user can choose the "From this tab" scope.
+    ///
+    /// A tab that shows no website, and that has nothing to go back or forward to, holds no data
+    /// to delete. The scope is then disabled, and the dialog uses "All data" instead.
+    let isCurrentTabOptionEnabled: Bool
+
+    private static func isCurrentTabOptionEnabled(for tab: Tab?) -> Bool {
+        guard let tab else { return true }
+        return tab.content.isExternalUrl || tab.canGoBack || tab.canGoForward
     }
 
     private func updateLastSelectedClearingOptionIfNeeded() {

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -97,6 +97,21 @@ final class FireDialogViewModel: ObservableObject {
             }
         }
 
+        var shouldShowDetailsDisclosure: Bool {
+            return shouldShowVisitsToggle
+        }
+
+        var shouldShowVisitsToggle: Bool {
+            switch self {
+            case .fireButton,
+                    .mainMenuAll,
+                    .historyView(query: .rangeFilter(.all)):
+                return true
+            case .historyView:
+                return false
+            }
+        }
+
         var shouldShowChatHistoryToggle: Bool {
             switch self {
             case .fireButton,
@@ -130,6 +145,7 @@ final class FireDialogViewModel: ObservableObject {
             case .historyView(query: .dateFilter(let date)): HistoryViewDeleteDialogModel.DeleteMode.date(date).title
             case .historyView(query: .domainFilter(let domains)): HistoryViewDeleteDialogModel.DeleteMode.sites(domains).title
             case .historyView(query: .rangeFilter(.older)): HistoryViewDeleteDialogModel.DeleteMode.older.title
+            case .historyView(query: .visits(let visits)): UserText.fireDialogHistoryItemsTitle(visits.uniqued(on: { $0.uuid }).count)
             case .historyView: UserText.fireDialogTitle
             }
             return title.replacingOccurrences(of: #"\n"#, with: " ")
@@ -294,6 +310,11 @@ final class FireDialogViewModel: ObservableObject {
         didSet {
             settings.lastSectionsExpandedState = isSectionsExpanded
         }
+    }
+
+    /// When current mode doesn't display details disclosure indicator, we should always expand sections
+    var shouldShowSectionsExpanded: Bool {
+        return isSectionsExpanded || !mode.shouldShowDetailsDisclosure
     }
 
     /// Collapses the "Choose what to delete" sections for all later dialogs, if the user did not

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -103,12 +103,10 @@ final class FireDialogViewModel: ObservableObject {
 
         var shouldShowVisitsToggle: Bool {
             switch self {
-            case .fireButton,
-                    .mainMenuAll,
-                    .historyView(query: .rangeFilter(.all)):
-                return true
-            case .historyView:
+            case .historyView(query: .visits):
                 return false
+            default:
+                return true
             }
         }
 
@@ -271,7 +269,9 @@ final class FireDialogViewModel: ObservableObject {
             pixelFiring?.fire(FireDialogPixel.fireDialogToggleCloseTabs, frequency: .dailyAndCount, options: .unenforcedPrefix)
         }
     }
-    /// when true, history is cleared for the selected scope.
+    /// when true, history is cleared for the selected scope when the toggle was shown.
+    ///
+    /// Use `shouldDeleteHistory` as source of truth that also covered toggle hidden case.
     @Published var includeHistory: Bool {
         didSet {
             settings.lastIncludeHistoryState = includeHistory
@@ -279,6 +279,12 @@ final class FireDialogViewModel: ObservableObject {
             pixelFiring?.fire(FireDialogPixel.fireDialogToggleClearHistory, frequency: .dailyAndCount, options: .unenforcedPrefix)
         }
     }
+
+    /// Whether history should be cleared.
+    var shouldDeleteHistory: Bool {
+        return includeHistory || !mode.shouldShowVisitsToggle
+    }
+
     /// when true, cookies/site data are cleared for the selected (non-fireproof) domains in scope.
     @Published var includeCookiesAndSiteData: Bool {
         didSet {

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -499,8 +499,23 @@ final class FireDialogViewModel: ObservableObject {
 
     var historyItemsCountForCurrentScope: Int { historyVisits.count }
 
+    var hasHistoryItemsInScope: Bool { historyItemsCountForCurrentScope > 0 }
+
     /// Cookies/sites are deleted for non-fireproofed visited eTLD+1 domains
     var cookiesSitesCountForCurrentScope: Int { selectable.count }
+
+    var hasCookiesAndSiteDataInScope: Bool { cookiesSitesCountForCurrentScope > 0 }
+
+    /// Whether the dialog deletes anything, which is what the Delete button needs to be enabled.
+    ///
+    /// This uses the same sources of truth as the confirmed result, so that the button is never
+    /// disabled while confirming would still delete something.
+    var isDeleteEnabled: Bool {
+        shouldCloseTabsAndWindows
+        || (shouldDeleteHistory && hasHistoryItemsInScope)
+        || (includeCookiesAndSiteData && hasCookiesAndSiteDataInScope)
+        || includeChatHistory
+    }
 
     /// Duck.ai chats aren't partitioned by tab/window, so this is a global count.
     var chatsCountForCurrentScope: Int { chats.count }

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -273,6 +273,8 @@ final class FireDialogViewModel: ObservableObject {
     }
 
     /// when true, selected tabs/windows are closed; when false, tabs remain open, but their history/session state is cleared if includeHistory is true.
+    ///
+    /// Use `shouldCloseTabsAndWindows` as source of truth that also covers toggle hidden case.
     @Published var includeTabsAndWindows: Bool {
         didSet {
             settings.lastIncludeTabsAndWindowsState = includeTabsAndWindows
@@ -280,9 +282,15 @@ final class FireDialogViewModel: ObservableObject {
             pixelFiring?.fire(FireDialogPixel.fireDialogToggleCloseTabs, frequency: .dailyAndCount, options: .unenforcedPrefix)
         }
     }
+
+    /// Whether tabs and windows should be closed. It's always `false` if the toggle is hidden.
+    var shouldCloseTabsAndWindows: Bool {
+        return mode.shouldShowCloseTabsToggle ? includeTabsAndWindows : false
+    }
+
     /// when true, history is cleared for the selected scope when the toggle was shown.
     ///
-    /// Use `shouldDeleteHistory` as source of truth that also covered toggle hidden case.
+    /// Use `shouldDeleteHistory` as source of truth that also covers toggle hidden case.
     @Published var includeHistory: Bool {
         didSet {
             settings.lastIncludeHistoryState = includeHistory
@@ -291,9 +299,9 @@ final class FireDialogViewModel: ObservableObject {
         }
     }
 
-    /// Whether history should be cleared.
+    /// Whether history should be cleared. It's always `true` if the toggle is hidden.
     var shouldDeleteHistory: Bool {
-        return includeHistory || !mode.shouldShowVisitsToggle
+        return mode.shouldShowVisitsToggle ? includeHistory : true
     }
 
     /// when true, cookies/site data are cleared for the selected (non-fireproof) domains in scope.

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -226,6 +226,17 @@ final class FireDialogViewModel: ObservableObject {
 
     private(set) var shouldShowPinnedTabsInfo: Bool = false
 
+    /// Title of the dialog.
+    ///
+    /// The history item count title belongs to the new dialog only, so the legacy dialog keeps
+    /// the generic title it was designed with.
+    var dialogTitle: String {
+        if case .historyView(query: .visits) = mode, !featureFlagger.isFeatureOn(.fireDialogSimplified) {
+            return UserText.fireDialogTitle
+        }
+        return mode.dialogTitle
+    }
+
     var shouldShowChatHistoryToggle: Bool {
         let isPresentedOnAIChatTab = tabCollectionViewModel?.selectedTab?.url?.isDuckAIURL ?? false
         // Only hide chats toggle when no chats in the new dialog, so default this to `true` when the flag is off.

--- a/macOS/IntegrationTests/Fire/FireCoordinatorIntegrationTests.swift
+++ b/macOS/IntegrationTests/Fire/FireCoordinatorIntegrationTests.swift
@@ -3165,7 +3165,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
                         XCTAssertEqual(config.viewModel.mode.shouldShowSegmentedControl, expected.showSegmentedControl, "showSegmentedControl", file: expected.file, line: expected.line + 3)
                         XCTAssertEqual(config.viewModel.mode.shouldShowCloseTabsToggle, expected.showCloseWindowsAndTabsToggle, "showCloseWindowsAndTabsToggle", file: expected.file, line: expected.line + 4)
                         XCTAssertEqual(config.viewModel.mode.shouldShowFireproofSection, expected.showFireproofSection, "showFireproofSection", file: expected.file, line: expected.line + 5)
-                        XCTAssertEqual(config.viewModel.mode.dialogTitle, expected.customTitle, "customTitle", file: expected.file, line: expected.line + 6)
+                        XCTAssertEqual(config.viewModel.dialogTitle, expected.customTitle, "customTitle", file: expected.file, line: expected.line + 6)
                         XCTAssertEqual(config.showIndividualSitesLink, expected.showIndividualSitesLink, "showIndividualSitesLink", file: expected.file, line: expected.line + 7)
                         XCTAssertEqual(config.viewModel.clearingOption, expected.expectedClearingOption, "clearingOption", file: expected.file, line: expected.line + 8)
                         XCTAssertEqual(config.viewModel.includeTabsAndWindows, expected.expectedIncludeTabsAndWindows, "includeTabsAndWindows", file: expected.file, line: expected.line + 9)

--- a/macOS/IntegrationTests/Fire/FireCoordinatorIntegrationTests.swift
+++ b/macOS/IntegrationTests/Fire/FireCoordinatorIntegrationTests.swift
@@ -100,6 +100,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.all)),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -148,6 +149,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.all)),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -196,6 +198,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.all)),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -251,6 +254,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.all)),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -321,6 +325,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.all)),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -391,6 +396,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.all)),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -451,6 +457,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .domainFilter(["cook.ie"])),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: false,
@@ -505,6 +512,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .domainFilter(["test.com"])),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: false,
@@ -574,6 +582,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.today)),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -628,6 +637,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.today)),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -698,6 +708,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.today)),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -768,6 +779,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.today)),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -849,6 +861,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.yesterday)),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: true,
@@ -927,6 +940,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .dateFilter(date)),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: true,
@@ -996,6 +1010,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .dateFilter(date)),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: true,
@@ -1067,6 +1082,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .domainFilter(["figma.com"])),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: false,
@@ -1134,6 +1150,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .domainFilter(["example.com"])),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: false,
@@ -1202,6 +1219,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .domainFilter(["a.com"])),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: false,
@@ -1269,6 +1287,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .domainFilter(["a.com", "b.com"])),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: false,
@@ -1339,6 +1358,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .domainFilter(["a.com", "b.com"])),
+            showVisitsToggle: true,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: false,
@@ -1408,6 +1428,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -1475,6 +1496,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -1539,6 +1561,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -1603,6 +1626,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -1670,6 +1694,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -1787,6 +1812,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -1852,6 +1878,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -1918,6 +1945,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -1982,6 +2010,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2041,6 +2070,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2100,6 +2130,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2166,6 +2197,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2232,6 +2264,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2296,6 +2329,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2355,6 +2389,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2414,6 +2449,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2481,6 +2517,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2544,6 +2581,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2607,6 +2645,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2672,6 +2711,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .fireButton,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2746,6 +2786,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .mainMenuAll,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2810,6 +2851,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .mainMenuAll,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2872,6 +2914,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .mainMenuAll,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2926,6 +2969,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .mainMenuAll,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -2978,6 +3022,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .mainMenuAll,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -3032,6 +3077,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .mainMenuAll,
+            showVisitsToggle: true,
             showSegmentedControl: true,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -3111,22 +3157,29 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
                     if let expected = self.dialogExpectedInput {
                         XCTAssertEqual(config.viewModel.mode, expected.mode, "mode", file: expected.file, line: expected.line + 1)
-                        XCTAssertEqual(config.viewModel.mode.shouldShowSegmentedControl, expected.showSegmentedControl, "showSegmentedControl", file: expected.file, line: expected.line + 2)
-                        XCTAssertEqual(config.viewModel.mode.shouldShowCloseTabsToggle, expected.showCloseWindowsAndTabsToggle, "showCloseWindowsAndTabsToggle", file: expected.file, line: expected.line + 3)
-                        XCTAssertEqual(config.viewModel.mode.shouldShowFireproofSection, expected.showFireproofSection, "showFireproofSection", file: expected.file, line: expected.line + 4)
-                        XCTAssertEqual(config.viewModel.mode.dialogTitle, expected.customTitle, "customTitle", file: expected.file, line: expected.line + 5)
-                        XCTAssertEqual(config.showIndividualSitesLink, expected.showIndividualSitesLink, "showIndividualSitesLink", file: expected.file, line: expected.line + 6)
-                        XCTAssertEqual(config.viewModel.clearingOption, expected.expectedClearingOption, "clearingOption", file: expected.file, line: expected.line + 7)
-                        XCTAssertEqual(config.viewModel.includeTabsAndWindows, expected.expectedIncludeTabsAndWindows, "includeTabsAndWindows", file: expected.file, line: expected.line + 8)
-                        XCTAssertEqual(config.viewModel.includeHistory, expected.expectedIncludeHistory, "includeHistory", file: expected.file, line: expected.line + 9)
-                        XCTAssertEqual(config.viewModel.includeCookiesAndSiteData, expected.expectedIncludeCookiesAndSiteData, "includeCookiesAndSiteData", file: expected.file, line: expected.line + 10)
+                        XCTAssertEqual(config.viewModel.mode.shouldShowVisitsToggle, expected.showVisitsToggle, "showVisitsToggle", file: expected.file, line: expected.line + 2)
+                        // The disclosure control only makes sense when there is more than one toggle to disclose.
+                        XCTAssertEqual(config.viewModel.mode.shouldShowDetailsDisclosure, expected.showVisitsToggle, "showDetailsDisclosure", file: expected.file, line: expected.line + 2)
+                        // Sections can only stay collapsed while the disclosure control is there to expand them.
+                        XCTAssertEqual(config.viewModel.shouldShowSectionsExpanded, expected.showVisitsToggle ? config.viewModel.isSectionsExpanded : true, "shouldShowSectionsExpanded", file: expected.file, line: expected.line + 2)
+                        XCTAssertEqual(config.viewModel.mode.shouldShowSegmentedControl, expected.showSegmentedControl, "showSegmentedControl", file: expected.file, line: expected.line + 3)
+                        XCTAssertEqual(config.viewModel.mode.shouldShowCloseTabsToggle, expected.showCloseWindowsAndTabsToggle, "showCloseWindowsAndTabsToggle", file: expected.file, line: expected.line + 4)
+                        XCTAssertEqual(config.viewModel.mode.shouldShowFireproofSection, expected.showFireproofSection, "showFireproofSection", file: expected.file, line: expected.line + 5)
+                        XCTAssertEqual(config.viewModel.mode.dialogTitle, expected.customTitle, "customTitle", file: expected.file, line: expected.line + 6)
+                        XCTAssertEqual(config.showIndividualSitesLink, expected.showIndividualSitesLink, "showIndividualSitesLink", file: expected.file, line: expected.line + 7)
+                        XCTAssertEqual(config.viewModel.clearingOption, expected.expectedClearingOption, "clearingOption", file: expected.file, line: expected.line + 8)
+                        XCTAssertEqual(config.viewModel.includeTabsAndWindows, expected.expectedIncludeTabsAndWindows, "includeTabsAndWindows", file: expected.file, line: expected.line + 9)
+                        XCTAssertEqual(config.viewModel.includeHistory, expected.expectedIncludeHistory, "includeHistory", file: expected.file, line: expected.line + 10)
+                        // Without the toggle, the user cannot exclude the history, so it is always deleted.
+                        XCTAssertEqual(config.viewModel.shouldDeleteHistory, expected.showVisitsToggle ? expected.expectedIncludeHistory : true, "shouldDeleteHistory", file: expected.file, line: expected.line + 10)
+                        XCTAssertEqual(config.viewModel.includeCookiesAndSiteData, expected.expectedIncludeCookiesAndSiteData, "includeCookiesAndSiteData", file: expected.file, line: expected.line + 11)
                         // Validate ViewModel data from provider
                         let actualSelectable = config.viewModel.selectable.map { $0.domain }.sorted()
-                        XCTAssertEqual(actualSelectable, expected.expectedSelectable?.sorted() ?? [], "selectable domains", file: expected.file, line: expected.line + 11)
+                        XCTAssertEqual(actualSelectable, expected.expectedSelectable?.sorted() ?? [], "selectable domains", file: expected.file, line: expected.line + 12)
                         let actualFireproofed = config.viewModel.fireproofed.map { $0.domain }.sorted()
-                        XCTAssertEqual(actualFireproofed, expected.expectedFireproofed?.sorted() ?? [], "fireproofed domains", file: expected.file, line: expected.line + 12)
-                        XCTAssertEqual(config.viewModel.selected, expected.expectedSelected ?? [], "selected indices", file: expected.file, line: expected.line + 13)
-                        XCTAssertEqual(config.viewModel.historyVisits ?? [], expected.expectedHistoryVisits ?? [], "historyVisits", file: expected.file, line: expected.line + 14)
+                        XCTAssertEqual(actualFireproofed, expected.expectedFireproofed?.sorted() ?? [], "fireproofed domains", file: expected.file, line: expected.line + 13)
+                        XCTAssertEqual(config.viewModel.selected, expected.expectedSelected ?? [], "selected indices", file: expected.file, line: expected.line + 14)
+                        XCTAssertEqual(config.viewModel.historyVisits ?? [], expected.expectedHistoryVisits ?? [], "historyVisits", file: expected.file, line: expected.line + 15)
                     }
 
                     var dialogConfirmedOptions = self.dialogConfirmedOptions
@@ -3175,6 +3228,9 @@ private struct DialogExpectedInput {
     let line: UInt
 
     var mode: FireDialogViewModel.Mode
+    /// Show the History (visits) toggle and, with it, the "Choose what to delete" disclosure control.
+    /// When hidden, the history of the selected records is always deleted.
+    var showVisitsToggle: Bool
     var showSegmentedControl: Bool
     var showCloseWindowsAndTabsToggle: Bool
     var showFireproofSection: Bool
@@ -3191,8 +3247,9 @@ private struct DialogExpectedInput {
     var expectedFireproofed: [String]?
     var expectedSelected: Set<Int>?
     var expectedHistoryVisits: [Visit]?
-    init(mode: FireDialogViewModel.Mode, showSegmentedControl: Bool, showCloseWindowsAndTabsToggle: Bool, showFireproofSection: Bool, customTitle: String?, showIndividualSitesLink: Bool, expectedClearingOption: FireDialogViewModel.ClearingOption, expectedIncludeTabsAndWindows: Bool, expectedIncludeHistory: Bool, expectedIncludeCookiesAndSiteData: Bool, expectedIncludeChatHistory: Bool, expectedSelectable: [String]?, expectedFireproofed: [String]?, expectedSelected: (any Sequence<Int>)?, expectedHistoryVisits: [Visit]? = nil, file: StaticString = #file, line: UInt = #line) {
+    init(mode: FireDialogViewModel.Mode, showVisitsToggle: Bool, showSegmentedControl: Bool, showCloseWindowsAndTabsToggle: Bool, showFireproofSection: Bool, customTitle: String?, showIndividualSitesLink: Bool, expectedClearingOption: FireDialogViewModel.ClearingOption, expectedIncludeTabsAndWindows: Bool, expectedIncludeHistory: Bool, expectedIncludeCookiesAndSiteData: Bool, expectedIncludeChatHistory: Bool, expectedSelectable: [String]?, expectedFireproofed: [String]?, expectedSelected: (any Sequence<Int>)?, expectedHistoryVisits: [Visit]? = nil, file: StaticString = #file, line: UInt = #line) {
         self.mode = mode
+        self.showVisitsToggle = showVisitsToggle
         self.showSegmentedControl = showSegmentedControl
         self.showCloseWindowsAndTabsToggle = showCloseWindowsAndTabsToggle
         self.showFireproofSection = showFireproofSection

--- a/macOS/IntegrationTests/Fire/FireCoordinatorIntegrationTests.swift
+++ b/macOS/IntegrationTests/Fire/FireCoordinatorIntegrationTests.swift
@@ -3169,6 +3169,8 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
                         XCTAssertEqual(config.showIndividualSitesLink, expected.showIndividualSitesLink, "showIndividualSitesLink", file: expected.file, line: expected.line + 7)
                         XCTAssertEqual(config.viewModel.clearingOption, expected.expectedClearingOption, "clearingOption", file: expected.file, line: expected.line + 8)
                         XCTAssertEqual(config.viewModel.includeTabsAndWindows, expected.expectedIncludeTabsAndWindows, "includeTabsAndWindows", file: expected.file, line: expected.line + 9)
+                        // Without the toggle, the user cannot ask for the tabs and windows to close.
+                        XCTAssertEqual(config.viewModel.shouldCloseTabsAndWindows, expected.showCloseWindowsAndTabsToggle ? expected.expectedIncludeTabsAndWindows : false, "shouldCloseTabsAndWindows", file: expected.file, line: expected.line + 9)
                         XCTAssertEqual(config.viewModel.includeHistory, expected.expectedIncludeHistory, "includeHistory", file: expected.file, line: expected.line + 10)
                         // Without the toggle, the user cannot exclude the history, so it is always deleted.
                         XCTAssertEqual(config.viewModel.shouldDeleteHistory, expected.showVisitsToggle ? expected.expectedIncludeHistory : true, "shouldDeleteHistory", file: expected.file, line: expected.line + 10)

--- a/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
+++ b/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
@@ -2321,6 +2321,60 @@ final class FireDialogViewModelTests: XCTestCase {
         }
     }
 
+    // MARK: - Delete button enablement
+
+    @MainActor func testWhenVisitsToggleIsHiddenAndHistoryWasTurnedOffEarlier_ThenDeleteStaysEnabled() {
+        // Scenario: An earlier dialog left both History and Cookies off. The user then selects
+        // history items in the History view and deletes them.
+        // Expectation: Delete stays enabled. The dialog shows no History toggle, so deleting the
+        // selected items is exactly what the button confirms, and the earlier choice must not
+        // leave the user unable to delete them.
+
+        let mockSettings = MockFireDialogViewSettings(lastIncludeHistoryState: false,
+                                                      lastIncludeCookiesAndSiteDataState: false)
+        let entry = makeHistoryEntry(url: "https://example.com")
+        let visits = [Visit(date: Date(), identifier: entry.url, historyEntry: entry)]
+
+        let viewModel = makeViewModel(settings: mockSettings,
+                                      mode: .historyView(query: .visits([makeVisitIdentifier(url: "https://example.com")])),
+                                      clearingOption: .allData,
+                                      scopeVisits: visits,
+                                      isFireDialogSimplified: true)
+
+        XCTAssertFalse(viewModel.includeHistory, "The persisted setting should stay off")
+        XCTAssertFalse(viewModel.includeCookiesAndSiteData, "The persisted setting should stay off")
+        XCTAssertTrue(viewModel.shouldDeleteHistory, "The selected items are deleted anyway")
+        XCTAssertTrue(viewModel.isDeleteEnabled, "Delete should stay enabled")
+    }
+
+    @MainActor func testWhenNothingIsSelectedForDeletion_ThenDeleteIsDisabled() {
+        // Scenario: The dialog offers all the toggles, and the user turned them all off.
+        // Expectation: Delete is disabled, because confirming would delete nothing.
+
+        let mockSettings = MockFireDialogViewSettings(lastIncludeTabsAndWindowsState: false,
+                                                      lastIncludeHistoryState: false,
+                                                      lastIncludeCookiesAndSiteDataState: false,
+                                                      lastIncludeChatHistoryState: false)
+
+        let viewModel = makeViewModel(settings: mockSettings, mode: .fireButton, isFireDialogSimplified: true)
+
+        XCTAssertFalse(viewModel.isDeleteEnabled, "Delete should be disabled when nothing is deleted")
+    }
+
+    @MainActor func testWhenOnlyClosingTabsIsSelected_ThenDeleteIsEnabled() {
+        // Scenario: The user turned every data toggle off, but keeps closing the tabs.
+        // Expectation: Delete stays enabled, because closing the tabs is still an action.
+
+        let mockSettings = MockFireDialogViewSettings(lastIncludeTabsAndWindowsState: true,
+                                                      lastIncludeHistoryState: false,
+                                                      lastIncludeCookiesAndSiteDataState: false,
+                                                      lastIncludeChatHistoryState: false)
+
+        let viewModel = makeViewModel(settings: mockSettings, mode: .fireButton, isFireDialogSimplified: true)
+
+        XCTAssertTrue(viewModel.isDeleteEnabled, "Delete should stay enabled to close the tabs")
+    }
+
     // MARK: - Current tab scope
 
     @MainActor func testWhenCurrentTabHasNoDataToDelete_ThenTheScopeIsDisabledAndAllDataIsUsed() {
@@ -2748,6 +2802,8 @@ final class FireDialogViewModelTests: XCTestCase {
     @MainActor
     private func makeViewModel(settings: any KeyedStoring<FireDialogViewSettings>,
                                mode: FireDialogViewModel.Mode = .fireButton,
+                               clearingOption: FireDialogViewModel.ClearingOption? = nil,
+                               scopeVisits: [Visit]? = nil,
                                isFireDialogSimplified: Bool = false) -> FireDialogViewModel {
         FireDialogViewModel(
             fireViewModel: .init(fire: fire),
@@ -2757,8 +2813,10 @@ final class FireDialogViewModelTests: XCTestCase {
             fireproofDomains: fireproofDomains,
             faviconManagement: fire.faviconManagement,
             featureFlagger: MockFeatureFlagger(featuresStub: [FeatureFlag.fireDialogSimplified.rawValue: isFireDialogSimplified]),
+            clearingOption: clearingOption,
             mode: mode,
             settings: settings,
+            scopeVisits: scopeVisits,
             tld: TLD(),
             windowControllersManager: windowControllersManager,
             dataClearingPreferences: dataClearingPreferences,

--- a/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
+++ b/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
@@ -2372,6 +2372,48 @@ final class FireDialogViewModelTests: XCTestCase {
         XCTAssertEqual(mode.dialogTitle, UserText.fireDialogHistoryItemsTitle(0))
     }
 
+    @MainActor func testWhenSimplifiedDialogIsOff_ThenSelectedVisitsKeepTheGenericDialogTitle() {
+        // Scenario: The user deletes selected history items while the simplified dialog is off.
+        // Expectation: The legacy dialog keeps the generic title. The history item count title
+        // belongs to the new dialog only.
+
+        let mode = FireDialogViewModel.Mode.historyView(query: .visits([
+            makeVisitIdentifier(url: "https://example.com"),
+            makeVisitIdentifier(url: "https://duckduckgo.com")
+        ]))
+
+        let viewModel = makeViewModel(settings: MockFireDialogViewSettings(), mode: mode, isFireDialogSimplified: false)
+
+        XCTAssertEqual(viewModel.dialogTitle, UserText.fireDialogTitle)
+    }
+
+    @MainActor func testWhenSimplifiedDialogIsOn_ThenSelectedVisitsShowTheNumberOfItems() {
+        // Scenario: The user deletes selected history items while the simplified dialog is on.
+        // Expectation: The dialog title shows how many items are deleted.
+
+        let mode = FireDialogViewModel.Mode.historyView(query: .visits([
+            makeVisitIdentifier(url: "https://example.com"),
+            makeVisitIdentifier(url: "https://duckduckgo.com")
+        ]))
+
+        let viewModel = makeViewModel(settings: MockFireDialogViewSettings(), mode: mode, isFireDialogSimplified: true)
+
+        XCTAssertEqual(viewModel.dialogTitle, UserText.fireDialogHistoryItemsTitle(2))
+    }
+
+    @MainActor func testDialogTitleOfOtherModesDoesNotDependOnTheSimplifiedDialogFlag() {
+        // Scenario: Any mode other than a history item selection.
+        // Expectation: Both dialogs show the title of the mode, so the flag changes nothing.
+
+        for mode in Self.modesWithVisitsToggle {
+            let legacy = makeViewModel(settings: MockFireDialogViewSettings(), mode: mode, isFireDialogSimplified: false)
+            XCTAssertEqual(legacy.dialogTitle, mode.dialogTitle, "\(mode)")
+
+            let simplified = makeViewModel(settings: MockFireDialogViewSettings(), mode: mode, isFireDialogSimplified: true)
+            XCTAssertEqual(simplified.dialogTitle, mode.dialogTitle, "\(mode)")
+        }
+    }
+
     @MainActor func testDialogTitlesOfOtherHistoryViewModesAreUnchanged() {
         // Scenario: The other History view entry points.
         // Expectation: Their titles keep using the History view delete dialog titles.
@@ -2546,7 +2588,8 @@ final class FireDialogViewModelTests: XCTestCase {
 
     @MainActor
     private func makeViewModel(settings: any KeyedStoring<FireDialogViewSettings>,
-                               mode: FireDialogViewModel.Mode = .fireButton) -> FireDialogViewModel {
+                               mode: FireDialogViewModel.Mode = .fireButton,
+                               isFireDialogSimplified: Bool = false) -> FireDialogViewModel {
         FireDialogViewModel(
             fireViewModel: .init(fire: fire),
             tabCollectionViewModel: tabCollectionVM,
@@ -2554,7 +2597,7 @@ final class FireDialogViewModelTests: XCTestCase {
             aiChatHistoryCleaner: MockAIChatHistoryCleaner(showCleanOption: true),
             fireproofDomains: fireproofDomains,
             faviconManagement: fire.faviconManagement,
-            featureFlagger: MockFeatureFlagger(),
+            featureFlagger: MockFeatureFlagger(featuresStub: [FeatureFlag.fireDialogSimplified.rawValue: isFireDialogSimplified]),
             mode: mode,
             settings: settings,
             tld: TLD(),

--- a/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
+++ b/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
@@ -2321,6 +2321,69 @@ final class FireDialogViewModelTests: XCTestCase {
         }
     }
 
+    // MARK: - Closing tabs and windows
+
+    /// Modes where the user can choose whether the tabs and windows are closed.
+    private static let modesWithCloseTabsToggle: [FireDialogViewModel.Mode] = [
+        .fireButton,
+        .mainMenuAll,
+        .historyView(query: .rangeFilter(.all)),
+        .historyView(query: .rangeFilter(.allSites)),
+        .historyView(query: .rangeFilter(.today))
+    ]
+
+    /// Modes scoped to history that no open tab shows, so there is nothing to close.
+    private static let modesWithoutCloseTabsToggle: [FireDialogViewModel.Mode] = [
+        .historyView(query: .rangeFilter(.yesterday)),
+        .historyView(query: .rangeFilter(.monday)),
+        .historyView(query: .rangeFilter(.older)),
+        .historyView(query: .dateFilter(Date())),
+        .historyView(query: .searchTerm("duck")),
+        .historyView(query: .domainFilter(["example.com"])),
+        .historyView(query: .visits([]))
+    ]
+
+    @MainActor func testCloseTabsToggleVisibilityPerMode() {
+        // Scenario: Any dialog mode.
+        // Expectation: Only the modes that can delete data shown by an open tab offer the toggle.
+
+        for mode in Self.modesWithCloseTabsToggle {
+            XCTAssertTrue(mode.shouldShowCloseTabsToggle, "\(mode) should show the Close tabs toggle")
+        }
+        for mode in Self.modesWithoutCloseTabsToggle {
+            XCTAssertFalse(mode.shouldShowCloseTabsToggle, "\(mode) should not show the Close tabs toggle")
+        }
+    }
+
+    @MainActor func testWhenCloseTabsToggleIsHidden_ThenTabsAndWindowsStayOpen() {
+        // Scenario: An earlier dialog left the Close tabs toggle on, then a dialog without that
+        // toggle is opened.
+        // Expectation: The tabs and windows stay open. The dialog shows no toggle, so the earlier
+        // choice must not close them behind the user's back.
+
+        let mockSettings = MockFireDialogViewSettings(lastIncludeTabsAndWindowsState: true)
+
+        for mode in Self.modesWithoutCloseTabsToggle {
+            let viewModel = makeViewModel(settings: mockSettings, mode: mode)
+
+            XCTAssertTrue(viewModel.includeTabsAndWindows, "\(mode) should keep the persisted setting")
+            XCTAssertFalse(viewModel.shouldCloseTabsAndWindows, "\(mode) should not close tabs and windows")
+        }
+    }
+
+    @MainActor func testWhenCloseTabsToggleIsShown_ThenClosingFollowsTheToggle() {
+        // Scenario: The dialog has a Close tabs toggle.
+        // Expectation: The tabs and windows are closed only when the toggle is on.
+
+        for mode in Self.modesWithCloseTabsToggle {
+            let keepingTabs = makeViewModel(settings: MockFireDialogViewSettings(lastIncludeTabsAndWindowsState: false), mode: mode)
+            XCTAssertFalse(keepingTabs.shouldCloseTabsAndWindows, "\(mode) should keep tabs and windows open")
+
+            let closingTabs = makeViewModel(settings: MockFireDialogViewSettings(lastIncludeTabsAndWindowsState: true), mode: mode)
+            XCTAssertTrue(closingTabs.shouldCloseTabsAndWindows, "\(mode) should close tabs and windows")
+        }
+    }
+
     // MARK: - Dialog title for selected history items
 
     @MainActor func testWhenModeIsSelectedVisits_ThenDialogTitleShowsTheNumberOfItems() {

--- a/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
+++ b/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
@@ -2209,6 +2209,183 @@ final class FireDialogViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel3.isSectionsExpanded, "Third dialog should be expanded")
     }
 
+    // MARK: - History (visits) toggle and details disclosure
+
+    /// Modes where the user can choose whether the browsing history is deleted.
+    private static let modesWithVisitsToggle: [FireDialogViewModel.Mode] = [
+        .fireButton,
+        .mainMenuAll,
+        .historyView(query: .rangeFilter(.all)),
+        .historyView(query: .rangeFilter(.allSites)),
+        .historyView(query: .rangeFilter(.today)),
+        .historyView(query: .rangeFilter(.yesterday)),
+        .historyView(query: .rangeFilter(.monday)),
+        .historyView(query: .rangeFilter(.older)),
+        .historyView(query: .dateFilter(Date())),
+        .historyView(query: .searchTerm("duck")),
+        .historyView(query: .domainFilter(["example.com"])),
+        .historyView(query: .domainFilter(["example.com", "duckduckgo.com"]))
+    ]
+
+    /// Modes scoped to records the user picked, where those records are always deleted.
+    private static let modesWithoutVisitsToggle: [FireDialogViewModel.Mode] = [
+        .historyView(query: .visits([])),
+        .historyView(query: .visits([VisitIdentifier(uuid: UUID().uuidString, url: URL(string: "https://example.com")!, date: Date())]))
+    ]
+
+    @MainActor func testWhenModeIsNotAHistoryItemSelection_ThenVisitsToggleIsShown() {
+        // Scenario: The dialog is opened from the fire button, the main menu, or a History view
+        // section, all of which delete a whole part of the history.
+        // Expectation: The History toggle is visible, so the user can exclude the browsing history
+        // and delete only the site data.
+
+        for mode in Self.modesWithVisitsToggle {
+            XCTAssertTrue(mode.shouldShowVisitsToggle, "\(mode) should show the History toggle")
+        }
+    }
+
+    @MainActor func testWhenModeIsAHistoryItemSelection_ThenVisitsToggleIsHidden() {
+        // Scenario: The user selects history items in the History view and deletes them.
+        // Expectation: The History toggle is hidden, because the selected items are the subject
+        // of the deletion and cannot be excluded from it.
+
+        for mode in Self.modesWithoutVisitsToggle {
+            XCTAssertFalse(mode.shouldShowVisitsToggle, "\(mode) should not show the History toggle")
+        }
+    }
+
+    @MainActor func testWhenVisitsToggleIsHidden_ThenHistoryIsDeletedRegardlessOfThePersistedSetting() {
+        // Scenario: The user turned the History toggle off in an earlier dialog, then deletes
+        // selected items in the History view.
+        // Expectation: The selected items are deleted. The dialog shows no History toggle, so the
+        // earlier choice must not silently reduce the deletion to the site data.
+
+        let mockSettings = MockFireDialogViewSettings(lastIncludeHistoryState: false)
+
+        for mode in Self.modesWithoutVisitsToggle {
+            let viewModel = makeViewModel(settings: mockSettings, mode: mode)
+
+            XCTAssertFalse(viewModel.includeHistory, "\(mode) should keep the persisted setting")
+            XCTAssertTrue(viewModel.shouldDeleteHistory, "\(mode) should delete the selected items anyway")
+        }
+    }
+
+    @MainActor func testWhenVisitsToggleIsShown_ThenHistoryDeletionFollowsTheToggle() {
+        // Scenario: The dialog has a History toggle.
+        // Expectation: The history is deleted only when the toggle is on.
+
+        for mode in Self.modesWithVisitsToggle {
+            let excludingHistory = makeViewModel(settings: MockFireDialogViewSettings(lastIncludeHistoryState: false), mode: mode)
+            XCTAssertFalse(excludingHistory.shouldDeleteHistory, "\(mode) should not delete the history")
+
+            let includingHistory = makeViewModel(settings: MockFireDialogViewSettings(lastIncludeHistoryState: true), mode: mode)
+            XCTAssertTrue(includingHistory.shouldDeleteHistory, "\(mode) should delete the history")
+        }
+    }
+
+    @MainActor func testDetailsDisclosureFollowsVisitsToggle() {
+        // Scenario: Any dialog mode.
+        // Expectation: The "Choose what to delete" disclosure control appears only together with
+        // the History toggle. Without it, too few rows remain to make the sections worth hiding.
+
+        for mode in Self.modesWithVisitsToggle + Self.modesWithoutVisitsToggle {
+            XCTAssertEqual(mode.shouldShowDetailsDisclosure, mode.shouldShowVisitsToggle, "\(mode)")
+        }
+    }
+
+    @MainActor func testWhenModeHidesDetailsDisclosure_ThenSectionsAreShownExpanded() {
+        // Scenario: A collapsed state is persisted, then a scoped history dialog is opened.
+        // Expectation: The sections are shown expanded. The dialog has no disclosure control,
+        // so a collapsed state would leave the user with no way to expand them.
+
+        let mockSettings = MockFireDialogViewSettings(lastSectionsExpandedState: false)
+
+        for mode in Self.modesWithoutVisitsToggle {
+            let viewModel = makeViewModel(settings: mockSettings, mode: mode)
+
+            XCTAssertFalse(viewModel.isSectionsExpanded, "\(mode) should keep the persisted state")
+            XCTAssertTrue(viewModel.shouldShowSectionsExpanded, "\(mode) should still show the sections expanded")
+        }
+    }
+
+    @MainActor func testWhenModeShowsDetailsDisclosure_ThenSectionsFollowPersistedState() {
+        // Scenario: The dialog has a disclosure control.
+        // Expectation: The sections follow the persisted expanded state.
+
+        for mode in Self.modesWithVisitsToggle {
+            let collapsedViewModel = makeViewModel(settings: MockFireDialogViewSettings(lastSectionsExpandedState: false), mode: mode)
+            XCTAssertFalse(collapsedViewModel.shouldShowSectionsExpanded, "\(mode) should stay collapsed")
+
+            let expandedViewModel = makeViewModel(settings: MockFireDialogViewSettings(lastSectionsExpandedState: true), mode: mode)
+            XCTAssertTrue(expandedViewModel.shouldShowSectionsExpanded, "\(mode) should stay expanded")
+        }
+    }
+
+    // MARK: - Dialog title for selected history items
+
+    @MainActor func testWhenModeIsSelectedVisits_ThenDialogTitleShowsTheNumberOfItems() {
+        // Scenario: The user selects history items in the History view and deletes them.
+        // Expectation: The dialog title shows how many items are deleted.
+
+        let mode = FireDialogViewModel.Mode.historyView(query: .visits([
+            makeVisitIdentifier(url: "https://example.com"),
+            makeVisitIdentifier(url: "https://duckduckgo.com"),
+            makeVisitIdentifier(url: "https://spreadprivacy.com")
+        ]))
+
+        XCTAssertEqual(mode.dialogTitle, UserText.fireDialogHistoryItemsTitle(3))
+        XCTAssertEqual(mode.dialogTitle, "Delete 3 History items?")
+    }
+
+    @MainActor func testWhenModeIsSingleSelectedVisit_ThenDialogTitleShowsOneItem() {
+        // Scenario: The user selects a single history item and deletes it.
+        // Expectation: The dialog title shows a count of one.
+
+        let mode = FireDialogViewModel.Mode.historyView(query: .visits([
+            makeVisitIdentifier(url: "https://example.com")
+        ]))
+
+        XCTAssertEqual(mode.dialogTitle, UserText.fireDialogHistoryItemsTitle(1))
+    }
+
+    @MainActor func testWhenSelectedVisitsShareHistoryEntry_ThenDialogTitleCountsTheEntryOnce() {
+        // Scenario: The user selects several visits of the same page, made on different days.
+        // Expectation: The title counts the history entry once, because deleting any of its
+        // visits deletes the same entry.
+
+        let uuid = UUID().uuidString
+        let mode = FireDialogViewModel.Mode.historyView(query: .visits([
+            .init(uuid: uuid, url: URL(string: "https://example.com")!, date: Date()),
+            .init(uuid: uuid, url: URL(string: "https://example.com")!, date: Date().addingTimeInterval(-.days(1))),
+            makeVisitIdentifier(url: "https://duckduckgo.com")
+        ]))
+
+        XCTAssertEqual(mode.dialogTitle, UserText.fireDialogHistoryItemsTitle(2))
+    }
+
+    @MainActor func testWhenNoVisitsAreSelected_ThenDialogTitleShowsZeroItems() {
+        // Scenario: The mode carries an empty selection.
+        // Expectation: The title renders without crashing and shows a count of zero.
+
+        let mode = FireDialogViewModel.Mode.historyView(query: .visits([]))
+
+        XCTAssertEqual(mode.dialogTitle, UserText.fireDialogHistoryItemsTitle(0))
+    }
+
+    @MainActor func testDialogTitlesOfOtherHistoryViewModesAreUnchanged() {
+        // Scenario: The other History view entry points.
+        // Expectation: Their titles keep using the History view delete dialog titles.
+
+        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .rangeFilter(.all)).dialogTitle,
+                       HistoryViewDeleteDialogModel.DeleteMode.all.title)
+        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .rangeFilter(.today)).dialogTitle,
+                       HistoryViewDeleteDialogModel.DeleteMode.today.title)
+        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .rangeFilter(.older)).dialogTitle,
+                       HistoryViewDeleteDialogModel.DeleteMode.older.title)
+        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .domainFilter(["example.com"])).dialogTitle,
+                       HistoryViewDeleteDialogModel.DeleteMode.sites(["example.com"]).title)
+    }
+
     // MARK: - Simplified Fire Dialog: currentWindow folding
 
     @MainActor func testClearingOption_WhenSimplifiedEnabledAndPersistedScopeIsCurrentWindow_FoldsToAllData() {
@@ -2368,7 +2545,8 @@ final class FireDialogViewModelTests: XCTestCase {
     }
 
     @MainActor
-    private func makeViewModel(settings: any KeyedStoring<FireDialogViewSettings>) -> FireDialogViewModel {
+    private func makeViewModel(settings: any KeyedStoring<FireDialogViewSettings>,
+                               mode: FireDialogViewModel.Mode = .fireButton) -> FireDialogViewModel {
         FireDialogViewModel(
             fireViewModel: .init(fire: fire),
             tabCollectionViewModel: tabCollectionVM,
@@ -2377,6 +2555,7 @@ final class FireDialogViewModelTests: XCTestCase {
             fireproofDomains: fireproofDomains,
             faviconManagement: fire.faviconManagement,
             featureFlagger: MockFeatureFlagger(),
+            mode: mode,
             settings: settings,
             tld: TLD(),
             windowControllersManager: windowControllersManager,
@@ -2422,6 +2601,11 @@ final class FireDialogViewModelTests: XCTestCase {
 
     private func makeFireproofDomains(_ domains: [String]) {
         domains.forEach { fireproofDomains.add(domain: $0) }
+    }
+
+    /// Makes an identifier of a single visit of a history entry that no other identifier refers to.
+    private func makeVisitIdentifier(url: String, date: Date = Date()) -> VisitIdentifier {
+        VisitIdentifier(uuid: UUID().uuidString, url: URL(string: url)!, date: date)
     }
 
     private func makeHistoryEntry(url: String) -> HistoryEntry {

--- a/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
+++ b/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
@@ -2321,6 +2321,98 @@ final class FireDialogViewModelTests: XCTestCase {
         }
     }
 
+    // MARK: - Current tab scope
+
+    @MainActor func testWhenCurrentTabHasNoDataToDelete_ThenTheScopeIsDisabledAndAllDataIsUsed() {
+        // Scenario: The fire button is used on a new tab page that was never navigated away from.
+        // Expectation: The tab holds nothing to delete, so the scope is disabled and the dialog
+        // uses All data. The stored last selected scope stays untouched, so the next dialog on a
+        // website tab starts from the user's own choice again.
+
+        let mockSettings = MockFireDialogViewSettings(lastSelectedClearingOption: .currentTab)
+        selectNewTabPageTab()
+
+        let viewModel = makeViewModel(tabCollectionViewModel: tabCollectionVM, settings: mockSettings)
+
+        XCTAssertFalse(viewModel.isCurrentTabOptionEnabled, "The current tab scope should be disabled")
+        XCTAssertEqual(viewModel.clearingOption, .allData, "The dialog should use All data")
+        XCTAssertEqual(mockSettings.lastSelectedClearingOption, .currentTab, "The user choice should stay stored")
+    }
+
+    @MainActor func testWhenCurrentTabShowsAWebsite_ThenTheScopeStaysEnabled() {
+        // Scenario: The fire button is used on a tab showing a website.
+        // Expectation: The tab holds data to delete, so the scope stays available and selected.
+
+        let mockSettings = MockFireDialogViewSettings(lastSelectedClearingOption: .currentTab)
+        tabCollectionVM.append(tab: makeTab(url: "https://example.com".url!))
+        tabCollectionVM.select(at: .unpinned(1))
+
+        let viewModel = makeViewModel(tabCollectionViewModel: tabCollectionVM, settings: mockSettings)
+
+        XCTAssertTrue(viewModel.isCurrentTabOptionEnabled, "The current tab scope should be available")
+        XCTAssertEqual(viewModel.clearingOption, .currentTab, "The dialog should keep the user choice")
+    }
+
+    @MainActor func testWhenCurrentTabHasNoDataToDeleteAndAllDataWasSelected_ThenNothingChanges() {
+        // Scenario: The user already chose All data, then uses the fire button on a new tab page.
+        // Expectation: The scope is disabled, and the stored choice stays as it is.
+
+        let mockSettings = MockFireDialogViewSettings(lastSelectedClearingOption: .allData)
+        selectNewTabPageTab()
+
+        let viewModel = makeViewModel(tabCollectionViewModel: tabCollectionVM, settings: mockSettings)
+
+        XCTAssertFalse(viewModel.isCurrentTabOptionEnabled, "The current tab scope should be disabled")
+        XCTAssertEqual(viewModel.clearingOption, .allData)
+        XCTAssertEqual(mockSettings.lastSelectedClearingOption, .allData, "The user choice should stay stored")
+    }
+
+    @MainActor func testWhenTheCurrentTabScopeIsDisabled_ThenTheDialogUsesAllDataWithoutStoringIt() {
+        // Scenario: The tab holds nothing to delete, which also covers a tab that cannot go back
+        // or forward. The state comes from the caller here, because a unit test cannot navigate.
+        // Expectation: The dialog uses All data, and the stored scope stays untouched.
+
+        let mockSettings = MockFireDialogViewSettings(lastSelectedClearingOption: .currentTab)
+
+        let viewModel = makeViewModel(tabCollectionViewModel: tabCollectionVM,
+                                      settings: mockSettings,
+                                      isCurrentTabOptionEnabled: false)
+
+        XCTAssertFalse(viewModel.isCurrentTabOptionEnabled)
+        XCTAssertEqual(viewModel.clearingOption, .allData)
+        XCTAssertEqual(mockSettings.lastSelectedClearingOption, .currentTab, "The user choice should stay stored")
+    }
+
+    @MainActor func testWhenSimplifiedDialogIsOff_ThenTheCurrentTabScopeStaysEnabled() {
+        // Scenario: The legacy dialog is used on a tab that holds nothing to delete.
+        // Expectation: Nothing changes. Disabling the scope belongs to the new dialog only.
+
+        let mockSettings = MockFireDialogViewSettings(lastSelectedClearingOption: .currentTab)
+        selectNewTabPageTab()
+
+        let viewModel = makeViewModel(tabCollectionViewModel: tabCollectionVM,
+                                      settings: mockSettings,
+                                      isFireDialogSimplified: false)
+
+        XCTAssertTrue(viewModel.isCurrentTabOptionEnabled, "The legacy dialog should keep the scope")
+        XCTAssertEqual(viewModel.clearingOption, .currentTab, "The legacy dialog should keep the user choice")
+    }
+
+    @MainActor func testWhenSimplifiedDialogIsOffAndTheCallerDisablesTheScope_ThenTheScopeStaysEnabled() {
+        // Scenario: The legacy dialog, with the caller reporting a tab without data to delete.
+        // Expectation: The flag decides, so the legacy dialog keeps the scope and the user choice.
+
+        let mockSettings = MockFireDialogViewSettings(lastSelectedClearingOption: .currentTab)
+
+        let viewModel = makeViewModel(tabCollectionViewModel: tabCollectionVM,
+                                      settings: mockSettings,
+                                      isCurrentTabOptionEnabled: false,
+                                      isFireDialogSimplified: false)
+
+        XCTAssertTrue(viewModel.isCurrentTabOptionEnabled)
+        XCTAssertEqual(viewModel.clearingOption, .currentTab)
+    }
+
     // MARK: - Closing tabs and windows
 
     /// Modes where the user can choose whether the tabs and windows are closed.
@@ -2575,10 +2667,14 @@ final class FireDialogViewModelTests: XCTestCase {
 
     @MainActor func testClearingOption_WhenSimplifiedEnabledAndScopeIsCurrentTab_RemainsCurrentTab() {
         // Scenario: The simplified Fire dialog is enabled but the selected scope is .currentTab.
-        // Action: Create the ViewModel with clearingOption: .currentTab.
+        // Action: Create the ViewModel with clearingOption: .currentTab, on a tab showing a
+        // website so that the scope holds data to delete.
         // Expectation: Only .currentWindow is folded; .currentTab is preserved.
 
         let featureFlagger = MockFeatureFlagger(featuresStub: [FeatureFlag.fireDialogSimplified.rawValue: true])
+
+        tabCollectionVM.append(tab: makeTab(url: "https://example.com".url!))
+        tabCollectionVM.select(at: .unpinned(1))
 
         let viewModel = FireDialogViewModel(
             fireViewModel: .init(fire: fire),
@@ -2707,6 +2803,36 @@ final class FireDialogViewModelTests: XCTestCase {
 
     private func makeFireproofDomains(_ domains: [String]) {
         domains.forEach { fireproofDomains.add(domain: $0) }
+    }
+
+    @MainActor
+    private func makeViewModel(tabCollectionViewModel: TabCollectionViewModel,
+                               settings: any KeyedStoring<FireDialogViewSettings>,
+                               isCurrentTabOptionEnabled: Bool? = nil,
+                               isFireDialogSimplified: Bool = true) -> FireDialogViewModel {
+        FireDialogViewModel(
+            fireViewModel: fireViewModel,
+            tabCollectionViewModel: tabCollectionViewModel,
+            historyCoordinating: fire.historyCoordinating,
+            aiChatHistoryCleaner: aiChatHistoryCleaner,
+            fireproofDomains: fireproofDomains,
+            faviconManagement: fire.faviconManagement,
+            featureFlagger: MockFeatureFlagger(featuresStub: [FeatureFlag.fireDialogSimplified.rawValue: isFireDialogSimplified]),
+            isCurrentTabOptionEnabled: isCurrentTabOptionEnabled,
+            settings: settings,
+            tld: TLD(),
+            windowControllersManager: windowControllersManager,
+            dataClearingPreferences: dataClearingPreferences,
+            pixelFiring: pixelFiringMock
+        )
+    }
+
+    /// Selects a new tab page that was never navigated away from, so it holds nothing to delete.
+    @MainActor
+    private func selectNewTabPageTab() {
+        let tab = Tab(content: .newtab, webViewConfiguration: schemeHandler.webViewConfiguration())
+        tabCollectionVM.append(tab: tab)
+        tabCollectionVM.select(at: .unpinned(1))
     }
 
     /// Makes an identifier of a single visit of a history entry that no other identifier refers to.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217483969104924?focus=true

### Description
* Add a simplified Fire Dialog for deleting items multi-selected in History View.
* Disable "From this tab" mode on internal pages when there's no back-forward history.

### Testing Steps
1. Enable `fireDialogSimplified` feature flag.
2. Open history view, select multiple items and click delete
3. Verify that the dialog looks similar to this:
<img width="438" height="325" alt="Screenshot 2026-08-14 at 15 17 28" src="https://github.com/user-attachments/assets/fc17dc0d-4641-4cff-b3e2-8689d62fb8d7" />

4. Verify that the history items are actually deleted.
5. Verify that other delete modes in History View use regular dialog with collapsible contents: deleting a day, deleting all, or deleting sites.
6. Click fire button in History View, verify that "From this tab" is disabled. Verify the same with Settings, new tab page and Bookmarks.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what gets deleted and whether tabs close when History toggles are hidden—data-clearing behavior must stay aligned with the Delete button and persisted settings.
> 
> **Overview**
> Adds a **compact Fire dialog** when users delete **multi-selected items** in History View (`historyView(query: .visits)`): the History toggle and “Choose what to delete” disclosure are hidden, sections stay expanded, and the title shows **“Delete N History items?”** (deduped by history entry). Cookies use the **“Include cookies & other data?”** label; overlay top spacing shortens when disclosure is hidden.
> 
> **View model** centralizes behavior behind `shouldDeleteHistory`, `shouldCloseTabsAndWindows`, `shouldShowSectionsExpanded`, `isDeleteEnabled`, and `dialogTitle` (legacy dialog keeps generic title for selected visits when `fireDialogSimplified` is off). Confirming deletion uses those flags so hidden toggles don’t block deletes or close tabs incorrectly.
> 
> With **`fireDialogSimplified`**, **“From this tab”** is disabled when the current tab has nothing to delete (no external URL and no back/forward); the UI falls back to **All data** without overwriting the stored scope preference. The segmented tab can be disabled visually (`isEnabled` on tab items).
> 
> **FireViewController** uses design-system `surfacePrimary` for the progress background when the simplified dialog is on. Unit and integration tests cover toggle visibility, delete enablement, titles, and coordinator expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e2fdad54a1f269ae9b40809113a3bbbbbbca25c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->