### PR TITLE
Migrate release workflows to Bitrise

### DIFF
--- a/.github/workflows/ios_adhoc.yml
+++ b/.github/workflows/ios_adhoc.yml
@@ -26,11 +26,11 @@ on:
 
 jobs:
   make-adhoc:
-    runs-on: macos-26-xlarge
+    runs-on: bitrise:macos26-m4pro
     name: Make ad-hoc build
 
     env:
-      RUNS_ON: macos-26-xlarge # keep this in sync with runs-on above
+      RUNS_ON: bitrise:macos26-m4pro # keep this in sync with runs-on above
 
     steps:
 

--- a/.github/workflows/ios_alpha.yml
+++ b/.github/workflows/ios_alpha.yml
@@ -20,10 +20,10 @@ on:
 
 jobs:
   build-alpha:
-    runs-on: macos-26
+    runs-on: bitrise:macos26-m4
     name: Build Alpha
     timeout-minutes: 30
-    
+
     concurrency:
       group: ios-alpha-build-${{ github.ref }}
       cancel-in-progress: true
@@ -151,7 +151,7 @@ jobs:
         bundle exec fastlane increment_build_number_for_version version:$app_version app_identifier:"com.duckduckgo.mobile.ios.alpha"
         build_version="$(cut -d ' ' -f 3 < Configuration/BuildNumber.xcconfig)"
         bundle exec fastlane build_alpha
-        
+
         # Export build metadata
         echo "app_version=${app_version}" >> $GITHUB_OUTPUT
         echo "build_version=${build_version}" >> $GITHUB_OUTPUT
@@ -172,7 +172,7 @@ jobs:
   upload:
     needs: build-alpha
     if: needs.build-alpha.outputs.should_skip != 'true'
-    runs-on: macos-26
+    runs-on: bitrise:macos26-m4
     name: Upload to TestFlight
     timeout-minutes: 15
 

--- a/.github/workflows/ios_bump_internal_release.yml
+++ b/.github/workflows/ios_bump_internal_release.yml
@@ -32,7 +32,7 @@ jobs:
   validate_input_conditions:
 
     name: Validate Input Conditions
-    runs-on: macos-26
+    runs-on: bitrise:macos26-m4
     timeout-minutes: 10
 
     env:
@@ -96,7 +96,7 @@ jobs:
 
     name: Increment Build Number
     needs: [ validate_input_conditions, run_tests ]
-    runs-on: macos-26-xlarge
+    runs-on: bitrise:macos26-m4
     timeout-minutes: 10
 
     outputs:

--- a/.github/workflows/ios_code_freeze.yml
+++ b/.github/workflows/ios_code_freeze.yml
@@ -47,7 +47,7 @@ jobs:
 
     name: Create Release Branch
 
-    runs-on: macos-26-xlarge
+    runs-on: bitrise:macos26-m4
     timeout-minutes: 10
 
     outputs:

--- a/.github/workflows/ios_promote_testflight.yml
+++ b/.github/workflows/ios_promote_testflight.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   promote-testflight-to-appstore:
-    runs-on: macos-26
+    runs-on: bitrise:macos26-m4
 
     steps:
     - name: Check out the code

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -65,7 +65,7 @@ on:
 
 jobs:
   make-release:
-    runs-on: macos-26-xlarge
+    runs-on: bitrise:macos26-m4pro
     name: Make App Store Connect Release
 
     env:

--- a/.github/workflows/ios_tag_release_update_asana.yml
+++ b/.github/workflows/ios_tag_release_update_asana.yml
@@ -88,7 +88,7 @@ jobs:
     outputs:
       stop_workflow: ${{ steps.download-stop-workflow.outcome == 'success' }}
 
-    runs-on: macos-26
+    runs-on: bitrise:macos26-m4
 
     steps:
       - name: Check out the code
@@ -122,7 +122,7 @@ jobs:
     # by the stop_workflow flag.
     if: needs.stop-workflow-if-needed.outputs.stop_workflow != 'true'
 
