### PR TITLE
iOS: Gate NTP remote messages through the promo queue

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/FlowManagers/SuggestionTrayManager.swift
@@ -61,6 +61,7 @@ extension SuggestionTrayManagerDelegate {
 }
 
 /// Manages the suggestion tray functionality including favorites and autocomplete
+@MainActor
 final class SuggestionTrayManager: NSObject {
     
     // MARK: - Properties

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -203,7 +203,6 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
             switchBarHandler.updateBarPosition(isTop: isUsingTopBarPosition)
         }
         setupView()
-        prepareHomePageMessagesForActivation()
         installComponents()
         setupSubscriptions()
         observeRemoteMessagesChanges()
@@ -216,6 +215,8 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        prepareHomePageMessagesForActivation()
 
         if aiChatHistoryManager == nil {
             installChatHistoryList()
@@ -240,6 +241,7 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+        suggestionTrayDependencies?.newTabPageDependencies.homePageMessagesConfiguration.deactivateNTPHost(.omniBar)
         aiChatHistoryManager?.tearDown()
         aiChatHistoryManager = nil
     }
@@ -623,8 +625,12 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
         let homePageMessagesConfiguration = dependencies.newTabPageDependencies.homePageMessagesConfiguration
         guard homePageMessagesConfiguration.mode == .coordinated else { return }
 
-        let openedAfterIdle = dependencies.tabsModelProvider().currentTab?.openedAfterIdle ?? false
-        homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: openedAfterIdle)
+        guard !switchBarHandler.isFireTab else {
+            homePageMessagesConfiguration.deactivateNTPHost(.omniBar)
+            return
+        }
+
+        homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: escapeHatchModel != nil, host: .omniBar)
     }
 
     private func scheduleAnimation(_ animation: @escaping () -> Void, completion: ((UIViewAnimatingPosition) -> Void)? = nil) {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -241,7 +241,6 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        suggestionTrayDependencies?.newTabPageDependencies.homePageMessagesConfiguration.deactivateNTPHost(.omniBar)
         aiChatHistoryManager?.tearDown()
         aiChatHistoryManager = nil
     }
@@ -625,12 +624,9 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
         let homePageMessagesConfiguration = dependencies.newTabPageDependencies.homePageMessagesConfiguration
         guard homePageMessagesConfiguration.mode == .coordinated else { return }
 
-        guard !switchBarHandler.isFireTab else {
-            homePageMessagesConfiguration.deactivateNTPHost(.omniBar)
-            return
-        }
+        guard !switchBarHandler.isFireTab else { return }
 
-        homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: escapeHatchModel != nil, host: .omniBar)
+        homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: escapeHatchModel != nil)
     }
 
     private func scheduleAnimation(_ animation: @escaping () -> Void, completion: ((UIViewAnimatingPosition) -> Void)? = nil) {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -620,8 +620,11 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
     private func prepareHomePageMessagesForActivation() {
         guard let dependencies = suggestionTrayDependencies else { return }
 
+        let homePageMessagesConfiguration = dependencies.newTabPageDependencies.homePageMessagesConfiguration
+        guard homePageMessagesConfiguration.mode == .coordinated else { return }
+
         let openedAfterIdle = dependencies.tabsModelProvider().currentTab?.openedAfterIdle ?? false
-        dependencies.newTabPageDependencies.homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: openedAfterIdle)
+        homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: openedAfterIdle)
     }
 
     private func scheduleAnimation(_ animation: @escaping () -> Void, completion: ((UIViewAnimatingPosition) -> Void)? = nil) {

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/OmniBarEditingStateViewController.swift
@@ -203,6 +203,7 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
             switchBarHandler.updateBarPosition(isTop: isUsingTopBarPosition)
         }
         setupView()
+        prepareHomePageMessagesForActivation()
         installComponents()
         setupSubscriptions()
         observeRemoteMessagesChanges()
@@ -595,6 +596,18 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
     }
 
     private func observeRemoteMessagesChanges() {
+        guard let configuration = suggestionTrayDependencies?.newTabPageDependencies.homePageMessagesConfiguration else { return }
+
+        if configuration.mode == .coordinated {
+            notificationCancellable = configuration.contentDidChangePublisher
+                .sink { [weak self] _ in
+                    guard let self else { return }
+                    self.suggestionTrayManager?.showInitialSuggestions()
+                    self.updateDaxVisibility()
+                }
+            return
+        }
+
         notificationCancellable = NotificationCenter.default.publisher(for: RemoteMessagingStore.Notifications.remoteMessagesDidChange)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
@@ -602,6 +615,13 @@ final class OmniBarEditingStateViewController: UIViewController, OmniBarEditingS
                 self.suggestionTrayManager?.showInitialSuggestions()
                 self.updateDaxVisibility()
             }
