### PR TITLE
Fix: BSK Unit Tests

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/Common/Extensions/URLExtension.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Common/Extensions/URLExtension.swift
@@ -25,6 +25,8 @@ extension URL {
 
     public static let empty = (NSURL(string: "") ?? NSURL()) as URL
 
+    public static let blankPage = URL(string: "about:blank")!
+
     public var isEmpty: Bool {
         absoluteString.isEmpty
     }

--- a/SharedPackages/BrowserServicesKit/Sources/Navigation/FrameInfo.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Navigation/FrameInfo.swift
@@ -57,7 +57,7 @@ public struct FrameInfo {
     public init(webView: WKWebView?, isMainFrame: Bool, url: URL, securityOrigin: SecurityOrigin) {
         self.webView = webView
         self.isMainFrame = isMainFrame
-        self.url = url
+        self.url = url.absoluteString.isEmpty ? .blankPage : url
         self.securityOrigin = securityOrigin
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/Navigation/FrameInfo.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Navigation/FrameInfo.swift
@@ -36,7 +36,7 @@ public struct FrameInfo {
         self.webView = webView
         self.handle = handle
         self.isMainFrame = isMainFrame
-        self.url = url
+        self.url = url.absoluteString.isEmpty ? .blankPage : url
         self.securityOrigin = securityOrigin
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/Navigation/NavigationAction.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Navigation/NavigationAction.swift
@@ -131,12 +131,15 @@ public struct NavigationAction {
         }
         var navigationType = navigationType
 
-        if case .other = navigationAction.navigationType,
+        let targetFrameURL = navigationAction.targetFrame?.safeRequest?.url
+        let isTargetFrameBlankOrEmpty = targetFrameURL?.isEmpty == true || targetFrameURL == .blankPage
+
+        if [.other, .backForward].contains(navigationAction.navigationType),
            case .returnCacheDataElseLoad = navigationAction.request.cachePolicy,
            navigationType == nil,
            redirectHistory == nil,
            navigationAction.targetFrame?.isMainFrame == true,
-           navigationAction.targetFrame?.safeRequest?.url?.isEmpty == true,
+           isTargetFrameBlankOrEmpty,
            webView.backForwardList.currentItem != nil {
 
             // go back after failing session restoration has `other` Navigation Type

--- a/SharedPackages/BrowserServicesKit/Tests/NavigationTests/FrameInfoTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/NavigationTests/FrameInfoTests.swift
@@ -1,0 +1,72 @@
+//
+//  FrameInfoTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#if os(macOS)
+
+import Common
+import WebKit
+import XCTest
+@testable import Navigation
+
+@available(iOS 15.0, *)
+final class FrameInfoTests: XCTestCase {
+
+    @MainActor
+    func testWhenUrlIsEmptyThenFrameInfoUrlIsAboutBlank() {
+        let webView = WKWebView(frame: .zero)
+        let frame = FrameInfo(webView: webView,
+                              handle: webView.mainFrameHandle,
+                              isMainFrame: true,
+                              url: .empty,
+                              securityOrigin: .empty)
+
+        XCTAssertEqual(frame.url, .blankPage)
+    }
+
+    /// `WKFrameInfo.request` may be `null` for a newly created frame, see `WKFrameInfo.safeRequest`.
+    @MainActor
+    func testWhenFrameHasNoRequestThenFrameInfoUrlIsAboutBlank() {
+        let webView = WKWebView(frame: .zero)
+        let frame = FrameInfo(frame: .mock(for: webView))
+
+        XCTAssertEqual(frame.url, .blankPage)
+    }
+
+    @MainActor
+    func testWhenUrlIsNotEmptyThenFrameInfoUrlIsPreserved() {
+        let webView = WKWebView(frame: .zero)
+        let url = URL(string: "https://duckduckgo.com/")!
+        let frame = FrameInfo(webView: webView,
+                              handle: webView.mainFrameHandle,
+                              isMainFrame: true,
+                              url: url,
+                              securityOrigin: url.securityOrigin)
+
+        XCTAssertEqual(frame.url, url)
+    }
+
+    @MainActor
+    func testWhenWebViewHasNoUrlThenMainFrameUrlIsAboutBlank() {
+        let webView = WKWebView(frame: .zero)
+        XCTAssertNil(webView.url)
+
+        XCTAssertEqual(FrameInfo.mainFrame(for: webView).url, .blankPage)
+    }
+}
+
+#endif

--- a/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -160,8 +160,6 @@ extension URL {
     }
 #endif
 
-    static let blankPage = URL(string: "about:blank")!
-
     static let newtab = URL(string: "duck://newtab")!
     static let welcome = URL(string: "duck://welcome")!
     static let settings = URL(string: "duck://settings")!


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1217474898313035?focus=true
Tech Design URL:
CC:

### Description
I've tracked down our breaking BSK tests to a change introduced in WebKit:

- [NavigationRequester](https://github.com/WebKit/WebKit/blame/WebKit-7624.4.5.11.1/Source/WebCore/loader/NavigationRequester.cpp#L36) in Safari `20624.4.5`
- [NavigationRequester](https://github.com/WebKit/WebKit/blame/WebKit-7624.4.5/Source/WebCore/loader/NavigationRequester.cpp#L36) in Safari `20624.4.5`

Extra details:
https://app.asana.com/1/137249556945/task/1217474898313035/comment/1217498052877519?focus=true

### Testing Steps
- [ ] Verify the CI is green

### Impact
High: Could affect user privacy, lose user data, break core functionality

#### What could go wrong?
This could introduce a regression in the Navigation handling infrastructure.

### Quality Considerations
Nothing in particular

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes classification of navigation actions (session restoration vs back/forward) in core navigation infrastructure; misclassification could affect history and restoration behavior.
> 
> **Overview**
> Aligns **FrameInfo** and **NavigationAction** with newer WebKit behavior where main-frame navigations can report **`about:blank`** instead of an empty URL string.
> 
> **`URL.blankPage`** is now defined in shared Common (macOS’s local duplicate was removed). **`FrameInfo`** stores **`about:blank`** whenever the incoming URL’s absolute string is empty, including paths that still pass **`.empty`** from **`WKFrameInfo`** or a nil **`webView.url`**.
> 
> **NavigationAction** broadens session-restoration / back-forward heuristics: the blank-frame check now matches both empty and **`about:blank`** target URLs, and **`backForward`** navigation types are included alongside **`other`** when **`returnCacheDataElseLoad`** and other conditions hold.
> 
> **FrameInfoTests** cover empty URL, missing frame request, preserved real URLs, and nil web view URL on main frame.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca4c4299a2a1f5880863526e110816c6514da5e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->