-    runs-on: macos-26-xlarge
+    runs-on: bitrise:macos26-m4
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/macos_alpha_release.yml
+++ b/.github/workflows/macos_alpha_release.yml
@@ -22,7 +22,7 @@ jobs:
   calculate-alpha-build-number:
     name: Calculate Alpha Build Number
 
-    runs-on: macos-26
+    runs-on: bitrise:macos26-m4
 
     outputs:
       build-number: ${{ steps.update-build-number.outputs.build-number }}
@@ -111,7 +111,7 @@ jobs:
 
     needs: dmg-release
 
-    runs-on: macos-26
+    runs-on: bitrise:macos26-m4
 
     defaults:
       run:

--- a/.github/workflows/macos_build_appstore.yml
+++ b/.github/workflows/macos_build_appstore.yml
@@ -77,7 +77,7 @@ jobs:
       group: macos-appstore-build-${{ github.event.inputs.destination || inputs.destination }}
       cancel-in-progress: true
 
-    runs-on: macos-26-xlarge
+    runs-on: bitrise:macos26-m4pro
 
     env:
       destination: ${{ github.event.inputs.destination || inputs.destination }}
@@ -230,7 +230,7 @@ jobs:
       group: macos-appstore-upload-${{ github.event.inputs.destination || inputs.destination }}
       cancel-in-progress: true
 
-    runs-on: macos-26
+    runs-on: bitrise:macos26-m4
 
     env:
       destination: ${{ github.event.inputs.destination || inputs.destination }}

--- a/.github/workflows/macos_build_notarized.yml
+++ b/.github/workflows/macos_build_notarized.yml
@@ -93,7 +93,7 @@ jobs:
 
     name: Export Notarized App
 
-    runs-on: macos-26-xlarge
+    runs-on: bitrise:macos26-m4pro
 
     outputs:
       app-version: ${{ steps.set-outputs.outputs.app-version }}
@@ -104,7 +104,7 @@ jobs:
       dsym-url: ${{ steps.upload-dsyms-to-s3-test-build.outputs.dsym-url }}
 
     env:
-      RUNS_ON: macos-26-xlarge # keep this in sync with runs-on above
+      RUNS_ON: bitrise:macos26-m4pro # keep this in sync with runs-on above
       release-type: ${{ github.event.inputs.release-type || inputs.release-type }}
       asana-task-url: ${{ github.event.inputs.asana-task-url || inputs.asana-task-url }}
       branch: ${{ inputs.branch || github.ref_name }}
@@ -384,7 +384,7 @@ jobs:
     needs: export-notarized-app
     if: ${{ github.event.inputs.create-dmg == true || inputs.create-dmg == true }}
 
-    runs-on: macos-26
+    runs-on: bitrise:macos26-m4
 
     outputs:
       dmg-url: ${{ steps.upload-dmg-to-s3.outputs.dmg-url }}
@@ -396,7 +396,7 @@ jobs:
       branch: ${{ inputs.branch || github.ref_name }}
       upload-to: ${{ needs.export-notarized-app.outputs.upload-to }}
       release-type: ${{ github.event.inputs.release-type || inputs.release-type }}
-      RUNS_ON: macos-26 # keep this in sync with runs-on above
+      RUNS_ON: bitrise:macos26-m4 # keep this in sync with runs-on above
 
     steps:
 
@@ -586,7 +586,7 @@ jobs:
     needs: [export-notarized-app, create-dmg]
     if: ${{ always() && inputs.skip-notify == false }}
 
-    runs-on: macos-26
+    runs-on: bitrise:macos26-m4
 
     env:
       branch: ${{ inputs.branch || github.ref_name }}

--- a/.github/workflows/macos_bump_internal_release.yml
+++ b/.github/workflows/macos_bump_internal_release.yml
@@ -39,7 +39,7 @@ jobs:
 
     # This doesn't need Xcode, so could technically run on Ubuntu, but find_asana_release_task.sh
     # uses BSD-specific `date` syntax, that doesn't work with GNU `date` (available on Linux).