+    }
+
+    private func prepareHomePageMessagesForActivation() {
+        guard let dependencies = suggestionTrayDependencies else { return }
+
+        let openedAfterIdle = dependencies.tabsModelProvider().currentTab?.openedAfterIdle ?? false
+        dependencies.newTabPageDependencies.homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: openedAfterIdle)
     }
 
     private func scheduleAnimation(_ animation: @escaping () -> Void, completion: ((UIViewAnimatingPosition) -> Void)? = nil) {

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
@@ -146,6 +146,9 @@ struct Foreground: ForegroundHandling {
                 // This helps distinguish database corruption from fresh installs/restores
                 BoolFileMarker(name: .hasSuccessfullyLaunchedBefore)?.mark()
 
+                // A launch action may replace a restored NTP, so prepare only after that action has settled.
+                appDependencies.mainCoordinator.prepareHomePageMessagesForForegroundIfNeeded()
+
                 // Present any eligible modal prompt
                 appDependencies.mainCoordinator.presentModalPromptIfNeeded()
             }

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -340,6 +340,7 @@ struct Launching: LaunchingHandling {
                                               maliciousSiteProtectionService: maliciousSiteProtectionService,
                                               customConfigurationURLProvider: AppDependencyProvider.shared.configurationURLProvider,
                                               didFinishLaunchingStartTime: isAppLaunchedInBackground ? nil : didFinishLaunchingStartTime,
+                                              isAppLaunchedInBackground: isAppLaunchedInBackground,
                                               keyValueStore: appKeyValueFileStoreService.keyValueFilesStore,
                                               systemSettingsPiPTutorialManager: systemSettingsPiPTutorialService.manager,
                                               daxDialogsManager: daxDialogs,

--- a/iOS/DuckDuckGo/HomeMessageView.swift
+++ b/iOS/DuckDuckGo/HomeMessageView.swift
@@ -315,6 +315,7 @@ private enum HomeMessagePreviewSamples {
 
     static func makeView(id: String, modelType: HomeSupportedMessageDisplayType) -> HomeMessageView {
         HomeMessageView(viewModel: HomeMessageViewModel(messageId: id,
+                                                        acquisitionIdentity: nil,
                                                         modelType: modelType,
                                                         messageActionHandler: RemoteMessagingActionHandler(),
                                                         preloadedImage: nil,

--- a/iOS/DuckDuckGo/HomeMessageViewModel.swift
+++ b/iOS/DuckDuckGo/HomeMessageViewModel.swift
@@ -53,6 +53,11 @@ enum HomeSupportedMessageDisplayType {
 
 struct HomeMessageViewModel {
 
+    enum ViewIdentity: Hashable {
+        case legacy(messageID: String)
+        case coordinated(messageID: String, acquisitionIdentity: PromoQueueAcquisitionIdentity)
+    }
+
     enum ButtonAction: Equatable {
         case close
         case action(isShare: Bool) // a generic action that is specific to the type of message
@@ -61,6 +66,7 @@ struct HomeMessageViewModel {
     }
 
     let messageId: String
+    let acquisitionIdentity: PromoQueueAcquisitionIdentity?
     let modelType: HomeSupportedMessageDisplayType
     let messageActionHandler: RemoteMessagingActionHandling
     let preloadedImage: UIImage?
@@ -158,6 +164,13 @@ struct HomeMessageViewModel {
     let onDidClose: (ButtonAction?) async -> Void
     let onDidAppear: () -> Void
     let onAttachAdditionalParameters: ((_ useCase: SubscriptionDataReportingUseCase, _ params: [String: String]) -> [String: String])?
+
+    var viewIdentity: ViewIdentity {
+        if let acquisitionIdentity {
+            return .coordinated(messageID: messageId, acquisitionIdentity: acquisitionIdentity)
+        }
+        return .legacy(messageID: messageId)
+    }
 
     func mapActionToViewModel(
         remoteAction: RemoteAction,

--- a/iOS/DuckDuckGo/HomeMessageViewModelBuilder.swift
+++ b/iOS/DuckDuckGo/HomeMessageViewModelBuilder.swift
@@ -24,11 +24,19 @@ import RemoteMessaging
 
 struct HomeMessageViewModelBuilder {
 
+    static func canBuild(for remoteMessage: RemoteMessageModel) -> Bool {
+        guard let content = remoteMessage.content else {
+            return false
+        }
+        return HomeSupportedMessageDisplayType(content) != nil
+    }
+
     static func build(for remoteMessage: RemoteMessageModel,
                       with subscriptionDataReporter: SubscriptionDataReporting?,
                       messageActionHandler: RemoteMessagingActionHandling,
                       imageLoader: RemoteMessagingImageLoading,
                       pixelReporter: RemoteMessagingPixelReporting?,
+                      acquisitionIdentity: PromoQueueAcquisitionIdentity? = nil,
                       onDidClose: @escaping (HomeMessageViewModel.ButtonAction?) async -> Void,
                       onDidAppear: @escaping () -> Void) -> HomeMessageViewModel? {
         guard
@@ -65,6 +73,7 @@ struct HomeMessageViewModelBuilder {
 
         return HomeMessageViewModel(
             messageId: remoteMessage.id,
+            acquisitionIdentity: acquisitionIdentity,
             modelType: homeSupportedMessageDisplayType,
             messageActionHandler: messageActionHandler,
             preloadedImage: preloadedImage,

--- a/iOS/DuckDuckGo/HomePageConfiguration.swift
+++ b/iOS/DuckDuckGo/HomePageConfiguration.swift
@@ -17,109 +17,357 @@
 //  limitations under the License.
 //
 
-import Foundation
 import BrowserServicesKit
-import RemoteMessaging
+import Combine
 import Common
-import FoundationExtensions
 import Core
-import Bookmarks
+import Foundation
+import FoundationExtensions
+import RemoteMessaging
 import os.log
 
+@MainActor
 final class HomePageConfiguration: HomePageMessagesConfiguration {
 
-    // MARK: - Messages
-    
-    private var homeMessageStorage: HomeMessageStorage
-    private var remoteMessagingStore: RemoteMessagingStoring
+    private enum PreparationPolicy {
+        case noTrigger
+        case afterIdleThenNoTrigger
+
+        init(openedAfterIdle: Bool) {
+            self = openedAfterIdle ? .afterIdleThenNoTrigger : .noTrigger
+        }
+    }
+
+    private struct SelectedRemoteMessage {
+        let message: RemoteMessageModel
+        let triggerFilter: TriggerFilter
+    }
+
+    private struct RMFOwnership {
+        let message: RemoteMessageModel
+        let lease: PromoQueueRemoteMessageLease
+        let selectedTriggerFilter: TriggerFilter
+        let presentationContext: HomeMessagePresentationContext
+    }
+
+    private let homeMessageStorage: HomeMessageStorage
+    private let remoteMessagingStore: RemoteMessagingStoring
     private let subscriptionDataReporter: SubscriptionDataReporting
     private let isStillOnboarding: () -> Bool
+    private let promoGate: PromoGating?
+    private let notificationCenter: NotificationCenter
+    private let contentDidChangeSubject = PassthroughSubject<Void, Never>()
+
+    private var remoteMessagesCancellable: AnyCancellable?
+    private var rmfOwnership: RMFOwnership?
+    private var isRMFAdmissionEnabled: Bool
+    private var lastPreparationPolicy: PreparationPolicy?
 
     var homeMessages: [HomeMessage] = []
+    let mode: PromoCoordinationMode
+
+    var contentDidChangePublisher: AnyPublisher<Void, Never> {
+        contentDidChangeSubject.eraseToAnyPublisher()
+    }
 
     init(variantManager: VariantManager? = nil,
          remoteMessagingStore: RemoteMessagingStoring,
          subscriptionDataReporter: SubscriptionDataReporting,
-         isStillOnboarding: @escaping () -> Bool
+         isStillOnboarding: @escaping () -> Bool,
+         promoGate: PromoGating? = nil,
+         isRMFAdmissionEnabled: Bool = true,
+         notificationCenter: NotificationCenter = .default
     ) {
         homeMessageStorage = HomeMessageStorage(variantManager: variantManager)
         self.remoteMessagingStore = remoteMessagingStore
         self.subscriptionDataReporter = subscriptionDataReporter
         self.isStillOnboarding = isStillOnboarding
-        homeMessages = buildHomeMessages(openedAfterIdle: false)
+        self.promoGate = promoGate
+        self.notificationCenter = notificationCenter
+        mode = promoGate?.mode ?? .legacy
+        self.isRMFAdmissionEnabled = isRMFAdmissionEnabled
+
+        switch mode {
+        case .legacy:
+            homeMessages = buildLegacyHomeMessages(openedAfterIdle: false)
+        case .coordinated:
+            homeMessages = nonRemoteHomeMessages
+            observeRemoteMessagesChanges()
+        }
     }
 
     func refresh(openedAfterIdle: Bool = false) {
-        homeMessages = buildHomeMessages(openedAfterIdle: openedAfterIdle)
+        switch mode {
+        case .legacy:
+            homeMessages = buildLegacyHomeMessages(openedAfterIdle: openedAfterIdle)
+        case .coordinated:
+            prepareForNTP(openedAfterIdle: openedAfterIdle)
+        }
     }
 
-    private func buildHomeMessages(openedAfterIdle: Bool) -> [HomeMessage] {
-        var messages = homeMessageStorage.messagesToBeShown
-
-        if isStillOnboarding() {
-            return messages
+    func prepareForNTP(openedAfterIdle: Bool) {
+        guard mode == .coordinated else {
+            homeMessages = buildLegacyHomeMessages(openedAfterIdle: openedAfterIdle)
+            return
+        }
+        guard isRMFAdmissionEnabled else {
+            return
         }
 
-        guard let remoteMessage = remoteMessageToShow(openedAfterIdle: openedAfterIdle) else {
-            return messages
-        }
-
-        messages.append(remoteMessage)
-        return messages
+        let preparationPolicy = PreparationPolicy(openedAfterIdle: openedAfterIdle)
+        lastPreparationPolicy = preparationPolicy
+        reconcileCoordinatedMessages(using: preparationPolicy)
     }
 
-    private func remoteMessageToShow(openedAfterIdle: Bool) -> HomeMessage? {
-        let remoteMessageToPresent: RemoteMessageModel?
-        if openedAfterIdle,
-           let idleMessage = remoteMessagingStore.fetchScheduledRemoteMessage(surfaces: .newTabPage, triggerFilter: .specific(.afterIdle)) {
-            remoteMessageToPresent = idleMessage
-        } else {
-            remoteMessageToPresent = remoteMessagingStore.fetchScheduledRemoteMessage(surfaces: .newTabPage, triggerFilter: .noTrigger)
+    func handleAppBackgrounded() {
+        guard mode == .coordinated else {
+            return
         }
-        guard let remoteMessageToPresent else { return nil }
-        Logger.remoteMessaging.info("Remote message to show: \(remoteMessageToPresent.id, privacy: .public)")
-        return .remoteMessage(remoteMessage: remoteMessageToPresent)
+
+        isRMFAdmissionEnabled = false
+        lastPreparationPolicy = nil
+        endCurrentRMFOwnership(replacingWith: nonRemoteHomeMessages)
     }
 
-    @MainActor
+    func handleAppForegrounded() {
+        guard mode == .coordinated else {
+            return
+        }
+
+        isRMFAdmissionEnabled = true
+    }
+
     func dismissHomeMessage(_ homeMessage: HomeMessage) async {
-        switch homeMessage {
-        case .remoteMessage(let remoteMessage):
-            Logger.remoteMessaging.info("Home message dismissed: \(remoteMessage.id)")
-            await remoteMessagingStore.dismissRemoteMessage(withID: remoteMessage.id)
-            if let index = homeMessages.firstIndex(of: homeMessage) {
-                homeMessages.remove(at: index)
-            }
-            NotificationCenter.default.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
-        default:
-            break
-        }
+        await dismissHomeMessage(homeMessage, presentationContext: nil)
     }
 
     func didAppear(_ homeMessage: HomeMessage) {
-        switch homeMessage {
-        case .remoteMessage(let remoteMessage):
-            Logger.remoteMessaging.info("Remote message shown: \(remoteMessage.id, privacy: .public)")
-            if remoteMessage.isMetricsEnabled {
-                Pixel.fire(pixel: .remoteMessageShown,
-                           withAdditionalParameters: additionalParameters(for: remoteMessage.id))
-            }
+        didAppear(homeMessage, presentationContext: nil)
+    }
 
-            if !remoteMessagingStore.hasShownRemoteMessage(withID: remoteMessage.id) {
-                Logger.remoteMessaging.info("Remote message shown for first time: \(remoteMessage.id, privacy: .public)")
-                if remoteMessage.isMetricsEnabled {
-                    Pixel.fire(pixel: .remoteMessageShownUnique,
-                               withAdditionalParameters: additionalParameters(for: remoteMessage.id))
-                }
-                Task {
-                    await remoteMessagingStore.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
-                }
-            }
+    func presentationContext(for homeMessage: HomeMessage) -> HomeMessagePresentationContext? {
+        guard mode == .coordinated,
+              case .remoteMessage(let remoteMessage) = homeMessage,
+              let rmfOwnership,
+              rmfOwnership.presentationContext.messageID == remoteMessage.id else {
+            return nil
+        }
+        return rmfOwnership.presentationContext
+    }
 
-        default:
-            break
+    func dismissHomeMessage(_ homeMessage: HomeMessage, presentationContext: HomeMessagePresentationContext?) async {
+        guard case .remoteMessage(let remoteMessage) = homeMessage else {
+            return
         }
 
+        guard mode == .coordinated else {
+            await dismissLegacyRemoteMessage(remoteMessage, homeMessage: homeMessage)
+            return
+        }
+
+        guard let presentationContext,
+              isCurrent(presentationContext, for: remoteMessage.id) else {
+            return
+        }
+
+        Logger.remoteMessaging.info("Home message dismissed: \(remoteMessage.id)")
+        await remoteMessagingStore.dismissRemoteMessage(withID: remoteMessage.id)
+
+        if isCurrent(presentationContext, for: remoteMessage.id) {
+            endCurrentRMFOwnership(replacingWith: nonRemoteHomeMessages)
+        }
+
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+    }
+
+    func didAppear(_ homeMessage: HomeMessage, presentationContext: HomeMessagePresentationContext?) {
+        guard case .remoteMessage(let remoteMessage) = homeMessage else {
+            return
+        }
+
+        guard mode == .coordinated else {
+            reportRemoteMessageShown(remoteMessage)
+            return
+        }
+
+        guard let presentationContext,
+              isCurrent(presentationContext, for: remoteMessage.id),
+              let rmfOwnership,
+              rmfOwnership.lease.markShown() else {
+            return
+        }
+
+        reportRemoteMessageShown(rmfOwnership.message)
+    }
+
+    private var nonRemoteHomeMessages: [HomeMessage] {
+        homeMessageStorage.messagesToBeShown
+    }
+
+    private func buildLegacyHomeMessages(openedAfterIdle: Bool) -> [HomeMessage] {
+        var messages = nonRemoteHomeMessages
+        guard !isStillOnboarding(),
+              let selectedRemoteMessage = selectedRemoteMessage(using: PreparationPolicy(openedAfterIdle: openedAfterIdle)) else {
+            return messages
+        }
+
+        messages.append(.remoteMessage(remoteMessage: selectedRemoteMessage.message))
+        return messages
+    }
+
+    private func observeRemoteMessagesChanges() {
+        remoteMessagesCancellable = notificationCenter.publisher(for: RemoteMessagingStore.Notifications.remoteMessagesDidChange)
+            .sink { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.handleRemoteMessagesChanged()
+                }
+            }
+    }
+
+    private func handleRemoteMessagesChanged() {
+        guard mode == .coordinated else {
+            return
+        }
+
+        guard isRMFAdmissionEnabled else {
+            endCurrentRMFOwnership(replacingWith: nonRemoteHomeMessages)
+            return
+        }
+
+        guard rmfOwnership != nil || lastPreparationPolicy != nil else {
+            publishCoordinatedMessages(nonRemoteHomeMessages)
+            return
+        }
+
+        reconcileCoordinatedMessages(using: lastPreparationPolicy)
+    }
+
+    private func reconcileCoordinatedMessages(using preparationPolicy: PreparationPolicy?) {
+        let nonRemoteMessages = nonRemoteHomeMessages
+
+        guard !isStillOnboarding() else {
+            endCurrentRMFOwnership(replacingWith: nonRemoteMessages)
+            return
+        }
+
+        if let rmfOwnership {
+            let currentCandidate = remoteMessage(triggerFilter: rmfOwnership.selectedTriggerFilter)
+            if let currentCandidate,
+               currentCandidate.id == rmfOwnership.lease.messageID,
+               HomeMessageViewModelBuilder.canBuild(for: currentCandidate) {
+                self.rmfOwnership = RMFOwnership(
+                    message: currentCandidate,
+                    lease: rmfOwnership.lease,
+                    selectedTriggerFilter: rmfOwnership.selectedTriggerFilter,
+                    presentationContext: rmfOwnership.presentationContext
+                )
+                publishCoordinatedMessages(nonRemoteMessages + [.remoteMessage(remoteMessage: currentCandidate)])
+                return
+            }
+
+            endCurrentRMFOwnership(replacingWith: nonRemoteMessages)
+        }
+
+        guard isRMFAdmissionEnabled,
+              let preparationPolicy,
+              let selectedRemoteMessage = selectedRemoteMessage(using: preparationPolicy),
+              HomeMessageViewModelBuilder.canBuild(for: selectedRemoteMessage.message),
+              let promoGate,
+              let lease = promoGate.tryAcquireRemoteMessageLease(for: selectedRemoteMessage.message.id) else {
+            publishCoordinatedMessages(nonRemoteMessages)
+            return
+        }
+
+        let presentationContext = HomeMessagePresentationContext(
+            messageID: selectedRemoteMessage.message.id,
+            acquisitionIdentity: lease.acquisitionIdentity
+        )
+        rmfOwnership = RMFOwnership(
+            message: selectedRemoteMessage.message,
+            lease: lease,
+            selectedTriggerFilter: selectedRemoteMessage.triggerFilter,
+            presentationContext: presentationContext
+        )
+        publishCoordinatedMessages(nonRemoteMessages + [.remoteMessage(remoteMessage: selectedRemoteMessage.message)])
+    }
+
+    private func selectedRemoteMessage(using preparationPolicy: PreparationPolicy) -> SelectedRemoteMessage? {
+        switch preparationPolicy {
+        case .noTrigger:
+            return remoteMessage(triggerFilter: .noTrigger).map {
+                SelectedRemoteMessage(message: $0, triggerFilter: .noTrigger)
+            }
+        case .afterIdleThenNoTrigger:
+            if let afterIdleMessage = remoteMessage(triggerFilter: .specific(.afterIdle)) {
+                return SelectedRemoteMessage(message: afterIdleMessage, triggerFilter: .specific(.afterIdle))
+            }
+            return remoteMessage(triggerFilter: .noTrigger).map {
+                SelectedRemoteMessage(message: $0, triggerFilter: .noTrigger)
+            }
+        }
+    }
+
+    private func remoteMessage(triggerFilter: TriggerFilter) -> RemoteMessageModel? {
+        let remoteMessage = remoteMessagingStore.fetchScheduledRemoteMessage(
+            surfaces: .newTabPage,
+            triggerFilter: triggerFilter
+        )
+        if let remoteMessage {
+            Logger.remoteMessaging.info("Remote message to show: \(remoteMessage.id, privacy: .public)")
+        }
+        return remoteMessage
+    }
+
+    private func publishCoordinatedMessages(_ messages: [HomeMessage]) {
+        guard homeMessages != messages else {
+            return
+        }
+
+        homeMessages = messages
+        contentDidChangeSubject.send(())
+    }
+
+    private func endCurrentRMFOwnership(replacingWith messages: [HomeMessage]) {
+        let ownership = rmfOwnership
+        publishCoordinatedMessages(messages)
+        ownership?.lease.release()
+        rmfOwnership = nil
+    }
+
+    private func isCurrent(_ presentationContext: HomeMessagePresentationContext, for messageID: String) -> Bool {
+        guard let rmfOwnership else {
+            return false
+        }
+        return presentationContext.messageID == messageID &&
+            rmfOwnership.presentationContext == presentationContext
+    }
+
+    private func dismissLegacyRemoteMessage(_ remoteMessage: RemoteMessageModel, homeMessage: HomeMessage) async {
+        Logger.remoteMessaging.info("Home message dismissed: \(remoteMessage.id)")
+        await remoteMessagingStore.dismissRemoteMessage(withID: remoteMessage.id)
+        if let index = homeMessages.firstIndex(of: homeMessage) {
+            homeMessages.remove(at: index)
+        }
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+    }
+
+    private func reportRemoteMessageShown(_ remoteMessage: RemoteMessageModel) {
+        Logger.remoteMessaging.info("Remote message shown: \(remoteMessage.id, privacy: .public)")
+        if remoteMessage.isMetricsEnabled {
+            Pixel.fire(pixel: .remoteMessageShown,
+                       withAdditionalParameters: additionalParameters(for: remoteMessage.id))
+        }
+
+        if !remoteMessagingStore.hasShownRemoteMessage(withID: remoteMessage.id) {
+            Logger.remoteMessaging.info("Remote message shown for first time: \(remoteMessage.id, privacy: .public)")
+            if remoteMessage.isMetricsEnabled {
+                Pixel.fire(pixel: .remoteMessageShownUnique,
+                           withAdditionalParameters: additionalParameters(for: remoteMessage.id))
+            }
+            Task {
+                await remoteMessagingStore.updateRemoteMessage(withID: remoteMessage.id, asShown: true)
+            }
+        }
     }
 
     private func additionalParameters(for messageID: String) -> [String: String] {

--- a/iOS/DuckDuckGo/HomePageConfiguration.swift
+++ b/iOS/DuckDuckGo/HomePageConfiguration.swift
@@ -61,7 +61,8 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
     private var remoteMessagesCancellable: AnyCancellable?
     private var rmfOwnership: RMFOwnership?
     private var isRMFAdmissionEnabled: Bool
-    private var lastPreparationPolicy: PreparationPolicy?
+    private var activeNTPHostPolicies: [HomePageMessagesHost: PreparationPolicy] = [:]
+    private var activeNTPHostsByRecency: [HomePageMessagesHost] = []
 
     var homeMessages: [HomeMessage] = []
     let mode: PromoCoordinationMode
@@ -106,14 +107,27 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
     }
 
     func prepareForNTP(openedAfterIdle: Bool) {
+        prepareForNTP(openedAfterIdle: openedAfterIdle, host: .newTabPage)
+    }
+
+    func prepareForNTP(openedAfterIdle: Bool, host: HomePageMessagesHost) {
         guard mode == .coordinated else { return }
         guard isRMFAdmissionEnabled else {
             return
         }
 
         let preparationPolicy = PreparationPolicy(openedAfterIdle: openedAfterIdle)
-        lastPreparationPolicy = preparationPolicy
+        activeNTPHostPolicies[host] = preparationPolicy
+        activeNTPHostsByRecency.removeAll { $0 == host }
+        activeNTPHostsByRecency.append(host)
         reconcileCoordinatedMessages(using: preparationPolicy)
+    }
+
+    func deactivateNTPHost(_ host: HomePageMessagesHost) {
+        guard mode == .coordinated else { return }
+
+        activeNTPHostPolicies[host] = nil
+        activeNTPHostsByRecency.removeAll { $0 == host }
     }
 
     func handleAppBackgrounded() {
@@ -122,7 +136,8 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
         }
 
         isRMFAdmissionEnabled = false
-        lastPreparationPolicy = nil
+        activeNTPHostPolicies.removeAll()
+        activeNTPHostsByRecency.removeAll()
     }
 
     func handleAppForegrounded() {
@@ -201,6 +216,13 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
         homeMessageStorage.messagesToBeShown
     }
 
+    private var currentPreparationPolicy: PreparationPolicy? {
+        guard let activeHost = activeNTPHostsByRecency.last else {
+            return nil
+        }
+        return activeNTPHostPolicies[activeHost]
+    }
+
     private func buildLegacyHomeMessages(openedAfterIdle: Bool) -> [HomeMessage] {
         var messages = nonRemoteHomeMessages
         guard !isStillOnboarding(),
@@ -226,12 +248,12 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
             return
         }
 
-        guard rmfOwnership != nil || lastPreparationPolicy != nil else {
+        guard rmfOwnership != nil || currentPreparationPolicy != nil else {
             publishCoordinatedMessages(nonRemoteHomeMessages)
             return
         }
 
-        reconcileCoordinatedMessages(using: lastPreparationPolicy)
+        reconcileCoordinatedMessages(using: currentPreparationPolicy)
     }
 
     private func reconcileCoordinatedMessages(using preparationPolicy: PreparationPolicy?) {

--- a/iOS/DuckDuckGo/HomePageConfiguration.swift
+++ b/iOS/DuckDuckGo/HomePageConfiguration.swift
@@ -232,14 +232,20 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
         reconcileCoordinatedMessages(reason: .storeChanged)
     }
 
+    /// Reconciles every coordinated RMF input into the single shared NTP message source.
+    /// Existing ownership remains authoritative while its pinned candidate is valid. Store changes and foreground validation may
+    /// retain or end that ownership, but only an explicit NTP preparation may acquire and publish a new RMF.
     private func reconcileCoordinatedMessages(reason: ReconciliationReason) {
         let nonRemoteMessages = nonRemoteHomeMessages
 
+        // Onboarding makes RMF ineligible regardless of the reconciliation trigger, so remove any publication before releasing its lease.
         guard !isStillOnboarding() else {
             endCurrentRMFOwnership(replacingWith: nonRemoteMessages)
             return
         }
 
+        // Revalidate the current message using the trigger filter that originally selected it. Keeping the same lease and presentation
+        // context preserves ownership and SwiftUI identity across content refreshes and foreground transitions.
         if let rmfOwnership {
             let currentCandidate = remoteMessage(triggerFilter: rmfOwnership.selectedTriggerFilter)
             if let currentCandidate,
@@ -257,11 +263,15 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
 
             endCurrentRMFOwnership(replacingWith: nonRemoteMessages)
 
+            // Store and foreground events only reconcile authoritative state. They must not replace an invalid owner with an RMF that
+            // no active NTP requested, so fresh selection continues only from an explicit preparation checkpoint.
             guard case .preparation = reason else {
                 return
             }
         }
 
+        // Select a renderable candidate and acquire the queue lease before publishing it. This ordering prevents an RMF from flashing
+        // while another promo owns the queue and keeps background or otherwise inactive NTPs from acquiring.
         guard case .preparation(let preparationPolicy) = reason,
               isRMFAdmissionEnabled,
               let selectedRemoteMessage = selectedRemoteMessage(using: preparationPolicy),

--- a/iOS/DuckDuckGo/HomePageConfiguration.swift
+++ b/iOS/DuckDuckGo/HomePageConfiguration.swift
@@ -38,6 +38,12 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
         }
     }
 
+    private enum ReconciliationReason {
+        case preparation(PreparationPolicy)
+        case storeChanged
+        case foregroundValidation
+    }
+
     private struct SelectedRemoteMessage {
         let message: RemoteMessageModel
         let triggerFilter: TriggerFilter
@@ -61,8 +67,6 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
     private var remoteMessagesCancellable: AnyCancellable?
     private var rmfOwnership: RMFOwnership?
     private var isRMFAdmissionEnabled: Bool
-    private var activeNTPHostPolicies: [HomePageMessagesHost: PreparationPolicy] = [:]
-    private var activeNTPHostsByRecency: [HomePageMessagesHost] = []
 
     var homeMessages: [HomeMessage] = []
     let mode: PromoCoordinationMode
@@ -107,27 +111,13 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
     }
 
     func prepareForNTP(openedAfterIdle: Bool) {
-        prepareForNTP(openedAfterIdle: openedAfterIdle, host: .newTabPage)
-    }
-
-    func prepareForNTP(openedAfterIdle: Bool, host: HomePageMessagesHost) {
         guard mode == .coordinated else { return }
         guard isRMFAdmissionEnabled else {
             return
         }
 
         let preparationPolicy = PreparationPolicy(openedAfterIdle: openedAfterIdle)
-        activeNTPHostPolicies[host] = preparationPolicy
-        activeNTPHostsByRecency.removeAll { $0 == host }
-        activeNTPHostsByRecency.append(host)
-        reconcileCoordinatedMessages(using: preparationPolicy)
-    }
-
-    func deactivateNTPHost(_ host: HomePageMessagesHost) {
-        guard mode == .coordinated else { return }
-
-        activeNTPHostPolicies[host] = nil
-        activeNTPHostsByRecency.removeAll { $0 == host }
+        reconcileCoordinatedMessages(reason: .preparation(preparationPolicy))
     }
 
     func handleAppBackgrounded() {
@@ -136,8 +126,6 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
         }
 
         isRMFAdmissionEnabled = false
-        activeNTPHostPolicies.removeAll()
-        activeNTPHostsByRecency.removeAll()
     }
 
     func handleAppForegrounded() {
@@ -146,7 +134,7 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
         }
 
         isRMFAdmissionEnabled = true
-        reconcileCoordinatedMessages(using: nil)
+        reconcileCoordinatedMessages(reason: .foregroundValidation)
     }
 
     func dismissHomeMessage(_ homeMessage: HomeMessage) async {
@@ -216,13 +204,6 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
         homeMessageStorage.messagesToBeShown
     }
 
-    private var currentPreparationPolicy: PreparationPolicy? {
-        guard let activeHost = activeNTPHostsByRecency.last else {
-            return nil
-        }
-        return activeNTPHostPolicies[activeHost]
-    }
-
     private func buildLegacyHomeMessages(openedAfterIdle: Bool) -> [HomeMessage] {
         var messages = nonRemoteHomeMessages
         guard !isStillOnboarding(),
@@ -248,15 +229,10 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
             return
         }
 
-        guard rmfOwnership != nil || currentPreparationPolicy != nil else {
-            publishCoordinatedMessages(nonRemoteHomeMessages)
-            return
-        }
-
-        reconcileCoordinatedMessages(using: currentPreparationPolicy)
+        reconcileCoordinatedMessages(reason: .storeChanged)
     }
 
-    private func reconcileCoordinatedMessages(using preparationPolicy: PreparationPolicy?) {
+    private func reconcileCoordinatedMessages(reason: ReconciliationReason) {
         let nonRemoteMessages = nonRemoteHomeMessages
 
         guard !isStillOnboarding() else {
@@ -280,10 +256,14 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
             }
 
             endCurrentRMFOwnership(replacingWith: nonRemoteMessages)
+
+            guard case .preparation = reason else {
+                return
+            }
         }
 
-        guard isRMFAdmissionEnabled,
-              let preparationPolicy,
+        guard case .preparation(let preparationPolicy) = reason,
+              isRMFAdmissionEnabled,
               let selectedRemoteMessage = selectedRemoteMessage(using: preparationPolicy),
               HomeMessageViewModelBuilder.canBuild(for: selectedRemoteMessage.message),
               let promoGate,

--- a/iOS/DuckDuckGo/HomePageConfiguration.swift
+++ b/iOS/DuckDuckGo/HomePageConfiguration.swift
@@ -123,7 +123,6 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
 
         isRMFAdmissionEnabled = false
         lastPreparationPolicy = nil
-        endCurrentRMFOwnership(replacingWith: nonRemoteHomeMessages)
     }
 
     func handleAppForegrounded() {
@@ -132,6 +131,7 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
         }
 
         isRMFAdmissionEnabled = true
+        reconcileCoordinatedMessages(using: nil)
     }
 
     func dismissHomeMessage(_ homeMessage: HomeMessage) async {
@@ -223,11 +223,6 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
 
     private func handleRemoteMessagesChanged() {
         guard mode == .coordinated else {
-            return
-        }
-
-        guard isRMFAdmissionEnabled else {
-            endCurrentRMFOwnership(replacingWith: nonRemoteHomeMessages)
             return
         }
 

--- a/iOS/DuckDuckGo/HomePageConfiguration.swift
+++ b/iOS/DuckDuckGo/HomePageConfiguration.swift
@@ -106,10 +106,7 @@ final class HomePageConfiguration: HomePageMessagesConfiguration {
     }
 
     func prepareForNTP(openedAfterIdle: Bool) {
-        guard mode == .coordinated else {
-            homeMessages = buildLegacyHomeMessages(openedAfterIdle: openedAfterIdle)
-            return
-        }
+        guard mode == .coordinated else { return }
         guard isRMFAdmissionEnabled else {
             return
         }

--- a/iOS/DuckDuckGo/HomePageMessagesConfiguration.swift
+++ b/iOS/DuckDuckGo/HomePageMessagesConfiguration.swift
@@ -25,12 +25,6 @@ struct HomeMessagePresentationContext: Hashable {
     let acquisitionIdentity: PromoQueueAcquisitionIdentity
 }
 
-enum HomePageMessagesHost: Hashable {
-    case newTabPage
-    case unifiedInput
-    case omniBar
-}
-
 @MainActor
 protocol HomePageMessagesConfiguration {
     var homeMessages: [HomeMessage] { get }
@@ -39,8 +33,6 @@ protocol HomePageMessagesConfiguration {
 
     func refresh(openedAfterIdle: Bool)
     func prepareForNTP(openedAfterIdle: Bool)
-    func prepareForNTP(openedAfterIdle: Bool, host: HomePageMessagesHost)
-    func deactivateNTPHost(_ host: HomePageMessagesHost)
     func handleAppBackgrounded()
     func handleAppForegrounded()
     func presentationContext(for homeMessage: HomeMessage) -> HomeMessagePresentationContext?
@@ -67,12 +59,6 @@ extension HomePageMessagesConfiguration {
     func prepareForNTP(openedAfterIdle: Bool) {
         refresh(openedAfterIdle: openedAfterIdle)
     }
-
-    func prepareForNTP(openedAfterIdle: Bool, host: HomePageMessagesHost) {
-        prepareForNTP(openedAfterIdle: openedAfterIdle)
-    }
-
-    func deactivateNTPHost(_ host: HomePageMessagesHost) {}
 
     func handleAppBackgrounded() {}
 

--- a/iOS/DuckDuckGo/HomePageMessagesConfiguration.swift
+++ b/iOS/DuckDuckGo/HomePageMessagesConfiguration.swift
@@ -17,19 +17,62 @@
 //  limitations under the License.
 //
 
+import Combine
 import Foundation
 
+struct HomeMessagePresentationContext: Hashable {
+    let messageID: String
+    let acquisitionIdentity: PromoQueueAcquisitionIdentity
+}
+
+@MainActor
 protocol HomePageMessagesConfiguration {
     var homeMessages: [HomeMessage] { get }
+    var mode: PromoCoordinationMode { get }
+    var contentDidChangePublisher: AnyPublisher<Void, Never> { get }
 
     func refresh(openedAfterIdle: Bool)
+    func prepareForNTP(openedAfterIdle: Bool)
+    func handleAppBackgrounded()
+    func handleAppForegrounded()
+    func presentationContext(for homeMessage: HomeMessage) -> HomeMessagePresentationContext?
     
     func dismissHomeMessage(_ homeMessage: HomeMessage) async
+    func dismissHomeMessage(_ homeMessage: HomeMessage, presentationContext: HomeMessagePresentationContext?) async
     func didAppear(_ homeMessage: HomeMessage)
+    func didAppear(_ homeMessage: HomeMessage, presentationContext: HomeMessagePresentationContext?)
 }
 
 extension HomePageMessagesConfiguration {
+    var mode: PromoCoordinationMode {
+        .legacy
+    }
+
+    var contentDidChangePublisher: AnyPublisher<Void, Never> {
+        Empty(completeImmediately: false).eraseToAnyPublisher()
+    }
+
     func refresh() {
         refresh(openedAfterIdle: false)
+    }
+
+    func prepareForNTP(openedAfterIdle: Bool) {
+        refresh(openedAfterIdle: openedAfterIdle)
+    }
+
+    func handleAppBackgrounded() {}
+
+    func handleAppForegrounded() {}
+
+    func presentationContext(for homeMessage: HomeMessage) -> HomeMessagePresentationContext? {
+        nil
+    }
+
+    func dismissHomeMessage(_ homeMessage: HomeMessage, presentationContext: HomeMessagePresentationContext?) async {
+        await dismissHomeMessage(homeMessage)
+    }
+
+    func didAppear(_ homeMessage: HomeMessage, presentationContext: HomeMessagePresentationContext?) {
+        didAppear(homeMessage)
     }
 }

--- a/iOS/DuckDuckGo/HomePageMessagesConfiguration.swift
+++ b/iOS/DuckDuckGo/HomePageMessagesConfiguration.swift
@@ -25,6 +25,12 @@ struct HomeMessagePresentationContext: Hashable {
     let acquisitionIdentity: PromoQueueAcquisitionIdentity
 }
 
+enum HomePageMessagesHost: Hashable {
+    case newTabPage
+    case unifiedInput
+    case omniBar
+}
+
 @MainActor
 protocol HomePageMessagesConfiguration {
     var homeMessages: [HomeMessage] { get }
@@ -33,6 +39,8 @@ protocol HomePageMessagesConfiguration {
 
     func refresh(openedAfterIdle: Bool)
     func prepareForNTP(openedAfterIdle: Bool)
+    func prepareForNTP(openedAfterIdle: Bool, host: HomePageMessagesHost)
+    func deactivateNTPHost(_ host: HomePageMessagesHost)
     func handleAppBackgrounded()
     func handleAppForegrounded()
     func presentationContext(for homeMessage: HomeMessage) -> HomeMessagePresentationContext?
@@ -59,6 +67,12 @@ extension HomePageMessagesConfiguration {
     func prepareForNTP(openedAfterIdle: Bool) {
         refresh(openedAfterIdle: openedAfterIdle)
     }
+
+    func prepareForNTP(openedAfterIdle: Bool, host: HomePageMessagesHost) {
+        prepareForNTP(openedAfterIdle: openedAfterIdle)
+    }
+
+    func deactivateNTPHost(_ host: HomePageMessagesHost) {}
 
     func handleAppBackgrounded() {}
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5544,7 +5544,9 @@ extension MainViewController: OmniBarDelegate {
 
         guard newTabPageViewController == nil else { return }
 
-        homePageConfiguration.prepareForNTP(openedAfterIdle: currentTab?.tabModel.openedAfterIdle ?? false)
+        if homePageConfiguration.mode == .coordinated {
+            homePageConfiguration.prepareForNTP(openedAfterIdle: currentTab?.tabModel.openedAfterIdle ?? false)
+        }
 
         if isPad {
             // iPad routes all suggestion show/hide through the focus model (favorites vs autocomplete

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2058,14 +2058,14 @@ class MainViewController: UIViewController {
         currentTab?.dismiss()
         removeHomeScreen()
 
-        let hatch = buildEscapeHatch(openedAfterIdle: openedAfterIdle)
-        if homePageConfiguration.mode == .coordinated {
-            homePageConfiguration.prepareForNTP(openedAfterIdle: hatch != nil)
-        }
-
         // Access the tab model directly as we don't want to create a new tab controller here
         guard let tabModel = tabManager.currentTabsModel.currentTab else {
             fatalError("No tab model")
+        }
+
+        let hatch = buildEscapeHatch(openedAfterIdle: openedAfterIdle)
+        if homePageConfiguration.mode == .coordinated, !tabModel.fireTab {
+            homePageConfiguration.prepareForNTP(openedAfterIdle: hatch != nil, host: .newTabPage)
         }
         
         let shouldSaveTabs = tabModel.viewed == false || tabModel.openedAfterIdle != openedAfterIdle
@@ -2231,6 +2231,7 @@ class MainViewController: UIViewController {
     }
 
     fileprivate func removeHomeScreen() {
+        homePageConfiguration.deactivateNTPHost(.newTabPage)
         newTabPageViewController?.willMove(toParent: nil)
         newTabPageViewController?.dismiss()
         newTabPageViewController = nil
@@ -5545,7 +5546,11 @@ extension MainViewController: OmniBarDelegate {
         guard newTabPageViewController == nil else { return }
 
         if homePageConfiguration.mode == .coordinated {
-            homePageConfiguration.prepareForNTP(openedAfterIdle: currentTab?.tabModel.openedAfterIdle ?? false)
+            if isCurrentTabFireTab() {
+                homePageConfiguration.deactivateNTPHost(.omniBar)
+            } else {
+                homePageConfiguration.prepareForNTP(openedAfterIdle: escapeHatchForEditingState() != nil, host: .omniBar)
+            }
         }
 
         if isPad {
@@ -5724,6 +5729,8 @@ extension MainViewController: OmniBarDelegate {
     }
 
     func onDidEndEditing() {
+        homePageConfiguration.deactivateNTPHost(.omniBar)
+
         // Restore the tab's committed mode — the user may have toggled without submitting.
         // Safe on iPhone: the experimental editing state prevents textFieldDidEndEditing from
         // firing (text field never becomes first responder during that flow).
@@ -5883,6 +5890,19 @@ extension MainViewController: OmniBarDelegate {
             return nil
         }
         return model
+    }
+
+    func prepareHomePageMessagesForForegroundIfNeeded() {
+        guard isNewTabPageVisible,
+              let currentTab = tabManager.currentTabsModel.currentTab,
+              !currentTab.fireTab else {
+            return
+        }
+
+        homePageConfiguration.prepareForNTP(
+            openedAfterIdle: escapeHatchForEditingState() != nil,
+            host: .newTabPage
+        )
     }
 
     private func clearEscapeHatch() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2065,7 +2065,7 @@ class MainViewController: UIViewController {
 
         let hatch = buildEscapeHatch(openedAfterIdle: openedAfterIdle)
         if homePageConfiguration.mode == .coordinated, !tabModel.fireTab {
-            homePageConfiguration.prepareForNTP(openedAfterIdle: hatch != nil, host: .newTabPage)
+            homePageConfiguration.prepareForNTP(openedAfterIdle: hatch != nil)
         }
         
         let shouldSaveTabs = tabModel.viewed == false || tabModel.openedAfterIdle != openedAfterIdle
@@ -2231,7 +2231,6 @@ class MainViewController: UIViewController {
     }
 
     fileprivate func removeHomeScreen() {
-        homePageConfiguration.deactivateNTPHost(.newTabPage)
         newTabPageViewController?.willMove(toParent: nil)
         newTabPageViewController?.dismiss()
         newTabPageViewController = nil
@@ -5564,12 +5563,9 @@ extension MainViewController: OmniBarDelegate {
 
     private func prepareHomePageMessagesForOmniBar() {
         guard homePageConfiguration.mode == .coordinated else { return }
+        guard !isCurrentTabFireTab() else { return }
 
-        if isCurrentTabFireTab() {
-            homePageConfiguration.deactivateNTPHost(.omniBar)
-        } else {
-            homePageConfiguration.prepareForNTP(openedAfterIdle: escapeHatchForEditingState() != nil, host: .omniBar)
-        }
+        homePageConfiguration.prepareForNTP(openedAfterIdle: escapeHatchForEditingState() != nil)
     }
 
     private func installContextualSheetDismissGesture() {
@@ -5733,8 +5729,6 @@ extension MainViewController: OmniBarDelegate {
     }
 
     func onDidEndEditing() {
-        homePageConfiguration.deactivateNTPHost(.omniBar)
-
         // Restore the tab's committed mode — the user may have toggled without submitting.
         // Safe on iPhone: the experimental editing state prevents textFieldDidEndEditing from
         // firing (text field never becomes first responder during that flow).
@@ -5903,10 +5897,7 @@ extension MainViewController: OmniBarDelegate {
             return
         }
 
-        homePageConfiguration.prepareForNTP(
-            openedAfterIdle: escapeHatchForEditingState() != nil,
-            host: .newTabPage
-        )
+        homePageConfiguration.prepareForNTP(openedAfterIdle: escapeHatchForEditingState() != nil)
     }
 
     private func clearEscapeHatch() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5545,13 +5545,7 @@ extension MainViewController: OmniBarDelegate {
 
         guard newTabPageViewController == nil else { return }
 
-        if homePageConfiguration.mode == .coordinated {
-            if isCurrentTabFireTab() {
-                homePageConfiguration.deactivateNTPHost(.omniBar)
-            } else {
-                homePageConfiguration.prepareForNTP(openedAfterIdle: escapeHatchForEditingState() != nil, host: .omniBar)
-            }
-        }
+        prepareHomePageMessagesForOmniBar()
 
         if isPad {
             // iPad routes all suggestion show/hide through the focus model (favorites vs autocomplete
@@ -5566,6 +5560,16 @@ extension MainViewController: OmniBarDelegate {
             }
         }
         themeColorManager.updateThemeColor()
+    }
+
+    private func prepareHomePageMessagesForOmniBar() {
+        guard homePageConfiguration.mode == .coordinated else { return }
+
+        if isCurrentTabFireTab() {
+            homePageConfiguration.deactivateNTPHost(.omniBar)
+        } else {
+            homePageConfiguration.prepareForNTP(openedAfterIdle: escapeHatchForEditingState() != nil, host: .omniBar)
+        }
     }
 
     private func installContextualSheetDismissGesture() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2059,7 +2059,9 @@ class MainViewController: UIViewController {
         removeHomeScreen()
 
         let hatch = buildEscapeHatch(openedAfterIdle: openedAfterIdle)
-        homePageConfiguration.prepareForNTP(openedAfterIdle: hatch != nil)
+        if homePageConfiguration.mode == .coordinated {
+            homePageConfiguration.prepareForNTP(openedAfterIdle: hatch != nil)
+        }
 
         // Access the tab model directly as we don't want to create a new tab controller here
         guard let tabModel = tabManager.currentTabsModel.currentTab else {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -413,6 +413,7 @@ class MainViewController: UIViewController {
     private var iPadAIChatQuery = ""
     /// Owns the iPad popover's suggestion decision + Duck.ai surface lifecycle (built in `loadSuggestionTray`).
     private var popoverSuggestionsCoordinator: PopoverSuggestionsCoordinator?
+    private var homePageMessagesCancellable: AnyCancellable?
 
     private(set) var webExtensionEventsCoordinator: WebExtensionEventsCoordinator?
     func setWebExtensionEventsCoordinator(_ coordinator: WebExtensionEventsCoordinator?) {
@@ -1065,6 +1066,32 @@ class MainViewController: UIViewController {
                 tray: controller,
                 host: self,
                 navigationDelegate: self)
+        }
+
+        observeHomePageMessageChanges()
+    }
+
+    private func observeHomePageMessageChanges() {
+        guard homePageConfiguration.mode == .coordinated else { return }
+
+        homePageMessagesCancellable = homePageConfiguration.contentDidChangePublisher
+            .sink { [weak self] _ in
+                self?.reevaluateSuggestionTrayAfterHomeMessagesChanged()
+            }
+    }
+
+    private func reevaluateSuggestionTrayAfterHomeMessagesChanged() {
+        guard newTabPageViewController == nil,
+              omniBar.isTextFieldEditing,
+              !(presentedViewController is OmniBarEditingStateViewController),
+              unifiedToggleInputCoordinator?.isOmnibarSession != true else { return }
+
+        if isPad {
+            refreshPopoverSuggestions()
+        } else if !isModeToggleInAIChatMode, omniBar.text?.isEmpty != false {
+            if !tryToShowSuggestionTray(.favorites) {
+                hideSuggestionTray()
+            }
         }
     }
 
@@ -2032,7 +2059,7 @@ class MainViewController: UIViewController {
         removeHomeScreen()
 
         let hatch = buildEscapeHatch(openedAfterIdle: openedAfterIdle)
-        homePageConfiguration.refresh(openedAfterIdle: hatch != nil)
+        homePageConfiguration.prepareForNTP(openedAfterIdle: hatch != nil)
 
         // Access the tab model directly as we don't want to create a new tab controller here
         guard let tabModel = tabManager.currentTabsModel.currentTab else {
@@ -5514,6 +5541,8 @@ extension MainViewController: OmniBarDelegate {
         }
 
         guard newTabPageViewController == nil else { return }
+
+        homePageConfiguration.prepareForNTP(openedAfterIdle: currentTab?.tabModel.openedAfterIdle ?? false)
 
         if isPad {
             // iPad routes all suggestion show/hide through the focus model (favorites vs autocomplete

--- a/iOS/DuckDuckGo/NewTabPageMessagesModel.swift
+++ b/iOS/DuckDuckGo/NewTabPageMessagesModel.swift
@@ -17,15 +17,18 @@
 //  limitations under the License.
 //
 
+import Combine
 import Core
 import Foundation
 import RemoteMessaging
 
+@MainActor
 final class NewTabPageMessagesModel: ObservableObject {
 
     @Published private(set) var homeMessageViewModels: [HomeMessageViewModel] = []
 
-    private var observable: NSObjectProtocol?
+    private var messagesCancellable: AnyCancellable?
+    private var legacyNotificationObserver: NSObjectProtocol?
 
     private let homePageMessagesConfiguration: HomePageMessagesConfiguration
     private let notificationCenter: NotificationCenter
@@ -55,24 +58,39 @@ final class NewTabPageMessagesModel: ObservableObject {
     }
 
     func load() {
-        observable = notificationCenter.addObserver(
-            forName: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
-            object: nil,
-            queue: .main) { [weak self] _ in
-                self?.refresh()
+        switch homePageMessagesConfiguration.mode {
+        case .legacy:
+            legacyNotificationObserver = notificationCenter.addObserver(
+                forName: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.refresh()
+                }
+            }
+            refresh()
+        case .coordinated:
+            messagesCancellable = homePageMessagesConfiguration.contentDidChangePublisher
+                .sink { [weak self] _ in
+                    self?.updateHomeMessageViewModel()
+                }
+            updateHomeMessageViewModel()
         }
-
-        refresh()
     }
 
-    @MainActor
     func dismissHomeMessage(_ homeMessage: HomeMessage) async {
-        await homePageMessagesConfiguration.dismissHomeMessage(homeMessage)
-        updateHomeMessageViewModel()
+        await dismissHomeMessage(
+            homeMessage,
+            presentationContext: homePageMessagesConfiguration.presentationContext(for: homeMessage)
+        )
     }
 
     func didAppear(_ homeMessage: HomeMessage) {
-        homePageMessagesConfiguration.didAppear(homeMessage)
+        homePageMessagesConfiguration.didAppear(
+            homeMessage,
+            presentationContext: homePageMessagesConfiguration.presentationContext(for: homeMessage)
+        )
     }
 
     // MARK: - Private
@@ -82,8 +100,23 @@ final class NewTabPageMessagesModel: ObservableObject {
     var onMessageInteraction: ((NewTabPageMessageInteraction) -> Void)?
 
     func refresh() {
-        homePageMessagesConfiguration.refresh(openedAfterIdle: isOpenedAfterIdle())
+        if homePageMessagesConfiguration.mode == .legacy {
+            homePageMessagesConfiguration.refresh(openedAfterIdle: isOpenedAfterIdle())
+        }
         updateHomeMessageViewModel()
+    }
+
+    private func dismissHomeMessage(
+        _ homeMessage: HomeMessage,
+        presentationContext: HomeMessagePresentationContext?
+    ) async {
+        await homePageMessagesConfiguration.dismissHomeMessage(
+            homeMessage,
+            presentationContext: presentationContext
+        )
+        if homePageMessagesConfiguration.mode == .legacy {
+            updateHomeMessageViewModel()
+        }
     }
 
     private func updateHomeMessageViewModel() {
@@ -97,6 +130,7 @@ final class NewTabPageMessagesModel: ObservableObject {
         switch message {
         case .placeholder:
             return HomeMessageViewModel(messageId: "",
+                                        acquisitionIdentity: nil,
                                         modelType: .small(titleText: "", descriptionText: ""),
                                         messageActionHandler: messageActionHandler,
                                         preloadedImage: nil,
@@ -109,16 +143,19 @@ final class NewTabPageMessagesModel: ObservableObject {
             }
 
         case .remoteMessage(let remoteMessage):
+            let presentationContext = homePageMessagesConfiguration.presentationContext(for: message)
 
-            // call didAppear here to support marking messages as shown when they appear on the new tab page
-            // as a result of refreshing a config while the user was on a new tab page already.
-            didAppear(message)
+            if homePageMessagesConfiguration.mode == .legacy {
+                // Preserve legacy map-time accounting. Coordinated mode confirms only from actual appearance.
+                homePageMessagesConfiguration.didAppear(message)
+            }
 
             return HomeMessageViewModelBuilder.build(for: remoteMessage,
                                                      with: subscriptionDataReporter,
                                                      messageActionHandler: messageActionHandler,
                                                      imageLoader: imageLoader,
-                                                     pixelReporter: pixelReporter) { @MainActor [weak self] action in
+                                                     pixelReporter: pixelReporter,
+                                                     acquisitionIdentity: presentationContext?.acquisitionIdentity) { @MainActor [weak self] action in
                 guard let action,
                       let self else { return }
 
@@ -128,7 +165,7 @@ final class NewTabPageMessagesModel: ObservableObject {
 
                 case .action(let isSharing):
                     if !isSharing {
-                        await self.dismissHomeMessage(message)
+                        await self.dismissHomeMessage(message, presentationContext: presentationContext)
                     }
                     if remoteMessage.isMetricsEnabled {
                         pixelFiring.fire(.remoteMessageActionClicked,
@@ -137,7 +174,7 @@ final class NewTabPageMessagesModel: ObservableObject {
 
                 case .primaryAction(let isSharing):
                     if !isSharing {
-                        await self.dismissHomeMessage(message)
+                        await self.dismissHomeMessage(message, presentationContext: presentationContext)
                     }
                     if remoteMessage.isMetricsEnabled {
                         pixelFiring.fire(.remoteMessagePrimaryActionClicked,
@@ -146,7 +183,7 @@ final class NewTabPageMessagesModel: ObservableObject {
 
                 case .secondaryAction(let isSharing):
                     if !isSharing {
-                        await self.dismissHomeMessage(message)
+                        await self.dismissHomeMessage(message, presentationContext: presentationContext)
                     }
                     if remoteMessage.isMetricsEnabled {
                         pixelFiring.fire(.remoteMessageSecondaryActionClicked,
@@ -154,7 +191,7 @@ final class NewTabPageMessagesModel: ObservableObject {
                     }
 
                 case .close:
-                    await self.dismissHomeMessage(message)
+                    await self.dismissHomeMessage(message, presentationContext: presentationContext)
                     if remoteMessage.isMetricsEnabled {
                         pixelFiring.fire(.remoteMessageDismissed,
                                          withAdditionalParameters: self.additionalParameters(for: remoteMessage.id))
@@ -162,7 +199,10 @@ final class NewTabPageMessagesModel: ObservableObject {
 
                 }
             } onDidAppear: { [weak self] in
-                self?.didAppear(message)
+                self?.homePageMessagesConfiguration.didAppear(
+                    message,
+                    presentationContext: presentationContext
+                )
             }
         }
     }

--- a/iOS/DuckDuckGo/NewTabPageView.swift
+++ b/iOS/DuckDuckGo/NewTabPageView.swift
@@ -228,7 +228,7 @@ private extension NewTabPageView {
     }
 
     private var messagesSectionView: some View {
-        ForEach(messagesModel.homeMessageViewModels, id: \.messageId) { messageModel in
+        ForEach(messagesModel.homeMessageViewModels, id: \.viewIdentity) { messageModel in
             HomeMessageView(viewModel: messageModel)
                 .frame(maxWidth: horizontalSizeClass == .regular ? Metrics.messageMaximumWidthPad : Metrics.messageMaximumWidth)
                 .transition(.scale.combined(with: .opacity))

--- a/iOS/DuckDuckGo/RemoteMessagingUIPreviewsDebugView.swift
+++ b/iOS/DuckDuckGo/RemoteMessagingUIPreviewsDebugView.swift
@@ -77,6 +77,7 @@ struct RemoteMessagingUIPreviewsDebugView: View {
     private func viewModel(id: String, modelType: HomeSupportedMessageDisplayType) -> HomeMessageViewModel {
         HomeMessageViewModel(
             messageId: "preview-\(id)",
+            acquisitionIdentity: nil,
             modelType: modelType,
             messageActionHandler: NoOpRemoteMessagingActionHandler(),
             preloadedImage: previewImage(for: modelType),

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -668,6 +668,15 @@ final class MainCoordinator {
         promoCoordinationService.presentModalPromptIfNeeded(from: controller)
     }
 
+    func prepareHomePageMessagesForForegroundIfNeeded() {
+        guard controller.isNewTabPageVisible,
+              let currentTab = tabManager.currentTabsModel.currentTab else {
+            return
+        }
+
+        homePageConfiguration.prepareForNTP(openedAfterIdle: currentTab.openedAfterIdle)
+    }
+
     // MARK: App Lifecycle handling
 
     func onForeground(isFirstForeground: Bool) {

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -669,12 +669,7 @@ final class MainCoordinator {
     }
 
     func prepareHomePageMessagesForForegroundIfNeeded() {
-        guard controller.isNewTabPageVisible,
-              let currentTab = tabManager.currentTabsModel.currentTab else {
-            return
-        }
-
-        homePageConfiguration.prepareForNTP(openedAfterIdle: currentTab.openedAfterIdle)
+        controller.prepareHomePageMessagesForForegroundIfNeeded()
     }
 
     // MARK: App Lifecycle handling

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -71,6 +71,7 @@ final class MainCoordinator {
     private let subscriptionManager: any SubscriptionManager
     private let featureFlagger: FeatureFlagger
     private let promoCoordinationService: PromoCoordinationService
+    private let homePageConfiguration: HomePageConfiguration
     private let launchSourceManager: LaunchSourceManaging
     private let keyValueStore: ThrowingKeyValueStoring
     private let onboardingSearchExperienceSelectionHandler: OnboardingSearchExperienceSelectionHandler
@@ -122,6 +123,7 @@ final class MainCoordinator {
          maliciousSiteProtectionService: MaliciousSiteProtectionService,
          customConfigurationURLProvider: CustomConfigurationURLProviding,
          didFinishLaunchingStartTime: CFAbsoluteTime?,
+         isAppLaunchedInBackground: Bool,
          keyValueStore: ThrowingKeyValueStoring,
          systemSettingsPiPTutorialManager: SystemSettingsPiPTutorialManaging,
          daxDialogsManager: DaxDialogsManaging,
@@ -158,7 +160,10 @@ final class MainCoordinator {
         let homePageConfiguration = HomePageConfiguration(variantManager: AppDependencyProvider.shared.variantManager,
                                                           remoteMessagingStore: remoteMessagingService.remoteMessagingClient.store,
                                                           subscriptionDataReporter: reportingService.subscriptionDataReporter,
-                                                          isStillOnboarding: { daxDialogsManager.isStillOnboarding() })
+                                                          isStillOnboarding: { daxDialogsManager.isStillOnboarding() },
+                                                          promoGate: promoCoordinationService,
+                                                          isRMFAdmissionEnabled: !isAppLaunchedInBackground)
+        self.homePageConfiguration = homePageConfiguration
         let previewsSource = DefaultTabPreviewsSource()
         let tabsPersistence = try TabsModelPersistence()
         let tabsModelProvider = try Self.prepareTabsModel(previewsSource: previewsSource, tabsPersistence: tabsPersistence)
@@ -666,6 +671,8 @@ final class MainCoordinator {
     // MARK: App Lifecycle handling
 
     func onForeground(isFirstForeground: Bool) {
+        homePageConfiguration.handleAppForegrounded()
+
         // Apply tracker animation suppression based on launch source
         // Must be called after launchSourceManager.handleAppAction sets the source
         if isFirstForeground {
@@ -687,6 +694,7 @@ final class MainCoordinator {
     }
 
     func onBackground() {
+        homePageConfiguration.handleAppBackgrounded()
         resetAppStartTime()
         Task {
             await privacyStats.handleAppTermination()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -247,11 +247,8 @@ final class UnifiedInputContentContainerViewController: UIViewController {
             return
         }
 
-        if fireMode {
-            homePageMessagesConfiguration.deactivateNTPHost(.unifiedInput)
-        } else {
-            homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: escapeHatchModel != nil, host: .unifiedInput)
-        }
+        guard !fireMode else { return }
+        homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: escapeHatchModel != nil)
     }
 
     func setInputMode(_ mode: TextEntryMode, animated: Bool = true) {
@@ -272,12 +269,9 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         markNeedsVisibleRefresh()
         if active {
             if let homePageMessagesConfiguration = suggestionTrayDependencies?.newTabPageDependencies.homePageMessagesConfiguration,
-               homePageMessagesConfiguration.mode == .coordinated {
-                if switchBarHandler.isFireTab {
-                    homePageMessagesConfiguration.deactivateNTPHost(.unifiedInput)
-                } else {
-                    homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: escapeHatchModel != nil, host: .unifiedInput)
-                }
+               homePageMessagesConfiguration.mode == .coordinated,
+               !switchBarHandler.isFireTab {
+                homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: escapeHatchModel != nil)
             }
             unifiedSuggestionsHost?.setIsFireTab(switchBarHandler.isFireTab)
             unifiedSuggestionsHost?.setLandscape(isLandscapeOrientation)
@@ -288,7 +282,6 @@ final class UnifiedInputContentContainerViewController: UIViewController {
             syncDuckAISurfaceWithSettings()
             duckAISurface?.refreshRecents()
         } else {
-            suggestionTrayDependencies?.newTabPageDependencies.homePageMessagesConfiguration.deactivateNTPHost(.unifiedInput)
             fireSearchSuggestionsDisplayPixels()
         }
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -240,6 +240,18 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         // The fire empty state is a SwiftUI host content state now — just flip the flag; no manager rebuild.
         unifiedSuggestionsHost?.setIsFireTab(fireMode)
         rebuildDuckAISuggestionsCoordinator()
+
+        guard isContentActive,
+              let homePageMessagesConfiguration = suggestionTrayDependencies?.newTabPageDependencies.homePageMessagesConfiguration,
+              homePageMessagesConfiguration.mode == .coordinated else {
+            return
+        }
+
+        if fireMode {
+            homePageMessagesConfiguration.deactivateNTPHost(.unifiedInput)
+        } else {
+            homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: escapeHatchModel != nil, host: .unifiedInput)
+        }
     }
 
     func setInputMode(_ mode: TextEntryMode, animated: Bool = true) {
@@ -261,7 +273,11 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         if active {
             if let homePageMessagesConfiguration = suggestionTrayDependencies?.newTabPageDependencies.homePageMessagesConfiguration,
                homePageMessagesConfiguration.mode == .coordinated {
-                homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: sessionOpenedAfterIdle)
+                if switchBarHandler.isFireTab {
+                    homePageMessagesConfiguration.deactivateNTPHost(.unifiedInput)
+                } else {
+                    homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: escapeHatchModel != nil, host: .unifiedInput)
+                }
             }
             unifiedSuggestionsHost?.setIsFireTab(switchBarHandler.isFireTab)
             unifiedSuggestionsHost?.setLandscape(isLandscapeOrientation)
@@ -272,6 +288,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
             syncDuckAISurfaceWithSettings()
             duckAISurface?.refreshRecents()
         } else {
+            suggestionTrayDependencies?.newTabPageDependencies.homePageMessagesConfiguration.deactivateNTPHost(.unifiedInput)
             fireSearchSuggestionsDisplayPixels()
         }
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -259,7 +259,10 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         isContentActive = active
         markNeedsVisibleRefresh()
         if active {
-            suggestionTrayDependencies?.newTabPageDependencies.homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: sessionOpenedAfterIdle)
+            if let homePageMessagesConfiguration = suggestionTrayDependencies?.newTabPageDependencies.homePageMessagesConfiguration,
+               homePageMessagesConfiguration.mode == .coordinated {
+                homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: sessionOpenedAfterIdle)
+            }
             unifiedSuggestionsHost?.setIsFireTab(switchBarHandler.isFireTab)
             unifiedSuggestionsHost?.setLandscape(isLandscapeOrientation)
             unifiedSuggestionsHost?.prepareForActivation()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -259,6 +259,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
         isContentActive = active
         markNeedsVisibleRefresh()
         if active {
+            suggestionTrayDependencies?.newTabPageDependencies.homePageMessagesConfiguration.prepareForNTP(openedAfterIdle: sessionOpenedAfterIdle)
             unifiedSuggestionsHost?.setIsFireTab(switchBarHandler.isFireTab)
             unifiedSuggestionsHost?.setLandscape(isLandscapeOrientation)
             unifiedSuggestionsHost?.prepareForActivation()
@@ -582,7 +583,7 @@ final class UnifiedInputContentContainerViewController: UIViewController {
             !dependencies.newTabPageDependencies.homePageMessagesConfiguration.homeMessages.isEmpty
         }
 
-        let searchStateChanged = dependencies.favoritesViewModel.localUpdates
+        var searchStateChanged = dependencies.favoritesViewModel.localUpdates
             .merge(with: dependencies.favoritesViewModel.externalUpdates)
             // Favorites changes fire on the Core Data context queue; marshal here so the merged
             // inputs (and the view model's `@Published content` mutation) stay on main.
@@ -591,6 +592,12 @@ final class UnifiedInputContentContainerViewController: UIViewController {
             // so the re-resolve it drives stays synchronous, landing before the host becomes visible.
             .merge(with: activationResolveTrigger)
             .eraseToAnyPublisher()
+        let homePageMessagesConfiguration = dependencies.newTabPageDependencies.homePageMessagesConfiguration
+        if homePageMessagesConfiguration.mode == .coordinated {
+            searchStateChanged = searchStateChanged
+                .merge(with: homePageMessagesConfiguration.contentDidChangePublisher)
+                .eraseToAnyPublisher()
+        }
         let inputsPublisher = makeMergedInputsPublisher(hasFavorites: hasFavorites,
                                                         hasMessages: hasMessages,
                                                         searchStateChanged: searchStateChanged)
@@ -822,6 +829,9 @@ final class UnifiedInputContentContainerViewController: UIViewController {
     }
 
     private func observeRemoteMessagesChanges() {
+        guard let configuration = suggestionTrayDependencies?.newTabPageDependencies.homePageMessagesConfiguration,
+              configuration.mode == .legacy else { return }
+
         notificationCancellable = NotificationCenter.default.publisher(for: RemoteMessagingStore.Notifications.remoteMessagesDidChange)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/iOS/DuckDuckGoTests/HomeMessageViewModelBuilderTests.swift
+++ b/iOS/DuckDuckGoTests/HomeMessageViewModelBuilderTests.swift
@@ -26,6 +26,58 @@ import UIKit
 @Suite("RMF - Home Message View Model Builder")
 struct HomeMessageViewModelBuilderTests {
 
+    @Test("Renderability uses the same supported content conversion as build")
+    func renderabilityMatchesBuilderSupport() {
+        let supportedMessage = makeRemoteMessage(
+            content: .small(titleText: "Title", descriptionText: "Description"),
+            isMetricsEnabled: false
+        )
+        let missingContentMessage = RemoteMessageModel(
+            id: "missing-content",
+            surfaces: .newTabPage,
+            content: nil,
+            matchingRules: [],
+            exclusionRules: [],
+            isMetricsEnabled: false
+        )
+        let cardsListMessage = makeRemoteMessage(
+            content: .cardsList(
+                titleText: "Title",
+                placeholder: nil,
+                imageUrl: nil,
+                items: [],
+                primaryActionText: "Continue",
+                primaryAction: .dismiss
+            ),
+            isMetricsEnabled: false
+        )
+
+        #expect(HomeMessageViewModelBuilder.canBuild(for: supportedMessage))
+        #expect(!HomeMessageViewModelBuilder.canBuild(for: missingContentMessage))
+        #expect(!HomeMessageViewModelBuilder.canBuild(for: cardsListMessage))
+    }
+
+    @Test("Renderability check has no image reporting side effects")
+    func renderabilityHasNoImageSideEffects() {
+        let message = makeRemoteMessage(
+            content: .medium(
+                titleText: "Title",
+                descriptionText: "Description",
+                placeholder: .announce,
+                imageUrl: URL(string: "https://example.com/image.png")
+            ),
+            isMetricsEnabled: true
+        )
+        let imageLoader = MockRemoteMessagingImageLoader()
+        imageLoader.cachedImageToReturn = UIImage()
+        let pixelReporter = MockRemoteMessagingPixelReporter()
+
+        #expect(HomeMessageViewModelBuilder.canBuild(for: message))
+        #expect(imageLoader.cachedImageCalledWithUrl == nil)
+        #expect(!pixelReporter.didCallMeasureRemoteMessageImageLoadSuccess)
+        #expect(!pixelReporter.didCallMeasureRemoteMessageImageLoadFailed)
+    }
+
     @Test("When message has no imageUrl then loadRemoteImage is nil")
     func whenMessageHasNoImageUrlThenLoadRemoteImageIsNil() throws {
         let message = makeRemoteMessage(

--- a/iOS/DuckDuckGoTests/HomeMessageViewModelBuilderTests.swift
+++ b/iOS/DuckDuckGoTests/HomeMessageViewModelBuilderTests.swift
@@ -26,7 +26,8 @@ import UIKit
 @Suite("RMF - Home Message View Model Builder")
 struct HomeMessageViewModelBuilderTests {
 
-    @Test("Renderability uses the same supported content conversion as build")
+    @available(iOS 16, *)
+    @Test("Renderability uses the same supported content conversion as build", .timeLimit(.minutes(1)))
     func renderabilityMatchesBuilderSupport() {
         let supportedMessage = makeRemoteMessage(
             content: .small(titleText: "Title", descriptionText: "Description"),
@@ -55,27 +56,6 @@ struct HomeMessageViewModelBuilderTests {
         #expect(HomeMessageViewModelBuilder.canBuild(for: supportedMessage))
         #expect(!HomeMessageViewModelBuilder.canBuild(for: missingContentMessage))
         #expect(!HomeMessageViewModelBuilder.canBuild(for: cardsListMessage))
-    }
-
-    @Test("Renderability check has no image reporting side effects")
-    func renderabilityHasNoImageSideEffects() {
-        let message = makeRemoteMessage(
-            content: .medium(
-                titleText: "Title",
-                descriptionText: "Description",
-                placeholder: .announce,
-                imageUrl: URL(string: "https://example.com/image.png")
-            ),
-            isMetricsEnabled: true
-        )
-        let imageLoader = MockRemoteMessagingImageLoader()
-        imageLoader.cachedImageToReturn = UIImage()
-        let pixelReporter = MockRemoteMessagingPixelReporter()
-
-        #expect(HomeMessageViewModelBuilder.canBuild(for: message))
-        #expect(imageLoader.cachedImageCalledWithUrl == nil)
-        #expect(!pixelReporter.didCallMeasureRemoteMessageImageLoadSuccess)
-        #expect(!pixelReporter.didCallMeasureRemoteMessageImageLoadFailed)
     }
 
     @Test("When message has no imageUrl then loadRemoteImage is nil")

--- a/iOS/DuckDuckGoTests/HomeMessageViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/HomeMessageViewModelTests.swift
@@ -33,6 +33,7 @@ struct HomeMessageViewModelTests {
     ) -> HomeMessageViewModel {
         HomeMessageViewModel(
             messageId: "test-message",
+            acquisitionIdentity: nil,
             modelType: modelType,
             messageActionHandler: mockActionHandler,
             preloadedImage: nil,

--- a/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
+++ b/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
@@ -170,8 +170,7 @@ struct HomePageConfigurationTests {
         )
 
         sut.handleAppForegrounded()
-        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
-        await Task.yield()
+        await postRemoteMessagesDidChange(notificationCenter)
 
         #expect(store.fetchedTriggerFilters.isEmpty)
         #expect(gate.acquiredMessageIDs.isEmpty)
@@ -199,6 +198,29 @@ struct HomePageConfigurationTests {
     }
 
     @available(iOS 16, *)
+    @Test("First owner wins and keeps its pinned trigger when a later preparation uses another policy", .timeLimit(.minutes(1)))
+    func firstOwnerWinsAndKeepsPinnedTrigger() {
+        let original = makeRemoteMessage(id: "original")
+        let afterIdleCandidate = makeRemoteMessage(id: "after-idle")
+        let store = FilteredRemoteMessagingStore(afterIdleMessage: afterIdleCandidate, noTriggerMessage: original)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate)
+
+        sut.prepareForNTP(openedAfterIdle: false)
+        let context = sut.presentationContext(for: .remoteMessage(remoteMessage: original))
+        let owner = gate.arbiter.snapshot.owner
+        store.fetchedTriggerFilters.removeAll()
+
+        sut.prepareForNTP(openedAfterIdle: true)
+
+        #expect(store.fetchedTriggerFilters == [.noTrigger])
+        #expect(gate.acquiredMessageIDs == ["original"])
+        #expect(gate.arbiter.snapshot.owner == owner)
+        #expect(sut.presentationContext(for: .remoteMessage(remoteMessage: original)) == context)
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: original)])
+    }
+
+    @available(iOS 16, *)
     @Test("Unsupported content is rejected before gate acquisition", .timeLimit(.minutes(1)))
     func unsupportedContentDoesNotAcquire() {
         let unsupported = makeRemoteMessage(id: "unsupported", content: nil)
@@ -213,8 +235,62 @@ struct HomePageConfigurationTests {
     }
 
     @available(iOS 16, *)
-    @Test("A coordinated store refresh retries a denied candidate with the last preparation policy", .timeLimit(.minutes(1)))
-    func storeRefreshRetriesDeniedCandidate() async {
+    @Test("A message arriving after an empty preparation waits for the next explicit preparation", .timeLimit(.minutes(1)))
+    func messageArrivingAfterEmptyPreparationWaitsForNextPreparation() async {
+        let notificationCenter = NotificationCenter()
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore()
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+
+        sut.prepareForNTP(openedAfterIdle: false)
+        store.noTriggerMessage = message
+        store.fetchedTriggerFilters.removeAll()
+        await postRemoteMessagesDidChange(notificationCenter)
+
+        #expect(store.fetchedTriggerFilters.isEmpty)
+        #expect(gate.acquiredMessageIDs.isEmpty)
+        #expect(gate.arbiter.snapshot.owner == nil)
+        #expect(sut.homeMessages.isEmpty)
+
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        #expect(store.fetchedTriggerFilters == [.noTrigger])
+        #expect(gate.acquiredMessageIDs == ["message"])
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
+    }
+
+    @available(iOS 16, *)
+    @Test("Modal denial is not retried by a store notification", .timeLimit(.minutes(1)))
+    func modalDenialWaitsForNextPreparation() async throws {
+        let notificationCenter = NotificationCenter()
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let gate = MockPromoGate()
+        guard case .acquired(let modalLease) = gate.arbiter.acquireModalLease() else {
+            Issue.record("Expected the test modal lease to acquire")
+            return
+        }
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+
+        sut.prepareForNTP(openedAfterIdle: false)
+        modalLease.release()
+        store.fetchedTriggerFilters.removeAll()
+        await postRemoteMessagesDidChange(notificationCenter)
+
+        #expect(store.fetchedTriggerFilters.isEmpty)
+        #expect(gate.acquiredMessageIDs == ["message"])
+        #expect(sut.homeMessages.isEmpty)
+
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        #expect(gate.acquiredMessageIDs == ["message", "message"])
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
+    }
+
+    @available(iOS 16, *)
+    @Test("Cooldown denial is not retained as an implicit store-change retry", .timeLimit(.minutes(1)))
+    func cooldownDenialWaitsForNextPreparation() async {
         let notificationCenter = NotificationCenter()
         let message = makeRemoteMessage(id: "after-idle")
         let store = FilteredRemoteMessagingStore(afterIdleMessage: message)
@@ -223,12 +299,15 @@ struct HomePageConfigurationTests {
         let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
 
         sut.prepareForNTP(openedAfterIdle: true)
-        #expect(sut.homeMessages.isEmpty)
-
         gate.grantsAcquisition = true
         store.fetchedTriggerFilters.removeAll()
-        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
-        await Task.yield()
+        await postRemoteMessagesDidChange(notificationCenter)
+
+        #expect(store.fetchedTriggerFilters.isEmpty)
+        #expect(gate.acquiredMessageIDs == ["after-idle"])
+        #expect(sut.homeMessages.isEmpty)
+
+        sut.prepareForNTP(openedAfterIdle: true)
 
         #expect(store.fetchedTriggerFilters == [.specific(.afterIdle)])
         #expect(gate.acquiredMessageIDs == ["after-idle", "after-idle"])
@@ -236,112 +315,35 @@ struct HomePageConfigurationTests {
     }
 
     @available(iOS 16, *)
-    @Test("A store notification cannot acquire after the last NTP host deactivates, but reactivation can", .timeLimit(.minutes(1)))
-    func storeNotificationAfterLastHostDeactivationDoesNotAcquireButReactivationDoes() async {
+    @Test("A same-ID store refresh retains lease, identity, context, and shown-once accounting", .timeLimit(.minutes(1)))
+    func sameIDRefreshRetainsOwnershipIdentityAndAppearanceHistory() async {
         let notificationCenter = NotificationCenter()
         let message = makeRemoteMessage(id: "message")
-        let store = FilteredRemoteMessagingStore()
-        let gate = MockPromoGate()
-        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
-
-        sut.prepareForNTP(openedAfterIdle: false, host: .newTabPage)
-        sut.deactivateNTPHost(.newTabPage)
-        store.noTriggerMessage = message
-        store.fetchedTriggerFilters.removeAll()
-
-        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
-        await Task.yield()
-
-        #expect(store.fetchedTriggerFilters.isEmpty)
-        #expect(gate.acquiredMessageIDs.isEmpty)
-        #expect(gate.arbiter.snapshot.owner == nil)
-        #expect(sut.homeMessages.isEmpty)
-
-        sut.prepareForNTP(openedAfterIdle: false, host: .newTabPage)
-
-        #expect(store.fetchedTriggerFilters == [.noTrigger])
-        #expect(gate.acquiredMessageIDs == ["message"])
-        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
-    }
-
-    @available(iOS 16, *)
-    @Test("A store notification acquires while an eligible NTP host remains active", .timeLimit(.minutes(1)))
-    func storeNotificationAcquiresWhileEligibleHostRemainsActive() async {
-        let notificationCenter = NotificationCenter()
-        let message = makeRemoteMessage(id: "message")
-        let store = FilteredRemoteMessagingStore()
-        let gate = MockPromoGate()
-        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
-
-        sut.prepareForNTP(openedAfterIdle: false, host: .newTabPage)
-        store.noTriggerMessage = message
-        store.fetchedTriggerFilters.removeAll()
-
-        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
-        await Task.yield()
-
-        #expect(store.fetchedTriggerFilters == [.noTrigger])
-        #expect(gate.acquiredMessageIDs == ["message"])
-        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
-    }
-
-    @available(iOS 16, *)
-    @Test("Deactivating the most recent NTP host restores the remaining host policy", .timeLimit(.minutes(1)))
-    func deactivatingMostRecentHostFallsBackToRemainingHostPolicy() async {
-        let notificationCenter = NotificationCenter()
-        let message = makeRemoteMessage(id: "message")
-        let store = FilteredRemoteMessagingStore()
-        let gate = MockPromoGate()
-        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
-
-        sut.prepareForNTP(openedAfterIdle: false, host: .newTabPage)
-        sut.prepareForNTP(openedAfterIdle: true, host: .unifiedInput)
-        sut.deactivateNTPHost(.unifiedInput)
-        store.noTriggerMessage = message
-        store.fetchedTriggerFilters.removeAll()
-
-        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
-        await Task.yield()
-
-        #expect(store.fetchedTriggerFilters == [.noTrigger])
-        #expect(gate.acquiredMessageIDs == ["message"])
-        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
-    }
-
-    @available(iOS 16, *)
-    @Test("One store notification selects once and synchronously converges all source consumers", .timeLimit(.minutes(1)))
-    func storeNotificationConvergesTwoModelsAndDirectConsumer() async {
-        let notificationCenter = NotificationCenter()
-        let message = makeRemoteMessage(id: "message")
+        let refreshedMessage = makeRemoteMessage(
+            id: "message",
+            content: .small(titleText: "Updated title", descriptionText: "Updated description")
+        )
         let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
         let gate = MockPromoGate()
-        gate.grantsAcquisition = false
         let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
         sut.prepareForNTP(openedAfterIdle: false)
+        let originalContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+        sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: originalContext)
+        let originalOwner = gate.arbiter.snapshot.owner
 
-        let firstModel = makeMessagesModel(configuration: sut, notificationCenter: notificationCenter)
-        let secondModel = makeMessagesModel(configuration: sut, notificationCenter: notificationCenter)
-        firstModel.load()
-        secondModel.load()
-        var directConsumerMessages: [HomeMessage] = []
-        var directConsumerCallCount = 0
-        let cancellable = sut.contentDidChangePublisher.sink {
-            directConsumerCallCount += 1
-            directConsumerMessages = sut.homeMessages
-        }
-
-        gate.grantsAcquisition = true
+        store.noTriggerMessage = refreshedMessage
         store.fetchedTriggerFilters.removeAll()
-        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
-        await Task.yield()
+        await postRemoteMessagesDidChange(notificationCenter)
+        let refreshedContext = sut.presentationContext(for: .remoteMessage(remoteMessage: refreshedMessage))
+        sut.didAppear(.remoteMessage(remoteMessage: refreshedMessage), presentationContext: refreshedContext)
 
         #expect(store.fetchedTriggerFilters == [.noTrigger])
-        #expect(gate.acquiredMessageIDs == ["message", "message"])
-        #expect(firstModel.homeMessageViewModels.map(\.messageId) == ["message"])
-        #expect(secondModel.homeMessageViewModels.map(\.messageId) == ["message"])
-        #expect(directConsumerMessages == [.remoteMessage(remoteMessage: message)])
-        #expect(directConsumerCallCount == 1)
-        withExtendedLifetime(cancellable) {}
+        #expect(gate.acquiredMessageIDs == ["message"])
+        #expect(gate.arbiter.snapshot.owner == originalOwner)
+        #expect(refreshedContext == originalContext)
+        #expect(gate.cooldownPolicy.recordConfirmedRemoteMessageAppearanceCallCount == 1)
+        #expect(store.hasShownRemoteMessageCallCount == 1)
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: refreshedMessage)])
     }
 
     @available(iOS 16, *)
@@ -440,18 +442,17 @@ struct HomePageConfigurationTests {
     }
 
     @available(iOS 16, *)
-    @Test("An owned RMF survives host disappearance and foreground with one appearance", .timeLimit(.minutes(1)))
-    func ownedRemoteMessageSurvivesHostDeactivationAndForegroundWithOneAppearance() {
+    @Test("An owned RMF needs no container teardown callback and survives foreground with one appearance", .timeLimit(.minutes(1)))
+    func ownedRemoteMessageSurvivesForegroundWithOneAppearance() {
         let message = makeRemoteMessage(id: "message")
         let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
         let gate = MockPromoGate()
         let sut = makeCoordinatedConfiguration(store: store, gate: gate)
 
-        sut.prepareForNTP(openedAfterIdle: false, host: .newTabPage)
+        sut.prepareForNTP(openedAfterIdle: false)
         let context = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
         sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
 
-        sut.deactivateNTPHost(.newTabPage)
         sut.handleAppBackgrounded()
         sut.handleAppForegrounded()
         sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
@@ -566,8 +567,7 @@ struct HomePageConfigurationTests {
 
         sut.handleAppBackgrounded()
         sut.prepareForNTP(openedAfterIdle: false)
-        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
-        await Task.yield()
+        await postRemoteMessagesDidChange(notificationCenter)
         sut.handleAppForegrounded()
 
         #expect(store.fetchedTriggerFilters.isEmpty)
@@ -589,8 +589,7 @@ struct HomePageConfigurationTests {
         store.fetchedTriggerFilters.removeAll()
 
         sut.handleAppBackgrounded()
-        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
-        await Task.yield()
+        await postRemoteMessagesDidChange(notificationCenter)
 
         #expect(store.fetchedTriggerFilters == [.noTrigger])
         #expect(gate.acquiredMessageIDs == ["message"])
@@ -612,8 +611,7 @@ struct HomePageConfigurationTests {
 
         sut.handleAppBackgrounded()
         store.noTriggerMessage = replacement
-        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
-        await Task.yield()
+        await postRemoteMessagesDidChange(notificationCenter)
 
         #expect(gate.acquiredMessageIDs == ["original"])
         #expect(gate.arbiter.snapshot.owner == nil)
@@ -661,6 +659,31 @@ struct HomePageConfigurationTests {
     }
 
     @available(iOS 16, *)
+    @Test("An ownerless foreground validation waits for the visible NTP preparation checkpoint", .timeLimit(.minutes(1)))
+    func foregroundOwnerlessValidationWaitsForPreparation() {
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(
+            store: store,
+            gate: gate,
+            isRMFAdmissionEnabled: false
+        )
+
+        sut.handleAppForegrounded()
+
+        #expect(store.fetchedTriggerFilters.isEmpty)
+        #expect(gate.acquiredMessageIDs.isEmpty)
+        #expect(sut.homeMessages.isEmpty)
+
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        #expect(store.fetchedTriggerFilters == [.noTrigger])
+        #expect(gate.acquiredMessageIDs == ["message"])
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
+    }
+
+    @available(iOS 16, *)
     @Test("Legacy lifecycle hooks leave RMF behavior unchanged", .timeLimit(.minutes(1)))
     func legacyLifecycleHooksAreNoOp() {
         let message = makeRemoteMessage(id: "message")
@@ -672,14 +695,41 @@ struct HomePageConfigurationTests {
         )
         let homeMessages = sut.homeMessages
 
-        sut.prepareForNTP(openedAfterIdle: true, host: .unifiedInput)
-        sut.deactivateNTPHost(.unifiedInput)
+        sut.prepareForNTP(openedAfterIdle: true)
         sut.handleAppBackgrounded()
         sut.handleAppForegrounded()
 
         #expect(sut.homeMessages == homeMessages)
         #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
         #expect(store.fetchedTriggerFilters == [.noTrigger])
+    }
+
+    @available(iOS 16, *)
+    @Test("A dismissal notification cannot acquire the next message", .timeLimit(.minutes(1)))
+    func dismissalNotificationWaitsForNextPreparation() async {
+        let notificationCenter = NotificationCenter()
+        let original = makeRemoteMessage(id: "original")
+        let replacement = makeRemoteMessage(id: "replacement")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: original)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+        sut.prepareForNTP(openedAfterIdle: false)
+        let context = sut.presentationContext(for: .remoteMessage(remoteMessage: original))
+        store.dismissRemoteMessageHandler = {
+            store.noTriggerMessage = replacement
+        }
+
+        await sut.dismissHomeMessage(.remoteMessage(remoteMessage: original), presentationContext: context)
+        await waitForMainActorQueue()
+
+        #expect(gate.acquiredMessageIDs == ["original"])
+        #expect(gate.arbiter.snapshot.owner == nil)
+        #expect(sut.homeMessages.isEmpty)
+
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        #expect(gate.acquiredMessageIDs == ["original", "replacement"])
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: replacement)])
     }
 
     @available(iOS 16, *)
@@ -719,8 +769,7 @@ struct HomePageConfigurationTests {
         }
 
         store.noTriggerMessage = nil
-        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
-        await Task.yield()
+        await postRemoteMessagesDidChange(notificationCenter)
         store.noTriggerMessage = message
         sut.prepareForNTP(openedAfterIdle: false)
         let newContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
@@ -744,7 +793,7 @@ struct HomePageConfigurationTests {
         #expect(reconciliationNotificationCount == 1)
         #expect(ownerAtReconciliationNotification != nil)
 
-        await Task.yield()
+        await waitForMainActorQueue()
 
         #expect(oldContext != newContext)
         #expect(sut.presentationContext(for: .remoteMessage(remoteMessage: message)) == nil)
@@ -753,8 +802,8 @@ struct HomePageConfigurationTests {
     }
 
     @available(iOS 16, *)
-    @Test("Ordered teardown signals while the old lease still owns the slot", .timeLimit(.minutes(1)))
-    func teardownSignalsBeforeRelease() async {
+    @Test("Removal unpublishes before release without notification-driven reacquisition", .timeLimit(.minutes(1)))
+    func removalSignalsBeforeReleaseWithoutReacquisition() async {
         let notificationCenter = NotificationCenter()
         let message = makeRemoteMessage(id: "message")
         let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
@@ -768,8 +817,7 @@ struct HomePageConfigurationTests {
         }
         store.noTriggerMessage = nil
 
-        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
-        await Task.yield()
+        await postRemoteMessagesDidChange(notificationCenter)
 
         #expect(ownerAtSignal != nil)
         #expect(gate.arbiter.snapshot.owner == nil)
@@ -778,8 +826,26 @@ struct HomePageConfigurationTests {
     }
 
     @available(iOS 16, *)
-    @Test("Replacement unpublishes before releasing the old owner, then publishes a new identity", .timeLimit(.minutes(1)))
-    func replacementUsesOrderedTeardownAndFreshIdentity() async {
+    @Test("Expiry releases ownership without notification-driven reacquisition", .timeLimit(.minutes(1)))
+    func expiryReleasesWithoutReacquisition() async {
+        let notificationCenter = NotificationCenter()
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        store.isScheduledMessageExpired = true
+        await postRemoteMessagesDidChange(notificationCenter)
+
+        #expect(gate.acquiredMessageIDs == ["message"])
+        #expect(gate.arbiter.snapshot.owner == nil)
+        #expect(sut.homeMessages.isEmpty)
+    }
+
+    @available(iOS 16, *)
+    @Test("Replacement unpublishes before release and waits for explicit preparation", .timeLimit(.minutes(1)))
+    func replacementUsesOrderedTeardownAndWaitsForPreparation() async {
         let notificationCenter = NotificationCenter()
         let original = makeRemoteMessage(id: "original")
         let replacement = makeRemoteMessage(id: "replacement")
@@ -794,14 +860,17 @@ struct HomePageConfigurationTests {
         }
 
         store.noTriggerMessage = replacement
-        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
-        await Task.yield()
-        let replacementContext = sut.presentationContext(for: .remoteMessage(remoteMessage: replacement))
+        await postRemoteMessagesDidChange(notificationCenter)
 
-        #expect(ownersAtSignal.count == 2)
-        #expect(ownersAtSignal[0] != nil)
-        #expect(ownersAtSignal[1] != nil)
-        #expect(originalContext != replacementContext)
+        #expect(ownersAtSignal.count == 1 && ownersAtSignal[0] != nil)
+        #expect(gate.acquiredMessageIDs == ["original"] && gate.arbiter.snapshot.owner == nil)
+        #expect(sut.presentationContext(for: .remoteMessage(remoteMessage: replacement)) == nil && sut.homeMessages.isEmpty)
+
+        sut.prepareForNTP(openedAfterIdle: false)
+        let preparedReplacementContext = sut.presentationContext(for: .remoteMessage(remoteMessage: replacement))
+
+        #expect(ownersAtSignal.count == 2 && ownersAtSignal[1] != nil)
+        #expect(gate.acquiredMessageIDs == ["original", "replacement"] && originalContext != preparedReplacementContext)
         #expect(sut.homeMessages == [.remoteMessage(remoteMessage: replacement)])
         withExtendedLifetime(cancellable) {}
     }
@@ -828,8 +897,7 @@ struct HomePageConfigurationTests {
         }
 
         isStillOnboarding = true
-        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
-        await Task.yield()
+        await postRemoteMessagesDidChange(notificationCenter)
 
         #expect(ownerAtSignal != nil)
         #expect(gate.arbiter.snapshot.owner == nil)
@@ -851,6 +919,19 @@ struct HomePageConfigurationTests {
             isRMFAdmissionEnabled: isRMFAdmissionEnabled,
             notificationCenter: notificationCenter
         )
+    }
+
+    private func postRemoteMessagesDidChange(_ notificationCenter: NotificationCenter) async {
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+        await waitForMainActorQueue()
+    }
+
+    private func waitForMainActorQueue() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
     }
 
     private func makeRemoteMessage(
@@ -935,6 +1016,7 @@ private final class FilteredRemoteMessagingStore: RemoteMessagingStoring {
     var afterIdleMessage: RemoteMessageModel?
     var noTriggerMessage: RemoteMessageModel?
     var shownMessageIDs: Set<String> = []
+    var isScheduledMessageExpired = false
     var fetchedTriggerFilters: [TriggerFilter] = []
     private(set) var dismissedMessageIDs: [String] = []
     private(set) var updatedShownMessageIDs: [String] = []
@@ -961,7 +1043,9 @@ private final class FilteredRemoteMessagingStore: RemoteMessagingStoring {
         case .any:
             candidate = afterIdleMessage ?? noTriggerMessage
         }
-        guard let candidate, !dismissedMessageIDs.contains(candidate.id) else {
+        guard let candidate,
+              !isScheduledMessageExpired,
+              !dismissedMessageIDs.contains(candidate.id) else {
             return nil
         }
         return candidate

--- a/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
+++ b/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
@@ -17,11 +17,14 @@
 //  limitations under the License.
 //
 
-import Testing
+import Combine
+import Foundation
 import RemoteMessaging
 import RemoteMessagingTestsUtils
+import Testing
 @testable import DuckDuckGo
 
+@MainActor
 struct HomePageConfigurationTests {
 
     @Test("Check Home Page Configuration Fetches Remote Messages With NewTabPage Surface")
@@ -110,4 +113,590 @@ struct HomePageConfigurationTests {
         #expect(storeMock.capturedTriggerFilter == .noTrigger)
     }
 
+    @Test("Coordinated initialization defers RMF selection until explicit preparation")
+    func coordinatedInitializationDefersSelection() {
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: makeRemoteMessage(id: "message"))
+        let gate = MockPromoGate()
+
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate)
+
+        #expect(store.fetchedTriggerFilters.isEmpty)
+        #expect(gate.acquiredMessageIDs.isEmpty)
+        #expect(sut.homeMessages.isEmpty)
+
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        #expect(store.fetchedTriggerFilters == [.noTrigger])
+        #expect(gate.acquiredMessageIDs == ["message"])
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: makeRemoteMessage(id: "message"))])
+    }
+
+    @Test("Disabled preparation neither selects nor arms a later store refresh")
+    func disabledPreparationDoesNotArmRefresh() async {
+        let notificationCenter = NotificationCenter()
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: makeRemoteMessage(id: "message"))
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(
+            store: store,
+            gate: gate,
+            isRMFAdmissionEnabled: false,
+            notificationCenter: notificationCenter
+        )
+
+        sut.prepareForNTP(openedAfterIdle: true)
+        sut.handleAppForegrounded()
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+        await Task.yield()
+
+        #expect(store.fetchedTriggerFilters.isEmpty)
+        #expect(gate.acquiredMessageIDs.isEmpty)
+
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        #expect(store.fetchedTriggerFilters == [.noTrigger])
+        #expect(gate.acquiredMessageIDs == ["message"])
+    }
+
+    @Test("After-idle fallback pins the actual no-trigger filter for the ownership")
+    func afterIdleFallbackPinsActualFilter() {
+        let original = makeRemoteMessage(id: "original")
+        let replacement = makeRemoteMessage(id: "replacement")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: original)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate)
+
+        sut.prepareForNTP(openedAfterIdle: true)
+        store.afterIdleMessage = replacement
+        store.fetchedTriggerFilters.removeAll()
+
+        sut.prepareForNTP(openedAfterIdle: true)
+
+        #expect(store.fetchedTriggerFilters == [.noTrigger])
+        #expect(gate.acquiredMessageIDs == ["original"])
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: original)])
+    }
+
+    @Test("Unsupported content is rejected before gate acquisition")
+    func unsupportedContentDoesNotAcquire() {
+        let unsupported = makeRemoteMessage(id: "unsupported", content: nil)
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: unsupported)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate)
+
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        #expect(gate.acquiredMessageIDs.isEmpty)
+        #expect(sut.homeMessages.isEmpty)
+    }
+
+    @Test("A coordinated store refresh retries a denied candidate with the last preparation policy")
+    func storeRefreshRetriesDeniedCandidate() async {
+        let notificationCenter = NotificationCenter()
+        let message = makeRemoteMessage(id: "after-idle")
+        let store = FilteredRemoteMessagingStore(afterIdleMessage: message)
+        let gate = MockPromoGate()
+        gate.grantsAcquisition = false
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+
+        sut.prepareForNTP(openedAfterIdle: true)
+        #expect(sut.homeMessages.isEmpty)
+
+        gate.grantsAcquisition = true
+        store.fetchedTriggerFilters.removeAll()
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+        await Task.yield()
+
+        #expect(store.fetchedTriggerFilters == [.specific(.afterIdle)])
+        #expect(gate.acquiredMessageIDs == ["after-idle", "after-idle"])
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
+    }
+
+    @Test("One store notification selects once and synchronously converges all source consumers")
+    func storeNotificationConvergesTwoModelsAndDirectConsumer() async {
+        let notificationCenter = NotificationCenter()
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let gate = MockPromoGate()
+        gate.grantsAcquisition = false
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        let firstModel = makeMessagesModel(configuration: sut, notificationCenter: notificationCenter)
+        let secondModel = makeMessagesModel(configuration: sut, notificationCenter: notificationCenter)
+        firstModel.load()
+        secondModel.load()
+        var directConsumerMessages: [HomeMessage] = []
+        var directConsumerCallCount = 0
+        let cancellable = sut.contentDidChangePublisher.sink {
+            directConsumerCallCount += 1
+            directConsumerMessages = sut.homeMessages
+        }
+
+        gate.grantsAcquisition = true
+        store.fetchedTriggerFilters.removeAll()
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+        await Task.yield()
+
+        #expect(store.fetchedTriggerFilters == [.noTrigger])
+        #expect(gate.acquiredMessageIDs == ["message", "message"])
+        #expect(firstModel.homeMessageViewModels.map(\.messageId) == ["message"])
+        #expect(secondModel.homeMessageViewModels.map(\.messageId) == ["message"])
+        #expect(directConsumerMessages == [.remoteMessage(remoteMessage: message)])
+        #expect(directConsumerCallCount == 1)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    @Test("A modal-owned slot prevents RMF publication and store mutation")
+    func modalOwnershipBlocksRemoteMessageAdmission() throws {
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let gate = MockPromoGate()
+        guard case .acquired(let modalLease) = gate.arbiter.acquireModalLease() else {
+            Issue.record("Expected the test modal lease to acquire")
+            return
+        }
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate)
+
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        #expect(sut.homeMessages.isEmpty)
+        #expect(store.dismissedMessageIDs.isEmpty)
+        #expect(store.updatedShownMessageIDs.isEmpty)
+        #expect(gate.arbiter.snapshot.hasModalLease)
+        _ = modalLease
+    }
+
+    @Test("The complete ownership context is retained before RMF publication")
+    func ownershipIsRetainedBeforePublication() {
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate)
+        var contextAtPublication: HomeMessagePresentationContext?
+        var ownerAtPublication: PromoQueueLeaseOwnerSnapshot?
+        let cancellable = sut.contentDidChangePublisher.sink {
+            contextAtPublication = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+            ownerAtPublication = gate.arbiter.snapshot.owner
+        }
+
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        #expect(contextAtPublication != nil)
+        #expect(ownerAtPublication != nil)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    @Test("Same ownership keeps identity while background reacquisition changes it")
+    func ownershipIdentityLifecycle() {
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate)
+
+        sut.prepareForNTP(openedAfterIdle: false)
+        let firstContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+
+        sut.prepareForNTP(openedAfterIdle: true)
+        let refreshedContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+
+        sut.handleAppBackgrounded()
+        sut.handleAppForegrounded()
+        sut.prepareForNTP(openedAfterIdle: false)
+        let reacquiredContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+
+        #expect(firstContext == refreshedContext)
+        #expect(firstContext != reacquiredContext)
+        #expect(gate.acquiredMessageIDs == ["message", "message"])
+    }
+
+    @Test("Only the first current appearance confirms history and stale appearance is ignored")
+    func appearanceIsIdentityCheckedAndConfirmedOnce() {
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate)
+        sut.prepareForNTP(openedAfterIdle: false)
+        let context = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+
+        sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
+        sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
+        sut.handleAppBackgrounded()
+        sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
+
+        #expect(gate.cooldownPolicy.recordConfirmedRemoteMessageAppearanceCallCount == 1)
+        #expect(store.hasShownRemoteMessageCallCount == 1)
+    }
+
+    @Test("An appeared RMF records real history once and is cooldown-blocked after background")
+    func appearedRemoteMessageIsCooldownBlockedAfterBackground() async {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let history = RecordingPromoQueueRemoteMessageHistory()
+        let arbiter = PromoQueueLeaseArbiter()
+        let policy = PromoQueueCooldownPolicy(
+            modalPresentationStore: MockPromptCooldownStore(),
+            remoteMessageHistory: history,
+            dateProvider: { now }
+        )
+        let service = makePromoCoordinationService(arbiter: arbiter, cooldownPolicy: policy)
+        let sut = HomePageConfiguration(
+            remoteMessagingStore: store,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false },
+            promoGate: service
+        )
+
+        sut.prepareForNTP(openedAfterIdle: false)
+        let context = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+        sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
+        sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
+        while store.updatedShownMessageIDs.isEmpty {
+            await Task.yield()
+        }
+
+        var ownerAtBackgroundSignal: PromoQueueLeaseOwnerSnapshot?
+        let cancellable = sut.contentDidChangePublisher.sink {
+            ownerAtBackgroundSignal = arbiter.snapshot.owner
+        }
+        sut.handleAppBackgrounded()
+        sut.handleAppForegrounded()
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        #expect(history.recordedDates == [now])
+        #expect(store.hasShownRemoteMessageCallCount == 1)
+        #expect(store.updatedShownMessageIDs == ["message"])
+        #expect(ownerAtBackgroundSignal != nil)
+        #expect(sut.homeMessages.isEmpty)
+        #expect(arbiter.snapshot.owner == nil)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    @Test("A never-appeared RMF can reacquire after background without writing history")
+    func neverAppearedRemoteMessageCanReacquireAfterBackground() {
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let history = RecordingPromoQueueRemoteMessageHistory()
+        let arbiter = PromoQueueLeaseArbiter()
+        let policy = PromoQueueCooldownPolicy(
+            modalPresentationStore: MockPromptCooldownStore(),
+            remoteMessageHistory: history
+        )
+        let service = makePromoCoordinationService(arbiter: arbiter, cooldownPolicy: policy)
+        let sut = HomePageConfiguration(
+            remoteMessagingStore: store,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false },
+            promoGate: service
+        )
+
+        sut.prepareForNTP(openedAfterIdle: false)
+        let firstContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+        sut.handleAppBackgrounded()
+        sut.handleAppForegrounded()
+        sut.prepareForNTP(openedAfterIdle: false)
+        let secondContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+
+        #expect(history.recordedDates.isEmpty)
+        #expect(firstContext != secondContext)
+        #expect(secondContext != nil)
+        #expect(arbiter.snapshot.owner != nil)
+    }
+
+    @Test("A dismissal made stale while awaiting cannot release a reacquired same-ID owner")
+    func staleDismissalCompletionCannotReleaseReacquiredOwner() async {
+        let notificationCenter = NotificationCenter()
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+        sut.prepareForNTP(openedAfterIdle: false)
+        let oldContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+        var dismissalContinuation: CheckedContinuation<Void, Never>?
+        var reconciliationNotificationCount = 0
+        var ownerAtReconciliationNotification: PromoQueueLeaseOwnerSnapshot?
+        let notificationObserver = notificationCenter.addObserver(
+            forName: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            MainActor.assumeIsolated {
+                reconciliationNotificationCount += 1
+                ownerAtReconciliationNotification = gate.arbiter.snapshot.owner
+            }
+        }
+        store.dismissRemoteMessageHandler = {
+            await withCheckedContinuation { continuation in
+                dismissalContinuation = continuation
+            }
+        }
+
+        let dismissalTask = Task {
+            await sut.dismissHomeMessage(
+                .remoteMessage(remoteMessage: message),
+                presentationContext: oldContext
+            )
+        }
+        while dismissalContinuation == nil {
+            await Task.yield()
+        }
+
+        sut.handleAppBackgrounded()
+        sut.handleAppForegrounded()
+        sut.prepareForNTP(openedAfterIdle: false)
+        let newContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+        dismissalContinuation?.resume()
+        await dismissalTask.value
+
+        #expect(reconciliationNotificationCount == 1)
+        #expect(ownerAtReconciliationNotification != nil)
+
+        await Task.yield()
+
+        #expect(oldContext != newContext)
+        #expect(sut.presentationContext(for: .remoteMessage(remoteMessage: message)) == nil)
+        #expect(gate.arbiter.snapshot.owner == nil)
+        #expect(store.dismissedMessageIDs == ["message"])
+        notificationCenter.removeObserver(notificationObserver)
+    }
+
+    @Test("Ordered teardown signals while the old lease still owns the slot")
+    func teardownSignalsBeforeRelease() async {
+        let notificationCenter = NotificationCenter()
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        var ownerAtSignal: PromoQueueLeaseOwnerSnapshot?
+        let cancellable = sut.contentDidChangePublisher.sink {
+            ownerAtSignal = gate.arbiter.snapshot.owner
+        }
+        store.noTriggerMessage = nil
+
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+        await Task.yield()
+
+        #expect(ownerAtSignal != nil)
+        #expect(gate.arbiter.snapshot.owner == nil)
+        #expect(sut.homeMessages.isEmpty)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    @Test("Replacement unpublishes before releasing the old owner, then publishes a new identity")
+    func replacementUsesOrderedTeardownAndFreshIdentity() async {
+        let notificationCenter = NotificationCenter()
+        let original = makeRemoteMessage(id: "original")
+        let replacement = makeRemoteMessage(id: "replacement")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: original)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+        sut.prepareForNTP(openedAfterIdle: false)
+        let originalContext = sut.presentationContext(for: .remoteMessage(remoteMessage: original))
+        var ownersAtSignal: [PromoQueueLeaseOwnerSnapshot?] = []
+        let cancellable = sut.contentDidChangePublisher.sink {
+            ownersAtSignal.append(gate.arbiter.snapshot.owner)
+        }
+
+        store.noTriggerMessage = replacement
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+        await Task.yield()
+        let replacementContext = sut.presentationContext(for: .remoteMessage(remoteMessage: replacement))
+
+        #expect(ownersAtSignal.count == 2)
+        #expect(ownersAtSignal[0] != nil)
+        #expect(ownersAtSignal[1] != nil)
+        #expect(originalContext != replacementContext)
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: replacement)])
+        withExtendedLifetime(cancellable) {}
+    }
+
+    @Test("Onboarding suppression unpublishes before releasing current ownership")
+    func onboardingSuppressionUsesOrderedTeardown() async {
+        let notificationCenter = NotificationCenter()
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let gate = MockPromoGate()
+        var isStillOnboarding = false
+        let sut = HomePageConfiguration(
+            remoteMessagingStore: store,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { isStillOnboarding },
+            promoGate: gate,
+            notificationCenter: notificationCenter
+        )
+        sut.prepareForNTP(openedAfterIdle: false)
+        var ownerAtSignal: PromoQueueLeaseOwnerSnapshot?
+        let cancellable = sut.contentDidChangePublisher.sink {
+            ownerAtSignal = gate.arbiter.snapshot.owner
+        }
+
+        isStillOnboarding = true
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+        await Task.yield()
+
+        #expect(ownerAtSignal != nil)
+        #expect(gate.arbiter.snapshot.owner == nil)
+        #expect(sut.homeMessages.isEmpty)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    private func makeCoordinatedConfiguration(
+        store: RemoteMessagingStoring,
+        gate: MockPromoGate,
+        isRMFAdmissionEnabled: Bool = true,
+        notificationCenter: NotificationCenter = NotificationCenter()
+    ) -> HomePageConfiguration {
+        HomePageConfiguration(
+            remoteMessagingStore: store,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false },
+            promoGate: gate,
+            isRMFAdmissionEnabled: isRMFAdmissionEnabled,
+            notificationCenter: notificationCenter
+        )
+    }
+
+    private func makeRemoteMessage(
+        id: String,
+        content: RemoteMessageModelType? = .small(titleText: "Title", descriptionText: "Description")
+    ) -> RemoteMessageModel {
+        RemoteMessageModel(
+            id: id,
+            surfaces: .newTabPage,
+            content: content,
+            matchingRules: [],
+            exclusionRules: [],
+            isMetricsEnabled: false
+        )
+    }
+
+    private func makeMessagesModel(
+        configuration: HomePageMessagesConfiguration,
+        notificationCenter: NotificationCenter
+    ) -> NewTabPageMessagesModel {
+        NewTabPageMessagesModel(
+            homePageMessagesConfiguration: configuration,
+            notificationCenter: notificationCenter,
+            messageActionHandler: RemoteMessagingActionHandler(
+                lastSearchStateRefresher: RemoteMessagingSurveyLastSearchStateRefresher()
+            ),
+            imageLoader: MockRemoteMessagingImageLoader()
+        )
+    }
+
+    private func makePromoCoordinationService(
+        arbiter: PromoQueueLeaseArbiter,
+        cooldownPolicy: PromoQueueCooldownPolicying
+    ) -> PromoCoordinationService {
+        PromoCoordinationService(
+            launchSourceManager: MockLaunchSourceManager(),
+            modalPromptCoordinationManager: MockModalPromptCoordinationManager(),
+            mode: .coordinated,
+            promoQueueLeaseArbiter: arbiter,
+            promoQueueCooldownPolicy: cooldownPolicy
+        )
+    }
+
+}
+
+@MainActor
+private final class RecordingPromoQueueRemoteMessageHistory: PromoQueueRemoteMessageHistory {
+    private(set) var recordedDates: [Date] = []
+
+    var lastConfirmedAppearance: Date? {
+        recordedDates.last
+    }
+
+    func recordConfirmedAppearance(at date: Date) {
+        recordedDates.append(date)
+    }
+
+    func reset() {
+        recordedDates.removeAll()
+    }
+}
+
+@MainActor
+private final class MockPromoGate: PromoGating {
+    let mode = PromoCoordinationMode.coordinated
+    let arbiter = PromoQueueLeaseArbiter()
+    let cooldownPolicy = MockPromoQueueCooldownPolicy()
+    var grantsAcquisition = true
+    private(set) var acquiredMessageIDs: [String] = []
+
+    func tryAcquireRemoteMessageLease(for messageID: String) -> PromoQueueRemoteMessageLease? {
+        acquiredMessageIDs.append(messageID)
+        guard grantsAcquisition,
+              case .acquired(let arbiterLease) = arbiter.acquireRemoteMessageLease(for: messageID) else {
+            return nil
+        }
+        return PromoQueueRemoteMessageLease(arbiterLease: arbiterLease, cooldownPolicy: cooldownPolicy)
+    }
+}
+
+private final class FilteredRemoteMessagingStore: RemoteMessagingStoring {
+    var afterIdleMessage: RemoteMessageModel?
+    var noTriggerMessage: RemoteMessageModel?
+    var shownMessageIDs: Set<String> = []
+    var fetchedTriggerFilters: [TriggerFilter] = []
+    private(set) var dismissedMessageIDs: [String] = []
+    private(set) var updatedShownMessageIDs: [String] = []
+    private(set) var hasShownRemoteMessageCallCount = 0
+    var dismissRemoteMessageHandler: (() async -> Void)?
+
+    init(afterIdleMessage: RemoteMessageModel? = nil, noTriggerMessage: RemoteMessageModel? = nil) {
+        self.afterIdleMessage = afterIdleMessage
+        self.noTriggerMessage = noTriggerMessage
+    }
+
+    func saveProcessedResult(_ processorResult: RemoteMessagingConfigProcessor.ProcessorResult) async {}
+    func fetchRemoteMessagingConfig() -> RemoteMessagingConfig? { nil }
+
+    func fetchScheduledRemoteMessage(surfaces: RemoteMessageSurfaceType, triggerFilter: TriggerFilter) -> RemoteMessageModel? {
+        fetchedTriggerFilters.append(triggerFilter)
+        let candidate: RemoteMessageModel?
+        switch triggerFilter {
+        case .specific(.afterIdle):
+            candidate = afterIdleMessage
+        case .noTrigger:
+            candidate = noTriggerMessage
+        case .any:
+            candidate = afterIdleMessage ?? noTriggerMessage
+        }
+        guard let candidate, !dismissedMessageIDs.contains(candidate.id) else {
+            return nil
+        }
+        return candidate
+    }
+
+    func hasShownRemoteMessage(withID id: String) -> Bool {
+        hasShownRemoteMessageCallCount += 1
+        return shownMessageIDs.contains(id)
+    }
+
+    func fetchShownRemoteMessageIDs() -> [String] {
+        Array(shownMessageIDs)
+    }
+
+    func dismissRemoteMessage(withID id: String) async {
+        await dismissRemoteMessageHandler?()
+        dismissedMessageIDs.append(id)
+    }
+
+    func fetchDismissedRemoteMessageIDs() -> [String] {
+        dismissedMessageIDs
+    }
+
+    func updateRemoteMessage(withID id: String, asShown shown: Bool) async {
+        updatedShownMessageIDs.append(id)
+        if shown {
+            shownMessageIDs.insert(id)
+        } else {
+            shownMessageIDs.remove(id)
+        }
+    }
+
+    func resetRemoteMessages() async {}
 }

--- a/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
+++ b/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
@@ -133,8 +133,32 @@ struct HomePageConfigurationTests {
     }
 
     @available(iOS 16, *)
-    @Test("True background launch and ownerless foreground remain inert until NTP preparation", .timeLimit(.minutes(1)))
-    func disabledPreparationDoesNotArmRefresh() async {
+    @Test("Background launch with an attached NTP acquires at the foreground-ready checkpoint", .timeLimit(.minutes(1)))
+    func backgroundLaunchWithAttachedNTPPreparesWhenForegroundReady() {
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: makeRemoteMessage(id: "message"))
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(
+            store: store,
+            gate: gate,
+            isRMFAdmissionEnabled: false
+        )
+
+        sut.prepareForNTP(openedAfterIdle: true)
+
+        #expect(store.fetchedTriggerFilters.isEmpty)
+        #expect(gate.acquiredMessageIDs.isEmpty)
+
+        sut.handleAppForegrounded()
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        #expect(store.fetchedTriggerFilters == [.noTrigger])
+        #expect(gate.acquiredMessageIDs == ["message"])
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: makeRemoteMessage(id: "message"))])
+    }
+
+    @available(iOS 16, *)
+    @Test("Ownerless foreground without an attached NTP remains inert", .timeLimit(.minutes(1)))
+    func ownerlessForegroundWithoutAttachedNTPRemainsInert() async {
         let notificationCenter = NotificationCenter()
         let store = FilteredRemoteMessagingStore(noTriggerMessage: makeRemoteMessage(id: "message"))
         let gate = MockPromoGate()
@@ -145,7 +169,6 @@ struct HomePageConfigurationTests {
             notificationCenter: notificationCenter
         )
 
-        sut.prepareForNTP(openedAfterIdle: true)
         sut.handleAppForegrounded()
         notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
         await Task.yield()
@@ -153,11 +176,6 @@ struct HomePageConfigurationTests {
         #expect(store.fetchedTriggerFilters.isEmpty)
         #expect(gate.acquiredMessageIDs.isEmpty)
         #expect(sut.homeMessages.isEmpty)
-
-        sut.prepareForNTP(openedAfterIdle: false)
-
-        #expect(store.fetchedTriggerFilters == [.noTrigger])
-        #expect(gate.acquiredMessageIDs == ["message"])
     }
 
     @available(iOS 16, *)

--- a/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
+++ b/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
@@ -133,7 +133,7 @@ struct HomePageConfigurationTests {
     }
 
     @available(iOS 16, *)
-    @Test("Disabled preparation neither selects nor arms a later store refresh", .timeLimit(.minutes(1)))
+    @Test("True background launch and ownerless foreground remain inert until NTP preparation", .timeLimit(.minutes(1)))
     func disabledPreparationDoesNotArmRefresh() async {
         let notificationCenter = NotificationCenter()
         let store = FilteredRemoteMessagingStore(noTriggerMessage: makeRemoteMessage(id: "message"))
@@ -152,6 +152,7 @@ struct HomePageConfigurationTests {
 
         #expect(store.fetchedTriggerFilters.isEmpty)
         #expect(gate.acquiredMessageIDs.isEmpty)
+        #expect(sut.homeMessages.isEmpty)
 
         sut.prepareForNTP(openedAfterIdle: false)
 
@@ -295,31 +296,39 @@ struct HomePageConfigurationTests {
     }
 
     @available(iOS 16, *)
-    @Test("Same ownership keeps identity while background reacquisition changes it", .timeLimit(.minutes(1)))
-    func ownershipIdentityLifecycle() {
+    @Test("A published RMF keeps publication, identity, and lease through background and foreground", .timeLimit(.minutes(1)))
+    func ownershipSurvivesBackgroundAndForeground() {
         let message = makeRemoteMessage(id: "message")
         let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
         let gate = MockPromoGate()
         let sut = makeCoordinatedConfiguration(store: store, gate: gate)
 
         sut.prepareForNTP(openedAfterIdle: false)
-        let firstContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
-
-        sut.prepareForNTP(openedAfterIdle: true)
-        let refreshedContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+        let context = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+        let owner = gate.arbiter.snapshot.owner
+        var contentDidChangeCount = 0
+        let cancellable = sut.contentDidChangePublisher.sink {
+            contentDidChangeCount += 1
+        }
 
         sut.handleAppBackgrounded()
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
+        #expect(sut.presentationContext(for: .remoteMessage(remoteMessage: message)) == context)
+        #expect(gate.arbiter.snapshot.owner == owner)
+
         sut.handleAppForegrounded()
         sut.prepareForNTP(openedAfterIdle: false)
-        let reacquiredContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
 
-        #expect(firstContext == refreshedContext)
-        #expect(firstContext != reacquiredContext)
-        #expect(gate.acquiredMessageIDs == ["message", "message"])
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
+        #expect(sut.presentationContext(for: .remoteMessage(remoteMessage: message)) == context)
+        #expect(gate.arbiter.snapshot.owner == owner)
+        #expect(gate.acquiredMessageIDs == ["message"])
+        #expect(contentDidChangeCount == 0)
+        withExtendedLifetime(cancellable) {}
     }
 
     @available(iOS 16, *)
-    @Test("Only the first current appearance confirms history and stale appearance is ignored", .timeLimit(.minutes(1)))
+    @Test("Only the first appearance is confirmed across background and foreground", .timeLimit(.minutes(1)))
     func appearanceIsIdentityCheckedAndConfirmedOnce() {
         let message = makeRemoteMessage(id: "message")
         let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
@@ -331,15 +340,17 @@ struct HomePageConfigurationTests {
         sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
         sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
         sut.handleAppBackgrounded()
+        sut.handleAppForegrounded()
         sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
 
         #expect(gate.cooldownPolicy.recordConfirmedRemoteMessageAppearanceCallCount == 1)
         #expect(store.hasShownRemoteMessageCallCount == 1)
+        #expect(sut.presentationContext(for: .remoteMessage(remoteMessage: message)) == context)
     }
 
     @available(iOS 16, *)
-    @Test("An appeared RMF records real history once and is cooldown-blocked after background", .timeLimit(.minutes(1)))
-    func appearedRemoteMessageIsCooldownBlockedAfterBackground() async {
+    @Test("An appeared RMF keeps history and blocks modal evaluation after foreground", .timeLimit(.minutes(1)))
+    func appearedRemoteMessageRetainsOwnershipAndBlocksModalAfterForeground() async {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let message = makeRemoteMessage(id: "message")
         let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
@@ -357,7 +368,16 @@ struct HomePageConfigurationTests {
             remoteMessageHistory: history,
             dateProvider: { now }
         )
-        let service = makePromoCoordinationService(arbiter: arbiter, cooldownPolicy: policy)
+        let launchSourceManager = MockLaunchSourceManager()
+        launchSourceManager.source = .standard
+        let modalManager = MockModalPromptCoordinationManager()
+        let service = PromoCoordinationService(
+            launchSourceManager: launchSourceManager,
+            modalPromptCoordinationManager: modalManager,
+            mode: .coordinated,
+            promoQueueLeaseArbiter: arbiter,
+            promoQueueCooldownPolicy: policy
+        )
         let sut = HomePageConfiguration(
             remoteMessagingStore: store,
             subscriptionDataReporter: MockSubscriptionDataReporter(),
@@ -369,32 +389,29 @@ struct HomePageConfigurationTests {
         let context = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
         sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
         sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
+        let owner = arbiter.snapshot.owner
         var shownPersistenceIterator = shownPersistenceEvents.makeAsyncIterator()
         guard await shownPersistenceIterator.next() != nil else {
             Issue.record("Expected shown persistence to be invoked")
             return
         }
 
-        var ownerAtBackgroundSignal: PromoQueueLeaseOwnerSnapshot?
-        let cancellable = sut.contentDidChangePublisher.sink {
-            ownerAtBackgroundSignal = arbiter.snapshot.owner
-        }
         sut.handleAppBackgrounded()
         sut.handleAppForegrounded()
-        sut.prepareForNTP(openedAfterIdle: false)
+        service.presentModalPromptIfNeeded(from: MockModalPromptPresenter())
 
         #expect(history.recordedDates == [now])
         #expect(store.hasShownRemoteMessageCallCount == 1)
         #expect(store.updatedShownMessageIDs == ["message"])
-        #expect(ownerAtBackgroundSignal != nil)
-        #expect(sut.homeMessages.isEmpty)
-        #expect(arbiter.snapshot.owner == nil)
-        withExtendedLifetime(cancellable) {}
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
+        #expect(sut.presentationContext(for: .remoteMessage(remoteMessage: message)) == context)
+        #expect(arbiter.snapshot.owner == owner)
+        #expect(!modalManager.didCallPresentModalPromptIfNeeded)
     }
 
     @available(iOS 16, *)
-    @Test("A never-appeared RMF can reacquire after background without writing history", .timeLimit(.minutes(1)))
-    func neverAppearedRemoteMessageCanReacquireAfterBackground() {
+    @Test("A never-appeared RMF keeps ownership through background without writing history", .timeLimit(.minutes(1)))
+    func neverAppearedRemoteMessageRetainsOwnershipAcrossBackground() {
         let message = makeRemoteMessage(id: "message")
         let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
         let history = RecordingPromoQueueRemoteMessageHistory()
@@ -412,16 +429,139 @@ struct HomePageConfigurationTests {
         )
 
         sut.prepareForNTP(openedAfterIdle: false)
-        let firstContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+        let context = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+        let owner = arbiter.snapshot.owner
         sut.handleAppBackgrounded()
         sut.handleAppForegrounded()
-        sut.prepareForNTP(openedAfterIdle: false)
-        let secondContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
 
         #expect(history.recordedDates.isEmpty)
-        #expect(firstContext != secondContext)
-        #expect(secondContext != nil)
-        #expect(arbiter.snapshot.owner != nil)
+        #expect(sut.presentationContext(for: .remoteMessage(remoteMessage: message)) == context)
+        #expect(arbiter.snapshot.owner == owner)
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
+    }
+
+    @available(iOS 16, *)
+    @Test("Backgrounding without an owner cannot acquire and foregrounding remains inert", .timeLimit(.minutes(1)))
+    func backgroundWithoutOwnerDoesNotAcquire() async {
+        let notificationCenter = NotificationCenter()
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: makeRemoteMessage(id: "message"))
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+
+        sut.handleAppBackgrounded()
+        sut.prepareForNTP(openedAfterIdle: false)
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+        await Task.yield()
+        sut.handleAppForegrounded()
+
+        #expect(store.fetchedTriggerFilters.isEmpty)
+        #expect(gate.acquiredMessageIDs.isEmpty)
+        #expect(sut.homeMessages.isEmpty)
+    }
+
+    @available(iOS 16, *)
+    @Test("An inactive store refresh retains the same valid owner", .timeLimit(.minutes(1)))
+    func inactiveStoreRefreshRetainsValidOwner() async {
+        let notificationCenter = NotificationCenter()
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+        sut.prepareForNTP(openedAfterIdle: false)
+        let context = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+        let owner = gate.arbiter.snapshot.owner
+        store.fetchedTriggerFilters.removeAll()
+
+        sut.handleAppBackgrounded()
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+        await Task.yield()
+
+        #expect(store.fetchedTriggerFilters == [.noTrigger])
+        #expect(gate.acquiredMessageIDs == ["message"])
+        #expect(sut.presentationContext(for: .remoteMessage(remoteMessage: message)) == context)
+        #expect(gate.arbiter.snapshot.owner == owner)
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
+    }
+
+    @available(iOS 16, *)
+    @Test("An inactive replacement releases the old owner without acquiring the replacement", .timeLimit(.minutes(1)))
+    func inactiveReplacementDoesNotAcquire() async {
+        let notificationCenter = NotificationCenter()
+        let original = makeRemoteMessage(id: "original")
+        let replacement = makeRemoteMessage(id: "replacement")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: original)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        sut.handleAppBackgrounded()
+        store.noTriggerMessage = replacement
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+        await Task.yield()
+
+        #expect(gate.acquiredMessageIDs == ["original"])
+        #expect(gate.arbiter.snapshot.owner == nil)
+        #expect(sut.homeMessages.isEmpty)
+
+        sut.handleAppForegrounded()
+
+        #expect(gate.acquiredMessageIDs == ["original"])
+        #expect(sut.homeMessages.isEmpty)
+    }
+
+    @available(iOS 16, *)
+    @Test("Foreground revalidation releases an invalid owner before modal evaluation", .timeLimit(.minutes(1)))
+    func foregroundReleasesInvalidOwnerBeforeModalEvaluation() {
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let arbiter = PromoQueueLeaseArbiter()
+        let cooldownPolicy = MockPromoQueueCooldownPolicy()
+        let launchSourceManager = MockLaunchSourceManager()
+        launchSourceManager.source = .standard
+        let modalManager = MockModalPromptCoordinationManager()
+        let service = PromoCoordinationService(
+            launchSourceManager: launchSourceManager,
+            modalPromptCoordinationManager: modalManager,
+            mode: .coordinated,
+            promoQueueLeaseArbiter: arbiter,
+            promoQueueCooldownPolicy: cooldownPolicy
+        )
+        let sut = HomePageConfiguration(
+            remoteMessagingStore: store,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false },
+            promoGate: service
+        )
+        sut.prepareForNTP(openedAfterIdle: false)
+
+        sut.handleAppBackgrounded()
+        store.noTriggerMessage = nil
+        sut.handleAppForegrounded()
+        service.presentModalPromptIfNeeded(from: MockModalPromptPresenter())
+
+        #expect(sut.homeMessages.isEmpty)
+        #expect(modalManager.didCallPresentModalPromptIfNeeded)
+        #expect(arbiter.snapshot.hasModalLease)
+    }
+
+    @available(iOS 16, *)
+    @Test("Legacy lifecycle hooks leave RMF behavior unchanged", .timeLimit(.minutes(1)))
+    func legacyLifecycleHooksAreNoOp() {
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let sut = HomePageConfiguration(
+            remoteMessagingStore: store,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false }
+        )
+        let homeMessages = sut.homeMessages
+
+        sut.handleAppBackgrounded()
+        sut.handleAppForegrounded()
+
+        #expect(sut.homeMessages == homeMessages)
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
+        #expect(store.fetchedTriggerFilters == [.noTrigger])
     }
 
     @available(iOS 16, *)
@@ -436,19 +576,6 @@ struct HomePageConfigurationTests {
         let oldContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
         let (dismissalEnteredEvents, dismissalEnteredContinuation) = AsyncStream.makeStream(of: Void.self)
         let (dismissalResumeEvents, dismissalResumeContinuation) = AsyncStream.makeStream(of: Void.self)
-        var reconciliationNotificationCount = 0
-        var ownerAtReconciliationNotification: PromoQueueLeaseOwnerSnapshot?
-        let notificationObserver = notificationCenter.addObserver(
-            forName: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
-            object: nil,
-            queue: nil
-        ) { _ in
-            MainActor.assumeIsolated {
-                reconciliationNotificationCount += 1
-                ownerAtReconciliationNotification = gate.arbiter.snapshot.owner
-            }
-        }
-        defer { notificationCenter.removeObserver(notificationObserver) }
         store.dismissRemoteMessageHandler = {
             dismissalEnteredContinuation.yield()
             dismissalEnteredContinuation.finish()
@@ -473,10 +600,25 @@ struct HomePageConfigurationTests {
             return
         }
 
-        sut.handleAppBackgrounded()
-        sut.handleAppForegrounded()
+        store.noTriggerMessage = nil
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+        await Task.yield()
+        store.noTriggerMessage = message
         sut.prepareForNTP(openedAfterIdle: false)
         let newContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+        var reconciliationNotificationCount = 0
+        var ownerAtReconciliationNotification: PromoQueueLeaseOwnerSnapshot?
+        let notificationObserver = notificationCenter.addObserver(
+            forName: RemoteMessagingStore.Notifications.remoteMessagesDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            MainActor.assumeIsolated {
+                reconciliationNotificationCount += 1
+                ownerAtReconciliationNotification = gate.arbiter.snapshot.owner
+            }
+        }
+        defer { notificationCenter.removeObserver(notificationObserver) }
         dismissalResumeContinuation.yield()
         dismissalResumeContinuation.finish()
         await dismissalTask.value

--- a/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
+++ b/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
@@ -236,6 +236,79 @@ struct HomePageConfigurationTests {
     }
 
     @available(iOS 16, *)
+    @Test("A store notification cannot acquire after the last NTP host deactivates, but reactivation can", .timeLimit(.minutes(1)))
+    func storeNotificationAfterLastHostDeactivationDoesNotAcquireButReactivationDoes() async {
+        let notificationCenter = NotificationCenter()
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore()
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+
+        sut.prepareForNTP(openedAfterIdle: false, host: .newTabPage)
+        sut.deactivateNTPHost(.newTabPage)
+        store.noTriggerMessage = message
+        store.fetchedTriggerFilters.removeAll()
+
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+        await Task.yield()
+
+        #expect(store.fetchedTriggerFilters.isEmpty)
+        #expect(gate.acquiredMessageIDs.isEmpty)
+        #expect(gate.arbiter.snapshot.owner == nil)
+        #expect(sut.homeMessages.isEmpty)
+
+        sut.prepareForNTP(openedAfterIdle: false, host: .newTabPage)
+
+        #expect(store.fetchedTriggerFilters == [.noTrigger])
+        #expect(gate.acquiredMessageIDs == ["message"])
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
+    }
+
+    @available(iOS 16, *)
+    @Test("A store notification acquires while an eligible NTP host remains active", .timeLimit(.minutes(1)))
+    func storeNotificationAcquiresWhileEligibleHostRemainsActive() async {
+        let notificationCenter = NotificationCenter()
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore()
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+
+        sut.prepareForNTP(openedAfterIdle: false, host: .newTabPage)
+        store.noTriggerMessage = message
+        store.fetchedTriggerFilters.removeAll()
+
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+        await Task.yield()
+
+        #expect(store.fetchedTriggerFilters == [.noTrigger])
+        #expect(gate.acquiredMessageIDs == ["message"])
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
+    }
+
+    @available(iOS 16, *)
+    @Test("Deactivating the most recent NTP host restores the remaining host policy", .timeLimit(.minutes(1)))
+    func deactivatingMostRecentHostFallsBackToRemainingHostPolicy() async {
+        let notificationCenter = NotificationCenter()
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore()
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
+
+        sut.prepareForNTP(openedAfterIdle: false, host: .newTabPage)
+        sut.prepareForNTP(openedAfterIdle: true, host: .unifiedInput)
+        sut.deactivateNTPHost(.unifiedInput)
+        store.noTriggerMessage = message
+        store.fetchedTriggerFilters.removeAll()
+
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+        await Task.yield()
+
+        #expect(store.fetchedTriggerFilters == [.noTrigger])
+        #expect(gate.acquiredMessageIDs == ["message"])
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
+    }
+
+    @available(iOS 16, *)
     @Test("One store notification selects once and synchronously converges all source consumers", .timeLimit(.minutes(1)))
     func storeNotificationConvergesTwoModelsAndDirectConsumer() async {
         let notificationCenter = NotificationCenter()
@@ -364,6 +437,31 @@ struct HomePageConfigurationTests {
         #expect(gate.cooldownPolicy.recordConfirmedRemoteMessageAppearanceCallCount == 1)
         #expect(store.hasShownRemoteMessageCallCount == 1)
         #expect(sut.presentationContext(for: .remoteMessage(remoteMessage: message)) == context)
+    }
+
+    @available(iOS 16, *)
+    @Test("An owned RMF survives host disappearance and foreground with one appearance", .timeLimit(.minutes(1)))
+    func ownedRemoteMessageSurvivesHostDeactivationAndForegroundWithOneAppearance() {
+        let message = makeRemoteMessage(id: "message")
+        let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let gate = MockPromoGate()
+        let sut = makeCoordinatedConfiguration(store: store, gate: gate)
+
+        sut.prepareForNTP(openedAfterIdle: false, host: .newTabPage)
+        let context = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
+        sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
+
+        sut.deactivateNTPHost(.newTabPage)
+        sut.handleAppBackgrounded()
+        sut.handleAppForegrounded()
+        sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
+
+        #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
+        #expect(sut.presentationContext(for: .remoteMessage(remoteMessage: message)) == context)
+        #expect(gate.arbiter.snapshot.owner != nil)
+        #expect(gate.acquiredMessageIDs == ["message"])
+        #expect(gate.cooldownPolicy.recordConfirmedRemoteMessageAppearanceCallCount == 1)
+        #expect(store.hasShownRemoteMessageCallCount == 1)
     }
 
     @available(iOS 16, *)
@@ -574,6 +672,8 @@ struct HomePageConfigurationTests {
         )
         let homeMessages = sut.homeMessages
 
+        sut.prepareForNTP(openedAfterIdle: true, host: .unifiedInput)
+        sut.deactivateNTPHost(.unifiedInput)
         sut.handleAppBackgrounded()
         sut.handleAppForegrounded()
 

--- a/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
+++ b/iOS/DuckDuckGoTests/HomePageConfigurationTests.swift
@@ -113,7 +113,8 @@ struct HomePageConfigurationTests {
         #expect(storeMock.capturedTriggerFilter == .noTrigger)
     }
 
-    @Test("Coordinated initialization defers RMF selection until explicit preparation")
+    @available(iOS 16, *)
+    @Test("Coordinated initialization defers RMF selection until explicit preparation", .timeLimit(.minutes(1)))
     func coordinatedInitializationDefersSelection() {
         let store = FilteredRemoteMessagingStore(noTriggerMessage: makeRemoteMessage(id: "message"))
         let gate = MockPromoGate()
@@ -131,7 +132,8 @@ struct HomePageConfigurationTests {
         #expect(sut.homeMessages == [.remoteMessage(remoteMessage: makeRemoteMessage(id: "message"))])
     }
 
-    @Test("Disabled preparation neither selects nor arms a later store refresh")
+    @available(iOS 16, *)
+    @Test("Disabled preparation neither selects nor arms a later store refresh", .timeLimit(.minutes(1)))
     func disabledPreparationDoesNotArmRefresh() async {
         let notificationCenter = NotificationCenter()
         let store = FilteredRemoteMessagingStore(noTriggerMessage: makeRemoteMessage(id: "message"))
@@ -157,7 +159,8 @@ struct HomePageConfigurationTests {
         #expect(gate.acquiredMessageIDs == ["message"])
     }
 
-    @Test("After-idle fallback pins the actual no-trigger filter for the ownership")
+    @available(iOS 16, *)
+    @Test("After-idle fallback pins the actual no-trigger filter for the ownership", .timeLimit(.minutes(1)))
     func afterIdleFallbackPinsActualFilter() {
         let original = makeRemoteMessage(id: "original")
         let replacement = makeRemoteMessage(id: "replacement")
@@ -176,7 +179,8 @@ struct HomePageConfigurationTests {
         #expect(sut.homeMessages == [.remoteMessage(remoteMessage: original)])
     }
 
-    @Test("Unsupported content is rejected before gate acquisition")
+    @available(iOS 16, *)
+    @Test("Unsupported content is rejected before gate acquisition", .timeLimit(.minutes(1)))
     func unsupportedContentDoesNotAcquire() {
         let unsupported = makeRemoteMessage(id: "unsupported", content: nil)
         let store = FilteredRemoteMessagingStore(noTriggerMessage: unsupported)
@@ -189,7 +193,8 @@ struct HomePageConfigurationTests {
         #expect(sut.homeMessages.isEmpty)
     }
 
-    @Test("A coordinated store refresh retries a denied candidate with the last preparation policy")
+    @available(iOS 16, *)
+    @Test("A coordinated store refresh retries a denied candidate with the last preparation policy", .timeLimit(.minutes(1)))
     func storeRefreshRetriesDeniedCandidate() async {
         let notificationCenter = NotificationCenter()
         let message = makeRemoteMessage(id: "after-idle")
@@ -211,7 +216,8 @@ struct HomePageConfigurationTests {
         #expect(sut.homeMessages == [.remoteMessage(remoteMessage: message)])
     }
 
-    @Test("One store notification selects once and synchronously converges all source consumers")
+    @available(iOS 16, *)
+    @Test("One store notification selects once and synchronously converges all source consumers", .timeLimit(.minutes(1)))
     func storeNotificationConvergesTwoModelsAndDirectConsumer() async {
         let notificationCenter = NotificationCenter()
         let message = makeRemoteMessage(id: "message")
@@ -246,7 +252,8 @@ struct HomePageConfigurationTests {
         withExtendedLifetime(cancellable) {}
     }
 
-    @Test("A modal-owned slot prevents RMF publication and store mutation")
+    @available(iOS 16, *)
+    @Test("A modal-owned slot prevents RMF publication and store mutation", .timeLimit(.minutes(1)))
     func modalOwnershipBlocksRemoteMessageAdmission() throws {
         let message = makeRemoteMessage(id: "message")
         let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
@@ -266,7 +273,8 @@ struct HomePageConfigurationTests {
         _ = modalLease
     }
 
-    @Test("The complete ownership context is retained before RMF publication")
+    @available(iOS 16, *)
+    @Test("The complete ownership context is retained before RMF publication", .timeLimit(.minutes(1)))
     func ownershipIsRetainedBeforePublication() {
         let message = makeRemoteMessage(id: "message")
         let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
@@ -286,7 +294,8 @@ struct HomePageConfigurationTests {
         withExtendedLifetime(cancellable) {}
     }
 
-    @Test("Same ownership keeps identity while background reacquisition changes it")
+    @available(iOS 16, *)
+    @Test("Same ownership keeps identity while background reacquisition changes it", .timeLimit(.minutes(1)))
     func ownershipIdentityLifecycle() {
         let message = makeRemoteMessage(id: "message")
         let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
@@ -309,7 +318,8 @@ struct HomePageConfigurationTests {
         #expect(gate.acquiredMessageIDs == ["message", "message"])
     }
 
-    @Test("Only the first current appearance confirms history and stale appearance is ignored")
+    @available(iOS 16, *)
+    @Test("Only the first current appearance confirms history and stale appearance is ignored", .timeLimit(.minutes(1)))
     func appearanceIsIdentityCheckedAndConfirmedOnce() {
         let message = makeRemoteMessage(id: "message")
         let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
@@ -327,11 +337,19 @@ struct HomePageConfigurationTests {
         #expect(store.hasShownRemoteMessageCallCount == 1)
     }
 
-    @Test("An appeared RMF records real history once and is cooldown-blocked after background")
+    @available(iOS 16, *)
+    @Test("An appeared RMF records real history once and is cooldown-blocked after background", .timeLimit(.minutes(1)))
     func appearedRemoteMessageIsCooldownBlockedAfterBackground() async {
         let now = Date(timeIntervalSince1970: 1_000_000)
         let message = makeRemoteMessage(id: "message")
         let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
+        let (shownPersistenceEvents, shownPersistenceContinuation) = AsyncStream.makeStream(of: Void.self)
+        defer { shownPersistenceContinuation.finish() }
+        store.onShownPersistence = { persistedMessageID in
+            guard persistedMessageID == message.id else { return }
+            shownPersistenceContinuation.yield()
+            shownPersistenceContinuation.finish()
+        }
         let history = RecordingPromoQueueRemoteMessageHistory()
         let arbiter = PromoQueueLeaseArbiter()
         let policy = PromoQueueCooldownPolicy(
@@ -351,8 +369,10 @@ struct HomePageConfigurationTests {
         let context = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
         sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
         sut.didAppear(.remoteMessage(remoteMessage: message), presentationContext: context)
-        while store.updatedShownMessageIDs.isEmpty {
-            await Task.yield()
+        var shownPersistenceIterator = shownPersistenceEvents.makeAsyncIterator()
+        guard await shownPersistenceIterator.next() != nil else {
+            Issue.record("Expected shown persistence to be invoked")
+            return
         }
 
         var ownerAtBackgroundSignal: PromoQueueLeaseOwnerSnapshot?
@@ -372,7 +392,8 @@ struct HomePageConfigurationTests {
         withExtendedLifetime(cancellable) {}
     }
 
-    @Test("A never-appeared RMF can reacquire after background without writing history")
+    @available(iOS 16, *)
+    @Test("A never-appeared RMF can reacquire after background without writing history", .timeLimit(.minutes(1)))
     func neverAppearedRemoteMessageCanReacquireAfterBackground() {
         let message = makeRemoteMessage(id: "message")
         let store = FilteredRemoteMessagingStore(noTriggerMessage: message)
@@ -403,7 +424,8 @@ struct HomePageConfigurationTests {
         #expect(arbiter.snapshot.owner != nil)
     }
 
-    @Test("A dismissal made stale while awaiting cannot release a reacquired same-ID owner")
+    @available(iOS 16, *)
+    @Test("A dismissal made stale while awaiting cannot release a reacquired same-ID owner", .timeLimit(.minutes(1)))
     func staleDismissalCompletionCannotReleaseReacquiredOwner() async {
         let notificationCenter = NotificationCenter()
         let message = makeRemoteMessage(id: "message")
@@ -412,7 +434,8 @@ struct HomePageConfigurationTests {
         let sut = makeCoordinatedConfiguration(store: store, gate: gate, notificationCenter: notificationCenter)
         sut.prepareForNTP(openedAfterIdle: false)
         let oldContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
-        var dismissalContinuation: CheckedContinuation<Void, Never>?
+        let (dismissalEnteredEvents, dismissalEnteredContinuation) = AsyncStream.makeStream(of: Void.self)
+        let (dismissalResumeEvents, dismissalResumeContinuation) = AsyncStream.makeStream(of: Void.self)
         var reconciliationNotificationCount = 0
         var ownerAtReconciliationNotification: PromoQueueLeaseOwnerSnapshot?
         let notificationObserver = notificationCenter.addObserver(
@@ -425,10 +448,12 @@ struct HomePageConfigurationTests {
                 ownerAtReconciliationNotification = gate.arbiter.snapshot.owner
             }
         }
+        defer { notificationCenter.removeObserver(notificationObserver) }
         store.dismissRemoteMessageHandler = {
-            await withCheckedContinuation { continuation in
-                dismissalContinuation = continuation
-            }
+            dismissalEnteredContinuation.yield()
+            dismissalEnteredContinuation.finish()
+            var dismissalResumeIterator = dismissalResumeEvents.makeAsyncIterator()
+            _ = await dismissalResumeIterator.next()
         }
 
         let dismissalTask = Task {
@@ -437,15 +462,23 @@ struct HomePageConfigurationTests {
                 presentationContext: oldContext
             )
         }
-        while dismissalContinuation == nil {
-            await Task.yield()
+        defer {
+            dismissalEnteredContinuation.finish()
+            dismissalResumeContinuation.finish()
+            dismissalTask.cancel()
+        }
+        var dismissalEnteredIterator = dismissalEnteredEvents.makeAsyncIterator()
+        guard await dismissalEnteredIterator.next() != nil else {
+            Issue.record("Expected dismissal persistence to begin")
+            return
         }
 
         sut.handleAppBackgrounded()
         sut.handleAppForegrounded()
         sut.prepareForNTP(openedAfterIdle: false)
         let newContext = sut.presentationContext(for: .remoteMessage(remoteMessage: message))
-        dismissalContinuation?.resume()
+        dismissalResumeContinuation.yield()
+        dismissalResumeContinuation.finish()
         await dismissalTask.value
 
         #expect(reconciliationNotificationCount == 1)
@@ -457,10 +490,10 @@ struct HomePageConfigurationTests {
         #expect(sut.presentationContext(for: .remoteMessage(remoteMessage: message)) == nil)
         #expect(gate.arbiter.snapshot.owner == nil)
         #expect(store.dismissedMessageIDs == ["message"])
-        notificationCenter.removeObserver(notificationObserver)
     }
 
-    @Test("Ordered teardown signals while the old lease still owns the slot")
+    @available(iOS 16, *)
+    @Test("Ordered teardown signals while the old lease still owns the slot", .timeLimit(.minutes(1)))
     func teardownSignalsBeforeRelease() async {
         let notificationCenter = NotificationCenter()
         let message = makeRemoteMessage(id: "message")
@@ -484,7 +517,8 @@ struct HomePageConfigurationTests {
         withExtendedLifetime(cancellable) {}
     }
 
-    @Test("Replacement unpublishes before releasing the old owner, then publishes a new identity")
+    @available(iOS 16, *)
+    @Test("Replacement unpublishes before releasing the old owner, then publishes a new identity", .timeLimit(.minutes(1)))
     func replacementUsesOrderedTeardownAndFreshIdentity() async {
         let notificationCenter = NotificationCenter()
         let original = makeRemoteMessage(id: "original")
@@ -512,7 +546,8 @@ struct HomePageConfigurationTests {
         withExtendedLifetime(cancellable) {}
     }
 
-    @Test("Onboarding suppression unpublishes before releasing current ownership")
+    @available(iOS 16, *)
+    @Test("Onboarding suppression unpublishes before releasing current ownership", .timeLimit(.minutes(1)))
     func onboardingSuppressionUsesOrderedTeardown() async {
         let notificationCenter = NotificationCenter()
         let message = makeRemoteMessage(id: "message")
@@ -645,6 +680,7 @@ private final class FilteredRemoteMessagingStore: RemoteMessagingStoring {
     private(set) var updatedShownMessageIDs: [String] = []
     private(set) var hasShownRemoteMessageCallCount = 0
     var dismissRemoteMessageHandler: (() async -> Void)?
+    var onShownPersistence: ((String) -> Void)?
 
     init(afterIdleMessage: RemoteMessageModel? = nil, noTriggerMessage: RemoteMessageModel? = nil) {
         self.afterIdleMessage = afterIdleMessage
@@ -693,6 +729,7 @@ private final class FilteredRemoteMessagingStore: RemoteMessagingStoring {
         updatedShownMessageIDs.append(id)
         if shown {
             shownMessageIDs.insert(id)
+            onShownPersistence?(id)
         } else {
             shownMessageIDs.remove(id)
         }

--- a/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageMessagesModelTests.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+import Combine
 import Core
 import RemoteMessaging
 import XCTest
@@ -67,6 +68,56 @@ final class NewTabPageMessagesModelTests: XCTestCase {
                                 object: nil)
 
         XCTAssertEqual(sut.homeMessageViewModels.count, 1)
+    }
+
+    func testCoordinatedLoadReadsSharedSourceWithoutRefreshingOrEagerAppearance() throws {
+        let message = HomeMessage.mockRemote(withType: .small(titleText: "Title", descriptionText: "Description"))
+        let configuration = CoordinatedMessagesConfigurationMock(homeMessages: [message])
+        let sut = createSUT(configuration: configuration)
+
+        sut.load()
+
+        XCTAssertEqual(configuration.refreshCallCount, 0)
+        XCTAssertEqual(configuration.didAppearCallCount, 0)
+        let viewModel = try XCTUnwrap(sut.homeMessageViewModels.first)
+        XCTAssertEqual(viewModel.acquisitionIdentity, configuration.presentationContext.acquisitionIdentity)
+    }
+
+    func testCoordinatedSignalSynchronouslyConvergesTwoModelsWithoutGlobalNotification() {
+        let configuration = CoordinatedMessagesConfigurationMock(homeMessages: [])
+        let first = createSUT(configuration: configuration)
+        let second = createSUT(configuration: configuration)
+        first.load()
+        second.load()
+
+        configuration.homeMessages = [.placeholder]
+        configuration.sendContentDidChange()
+
+        XCTAssertEqual(first.homeMessageViewModels.count, 1)
+        XCTAssertEqual(second.homeMessageViewModels.count, 1)
+        XCTAssertEqual(configuration.refreshCallCount, 0)
+
+        configuration.homeMessages = []
+        notificationCenter.post(name: RemoteMessagingStore.Notifications.remoteMessagesDidChange, object: nil)
+
+        XCTAssertEqual(first.homeMessageViewModels.count, 1)
+        XCTAssertEqual(second.homeMessageViewModels.count, 1)
+    }
+
+    func testCoordinatedCallbacksRoundTripCapturedPresentationContext() async throws {
+        let message = HomeMessage.mockRemote(withType: .small(titleText: "Title", descriptionText: "Description"))
+        let configuration = CoordinatedMessagesConfigurationMock(homeMessages: [message])
+        let sut = createSUT(configuration: configuration)
+        sut.load()
+        let viewModel = try XCTUnwrap(sut.homeMessageViewModels.first)
+
+        viewModel.onDidAppear()
+        await viewModel.onDidClose(.close)
+
+        XCTAssertEqual(configuration.lastAppearedContext, configuration.presentationContext)
+        XCTAssertEqual(configuration.lastDismissedContext, configuration.presentationContext)
+        XCTAssertEqual(configuration.didAppearCallCount, 1)
+        XCTAssertEqual(configuration.dismissCallCount, 1)
     }
 
     // MARK: Callbacks
@@ -329,15 +380,81 @@ final class NewTabPageMessagesModelTests: XCTestCase {
     // MARK: - Helpers
 
     private func createSUT(isOpenedAfterIdle: Bool = false) -> NewTabPageMessagesModel {
+        createSUT(configuration: messagesConfiguration, isOpenedAfterIdle: isOpenedAfterIdle)
+    }
+
+    private func createSUT(
+        configuration: HomePageMessagesConfiguration,
+        isOpenedAfterIdle: Bool = false
+    ) -> NewTabPageMessagesModel {
         let remoteMessageActionHandler = RemoteMessagingActionHandler(lastSearchStateRefresher: RemoteMessagingSurveyLastSearchStateRefresher())
         remoteMessageActionHandler.messageNavigator = DefaultMessageNavigator(delegate: self)
 
-        return NewTabPageMessagesModel(homePageMessagesConfiguration: messagesConfiguration,
+        return NewTabPageMessagesModel(homePageMessagesConfiguration: configuration,
                                 notificationCenter: notificationCenter,
                                 pixelFiring: PixelFiringMock.self,
                                 messageActionHandler: remoteMessageActionHandler,
                                 imageLoader: MockRemoteMessagingImageLoader(),
                                 isOpenedAfterIdle: { isOpenedAfterIdle })
+    }
+}
+
+@MainActor
+private final class CoordinatedMessagesConfigurationMock: HomePageMessagesConfiguration {
+    let mode = PromoCoordinationMode.coordinated
+    let presentationContext: HomeMessagePresentationContext
+    var homeMessages: [HomeMessage]
+
+    private let contentDidChangeSubject = PassthroughSubject<Void, Never>()
+    private let arbiterLease: PromoQueueRemoteMessageArbiterLease
+
+    private(set) var refreshCallCount = 0
+    private(set) var didAppearCallCount = 0
+    private(set) var dismissCallCount = 0
+    private(set) var lastAppearedContext: HomeMessagePresentationContext?
+    private(set) var lastDismissedContext: HomeMessagePresentationContext?
+
+    var contentDidChangePublisher: AnyPublisher<Void, Never> {
+        contentDidChangeSubject.eraseToAnyPublisher()
+    }
+
+    init(homeMessages: [HomeMessage]) {
+        self.homeMessages = homeMessages
+        let arbiter = PromoQueueLeaseArbiter()
+        guard case .acquired(let arbiterLease) = arbiter.acquireRemoteMessageLease(for: "foo") else {
+            fatalError("Expected the test arbiter to grant its first RMF acquisition")
+        }
+        self.arbiterLease = arbiterLease
+        presentationContext = HomeMessagePresentationContext(
+            messageID: "foo",
+            acquisitionIdentity: arbiterLease.acquisitionIdentity
+        )
+    }
+
+    func sendContentDidChange() {
+        contentDidChangeSubject.send(())
+    }
+
+    func refresh(openedAfterIdle: Bool) {
+        refreshCallCount += 1
+    }
+
+    func dismissHomeMessage(_ homeMessage: HomeMessage) async {}
+
+    func dismissHomeMessage(_ homeMessage: HomeMessage, presentationContext: HomeMessagePresentationContext?) async {
+        dismissCallCount += 1
+        lastDismissedContext = presentationContext
+    }
+
+    func didAppear(_ homeMessage: HomeMessage) {}
+
+    func didAppear(_ homeMessage: HomeMessage, presentationContext: HomeMessagePresentationContext?) {
+        didAppearCallCount += 1
+        lastAppearedContext = presentationContext
+    }
+
+    func presentationContext(for homeMessage: HomeMessage) -> HomeMessagePresentationContext? {
+        presentationContext
     }
 }
 

--- a/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
+++ b/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
@@ -234,6 +234,7 @@ private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibi
     }
 
     override func tearDownWithError() throws {
+        UserDefaults.app.removeObject(forKey: FireModeCapability.isFireModeEnabledKey)
         sut = nil
         makeHost = nil
         try super.tearDownWithError()
@@ -299,6 +300,160 @@ private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibi
         XCTAssertEqual(coordinatedStore.fetchedTriggerFilters, [.noTrigger])
         XCTAssertEqual(coordinatedConfiguration.homeMessages, expectedMessages)
         XCTAssertEqual(gate.acquiredMessageIDs, [message.id])
+    }
+
+    func testWhenFireNTPAttachesOrReachesForegroundReadyThenItDoesNotAcquireRemoteMessage() {
+        enableFireModeForTest()
+        let message = makeRemoteMessage(id: "message")
+        let store = ActivationRemoteMessagingStore(message: message)
+        let gate = ActivationPromoGate()
+        let configuration = HomePageConfiguration(
+            remoteMessagingStore: store,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false },
+            promoGate: gate
+        )
+        let host = makeHost(configuration)
+        host.tabManager.setBrowsingMode(.fire, source: .tabSelection)
+        host.tabManager.addHomeTab()
+
+        _ = host.view
+        host.prepareHomePageMessagesForForegroundIfNeeded()
+
+        XCTAssertTrue(store.fetchedTriggerFilters.isEmpty)
+        XCTAssertTrue(gate.acquiredMessageIDs.isEmpty)
+        XCTAssertNil(gate.owner)
+        XCTAssertTrue(configuration.homeMessages.isEmpty)
+    }
+
+    func testWhenFireConditionalHostActivatesThenItDoesNotAcquireRemoteMessage() throws {
+        enableFireModeForTest()
+        let websiteURL = try XCTUnwrap(URL(string: "https://example.com"))
+        let message = makeRemoteMessage(id: "message")
+        let store = ActivationRemoteMessagingStore(message: message)
+        let gate = ActivationPromoGate()
+        let configuration = HomePageConfiguration(
+            remoteMessagingStore: store,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false },
+            promoGate: gate
+        )
+        let host = makeHost(configuration)
+        host.tabManager.setBrowsingMode(.fire, source: .tabSelection)
+        host.tabManager.addHomeTab()
+        host.suggestionTrayController = makeSuggestionTraySpy(for: host, websiteURL: websiteURL)
+
+        host.onTextFieldWillBeginEditing(host.viewCoordinator.omniBar.barView, tapped: false)
+
+        XCTAssertTrue(store.fetchedTriggerFilters.isEmpty)
+        XCTAssertTrue(gate.acquiredMessageIDs.isEmpty)
+        XCTAssertNil(gate.owner)
+        XCTAssertTrue(configuration.homeMessages.isEmpty)
+    }
+
+    func testWhenOwnedRemoteMessageEntersFireNTPThenItKeepsTheExistingOwner() {
+        enableFireModeForTest()
+        let message = makeRemoteMessage(id: "message")
+        let store = ActivationRemoteMessagingStore(message: message)
+        let gate = ActivationPromoGate()
+        let configuration = HomePageConfiguration(
+            remoteMessagingStore: store,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false },
+            promoGate: gate
+        )
+        let host = makeHost(configuration)
+
+        _ = host.view
+        let context = configuration.presentationContext(for: .remoteMessage(remoteMessage: message))
+        host.tabManager.setBrowsingMode(.fire, source: .tabSelection)
+        host.newTab(allowingKeyboard: false)
+
+        XCTAssertEqual(gate.acquiredMessageIDs, [message.id])
+        XCTAssertEqual(configuration.presentationContext(for: .remoteMessage(remoteMessage: message)), context)
+        XCTAssertEqual(configuration.homeMessages, [.remoteMessage(remoteMessage: message)])
+    }
+
+    func testWhenNormalRestoredNTPReachesForegroundReadyThenItAcquiresRemoteMessage() {
+        let message = makeRemoteMessage(id: "message")
+        let store = ActivationRemoteMessagingStore(message: message)
+        let gate = ActivationPromoGate()
+        let configuration = HomePageConfiguration(
+            remoteMessagingStore: store,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false },
+            promoGate: gate,
+            isRMFAdmissionEnabled: false
+        )
+        let host = makeHost(configuration)
+
+        _ = host.view
+        configuration.handleAppForegrounded()
+        host.prepareHomePageMessagesForForegroundIfNeeded()
+
+        XCTAssertEqual(store.fetchedTriggerFilters, [.noTrigger])
+        XCTAssertEqual(gate.acquiredMessageIDs, [message.id])
+        XCTAssertEqual(configuration.homeMessages, [.remoteMessage(remoteMessage: message)])
+    }
+
+    func testWhenConditionalHostHasRawIdleWithoutHatchThenItUsesNoTriggerPolicy() throws {
+        let websiteURL = try XCTUnwrap(URL(string: "https://example.com"))
+        let afterIdleMessage = makeRemoteMessage(id: "after-idle")
+        let store = ActivationRemoteMessagingStore(afterIdleMessage: afterIdleMessage)
+        let gate = ActivationPromoGate()
+        let configuration = HomePageConfiguration(
+            remoteMessagingStore: store,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false },
+            promoGate: gate
+        )
+        let host = makeHost(configuration)
+        host.tabManager.currentTabsModel.currentTab?.openedAfterIdle = true
+        host.suggestionTrayController = makeSuggestionTraySpy(for: host, websiteURL: websiteURL)
+
+        host.onTextFieldWillBeginEditing(host.viewCoordinator.omniBar.barView, tapped: false)
+
+        XCTAssertEqual(store.fetchedTriggerFilters, [.noTrigger])
+        XCTAssertTrue(gate.acquiredMessageIDs.isEmpty)
+        XCTAssertTrue(configuration.homeMessages.isEmpty)
+    }
+
+    func testWhenForegroundNTPHasRawIdleWithoutHatchThenItUsesNoTriggerPolicy() {
+        let afterIdleMessage = makeRemoteMessage(id: "after-idle")
+        let store = ActivationRemoteMessagingStore(afterIdleMessage: afterIdleMessage)
+        let gate = ActivationPromoGate()
+        let configuration = HomePageConfiguration(
+            remoteMessagingStore: store,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false },
+            promoGate: gate,
+            isRMFAdmissionEnabled: false
+        )
+        let host = makeHost(configuration)
+
+        _ = host.view
+        configuration.handleAppForegrounded()
+        host.tabManager.currentTabsModel.currentTab?.openedAfterIdle = true
+        host.prepareHomePageMessagesForForegroundIfNeeded()
+
+        XCTAssertEqual(store.fetchedTriggerFilters, [.noTrigger])
+        XCTAssertTrue(gate.acquiredMessageIDs.isEmpty)
+        XCTAssertTrue(configuration.homeMessages.isEmpty)
+    }
+
+    private func makeRemoteMessage(id: String) -> RemoteMessageModel {
+        RemoteMessageModel(
+            id: id,
+            surfaces: .newTabPage,
+            content: .small(titleText: "Title", descriptionText: "Description"),
+            matchingRules: [],
+            exclusionRules: [],
+            isMetricsEnabled: false
+        )
+    }
+
+    private func enableFireModeForTest() {
+        UserDefaults.app.set(true, forKey: FireModeCapability.isFireModeEnabledKey)
     }
 
     private func makeSuggestionTraySpy(for host: MainViewController, websiteURL: URL) -> SuggestionTrayEligibilitySpy {
@@ -389,6 +544,10 @@ private final class ActivationPromoGate: PromoGating {
     private let cooldownPolicy = MockPromoQueueCooldownPolicy()
     private(set) var acquiredMessageIDs: [String] = []
 
+    var owner: PromoQueueLeaseOwnerSnapshot? {
+        arbiter.snapshot.owner
+    }
+
     func tryAcquireRemoteMessageLease(for messageID: String) -> PromoQueueRemoteMessageLease? {
         acquiredMessageIDs.append(messageID)
         guard case .acquired(let lease) = arbiter.acquireRemoteMessageLease(for: messageID) else {
@@ -399,11 +558,18 @@ private final class ActivationPromoGate: PromoGating {
 }
 
 private final class ActivationRemoteMessagingStore: RemoteMessagingStoring {
-    let message: RemoteMessageModel
+    let afterIdleMessage: RemoteMessageModel?
+    let noTriggerMessage: RemoteMessageModel?
     private(set) var fetchedTriggerFilters: [TriggerFilter] = []
 
     init(message: RemoteMessageModel) {
-        self.message = message
+        afterIdleMessage = nil
+        noTriggerMessage = message
+    }
+
+    init(afterIdleMessage: RemoteMessageModel) {
+        self.afterIdleMessage = afterIdleMessage
+        noTriggerMessage = nil
     }
 
     func resetFetches() {
@@ -415,7 +581,14 @@ private final class ActivationRemoteMessagingStore: RemoteMessagingStoring {
 
     func fetchScheduledRemoteMessage(surfaces: RemoteMessageSurfaceType, triggerFilter: TriggerFilter) -> RemoteMessageModel? {
         fetchedTriggerFilters.append(triggerFilter)
-        return triggerFilter == .noTrigger ? message : nil
+        switch triggerFilter {
+        case .specific(.afterIdle):
+            return afterIdleMessage
+        case .noTrigger:
+            return noTriggerMessage
+        case .any:
+            return afterIdleMessage ?? noTriggerMessage
+        }
     }
 
     func hasShownRemoteMessage(withID id: String) -> Bool { false }

--- a/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
+++ b/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
@@ -396,6 +396,56 @@ private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibi
         XCTAssertEqual(configuration.homeMessages, [.remoteMessage(remoteMessage: message)])
     }
 
+    func testWhenRestoredWebsiteReachesForegroundReadyThenItDoesNotAcquireRemoteMessage() throws {
+        let websiteURL = try XCTUnwrap(URL(string: "https://example.com"))
+        let message = makeRemoteMessage(id: "message")
+        let store = ActivationRemoteMessagingStore(message: message)
+        let gate = ActivationPromoGate()
+        let configuration = HomePageConfiguration(
+            remoteMessagingStore: store,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false },
+            promoGate: gate,
+            isRMFAdmissionEnabled: false
+        )
+        let host = makeHost(configuration)
+
+        host.tabManager.currentTabsModel.currentTab?.link = Link(title: nil, url: websiteURL)
+        _ = host.view
+        host.newTabPageViewController = nil
+        configuration.handleAppForegrounded()
+        host.prepareHomePageMessagesForForegroundIfNeeded()
+
+        XCTAssertTrue(store.fetchedTriggerFilters.isEmpty)
+        XCTAssertTrue(gate.acquiredMessageIDs.isEmpty)
+        XCTAssertNil(gate.owner)
+        XCTAssertTrue(configuration.homeMessages.isEmpty)
+    }
+
+    func testWhenUnifiedInputConditionalHostIsInactiveThenFireModeRefreshDoesNotAcquireRemoteMessage() {
+        let message = makeRemoteMessage(id: "message")
+        let store = ActivationRemoteMessagingStore(message: message)
+        let gate = ActivationPromoGate()
+        let configuration = HomePageConfiguration(
+            remoteMessagingStore: store,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false },
+            promoGate: gate
+        )
+        let mainHost = makeHost(configuration)
+        let conditionalHost = UnifiedInputContentContainerViewController(
+            switchBarHandler: InactiveConditionalHostSwitchBarHandler()
+        )
+        conditionalHost.suggestionTrayDependencies = mainHost.suggestionTrayDependencies
+
+        conditionalHost.refreshFireMode(fireMode: false)
+
+        XCTAssertTrue(store.fetchedTriggerFilters.isEmpty)
+        XCTAssertTrue(gate.acquiredMessageIDs.isEmpty)
+        XCTAssertNil(gate.owner)
+        XCTAssertTrue(configuration.homeMessages.isEmpty)
+    }
+
     func testWhenConditionalHostHasRawIdleWithoutHatchThenItUsesNoTriggerPolicy() throws {
         let websiteURL = try XCTUnwrap(URL(string: "https://example.com"))
         let afterIdleMessage = makeRemoteMessage(id: "after-idle")
@@ -597,4 +647,42 @@ private final class ActivationRemoteMessagingStore: RemoteMessagingStoring {
     func fetchDismissedRemoteMessageIDs() -> [String] { [] }
     func updateRemoteMessage(withID id: String, asShown shown: Bool) async {}
     func resetRemoteMessages() async {}
+}
+
+private final class InactiveConditionalHostSwitchBarHandler: SwitchBarHandling {
+    var currentText = ""
+    var currentToggleState = TextEntryMode.search
+    var isVoiceSearchEnabled = false
+    var isAIVoiceChatEnabled = false
+    var hasUserInteractedWithText = false
+    var isCurrentTextValidURL = false
+    var buttonState = SwitchBarButtonState.noButtons
+    var isTopBarPosition = true
+    var isToggleEnabled = true
+    var isFireTab = false
+    var isUsingExpandedBottomBarHeight = false
+    var isUsingFadeOutAnimation = false
+    var shouldDisableAutocorrectOnEmpty = false
+    var hidesVoiceButton = false
+    var hasSubmittedPrompt = false
+    var modeParameters: [String: String] = [:]
+
+    var hasSubmittedPromptPublisher: AnyPublisher<Bool, Never> { Just(false).eraseToAnyPublisher() }
+    var currentTextPublisher: AnyPublisher<String, Never> { Empty().eraseToAnyPublisher() }
+    var toggleStatePublisher: AnyPublisher<TextEntryMode, Never> { Empty().eraseToAnyPublisher() }
+    var textSubmissionPublisher: AnyPublisher<(text: String, mode: TextEntryMode), Never> { Empty().eraseToAnyPublisher() }
+    var microphoneButtonTappedPublisher: AnyPublisher<Void, Never> { Empty().eraseToAnyPublisher() }
+    var clearButtonTappedPublisher: AnyPublisher<Void, Never> { Empty().eraseToAnyPublisher() }
+    var hasUserInteractedWithTextPublisher: AnyPublisher<Bool, Never> { Empty().eraseToAnyPublisher() }
+    var isCurrentTextValidURLPublisher: AnyPublisher<Bool, Never> { Empty().eraseToAnyPublisher() }
+    var currentButtonStatePublisher: AnyPublisher<SwitchBarButtonState, Never> { Empty().eraseToAnyPublisher() }
+
+    func updateCurrentText(_ text: String) {}
+    func submitText(_ text: String) {}
+    func setToggleState(_ state: TextEntryMode) {}
+    func clearText() {}
+    func microphoneButtonTapped() {}
+    func markUserInteraction() {}
+    func clearButtonTapped() {}
+    func updateBarPosition(isTop: Bool) {}
 }

--- a/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
+++ b/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
@@ -48,6 +48,7 @@ private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibi
  @MainActor
  final class OnboardingDaxFavouritesTests: XCTestCase {
     private var sut: MainViewController!
+    private var makeHost: ((HomePageConfiguration) -> MainViewController)!
     private var tutorialSettingsMock: MockTutorialSettings!
     private var contextualOnboardingLogicMock: ContextualOnboardingLogicMock!
 
@@ -160,69 +161,72 @@ private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibi
                                         privacyConfigurationManager: mockConfigManager,
                                         appSettings: AppSettingsMock(),
                                         aiChatSyncCleaner: MockAIChatSyncCleaning())
-        sut = MainViewController(
-            privacyConfigurationManager: mockConfigManager,
-            bookmarksDatabase: db,
-            historyManager: historyManager,
-            homePageConfiguration: homePageConfiguration,
-            syncService: syncService,
-            syncDataProviders: dataProviders,
-            userScriptsDependencies: mockScriptDependencies,
-            contentBlockingAssetsPublisher: PassthroughSubject<ContentBlockingUpdating.NewContent, Never>().eraseToAnyPublisher(),
-            appSettings: AppSettingsMock(),
-            previewsSource: MockTabPreviewsSource(),
-            tabManager: tabManager,
-            syncPausedStateManager: CapturingSyncPausedStateManager(),
-            subscriptionDataReporter: subscriptionDataReporter,
-            contextualOnboardingLogic: contextualOnboardingLogicMock,
-            contextualOnboardingPixelReporter: onboardingPixelReporter,
-            tutorialSettings: tutorialSettingsMock,
-            subscriptionFeatureAvailability: SubscriptionFeatureAvailabilityMock.enabled,
-            voiceSearchHelper: MockVoiceSearchHelper(isSpeechRecognizerAvailable: true, voiceSearchEnabled: true),
-            featureFlagger: featureFlagger,
-            idleReturnEligibilityManager: MockIdleReturnEligibilityManagerForMainVC(),
-            afterInactivityOptionAdapter: AfterInactivityOptionAdapter(initialOption: .lastUsedTab, keyValueStore: keyValueStore),
-            lastTabShortcutAdapter: LastTabShortcutAdapter(keyValueStore: keyValueStore),
-            syncAutoRestoreHandler: syncAutoRestoreHandler,
-            contentScopeExperimentsManager: MockContentScopeExperimentManager(),
-            fireproofing: fireproofing,
-            favicons: Favicons(),
-            textZoomCoordinatorProvider: textZoomCoordinatorProvider,
-            websiteDataManager: mockWebsiteDataManager,
-            appDidFinishLaunchingStartTime: nil,
-            maliciousSiteProtectionPreferencesManager: MockMaliciousSiteProtectionPreferencesManager(),
-            aiChatSettings: aiChatSettings,
-            aiChatAddressBarExperience: AIChatAddressBarExperience(featureFlagger: featureFlagger,
-                                                                   aiChatSettings: aiChatSettings),
-            themeManager: MockThemeManager(),
-            keyValueStore: keyValueStore,
-            customConfigurationURLProvider: MockCustomURLProvider(),
-            systemSettingsPiPTutorialManager: MockSystemSettingsPiPTutorialManager(),
-            daxDialogsManager: MockDaxDialogsManager(),
-            dbpIOSPublicInterface: nil,
-            freemiumPIREligibilityChecker: DefaultFreemiumPIREligibilityChecker(
+        makeHost = { homePageConfiguration in
+            MainViewController(
+                privacyConfigurationManager: mockConfigManager,
+                bookmarksDatabase: db,
+                historyManager: historyManager,
+                homePageConfiguration: homePageConfiguration,
+                syncService: syncService,
+                syncDataProviders: dataProviders,
+                userScriptsDependencies: mockScriptDependencies,
+                contentBlockingAssetsPublisher: PassthroughSubject<ContentBlockingUpdating.NewContent, Never>().eraseToAnyPublisher(),
+                appSettings: AppSettingsMock(),
+                previewsSource: MockTabPreviewsSource(),
+                tabManager: tabManager,
+                syncPausedStateManager: CapturingSyncPausedStateManager(),
+                subscriptionDataReporter: subscriptionDataReporter,
+                contextualOnboardingLogic: self.contextualOnboardingLogicMock,
+                contextualOnboardingPixelReporter: onboardingPixelReporter,
+                tutorialSettings: self.tutorialSettingsMock,
+                subscriptionFeatureAvailability: SubscriptionFeatureAvailabilityMock.enabled,
+                voiceSearchHelper: MockVoiceSearchHelper(isSpeechRecognizerAvailable: true, voiceSearchEnabled: true),
                 featureFlagger: featureFlagger,
-                runPrerequisitesDelegate: nil,
-                subscriptionAuthenticationStateProvider: SubscriptionManagerMock(),
-                freemiumPIRDebugSettings: freemiumPIRDebugSettings
-            ),
-            freemiumPIRDebugSettings: freemiumPIRDebugSettings,
-            freemiumDBPUserStateManager: freemiumDBPUserStateManager,
-            profileStateManager: DefaultDBPProfileStateManager(keyValueStore: freemiumDBPUserDefaults),
-            launchSourceManager: LaunchSourceManager(),
-            winBackOfferVisibilityManager: MockWinBackOfferVisibilityManager(),
-            mobileCustomization: MobileCustomization(keyValueStore: MockThrowingKeyValueStore()),
-            remoteMessagingActionHandler: MockRemoteMessagingActionHandler(),
-            remoteMessagingImageLoader: MockRemoteMessagingImageLoader(),
-            remoteMessagingPixelReporter: MockRemoteMessagingPixelReporter(),
-            productSurfaceTelemetry: MockProductSurfaceTelemetry(),
-            fireExecutor: fireExecutor,
-            remoteMessagingDebugHandler: MockRemoteMessagingDebugHandler(),
-            privacyStats: MockPrivacyStats(),
-            whatsNewRepository: MockWhatsNewMessageRepository(scheduledRemoteMessage: nil),
-            darkReaderFeatureSettings: MockDarkReaderFeatureSettings(),
-            onboardingManager: OnboardingManagerMock(),
-        )
+                idleReturnEligibilityManager: MockIdleReturnEligibilityManagerForMainVC(),
+                afterInactivityOptionAdapter: AfterInactivityOptionAdapter(initialOption: .lastUsedTab, keyValueStore: self.keyValueStore),
+                lastTabShortcutAdapter: LastTabShortcutAdapter(keyValueStore: self.keyValueStore),
+                syncAutoRestoreHandler: syncAutoRestoreHandler,
+                contentScopeExperimentsManager: MockContentScopeExperimentManager(),
+                fireproofing: fireproofing,
+                favicons: Favicons(),
+                textZoomCoordinatorProvider: textZoomCoordinatorProvider,
+                websiteDataManager: self.mockWebsiteDataManager,
+                appDidFinishLaunchingStartTime: nil,
+                maliciousSiteProtectionPreferencesManager: MockMaliciousSiteProtectionPreferencesManager(),
+                aiChatSettings: aiChatSettings,
+                aiChatAddressBarExperience: AIChatAddressBarExperience(featureFlagger: featureFlagger,
+                                                                       aiChatSettings: aiChatSettings),
+                themeManager: MockThemeManager(),
+                keyValueStore: self.keyValueStore,
+                customConfigurationURLProvider: MockCustomURLProvider(),
+                systemSettingsPiPTutorialManager: MockSystemSettingsPiPTutorialManager(),
+                daxDialogsManager: MockDaxDialogsManager(),
+                dbpIOSPublicInterface: nil,
+                freemiumPIREligibilityChecker: DefaultFreemiumPIREligibilityChecker(
+                    featureFlagger: featureFlagger,
+                    runPrerequisitesDelegate: nil,
+                    subscriptionAuthenticationStateProvider: SubscriptionManagerMock(),
+                    freemiumPIRDebugSettings: freemiumPIRDebugSettings
+                ),
+                freemiumPIRDebugSettings: freemiumPIRDebugSettings,
+                freemiumDBPUserStateManager: freemiumDBPUserStateManager,
+                profileStateManager: DefaultDBPProfileStateManager(keyValueStore: freemiumDBPUserDefaults),
+                launchSourceManager: LaunchSourceManager(),
+                winBackOfferVisibilityManager: MockWinBackOfferVisibilityManager(),
+                mobileCustomization: MobileCustomization(keyValueStore: MockThrowingKeyValueStore()),
+                remoteMessagingActionHandler: MockRemoteMessagingActionHandler(),
+                remoteMessagingImageLoader: MockRemoteMessagingImageLoader(),
+                remoteMessagingPixelReporter: MockRemoteMessagingPixelReporter(),
+                productSurfaceTelemetry: MockProductSurfaceTelemetry(),
+                fireExecutor: fireExecutor,
+                remoteMessagingDebugHandler: MockRemoteMessagingDebugHandler(),
+                privacyStats: MockPrivacyStats(),
+                whatsNewRepository: MockWhatsNewMessageRepository(scheduledRemoteMessage: nil),
+                darkReaderFeatureSettings: MockDarkReaderFeatureSettings(),
+                onboardingManager: OnboardingManagerMock()
+            )
+        }
+        sut = makeHost(homePageConfiguration)
         let window = UIWindow(frame: UIScreen.main.bounds)
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()
@@ -231,7 +235,92 @@ private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibi
 
     override func tearDownWithError() throws {
         sut = nil
+        makeHost = nil
         try super.tearDownWithError()
+    }
+
+    func testWhenSuggestionTrayActivatesThenPromoPreparationRespectsCoordinationMode() throws {
+        let websiteURL = try XCTUnwrap(URL(string: "https://example.com"))
+        let message = RemoteMessageModel(
+            id: "message",
+            surfaces: .newTabPage,
+            content: .small(titleText: "Title", descriptionText: "Description"),
+            matchingRules: [],
+            exclusionRules: [],
+            isMetricsEnabled: false
+        )
+        let legacyStore = ActivationRemoteMessagingStore(message: message)
+        let legacyConfiguration = HomePageConfiguration(
+            remoteMessagingStore: legacyStore,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false }
+        )
+        let legacyHost = makeHost(legacyConfiguration)
+        let legacyTray = makeSuggestionTraySpy(for: legacyHost, websiteURL: websiteURL)
+        legacyHost.suggestionTrayController = legacyTray
+        let legacyMessagesBeforeFocus = legacyConfiguration.homeMessages
+        legacyStore.resetFetches()
+
+        legacyHost.onTextFieldWillBeginEditing(legacyHost.viewCoordinator.omniBar.barView, tapped: false)
+
+        XCTAssertEqual(legacyTray.eligibilityRequests, [.favorites])
+        XCTAssertTrue(legacyStore.fetchedTriggerFilters.isEmpty)
+        XCTAssertEqual(legacyConfiguration.homeMessages, legacyMessagesBeforeFocus)
+
+        let coordinatedStore = ActivationRemoteMessagingStore(message: message)
+        let gate = ActivationPromoGate()
+        let coordinatedConfiguration = HomePageConfiguration(
+            remoteMessagingStore: coordinatedStore,
+            subscriptionDataReporter: MockSubscriptionDataReporter(),
+            isStillOnboarding: { false },
+            promoGate: gate
+        )
+        XCTAssertTrue(coordinatedConfiguration.homeMessages.isEmpty)
+        XCTAssertTrue(coordinatedStore.fetchedTriggerFilters.isEmpty)
+        let coordinatedHost = makeHost(coordinatedConfiguration)
+        let coordinatedTray = makeSuggestionTraySpy(for: coordinatedHost, websiteURL: websiteURL)
+        var filtersAtEligibility: [TriggerFilter] = []
+        var messagesAtEligibility: [HomeMessage] = []
+        var acquiredMessageIDsAtEligibility: [String] = []
+        coordinatedTray.onEligibilityCheck = {
+            filtersAtEligibility = coordinatedStore.fetchedTriggerFilters
+            messagesAtEligibility = coordinatedConfiguration.homeMessages
+            acquiredMessageIDsAtEligibility = gate.acquiredMessageIDs
+        }
+        coordinatedHost.suggestionTrayController = coordinatedTray
+
+        coordinatedHost.onTextFieldWillBeginEditing(coordinatedHost.viewCoordinator.omniBar.barView, tapped: false)
+
+        let expectedMessages = [HomeMessage.remoteMessage(remoteMessage: message)]
+        XCTAssertEqual(coordinatedTray.eligibilityRequests, [.favorites])
+        XCTAssertEqual(filtersAtEligibility, [.noTrigger])
+        XCTAssertEqual(messagesAtEligibility, expectedMessages)
+        XCTAssertEqual(acquiredMessageIDsAtEligibility, [message.id])
+        XCTAssertEqual(coordinatedStore.fetchedTriggerFilters, [.noTrigger])
+        XCTAssertEqual(coordinatedConfiguration.homeMessages, expectedMessages)
+        XCTAssertEqual(gate.acquiredMessageIDs, [message.id])
+    }
+
+    private func makeSuggestionTraySpy(for host: MainViewController, websiteURL: URL) -> SuggestionTrayEligibilitySpy {
+        host.tabManager.currentTabsModel.currentTab?.link = Link(title: nil, url: websiteURL)
+        _ = host.view
+        host.newTabPageViewController = nil
+        let dependencies = host.suggestionTrayDependencies
+        let tray = SuggestionTrayEligibilitySpy(
+            favoritesViewModel: dependencies.favoritesViewModel,
+            bookmarksDatabase: dependencies.bookmarksDatabase,
+            historyManager: dependencies.historyManager,
+            tabsModelProvider: dependencies.tabsModelProvider,
+            featureFlagger: dependencies.featureFlagger,
+            appSettings: dependencies.appSettings,
+            aiChatSettings: dependencies.aiChatSettings,
+            featureDiscovery: dependencies.featureDiscovery,
+            newTabPageDependencies: dependencies.newTabPageDependencies,
+            productSurfaceTelemetry: dependencies.productSurfaceTelemetry,
+            hideBorder: false
+        )
+        _ = tray.view
+        return tray
     }
 
     func testWhenMarkOnboardingSeenIsCalled_ThenSetHasSeenOnboardingTrue() {
@@ -279,4 +368,60 @@ private final class MockIdleReturnEligibilityManagerForMainVC: IdleReturnEligibi
         XCTAssertTrue(contextualOnboardingLogicMock.didCallEnableAddFavoriteFlow)
     }
 
+}
+
+@MainActor
+private final class SuggestionTrayEligibilitySpy: SuggestionTrayViewController {
+    private(set) var eligibilityRequests: [SuggestionType] = []
+    var onEligibilityCheck: (() -> Void)?
+
+    override func canShow(for type: SuggestionType, animated: Bool = true) -> Bool {
+        eligibilityRequests.append(type)
+        onEligibilityCheck?()
+        return false
+    }
+}
+
+@MainActor
+private final class ActivationPromoGate: PromoGating {
+    let mode = PromoCoordinationMode.coordinated
+    private let arbiter = PromoQueueLeaseArbiter()
+    private let cooldownPolicy = MockPromoQueueCooldownPolicy()
+    private(set) var acquiredMessageIDs: [String] = []
+
+    func tryAcquireRemoteMessageLease(for messageID: String) -> PromoQueueRemoteMessageLease? {
+        acquiredMessageIDs.append(messageID)
+        guard case .acquired(let lease) = arbiter.acquireRemoteMessageLease(for: messageID) else {
+            return nil
+        }
+        return PromoQueueRemoteMessageLease(arbiterLease: lease, cooldownPolicy: cooldownPolicy)
+    }
+}
+
+private final class ActivationRemoteMessagingStore: RemoteMessagingStoring {
+    let message: RemoteMessageModel
+    private(set) var fetchedTriggerFilters: [TriggerFilter] = []
+
+    init(message: RemoteMessageModel) {
+        self.message = message
+    }
+
+    func resetFetches() {
+        fetchedTriggerFilters.removeAll()
+    }
+
+    func saveProcessedResult(_ processorResult: RemoteMessagingConfigProcessor.ProcessorResult) async {}
+    func fetchRemoteMessagingConfig() -> RemoteMessagingConfig? { nil }
+
+    func fetchScheduledRemoteMessage(surfaces: RemoteMessageSurfaceType, triggerFilter: TriggerFilter) -> RemoteMessageModel? {
+        fetchedTriggerFilters.append(triggerFilter)
+        return triggerFilter == .noTrigger ? message : nil
+    }
+
+    func hasShownRemoteMessage(withID id: String) -> Bool { false }
+    func fetchShownRemoteMessageIDs() -> [String] { [] }
+    func dismissRemoteMessage(withID id: String) async {}
+    func fetchDismissedRemoteMessageIDs() -> [String] { [] }
+    func updateRemoteMessage(withID id: String, asShown shown: Bool) async {}
+    func resetRemoteMessages() async {}
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217517616514376
Tech Design URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1216624996708289?focus=true
CC: N/A

### Description
- Gate new-tab remote-message selection at one app-scoped source shared by every supported new-tab host.
- Defer coordinated selection until an explicit activation checkpoint and publish content only after ownership is retained.
- Preserve the legacy path when coordination is disabled

#### Adding New Promos and NTP Surfaces on iOS

The new design fixes issues raised [here](https://github.com/duckduckgo/apple-browsers/pull/6194#pullrequestreview-4923844516). 

- **Adding a launch-modal promo:**  the workflow is functionally unchanged. The provider interface itself was not changed by Promo Queue. A correctly integrated ModalPromptProvider automatically participates because the central service and manager now handle queue admission internally.

- **NTP containers and RMF surfaces:**: Promo Queue introduced the explicit prepareForNTP(openedAfterIdle:) activation seam and the shared contentDidChangePublisher. For a new container using the existing HomePageConfiguration source, the only Promo Queue-specific method the author calls is prepareForNTP(openedAfterIdle:), once when the container becomes active and before checking for content. The container may observe contentDidChangePublisher as ordinary data-source wiring

<img width="1154" height="698" alt="Screenshot 2026-08-17 at 02 34 28" src="https://github.com/user-attachments/assets/d4a0e457-8e36-4136-9c14-1e374e7ec7c2" />

### Testing Steps
Launch with  `promoPresentationCoordination`  disabled → existing modal and remote-message behavior remains unchanged.

Since this is a stacked PR, two out of three, and the new feature flag is off by default, I suggest holding off on manual testing till https://github.com/duckduckgo/apple-browsers/pull/6369 which adds a debug screen.

### Impact
**Medium**

#### What could go wrong?
A remote message could appear without ownership, remain blank after a denied checkpoint, or release a replacement owner → mitigated by retained-before-publication ordering, shared-source identity validation, ordered teardown, and focused host regression tests.

### Quality Considerations
- The feature remains disabled by default.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches promo-queue ownership and RMF admission timing across multiple NTP entry points; mitigated by legacy fallback, feature flag default-off, and broad tests, but wrong ordering could still flash or block promos.
> 
> **Overview**
> When **promo presentation coordination** is on, new-tab **remote messages (RMFs)** no longer refresh inline with legacy `refresh`—they are selected only at explicit **NTP activation** checkpoints (`prepareForNTP`) and published from a single **`HomePageConfiguration`** source after a **promo-queue lease** is acquired.
> 
> **`HomePageConfiguration`** adds coordinated reconciliation (ownership retention, ordered teardown, foreground/background admission gating, presentation-context–validated dismiss/appear) and signals updates via **`contentDidChangePublisher`** instead of relying solely on global store notifications. **Fire tabs**, background launch, and inactive hosts skip acquisition; **legacy mode** behavior stays unchanged.
> 
> NTP hosts (**`MainViewController`**, omnibar editing, unified input) call **`prepareForNTP`** when the surface becomes active; **foreground** preparation runs after launch actions settle. UI models use **`viewIdentity`** / acquisition identity so coordinated messages keep stable SwiftUI identity across content refreshes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6857125cf3e587d2bc7c4491f9d265025484564a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->