### PR TITLE
Read unified Sync device info with legacy fallback

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -511,6 +511,7 @@ public class DDGSync: DDGSyncing {
                 deviceInfoMigrationTask = nil
                 deviceInfoMigrationTaskID = nil
                 try dependencies.secureStore.removeAccount()
+                clearAccountInfoKeyCache(for: storedAccount)
                 deviceInfoMigrationCoordinator.reset()
                 didRemoveAccount = true
             } catch {
@@ -786,6 +787,7 @@ public class DDGSync: DDGSyncing {
     }
 
     private func removeAccount(reason: SyncError.AccountRemovedReason) throws {
+        let account = try? dependencies.secureStore.account()
         deviceInfoMigrationTask?.cancel()
         deviceInfoMigrationTask = nil
         deviceInfoMigrationTaskID = nil
@@ -803,9 +805,20 @@ public class DDGSync: DDGSyncing {
         syncQueue = nil
         authState = .inactive
         try dependencies.secureStore.removeAccount()
+        clearAccountInfoKeyCache(for: account)
         deviceInfoMigrationCoordinator.reset()
         try dependencies.keyValueStore.set(nil, forKey: Constants.syncEnabledKey)
         dependencies.errorEvents.fire(.accountRemoved(reason))
+    }
+
+    private func clearAccountInfoKeyCache(for account: SyncAccount?) {
+        guard let account else {
+            return
+        }
+        let accountInfoKeys = dependencies.accountInfoKeys
+        Task {
+            await accountInfoKeys.clearCachedKey(for: account)
+        }
     }
 
     private func handleUnauthenticatedAndMap(_ error: Error,

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -247,7 +247,7 @@ public class DDGSync: DDGSyncing {
         }
 
         do {
-            try await dependencies.account.fetchDevicesForAccount(account).devices
+            return try await dependencies.account.fetchDevicesForAccount(account).devices
         } catch {
             throw handleUnauthenticatedAndMap(error)
         }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -247,7 +247,7 @@ public class DDGSync: DDGSyncing {
         }
 
         do {
-            return try await dependencies.account.fetchDevicesForAccount(account)
+            try await dependencies.account.fetchDevicesForAccount(account).devices
         } catch {
             throw handleUnauthenticatedAndMap(error)
         }
@@ -321,6 +321,18 @@ public class DDGSync: DDGSyncing {
         return (refreshedKeyID: refreshedKey.kid,
                 reloadedKeyID: reloadedKey.kid,
                 keySizeInBits: SecKeyGetBlockSize(reloadedKey.publicKey) * 8)
+    }
+
+    public func fetchDevicesForDebug() async throws -> [RegisteredDeviceDebugInfo] {
+        guard let account = try dependencies.secureStore.account() else {
+            throw SyncError.accountNotFound
+        }
+
+        do {
+            return try await dependencies.account.fetchDevicesForAccount(account).debugDevices
+        } catch {
+            throw handleUnauthenticatedAndMap(error)
+        }
     }
 
     public func isDeviceInfoMigrationCompleteForDebug() throws -> Bool {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSyncing.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSyncing.swift
@@ -289,6 +289,8 @@ public protocol DDGSyncingDebuggingSupport {
     func ensureAccountInfoKeyForDebug() async throws -> Int
     /// Refreshes the account_info key and returns metadata from a subsequent cache-first reload.
     func validateAccountInfoKeyForDebug() async throws -> (refreshedKeyID: String, reloadedKeyID: String, keySizeInBits: Int)
+    /// Fetches devices through the production mapping path and includes the source used for each displayed device.
+    func fetchDevicesForDebug() async throws -> [RegisteredDeviceDebugInfo]
     func isDeviceInfoMigrationCompleteForDebug() throws -> Bool
     func runDeviceInfoMigrationForDebug() async throws
     func resetDeviceInfoMigrationForDebug()
@@ -303,6 +305,10 @@ public extension DDGSyncingDebuggingSupport {
         throw SyncError.accountNotFound
     }
 
+    func fetchDevicesForDebug() async throws -> [RegisteredDeviceDebugInfo] {
+        throw SyncError.accountNotFound
+    }
+
     func isDeviceInfoMigrationCompleteForDebug() throws -> Bool {
         throw SyncError.accountNotFound
     }
@@ -312,6 +318,19 @@ public extension DDGSyncingDebuggingSupport {
     }
 
     func resetDeviceInfoMigrationForDebug() {}
+}
+
+public struct RegisteredDeviceDebugInfo: Sendable {
+
+    public enum Source: String, Sendable {
+        case deviceInfo = "device_info"
+        case legacy
+        case placeholder
+    }
+
+    public let device: RegisteredDevice
+    public let source: Source
+    public let deviceInfoIssue: String?
 }
 
 public enum ServerEnvironment: LosslessStringConvertible {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -148,6 +148,7 @@ struct AccountManager: AccountManaging {
         guard let token = account.token else {
             throw SyncError.noToken
         }
+        let isUnifiedReadEnabled = canReadUnifiedDeviceList()
 
         let request = api.createAuthenticatedGetRequest(url: endpoints.devices, authToken: token)
         let result = try await request.execute()
@@ -168,8 +169,11 @@ struct AccountManager: AccountManaging {
             } else {
                 entries = result.devices?.entries ?? []
             }
-            let mappingResult = await registeredDeviceMapper.registeredDevicesWithRepairState(from: entries, account: account)
-            guard !canReadUnifiedDeviceList() else {
+            let mappingResult = await registeredDeviceMapper.registeredDevicesWithRepairState(
+                from: entries,
+                account: account,
+                isUnifiedReadEnabled: isUnifiedReadEnabled)
+            guard !isUnifiedReadEnabled else {
                 return mappingResult
             }
             return try await applyingLegacyDecryptFailureBehavior(to: mappingResult,
@@ -213,6 +217,7 @@ struct AccountManager: AccountManaging {
         guard let token = account.token else {
             throw SyncError.noToken
         }
+        let isUnifiedReadEnabled = canReadUnifiedDeviceList()
 
         let parameters = UpdateDevices.Parameters(updates: [update])
         let requestJSON = try JSONEncoder.snakeCaseKeys.encode(parameters)
@@ -232,12 +237,14 @@ struct AccountManager: AccountManaging {
 
         Logger.sync.debug("Sync-UnifiedDevices: device update PATCH succeeded")
         let entries: [RegisteredDeviceEntry]
-        if canReadUnifiedDeviceList(), !result.devicesV2.isEmpty {
+        if isUnifiedReadEnabled, !result.devicesV2.isEmpty {
             entries = result.devicesV2
         } else {
             entries = result.devices
         }
-        return await registeredDeviceMapper.registeredDevices(from: entries, account: account)
+        return await registeredDeviceMapper.registeredDevices(from: entries,
+                                                              account: account,
+                                                              isUnifiedReadEnabled: isUnifiedReadEnabled)
     }
 
     func refreshToken(_ account: SyncAccount, deviceName: String) async throws -> LoginResult {
@@ -298,6 +305,7 @@ struct AccountManager: AccountManaging {
                        deviceName: String,
                        deviceType: String) async throws -> LoginResult {
 
+        let isUnifiedReadEnabled = canReadUnifiedDeviceList()
         let encryptedDeviceName = try crypter.encryptAndBase64Encode(deviceName, using: info.primaryKey)
         let encryptedDeviceType = try crypter.encryptAndBase64Encode(deviceType, using: info.primaryKey)
 
@@ -342,10 +350,12 @@ struct AccountManager: AccountManaging {
                                   token: token,
                                   state: .addingNewDevice)
         let devices: [RegisteredDevice]
-        if canReadUnifiedDeviceList(),
+        if isUnifiedReadEnabled,
            let devicesV2 = result.devicesV2,
            !devicesV2.isEmpty {
-            devices = await registeredDeviceMapper.registeredDevices(from: devicesV2, account: account)
+            devices = await registeredDeviceMapper.registeredDevices(from: devicesV2,
+                                                                      account: account,
+                                                                      isUnifiedReadEnabled: isUnifiedReadEnabled)
         } else {
             devices = result.devices.compactMap { device in
                 registeredDeviceMapper.registeredDevice(fromDefaultCredentialLoginEntryWithID: device.id,

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -161,7 +161,8 @@ struct AccountManager: AccountManaging {
             throw SyncError.unableToDecodeResponse("Failed to decode devices")
         }
 
-        // Scoped access enabled: prefer entries_v2 so both native and 3party devices are represented.
+        // Scoped access enabled: never auto-logout. Prefer entries_v2; otherwise map legacy entries with
+        // decrypt-or-generic-fallback (undecryptable native -> "Unknown", undecryptable 3party -> "Browser").
         if isScopedAccessCredentialsEnabled() {
             let entries: [RegisteredDeviceEntry]
             if let entriesV2 = result.devices?.entriesV2, !entriesV2.isEmpty {
@@ -169,15 +170,10 @@ struct AccountManager: AccountManaging {
             } else {
                 entries = result.devices?.entries ?? []
             }
-            let mappingResult = await registeredDeviceMapper.registeredDevicesWithRepairState(
+            return await registeredDeviceMapper.registeredDevicesWithRepairState(
                 from: entries,
                 account: account,
                 isUnifiedReadEnabled: isUnifiedReadEnabled)
-            guard !isUnifiedReadEnabled else {
-                return mappingResult
-            }
-            return try await applyingLegacyDecryptFailureBehavior(to: mappingResult,
-                                                                  token: token)
         }
 
         // Legacy behaviour (scoped access disabled): invalid native devices are automatically logged out.
@@ -195,22 +191,6 @@ struct AccountManager: AccountManaging {
             devices: devices,
             needsCurrentDeviceInfoRepair: false,
             debugDevices: devices.map { RegisteredDeviceDebugInfo(device: $0, source: .legacy, deviceInfoIssue: nil) })
-    }
-
-    private func applyingLegacyDecryptFailureBehavior(to mappingResult: RegisteredDeviceMappingResult,
-                                                      token: String) async throws -> RegisteredDeviceMappingResult {
-        for deviceID in mappingResult.unresolvedNativeDeviceIDs {
-            try await logout(deviceId: deviceID, token: token)
-        }
-
-        let loggedOutDeviceIDs = Set(mappingResult.unresolvedNativeDeviceIDs)
-        guard !loggedOutDeviceIDs.isEmpty else {
-            return mappingResult
-        }
-        return RegisteredDeviceMappingResult(
-            devices: mappingResult.devices.filter { !loggedOutDeviceIDs.contains($0.id) },
-            needsCurrentDeviceInfoRepair: false,
-            debugDevices: mappingResult.debugDevices.filter { !loggedOutDeviceIDs.contains($0.device.id) })
     }
 
     func updateDevice(_ update: UpdateDevices.Update, for account: SyncAccount) async throws -> [RegisteredDevice] {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -29,6 +29,7 @@ struct AccountManager: AccountManaging {
     let api: RemoteAPIRequestCreating
     let crypter: CryptingInternal
     let registeredDeviceMapper: any RegisteredDeviceMapping
+    let accountInfoKeys: (any AccountInfoKeyManaging)?
     let accountInfoKeyFactory: AccountInfoKeyFactory
     let deviceInfoCodec: DeviceInfoCoding
     let isScopedAccessCredentialsEnabled: () -> Bool
@@ -39,6 +40,7 @@ struct AccountManager: AccountManaging {
          api: RemoteAPIRequestCreating,
          crypter: CryptingInternal,
          registeredDeviceMapper: (any RegisteredDeviceMapping)? = nil,
+         accountInfoKeys: (any AccountInfoKeyManaging)? = nil,
          accountInfoKeyFactory: AccountInfoKeyFactory? = nil,
          deviceInfoCodec: DeviceInfoCoding = DeviceInfoCodec(),
          isScopedAccessCredentialsEnabled: @escaping () -> Bool,
@@ -51,6 +53,7 @@ struct AccountManager: AccountManaging {
             crypter: crypter,
             isScopedAccessCredentialsEnabled: isScopedAccessCredentialsEnabled,
             canReadUnifiedDeviceList: canReadUnifiedDeviceList)
+        self.accountInfoKeys = accountInfoKeys
         self.accountInfoKeyFactory = accountInfoKeyFactory ?? DefaultAccountInfoKeyFactory(crypter: crypter)
         self.deviceInfoCodec = deviceInfoCodec
         self.isScopedAccessCredentialsEnabled = isScopedAccessCredentialsEnabled
@@ -333,6 +336,21 @@ struct AccountManager: AccountManaging {
         if isUnifiedReadEnabled,
            let devicesV2 = result.devicesV2,
            !devicesV2.isEmpty {
+            if devicesV2.contains(where: { $0.info != nil }),
+               let accountInfoKeys,
+               let protectedKeys = result.keys,
+               !protectedKeys.isEmpty {
+                do {
+                    // Preloading uses only login response data; normal key loading handles missing credentials.
+                    try await accountInfoKeys.preloadKey(from: protectedKeys,
+                                                         accessCredentials: result.accessCredentials ?? [],
+                                                         for: account)
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    // Device info remains additive; normal key loading can still use cached or refreshed keys.
+                }
+            }
             devices = await registeredDeviceMapper.registeredDevices(from: devicesV2,
                                                                       account: account,
                                                                       isUnifiedReadEnabled: isUnifiedReadEnabled)

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -33,6 +33,7 @@ struct AccountManager: AccountManaging {
     let deviceInfoCodec: DeviceInfoCoding
     let isScopedAccessCredentialsEnabled: () -> Bool
     let canWriteUnifiedDeviceList: () -> Bool
+    let canReadUnifiedDeviceList: () -> Bool
 
     init(endpoints: Endpoints,
          api: RemoteAPIRequestCreating,
@@ -41,16 +42,20 @@ struct AccountManager: AccountManaging {
          accountInfoKeyFactory: AccountInfoKeyFactory? = nil,
          deviceInfoCodec: DeviceInfoCoding = DeviceInfoCodec(),
          isScopedAccessCredentialsEnabled: @escaping () -> Bool,
-         canWriteUnifiedDeviceList: @escaping () -> Bool = { false }) {
+         canWriteUnifiedDeviceList: @escaping () -> Bool = { false },
+         canReadUnifiedDeviceList: @escaping () -> Bool = { false }) {
         self.endpoints = endpoints
         self.api = api
         self.crypter = crypter
-        self.registeredDeviceMapper = registeredDeviceMapper ?? RegisteredDeviceMapper(crypter: crypter,
-                                                                                       isScopedAccessCredentialsEnabled: isScopedAccessCredentialsEnabled)
+        self.registeredDeviceMapper = registeredDeviceMapper ?? RegisteredDeviceMapper(
+            crypter: crypter,
+            isScopedAccessCredentialsEnabled: isScopedAccessCredentialsEnabled,
+            canReadUnifiedDeviceList: canReadUnifiedDeviceList)
         self.accountInfoKeyFactory = accountInfoKeyFactory ?? DefaultAccountInfoKeyFactory(crypter: crypter)
         self.deviceInfoCodec = deviceInfoCodec
         self.isScopedAccessCredentialsEnabled = isScopedAccessCredentialsEnabled
         self.canWriteUnifiedDeviceList = canWriteUnifiedDeviceList
+        self.canReadUnifiedDeviceList = canReadUnifiedDeviceList
     }
 
     func createAccount(deviceName: String, deviceType: String) async throws -> SyncAccount {
@@ -181,7 +186,7 @@ struct AccountManager: AccountManaging {
         return devices
     }
 
-    func updateDevice(_ update: UpdateDevices.Update, for account: SyncAccount) async throws -> UpdateDevices.Result {
+    func updateDevice(_ update: UpdateDevices.Update, for account: SyncAccount) async throws -> [RegisteredDevice] {
         guard let token = account.token else {
             throw SyncError.noToken
         }
@@ -203,7 +208,13 @@ struct AccountManager: AccountManaging {
         }
 
         Logger.sync.debug("Sync-UnifiedDevices: device update PATCH succeeded")
-        return result
+        let entries: [RegisteredDeviceEntry]
+        if canReadUnifiedDeviceList(), !result.devicesV2.isEmpty {
+            entries = result.devicesV2
+        } else {
+            entries = result.devices
+        }
+        return await registeredDeviceMapper.registeredDevices(from: entries, account: account)
     }
 
     func refreshToken(_ account: SyncAccount, deviceName: String) async throws -> LoginResult {
@@ -299,26 +310,32 @@ struct AccountManager: AccountManaging {
         let secretKey = try crypter.extractSecretKey(protectedSecretKey: protectedSecretKey,
                                                      stretchedPrimaryKey: info.stretchedPrimaryKey)
 
-        return LoginResult(
-            account: SyncAccount(
-                deviceId: deviceId,
-                deviceName: deviceName,
-                deviceType: deviceType,
-                userId: info.userId,
-                primaryKey: info.primaryKey,
-                secretKey: secretKey,
-                token: token,
-                state: .addingNewDevice
-            ),
-            devices: result.devices.compactMap { device in
+        let account = SyncAccount(deviceId: deviceId,
+                                  deviceName: deviceName,
+                                  deviceType: deviceType,
+                                  userId: info.userId,
+                                  primaryKey: info.primaryKey,
+                                  secretKey: secretKey,
+                                  token: token,
+                                  state: .addingNewDevice)
+        let devices: [RegisteredDevice]
+        if canReadUnifiedDeviceList(),
+           let devicesV2 = result.devicesV2,
+           !devicesV2.isEmpty {
+            devices = await registeredDeviceMapper.registeredDevices(from: devicesV2, account: account)
+        } else {
+            devices = result.devices.compactMap { device in
                 registeredDeviceMapper.registeredDevice(fromDefaultCredentialLoginEntryWithID: device.id,
                                                         encryptedName: device.name,
                                                         encryptedType: device.type,
                                                         primaryKey: info.primaryKey)
-            },
-            keys: result.keys,
-            accessCredentials: result.accessCredentials
-        )
+            }
+        }
+
+        return LoginResult(account: account,
+                           devices: devices,
+                           keys: result.keys,
+                           accessCredentials: result.accessCredentials)
 
     }
 
@@ -346,6 +363,7 @@ struct AccountManager: AccountManaging {
 
         struct Result: Decodable {
             let devices: [Device]
+            let devicesV2: [RegisteredDeviceEntry]?
             let token: String
             let protectedEncryptionKey: String
             let accessCredentials: [AccessCredential]?

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -144,7 +144,7 @@ struct AccountManager: AccountManaging {
         }
     }
 
-    func fetchDevicesForAccount(_ account: SyncAccount) async throws -> [RegisteredDevice] {
+    func fetchDevicesForAccount(_ account: SyncAccount) async throws -> RegisteredDeviceMappingResult {
         guard let token = account.token else {
             throw SyncError.noToken
         }
@@ -169,7 +169,7 @@ struct AccountManager: AccountManaging {
             } else {
                 entries = result.devices?.entries ?? []
             }
-            return await registeredDeviceMapper.registeredDevices(from: entries, account: account)
+            return await registeredDeviceMapper.registeredDevicesWithRepairState(from: entries, account: account)
         }
 
         // Legacy behaviour (scoped access disabled): invalid native devices are automatically logged out.
@@ -183,7 +183,10 @@ struct AccountManager: AccountManaging {
                 }
             }
         }
-        return devices
+        return RegisteredDeviceMappingResult(
+            devices: devices,
+            needsCurrentDeviceInfoRepair: false,
+            debugDevices: devices.map { RegisteredDeviceDebugInfo(device: $0, source: .legacy, deviceInfoIssue: nil) })
     }
 
     func updateDevice(_ update: UpdateDevices.Update, for account: SyncAccount) async throws -> [RegisteredDevice] {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -160,8 +160,7 @@ struct AccountManager: AccountManaging {
             throw SyncError.unableToDecodeResponse("Failed to decode devices")
         }
 
-        // Scoped access enabled: never auto-logout. Prefer entries_v2; otherwise map legacy entries with
-        // decrypt-or-generic-fallback (undecryptable native -> "Unknown", undecryptable 3party -> "Browser").
+        // Scoped access enabled: prefer entries_v2 so both native and 3party devices are represented.
         if isScopedAccessCredentialsEnabled() {
             let entries: [RegisteredDeviceEntry]
             if let entriesV2 = result.devices?.entriesV2, !entriesV2.isEmpty {
@@ -169,7 +168,12 @@ struct AccountManager: AccountManaging {
             } else {
                 entries = result.devices?.entries ?? []
             }
-            return await registeredDeviceMapper.registeredDevicesWithRepairState(from: entries, account: account)
+            let mappingResult = await registeredDeviceMapper.registeredDevicesWithRepairState(from: entries, account: account)
+            guard !canReadUnifiedDeviceList() else {
+                return mappingResult
+            }
+            return try await applyingLegacyDecryptFailureBehavior(to: mappingResult,
+                                                                  token: token)
         }
 
         // Legacy behaviour (scoped access disabled): invalid native devices are automatically logged out.
@@ -187,6 +191,22 @@ struct AccountManager: AccountManaging {
             devices: devices,
             needsCurrentDeviceInfoRepair: false,
             debugDevices: devices.map { RegisteredDeviceDebugInfo(device: $0, source: .legacy, deviceInfoIssue: nil) })
+    }
+
+    private func applyingLegacyDecryptFailureBehavior(to mappingResult: RegisteredDeviceMappingResult,
+                                                      token: String) async throws -> RegisteredDeviceMappingResult {
+        for deviceID in mappingResult.unresolvedNativeDeviceIDs {
+            try await logout(deviceId: deviceID, token: token)
+        }
+
+        let loggedOutDeviceIDs = Set(mappingResult.unresolvedNativeDeviceIDs)
+        guard !loggedOutDeviceIDs.isEmpty else {
+            return mappingResult
+        }
+        return RegisteredDeviceMappingResult(
+            devices: mappingResult.devices.filter { !loggedOutDeviceIDs.contains($0.id) },
+            needsCurrentDeviceInfoRepair: false,
+            debugDevices: mappingResult.debugDevices.filter { !loggedOutDeviceIDs.contains($0.device.id) })
     }
 
     func updateDevice(_ update: UpdateDevices.Update, for account: SyncAccount) async throws -> [RegisteredDevice] {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoCodec.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoCodec.swift
@@ -29,6 +29,7 @@ struct DeviceInfo: Codable, Equatable, Sendable {
 enum DeviceInfoCodecError: Error, Equatable {
     case invalidProtectedKey
     case invalidPayload
+    case unexpectedKeyID
 }
 
 protocol DeviceInfoCoding {
@@ -53,9 +54,14 @@ struct DeviceInfoCodec: DeviceInfoCoding {
     }
 
     func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKey) throws -> DeviceInfo {
-        let payload = try jweCompactCodec.decryptRSAOAEP256(token: encryptedDeviceInfo,
+        let payload: Data
+        do {
+            payload = try jweCompactCodec.decryptRSAOAEP256(token: encryptedDeviceInfo,
                                                            privateKey: key.privateKey,
                                                            expectedKid: key.kid)
+        } catch JWECompactCodecError.unexpectedKeyID {
+            throw DeviceInfoCodecError.unexpectedKeyID
+        }
         do {
             return try JSONDecoder().decode(DeviceInfo.self, from: payload)
         } catch {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/JWECompactCodec.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/JWECompactCodec.swift
@@ -24,6 +24,7 @@ enum JWECompactCodecError: Error, Equatable {
     case invalidDirectTokenShape
     case invalidBase64URLComponent
     case unsupportedProtectedHeader
+    case unexpectedKeyID
     case invalidDirectProtectedHeaderKid
     case invalidPublicKey
     case invalidPrivateKey
@@ -143,7 +144,7 @@ final class JWECompactCodec {
         let components = try decodeCompactToken(token)
         let protectedHeader = try decodeRSAOAEP256ProtectedHeader(components.protectedHeader)
         if let expectedKid, protectedHeader.kid != expectedKid {
-            throw JWECompactCodecError.unsupportedProtectedHeader
+            throw JWECompactCodecError.unexpectedKeyID
         }
 
         let contentEncryptionKey = try decryptContentEncryptionKey(components.encryptedContentEncryptionKey, privateKey: privateKey)

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2MessageCrypto.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/PairingV2/PairingV2MessageCrypto.swift
@@ -196,6 +196,7 @@ final class PairingV2MessageCrypto {
         case .invalidBase64URLComponent:
             return .invalidBase64URLComponent
         case .unsupportedProtectedHeader,
+                .unexpectedKeyID,
                 .invalidDirectTokenShape,
                 .invalidDirectProtectedHeaderKid:
             return .unsupportedProtectedHeader

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -91,18 +91,24 @@ struct ProductionDependencies: SyncDependencies {
                                                          crypter: crypter,
                                                          accountInfoKeyFactory: accountInfoKeyFactory,
                                                          canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() })
-        accountInfoKeys = AccountInfoKeyManager(secureStore: secureStore,
-                                                scopedAccess: scopedAccess,
-                                                crypter: crypter)
+        let accountInfoKeyManager = AccountInfoKeyManager(secureStore: secureStore,
+                                                          scopedAccess: scopedAccess,
+                                                          crypter: crypter)
+        accountInfoKeys = accountInfoKeyManager
+        let deviceInfoCodec = DeviceInfoCodec()
         let registeredDeviceMapper = RegisteredDeviceMapper(crypter: crypter,
                                                             scopedAccess: scopedAccess,
+                                                            accountInfoKeys: accountInfoKeyManager,
+                                                            deviceInfoCodec: deviceInfoCodec,
                                                             cachedScopedPassword: secureStore.scopedPassword,
-                                                            isScopedAccessCredentialsEnabled: { syncFeatureFlags.isScopedAccessCredentialsEnabled() })
+                                                            isScopedAccessCredentialsEnabled: { syncFeatureFlags.isScopedAccessCredentialsEnabled() },
+                                                            canReadUnifiedDeviceList: { syncFeatureFlags.canReadUnifiedDeviceList() })
         account = AccountManager(endpoints: endpoints,
                                  api: api,
                                  crypter: crypter,
                                  registeredDeviceMapper: registeredDeviceMapper,
                                  accountInfoKeyFactory: accountInfoKeyFactory,
+                                 deviceInfoCodec: deviceInfoCodec,
                                  isScopedAccessCredentialsEnabled: { syncFeatureFlags.isScopedAccessCredentialsEnabled() },
                                  canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() })
         self.scopedAccess = scopedAccess

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -110,7 +110,8 @@ struct ProductionDependencies: SyncDependencies {
                                  accountInfoKeyFactory: accountInfoKeyFactory,
                                  deviceInfoCodec: deviceInfoCodec,
                                  isScopedAccessCredentialsEnabled: { syncFeatureFlags.isScopedAccessCredentialsEnabled() },
-                                 canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() })
+                                 canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() },
+                                 canReadUnifiedDeviceList: { syncFeatureFlags.canReadUnifiedDeviceList() })
         self.scopedAccess = scopedAccess
         scheduler = SyncScheduler()
     }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -107,6 +107,7 @@ struct ProductionDependencies: SyncDependencies {
                                  api: api,
                                  crypter: crypter,
                                  registeredDeviceMapper: registeredDeviceMapper,
+                                 accountInfoKeys: accountInfoKeyManager,
                                  accountInfoKeyFactory: accountInfoKeyFactory,
                                  deviceInfoCodec: deviceInfoCodec,
                                  isScopedAccessCredentialsEnabled: { syncFeatureFlags.isScopedAccessCredentialsEnabled() },

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -50,6 +50,7 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
 
     private struct MappingAttempt {
         let device: RegisteredDevice
+        let usedUnifiedDeviceInfo: Bool
         let unifiedDeviceInfoFailure: UnifiedDeviceInfoFailure?
     }
 
@@ -85,26 +86,30 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
         let accountInfoKey = await accountInfoKeyIfNeeded(for: entries,
                                                           account: account,
                                                           isUnifiedReadEnabled: isUnifiedReadEnabled)
-        let thirdPartyMainKey = await thirdPartyMainKeyIfNeeded(for: entries, account: account)
         let initialMappings = entries.map {
             registeredDevice(from: $0,
                              account: account,
                              accountInfoKey: accountInfoKey,
-                             thirdPartyMainKey: thirdPartyMainKey,
+                             thirdPartyMainKey: nil,
                              isUnifiedReadEnabled: isUnifiedReadEnabled)
         }
-        guard initialMappings.contains(where: { $0.unifiedDeviceInfoFailure == .staleKey }),
-              let accountInfoKeys,
-              let refreshedAccountInfoKey = try? await accountInfoKeys.refreshKey(for: account) else {
-            return initialMappings.map(\.device)
+        let finalMappings: [MappingAttempt]
+        if initialMappings.contains(where: { $0.unifiedDeviceInfoFailure == .staleKey }),
+           let accountInfoKeys,
+           let refreshedAccountInfoKey = try? await accountInfoKeys.refreshKey(for: account) {
+            finalMappings = entries.map {
+                registeredDevice(from: $0,
+                                 account: account,
+                                 accountInfoKey: refreshedAccountInfoKey,
+                                 thirdPartyMainKey: nil,
+                                 isUnifiedReadEnabled: isUnifiedReadEnabled)
+            }
+        } else {
+            finalMappings = initialMappings
         }
-        return entries.map {
-            registeredDevice(from: $0,
-                             account: account,
-                             accountInfoKey: refreshedAccountInfoKey,
-                             thirdPartyMainKey: thirdPartyMainKey,
-                             isUnifiedReadEnabled: isUnifiedReadEnabled).device
-        }
+        return await devicesApplyingThirdPartyFallback(to: finalMappings,
+                                                       entries: entries,
+                                                       account: account)
     }
 
     func registeredDevice(fromLegacyEntry entry: RegisteredDeviceEntry, account: SyncAccount) -> RegisteredDevice? {
@@ -144,6 +149,7 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
                                          name: deviceInfo.name,
                                          type: deviceInfo.type,
                                          credentialId: entry.credentialId ?? SyncCredentialID.defaultCredential),
+                usedUnifiedDeviceInfo: true,
                 unifiedDeviceInfoFailure: nil)
         }
 
@@ -156,7 +162,31 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
         } else {
             failure = nil
         }
-        return MappingAttempt(device: device, unifiedDeviceInfoFailure: failure)
+        return MappingAttempt(device: device,
+                              usedUnifiedDeviceInfo: false,
+                              unifiedDeviceInfoFailure: failure)
+    }
+
+    private func devicesApplyingThirdPartyFallback(to mappings: [MappingAttempt],
+                                                   entries: [RegisteredDeviceEntry],
+                                                   account: SyncAccount) async -> [RegisteredDevice] {
+        let fallbackEntryIndices = entries.indices.filter {
+            entries[$0].credentialId == SyncCredentialID.thirdParty
+                && !mappings[$0].usedUnifiedDeviceInfo
+        }
+        let fallbackEntries = fallbackEntryIndices.map { entries[$0] }
+        guard !fallbackEntries.isEmpty,
+              let thirdPartyMainKey = await thirdPartyMainKeyIfNeeded(for: fallbackEntries, account: account) else {
+            return mappings.map(\.device)
+        }
+
+        var devices = mappings.map(\.device)
+        for index in fallbackEntryIndices {
+            let entry = entries[index]
+            devices[index] = decryptedThirdPartyRegisteredDevice(from: entry, thirdPartyMainKey: thirdPartyMainKey)
+                ?? fallbackRegisteredDevice(from: entry)
+        }
+        return devices
     }
 
     private func readUnifiedDeviceInfo(from entry: RegisteredDeviceEntry,

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -39,7 +39,8 @@ struct RegisteredDeviceMappingResult {
 
 protocol RegisteredDeviceMapping {
     func registeredDevicesWithRepairState(from entries: [RegisteredDeviceEntry],
-                                          account: SyncAccount) async -> RegisteredDeviceMappingResult
+                                          account: SyncAccount,
+                                          isUnifiedReadEnabled: Bool) async -> RegisteredDeviceMappingResult
     func registeredDevice(fromLegacyEntry entry: RegisteredDeviceEntry, account: SyncAccount) -> RegisteredDevice?
     func registeredDevice(fromDefaultCredentialLoginEntryWithID id: String,
                           encryptedName: String,
@@ -48,8 +49,12 @@ protocol RegisteredDeviceMapping {
 }
 
 extension RegisteredDeviceMapping {
-    func registeredDevices(from entries: [RegisteredDeviceEntry], account: SyncAccount) async -> [RegisteredDevice] {
-        await registeredDevicesWithRepairState(from: entries, account: account).devices
+    func registeredDevices(from entries: [RegisteredDeviceEntry],
+                           account: SyncAccount,
+                           isUnifiedReadEnabled: Bool) async -> [RegisteredDevice] {
+        await registeredDevicesWithRepairState(from: entries,
+                                               account: account,
+                                               isUnifiedReadEnabled: isUnifiedReadEnabled).devices
     }
 }
 
@@ -131,7 +136,18 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
 
     func registeredDevicesWithRepairState(from entries: [RegisteredDeviceEntry],
                                           account: SyncAccount) async -> RegisteredDeviceMappingResult {
-        let isUnifiedReadEnabled = canReadUnifiedDeviceList()
+        await registeredDevicesWithRepairState(from: entries,
+                                               account: account,
+                                               isUnifiedReadEnabled: canReadUnifiedDeviceList())
+    }
+
+    func registeredDevices(from entries: [RegisteredDeviceEntry], account: SyncAccount) async -> [RegisteredDevice] {
+        await registeredDevicesWithRepairState(from: entries, account: account).devices
+    }
+
+    func registeredDevicesWithRepairState(from entries: [RegisteredDeviceEntry],
+                                          account: SyncAccount,
+                                          isUnifiedReadEnabled: Bool) async -> RegisteredDeviceMappingResult {
         let accountInfoKey = await accountInfoKeyIfNeeded(for: entries,
                                                           account: account,
                                                           isUnifiedReadEnabled: isUnifiedReadEnabled)

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -132,7 +132,7 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
 
     private func registeredDevice(from entry: RegisteredDeviceEntry,
                                   account: SyncAccount,
-                                  accountInfoKey: AccountInfoKeyMaterial?,
+                                  accountInfoKey: AccountInfoKey?,
                                   thirdPartyMainKey: Data?,
                                   isUnifiedReadEnabled: Bool) -> MappingAttempt {
         let unifiedDeviceInfo = readUnifiedDeviceInfo(from: entry,
@@ -160,7 +160,7 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
     }
 
     private func readUnifiedDeviceInfo(from entry: RegisteredDeviceEntry,
-                                       accountInfoKey: AccountInfoKeyMaterial?,
+                                       accountInfoKey: AccountInfoKey?,
                                        isUnifiedReadEnabled: Bool) -> UnifiedDeviceInfoReadResult {
         guard isUnifiedReadEnabled else {
             return .notAttempted
@@ -236,7 +236,7 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
 
     private func accountInfoKeyIfNeeded(for entries: [RegisteredDeviceEntry],
                                         account: SyncAccount,
-                                        isUnifiedReadEnabled: Bool) async -> AccountInfoKeyMaterial? {
+                                        isUnifiedReadEnabled: Bool) async -> AccountInfoKey? {
         guard isUnifiedReadEnabled,
               entries.contains(where: { $0.info != nil }),
               let accountInfoKeys else {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -37,19 +37,28 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
 
     let crypter: CryptingInternal
     let scopedAccess: ScopedAccessCredentialManaging?
+    let accountInfoKeys: AccountInfoKeyManaging?
+    let deviceInfoCodec: DeviceInfoCoding
     let cachedScopedPassword: () throws -> Data?
     let isScopedAccessCredentialsEnabled: () -> Bool
+    let canReadUnifiedDeviceList: () -> Bool
     private let jweCompactCodec: JWECompactCodec
 
     init(crypter: CryptingInternal,
          scopedAccess: ScopedAccessCredentialManaging? = nil,
+         accountInfoKeys: AccountInfoKeyManaging? = nil,
+         deviceInfoCodec: DeviceInfoCoding = DeviceInfoCodec(),
          cachedScopedPassword: @escaping () throws -> Data? = { nil },
          isScopedAccessCredentialsEnabled: @escaping () -> Bool,
+         canReadUnifiedDeviceList: @escaping () -> Bool = { false },
          jweCompactCodec: JWECompactCodec = JWECompactCodec()) {
         self.crypter = crypter
         self.scopedAccess = scopedAccess
+        self.accountInfoKeys = accountInfoKeys
+        self.deviceInfoCodec = deviceInfoCodec
         self.cachedScopedPassword = cachedScopedPassword
         self.isScopedAccessCredentialsEnabled = isScopedAccessCredentialsEnabled
+        self.canReadUnifiedDeviceList = canReadUnifiedDeviceList
         self.jweCompactCodec = jweCompactCodec
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -63,8 +63,14 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
     }
 
     func registeredDevices(from entries: [RegisteredDeviceEntry], account: SyncAccount) async -> [RegisteredDevice] {
+        let accountInfoKey = await accountInfoKeyIfNeeded(for: entries, account: account)
         let thirdPartyMainKey = await thirdPartyMainKeyIfNeeded(for: entries, account: account)
-        return entries.map { registeredDevice(from: $0, account: account, thirdPartyMainKey: thirdPartyMainKey) }
+        return entries.map {
+            registeredDevice(from: $0,
+                             account: account,
+                             accountInfoKey: accountInfoKey,
+                             thirdPartyMainKey: thirdPartyMainKey)
+        }
     }
 
     func registeredDevice(fromLegacyEntry entry: RegisteredDeviceEntry, account: SyncAccount) -> RegisteredDevice? {
@@ -90,12 +96,34 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
                                                          credentialId: SyncCredentialID.defaultCredential)
     }
 
-    private func registeredDevice(from entry: RegisteredDeviceEntry, account: SyncAccount, thirdPartyMainKey: Data?) -> RegisteredDevice {
+    private func registeredDevice(from entry: RegisteredDeviceEntry,
+                                  account: SyncAccount,
+                                  accountInfoKey: AccountInfoKeyMaterial?,
+                                  thirdPartyMainKey: Data?) -> RegisteredDevice {
         // Keep every server entry visible even if one encrypted field is malformed or uses a key we cannot recover.
-        decryptedRegisteredDevice(from: entry, account: account, thirdPartyMainKey: thirdPartyMainKey) ?? fallbackRegisteredDevice(from: entry)
+        return decryptedUnifiedRegisteredDevice(from: entry, accountInfoKey: accountInfoKey)
+            ?? decryptedLegacyRegisteredDevice(from: entry, account: account, thirdPartyMainKey: thirdPartyMainKey)
+            ?? fallbackRegisteredDevice(from: entry)
     }
 
-    private func decryptedRegisteredDevice(from entry: RegisteredDeviceEntry, account: SyncAccount, thirdPartyMainKey: Data?) -> RegisteredDevice? {
+    private func decryptedUnifiedRegisteredDevice(from entry: RegisteredDeviceEntry,
+                                                  accountInfoKey: AccountInfoKeyMaterial?) -> RegisteredDevice? {
+        guard canReadUnifiedDeviceList(),
+              let accountInfoKey,
+              let encryptedDeviceInfo = entry.info,
+              let deviceInfo = try? deviceInfoCodec.decrypt(encryptedDeviceInfo, using: accountInfoKey) else {
+            return nil
+        }
+
+        return RegisteredDevice(id: entry.id,
+                                name: deviceInfo.name,
+                                type: deviceInfo.type,
+                                credentialId: entry.credentialId ?? SyncCredentialID.defaultCredential)
+    }
+
+    private func decryptedLegacyRegisteredDevice(from entry: RegisteredDeviceEntry,
+                                                 account: SyncAccount,
+                                                 thirdPartyMainKey: Data?) -> RegisteredDevice? {
         switch entry.credentialId {
         case SyncCredentialID.thirdParty:
             return decryptedThirdPartyRegisteredDevice(from: entry, thirdPartyMainKey: thirdPartyMainKey)
@@ -145,6 +173,15 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
 
         // 3party device fields are direct JWE plaintext strings, not base64-wrapped values.
         return String(data: plaintext, encoding: .utf8)
+    }
+
+    private func accountInfoKeyIfNeeded(for entries: [RegisteredDeviceEntry], account: SyncAccount) async -> AccountInfoKeyMaterial? {
+        guard canReadUnifiedDeviceList(),
+              entries.contains(where: { $0.info != nil }),
+              let accountInfoKeys else {
+            return nil
+        }
+        return try? await accountInfoKeys.loadKey(for: account)
     }
 
     private func thirdPartyMainKeyIfNeeded(for entries: [RegisteredDeviceEntry], account: SyncAccount) async -> Data? {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -19,13 +19,34 @@
 import Foundation
 import os.log
 
+struct RegisteredDeviceMappingResult {
+    let devices: [RegisteredDevice]
+    let needsCurrentDeviceInfoRepair: Bool
+    let debugDevices: [RegisteredDeviceDebugInfo]
+
+    init(devices: [RegisteredDevice],
+         needsCurrentDeviceInfoRepair: Bool,
+         debugDevices: [RegisteredDeviceDebugInfo] = []) {
+        self.devices = devices
+        self.needsCurrentDeviceInfoRepair = needsCurrentDeviceInfoRepair
+        self.debugDevices = debugDevices
+    }
+}
+
 protocol RegisteredDeviceMapping {
-    func registeredDevices(from entries: [RegisteredDeviceEntry], account: SyncAccount) async -> [RegisteredDevice]
+    func registeredDevicesWithRepairState(from entries: [RegisteredDeviceEntry],
+                                          account: SyncAccount) async -> RegisteredDeviceMappingResult
     func registeredDevice(fromLegacyEntry entry: RegisteredDeviceEntry, account: SyncAccount) -> RegisteredDevice?
     func registeredDevice(fromDefaultCredentialLoginEntryWithID id: String,
                           encryptedName: String,
                           encryptedType: String?,
                           primaryKey: Data) -> RegisteredDevice?
+}
+
+extension RegisteredDeviceMapping {
+    func registeredDevices(from entries: [RegisteredDeviceEntry], account: SyncAccount) async -> [RegisteredDevice] {
+        await registeredDevicesWithRepairState(from: entries, account: account).devices
+    }
 }
 
 /// Maps raw Sync device payloads into app-facing devices without hiding entries that cannot be decrypted locally.
@@ -40,6 +61,15 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
         case keyUnavailable
         case staleKey
         case corrupt
+
+        var description: String {
+            switch self {
+            case .missing: return "Missing device_info"
+            case .keyUnavailable: return "account_info key unavailable"
+            case .staleKey: return "device_info uses a different account_info key"
+            case .corrupt: return "Unable to decrypt device_info"
+            }
+        }
     }
 
     private enum UnifiedDeviceInfoReadResult {
@@ -50,7 +80,7 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
 
     private struct MappingAttempt {
         let device: RegisteredDevice
-        let usedUnifiedDeviceInfo: Bool
+        let source: RegisteredDeviceDebugInfo.Source
         let unifiedDeviceInfoFailure: UnifiedDeviceInfoFailure?
     }
 
@@ -81,7 +111,8 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
         self.jweCompactCodec = jweCompactCodec
     }
 
-    func registeredDevices(from entries: [RegisteredDeviceEntry], account: SyncAccount) async -> [RegisteredDevice] {
+    func registeredDevicesWithRepairState(from entries: [RegisteredDeviceEntry],
+                                          account: SyncAccount) async -> RegisteredDeviceMappingResult {
         let isUnifiedReadEnabled = canReadUnifiedDeviceList()
         let accountInfoKey = await accountInfoKeyIfNeeded(for: entries,
                                                           account: account,
@@ -107,9 +138,19 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
         } else {
             finalMappings = initialMappings
         }
-        return await devicesApplyingThirdPartyFallback(to: finalMappings,
-                                                       entries: entries,
-                                                       account: account)
+        let resolvedMappings = await mappingsApplyingThirdPartyFallback(to: finalMappings,
+                                                                        entries: entries,
+                                                                        account: account)
+        return RegisteredDeviceMappingResult(
+            devices: resolvedMappings.map(\.device),
+            needsCurrentDeviceInfoRepair: needsCurrentDeviceInfoRepair(in: resolvedMappings,
+                                                                       entries: entries,
+                                                                       account: account),
+            debugDevices: resolvedMappings.map {
+                RegisteredDeviceDebugInfo(device: $0.device,
+                                          source: $0.source,
+                                          deviceInfoIssue: $0.unifiedDeviceInfoFailure?.description)
+            })
     }
 
     func registeredDevice(fromLegacyEntry entry: RegisteredDeviceEntry, account: SyncAccount) -> RegisteredDevice? {
@@ -149,13 +190,13 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
                                          name: deviceInfo.name,
                                          type: deviceInfo.type,
                                          credentialId: entry.credentialId ?? SyncCredentialID.defaultCredential),
-                usedUnifiedDeviceInfo: true,
+                source: .deviceInfo,
                 unifiedDeviceInfoFailure: nil)
         }
 
         // Keep every server entry visible even if one encrypted field is malformed or uses a key we cannot recover.
-        let device = decryptedLegacyRegisteredDevice(from: entry, account: account, thirdPartyMainKey: thirdPartyMainKey)
-            ?? fallbackRegisteredDevice(from: entry)
+        let legacyDevice = decryptedLegacyRegisteredDevice(from: entry, account: account, thirdPartyMainKey: thirdPartyMainKey)
+        let device = legacyDevice ?? fallbackRegisteredDevice(from: entry)
         let failure: UnifiedDeviceInfoFailure?
         if case .failed(let unifiedDeviceInfoFailure) = unifiedDeviceInfo {
             failure = unifiedDeviceInfoFailure
@@ -163,30 +204,53 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
             failure = nil
         }
         return MappingAttempt(device: device,
-                              usedUnifiedDeviceInfo: false,
+                              source: legacyDevice == nil ? .placeholder : .legacy,
                               unifiedDeviceInfoFailure: failure)
     }
 
-    private func devicesApplyingThirdPartyFallback(to mappings: [MappingAttempt],
-                                                   entries: [RegisteredDeviceEntry],
-                                                   account: SyncAccount) async -> [RegisteredDevice] {
+    private func mappingsApplyingThirdPartyFallback(to mappings: [MappingAttempt],
+                                                    entries: [RegisteredDeviceEntry],
+                                                    account: SyncAccount) async -> [MappingAttempt] {
         let fallbackEntryIndices = entries.indices.filter {
             entries[$0].credentialId == SyncCredentialID.thirdParty
-                && !mappings[$0].usedUnifiedDeviceInfo
+                && mappings[$0].source != .deviceInfo
         }
         let fallbackEntries = fallbackEntryIndices.map { entries[$0] }
         guard !fallbackEntries.isEmpty,
               let thirdPartyMainKey = await thirdPartyMainKeyIfNeeded(for: fallbackEntries, account: account) else {
-            return mappings.map(\.device)
+            return mappings
         }
 
-        var devices = mappings.map(\.device)
+        var mappings = mappings
         for index in fallbackEntryIndices {
             let entry = entries[index]
-            devices[index] = decryptedThirdPartyRegisteredDevice(from: entry, thirdPartyMainKey: thirdPartyMainKey)
-                ?? fallbackRegisteredDevice(from: entry)
+            guard let device = decryptedThirdPartyRegisteredDevice(from: entry, thirdPartyMainKey: thirdPartyMainKey) else {
+                continue
+            }
+            mappings[index] = MappingAttempt(device: device,
+                                             source: .legacy,
+                                             unifiedDeviceInfoFailure: mappings[index].unifiedDeviceInfoFailure)
         }
-        return devices
+        return mappings
+    }
+
+    private func needsCurrentDeviceInfoRepair(in mappings: [MappingAttempt],
+                                              entries: [RegisteredDeviceEntry],
+                                              account: SyncAccount) -> Bool {
+        zip(entries, mappings).contains { entry, mapping in
+            guard entry.id == account.deviceId else {
+                return false
+            }
+            guard let failure = mapping.unifiedDeviceInfoFailure else {
+                return false
+            }
+            switch failure {
+            case .missing, .staleKey, .corrupt:
+                return true
+            case .keyUnavailable:
+                return false
+            }
+        }
     }
 
     private func readUnifiedDeviceInfo(from entry: RegisteredDeviceEntry,

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -22,17 +22,14 @@ import os.log
 struct RegisteredDeviceMappingResult {
     let devices: [RegisteredDevice]
     let needsCurrentDeviceInfoRepair: Bool
-    let unresolvedNativeDeviceIDs: [String]
     // Diagnostics for the Sync debug UI only; not used to drive device-list behaviour.
     let debugDevices: [RegisteredDeviceDebugInfo]
 
     init(devices: [RegisteredDevice],
          needsCurrentDeviceInfoRepair: Bool,
-         unresolvedNativeDeviceIDs: [String] = [],
          debugDevices: [RegisteredDeviceDebugInfo] = []) {
         self.devices = devices
         self.needsCurrentDeviceInfoRepair = needsCurrentDeviceInfoRepair
-        self.unresolvedNativeDeviceIDs = unresolvedNativeDeviceIDs
         self.debugDevices = debugDevices
     }
 }
@@ -180,13 +177,6 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
             needsCurrentDeviceInfoRepair: needsCurrentDeviceInfoRepair(in: resolvedMappings,
                                                                        entries: entries,
                                                                        account: account),
-            unresolvedNativeDeviceIDs: zip(entries, resolvedMappings).compactMap { entry, mapping in
-                guard entry.credentialId == nil || entry.credentialId == SyncCredentialID.defaultCredential,
-                      mapping.source == .placeholder else {
-                    return nil
-                }
-                return entry.id
-            },
             debugDevices: resolvedMappings.map {
                 RegisteredDeviceDebugInfo(device: $0.device,
                                           source: $0.source.debugSource,

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -35,6 +35,24 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
     private static let undecryptableDeviceName = "Unknown"
     private static let undecryptableDeviceType = "unknown"
 
+    private enum UnifiedDeviceInfoFailure: Equatable {
+        case missing
+        case keyUnavailable
+        case staleKey
+        case corrupt
+    }
+
+    private enum UnifiedDeviceInfoReadResult {
+        case notAttempted
+        case decrypted(DeviceInfo)
+        case failed(UnifiedDeviceInfoFailure)
+    }
+
+    private struct MappingAttempt {
+        let device: RegisteredDevice
+        let unifiedDeviceInfoFailure: UnifiedDeviceInfoFailure?
+    }
+
     let crypter: CryptingInternal
     let scopedAccess: ScopedAccessCredentialManaging?
     let accountInfoKeys: AccountInfoKeyManaging?
@@ -63,13 +81,29 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
     }
 
     func registeredDevices(from entries: [RegisteredDeviceEntry], account: SyncAccount) async -> [RegisteredDevice] {
-        let accountInfoKey = await accountInfoKeyIfNeeded(for: entries, account: account)
+        let isUnifiedReadEnabled = canReadUnifiedDeviceList()
+        let accountInfoKey = await accountInfoKeyIfNeeded(for: entries,
+                                                          account: account,
+                                                          isUnifiedReadEnabled: isUnifiedReadEnabled)
         let thirdPartyMainKey = await thirdPartyMainKeyIfNeeded(for: entries, account: account)
-        return entries.map {
+        let initialMappings = entries.map {
             registeredDevice(from: $0,
                              account: account,
                              accountInfoKey: accountInfoKey,
-                             thirdPartyMainKey: thirdPartyMainKey)
+                             thirdPartyMainKey: thirdPartyMainKey,
+                             isUnifiedReadEnabled: isUnifiedReadEnabled)
+        }
+        guard initialMappings.contains(where: { $0.unifiedDeviceInfoFailure == .staleKey }),
+              let accountInfoKeys,
+              let refreshedAccountInfoKey = try? await accountInfoKeys.refreshKey(for: account) else {
+            return initialMappings.map(\.device)
+        }
+        return entries.map {
+            registeredDevice(from: $0,
+                             account: account,
+                             accountInfoKey: refreshedAccountInfoKey,
+                             thirdPartyMainKey: thirdPartyMainKey,
+                             isUnifiedReadEnabled: isUnifiedReadEnabled).device
         }
     }
 
@@ -99,26 +133,51 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
     private func registeredDevice(from entry: RegisteredDeviceEntry,
                                   account: SyncAccount,
                                   accountInfoKey: AccountInfoKeyMaterial?,
-                                  thirdPartyMainKey: Data?) -> RegisteredDevice {
-        // Keep every server entry visible even if one encrypted field is malformed or uses a key we cannot recover.
-        return decryptedUnifiedRegisteredDevice(from: entry, accountInfoKey: accountInfoKey)
-            ?? decryptedLegacyRegisteredDevice(from: entry, account: account, thirdPartyMainKey: thirdPartyMainKey)
-            ?? fallbackRegisteredDevice(from: entry)
-    }
-
-    private func decryptedUnifiedRegisteredDevice(from entry: RegisteredDeviceEntry,
-                                                  accountInfoKey: AccountInfoKeyMaterial?) -> RegisteredDevice? {
-        guard canReadUnifiedDeviceList(),
-              let accountInfoKey,
-              let encryptedDeviceInfo = entry.info,
-              let deviceInfo = try? deviceInfoCodec.decrypt(encryptedDeviceInfo, using: accountInfoKey) else {
-            return nil
+                                  thirdPartyMainKey: Data?,
+                                  isUnifiedReadEnabled: Bool) -> MappingAttempt {
+        let unifiedDeviceInfo = readUnifiedDeviceInfo(from: entry,
+                                                      accountInfoKey: accountInfoKey,
+                                                      isUnifiedReadEnabled: isUnifiedReadEnabled)
+        if case .decrypted(let deviceInfo) = unifiedDeviceInfo {
+            return MappingAttempt(
+                device: RegisteredDevice(id: entry.id,
+                                         name: deviceInfo.name,
+                                         type: deviceInfo.type,
+                                         credentialId: entry.credentialId ?? SyncCredentialID.defaultCredential),
+                unifiedDeviceInfoFailure: nil)
         }
 
-        return RegisteredDevice(id: entry.id,
-                                name: deviceInfo.name,
-                                type: deviceInfo.type,
-                                credentialId: entry.credentialId ?? SyncCredentialID.defaultCredential)
+        // Keep every server entry visible even if one encrypted field is malformed or uses a key we cannot recover.
+        let device = decryptedLegacyRegisteredDevice(from: entry, account: account, thirdPartyMainKey: thirdPartyMainKey)
+            ?? fallbackRegisteredDevice(from: entry)
+        let failure: UnifiedDeviceInfoFailure?
+        if case .failed(let unifiedDeviceInfoFailure) = unifiedDeviceInfo {
+            failure = unifiedDeviceInfoFailure
+        } else {
+            failure = nil
+        }
+        return MappingAttempt(device: device, unifiedDeviceInfoFailure: failure)
+    }
+
+    private func readUnifiedDeviceInfo(from entry: RegisteredDeviceEntry,
+                                       accountInfoKey: AccountInfoKeyMaterial?,
+                                       isUnifiedReadEnabled: Bool) -> UnifiedDeviceInfoReadResult {
+        guard isUnifiedReadEnabled else {
+            return .notAttempted
+        }
+        guard let encryptedDeviceInfo = entry.info else {
+            return .failed(.missing)
+        }
+        guard let accountInfoKey else {
+            return .failed(.keyUnavailable)
+        }
+        do {
+            return .decrypted(try deviceInfoCodec.decrypt(encryptedDeviceInfo, using: accountInfoKey))
+        } catch DeviceInfoCodecError.unexpectedKeyID {
+            return .failed(.staleKey)
+        } catch {
+            return .failed(.corrupt)
+        }
     }
 
     private func decryptedLegacyRegisteredDevice(from entry: RegisteredDeviceEntry,
@@ -175,8 +234,10 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
         return String(data: plaintext, encoding: .utf8)
     }
 
-    private func accountInfoKeyIfNeeded(for entries: [RegisteredDeviceEntry], account: SyncAccount) async -> AccountInfoKeyMaterial? {
-        guard canReadUnifiedDeviceList(),
+    private func accountInfoKeyIfNeeded(for entries: [RegisteredDeviceEntry],
+                                        account: SyncAccount,
+                                        isUnifiedReadEnabled: Bool) async -> AccountInfoKeyMaterial? {
+        guard isUnifiedReadEnabled,
               entries.contains(where: { $0.info != nil }),
               let accountInfoKeys else {
             return nil

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -22,13 +22,17 @@ import os.log
 struct RegisteredDeviceMappingResult {
     let devices: [RegisteredDevice]
     let needsCurrentDeviceInfoRepair: Bool
+    let unresolvedNativeDeviceIDs: [String]
+    // Diagnostics for the Sync debug UI only; not used to drive device-list behaviour.
     let debugDevices: [RegisteredDeviceDebugInfo]
 
     init(devices: [RegisteredDevice],
          needsCurrentDeviceInfoRepair: Bool,
+         unresolvedNativeDeviceIDs: [String] = [],
          debugDevices: [RegisteredDeviceDebugInfo] = []) {
         self.devices = devices
         self.needsCurrentDeviceInfoRepair = needsCurrentDeviceInfoRepair
+        self.unresolvedNativeDeviceIDs = unresolvedNativeDeviceIDs
         self.debugDevices = debugDevices
     }
 }
@@ -78,9 +82,23 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
         case failed(UnifiedDeviceInfoFailure)
     }
 
+    private enum MappingSource: Equatable {
+        case deviceInfo
+        case legacy
+        case placeholder
+
+        var debugSource: RegisteredDeviceDebugInfo.Source {
+            switch self {
+            case .deviceInfo: return .deviceInfo
+            case .legacy: return .legacy
+            case .placeholder: return .placeholder
+            }
+        }
+    }
+
     private struct MappingAttempt {
         let device: RegisteredDevice
-        let source: RegisteredDeviceDebugInfo.Source
+        let source: MappingSource
         let unifiedDeviceInfoFailure: UnifiedDeviceInfoFailure?
     }
 
@@ -146,9 +164,16 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
             needsCurrentDeviceInfoRepair: needsCurrentDeviceInfoRepair(in: resolvedMappings,
                                                                        entries: entries,
                                                                        account: account),
+            unresolvedNativeDeviceIDs: zip(entries, resolvedMappings).compactMap { entry, mapping in
+                guard entry.credentialId == nil || entry.credentialId == SyncCredentialID.defaultCredential,
+                      mapping.source == .placeholder else {
+                    return nil
+                }
+                return entry.id
+            },
             debugDevices: resolvedMappings.map {
                 RegisteredDeviceDebugInfo(device: $0.device,
-                                          source: $0.source,
+                                          source: $0.source.debugSource,
                                           deviceInfoIssue: $0.unifiedDeviceInfoFailure?.description)
             })
     }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
@@ -36,6 +36,7 @@ enum AccountInfoKeyManagerError: Error, Equatable {
 
 protocol AccountInfoKeyManaging {
     func loadKey(for account: SyncAccount) async throws -> AccountInfoKey
+    func preloadKey(from protectedKeys: [ProtectedKey], accessCredentials: [AccessCredential], for account: SyncAccount) async throws
     func refreshKey(for account: SyncAccount) async throws -> AccountInfoKey
     func clearCachedKey(for account: SyncAccount) async
 }
@@ -97,6 +98,15 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
         return try await refreshKey(for: account)
     }
 
+    func preloadKey(from protectedKeys: [ProtectedKey], accessCredentials: [AccessCredential], for account: SyncAccount) async throws {
+        let key = try await makeAccountInfoKey(
+            from: protectedKeys.removingDuplicateWrappingIdentities(),
+            account: account,
+            providedAccessCredentials: accessCredentials)
+        cache(key, for: AccountIdentity(account: account))
+        Logger.sync.debug("Sync-UnifiedDevices: loaded account_info key from login response")
+    }
+
     func refreshKey(for account: SyncAccount) async throws -> AccountInfoKey {
         Logger.sync.debug("Sync-UnifiedDevices: fetching account_info key from server")
         let protectedKeys = try await scopedAccess.fetchProtectedKeys(account)
@@ -138,7 +148,8 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
     }
 
     private func makeAccountInfoKey(from protectedKeys: [ProtectedKey],
-                                    account: SyncAccount) async throws -> AccountInfoKey {
+                                    account: SyncAccount,
+                                    providedAccessCredentials: [AccessCredential]? = nil) async throws -> AccountInfoKey {
         let accountInfoKeys = protectedKeys.filter { $0.purpose == ProtectedKeyPurpose.accountInfo }
         guard let firstKey = accountInfoKeys.first else {
             throw AccountInfoKeyManagerError.missingProtectedKey
@@ -159,7 +170,9 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
             }
             hasSupportedWrapper = true
             do {
-                let privateKeyPKCS8 = try await unwrapPrivateKey(protectedKey, account: account)
+                let privateKeyPKCS8 = try await unwrapPrivateKey(protectedKey,
+                                                                 account: account,
+                                                                 providedAccessCredentials: providedAccessCredentials)
                 let key = try makeAccountInfoKey(protectedKey: protectedKey, privateKeyPKCS8: privateKeyPKCS8)
                 if protectedKey.encryptedWith == SyncCredentialID.defaultCredential {
                     Logger.sync.debug("Sync-UnifiedDevices: unwrapped account_info key with ddg credential")
@@ -181,7 +194,9 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
         throw AccountInfoKeyManagerError.unableToUnwrapPrivateKey
     }
 
-    private func unwrapPrivateKey(_ protectedKey: ProtectedKey, account: SyncAccount) async throws -> Data {
+    private func unwrapPrivateKey(_ protectedKey: ProtectedKey,
+                                  account: SyncAccount,
+                                  providedAccessCredentials: [AccessCredential]?) async throws -> Data {
         switch protectedKey.encryptedWith {
         case SyncCredentialID.defaultCredential:
             guard let encryptedPrivateKey = Base64URL.decode(protectedKey.encryptedPrivateKey) else {
@@ -189,7 +204,8 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
             }
             return try crypter.decryptData(encryptedPrivateKey, using: account.secretKey)
         case SyncCredentialID.thirdParty:
-            let scopedPassword = try await scopedPassword(for: account)
+            let scopedPassword = try await scopedPassword(for: account,
+                                                          providedAccessCredentials: providedAccessCredentials)
             let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
             return try jweCompactCodec.decryptDirect(token: protectedKey.encryptedPrivateKey,
                                                      contentEncryptionKey: thirdPartyMainKey,
@@ -199,7 +215,18 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
         }
     }
 
-    private func scopedPassword(for account: SyncAccount) async throws -> Data {
+    private func scopedPassword(for account: SyncAccount,
+                                providedAccessCredentials: [AccessCredential]?) async throws -> Data {
+        if let providedAccessCredentials {
+            guard let scopedPassword = try scopedAccess.recoverScopedPassword(from: providedAccessCredentials,
+                                                                              primaryKey: account.primaryKey,
+                                                                              userID: account.userId),
+                  !scopedPassword.isEmpty else {
+                throw AccountInfoKeyManagerError.unavailableWrappingKey
+            }
+            return scopedPassword
+        }
+
         if let scopedPassword = try secureStore.scopedPassword(), !scopedPassword.isEmpty {
             return scopedPassword
         }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyManager.swift
@@ -37,14 +37,31 @@ enum AccountInfoKeyManagerError: Error, Equatable {
 protocol AccountInfoKeyManaging {
     func loadKey(for account: SyncAccount) async throws -> AccountInfoKey
     func refreshKey(for account: SyncAccount) async throws -> AccountInfoKey
+    func clearCachedKey(for account: SyncAccount) async
 }
 
 actor AccountInfoKeyManager: AccountInfoKeyManaging {
+
+    private struct AccountIdentity: Equatable {
+        let userID: String
+        let secretKey: Data
+
+        init(account: SyncAccount) {
+            userID = account.userId
+            secretKey = account.secretKey
+        }
+    }
+
+    private struct CachedAccountInfoKey {
+        let accountIdentity: AccountIdentity
+        let key: AccountInfoKey
+    }
 
     private let secureStore: SecureStoring
     private let scopedAccess: ScopedAccessCredentialManaging
     private let crypter: CryptingInternal
     private let jweCompactCodec: JWECompactCodec
+    private var cachedAccountInfoKey: CachedAccountInfoKey?
 
     init(secureStore: SecureStoring,
          scopedAccess: ScopedAccessCredentialManaging,
@@ -57,9 +74,17 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
     }
 
     func loadKey(for account: SyncAccount) async throws -> AccountInfoKey {
+        let accountIdentity = AccountIdentity(account: account)
+        if let cachedAccountInfoKey,
+           cachedAccountInfoKey.accountIdentity == accountIdentity {
+            return cachedAccountInfoKey.key
+        }
+        cachedAccountInfoKey = nil
+
         if let protectedKeys = cachedProtectedKeys() {
             do {
                 let key = try await makeAccountInfoKey(from: protectedKeys, account: account)
+                cache(key, for: accountIdentity)
                 Logger.sync.debug("Sync-UnifiedDevices: loaded account_info key from secure storage")
                 return key
             } catch is CancellationError {
@@ -78,7 +103,15 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
             .removingDuplicateWrappingIdentities()
         let key = try await makeAccountInfoKey(from: protectedKeys, account: account)
         cache(protectedKeys)
+        cache(key, for: AccountIdentity(account: account))
         return key
+    }
+
+    func clearCachedKey(for account: SyncAccount) {
+        guard cachedAccountInfoKey?.accountIdentity == AccountIdentity(account: account) else {
+            return
+        }
+        cachedAccountInfoKey = nil
     }
 
     private func cachedProtectedKeys() -> [ProtectedKey]? {
@@ -98,6 +131,10 @@ actor AccountInfoKeyManager: AccountInfoKeyManaging {
             return
         }
         try? secureStore.persistProtectedKeys(encodedKeys)
+    }
+
+    private func cache(_ key: AccountInfoKey, for accountIdentity: AccountIdentity) {
+        cachedAccountInfoKey = CachedAccountInfoKey(accountIdentity: accountIdentity, key: key)
     }
 
     private func makeAccountInfoKey(from protectedKeys: [ProtectedKey],

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
@@ -69,7 +69,7 @@ protocol AccountManaging {
     func logout(deviceId: String, token: String) async throws
 
     func fetchDevicesForAccount(_ account: SyncAccount) async throws -> [RegisteredDevice]
-    func updateDevice(_ update: UpdateDevices.Update, for account: SyncAccount) async throws -> UpdateDevices.Result
+    func updateDevice(_ update: UpdateDevices.Update, for account: SyncAccount) async throws -> [RegisteredDevice]
 }
 
 /// Manages the scoped ("3party") access credential: recovering, creating, and fetching its password and protected keys.

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
@@ -68,7 +68,7 @@ protocol AccountManaging {
 
     func logout(deviceId: String, token: String) async throws
 
-    func fetchDevicesForAccount(_ account: SyncAccount) async throws -> [RegisteredDevice]
+    func fetchDevicesForAccount(_ account: SyncAccount) async throws -> RegisteredDeviceMappingResult
     func updateDevice(_ update: UpdateDevices.Update, for account: SyncAccount) async throws -> [RegisteredDevice]
 }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -1034,7 +1034,7 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertFalse(api.createRequestCallArgs.contains { $0.url == endpoints.logoutDevice })
     }
 
-    func testWhenFetchingDevicesWithScopedAccessEnabledAndUnifiedReadDisabledThenRetainsLegacyDecryptFailureBehavior() async throws {
+    func testWhenFetchingDevicesWithScopedAccessEnabledAndUnifiedReadDisabledThenRetainsFallbackEntriesWithoutLogout() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         var crypter = CryptingMock()
@@ -1068,20 +1068,14 @@ final class AccountManagerTests: XCTestCase {
             }
         }
         """)
-        api.fakeRequests[endpoints.logoutDevice] = makeJSONRequest("""
-        {
-            "device_id": "native-device"
-        }
-        """)
-
         let result = try await accountManager.fetchDevicesForAccount(makeAccount(primaryKey: Data()))
 
-        XCTAssertEqual(result.devices.map(\.id), ["third-party-device"])
-        XCTAssertEqual(result.devices.map(\.name), ["Browser"])
-        XCTAssertEqual(result.devices.map(\.type), ["unknown"])
-        XCTAssertEqual(result.devices.map(\.credentialId), [SyncCredentialID.thirdParty])
+        XCTAssertEqual(result.devices.map(\.id), ["third-party-device", "native-device"])
+        XCTAssertEqual(result.devices.map(\.name), ["Browser", "Unknown"])
+        XCTAssertEqual(result.devices.map(\.type), ["unknown", "unknown"])
+        XCTAssertEqual(result.devices.map(\.credentialId), [SyncCredentialID.thirdParty, SyncCredentialID.defaultCredential])
         XCTAssertFalse(result.needsCurrentDeviceInfoRepair)
-        XCTAssertEqual(api.createRequestCallArgs.filter { $0.url == endpoints.logoutDevice }.count, 1)
+        XCTAssertFalse(api.createRequestCallArgs.contains { $0.url == endpoints.logoutDevice })
     }
 
     func testWhenFetchingDevicesWithScopedAccessDisabledThenLegacyUndecryptableDeviceIsLoggedOut() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -512,6 +512,90 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(result.devices.map(\.type), ["iOS"])
     }
 
+    func testWhenUnifiedReadIsEnabledThenLoginMapsDevicesV2() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let mapper = RegisteredDeviceMappingMock()
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            registeredDeviceMapper: mapper,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true })
+        api.fakeRequests[endpoints.login] = makeJSONRequest("""
+        {
+            "devices": [
+                {
+                    "id": "legacy-device",
+                    "name": "encrypted_Legacy",
+                    "type": "encrypted_desktop"
+                }
+            ],
+            "devices_v2": [
+                {
+                    "id": "unified-device",
+                    "name": "encrypted_Unified",
+                    "type": "encrypted_browser",
+                    "info": "encrypted-info",
+                    "credential_id": "3party"
+                }
+            ],
+            "token": "token-1",
+            "protected_encryption_key": ""
+        }
+        """)
+
+        let result = try await accountManager.login(.init(userId: "user-1", primaryKey: Data()),
+                                                    deviceName: "iPhone",
+                                                    deviceType: "iOS")
+
+        XCTAssertEqual(mapper.registeredDevicesCallEntryIDs, ["unified-device"])
+        XCTAssertTrue(mapper.defaultCredentialLoginEntryIDs.isEmpty)
+        XCTAssertEqual(result.devices.map(\.id), ["unified-device"])
+    }
+
+    func testWhenUnifiedReadIsDisabledThenLoginMapsLegacyDevices() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let mapper = RegisteredDeviceMappingMock()
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            registeredDeviceMapper: mapper,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { false })
+        api.fakeRequests[endpoints.login] = makeJSONRequest("""
+        {
+            "devices": [
+                {
+                    "id": "legacy-device",
+                    "name": "encrypted_Legacy",
+                    "type": "encrypted_desktop"
+                }
+            ],
+            "devices_v2": [
+                {
+                    "id": "unified-device",
+                    "name": "encrypted_Unified",
+                    "type": "encrypted_browser",
+                    "info": "encrypted-info",
+                    "credential_id": "3party"
+                }
+            ],
+            "token": "token-1",
+            "protected_encryption_key": ""
+        }
+        """)
+
+        let result = try await accountManager.login(.init(userId: "user-1", primaryKey: Data()),
+                                                    deviceName: "iPhone",
+                                                    deviceType: "iOS")
+
+        XCTAssertTrue(mapper.registeredDevicesCallEntryIDs.isEmpty)
+        XCTAssertEqual(mapper.defaultCredentialLoginEntryIDs, ["legacy-device"])
+        XCTAssertEqual(result.devices.map(\.id), ["legacy-device"])
+    }
+
     func testWhenLoggingInWithScopedAccessCredentialsEnabledThenLoginRequestIncludesSyncScope() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
@@ -685,16 +769,25 @@ final class AccountManagerTests: XCTestCase {
     func testWhenUpdatingDeviceThenUsesAuthenticatedPatchAndDecodesResponse() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
+        let mapper = RegisteredDeviceMappingMock()
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: CryptingMock(),
-                                            isScopedAccessCredentialsEnabled: { true })
+                                            registeredDeviceMapper: mapper,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true })
         api.fakeRequests[endpoints.devices] = makeJSONRequest("""
         {
-            "devices": [],
+            "devices": [
+                {
+                    "id": "legacy-device",
+                    "name": "encrypted-legacy-name",
+                    "type": "encrypted-legacy-type"
+                }
+            ],
             "devices_v2": [
                 {
-                    "id": "device-1",
+                    "id": "unified-device",
                     "name": "encrypted-name",
                     "type": "encrypted-type",
                     "info": "encrypted-info",
@@ -719,7 +812,45 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(updates.first?["name"] as? String, "encrypted-name")
         XCTAssertEqual(updates.first?["type"] as? String, "encrypted-type")
         XCTAssertEqual(updates.first?["info"] as? String, "encrypted-info")
-        XCTAssertEqual(result.devicesV2.map(\.id), ["device-1"])
+        XCTAssertEqual(mapper.registeredDevicesCallEntryIDs, ["unified-device"])
+        XCTAssertEqual(result.map(\.id), ["unified-device"])
+    }
+
+    func testWhenUnifiedReadIsDisabledThenUpdatingDeviceMapsLegacyResponse() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let mapper = RegisteredDeviceMappingMock()
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: CryptingMock(),
+                                            registeredDeviceMapper: mapper,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { false })
+        api.fakeRequests[endpoints.devices] = makeJSONRequest("""
+        {
+            "devices": [
+                {
+                    "id": "legacy-device",
+                    "name": "encrypted-legacy-name",
+                    "type": "encrypted-legacy-type"
+                }
+            ],
+            "devices_v2": [
+                {
+                    "id": "unified-device",
+                    "name": "encrypted-name",
+                    "type": "encrypted-type",
+                    "info": "encrypted-info",
+                    "credential_id": "ddg"
+                }
+            ]
+        }
+        """)
+
+        let devices = try await accountManager.updateDevice(makeDeviceUpdate(), for: makeAccount(primaryKey: Data()))
+
+        XCTAssertEqual(mapper.registeredDevicesCallEntryIDs, ["legacy-device"])
+        XCTAssertEqual(devices.map(\.id), ["legacy-device"])
     }
 
     func testWhenUpdatingDeviceWithoutTokenThenThrowsNoToken() async {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -588,7 +588,7 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(accountInfoKeys.preloadKeyCalls.count, 1)
         XCTAssertEqual(keyLoad.protectedKeys.map(\.kid), ["account-info-key"])
         XCTAssertEqual(keyLoad.accessCredentials.map(\.id), ["3party"])
-        XCTAssertEqual(keyLoad.account.userId, "user-1")
+        XCTAssertEqual(keyLoad.account.userId, result.account.userId)
     }
 
     func testWhenUnifiedReadIsDisabledThenLoginMapsLegacyDevices() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -516,12 +516,16 @@ final class AccountManagerTests: XCTestCase {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let mapper = RegisteredDeviceMappingMock()
+        var readFlagCallCount = 0
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: CryptingMock(),
                                             registeredDeviceMapper: mapper,
                                             isScopedAccessCredentialsEnabled: { true },
-                                            canReadUnifiedDeviceList: { true })
+                                            canReadUnifiedDeviceList: {
+                                                readFlagCallCount += 1
+                                                return true
+                                            })
         api.fakeRequests[endpoints.login] = makeJSONRequest("""
         {
             "devices": [
@@ -550,8 +554,10 @@ final class AccountManagerTests: XCTestCase {
                                                     deviceType: "iOS")
 
         XCTAssertEqual(mapper.registeredDevicesCallEntryIDs, ["unified-device"])
+        XCTAssertEqual(mapper.unifiedReadEnabledValues, [true])
         XCTAssertTrue(mapper.defaultCredentialLoginEntryIDs.isEmpty)
         XCTAssertEqual(result.devices.map(\.id), ["unified-device"])
+        XCTAssertEqual(readFlagCallCount, 1)
     }
 
     func testWhenUnifiedReadIsDisabledThenLoginMapsLegacyDevices() async throws {
@@ -770,12 +776,16 @@ final class AccountManagerTests: XCTestCase {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let mapper = RegisteredDeviceMappingMock()
+        var readFlagCallCount = 0
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: CryptingMock(),
                                             registeredDeviceMapper: mapper,
                                             isScopedAccessCredentialsEnabled: { true },
-                                            canReadUnifiedDeviceList: { true })
+                                            canReadUnifiedDeviceList: {
+                                                readFlagCallCount += 1
+                                                return true
+                                            })
         api.fakeRequests[endpoints.devices] = makeJSONRequest("""
         {
             "devices": [
@@ -813,7 +823,9 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(updates.first?["type"] as? String, "encrypted-type")
         XCTAssertEqual(updates.first?["info"] as? String, "encrypted-info")
         XCTAssertEqual(mapper.registeredDevicesCallEntryIDs, ["unified-device"])
+        XCTAssertEqual(mapper.unifiedReadEnabledValues, [true])
         XCTAssertEqual(result.map(\.id), ["unified-device"])
+        XCTAssertEqual(readFlagCallCount, 1)
     }
 
     func testWhenUnifiedReadIsDisabledThenUpdatingDeviceMapsLegacyResponse() async throws {
@@ -905,12 +917,16 @@ final class AccountManagerTests: XCTestCase {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let mapper = RegisteredDeviceMappingMock()
-        mapper.needsCurrentDeviceInfoRepair = true
+        var readFlagCallCount = 0
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: CryptingMock(),
                                             registeredDeviceMapper: mapper,
-                                            isScopedAccessCredentialsEnabled: { true })
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: {
+                                                readFlagCallCount += 1
+                                                return false
+                                            })
         api.fakeRequests[devicesURL(for: endpoints)] = makeJSONRequest("""
         {
             "devices": {
@@ -937,8 +953,9 @@ final class AccountManagerTests: XCTestCase {
         let devices = result.devices
 
         XCTAssertEqual(mapper.registeredDevicesCallEntryIDs, ["v2-device"])
+        XCTAssertEqual(mapper.unifiedReadEnabledValues, [false])
         XCTAssertEqual(devices.map(\.id), ["v2-device"])
-        XCTAssertTrue(result.needsCurrentDeviceInfoRepair)
+        XCTAssertEqual(readFlagCallCount, 1)
         XCTAssertFalse(api.createRequestCallArgs.contains { $0.url == endpoints.logoutDevice })
     }
 
@@ -1178,12 +1195,14 @@ private final class DeviceInfoCodingMock: DeviceInfoCoding {
 private final class RegisteredDeviceMappingMock: RegisteredDeviceMapping {
 
     private(set) var registeredDevicesCallEntryIDs: [String] = []
+    private(set) var unifiedReadEnabledValues: [Bool] = []
     private(set) var defaultCredentialLoginEntryIDs: [String] = []
-    var needsCurrentDeviceInfoRepair = false
 
     func registeredDevicesWithRepairState(from entries: [RegisteredDeviceEntry],
-                                          account: SyncAccount) async -> RegisteredDeviceMappingResult {
+                                          account: SyncAccount,
+                                          isUnifiedReadEnabled: Bool) async -> RegisteredDeviceMappingResult {
         registeredDevicesCallEntryIDs = entries.map(\.id)
+        unifiedReadEnabledValues.append(isUnifiedReadEnabled)
         let devices = entries.map { entry in
             RegisteredDevice(id: entry.id,
                              name: entry.name ?? "",
@@ -1191,7 +1210,7 @@ private final class RegisteredDeviceMappingMock: RegisteredDeviceMapping {
                              credentialId: entry.credentialId)
         }
         return RegisteredDeviceMappingResult(devices: devices,
-                                             needsCurrentDeviceInfoRepair: needsCurrentDeviceInfoRepair)
+                                             needsCurrentDeviceInfoRepair: false)
     }
 
     func registeredDevice(fromLegacyEntry entry: RegisteredDeviceEntry, account: SyncAccount) -> RegisteredDevice? {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -516,11 +516,16 @@ final class AccountManagerTests: XCTestCase {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let mapper = RegisteredDeviceMappingMock()
+        let accountInfoKeys = AccountInfoKeyManagingMock()
+        mapper.registeredDevicesHandler = {
+            XCTAssertEqual(accountInfoKeys.preloadKeyCalls.count, 1)
+        }
         var readFlagCallCount = 0
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: CryptingMock(),
                                             registeredDeviceMapper: mapper,
+                                            accountInfoKeys: accountInfoKeys,
                                             isScopedAccessCredentialsEnabled: { true },
                                             canReadUnifiedDeviceList: {
                                                 readFlagCallCount += 1
@@ -545,7 +550,28 @@ final class AccountManagerTests: XCTestCase {
                 }
             ],
             "token": "token-1",
-            "protected_encryption_key": ""
+            "protected_encryption_key": "",
+            "keys": [
+                {
+                    "kid": "account-info-key",
+                    "encrypted_private_key": "encrypted-private-key",
+                    "public_key": {
+                        "alg": "RSA-OAEP-256",
+                        "e": "AQAB",
+                        "kty": "RSA",
+                        "n": "modulus"
+                    },
+                    "encrypted_with": "3party",
+                    "purpose": "account_info"
+                }
+            ],
+            "access_credentials": [
+                {
+                    "id": "3party",
+                    "scope": "sync",
+                    "encrypted_3party_credential": "encrypted-credential"
+                }
+            ]
         }
         """)
 
@@ -558,16 +584,23 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertTrue(mapper.defaultCredentialLoginEntryIDs.isEmpty)
         XCTAssertEqual(result.devices.map(\.id), ["unified-device"])
         XCTAssertEqual(readFlagCallCount, 1)
+        let keyLoad = try XCTUnwrap(accountInfoKeys.preloadKeyCalls.first)
+        XCTAssertEqual(accountInfoKeys.preloadKeyCalls.count, 1)
+        XCTAssertEqual(keyLoad.protectedKeys.map(\.kid), ["account-info-key"])
+        XCTAssertEqual(keyLoad.accessCredentials.map(\.id), ["3party"])
+        XCTAssertEqual(keyLoad.account.userId, "user-1")
     }
 
     func testWhenUnifiedReadIsDisabledThenLoginMapsLegacyDevices() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let mapper = RegisteredDeviceMappingMock()
+        let accountInfoKeys = AccountInfoKeyManagingMock()
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: CryptingMock(),
                                             registeredDeviceMapper: mapper,
+                                            accountInfoKeys: accountInfoKeys,
                                             isScopedAccessCredentialsEnabled: { true },
                                             canReadUnifiedDeviceList: { false })
         api.fakeRequests[endpoints.login] = makeJSONRequest("""
@@ -589,7 +622,21 @@ final class AccountManagerTests: XCTestCase {
                 }
             ],
             "token": "token-1",
-            "protected_encryption_key": ""
+            "protected_encryption_key": "",
+            "keys": [
+                {
+                    "kid": "account-info-key",
+                    "encrypted_private_key": "encrypted-private-key",
+                    "public_key": {
+                        "alg": "RSA-OAEP-256",
+                        "e": "AQAB",
+                        "kty": "RSA",
+                        "n": "modulus"
+                    },
+                    "encrypted_with": "ddg",
+                    "purpose": "account_info"
+                }
+            ]
         }
         """)
 
@@ -600,6 +647,7 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertTrue(mapper.registeredDevicesCallEntryIDs.isEmpty)
         XCTAssertEqual(mapper.defaultCredentialLoginEntryIDs, ["legacy-device"])
         XCTAssertEqual(result.devices.map(\.id), ["legacy-device"])
+        XCTAssertTrue(accountInfoKeys.preloadKeyCalls.isEmpty)
     }
 
     func testWhenLoggingInWithScopedAccessCredentialsEnabledThenLoginRequestIncludesSyncScope() async throws {
@@ -1191,10 +1239,12 @@ private final class RegisteredDeviceMappingMock: RegisteredDeviceMapping {
     private(set) var registeredDevicesCallEntryIDs: [String] = []
     private(set) var unifiedReadEnabledValues: [Bool] = []
     private(set) var defaultCredentialLoginEntryIDs: [String] = []
+    var registeredDevicesHandler: (() -> Void)?
 
     func registeredDevicesWithRepairState(from entries: [RegisteredDeviceEntry],
                                           account: SyncAccount,
                                           isUnifiedReadEnabled: Bool) async -> RegisteredDeviceMappingResult {
+        registeredDevicesHandler?()
         registeredDevicesCallEntryIDs = entries.map(\.id)
         unifiedReadEnabledValues.append(isUnifiedReadEnabled)
         let devices = entries.map { entry in

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -774,6 +774,7 @@ final class AccountManagerTests: XCTestCase {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let mapper = RegisteredDeviceMappingMock()
+        mapper.needsCurrentDeviceInfoRepair = true
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: CryptingMock(),
@@ -801,10 +802,12 @@ final class AccountManagerTests: XCTestCase {
         }
         """)
 
-        let devices = try await accountManager.fetchDevicesForAccount(makeAccount(primaryKey: Data()))
+        let result = try await accountManager.fetchDevicesForAccount(makeAccount(primaryKey: Data()))
+        let devices = result.devices
 
         XCTAssertEqual(mapper.registeredDevicesCallEntryIDs, ["v2-device"])
         XCTAssertEqual(devices.map(\.id), ["v2-device"])
+        XCTAssertTrue(result.needsCurrentDeviceInfoRepair)
         XCTAssertFalse(api.createRequestCallArgs.contains { $0.url == endpoints.logoutDevice })
     }
 
@@ -832,7 +835,8 @@ final class AccountManagerTests: XCTestCase {
         }
         """)
 
-        let devices = try await accountManager.fetchDevicesForAccount(makeAccount(primaryKey: Data()))
+        let result = try await accountManager.fetchDevicesForAccount(makeAccount(primaryKey: Data()))
+        let devices = result.devices
 
         XCTAssertEqual(mapper.registeredDevicesCallEntryIDs, ["legacy-device"])
         XCTAssertEqual(devices.map(\.id), ["legacy-device"])
@@ -871,7 +875,8 @@ final class AccountManagerTests: XCTestCase {
         }
         """)
 
-        let devices = try await accountManager.fetchDevicesForAccount(makeAccount(primaryKey: Data()))
+        let result = try await accountManager.fetchDevicesForAccount(makeAccount(primaryKey: Data()))
+        let devices = result.devices
 
         XCTAssertEqual(devices.map(\.id), ["third-party-device", "native-device"])
         XCTAssertEqual(devices.map(\.name), ["Browser", "Unknown"])
@@ -910,7 +915,8 @@ final class AccountManagerTests: XCTestCase {
         }
         """)
 
-        let devices = try await accountManager.fetchDevicesForAccount(makeAccount(primaryKey: Data()))
+        let result = try await accountManager.fetchDevicesForAccount(makeAccount(primaryKey: Data()))
+        let devices = result.devices
 
         XCTAssertTrue(devices.isEmpty)
         XCTAssertTrue(api.createRequestCallArgs.contains { $0.url == endpoints.logoutDevice })
@@ -990,15 +996,20 @@ private final class DeviceInfoCodingMock: DeviceInfoCoding {
 private final class RegisteredDeviceMappingMock: RegisteredDeviceMapping {
 
     private(set) var registeredDevicesCallEntryIDs: [String] = []
+    private(set) var defaultCredentialLoginEntryIDs: [String] = []
+    var needsCurrentDeviceInfoRepair = false
 
-    func registeredDevices(from entries: [RegisteredDeviceEntry], account: SyncAccount) async -> [RegisteredDevice] {
+    func registeredDevicesWithRepairState(from entries: [RegisteredDeviceEntry],
+                                          account: SyncAccount) async -> RegisteredDeviceMappingResult {
         registeredDevicesCallEntryIDs = entries.map(\.id)
-        return entries.map { entry in
+        let devices = entries.map { entry in
             RegisteredDevice(id: entry.id,
                              name: entry.name ?? "",
                              type: entry.type ?? "",
                              credentialId: entry.credentialId)
         }
+        return RegisteredDeviceMappingResult(devices: devices,
+                                             needsCurrentDeviceInfoRepair: needsCurrentDeviceInfoRepair)
     }
 
     func registeredDevice(fromLegacyEntry entry: RegisteredDeviceEntry, account: SyncAccount) -> RegisteredDevice? {
@@ -1012,10 +1023,11 @@ private final class RegisteredDeviceMappingMock: RegisteredDeviceMapping {
                           encryptedName: String,
                           encryptedType: String?,
                           primaryKey: Data) -> RegisteredDevice? {
-        RegisteredDevice(id: id,
-                         name: encryptedName,
-                         type: encryptedType ?? "",
-                         credentialId: SyncCredentialID.defaultCredential)
+        defaultCredentialLoginEntryIDs.append(id)
+        return RegisteredDevice(id: id,
+                                name: encryptedName,
+                                type: encryptedType ?? "",
+                                credentialId: SyncCredentialID.defaultCredential)
     }
 
 }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -974,7 +974,7 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertFalse(api.createRequestCallArgs.contains { $0.url == endpoints.logoutDevice })
     }
 
-    func testWhenFetchingDevicesWithScopedAccessEnabledThenFallsBackUndecryptableEntriesWithoutLogout() async throws {
+    func testWhenFetchingDevicesWithUnifiedReadEnabledThenFallsBackUndecryptableEntriesWithoutLogout() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         var crypter = CryptingMock()
@@ -984,7 +984,8 @@ final class AccountManagerTests: XCTestCase {
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: crypter,
-                                            isScopedAccessCredentialsEnabled: { true })
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true })
         api.fakeRequests[devicesURL(for: endpoints)] = makeJSONRequest("""
         {
             "devices": {
@@ -1014,6 +1015,56 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(devices.map(\.type), ["unknown", "unknown"])
         XCTAssertEqual(devices.map(\.credentialId), [SyncCredentialID.thirdParty, SyncCredentialID.defaultCredential])
         XCTAssertFalse(api.createRequestCallArgs.contains { $0.url == endpoints.logoutDevice })
+    }
+
+    func testWhenFetchingDevicesWithScopedAccessEnabledAndUnifiedReadDisabledThenRetainsLegacyDecryptFailureBehavior() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        var crypter = CryptingMock()
+        crypter._base64DecodeAndDecrypt = { _ in
+            throw SyncError.failedToDecryptValue("test")
+        }
+        let accountManager = AccountManager(endpoints: endpoints,
+                                            api: api,
+                                            crypter: crypter,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { false })
+        api.fakeRequests[devicesURL(for: endpoints)] = makeJSONRequest("""
+        {
+            "devices": {
+                "entries_v2": [
+                    {
+                        "id": "third-party-device",
+                        "name": "undecryptable-name",
+                        "type": "undecryptable-type",
+                        "info": "ignored-device-info",
+                        "credential_id": "3party"
+                    },
+                    {
+                        "id": "native-device",
+                        "name": "undecryptable-name",
+                        "type": "undecryptable-type",
+                        "info": "ignored-device-info",
+                        "credential_id": "ddg"
+                    }
+                ]
+            }
+        }
+        """)
+        api.fakeRequests[endpoints.logoutDevice] = makeJSONRequest("""
+        {
+            "device_id": "native-device"
+        }
+        """)
+
+        let result = try await accountManager.fetchDevicesForAccount(makeAccount(primaryKey: Data()))
+
+        XCTAssertEqual(result.devices.map(\.id), ["third-party-device"])
+        XCTAssertEqual(result.devices.map(\.name), ["Browser"])
+        XCTAssertEqual(result.devices.map(\.type), ["unknown"])
+        XCTAssertEqual(result.devices.map(\.credentialId), [SyncCredentialID.thirdParty])
+        XCTAssertFalse(result.needsCurrentDeviceInfoRepair)
+        XCTAssertEqual(api.createRequestCallArgs.filter { $0.url == endpoints.logoutDevice }.count, 1)
     }
 
     func testWhenFetchingDevicesWithScopedAccessDisabledThenLegacyUndecryptableDeviceIsLoggedOut() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -838,13 +838,21 @@ final class DDGSyncTests: XCTestCase {
         (dependencies.secureStore as? SecureStorageStub)?.theProtectedKeysData = protectedKeysData
         let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
         dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let accountInfoKeys = try XCTUnwrap(dependencies.accountInfoKeys as? AccountInfoKeyManagingMock)
+        let accountInfoKeyCacheCleared = expectation(description: "Account-info key cache cleared")
+        accountInfoKeys.clearCachedKeyHandler = { account in
+            XCTAssertEqual(account.deviceId, SyncAccount.mock.deviceId)
+            accountInfoKeyCacheCleared.fulfill()
+        }
         let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
 
         try await syncService.disconnect()
+        await fulfillment(of: [accountInfoKeyCacheCleared], timeout: 1)
 
         XCTAssertNil((dependencies.secureStore as? SecureStorageStub)?.theAccount)
         XCTAssertNil((dependencies.secureStore as? SecureStorageStub)?.theScopedPassword)
         XCTAssertNil((dependencies.secureStore as? SecureStorageStub)?.theProtectedKeysData)
+        XCTAssertEqual(accountInfoKeys.clearCachedKeyCalls.map(\.deviceId), [SyncAccount.mock.deviceId])
         XCTAssertEqual(migrationCoordinator.resetCallCount, 1)
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoCodecTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoCodecTests.swift
@@ -74,6 +74,21 @@ final class DeviceInfoCodecTests: XCTestCase {
         }
     }
 
+    func testWhenEncryptedPayloadUsesUnexpectedKeyIDThenThrowsClassifiedError() throws {
+        let keyPair = try RSAKeyPairGenerator.makeKeyPair()
+        let accountInfoKey = AccountInfoKey(kid: "stale-key",
+                                            publicKey: keyPair.publicKey,
+                                            privateKey: keyPair.privateKey)
+        let encryptedPayload = try JWECompactCodec().encryptRSAOAEP256(
+            payload: try JSONEncoder().encode(DeviceInfo(name: "Mac", type: "desktop")),
+            recipientPublicKey: keyPair.publicKey,
+            kid: "current-key")
+
+        XCTAssertThrowsError(try DeviceInfoCodec().decrypt(encryptedPayload, using: accountInfoKey)) { error in
+            XCTAssertEqual(error as? DeviceInfoCodecError, .unexpectedKeyID)
+        }
+    }
+
     private func makeAccountInfoKey(from protectedKey: ProtectedKey,
                                     crypter: CryptingInternal) throws -> AccountInfoKey {
         let encryptedPrivateKey = try XCTUnwrap(Base64URL.decode(protectedKey.encryptedPrivateKey))

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
@@ -150,7 +150,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         accountManager.updateDeviceHandler = { _, _ in
             patchStarted.fulfill()
             await gate.wait()
-            return UpdateDevices.Result(devices: [], devicesV2: [])
+            return []
         }
         let migration = Task {
             await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/JWECompactCodecTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/JWECompactCodecTests.swift
@@ -114,7 +114,7 @@ final class JWECompactCodecTests: XCTestCase {
         XCTAssertThrowsError(try codec.decryptRSAOAEP256(token: token,
                                                          privateKey: keyPair.privateKey,
                                                          expectedKid: "other-sender")) { error in
-            XCTAssertEqual(error as? JWECompactCodecError, .unsupportedProtectedHeader)
+            XCTAssertEqual(error as? JWECompactCodecError, .unexpectedKeyID)
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -112,16 +112,27 @@ class AccountManagingMock: AccountManaging {
         }
     }
 
-    func fetchDevicesForAccount(_ account: SyncAccount) async throws -> [RegisteredDevice] {
-        [.mock]
+    var fetchDevicesForAccountCalls: [SyncAccount] = []
+    var fetchDevicesForAccountStub = RegisteredDeviceMappingResult(devices: [.mock], needsCurrentDeviceInfoRepair: false)
+    var fetchDevicesForAccountError: Error?
+    var fetchDevicesForAccountHandler: ((SyncAccount) async throws -> RegisteredDeviceMappingResult)?
+    func fetchDevicesForAccount(_ account: SyncAccount) async throws -> RegisteredDeviceMappingResult {
+        fetchDevicesForAccountCalls.append(account)
+        if let fetchDevicesForAccountHandler {
+            return try await fetchDevicesForAccountHandler(account)
+        }
+        if let fetchDevicesForAccountError {
+            throw fetchDevicesForAccountError
+        }
+        return fetchDevicesForAccountStub
     }
 
     var updateDeviceCalls: [(update: UpdateDevices.Update, account: SyncAccount)] = []
-    var updateDeviceStub: UpdateDevices.Result?
+    var updateDeviceStub: [RegisteredDevice]?
     var updateDeviceError: Error?
-    var updateDeviceHandler: ((UpdateDevices.Update, SyncAccount) async throws -> UpdateDevices.Result)?
+    var updateDeviceHandler: ((UpdateDevices.Update, SyncAccount) async throws -> [RegisteredDevice])?
     func updateDevice(_ update: UpdateDevices.Update,
-                      for account: SyncAccount) async throws -> UpdateDevices.Result {
+                      for account: SyncAccount) async throws -> [RegisteredDevice] {
         updateDeviceCalls.append((update: update, account: account))
         if let updateDeviceHandler {
             return try await updateDeviceHandler(update, account)
@@ -129,7 +140,7 @@ class AccountManagingMock: AccountManaging {
         if let updateDeviceError {
             throw updateDeviceError
         }
-        return updateDeviceStub ?? UpdateDevices.Result(devices: [], devicesV2: [])
+        return updateDeviceStub ?? []
     }
 }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -445,6 +445,13 @@ final class AccountInfoKeyManagingMock: AccountInfoKeyManaging {
         }
         return refreshKeyStub
     }
+
+    var clearCachedKeyCalls: [SyncAccount] = []
+    var clearCachedKeyHandler: ((SyncAccount) -> Void)?
+    func clearCachedKey(for account: SyncAccount) async {
+        clearCachedKeyCalls.append(account)
+        clearCachedKeyHandler?(account)
+    }
 }
 
 final class ScopedAccessCredentialManagingMock: ScopedAccessCredentialManaging {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -432,6 +432,19 @@ final class AccountInfoKeyManagingMock: AccountInfoKeyManaging {
         return loadKeyStub
     }
 
+    var preloadKeyCalls: [(protectedKeys: [ProtectedKey], accessCredentials: [AccessCredential], account: SyncAccount)] = []
+    var preloadKeyError: Error?
+    func preloadKey(from protectedKeys: [ProtectedKey],
+                    accessCredentials: [AccessCredential],
+                    for account: SyncAccount) async throws {
+        preloadKeyCalls.append((protectedKeys: protectedKeys,
+                                accessCredentials: accessCredentials,
+                                account: account))
+        if let preloadKeyError {
+            throw preloadKeyError
+        }
+    }
+
     var refreshKeyCalls: [SyncAccount] = []
     var refreshKeyStub: AccountInfoKey?
     var refreshKeyError: Error?

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
@@ -169,7 +169,7 @@ final class RegisteredDeviceMapperTests: XCTestCase {
         XCTAssertFalse(result.needsCurrentDeviceInfoRepair)
     }
 
-    func testWhenUnifiedReadIsDisabledAndNativeLegacyFieldsCannotBeDecryptedThenReportsUnresolvedDevice() async {
+    func testWhenUnifiedReadIsDisabledAndNativeLegacyFieldsCannotBeDecryptedThenReturnsUnknownPlaceholder() async {
         var crypter = CryptingMock()
         crypter._base64DecodeAndDecrypt = { _ in
             throw SyncError.failedToDecryptValue("test")
@@ -185,7 +185,6 @@ final class RegisteredDeviceMapperTests: XCTestCase {
 
         let result = await mapper.registeredDevicesWithRepairState(from: [entry], account: makeAccount())
 
-        XCTAssertEqual(result.unresolvedNativeDeviceIDs, ["native-device"])
         XCTAssertEqual(result.devices.map(\.name), ["Unknown"])
         XCTAssertFalse(result.needsCurrentDeviceInfoRepair)
     }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
@@ -85,12 +85,14 @@ final class RegisteredDeviceMapperTests: XCTestCase {
                                           info: "encrypted-info",
                                           credentialId: SyncCredentialID.defaultCredential)
 
-        let devices = await mapper.registeredDevices(from: [entry], account: makeAccount())
+        let result = await mapper.registeredDevicesWithRepairState(from: [entry], account: makeAccount())
+        let devices = result.devices
 
         XCTAssertEqual(devices.map(\.name), ["Legacy Mac"])
         XCTAssertEqual(devices.map(\.type), ["desktop"])
         XCTAssertTrue(accountInfoKeys.loadKeyCalls.isEmpty)
         XCTAssertTrue(deviceInfoCodec.decryptCalls.isEmpty)
+        XCTAssertFalse(result.needsCurrentDeviceInfoRepair)
     }
 
     func testWhenUnifiedEntriesAreMixedThenEachEntryFallsBackIndependently() async throws {
@@ -127,7 +129,8 @@ final class RegisteredDeviceMapperTests: XCTestCase {
                                   credentialId: SyncCredentialID.thirdParty)
         ]
 
-        let devices = await mapper.registeredDevices(from: entries, account: account)
+        let result = await mapper.registeredDevicesWithRepairState(from: entries, account: account)
+        let devices = result.devices
 
         XCTAssertEqual(devices.map(\.id), ["future-device", "native-device", "third-party-device"])
         XCTAssertEqual(devices.map(\.name), ["Future Browser", "Legacy Mac", "Browser"])
@@ -136,6 +139,7 @@ final class RegisteredDeviceMapperTests: XCTestCase {
         XCTAssertEqual(accountInfoKeys.loadKeyCalls.count, 1)
         XCTAssertTrue(accountInfoKeys.refreshKeyCalls.isEmpty)
         XCTAssertEqual(deviceInfoCodec.decryptCalls, ["valid-info", "invalid-info", "invalid-info"])
+        XCTAssertFalse(result.needsCurrentDeviceInfoRepair)
     }
 
     func testWhenUnifiedInfoUsesUnexpectedKeyIDThenRefreshesOnceAndRetriesAllEntries() async throws {
@@ -168,12 +172,14 @@ final class RegisteredDeviceMapperTests: XCTestCase {
                                   credentialId: SyncCredentialID.defaultCredential)
         ]
 
-        let devices = await mapper.registeredDevices(from: entries, account: account)
+        let result = await mapper.registeredDevicesWithRepairState(from: entries, account: account)
+        let devices = result.devices
 
         XCTAssertEqual(devices.map(\.name), ["Unified info-one", "Unified info-two"])
         XCTAssertEqual(accountInfoKeys.loadKeyCalls.map(\.deviceId), [account.deviceId])
         XCTAssertEqual(accountInfoKeys.refreshKeyCalls.map(\.deviceId), [account.deviceId])
         XCTAssertEqual(deviceInfoCodec.decryptCalls, ["info-one", "info-two", "info-one", "info-two"])
+        XCTAssertFalse(result.needsCurrentDeviceInfoRepair)
     }
 
     func testWhenUnifiedInfoStillUsesUnexpectedKeyIDAfterRefreshThenFallsBackWithoutRefreshingAgain() async throws {
@@ -190,36 +196,85 @@ final class RegisteredDeviceMapperTests: XCTestCase {
                                             deviceInfoCodec: deviceInfoCodec,
                                             isScopedAccessCredentialsEnabled: { true },
                                             canReadUnifiedDeviceList: { true })
-        let entry = RegisteredDeviceEntry(id: "native-device",
+        let entry = RegisteredDeviceEntry(id: account.deviceId,
                                           name: "encrypted_Legacy Mac",
                                           type: "encrypted_desktop",
                                           info: "encrypted-info",
                                           credentialId: SyncCredentialID.defaultCredential)
 
-        let devices = await mapper.registeredDevices(from: [entry], account: account)
+        let result = await mapper.registeredDevicesWithRepairState(from: [entry], account: account)
+        let devices = result.devices
 
         XCTAssertEqual(devices.map(\.name), ["Legacy Mac"])
         XCTAssertEqual(accountInfoKeys.loadKeyCalls.count, 1)
         XCTAssertEqual(accountInfoKeys.refreshKeyCalls.count, 1)
         XCTAssertEqual(deviceInfoCodec.decryptCalls, ["encrypted-info", "encrypted-info"])
+        XCTAssertTrue(result.needsCurrentDeviceInfoRepair)
     }
 
-    func testWhenUnifiedReadIsEnabledButNoEntryHasInfoThenDoesNotLoadAccountInfoKey() async {
+    func testWhenCurrentDeviceUnifiedInfoIsCorruptThenRequestsRepair() async throws {
+        let account = makeAccount()
+        let accountInfoKeys = AccountInfoKeyManagingMock()
+        accountInfoKeys.loadKeyStub = try makeAccountInfoKey()
+        let deviceInfoCodec = DeviceInfoReadingMock()
+        deviceInfoCodec.decryptHandler = { _, _ in
+            throw DeviceInfoCodecError.invalidPayload
+        }
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            accountInfoKeys: accountInfoKeys,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true })
+        let entry = RegisteredDeviceEntry(id: account.deviceId,
+                                          name: "encrypted_Legacy Mac",
+                                          type: "encrypted_desktop",
+                                          info: "corrupt-info",
+                                          credentialId: SyncCredentialID.defaultCredential)
+
+        let result = await mapper.registeredDevicesWithRepairState(from: [entry], account: account)
+
+        XCTAssertEqual(result.devices.map(\.name), ["Legacy Mac"])
+        XCTAssertTrue(result.needsCurrentDeviceInfoRepair)
+    }
+
+    func testWhenCurrentDeviceAccountInfoKeyIsUnavailableThenDoesNotRequestRepair() async {
+        let account = makeAccount()
         let accountInfoKeys = AccountInfoKeyManagingMock()
         let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
                                             accountInfoKeys: accountInfoKeys,
                                             isScopedAccessCredentialsEnabled: { true },
                                             canReadUnifiedDeviceList: { true })
-        let entry = RegisteredDeviceEntry(id: "native-device",
+        let entry = RegisteredDeviceEntry(id: account.deviceId,
+                                          name: "encrypted_Legacy Mac",
+                                          type: "encrypted_desktop",
+                                          info: "encrypted-info",
+                                          credentialId: SyncCredentialID.defaultCredential)
+
+        let result = await mapper.registeredDevicesWithRepairState(from: [entry], account: account)
+
+        XCTAssertEqual(result.devices.map(\.name), ["Legacy Mac"])
+        XCTAssertFalse(result.needsCurrentDeviceInfoRepair)
+    }
+
+    func testWhenUnifiedReadIsEnabledButNoEntryHasInfoThenDoesNotLoadAccountInfoKey() async {
+        let account = makeAccount()
+        let accountInfoKeys = AccountInfoKeyManagingMock()
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            accountInfoKeys: accountInfoKeys,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true })
+        let entry = RegisteredDeviceEntry(id: account.deviceId,
                                           name: "encrypted_Mac",
                                           type: "encrypted_desktop",
                                           info: nil,
                                           credentialId: SyncCredentialID.defaultCredential)
 
-        let devices = await mapper.registeredDevices(from: [entry], account: makeAccount())
+        let result = await mapper.registeredDevicesWithRepairState(from: [entry], account: account)
+        let devices = result.devices
 
         XCTAssertEqual(devices.map(\.name), ["Mac"])
         XCTAssertTrue(accountInfoKeys.loadKeyCalls.isEmpty)
+        XCTAssertTrue(result.needsCurrentDeviceInfoRepair)
     }
 
     func testWhenMappingThirdPartyEntryWithCachedScopedPasswordThenDecryptsJWEFields() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
@@ -42,7 +42,7 @@ final class RegisteredDeviceMapperTests: XCTestCase {
     func testWhenUnifiedReadIsEnabledThenPrefersDeviceInfoOverLegacyFields() async throws {
         let account = makeAccount()
         let accountInfoKeys = AccountInfoKeyManagingMock()
-        accountInfoKeys.loadKeyStub = try makeAccountInfoKeyMaterial()
+        accountInfoKeys.loadKeyStub = try makeAccountInfoKey()
         let deviceInfoCodec = DeviceInfoReadingMock()
         deviceInfoCodec.decryptHandler = { encryptedDeviceInfo, _ in
             XCTAssertEqual(encryptedDeviceInfo, "encrypted-info")
@@ -96,7 +96,7 @@ final class RegisteredDeviceMapperTests: XCTestCase {
     func testWhenUnifiedEntriesAreMixedThenEachEntryFallsBackIndependently() async throws {
         let account = makeAccount()
         let accountInfoKeys = AccountInfoKeyManagingMock()
-        accountInfoKeys.loadKeyStub = try makeAccountInfoKeyMaterial()
+        accountInfoKeys.loadKeyStub = try makeAccountInfoKey()
         let deviceInfoCodec = DeviceInfoReadingMock()
         deviceInfoCodec.decryptHandler = { encryptedDeviceInfo, _ in
             guard encryptedDeviceInfo == "valid-info" else {
@@ -141,8 +141,8 @@ final class RegisteredDeviceMapperTests: XCTestCase {
     func testWhenUnifiedInfoUsesUnexpectedKeyIDThenRefreshesOnceAndRetriesAllEntries() async throws {
         let account = makeAccount()
         let accountInfoKeys = AccountInfoKeyManagingMock()
-        accountInfoKeys.loadKeyStub = try makeAccountInfoKeyMaterial(kid: "stale-key")
-        accountInfoKeys.refreshKeyStub = try makeAccountInfoKeyMaterial(kid: "current-key")
+        accountInfoKeys.loadKeyStub = try makeAccountInfoKey(kid: "stale-key")
+        accountInfoKeys.refreshKeyStub = try makeAccountInfoKey(kid: "current-key")
         let deviceInfoCodec = DeviceInfoReadingMock()
         deviceInfoCodec.decryptHandler = { encryptedDeviceInfo, key in
             guard key.kid == "current-key" else {
@@ -179,8 +179,8 @@ final class RegisteredDeviceMapperTests: XCTestCase {
     func testWhenUnifiedInfoStillUsesUnexpectedKeyIDAfterRefreshThenFallsBackWithoutRefreshingAgain() async throws {
         let account = makeAccount()
         let accountInfoKeys = AccountInfoKeyManagingMock()
-        accountInfoKeys.loadKeyStub = try makeAccountInfoKeyMaterial(kid: "stale-key")
-        accountInfoKeys.refreshKeyStub = try makeAccountInfoKeyMaterial(kid: "refreshed-key")
+        accountInfoKeys.loadKeyStub = try makeAccountInfoKey(kid: "stale-key")
+        accountInfoKeys.refreshKeyStub = try makeAccountInfoKey(kid: "refreshed-key")
         let deviceInfoCodec = DeviceInfoReadingMock()
         deviceInfoCodec.decryptHandler = { _, _ in
             throw DeviceInfoCodecError.unexpectedKeyID
@@ -351,28 +351,28 @@ final class RegisteredDeviceMapperTests: XCTestCase {
                     state: .active)
     }
 
-    private func makeAccountInfoKeyMaterial(kid: String = "account-info-key") throws -> AccountInfoKeyMaterial {
+    private func makeAccountInfoKey(kid: String = "account-info-key") throws -> AccountInfoKey {
         let keyPair = try RSAKeyPairGenerator.makeKeyPair()
-        return AccountInfoKeyMaterial(kid: kid,
-                                      publicKey: keyPair.publicKey,
-                                      privateKey: keyPair.privateKey)
+        return AccountInfoKey(kid: kid,
+                              publicKey: keyPair.publicKey,
+                              privateKey: keyPair.privateKey)
     }
 }
 
 private final class DeviceInfoReadingMock: DeviceInfoCoding {
 
     private(set) var decryptCalls: [String] = []
-    var decryptHandler: ((String, AccountInfoKeyMaterial) throws -> DeviceInfo)?
+    var decryptHandler: ((String, AccountInfoKey) throws -> DeviceInfo)?
 
     func encrypt(_ deviceInfo: DeviceInfo, using protectedKey: ProtectedKey) throws -> String {
         throw DeviceInfoCodecError.invalidProtectedKey
     }
 
-    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKeyMaterial) throws -> String {
+    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKey) throws -> String {
         throw DeviceInfoCodecError.invalidProtectedKey
     }
 
-    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKeyMaterial) throws -> DeviceInfo {
+    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKey) throws -> DeviceInfo {
         decryptCalls.append(encryptedDeviceInfo)
         guard let decryptHandler else {
             throw DeviceInfoCodecError.invalidPayload

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
@@ -169,6 +169,27 @@ final class RegisteredDeviceMapperTests: XCTestCase {
         XCTAssertFalse(result.needsCurrentDeviceInfoRepair)
     }
 
+    func testWhenUnifiedReadIsDisabledAndNativeLegacyFieldsCannotBeDecryptedThenReportsUnresolvedDevice() async {
+        var crypter = CryptingMock()
+        crypter._base64DecodeAndDecrypt = { _ in
+            throw SyncError.failedToDecryptValue("test")
+        }
+        let mapper = RegisteredDeviceMapper(crypter: crypter,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { false })
+        let entry = RegisteredDeviceEntry(id: "native-device",
+                                          name: "undecryptable-name",
+                                          type: "undecryptable-type",
+                                          info: "ignored-device-info",
+                                          credentialId: SyncCredentialID.defaultCredential)
+
+        let result = await mapper.registeredDevicesWithRepairState(from: [entry], account: makeAccount())
+
+        XCTAssertEqual(result.unresolvedNativeDeviceIDs, ["native-device"])
+        XCTAssertEqual(result.devices.map(\.name), ["Unknown"])
+        XCTAssertFalse(result.needsCurrentDeviceInfoRepair)
+    }
+
     func testWhenUnifiedEntriesAreMixedThenEachEntryFallsBackIndependently() async throws {
         let account = makeAccount()
         let accountInfoKeys = AccountInfoKeyManagingMock()

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
@@ -39,6 +39,122 @@ final class RegisteredDeviceMapperTests: XCTestCase {
         XCTAssertEqual(device?.credentialId, SyncCredentialID.defaultCredential)
     }
 
+    func testWhenUnifiedReadIsEnabledThenPrefersDeviceInfoOverLegacyFields() async throws {
+        let account = makeAccount()
+        let accountInfoKeys = AccountInfoKeyManagingMock()
+        accountInfoKeys.loadKeyStub = try makeAccountInfoKeyMaterial()
+        let deviceInfoCodec = DeviceInfoReadingMock()
+        deviceInfoCodec.decryptHandler = { encryptedDeviceInfo, _ in
+            XCTAssertEqual(encryptedDeviceInfo, "encrypted-info")
+            return DeviceInfo(name: "Unified Mac", type: "desktop")
+        }
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            accountInfoKeys: accountInfoKeys,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true })
+        let entry = RegisteredDeviceEntry(id: "native-device",
+                                          name: "encrypted_Legacy Mac",
+                                          type: "encrypted_mobile",
+                                          info: "encrypted-info",
+                                          credentialId: SyncCredentialID.defaultCredential)
+
+        let devices = await mapper.registeredDevices(from: [entry], account: account)
+
+        XCTAssertEqual(devices.map(\.name), ["Unified Mac"])
+        XCTAssertEqual(devices.map(\.type), ["desktop"])
+        XCTAssertEqual(accountInfoKeys.loadKeyCalls.map(\.deviceId), [account.deviceId])
+        XCTAssertEqual(deviceInfoCodec.decryptCalls, ["encrypted-info"])
+    }
+
+    func testWhenUnifiedReadIsDisabledThenIgnoresDeviceInfoAndUsesLegacyFields() async {
+        let accountInfoKeys = AccountInfoKeyManagingMock()
+        let deviceInfoCodec = DeviceInfoReadingMock()
+        deviceInfoCodec.decryptHandler = { _, _ in
+            XCTFail("Unified device info should not be decrypted while reads are disabled")
+            throw DeviceInfoCodecError.invalidPayload
+        }
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            accountInfoKeys: accountInfoKeys,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { false })
+        let entry = RegisteredDeviceEntry(id: "native-device",
+                                          name: "encrypted_Legacy Mac",
+                                          type: "encrypted_desktop",
+                                          info: "encrypted-info",
+                                          credentialId: SyncCredentialID.defaultCredential)
+
+        let devices = await mapper.registeredDevices(from: [entry], account: makeAccount())
+
+        XCTAssertEqual(devices.map(\.name), ["Legacy Mac"])
+        XCTAssertEqual(devices.map(\.type), ["desktop"])
+        XCTAssertTrue(accountInfoKeys.loadKeyCalls.isEmpty)
+        XCTAssertTrue(deviceInfoCodec.decryptCalls.isEmpty)
+    }
+
+    func testWhenUnifiedEntriesAreMixedThenEachEntryFallsBackIndependently() async throws {
+        let account = makeAccount()
+        let accountInfoKeys = AccountInfoKeyManagingMock()
+        accountInfoKeys.loadKeyStub = try makeAccountInfoKeyMaterial()
+        let deviceInfoCodec = DeviceInfoReadingMock()
+        deviceInfoCodec.decryptHandler = { encryptedDeviceInfo, _ in
+            guard encryptedDeviceInfo == "valid-info" else {
+                throw DeviceInfoCodecError.invalidPayload
+            }
+            return DeviceInfo(name: "Future Browser", type: "browser")
+        }
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            accountInfoKeys: accountInfoKeys,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true })
+        let entries = [
+            RegisteredDeviceEntry(id: "future-device",
+                                  name: nil,
+                                  type: nil,
+                                  info: "valid-info",
+                                  credentialId: "future"),
+            RegisteredDeviceEntry(id: "native-device",
+                                  name: "encrypted_Legacy Mac",
+                                  type: "encrypted_desktop",
+                                  info: "invalid-info",
+                                  credentialId: SyncCredentialID.defaultCredential),
+            RegisteredDeviceEntry(id: "third-party-device",
+                                  name: nil,
+                                  type: nil,
+                                  info: "invalid-info",
+                                  credentialId: SyncCredentialID.thirdParty)
+        ]
+
+        let devices = await mapper.registeredDevices(from: entries, account: account)
+
+        XCTAssertEqual(devices.map(\.id), ["future-device", "native-device", "third-party-device"])
+        XCTAssertEqual(devices.map(\.name), ["Future Browser", "Legacy Mac", "Browser"])
+        XCTAssertEqual(devices.map(\.type), ["browser", "desktop", "unknown"])
+        XCTAssertEqual(devices.map(\.credentialId), ["future", SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty])
+        XCTAssertEqual(accountInfoKeys.loadKeyCalls.count, 1)
+        XCTAssertEqual(deviceInfoCodec.decryptCalls, ["valid-info", "invalid-info", "invalid-info"])
+    }
+
+    func testWhenUnifiedReadIsEnabledButNoEntryHasInfoThenDoesNotLoadAccountInfoKey() async {
+        let accountInfoKeys = AccountInfoKeyManagingMock()
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            accountInfoKeys: accountInfoKeys,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true })
+        let entry = RegisteredDeviceEntry(id: "native-device",
+                                          name: "encrypted_Mac",
+                                          type: "encrypted_desktop",
+                                          info: nil,
+                                          credentialId: SyncCredentialID.defaultCredential)
+
+        let devices = await mapper.registeredDevices(from: [entry], account: makeAccount())
+
+        XCTAssertEqual(devices.map(\.name), ["Mac"])
+        XCTAssertTrue(accountInfoKeys.loadKeyCalls.isEmpty)
+    }
+
     func testWhenMappingThirdPartyEntryWithCachedScopedPasswordThenDecryptsJWEFields() async throws {
         let account = makeAccount()
         let scopedPassword = Data(repeating: 7, count: 32)
@@ -166,5 +282,34 @@ final class RegisteredDeviceMapperTests: XCTestCase {
                     secretKey: Data(repeating: 2, count: 32),
                     token: "token-1",
                     state: .active)
+    }
+
+    private func makeAccountInfoKeyMaterial() throws -> AccountInfoKeyMaterial {
+        let keyPair = try RSAKeyPairGenerator.makeKeyPair()
+        return AccountInfoKeyMaterial(kid: "account-info-key",
+                                      publicKey: keyPair.publicKey,
+                                      privateKey: keyPair.privateKey)
+    }
+}
+
+private final class DeviceInfoReadingMock: DeviceInfoCoding {
+
+    private(set) var decryptCalls: [String] = []
+    var decryptHandler: ((String, AccountInfoKeyMaterial) throws -> DeviceInfo)?
+
+    func encrypt(_ deviceInfo: DeviceInfo, using protectedKey: ProtectedKey) throws -> String {
+        throw DeviceInfoCodecError.invalidProtectedKey
+    }
+
+    func encrypt(_ deviceInfo: DeviceInfo, using key: AccountInfoKeyMaterial) throws -> String {
+        throw DeviceInfoCodecError.invalidProtectedKey
+    }
+
+    func decrypt(_ encryptedDeviceInfo: String, using key: AccountInfoKeyMaterial) throws -> DeviceInfo {
+        decryptCalls.append(encryptedDeviceInfo)
+        guard let decryptHandler else {
+            throw DeviceInfoCodecError.invalidPayload
+        }
+        return try decryptHandler(encryptedDeviceInfo, key)
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
@@ -67,6 +67,80 @@ final class RegisteredDeviceMapperTests: XCTestCase {
         XCTAssertEqual(deviceInfoCodec.decryptCalls, ["encrypted-info"])
     }
 
+    func testWhenUnifiedThirdPartyInfoDecryptsThenDoesNotLoadLegacyThirdPartyKey() async throws {
+        let account = makeAccount()
+        let accountInfoKeys = AccountInfoKeyManagingMock()
+        accountInfoKeys.loadKeyStub = try makeAccountInfoKey()
+        let deviceInfoCodec = DeviceInfoReadingMock()
+        deviceInfoCodec.decryptHandler = { _, _ in
+            DeviceInfo(name: "Python Client", type: "browser")
+        }
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        var cachedScopedPasswordCalls = 0
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            scopedAccess: scopedAccess,
+                                            accountInfoKeys: accountInfoKeys,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            cachedScopedPassword: {
+                                                cachedScopedPasswordCalls += 1
+                                                return Data(repeating: 7, count: 32)
+                                            },
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true })
+        let entry = RegisteredDeviceEntry(id: "third-party-device",
+                                          name: "legacy-name",
+                                          type: "legacy-type",
+                                          info: "encrypted-info",
+                                          credentialId: SyncCredentialID.thirdParty)
+
+        let devices = await mapper.registeredDevices(from: [entry], account: account)
+
+        XCTAssertEqual(devices.map(\.name), ["Python Client"])
+        XCTAssertEqual(cachedScopedPasswordCalls, 0)
+        XCTAssertTrue(scopedAccess.fetchAccessCredentialsCalls.isEmpty)
+        XCTAssertTrue(scopedAccess.recoverScopedPasswordCalls.isEmpty)
+    }
+
+    func testWhenUnifiedThirdPartyInfoFailsThenLoadsLegacyThirdPartyKey() async throws {
+        let account = makeAccount()
+        let accountInfoKeys = AccountInfoKeyManagingMock()
+        accountInfoKeys.loadKeyStub = try makeAccountInfoKey()
+        let deviceInfoCodec = DeviceInfoReadingMock()
+        deviceInfoCodec.decryptHandler = { _, _ in
+            throw DeviceInfoCodecError.invalidPayload
+        }
+        let scopedPassword = Data(repeating: 7, count: 32)
+        let thirdPartyMainKey = ScopedAccessKeyDerivation.mainKey(from: scopedPassword, userID: account.userId)
+        let codec = JWECompactCodec()
+        var cachedScopedPasswordCalls = 0
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            accountInfoKeys: accountInfoKeys,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            cachedScopedPassword: {
+                                                cachedScopedPasswordCalls += 1
+                                                return scopedPassword
+                                            },
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true },
+                                            jweCompactCodec: codec)
+        let entry = RegisteredDeviceEntry(
+            id: "third-party-device",
+            name: try codec.encryptDirect(payload: Data("Python Client".utf8),
+                                          contentEncryptionKey: thirdPartyMainKey,
+                                          kid: SyncCredentialID.thirdParty),
+            type: try codec.encryptDirect(payload: Data("browser".utf8),
+                                          contentEncryptionKey: thirdPartyMainKey,
+                                          kid: SyncCredentialID.thirdParty),
+            info: "invalid-info",
+            credentialId: SyncCredentialID.thirdParty)
+
+        let devices = await mapper.registeredDevices(from: [entry], account: account)
+
+        XCTAssertEqual(devices.map(\.name), ["Python Client"])
+        XCTAssertEqual(devices.map(\.type), ["browser"])
+        XCTAssertEqual(cachedScopedPasswordCalls, 1)
+    }
+
     func testWhenUnifiedReadIsDisabledThenIgnoresDeviceInfoAndUsesLegacyFields() async {
         let accountInfoKeys = AccountInfoKeyManagingMock()
         let deviceInfoCodec = DeviceInfoReadingMock()

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
@@ -134,7 +134,74 @@ final class RegisteredDeviceMapperTests: XCTestCase {
         XCTAssertEqual(devices.map(\.type), ["browser", "desktop", "unknown"])
         XCTAssertEqual(devices.map(\.credentialId), ["future", SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty])
         XCTAssertEqual(accountInfoKeys.loadKeyCalls.count, 1)
+        XCTAssertTrue(accountInfoKeys.refreshKeyCalls.isEmpty)
         XCTAssertEqual(deviceInfoCodec.decryptCalls, ["valid-info", "invalid-info", "invalid-info"])
+    }
+
+    func testWhenUnifiedInfoUsesUnexpectedKeyIDThenRefreshesOnceAndRetriesAllEntries() async throws {
+        let account = makeAccount()
+        let accountInfoKeys = AccountInfoKeyManagingMock()
+        accountInfoKeys.loadKeyStub = try makeAccountInfoKeyMaterial(kid: "stale-key")
+        accountInfoKeys.refreshKeyStub = try makeAccountInfoKeyMaterial(kid: "current-key")
+        let deviceInfoCodec = DeviceInfoReadingMock()
+        deviceInfoCodec.decryptHandler = { encryptedDeviceInfo, key in
+            guard key.kid == "current-key" else {
+                throw DeviceInfoCodecError.unexpectedKeyID
+            }
+            return DeviceInfo(name: "Unified \(encryptedDeviceInfo)", type: "desktop")
+        }
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            accountInfoKeys: accountInfoKeys,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true })
+        let entries = [
+            RegisteredDeviceEntry(id: "device-1",
+                                  name: "encrypted_Legacy One",
+                                  type: "encrypted_desktop",
+                                  info: "info-one",
+                                  credentialId: SyncCredentialID.defaultCredential),
+            RegisteredDeviceEntry(id: "device-2",
+                                  name: "encrypted_Legacy Two",
+                                  type: "encrypted_desktop",
+                                  info: "info-two",
+                                  credentialId: SyncCredentialID.defaultCredential)
+        ]
+
+        let devices = await mapper.registeredDevices(from: entries, account: account)
+
+        XCTAssertEqual(devices.map(\.name), ["Unified info-one", "Unified info-two"])
+        XCTAssertEqual(accountInfoKeys.loadKeyCalls.map(\.deviceId), [account.deviceId])
+        XCTAssertEqual(accountInfoKeys.refreshKeyCalls.map(\.deviceId), [account.deviceId])
+        XCTAssertEqual(deviceInfoCodec.decryptCalls, ["info-one", "info-two", "info-one", "info-two"])
+    }
+
+    func testWhenUnifiedInfoStillUsesUnexpectedKeyIDAfterRefreshThenFallsBackWithoutRefreshingAgain() async throws {
+        let account = makeAccount()
+        let accountInfoKeys = AccountInfoKeyManagingMock()
+        accountInfoKeys.loadKeyStub = try makeAccountInfoKeyMaterial(kid: "stale-key")
+        accountInfoKeys.refreshKeyStub = try makeAccountInfoKeyMaterial(kid: "refreshed-key")
+        let deviceInfoCodec = DeviceInfoReadingMock()
+        deviceInfoCodec.decryptHandler = { _, _ in
+            throw DeviceInfoCodecError.unexpectedKeyID
+        }
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            accountInfoKeys: accountInfoKeys,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true })
+        let entry = RegisteredDeviceEntry(id: "native-device",
+                                          name: "encrypted_Legacy Mac",
+                                          type: "encrypted_desktop",
+                                          info: "encrypted-info",
+                                          credentialId: SyncCredentialID.defaultCredential)
+
+        let devices = await mapper.registeredDevices(from: [entry], account: account)
+
+        XCTAssertEqual(devices.map(\.name), ["Legacy Mac"])
+        XCTAssertEqual(accountInfoKeys.loadKeyCalls.count, 1)
+        XCTAssertEqual(accountInfoKeys.refreshKeyCalls.count, 1)
+        XCTAssertEqual(deviceInfoCodec.decryptCalls, ["encrypted-info", "encrypted-info"])
     }
 
     func testWhenUnifiedReadIsEnabledButNoEntryHasInfoThenDoesNotLoadAccountInfoKey() async {
@@ -284,9 +351,9 @@ final class RegisteredDeviceMapperTests: XCTestCase {
                     state: .active)
     }
 
-    private func makeAccountInfoKeyMaterial() throws -> AccountInfoKeyMaterial {
+    private func makeAccountInfoKeyMaterial(kid: String = "account-info-key") throws -> AccountInfoKeyMaterial {
         let keyPair = try RSAKeyPairGenerator.makeKeyPair()
-        return AccountInfoKeyMaterial(kid: "account-info-key",
+        return AccountInfoKeyMaterial(kid: kid,
                                       publicKey: keyPair.publicKey,
                                       privateKey: keyPair.privateKey)
     }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
@@ -45,6 +45,94 @@ struct AccountInfoKeyManagerTests {
     }
 
     @available(iOS 16, macOS 13, *)
+    @Test("Repeated loads use the in-memory key", .timeLimit(.minutes(1)))
+    func testWhenKeyIsLoadedRepeatedlyThenUsesInMemoryKeyMaterial() async throws {
+        let protectedKey = try makeDefaultCredentialProtectedKey()
+        let secureStore = SecureStorageStub()
+        secureStore.theProtectedKeysData = try JSONEncoder.snakeCaseKeys.encode([protectedKey])
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        let firstKey = try await manager.loadKey(for: account)
+        secureStore.theProtectedKeysData = nil
+        let secondKey = try await manager.loadKey(for: account)
+
+        #expect(firstKey.kid == protectedKey.kid)
+        #expect(secondKey.kid == protectedKey.kid)
+        #expect(secureStore.protectedKeysCalls == 1)
+        #expect(scopedAccess.fetchProtectedKeysCalls.isEmpty)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Changing accounts does not reuse the in-memory key", .timeLimit(.minutes(1)))
+    func testWhenAccountChangesThenDoesNotReuseInMemoryKeyMaterial() async throws {
+        let protectedKey = try makeDefaultCredentialProtectedKey()
+        let secureStore = SecureStorageStub()
+        secureStore.theProtectedKeysData = try JSONEncoder.snakeCaseKeys.encode([protectedKey])
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+        let otherAccount = SyncAccount(deviceId: "other-device",
+                                       deviceName: account.deviceName,
+                                       deviceType: account.deviceType,
+                                       userId: "other-user",
+                                       primaryKey: account.primaryKey,
+                                       secretKey: account.secretKey,
+                                       token: account.token,
+                                       state: account.state)
+
+        _ = try await manager.loadKey(for: account)
+        _ = try await manager.loadKey(for: otherAccount)
+
+        #expect(secureStore.protectedKeysCalls == 2)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Clearing the in-memory key reloads protected keys", .timeLimit(.minutes(1)))
+    func testWhenCachedKeyIsClearedThenLoadsProtectedKeyAgain() async throws {
+        let protectedKey = try makeDefaultCredentialProtectedKey()
+        let secureStore = SecureStorageStub()
+        secureStore.theProtectedKeysData = try JSONEncoder.snakeCaseKeys.encode([protectedKey])
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        _ = try await manager.loadKey(for: account)
+        await manager.clearCachedKey(for: account)
+        _ = try await manager.loadKey(for: account)
+
+        #expect(secureStore.protectedKeysCalls == 2)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Refreshing replaces the in-memory key", .timeLimit(.minutes(1)))
+    func testWhenKeyIsRefreshedThenSubsequentLoadsUseRefreshedInMemoryMaterial() async throws {
+        let cachedProtectedKey = try makeDefaultCredentialProtectedKey()
+        let refreshedProtectedKey = try makeDefaultCredentialProtectedKey()
+        let secureStore = SecureStorageStub()
+        secureStore.theProtectedKeysData = try JSONEncoder.snakeCaseKeys.encode([cachedProtectedKey])
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        scopedAccess.fetchProtectedKeysStub = [refreshedProtectedKey]
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        _ = try await manager.loadKey(for: account)
+        let refreshedKey = try await manager.refreshKey(for: account)
+        secureStore.theProtectedKeysData = nil
+        let loadedKey = try await manager.loadKey(for: account)
+
+        #expect(refreshedKey.kid == refreshedProtectedKey.kid)
+        #expect(loadedKey.kid == refreshedProtectedKey.kid)
+        #expect(secureStore.protectedKeysCalls == 1)
+        #expect(scopedAccess.fetchProtectedKeysCalls.map(\.userId) == [account.userId])
+    }
+
+    @available(iOS 16, macOS 13, *)
     @Test("A corrupt cache is replaced with server keys", .timeLimit(.minutes(1)))
     func testWhenCacheIsCorruptThenFetchesAndCachesServerKeys() async throws {
         let protectedKey = try makeDefaultCredentialProtectedKey()

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
@@ -66,6 +66,60 @@ struct AccountInfoKeyManagerTests {
     }
 
     @available(iOS 16, macOS 13, *)
+    @Test("A default-credential key from login is reused without fetching or persisting", .timeLimit(.minutes(1)))
+    func testWhenLoginProvidesDefaultCredentialKeyThenLoadsItInMemoryOnly() async throws {
+        let protectedKey = try makeDefaultCredentialProtectedKey()
+        let secureStore = SecureStorageStub()
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        try await manager.preloadKey(from: [protectedKey],
+                                     accessCredentials: [],
+                                     for: account)
+        let cachedKey = try await manager.loadKey(for: account)
+
+        #expect(cachedKey.kid == protectedKey.kid)
+        #expect(scopedAccess.fetchProtectedKeysCalls.isEmpty)
+        #expect(scopedAccess.fetchAccessCredentialsCalls.isEmpty)
+        #expect(secureStore.protectedKeysCalls == 0)
+        #expect(secureStore.theProtectedKeysData == nil)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("A third-party key from login uses the provided credential without fetching or persisting", .timeLimit(.minutes(1)))
+    func testWhenLoginProvidesThirdPartyKeyThenUsesResponseCredentialInMemoryOnly() async throws {
+        let scopedPassword = Data(repeating: 0x03, count: 32)
+        let protectedKey = try makeThirdPartyCredentialProtectedKey(scopedPassword: scopedPassword)
+        let accessCredentials = [
+            AccessCredential(id: SyncCredentialID.thirdParty,
+                             scope: "sync",
+                             encrypted3PartyCredential: "encrypted-credential")
+        ]
+        let secureStore = SecureStorageStub()
+        let scopedAccess = ScopedAccessCredentialManagingMock()
+        scopedAccess.recoverScopedPasswordStub = scopedPassword
+        let manager = AccountInfoKeyManager(secureStore: secureStore,
+                                            scopedAccess: scopedAccess,
+                                            crypter: crypter)
+
+        try await manager.preloadKey(from: [protectedKey],
+                                     accessCredentials: accessCredentials,
+                                     for: account)
+        let cachedKey = try await manager.loadKey(for: account)
+
+        let recoveryCall = try #require(scopedAccess.recoverScopedPasswordCalls.first)
+        #expect(cachedKey.kid == protectedKey.kid)
+        #expect(recoveryCall.accessCredentials?.map(\.id) == [SyncCredentialID.thirdParty])
+        #expect(scopedAccess.fetchProtectedKeysCalls.isEmpty)
+        #expect(scopedAccess.fetchAccessCredentialsCalls.isEmpty)
+        #expect(secureStore.protectedKeysCalls == 0)
+        #expect(secureStore.theProtectedKeysData == nil)
+        #expect(secureStore.theScopedPassword == nil)
+    }
+
+    @available(iOS 16, macOS 13, *)
     @Test("Changing accounts does not reuse the in-memory key", .timeLimit(.minutes(1)))
     func testWhenAccountChangesThenDoesNotReuseInMemoryKeyMaterial() async throws {
         let protectedKey = try makeDefaultCredentialProtectedKey()

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyManagerTests.swift
@@ -128,7 +128,7 @@ struct AccountInfoKeyManagerTests {
 
         #expect(refreshedKey.kid == refreshedProtectedKey.kid)
         #expect(loadedKey.kid == refreshedProtectedKey.kid)
-        #expect(secureStore.protectedKeysCalls == 1)
+        #expect(secureStore.protectedKeysCalls == 2)
         #expect(scopedAccess.fetchProtectedKeysCalls.map(\.userId) == [account.userId])
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SecureStorageStub.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SecureStorageStub.swift
@@ -29,6 +29,7 @@ class SecureStorageStub: SecureStoring {
     var mockWriteError: SyncError?
     var persistScopedPasswordCalls: [Data] = []
     var persistScopedPasswordCalled: (() -> Void)?
+    var protectedKeysCalls = 0
 
     func persistAccount(_ account: SyncAccount) throws {
         if let mockWriteError {
@@ -81,6 +82,7 @@ class SecureStorageStub: SecureStoring {
     }
 
     func protectedKeys() throws -> Data? {
+        protectedKeysCalls += 1
         if let mockReadError {
             throw mockReadError
         }

--- a/iOS/DuckDuckGo/SyncDebugViewController.swift
+++ b/iOS/DuckDuckGo/SyncDebugViewController.swift
@@ -59,6 +59,7 @@ class SyncDebugViewController: UITableViewController {
 
         case accountInfoKey
         case migration
+        case refreshDevices
 
     }
 
@@ -86,8 +87,10 @@ class SyncDebugViewController: UITableViewController {
 
     private let bookmarksDatabase: CoreDataDatabase
     private let sync: DDGSyncing
+    private var debugDevices: [RegisteredDeviceDebugInfo] = []
     private var accountInfoKeyStatus = "Not checked"
     private var migrationStatus = "Not checked"
+    private var isRefreshingDevices = false
 
     var syncCancellable: Cancellable?
 
@@ -155,17 +158,32 @@ class SyncDebugViewController: UITableViewController {
             }
 
         case .unifiedDevices:
-            switch UnifiedDeviceRows(rawValue: indexPath.row) {
-            case .accountInfoKey:
-                cell.textLabel?.text = "Account info key"
-                cell.detailTextLabel?.text = accountInfoKeyStatus
+            if let row = UnifiedDeviceRows(rawValue: indexPath.row) {
+                switch row {
+                case .accountInfoKey:
+                    cell.textLabel?.text = "Account info key"
+                    cell.detailTextLabel?.text = accountInfoKeyStatus
+                    cell.accessoryType = .disclosureIndicator
+                case .migration:
+                    cell.textLabel?.text = "Migration"
+                    cell.detailTextLabel?.text = migrationStatus
+                    cell.selectionStyle = .none
+                case .refreshDevices:
+                    cell.textLabel?.text = "Refresh devices"
+                    cell.detailTextLabel?.text = isRefreshingDevices ? "Loading…" : nil
+                    cell.selectionStyle = isRefreshingDevices ? .none : .default
+                }
+            } else {
+                let debugDevice = debugDevices[indexPath.row - UnifiedDeviceRows.allCases.count]
+                let device = debugDevice.device
+                let isCurrentDevice = device.id == sync.account?.deviceId
+                cell.textLabel?.text = isCurrentDevice ? "\(device.name) (this device)" : device.name
+                cell.detailTextLabel?.text = [
+                    device.type,
+                    device.credentialId ?? SyncCredentialID.defaultCredential,
+                    sourceDescription(for: debugDevice)
+                ].joined(separator: " • ")
                 cell.accessoryType = .disclosureIndicator
-            case .migration:
-                cell.textLabel?.text = "Migration"
-                cell.detailTextLabel?.text = migrationStatus
-                cell.selectionStyle = .none
-            case .none:
-                break
             }
 
         case .testActions:
@@ -235,7 +253,7 @@ class SyncDebugViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch Sections(rawValue: section) {
         case .info: return InfoRows.allCases.count
-        case .unifiedDevices: return UnifiedDeviceRows.allCases.count
+        case .unifiedDevices: return UnifiedDeviceRows.allCases.count + debugDevices.count
         case .testActions: return TestActionRows.allCases.count
         case .models: return ModelRows.allCases.count
         case .environment: return EnvironmentRows.allCases.count
@@ -276,11 +294,18 @@ class SyncDebugViewController: UITableViewController {
             default: break
             }
         case .unifiedDevices:
-            switch UnifiedDeviceRows(rawValue: indexPath.row) {
-            case .accountInfoKey:
-                validateAccountInfoKey()
-            case .migration, .none:
-                break
+            if let row = UnifiedDeviceRows(rawValue: indexPath.row) {
+                switch row {
+                case .accountInfoKey:
+                    validateAccountInfoKey()
+                case .migration:
+                    break
+                case .refreshDevices:
+                    refreshDevicesForDebug()
+                }
+            } else {
+                let debugDevice = debugDevices[indexPath.row - UnifiedDeviceRows.allCases.count]
+                showDeviceDetails(debugDevice)
             }
         case .testActions:
             switch TestActionRows(rawValue: indexPath.row) {
@@ -387,6 +412,27 @@ class SyncDebugViewController: UITableViewController {
         }
     }
 
+    private func refreshDevicesForDebug() {
+        guard !isRefreshingDevices else { return }
+
+        isRefreshingDevices = true
+        reloadUnifiedDevicesSection()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                isRefreshingDevices = false
+                reloadUnifiedDevicesSection()
+            }
+
+            do {
+                debugDevices = try await sync.fetchDevicesForDebug()
+            } catch {
+                debugDevices = []
+                showAlert(title: "Unable to Fetch Devices", message: String(reflecting: error))
+            }
+        }
+    }
+
     private func refreshMigrationStatus() {
         do {
             migrationStatus = try sync.isDeviceInfoMigrationCompleteForDebug() ? "Complete" : "Not complete"
@@ -406,6 +452,7 @@ class SyncDebugViewController: UITableViewController {
                 let isComplete = try sync.isDeviceInfoMigrationCompleteForDebug()
                 let message = isComplete ? "Migration is complete." : "Migration did not complete. Check the Sync logs for details."
                 showAlert(title: "Device Info Migration", message: message)
+                refreshDevicesForDebug()
             } catch {
                 showAlert(title: "Unable to Run Migration", message: String(reflecting: error))
             }
@@ -424,6 +471,35 @@ class SyncDebugViewController: UITableViewController {
             refreshMigrationStatus()
         })
         present(alertController, animated: true)
+    }
+
+    private func showDeviceDetails(_ debugDevice: RegisteredDeviceDebugInfo) {
+        let device = debugDevice.device
+        let issue = debugDevice.deviceInfoIssue ?? "None"
+        let message = """
+        ID: \(device.id)
+        Type: \(device.type)
+        Credential: \(device.credentialId ?? SyncCredentialID.defaultCredential)
+        Source: \(sourceDescription(for: debugDevice))
+        Device info issue: \(issue)
+        """
+        let alertController = UIAlertController(title: device.name, message: message, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "Copy ID", style: .default) { _ in
+            UIPasteboard.general.string = device.id
+        })
+        alertController.addAction(UIAlertAction(title: "OK", style: .cancel))
+        present(alertController, animated: true)
+    }
+
+    private func sourceDescription(for debugDevice: RegisteredDeviceDebugInfo) -> String {
+        switch debugDevice.source {
+        case .deviceInfo:
+            return debugDevice.source.rawValue
+        case .legacy:
+            return debugDevice.deviceInfoIssue == nil ? "legacy" : "legacy fallback"
+        case .placeholder:
+            return "placeholder"
+        }
     }
 
     private func abbreviatedKeyID(_ keyID: String) -> String {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1216959071260317?focus=true
Tech Design URL:
CC:

### Description
Sync accounts can now contain two representations of a device’s name and type:
- the existing legacy fields; and
- encrypted `device_info`, the shared format for the unified device list.

This PR adds support for reading the unified format when `canReadUnifiedDeviceList` is enabled. Each device is resolved independently: prefers `device_info`, falls back to that device’s legacy fields if the unified data cannot be used, and shows a generic placeholder only when neither representation is readable.

If `device_info` refers to key data that may be out of date locally, the app refreshes the account key once and retries before falling back. A missing or malformed entry therefore cannot hide the other devices, block the list, or sign the user out.

When the read flag is disabled, `device_info` is ignored completely and existing legacy behaviour remains unchanged, including its existing placeholder fallback. The device-management UI is unchanged.

iOS debug diagnostics show the selected source and any unified-data issue for each device, allowing verification of  unified, legacy-fallback, and placeholder behaviour.

### Testing Steps
**Prerequisite:** Test on iOS with macOS as a second device. Start with Sync disabled on both platforms and use a new Sync account. The iOS Sync debug screen provides the per-device diagnostics.

1. Enable `syncCanWriteUnifiedDeviceList` and `syncCanReadUnifiedDeviceList` on iOS.
2. Disable `syncCanWriteUnifiedDeviceList` on macOS.
3. Enable Sync on iOS to create a new account → account creation succeeds.
4. Pair macOS with the new iOS account → both devices connect successfully.
5. On iOS, open Debug > Sync and tap Refresh devices → the iOS device reports `device_info`, while the macOS device reports legacy fallback with a missing `device_info` issue.
6. Open the normal Sync device list on iOS → both devices appear with the correct names and types, and the account remains signed in.
7. Enable `syncCanWriteUnifiedDeviceList` on macOS and restart the macOS app → its current-device migration runs in the background.
8. Refresh devices from the iOS Sync debug screen → both devices now report `device_info`.
9. Open the normal Sync device list on both platforms → each platform displays the other device with the correct name and type.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync login, device listing, and crypto key handling; failures are designed to fall back rather than sign out, but incorrect mapping could still show wrong device names.
> 
> **Overview**
> When **`canReadUnifiedDeviceList`** is on, device fetch/login/update paths resolve each device from encrypted **`device_info`** (via the **`account_info`** key) before falling back to legacy name/type fields or generic placeholders, without auto-logout on decrypt failures.
> 
> **`RegisteredDeviceMapper`** returns a richer mapping result (including whether the current device needs **`device_info`** repair), refreshes the account key once on **`unexpectedKeyID`**, and exposes per-device debug metadata. **`AccountInfoKeyManager`** adds in-memory key caching, login-time **`preloadKey`**, and cache clearing on account removal; JWE decryption now surfaces key-ID mismatches distinctly.
> 
> **`fetchDevicesForDebug`** and the iOS Sync debug screen add **Refresh devices** to show source (`device_info`, legacy, placeholder) and unified-data issues. With the read flag off, **`device_info`** is ignored and prior legacy behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e45cded325b663f456bb5be10c33e6cceb8b100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->