-    runs-on: macos-26
+    runs-on: bitrise:macos26-m4
     timeout-minutes: 10
 
     env:

--- a/.github/workflows/macos_promote_testflight.yml
+++ b/.github/workflows/macos_promote_testflight.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   promote-testflight-to-appstore:
-    runs-on: macos-26
+    runs-on: bitrise:macos26-m4
 
     steps:
     - name: Check out the code

--- a/.github/workflows/macos_publish_dmg_release.yml
+++ b/.github/workflows/macos_publish_dmg_release.yml
@@ -88,9 +88,6 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v6
 
-      - name: Print macOS version
-        run: sw_vers
-
       - name: Download stop_workflow flag artifact
         id: download-stop-workflow
         continue-on-error: true

--- a/.github/workflows/macos_publish_dmg_release.yml
+++ b/.github/workflows/macos_publish_dmg_release.yml
@@ -82,7 +82,7 @@ jobs:
     outputs:
       stop_workflow: ${{ steps.download-stop-workflow.outcome == 'success' }}
 
-    runs-on: macos-26
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out the code
@@ -119,7 +119,7 @@ jobs:
     outputs:
       dmg-url: ${{ steps.set-common-env.outputs.dmg-url }}
 
-    runs-on: macos-26-xlarge
+    runs-on: bitrise:macos26-m4
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/macos_tag_release.yml
+++ b/.github/workflows/macos_tag_release.yml
@@ -74,7 +74,7 @@ jobs:
 
     # This doesn't need Xcode, so could technically run on Ubuntu, but actions that add comments and tasks
     # in Asana use BSD-specific sed syntax, that doesn't work with GNU sed (available on Linux).
-    runs-on: macos-26
+    runs-on: bitrise:macos26-m4
 
     env:
       asana-task-url: ${{ github.event.inputs.asana-task-url || inputs.asana-task-url }}

--- a/.github/workflows/update_code_signing.yml
+++ b/.github/workflows/update_code_signing.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   update_code_signing:
-    runs-on: macos-15
+    runs-on: macos-26
     name: Update Code Signing Assets
 
     steps:
@@ -99,6 +99,6 @@ jobs:
               lane="sync_signing_ci"
               ;;
           esac
- 
+
           cd "$platform"
           bundle exec fastlane ${lane}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1217382197304456?focus=true

### Description
Use Bitrise runners for iOS and macOS release workflows

### Testing Steps
N/A

### Impact
None: Internal tooling, documentation

#### What could go wrong?
If anything breaks, I'll be there fixing it on Monday morning.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only CI runner targets for release pipelines; misconfigured Bitrise labels or capacity could block iOS/macOS builds and releases without affecting app runtime code.
> 
> **Overview**
> **Moves iOS and macOS release-related GitHub Actions jobs from GitHub-hosted `macos-26` / `macos-26-xlarge` runners to Bitrise labels `bitrise:macos26-m4` and `bitrise:macos26-m4pro`.** Heavier build/export steps (ad-hoc xlarge, App Store builds, notarized exports) use **m4pro**; lighter jobs (TestFlight upload, promote, validate, DMG publish helpers) use **m4**.
> 
> **`RUNS_ON` env vars** in `ios_adhoc.yml` and `macos_build_notarized.yml` are updated to stay in sync with each job’s `runs-on` value (likely for scripts that report runner type).
> 
> In **`macos_publish_dmg_release.yml`**, the **`stop-workflow-if-needed`** job runs on **`ubuntu-latest`** instead of macOS, and the **`sw_vers`** step is removed there since it only downloads an artifact.
> 
> **`update_code_signing.yml`** bumps the runner from **`macos-15`** to **`macos-26`** on GitHub-hosted macOS (not Bitrise).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30113b07fbf3817c0ff697a7a9f9316411b2d63c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->