### PR TITLE
iOS: Add promo queue diagnostics

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1900,6 +1900,7 @@
 		B6A7C21A31A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C21931A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift */; };
 		B6A7C21C31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C21B31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift */; };
 		B6A7C21E31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C21D31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift */; };
+		B6A7C26131A1000100F00D01 /* ModalPromptCoordinationDebugViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C26031A1000100F00D01 /* ModalPromptCoordinationDebugViewModelTests.swift */; };
 		B6AD9E3728D4510A0019CDE9 /* ContentBlockingUpdatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AD9E3528D4510A0019CDE9 /* ContentBlockingUpdatingTests.swift */; };
 		B6AD9E3828D4512E0019CDE9 /* EmbeddedTrackerDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9801F08927E4B21100191874 /* EmbeddedTrackerDataTests.swift */; };
 		B6BA95C328891E33004ABA20 /* BrowsingMenuAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6BA95C228891E33004ABA20 /* BrowsingMenuAnimator.swift */; };
@@ -4763,6 +4764,7 @@
 		B6A7C21931A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationManagerPromoQueueTests.swift; sourceTree = "<group>"; };
 		B6A7C21B31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptRootAttachmentCheckerTests.swift; sourceTree = "<group>"; };
 		B6A7C21D31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationRealUIKitTests.swift; sourceTree = "<group>"; };
+		B6A7C26031A1000100F00D01 /* ModalPromptCoordinationDebugViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationDebugViewModelTests.swift; sourceTree = "<group>"; };
 		B6AD9E3528D4510A0019CDE9 /* ContentBlockingUpdatingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentBlockingUpdatingTests.swift; sourceTree = "<group>"; };
 		B6BA95C228891E33004ABA20 /* BrowsingMenuAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingMenuAnimator.swift; sourceTree = "<group>"; };
 		B772933186CDFE9E9DDBD2BF /* FileCorruptErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCorruptErrorViewController.swift; sourceTree = "<group>"; };
@@ -9235,6 +9237,7 @@
 				B6A7C21931A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift */,
 				B6A7C21B31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift */,
 				B6A7C21D31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift */,
+				B6A7C26031A1000100F00D01 /* ModalPromptCoordinationDebugViewModelTests.swift */,
 				B6A7C20431A1000100F00D01 /* PromoQueueLeaseArbiterTests.swift */,
 			);
 			path = ModalPromptCoordination;
@@ -14931,6 +14934,7 @@
 				B6A7C21A31A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift in Sources */,
 				B6A7C21C31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift in Sources */,
 				B6A7C21E31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift in Sources */,
+				B6A7C26131A1000100F00D01 /* ModalPromptCoordinationDebugViewModelTests.swift in Sources */,
 				B6A7C20531A1000100F00D01 /* PromoQueueLeaseArbiterTests.swift in Sources */,
 				B6A7C20A31A1000100F00D01 /* PromoPresentationCoordinationFeatureFlagTests.swift in Sources */,
 				98E5631D2DE8AF3100E6E75F /* CoreDataTestUtilities.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1636,7 +1636,7 @@
 		9F80A98A2EA9E4CF0079C5AD /* PromptCooldownMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F80A9882EA9E4CF0079C5AD /* PromptCooldownMigratorTests.swift */; };
 		9F81E5AD2FECE8F900EAB88E /* OnboardingIntroViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F81E5AC2FECE8F400EAB88E /* OnboardingIntroViewState.swift */; };
 		9F880BEE2F331CDF00BF211E /* FadeInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F880BED2F331CD900BF211E /* FadeInView.swift */; };
-		9F8828482EBAAF68006C878B /* ModalPromptCoordinationDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8828472EBAAF5A006C878B /* ModalPromptCoordinationDebugMenu.swift */; };
+		9F8828482EBAAF68006C878B /* PromptCoordinationDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8828472EBAAF5A006C878B /* PromptCoordinationDebugMenu.swift */; };
 		9F8BCBCE2EB43283004F071E /* RemoteMessagingPixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8BCBCD2EB43278004F071E /* RemoteMessagingPixelReporter.swift */; };
 		9F8E0F2D2CCA618E001EA7C5 /* VideoPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8E0F2C2CCA618E001EA7C5 /* VideoPlayerView.swift */; };
 		9F8FE9492BAE50E50071E372 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 9F8FE9482BAE50E50071E372 /* Lottie */; };
@@ -1900,7 +1900,7 @@
 		B6A7C21A31A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C21931A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift */; };
 		B6A7C21C31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C21B31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift */; };
 		B6A7C21E31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C21D31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift */; };
-		B6A7C26131A1000100F00D01 /* ModalPromptCoordinationDebugViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C26031A1000100F00D01 /* ModalPromptCoordinationDebugViewModelTests.swift */; };
+		B6A7C26131A1000100F00D01 /* PromptCoordinationDebugViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C26031A1000100F00D01 /* PromptCoordinationDebugViewModelTests.swift */; };
 		B6AD9E3728D4510A0019CDE9 /* ContentBlockingUpdatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AD9E3528D4510A0019CDE9 /* ContentBlockingUpdatingTests.swift */; };
 		B6AD9E3828D4512E0019CDE9 /* EmbeddedTrackerDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9801F08927E4B21100191874 /* EmbeddedTrackerDataTests.swift */; };
 		B6BA95C328891E33004ABA20 /* BrowsingMenuAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6BA95C228891E33004ABA20 /* BrowsingMenuAnimator.swift */; };
@@ -4533,7 +4533,7 @@
 		9F80A9882EA9E4CF0079C5AD /* PromptCooldownMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownMigratorTests.swift; sourceTree = "<group>"; };
 		9F81E5AC2FECE8F400EAB88E /* OnboardingIntroViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingIntroViewState.swift; sourceTree = "<group>"; };
 		9F880BED2F331CD900BF211E /* FadeInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FadeInView.swift; sourceTree = "<group>"; };
-		9F8828472EBAAF5A006C878B /* ModalPromptCoordinationDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationDebugMenu.swift; sourceTree = "<group>"; };
+		9F8828472EBAAF5A006C878B /* PromptCoordinationDebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCoordinationDebugMenu.swift; sourceTree = "<group>"; };
 		9F8BCBCD2EB43278004F071E /* RemoteMessagingPixelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMessagingPixelReporter.swift; sourceTree = "<group>"; };
 		9F8E0F2C2CCA618E001EA7C5 /* VideoPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerView.swift; sourceTree = "<group>"; };
 		9F94BBAE2EAB395800185F78 /* WhatsNewModalPromptProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewModalPromptProviderTests.swift; sourceTree = "<group>"; };
@@ -4764,7 +4764,7 @@
 		B6A7C21931A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationManagerPromoQueueTests.swift; sourceTree = "<group>"; };
 		B6A7C21B31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptRootAttachmentCheckerTests.swift; sourceTree = "<group>"; };
 		B6A7C21D31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationRealUIKitTests.swift; sourceTree = "<group>"; };
-		B6A7C26031A1000100F00D01 /* ModalPromptCoordinationDebugViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationDebugViewModelTests.swift; sourceTree = "<group>"; };
+		B6A7C26031A1000100F00D01 /* PromptCoordinationDebugViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCoordinationDebugViewModelTests.swift; sourceTree = "<group>"; };
 		B6AD9E3528D4510A0019CDE9 /* ContentBlockingUpdatingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentBlockingUpdatingTests.swift; sourceTree = "<group>"; };
 		B6BA95C228891E33004ABA20 /* BrowsingMenuAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingMenuAnimator.swift; sourceTree = "<group>"; };
 		B772933186CDFE9E9DDBD2BF /* FileCorruptErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCorruptErrorViewController.swift; sourceTree = "<group>"; };
@@ -8898,7 +8898,7 @@
 			isa = PBXGroup;
 			children = (
 				B6A7C20331A1000100F00D01 /* Arbitration */,
-				9F8828462EBAAF46006C878B /* DebugMenu */,
+				9F8828462EBAAF46006C878B /* PromptCoordination */,
 				9F387E002EA9812F006861F8 /* Factory */,
 				9F80A9862EA9DE3D0079C5AD /* Migrator */,
 				9F387E012EA9812F006861F8 /* Logging */,
@@ -9237,7 +9237,7 @@
 				B6A7C21931A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift */,
 				B6A7C21B31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift */,
 				B6A7C21D31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift */,
-				B6A7C26031A1000100F00D01 /* ModalPromptCoordinationDebugViewModelTests.swift */,
+				B6A7C26031A1000100F00D01 /* PromptCoordinationDebugViewModelTests.swift */,
 				B6A7C20431A1000100F00D01 /* PromoQueueLeaseArbiterTests.swift */,
 			);
 			path = ModalPromptCoordination;
@@ -9301,12 +9301,12 @@
 			path = Components;
 			sourceTree = "<group>";
 		};
-		9F8828462EBAAF46006C878B /* DebugMenu */ = {
+		9F8828462EBAAF46006C878B /* PromptCoordination */ = {
 			isa = PBXGroup;
 			children = (
-				9F8828472EBAAF5A006C878B /* ModalPromptCoordinationDebugMenu.swift */,
+				9F8828472EBAAF5A006C878B /* PromptCoordinationDebugMenu.swift */,
 			);
-			path = DebugMenu;
+			path = PromptCoordination;
 			sourceTree = "<group>";
 		};
 		9F8BCBCC2EB4324F004F071E /* Pixels */ = {
@@ -13664,7 +13664,7 @@
 				EEF7091F2DDE77B000BA3C36 /* SyncExtensions.swift in Sources */,
 				EE458D0D2AB1DA4600FC651A /* EventMapping+NetworkProtectionError.swift in Sources */,
 				6F5DCFCE2E854C2000758C8A /* UniversalOmniBarEditingStateTransition.swift in Sources */,
-				9F8828482EBAAF68006C878B /* ModalPromptCoordinationDebugMenu.swift in Sources */,
+				9F8828482EBAAF68006C878B /* PromptCoordinationDebugMenu.swift in Sources */,
 				CBB4A8672FD31A4D00A65956 /* UnifiedSuggestionsView.swift in Sources */,
 				F44D279F27F331BB0037F371 /* AutofillLoginPromptViewController.swift in Sources */,
 				C1BF0BA529B63D7200482B73 /* AutofillLoginPromptHelper.swift in Sources */,
@@ -14934,7 +14934,7 @@
 				B6A7C21A31A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift in Sources */,
 				B6A7C21C31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift in Sources */,
 				B6A7C21E31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift in Sources */,
-				B6A7C26131A1000100F00D01 /* ModalPromptCoordinationDebugViewModelTests.swift in Sources */,
+				B6A7C26131A1000100F00D01 /* PromptCoordinationDebugViewModelTests.swift in Sources */,
 				B6A7C20531A1000100F00D01 /* PromoQueueLeaseArbiterTests.swift in Sources */,
 				B6A7C20A31A1000100F00D01 /* PromoPresentationCoordinationFeatureFlagTests.swift in Sources */,
 				98E5631D2DE8AF3100E6E75F /* CoreDataTestUtilities.swift in Sources */,

--- a/iOS/DuckDuckGo/AppServices/PromoCoordinationService.swift
+++ b/iOS/DuckDuckGo/AppServices/PromoCoordinationService.swift
@@ -56,6 +56,23 @@ struct ModalPromptProviders {
     }
 }
 
+struct PromoCoordinationDiagnosticSnapshot: Equatable {
+    let mode: PromoCoordinationMode
+    let owner: PromoQueueLeaseOwnerSnapshot?
+    let cooldown: PromoQueueCooldownSnapshot
+}
+
+@MainActor
+protocol PromoCoordinationDiagnosticsProviding: AnyObject {
+    var diagnosticSnapshot: PromoCoordinationDiagnosticSnapshot { get }
+}
+
+@MainActor
+protocol PromoCoordinationCooldownResetting: AnyObject {
+    func resetModalCooldown()
+    func resetRemoteMessageCooldown()
+}
+
 /// Coordinates app-launch modal prompts with the shared new-tab remote-message source.
 @MainActor
 final class PromoCoordinationService {
@@ -154,4 +171,24 @@ extension PromoCoordinationService: PromoGating {
 
 extension PromoCoordinationService: RecentModalPromptStatusProviding {
     var wasModalPromptRecentlyPresented: Bool { modalPromptCoordinationManager.didPresentModalPromptThisSession }
+}
+
+extension PromoCoordinationService: PromoCoordinationDiagnosticsProviding {
+    var diagnosticSnapshot: PromoCoordinationDiagnosticSnapshot {
+        PromoCoordinationDiagnosticSnapshot(
+            mode: mode,
+            owner: promoQueueLeaseArbiter.snapshot.owner,
+            cooldown: promoQueueCooldownPolicy.snapshot
+        )
+    }
+}
+
+extension PromoCoordinationService: PromoCoordinationCooldownResetting {
+    func resetModalCooldown() {
+        promoQueueCooldownPolicy.resetModalCooldown()
+    }
+
+    func resetRemoteMessageCooldown() {
+        promoQueueCooldownPolicy.resetRemoteMessageCooldown()
+    }
 }

--- a/iOS/DuckDuckGo/DebugScreen.swift
+++ b/iOS/DuckDuckGo/DebugScreen.swift
@@ -58,6 +58,8 @@ enum DebugScreen: Identifiable {
         let remoteMessagingDebugHandler: RemoteMessagingDebugHandling
         let webExtensionManager: WebExtensionManaging?
         let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
+        let promoCoordinationDiagnosticsProvider: PromoCoordinationDiagnosticsProviding?
+        let promoCoordinationCooldownResetter: PromoCoordinationCooldownResetting?
 
     }
 

--- a/iOS/DuckDuckGo/DebugScreen.swift
+++ b/iOS/DuckDuckGo/DebugScreen.swift
@@ -65,7 +65,7 @@ enum DebugScreen: Identifiable {
 
     case controller(title: String, (Dependencies) -> UIViewController)
     case view(title: String, (Dependencies) -> any View)
-    case action(title: String, (Dependencies) -> Void)
+    case action(title: String, @MainActor (Dependencies) -> Void)
 
     var isAction: Bool {
         if case .action = self {

--- a/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
@@ -87,7 +87,7 @@ extension DebugScreensViewModel {
 
                 controller.presentShareSheet(withItems: [DiagnosticReportDataSource(delegate: Delegate(), tabManager: d.tabManager, fireproofing: d.fireproofing)], fromView: controller.view)
             }),
-            .action(title: "Reset Prompts Cooldown Period", resetModalPromptsCooldownPeriod),
+            resetModalPromptsCooldownPeriodScreen,
 
             // MARK: SwiftUI Views
             .view(title: "DuckUI", { _ in
@@ -316,9 +316,11 @@ extension DebugScreensViewModel {
         ].compactMap { $0 }
     }
     
-    private func resetModalPromptsCooldownPeriod(_ dependencies: DebugScreen.Dependencies) {
-        Task { @MainActor in
-            dependencies.promoCoordinationCooldownResetter?.resetModalCooldown()
+    private var resetModalPromptsCooldownPeriodScreen: DebugScreen? {
+        guard let cooldownResetter = dependencies.promoCoordinationCooldownResetter else { return nil }
+
+        return .action(title: "Reset Prompts Cooldown Period") { _ in
+            cooldownResetter.resetModalCooldown()
         }
     }
 

--- a/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
@@ -171,8 +171,8 @@ extension DebugScreensViewModel {
             .view(title: "Win-back Offer", { d in
                 WinBackOfferDebugView(keyValueStore: d.keyValueStore)
             }),
-            .view(title: "Modal Prompt Coordination", { d in
-                ModalPromptCoordinationDebugView(
+            .view(title: "Prompt Coordination", { d in
+                PromptCoordinationDebugView(
                     diagnosticsProvider: d.promoCoordinationDiagnosticsProvider,
                     cooldownResetter: d.promoCoordinationCooldownResetter
                 )

--- a/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
@@ -52,7 +52,10 @@ extension DebugScreensViewModel {
                 }
             }),
             .view(title: "CPM", { d in
-                CPMDebugScreensView(keyValueStore: d.keyValueStore)
+                CPMDebugScreensView(
+                    keyValueStore: d.keyValueStore,
+                    cooldownResetter: d.promoCoordinationCooldownResetter
+                )
             }),
             .action(title: "Reset Sync Promos", { d in
                 let syncPromoPresenter = SyncPromoManager(syncService: d.syncService)
@@ -169,10 +172,17 @@ extension DebugScreensViewModel {
                 WinBackOfferDebugView(keyValueStore: d.keyValueStore)
             }),
             .view(title: "Modal Prompt Coordination", { d in
-                ModalPromptCoordinationDebugView(keyValueStore: d.keyValueStore)
+                ModalPromptCoordinationDebugView(
+                    diagnosticsProvider: d.promoCoordinationDiagnosticsProvider,
+                    cooldownResetter: d.promoCoordinationCooldownResetter
+                )
             }),
             .view(title: "What's New", { dependencies in
-                WhatsNewDebugView(keyValueStore: dependencies.keyValueStore, remoteMessagingDebugHandler: dependencies.remoteMessagingDebugHandler)
+                WhatsNewDebugView(
+                    diagnosticsProvider: dependencies.promoCoordinationDiagnosticsProvider,
+                    cooldownResetter: dependencies.promoCoordinationCooldownResetter,
+                    remoteMessagingDebugHandler: dependencies.remoteMessagingDebugHandler
+                )
             }),
             .view(title: "Next Steps Dismissal", { d in
                 SettingsNextStepsDebugView(keyValueStore: d.keyValueStore)
@@ -307,12 +317,9 @@ extension DebugScreensViewModel {
     }
     
     private func resetModalPromptsCooldownPeriod(_ dependencies: DebugScreen.Dependencies) {
-        let store = PromptCooldownKeyValueFilesStore(
-            keyValueStore: dependencies.keyValueStore,
-            eventMapper: .init(mapping: { _, _, _, _ in })
-        )
-
-        store.lastPresentationTimestamp = nil
+        Task { @MainActor in
+            dependencies.promoCoordinationCooldownResetter?.resetModalCooldown()
+        }
     }
 
     private var webExtensionsDebugScreen: DebugScreen? {
@@ -336,6 +343,7 @@ extension DebugScreensViewModel {
 private struct CPMDebugScreensView: View {
 
     let keyValueStore: ThrowingKeyValueStoring
+    let cooldownResetter: PromoCoordinationCooldownResetting?
 
     var body: some View {
         List {
@@ -347,7 +355,7 @@ private struct CPMDebugScreensView: View {
                     // Clears the shown flag + shown count.
                     CookiePopupProtectionOptInPromptStore(keyValueStore: keyValueStore).reset()
                     // Also lift the global modal cooldown — otherwise the queue suppresses all prompts on launch until it expires.
-                    try? keyValueStore.set(nil, forKey: PromptCooldownKeyValueFilesStore.StorageKey.lastPromptShownTimestamp)
+                    cooldownResetter?.resetModalCooldown()
                     ActionMessageView.present(message: "Reset opt-in dialog launch state - DONE")
                 }
             }

--- a/iOS/DuckDuckGo/DebugScreensViewModel.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel.swift
@@ -128,6 +128,7 @@ class DebugScreensViewModel: ObservableObject {
         }
     }
 
+    @MainActor
     func executeAction(_ screen: DebugScreen) {
         switch screen {
         case .action(_, let action):

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -501,7 +501,9 @@ extension MainViewController {
                                                             syncAutoRestoreHandler: syncAutoRestoreHandler,
                                                             freemiumPIRDebugSettings: freemiumPIRDebugSettings,
                                                             freemiumDBPUserStateManager: freemiumDBPUserStateManager,
-                                                            duckAiNativeStorageHandler: duckAiNativeStorageHandler)
+                                                            duckAiNativeStorageHandler: duckAiNativeStorageHandler,
+                                                            promoCoordinationDiagnosticsProvider: promoCoordinationDiagnosticsProvider,
+                                                            promoCoordinationCooldownResetter: promoCoordinationCooldownResetter)
 
         let aiChatSettings = AIChatSettings(privacyConfigurationManager: privacyConfigurationManager)
         let serpSettingsProvider = SERPSettingsProvider(aiChatProvider: aiChatSettings)
@@ -625,7 +627,9 @@ extension MainViewController {
             subscriptionDataReporter: self.subscriptionDataReporter,
             remoteMessagingDebugHandler: self.remoteMessagingDebugHandler,
             webExtensionManager: self.webExtensionManager,
-            duckAiNativeStorageHandler: self.duckAiNativeStorageHandler))
+            duckAiNativeStorageHandler: self.duckAiNativeStorageHandler,
+            promoCoordinationDiagnosticsProvider: self.promoCoordinationDiagnosticsProvider,
+            promoCoordinationCooldownResetter: self.promoCoordinationCooldownResetter))
 
         debug.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: debug, action: #selector(DebugScreensViewController.dismissSelf))
 

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -502,8 +502,8 @@ extension MainViewController {
                                                             freemiumPIRDebugSettings: freemiumPIRDebugSettings,
                                                             freemiumDBPUserStateManager: freemiumDBPUserStateManager,
                                                             duckAiNativeStorageHandler: duckAiNativeStorageHandler,
-                                                            promoCoordinationDiagnosticsProvider: promoCoordinationDiagnosticsProvider,
-                                                            promoCoordinationCooldownResetter: promoCoordinationCooldownResetter)
+                                                            promoCoordinationDiagnosticsProvider: promoCoordinationService,
+                                                            promoCoordinationCooldownResetter: promoCoordinationService)
 
         let aiChatSettings = AIChatSettings(privacyConfigurationManager: privacyConfigurationManager)
         let serpSettingsProvider = SERPSettingsProvider(aiChatProvider: aiChatSettings)
@@ -628,8 +628,8 @@ extension MainViewController {
             remoteMessagingDebugHandler: self.remoteMessagingDebugHandler,
             webExtensionManager: self.webExtensionManager,
             duckAiNativeStorageHandler: self.duckAiNativeStorageHandler,
-            promoCoordinationDiagnosticsProvider: self.promoCoordinationDiagnosticsProvider,
-            promoCoordinationCooldownResetter: self.promoCoordinationCooldownResetter))
+            promoCoordinationDiagnosticsProvider: self.promoCoordinationService,
+            promoCoordinationCooldownResetter: self.promoCoordinationService))
 
         debug.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: debug, action: #selector(DebugScreensViewController.dismissSelf))
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -360,9 +360,10 @@ class MainViewController: UIViewController {
 
     let themeManager: ThemeManaging
     let keyValueStore: ThrowingKeyValueStoring
-    let recentModalPromptStatusProvider: RecentModalPromptStatusProviding?
-    let promoCoordinationDiagnosticsProvider: PromoCoordinationDiagnosticsProviding?
-    let promoCoordinationCooldownResetter: PromoCoordinationCooldownResetting?
+    let promoCoordinationService:
+        (any RecentModalPromptStatusProviding
+            & PromoCoordinationDiagnosticsProviding
+            & PromoCoordinationCooldownResetting)?
     let systemSettingsPiPTutorialManager: SystemSettingsPiPTutorialManaging
     let onboardingResumeStepStore: any KeyedStoring<OnboardingStoringKeys>
     var adBlockingAvailability: AdBlockingAvailabilityProviding { tabManager.adBlockingAvailability }
@@ -536,9 +537,9 @@ class MainViewController: UIViewController {
         toggleModeStorage: ToggleModeStoring = ToggleModeStorage(),
         onboardingResumeStepStore: (any KeyedStoring<OnboardingStoringKeys>)? = nil,
         onboardingManager: OnboardingManaging,
-        recentModalPromptStatusProvider: RecentModalPromptStatusProviding? = nil,
-        promoCoordinationDiagnosticsProvider: PromoCoordinationDiagnosticsProviding? = nil,
-        promoCoordinationCooldownResetter: PromoCoordinationCooldownResetting? = nil
+        promoCoordinationService: (any RecentModalPromptStatusProviding
+            & PromoCoordinationDiagnosticsProviding
+            & PromoCoordinationCooldownResetting)? = nil
     ) {
         self.remoteMessagingActionHandler = remoteMessagingActionHandler
         self.remoteMessagingImageLoader = remoteMessagingImageLoader
@@ -602,9 +603,7 @@ class MainViewController: UIViewController {
         self.maliciousSiteProtectionPreferencesManager = maliciousSiteProtectionPreferencesManager
         self.contentScopeExperimentsManager = contentScopeExperimentsManager
         self.keyValueStore = keyValueStore
-        self.recentModalPromptStatusProvider = recentModalPromptStatusProvider
-        self.promoCoordinationDiagnosticsProvider = promoCoordinationDiagnosticsProvider
-        self.promoCoordinationCooldownResetter = promoCoordinationCooldownResetter
+        self.promoCoordinationService = promoCoordinationService
         self.onboardingResumeStepStore = if let onboardingResumeStepStore { onboardingResumeStepStore } else { UserDefaults.app.keyedStoring() }
         self.customConfigurationURLProvider = customConfigurationURLProvider
         self.systemSettingsPiPTutorialManager = systemSettingsPiPTutorialManager

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -361,6 +361,8 @@ class MainViewController: UIViewController {
     let themeManager: ThemeManaging
     let keyValueStore: ThrowingKeyValueStoring
     let recentModalPromptStatusProvider: RecentModalPromptStatusProviding?
+    let promoCoordinationDiagnosticsProvider: PromoCoordinationDiagnosticsProviding?
+    let promoCoordinationCooldownResetter: PromoCoordinationCooldownResetting?
     let systemSettingsPiPTutorialManager: SystemSettingsPiPTutorialManaging
     let onboardingResumeStepStore: any KeyedStoring<OnboardingStoringKeys>
     var adBlockingAvailability: AdBlockingAvailabilityProviding { tabManager.adBlockingAvailability }
@@ -534,7 +536,9 @@ class MainViewController: UIViewController {
         toggleModeStorage: ToggleModeStoring = ToggleModeStorage(),
         onboardingResumeStepStore: (any KeyedStoring<OnboardingStoringKeys>)? = nil,
         onboardingManager: OnboardingManaging,
-        recentModalPromptStatusProvider: RecentModalPromptStatusProviding? = nil
+        recentModalPromptStatusProvider: RecentModalPromptStatusProviding? = nil,
+        promoCoordinationDiagnosticsProvider: PromoCoordinationDiagnosticsProviding? = nil,
+        promoCoordinationCooldownResetter: PromoCoordinationCooldownResetting? = nil
     ) {
         self.remoteMessagingActionHandler = remoteMessagingActionHandler
         self.remoteMessagingImageLoader = remoteMessagingImageLoader
@@ -599,6 +603,8 @@ class MainViewController: UIViewController {
         self.contentScopeExperimentsManager = contentScopeExperimentsManager
         self.keyValueStore = keyValueStore
         self.recentModalPromptStatusProvider = recentModalPromptStatusProvider
+        self.promoCoordinationDiagnosticsProvider = promoCoordinationDiagnosticsProvider
+        self.promoCoordinationCooldownResetter = promoCoordinationCooldownResetter
         self.onboardingResumeStepStore = if let onboardingResumeStepStore { onboardingResumeStepStore } else { UserDefaults.app.keyedStoring() }
         self.customConfigurationURLProvider = customConfigurationURLProvider
         self.systemSettingsPiPTutorialManager = systemSettingsPiPTutorialManager

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Arbitration/PromoQueueLeaseArbiter.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Arbitration/PromoQueueLeaseArbiter.swift
@@ -162,12 +162,10 @@ final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
     private var owner: Owner?
 
     var snapshot: PromoQueueLeaseSnapshot {
-        pruneOwnerWithDeallocatedToken()
-
         switch owner {
-        case .modal(let record):
+        case .modal(let record) where record.token != nil:
             return PromoQueueLeaseSnapshot(owner: .modal(ownershipIdentity: record.ownershipIdentity))
-        case .remoteMessage(let record):
+        case .remoteMessage(let record) where record.token != nil:
             return PromoQueueLeaseSnapshot(
                 owner: .remoteMessage(
                     messageID: record.messageID,
@@ -175,7 +173,7 @@ final class PromoQueueLeaseArbiter: PromoQueueLeaseArbitrating {
                     appearanceConfirmed: record.appearanceConfirmed
                 )
             )
-        case nil:
+        case .modal, .remoteMessage, nil:
             return PromoQueueLeaseSnapshot(owner: nil)
         }
     }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicy.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicy.swift
@@ -116,6 +116,8 @@ protocol PromoQueueCooldownPolicying: AnyObject {
     func evaluateRemoteMessageAdmission() -> PromoQueueCooldownDecision
     func evaluateModalAdmission() -> PromoQueueCooldownDecision
     func recordConfirmedRemoteMessageAppearance()
+    func resetModalCooldown()
+    func resetRemoteMessageCooldown()
 }
 
 @MainActor
@@ -161,6 +163,14 @@ final class PromoQueueCooldownPolicy: PromoQueueCooldownPolicying {
 
     func recordConfirmedRemoteMessageAppearance() {
         remoteMessageHistory.recordConfirmedAppearance(at: dateProvider())
+    }
+
+    func resetModalCooldown() {
+        modalPresentationStore.lastPresentationTimestamp = nil
+    }
+
+    func resetRemoteMessageCooldown() {
+        remoteMessageHistory.reset()
     }
 
     private func decision(nextEligibility: Date?) -> PromoQueueCooldownDecision {

--- a/iOS/DuckDuckGo/ModalPromptCoordination/DebugMenu/ModalPromptCoordinationDebugMenu.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/DebugMenu/ModalPromptCoordinationDebugMenu.swift
@@ -18,40 +18,86 @@
 //
 
 import SwiftUI
-import Persistence
-import class Common.EventMapping
 
 struct ModalPromptCoordinationDebugView: View {
     @StateObject private var viewModel: ModalPromptCoordinationDebugViewModel
 
-    init(keyValueStore: ThrowingKeyValueStoring) {
-        let store = PromptCooldownKeyValueFilesStore(keyValueStore: keyValueStore, eventMapper: .init(mapping: { _, _, _, _ in }))
-        self._viewModel = StateObject(wrappedValue: ModalPromptCoordinationDebugViewModel(store: store))
+    init(
+        diagnosticsProvider: PromoCoordinationDiagnosticsProviding?,
+        cooldownResetter: PromoCoordinationCooldownResetting?
+    ) {
+        self._viewModel = StateObject(
+            wrappedValue: ModalPromptCoordinationDebugViewModel(
+                diagnosticsProvider: diagnosticsProvider,
+                cooldownResetter: cooldownResetter
+            )
+        )
     }
 
     var body: some View {
         List {
             Section {
-                Text(viewModel.formattedCooldownPeriod)
-                if viewModel.isCooldownPeriodActive {
-                    Button("Reset Cooldown") {
-                        viewModel.resetCoolDownPeriod()
-                    }
+                diagnosticRow(title: "Mode", value: viewModel.modeDescription)
+                diagnosticRow(title: "Owner", value: viewModel.ownerDescription)
+                diagnosticRow(title: "RMF Appearance Confirmed", value: viewModel.remoteMessageAppearanceDescription)
+                Button("Refresh") {
+                    viewModel.refresh()
                 }
             } header: {
-                Text(verbatim: "Prompt Cooldown")
+                Text(verbatim: "Promo Queue")
             } footer: {
-                if viewModel.isCooldownPeriodActive {
-                    Text(verbatim: "Reset Cooldown period to allow modal prompt to show again.")
-                        .foregroundColor(.red)
-                }
+                Text(verbatim: "Feature flag changes require a relaunch.")
             }
+
+            Section {
+                diagnosticRow(title: "Last Modal Appearance", value: viewModel.lastConfirmedModalAppearanceDescription)
+                diagnosticRow(title: "Last RMF Appearance", value: viewModel.lastConfirmedRemoteMessageAppearanceDescription)
+                diagnosticRow(title: "Next RMF Eligibility", value: viewModel.nextRemoteMessageEligibilityDescription)
+                diagnosticRow(title: "Next Modal Eligibility", value: viewModel.nextModalEligibilityDescription)
+            } header: {
+                Text(verbatim: "Cooldowns")
+            } footer: {
+                Text(verbatim: "Eligibility dates do not schedule retries.")
+            }
+
+            Section {
+                Button("Reset Modal Cooldown (Debug Only)", role: .destructive) {
+                    viewModel.resetModalCooldown()
+                }
+                .disabled(!viewModel.canResetCooldowns)
+
+                Button("Reset RMF Cooldown (Debug Only)", role: .destructive) {
+                    viewModel.resetRemoteMessageCooldown()
+                }
+                .disabled(!viewModel.canResetCooldowns)
+            } header: {
+                Text(verbatim: "Manual Testing")
+            } footer: {
+                Text(verbatim: "Cooldown resets do not release an active owner or dismiss a message.")
+            }
+        }
+    }
+
+    private func diagnosticRow(title: String, value: String) -> some View {
+        HStack(alignment: .top) {
+            Text(verbatim: title)
+            Spacer()
+            Text(verbatim: value)
+                .multilineTextAlignment(.trailing)
+                .textSelection(.enabled)
         }
     }
 }
 
-private final class ModalPromptCoordinationDebugViewModel: ObservableObject {
-    private let store: PromptCooldownStore
+/// Internal debug UI contract; coordination state remains available only through the injected providers.
+@MainActor
+final class ModalPromptCoordinationDebugViewModel: ObservableObject {
+    private enum Text {
+        static let unavailable = "Unavailable"
+        static let never = "Never"
+        static let noCooldownBoundary = "No cooldown boundary"
+        static let notApplicable = "Not applicable"
+    }
 
     private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -61,34 +107,94 @@ private final class ModalPromptCoordinationDebugViewModel: ObservableObject {
         return formatter
     }()
 
-    @Published private(set) var isCooldownPeriodActive: Bool = false
-    @Published private(set) var formattedCooldownPeriod: String = ""
+    private let diagnosticsProvider: PromoCoordinationDiagnosticsProviding?
+    private let cooldownResetter: PromoCoordinationCooldownResetting?
+    private let dateFormatting: (Date) -> String
 
-    init(store: PromptCooldownStore) {
-        self.store = store
-        updateUI()
+    @Published private(set) var snapshot: PromoCoordinationDiagnosticSnapshot?
+
+    var canResetCooldowns: Bool {
+        cooldownResetter != nil
     }
 
-    func resetCoolDownPeriod() {
-        store.lastPresentationTimestamp = nil
-        updateUI()
+    var modeDescription: String {
+        guard let snapshot else { return Text.unavailable }
+
+        switch snapshot.mode {
+        case .legacy:
+            return "Legacy"
+        case .coordinated:
+            return "Coordinated"
+        }
     }
 
-    private func updateUI() {
-        isCooldownPeriodActive = isCooldownActive()
-        formattedCooldownPeriod = makeFormattedCooldownPeriod()
+    var ownerDescription: String {
+        guard let snapshot else { return Text.unavailable }
+
+        switch snapshot.owner {
+        case .modal(let ownershipIdentity):
+            return "Modal (ownership ID: \(ownershipIdentity.diagnosticDescription))"
+        case .remoteMessage(let messageID, let acquisitionIdentity, _):
+            return "RMF (message ID: \(messageID), acquisition ID: \(acquisitionIdentity.diagnosticDescription))"
+        case nil:
+            return "None"
+        }
     }
 
-    private func isCooldownActive() -> Bool {
-        store.lastPresentationTimestamp != nil
-    }
-
-    private func makeFormattedCooldownPeriod() -> String {
-        guard let timestamp = store.lastPresentationTimestamp else {
-            return "No Prompt Cooldown active."
+    var remoteMessageAppearanceDescription: String {
+        guard let snapshot else { return Text.unavailable }
+        guard case .remoteMessage(_, _, let appearanceConfirmed) = snapshot.owner else {
+            return Text.notApplicable
         }
 
-        let lastTimeStampDate = Date(timeIntervalSince1970: timestamp)
-        return "Modal Prompt shown \(Self.dateFormatter.string(from: lastTimeStampDate))."
+        return appearanceConfirmed ? "Yes" : "No"
+    }
+
+    var lastConfirmedModalAppearanceDescription: String {
+        formattedDate(snapshot?.cooldown.lastConfirmedModalAppearance, nilDescription: Text.never)
+    }
+
+    var lastConfirmedRemoteMessageAppearanceDescription: String {
+        formattedDate(snapshot?.cooldown.lastConfirmedRemoteMessageAppearance, nilDescription: Text.never)
+    }
+
+    var nextRemoteMessageEligibilityDescription: String {
+        formattedDate(snapshot?.cooldown.nextRemoteMessageEligibility, nilDescription: Text.noCooldownBoundary)
+    }
+
+    var nextModalEligibilityDescription: String {
+        formattedDate(snapshot?.cooldown.nextModalEligibility, nilDescription: Text.noCooldownBoundary)
+    }
+
+    init(
+        diagnosticsProvider: PromoCoordinationDiagnosticsProviding?,
+        cooldownResetter: PromoCoordinationCooldownResetting?,
+        dateFormatting: ((Date) -> String)? = nil
+    ) {
+        self.diagnosticsProvider = diagnosticsProvider
+        self.cooldownResetter = cooldownResetter
+        self.dateFormatting = dateFormatting ?? { Self.dateFormatter.string(from: $0) }
+        refresh()
+    }
+
+    func refresh() {
+        snapshot = diagnosticsProvider?.diagnosticSnapshot
+    }
+
+    func resetModalCooldown() {
+        cooldownResetter?.resetModalCooldown()
+        refresh()
+    }
+
+    func resetRemoteMessageCooldown() {
+        cooldownResetter?.resetRemoteMessageCooldown()
+        refresh()
+    }
+
+    private func formattedDate(_ date: Date?, nilDescription: String) -> String {
+        guard snapshot != nil else { return Text.unavailable }
+        guard let date else { return nilDescription }
+
+        return dateFormatting(date)
     }
 }

--- a/iOS/DuckDuckGo/ModalPromptCoordination/PromptCoordination/PromptCoordinationDebugMenu.swift
+++ b/iOS/DuckDuckGo/ModalPromptCoordination/PromptCoordination/PromptCoordinationDebugMenu.swift
@@ -1,5 +1,5 @@
 //
-//  ModalPromptCoordinationDebugMenu.swift
+//  PromptCoordinationDebugMenu.swift
 //  DuckDuckGo
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.
@@ -19,15 +19,15 @@
 
 import SwiftUI
 
-struct ModalPromptCoordinationDebugView: View {
-    @StateObject private var viewModel: ModalPromptCoordinationDebugViewModel
+struct PromptCoordinationDebugView: View {
+    @StateObject private var viewModel: PromptCoordinationDebugViewModel
 
     init(
         diagnosticsProvider: PromoCoordinationDiagnosticsProviding?,
         cooldownResetter: PromoCoordinationCooldownResetting?
     ) {
         self._viewModel = StateObject(
-            wrappedValue: ModalPromptCoordinationDebugViewModel(
+            wrappedValue: PromptCoordinationDebugViewModel(
                 diagnosticsProvider: diagnosticsProvider,
                 cooldownResetter: cooldownResetter
             )
@@ -44,7 +44,7 @@ struct ModalPromptCoordinationDebugView: View {
                     viewModel.refresh()
                 }
             } header: {
-                Text(verbatim: "Promo Queue")
+                Text(verbatim: "Prompt Coordination")
             } footer: {
                 Text(verbatim: "Feature flag changes require a relaunch.")
             }
@@ -76,6 +76,7 @@ struct ModalPromptCoordinationDebugView: View {
                 Text(verbatim: "Cooldown resets do not release an active owner or dismiss a message.")
             }
         }
+        .navigationTitle("Prompt Coordination")
     }
 
     private func diagnosticRow(title: String, value: String) -> some View {
@@ -91,7 +92,7 @@ struct ModalPromptCoordinationDebugView: View {
 
 /// Internal debug UI contract; coordination state remains available only through the injected providers.
 @MainActor
-final class ModalPromptCoordinationDebugViewModel: ObservableObject {
+final class PromptCoordinationDebugViewModel: ObservableObject {
     private enum Text {
         static let unavailable = "Unavailable"
         static let never = "Never"

--- a/iOS/DuckDuckGo/SettingsLegacyViewProvider.swift
+++ b/iOS/DuckDuckGo/SettingsLegacyViewProvider.swift
@@ -63,6 +63,8 @@ class SettingsLegacyViewProvider: ObservableObject {
     let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
     let freemiumPIRDebugSettings: FreemiumPIRDebugSettings
     let freemiumDBPUserStateManager: FreemiumDBPUserStateManaging
+    let promoCoordinationDiagnosticsProvider: PromoCoordinationDiagnosticsProviding?
+    let promoCoordinationCooldownResetter: PromoCoordinationCooldownResetting?
 
     init(syncService: any DDGSyncing,
          syncDataProviders: SyncDataProviders,
@@ -85,7 +87,9 @@ class SettingsLegacyViewProvider: ObservableObject {
          syncAutoRestoreHandler: SyncAutoRestoreHandling,
          freemiumPIRDebugSettings: FreemiumPIRDebugSettings,
          freemiumDBPUserStateManager: FreemiumDBPUserStateManaging,
-         duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil) {
+         duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil,
+         promoCoordinationDiagnosticsProvider: PromoCoordinationDiagnosticsProviding? = nil,
+         promoCoordinationCooldownResetter: PromoCoordinationCooldownResetting? = nil) {
         self.syncService = syncService
         self.syncDataProviders = syncDataProviders
         self.appSettings = appSettings
@@ -108,6 +112,8 @@ class SettingsLegacyViewProvider: ObservableObject {
         self.duckAiNativeStorageHandler = duckAiNativeStorageHandler
         self.freemiumPIRDebugSettings = freemiumPIRDebugSettings
         self.freemiumDBPUserStateManager = freemiumDBPUserStateManager
+        self.promoCoordinationDiagnosticsProvider = promoCoordinationDiagnosticsProvider
+        self.promoCoordinationCooldownResetter = promoCoordinationCooldownResetter
     }
     
     enum LegacyView {
@@ -164,7 +170,9 @@ class SettingsLegacyViewProvider: ObservableObject {
             subscriptionDataReporter: self.subscriptionDataReporter,
             remoteMessagingDebugHandler: self.remoteMessagingDebugHandler,
             webExtensionManager: self.webExtensionManager,
-            duckAiNativeStorageHandler: self.duckAiNativeStorageHandler))
+            duckAiNativeStorageHandler: self.duckAiNativeStorageHandler,
+            promoCoordinationDiagnosticsProvider: self.promoCoordinationDiagnosticsProvider,
+            promoCoordinationCooldownResetter: self.promoCoordinationCooldownResetter))
     }
 
     // Legacy UIKit Views (Pushed unmodified)

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -322,7 +322,9 @@ final class MainCoordinator {
                                         darkReaderFeatureSettings: darkReaderFeatureSettings,
                                         toggleModeStorage: toggleModeStorage,
                                         onboardingManager: onboardingManager,
-                                        recentModalPromptStatusProvider: promoCoordinationService)
+                                        recentModalPromptStatusProvider: promoCoordinationService,
+                                        promoCoordinationDiagnosticsProvider: promoCoordinationService,
+                                        promoCoordinationCooldownResetter: promoCoordinationService)
 
         setupWebExtensions(privacyConfigurationManager: privacyConfigurationManager)
 

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -322,9 +322,7 @@ final class MainCoordinator {
                                         darkReaderFeatureSettings: darkReaderFeatureSettings,
                                         toggleModeStorage: toggleModeStorage,
                                         onboardingManager: onboardingManager,
-                                        recentModalPromptStatusProvider: promoCoordinationService,
-                                        promoCoordinationDiagnosticsProvider: promoCoordinationService,
-                                        promoCoordinationCooldownResetter: promoCoordinationService)
+                                        promoCoordinationService: promoCoordinationService)
 
         setupWebExtensions(privacyConfigurationManager: privacyConfigurationManager)
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -84,7 +84,7 @@ extension MainViewController {
             stateStore: stateStore,
             syncService: syncService,
             aiChatSyncCleaner: aiChatSyncCleaner,
-            recentModalPromptStatusProvider: recentModalPromptStatusProvider,
+            recentModalPromptStatusProvider: promoCoordinationService,
             duckAIWideEventInstrumentation: duckAIWideEventInstrumentation,
             attachmentPasteEnabled: unifiedToggleInputFeature.isAttachmentPasteEnabled
         )

--- a/iOS/DuckDuckGo/WhatsNew/DebugMenu/WhatsNewDebugMenu.swift
+++ b/iOS/DuckDuckGo/WhatsNew/DebugMenu/WhatsNewDebugMenu.swift
@@ -27,9 +27,18 @@ import BrowserServicesKit
 struct WhatsNewDebugView: View {
     @StateObject private var viewModel: WhatsNewDebugViewModel
 
-    init(keyValueStore: ThrowingKeyValueStoring, remoteMessagingDebugHandler: RemoteMessagingDebugHandling? = nil) {
-        let store =  PromptCooldownKeyValueFilesStore(keyValueStore: keyValueStore, eventMapper: .init(mapping: { _, _, _, _ in }))
-        self._viewModel = StateObject(wrappedValue: WhatsNewDebugViewModel(store: store, remoteMessagingDebugHandler: remoteMessagingDebugHandler))
+    init(
+        diagnosticsProvider: PromoCoordinationDiagnosticsProviding?,
+        cooldownResetter: PromoCoordinationCooldownResetting?,
+        remoteMessagingDebugHandler: RemoteMessagingDebugHandling? = nil
+    ) {
+        self._viewModel = StateObject(
+            wrappedValue: WhatsNewDebugViewModel(
+                diagnosticsProvider: diagnosticsProvider,
+                cooldownResetter: cooldownResetter,
+                remoteMessagingDebugHandler: remoteMessagingDebugHandler
+            )
+        )
     }
 
     var body: some View {
@@ -59,8 +68,10 @@ struct WhatsNewDebugView: View {
     }
 }
 
+@MainActor
 private final class WhatsNewDebugViewModel: ObservableObject {
-    private let store: PromptCooldownStore
+    private let diagnosticsProvider: PromoCoordinationDiagnosticsProviding?
+    private let cooldownResetter: PromoCoordinationCooldownResetting?
     private let remoteMessagingDebugHandler: RemoteMessagingDebugHandling?
 
     private static let dateFormatter: DateFormatter = {
@@ -76,15 +87,20 @@ private final class WhatsNewDebugViewModel: ObservableObject {
     @Published private(set) var isCooldownPeriodActive: Bool = false
     @Published private(set) var formattedCooldownPeriod: String = ""
 
-    init(store: PromptCooldownStore, remoteMessagingDebugHandler: RemoteMessagingDebugHandling? = nil) {
-        self.store = store
+    init(
+        diagnosticsProvider: PromoCoordinationDiagnosticsProviding?,
+        cooldownResetter: PromoCoordinationCooldownResetting?,
+        remoteMessagingDebugHandler: RemoteMessagingDebugHandling? = nil
+    ) {
+        self.diagnosticsProvider = diagnosticsProvider
+        self.cooldownResetter = cooldownResetter
         self.remoteMessagingDebugHandler = remoteMessagingDebugHandler
         self.database = Database.shared
         updateUI()
     }
 
     func resetCoolDownPeriod() {
-        store.lastPresentationTimestamp = nil
+        cooldownResetter?.resetModalCooldown()
         updateUI()
     }
 
@@ -105,20 +121,16 @@ private final class WhatsNewDebugViewModel: ObservableObject {
     }
 
     private func updateUI() {
-        isCooldownPeriodActive = isCooldownActive()
-        formattedCooldownPeriod = makeFormattedCooldownPeriod()
+        let lastAppearance = diagnosticsProvider?.diagnosticSnapshot.cooldown.lastConfirmedModalAppearance
+        isCooldownPeriodActive = lastAppearance != nil
+        formattedCooldownPeriod = makeFormattedCooldownPeriod(lastAppearance)
     }
 
-    private func isCooldownActive() -> Bool {
-        store.lastPresentationTimestamp != nil
-    }
-
-    private func makeFormattedCooldownPeriod() -> String {
-        guard let timestamp = store.lastPresentationTimestamp else {
+    private func makeFormattedCooldownPeriod(_ date: Date?) -> String {
+        guard let date else {
             return "No Prompt Cooldown active."
         }
 
-        let lastTimeStampDate = Date(timeIntervalSince1970: timestamp)
-        return "Modal Prompt shown \(Self.dateFormatter.string(from: lastTimeStampDate))."
+        return "Modal Prompt shown \(Self.dateFormatter.string(from: date))."
     }
 }

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationDebugViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationDebugViewModelTests.swift
@@ -1,0 +1,194 @@
+//
+//  ModalPromptCoordinationDebugViewModelTests.swift
+//  DuckDuckGoTests
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import PersistenceTestingUtils
+import Testing
+@testable import DuckDuckGo
+
+@MainActor
+@Suite("Modal Prompt Coordination - Debug View Model")
+struct ModalPromptCoordinationDebugViewModelTests {
+
+    @available(iOS 16, *)
+    @Test("Refresh passively formats production diagnostics", .timeLimit(.minutes(1)))
+    func passiveRefreshAndFormatting() throws {
+        let arbiter = PromoQueueLeaseArbiter()
+
+        guard case .acquired(let modalLease) = arbiter.acquireModalLease() else {
+            Issue.record("Expected a modal lease")
+            return
+        }
+        let modalOwner = try #require(arbiter.snapshot.owner)
+        modalLease.release()
+
+        guard case .acquired(let remoteMessageLease) = arbiter.acquireRemoteMessageLease(for: "message") else {
+            Issue.record("Expected an RMF lease")
+            return
+        }
+        let unconfirmedRemoteMessageOwner = try #require(arbiter.snapshot.owner)
+        #expect(remoteMessageLease.confirmAppearance())
+        let confirmedRemoteMessageOwner = try #require(arbiter.snapshot.owner)
+
+        let modalDate = Date(timeIntervalSince1970: 1_000)
+        let remoteMessageDate = Date(timeIntervalSince1970: 2_000)
+        let remoteMessageEligibility = Date(timeIntervalSince1970: 3_000)
+        let modalEligibility = Date(timeIntervalSince1970: 4_000)
+        let cooldown = PromoQueueCooldownSnapshot(
+            lastConfirmedModalAppearance: modalDate,
+            lastConfirmedRemoteMessageAppearance: remoteMessageDate,
+            nextRemoteMessageEligibility: remoteMessageEligibility,
+            nextModalEligibility: modalEligibility
+        )
+        let scenarios = [
+            FormattingScenario(
+                mode: .legacy,
+                owner: nil,
+                expectedMode: "Legacy",
+                expectedOwner: "None",
+                expectedAppearance: "Not applicable"
+            ),
+            FormattingScenario(
+                mode: .coordinated,
+                owner: modalOwner,
+                expectedMode: "Coordinated",
+                expectedOwner: "Modal (ownership ID: \(modalLease.ownershipIdentity.diagnosticDescription))",
+                expectedAppearance: "Not applicable"
+            ),
+            FormattingScenario(
+                mode: .coordinated,
+                owner: unconfirmedRemoteMessageOwner,
+                expectedMode: "Coordinated",
+                expectedOwner: "RMF (message ID: message, acquisition ID: \(remoteMessageLease.acquisitionIdentity.diagnosticDescription))",
+                expectedAppearance: "No"
+            ),
+            FormattingScenario(
+                mode: .coordinated,
+                owner: confirmedRemoteMessageOwner,
+                expectedMode: "Coordinated",
+                expectedOwner: "RMF (message ID: message, acquisition ID: \(remoteMessageLease.acquisitionIdentity.diagnosticDescription))",
+                expectedAppearance: "Yes"
+            ),
+        ]
+        let provider = DiagnosticsProviderSpy(
+            snapshot: PromoCoordinationDiagnosticSnapshot(
+                mode: scenarios[0].mode,
+                owner: scenarios[0].owner,
+                cooldown: cooldown
+            )
+        )
+        let viewModel = ModalPromptCoordinationDebugViewModel(
+            diagnosticsProvider: provider,
+            cooldownResetter: nil,
+            dateFormatting: { "Date \(Int($0.timeIntervalSince1970))" }
+        )
+
+        for scenario in scenarios {
+            provider.snapshot = PromoCoordinationDiagnosticSnapshot(
+                mode: scenario.mode,
+                owner: scenario.owner,
+                cooldown: cooldown
+            )
+            viewModel.refresh()
+
+            #expect(viewModel.modeDescription == scenario.expectedMode)
+            #expect(viewModel.ownerDescription == scenario.expectedOwner)
+            #expect(viewModel.remoteMessageAppearanceDescription == scenario.expectedAppearance)
+            #expect(viewModel.lastConfirmedModalAppearanceDescription == "Date 1000")
+            #expect(viewModel.lastConfirmedRemoteMessageAppearanceDescription == "Date 2000")
+            #expect(viewModel.nextRemoteMessageEligibilityDescription == "Date 3000")
+            #expect(viewModel.nextModalEligibilityDescription == "Date 4000")
+            #expect(viewModel.snapshot?.owner == scenario.owner)
+        }
+
+        #expect(provider.snapshotReadCount == scenarios.count + 1)
+        _ = remoteMessageLease
+    }
+
+    @available(iOS 16, *)
+    @Test("RMF cooldown reset updates eligibility without changing ownership", .timeLimit(.minutes(1)))
+    func remoteMessageCooldownReset() throws {
+        let referenceDate = Date(timeIntervalSince1970: 1_775_000_000)
+        let keyValueStore = InMemoryThrowingKeyValueStore()
+        let remoteMessageHistory = PromoQueueRemoteMessageHistoryStore(keyValueStore: keyValueStore)
+        let policy = PromoQueueCooldownPolicy(
+            modalPresentationStore: MockPromptCooldownStore(),
+            remoteMessageHistory: remoteMessageHistory,
+            dateProvider: { referenceDate }
+        )
+        let arbiter = PromoQueueLeaseArbiter()
+        let launchSourceManager = MockLaunchSourceManager()
+        launchSourceManager.source = .standard
+        let service = PromoCoordinationService(
+            launchSourceManager: launchSourceManager,
+            modalPromptCoordinationManager: MockModalPromptCoordinationManager(),
+            mode: .coordinated,
+            promoQueueLeaseArbiter: arbiter,
+            promoQueueCooldownPolicy: policy
+        )
+        let lease = try #require(service.tryAcquireRemoteMessageLease(for: "message"))
+        #expect(lease.markShown())
+        let ownerBeforeReset = try #require(service.diagnosticSnapshot.owner)
+        let viewModel = ModalPromptCoordinationDebugViewModel(
+            diagnosticsProvider: service,
+            cooldownResetter: service,
+            dateFormatting: { "Date \(Int($0.timeIntervalSince1970))" }
+        )
+
+        #expect(viewModel.lastConfirmedRemoteMessageAppearanceDescription == "Date 1775000000")
+        #expect(viewModel.nextRemoteMessageEligibilityDescription == "Date 1775000600")
+        #expect(viewModel.nextModalEligibilityDescription == "Date 1775086400")
+
+        viewModel.resetRemoteMessageCooldown()
+
+        #expect(viewModel.lastConfirmedRemoteMessageAppearanceDescription == "Never")
+        #expect(viewModel.nextRemoteMessageEligibilityDescription == "No cooldown boundary")
+        #expect(viewModel.nextModalEligibilityDescription == "No cooldown boundary")
+        #expect(viewModel.snapshot?.owner == ownerBeforeReset)
+        #expect(viewModel.remoteMessageAppearanceDescription == "Yes")
+        #expect(service.diagnosticSnapshot.owner == ownerBeforeReset)
+
+        let reconstructedHistory = PromoQueueRemoteMessageHistoryStore(keyValueStore: keyValueStore)
+        #expect(reconstructedHistory.lastConfirmedAppearance == nil)
+        _ = lease
+    }
+}
+
+private struct FormattingScenario {
+    let mode: PromoCoordinationMode
+    let owner: PromoQueueLeaseOwnerSnapshot?
+    let expectedMode: String
+    let expectedOwner: String
+    let expectedAppearance: String
+}
+
+@MainActor
+private final class DiagnosticsProviderSpy: PromoCoordinationDiagnosticsProviding {
+    var snapshot: PromoCoordinationDiagnosticSnapshot
+    private(set) var snapshotReadCount = 0
+
+    init(snapshot: PromoCoordinationDiagnosticSnapshot) {
+        self.snapshot = snapshot
+    }
+
+    var diagnosticSnapshot: PromoCoordinationDiagnosticSnapshot {
+        snapshotReadCount += 1
+        return snapshot
+    }
+}

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationDebugViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/ModalPromptCoordinationDebugViewModelTests.swift
@@ -98,6 +98,10 @@ struct ModalPromptCoordinationDebugViewModelTests {
             cooldownResetter: nil,
             dateFormatting: { "Date \(Int($0.timeIntervalSince1970))" }
         )
+        #expect(viewModel.lastConfirmedModalAppearanceDescription == "Date 1000")
+        #expect(viewModel.lastConfirmedRemoteMessageAppearanceDescription == "Date 2000")
+        #expect(viewModel.nextRemoteMessageEligibilityDescription == "Date 3000")
+        #expect(viewModel.nextModalEligibilityDescription == "Date 4000")
 
         for scenario in scenarios {
             provider.snapshot = PromoCoordinationDiagnosticSnapshot(
@@ -110,14 +114,8 @@ struct ModalPromptCoordinationDebugViewModelTests {
             #expect(viewModel.modeDescription == scenario.expectedMode)
             #expect(viewModel.ownerDescription == scenario.expectedOwner)
             #expect(viewModel.remoteMessageAppearanceDescription == scenario.expectedAppearance)
-            #expect(viewModel.lastConfirmedModalAppearanceDescription == "Date 1000")
-            #expect(viewModel.lastConfirmedRemoteMessageAppearanceDescription == "Date 2000")
-            #expect(viewModel.nextRemoteMessageEligibilityDescription == "Date 3000")
-            #expect(viewModel.nextModalEligibilityDescription == "Date 4000")
-            #expect(viewModel.snapshot?.owner == scenario.owner)
         }
 
-        #expect(provider.snapshotReadCount == scenarios.count + 1)
         _ = remoteMessageLease
     }
 
@@ -160,7 +158,6 @@ struct ModalPromptCoordinationDebugViewModelTests {
         #expect(viewModel.lastConfirmedRemoteMessageAppearanceDescription == "Never")
         #expect(viewModel.nextRemoteMessageEligibilityDescription == "No cooldown boundary")
         #expect(viewModel.nextModalEligibilityDescription == "No cooldown boundary")
-        #expect(viewModel.snapshot?.owner == ownerBeforeReset)
         #expect(viewModel.remoteMessageAppearanceDescription == "Yes")
         #expect(service.diagnosticSnapshot.owner == ownerBeforeReset)
 
@@ -181,14 +178,12 @@ private struct FormattingScenario {
 @MainActor
 private final class DiagnosticsProviderSpy: PromoCoordinationDiagnosticsProviding {
     var snapshot: PromoCoordinationDiagnosticSnapshot
-    private(set) var snapshotReadCount = 0
 
     init(snapshot: PromoCoordinationDiagnosticSnapshot) {
         self.snapshot = snapshot
     }
 
     var diagnosticSnapshot: PromoCoordinationDiagnosticSnapshot {
-        snapshotReadCount += 1
-        return snapshot
+        snapshot
     }
 }

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
@@ -66,7 +66,7 @@ struct PromoQueueLeaseArbiterTests {
     }
 
     @available(iOS 16, *)
-    @Test("A deallocated token relinquishes ownership", .timeLimit(.minutes(1)))
+    @Test("Passive snapshots report a dropped token as ownerless and acquisition recovers", .timeLimit(.minutes(1)))
     func weakTokenRecovery() throws {
         let arbiter = PromoQueueLeaseArbiter()
 
@@ -82,6 +82,8 @@ struct PromoQueueLeaseArbiterTests {
             _ = droppedLease
         }
 
+        // Repeated reads remain observational; the subsequent acquisition path performs stale-record recovery.
+        #expect(arbiter.snapshot.owner == nil)
         #expect(arbiter.snapshot.owner == nil)
         let modalLease = try acquiredModalLease(from: arbiter.acquireModalLease())
         #expect(arbiter.snapshot.owner == .modal(ownershipIdentity: modalLease.ownershipIdentity))

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/PromoQueueLeaseArbiterTests.swift
@@ -82,8 +82,7 @@ struct PromoQueueLeaseArbiterTests {
             _ = droppedLease
         }
 
-        // Repeated reads remain observational; the subsequent acquisition path performs stale-record recovery.
-        #expect(arbiter.snapshot.owner == nil)
+        // The passive read remains observational; the subsequent acquisition path performs stale-record recovery.
         #expect(arbiter.snapshot.owner == nil)
         let modalLease = try acquiredModalLease(from: arbiter.acquireModalLease())
         #expect(arbiter.snapshot.owner == .modal(ownershipIdentity: modalLease.ownershipIdentity))

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/PromptCoordinationDebugViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/PromptCoordinationDebugViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-//  ModalPromptCoordinationDebugViewModelTests.swift
+//  PromptCoordinationDebugViewModelTests.swift
 //  DuckDuckGoTests
 //
 //  Copyright © 2026 DuckDuckGo. All rights reserved.
@@ -23,8 +23,8 @@ import Testing
 @testable import DuckDuckGo
 
 @MainActor
-@Suite("Modal Prompt Coordination - Debug View Model")
-struct ModalPromptCoordinationDebugViewModelTests {
+@Suite("Prompt Coordination - Debug View Model")
+struct PromptCoordinationDebugViewModelTests {
 
     @available(iOS 16, *)
     @Test("Refresh passively formats production diagnostics", .timeLimit(.minutes(1)))
@@ -93,7 +93,7 @@ struct ModalPromptCoordinationDebugViewModelTests {
                 cooldown: cooldown
             )
         )
-        let viewModel = ModalPromptCoordinationDebugViewModel(
+        let viewModel = PromptCoordinationDebugViewModel(
             diagnosticsProvider: provider,
             cooldownResetter: nil,
             dateFormatting: { "Date \(Int($0.timeIntervalSince1970))" }
@@ -143,7 +143,7 @@ struct ModalPromptCoordinationDebugViewModelTests {
         let lease = try #require(service.tryAcquireRemoteMessageLease(for: "message"))
         #expect(lease.markShown())
         let ownerBeforeReset = try #require(service.diagnosticSnapshot.owner)
-        let viewModel = ModalPromptCoordinationDebugViewModel(
+        let viewModel = PromptCoordinationDebugViewModel(
             diagnosticsProvider: service,
             cooldownResetter: service,
             dateFormatting: { "Date \(Int($0.timeIntervalSince1970))" }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/PromptCooldownMocks.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/ModalPromptCoordination/PromptCooldownMocks.swift
@@ -56,6 +56,8 @@ final class MockPromoQueueCooldownPolicy: PromoQueueCooldownPolicying {
     private(set) var remoteMessageAdmissionCallCount = 0
     private(set) var modalAdmissionCallCount = 0
     private(set) var recordConfirmedRemoteMessageAppearanceCallCount = 0
+    private(set) var resetModalCooldownCallCount = 0
+    private(set) var resetRemoteMessageCooldownCallCount = 0
 
     func evaluateRemoteMessageAdmission() -> PromoQueueCooldownDecision {
         remoteMessageAdmissionCallCount += 1
@@ -69,6 +71,14 @@ final class MockPromoQueueCooldownPolicy: PromoQueueCooldownPolicying {
 
     func recordConfirmedRemoteMessageAppearance() {
         recordConfirmedRemoteMessageAppearanceCallCount += 1
+    }
+
+    func resetModalCooldown() {
+        resetModalCooldownCallCount += 1
+    }
+
+    func resetRemoteMessageCooldown() {
+        resetRemoteMessageCooldownCallCount += 1
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217517616514377
Tech Design URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1216624996708289?focus=true
CC: N/A

### Description
- Extend the internal modal-prompt coordination screen with passive promo ownership, appearance-history, and cooldown diagnostics.
- Add explicit modal and remote-message cooldown resets that reuse the app’s production coordination state.

### Testing Steps

<details>
<summary>Common coordinated-mode setup</summary>

1. Complete onboarding.
2. Open **Settings → Debug → All debug options → Feature Flags**.
3. Enable **Internal User** and leave it enabled while using fixture URLs.
4. Set `promoPresentationCoordination` explicitly **ON**.
5. Force-quit and relaunch the app. The flag is latched at process startup.
6. Open **Debug → All debug options → Prompt Coordination**.
7. Confirm **Mode** says `Coordinated`.
8. Before each coordinated scenario:
   - Tap **Reset Modal Cooldown**.
   - Tap **Reset RMF Cooldown**.
   - Open **Remote Messaging** and tap **Delete All**.

</details>

<details>
<summary>Scenario 1: Feature-off legacy parity</summary>

**Proves:** Existing RMF and address-bar behavior remains unchanged when Promo Queue coordination is disabled.

Use this URL:

[Verified NTP RMF fixture](https://raw.githubusercontent.com/duckduckgo/apple-browsers/2cedeeb5add3fd62ee4a438ce775fded8442d149/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Resources/remote-messaging-config-metrics.json)

1. Open **Settings → Debug → All debug options → Feature Flags**.
2. Leave **Internal User** enabled.
3. Set `promoPresentationCoordination` explicitly **OFF**.
4. Force-quit and relaunch the app.
5. Open **Prompt Coordination** and confirm:
   - **Mode:** `Legacy`
   - **Owner:** `None`
6. Open **Remote Messaging** and tap **Delete All**.
7. Open **Configuration URLs → Remote Message Framework Config**.
8. Paste the metrics fixture URL and tap **Override**.
9. Confirm **Remote Messaging** contains:

   `ID: 1 | not shown | scheduled`

10. Close Settings and open a normal new tab.
11. Confirm the RMF card appears with title `title` and description `description`.
12. Focus the address bar, type a query, and activate a suggestion.
13. Repeat the basic focus/suggestion action through any available alternate address-bar host, such as the iPad/legacy suggestion tray or unified-input favorites.
14. Return to **Remote Messaging** and confirm:

    `ID: 1 | shown | scheduled`

15. Open **Prompt Coordination** and tap **Refresh**.

Expected result:

- The RMF renders normally.
- **Mode** remains `Legacy`.
- **Owner** remains `None`.

</details>

<details>
<summary>Scenario 2: RMF owner survives backgrounding and blocks a real modal</summary>

**Proves:** RMF publication and appearance, background persistence, and live RMF-owner exclusion of a production-routed launch modal.

Use this URL:

[Verified NTP RMF fixture](https://raw.githubusercontent.com/duckduckgo/apple-browsers/2cedeeb5add3fd62ee4a438ce775fded8442d149/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Resources/remote-messaging-config-metrics.json)

Preconditions:

- Use the coordinated-mode common setup.
- Duck.ai is enabled.
- Onboarding is complete and has not recorded an incompatible Private Search choice.

1. Open **Feature Flags**.
2. Confirm `promoPresentationCoordination` is **ON**.
3. Enable `showAIChatAddressBarChoiceScreen`.
4. Force-quit and relaunch the app.
5. Open **Prompt Coordination** and confirm **Mode** is `Coordinated`.
6. Navigate the current tab to a normal webpage so there is no active NTP.
7. Open **Duck.ai Toggle Prompt** and tap:
   - **Set Install Cooldown Elapsed**
   - **Reset Picker State (Selection + Shown Flag)**
8. Open **Prompt Coordination** and tap:
   - **Reset Modal Cooldown**
   - **Reset RMF Cooldown**
9. Open **Remote Messaging** and tap **Delete All**.
10. Override the RMF configuration URL with the metrics fixture.
11. Confirm:

    `ID: 1 | not shown | scheduled`

12. Close Settings. You should return to the webpage without an RMF.
13. Open a new tab.
14. Confirm the RMF card appears.
15. Open **Prompt Coordination**, tap **Refresh**, and confirm:
    - **Owner:** begins with `RMF (message ID: 1`
    - **RMF Appearance Confirmed:** `Yes`
    - **Last RMF Appearance:** contains a timestamp
16. Close Settings and return to the NTP.
17. Fully background the app, then foreground it.
18. Confirm the RMF is still visible.
19. Reopen **Prompt Coordination** and tap **Refresh**.
20. Inspect the relevant Promo Queue logs.

Expected result:

- The same RMF card remains visible; it is not removed or replaced.
- **Owner** remains RMF for message ID `1`.
- **RMF Appearance Confirmed** remains `Yes`.
- **Last RMF Appearance** remains populated.
- Logs classify the rejected modal attempt as a live-owner rejection

The retained RMF owner and owner-rejection log are the decisive evidence. Do not classify the result only from the 24-hour RMF-to-modal cooldown.

</details>

<details>
<summary>Scenario 3: Show a real coordinated launch modal</summary>

**Proves:** A genuine launch-promo provider can acquire modal ownership and present through `PromoCoordinationService`.

Use this URL:

[Verified What’s New modal fixture](https://raw.githubusercontent.com/duckduckgo/apple-browsers/6b117715492a8ca0bdb3135eb65965fa3e0b6f22/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/Resources/remote-messaging-config-cards-list-items.json)

For reliable provider isolation, use a fresh app installation or equivalent clean app-scoped state, then complete onboarding.

1. Repeat the coordinated-mode common setup.
2. Open **Prompt Coordination** and confirm **Mode** is `Coordinated`.
3. Tap:
   - **Reset Modal Cooldown**
   - **Reset RMF Cooldown**
4. Open **Remote Messaging** and tap **Delete All**.
5. Open **Configuration URLs → Remote Message Framework Config**.
6. Paste the What’s New fixture URL and tap **Override**.
7. Confirm **Remote Messaging** contains:

   `ID: whats_new_v1 | not shown | scheduled`

8. Close Settings completely.
9. Fully background the app, then foreground it to run the normal launch-modal checkpoint.
10. Confirm the **What’s New** sheet appears.
11. Dismiss it using **Got It**.
12. Open **Prompt Coordination** and tap **Refresh**.
13. Return to **Remote Messaging**.

Expected result:

- The genuine What’s New sheet appears.
- It is presented through the coordinated provider path, not through a direct debug presentation action.
- **Last Modal Appearance** contains a timestamp.
- The record eventually becomes:

  `ID: whats_new_v1 | shown | dismissed`

</details>

### Impact
**Low**

#### What could go wrong?
A diagnostic refresh or reset could mutate ownership or clear the wrong cooldown → mitigated by passive snapshots, separate authoritative reset paths, and focused ownership-preservation tests.

### Quality Considerations
- 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to internal debug UI and test-only reset paths on promo coordination; production presentation logic is read-only for diagnostics, with resets delegated to existing cooldown policy APIs.
> 
> **Overview**
> **Adds internal diagnostics and debug-only cooldown controls** for the coordinated promo queue, wired through `PromoCoordinationService` rather than separate debug stores.
> 
> `PromoCoordinationService` now exposes a **passive diagnostic snapshot** (coordination mode, current lease owner, cooldown boundaries) via `PromoCoordinationDiagnosticsProviding`, plus **authoritative modal and RMF cooldown resets** via `PromoCoordinationCooldownResetting` that call `PromoQueueCooldownPolicy`. Debug dependencies (`DebugScreen`, settings launch paths, `MainViewController`) inject the live service as both provider and resetter.
> 
> The old modal-only cooldown debug screen is replaced by **Prompt Coordination** (`PromptCoordinationDebugMenu.swift`), showing owner state, appearance history, eligibility dates, refresh, and separate modal/RMF reset buttons. **What’s New** and **CPM** debug flows now read cooldown from diagnostics and reset through the service; the global **Reset Prompts Cooldown Period** action uses `resetModalCooldown()` only.
> 
> `PromoQueueLeaseArbiter.snapshot` no longer prunes deallocated tokens on read—passive snapshots stay observational; acquisition paths still recover stale ownership (test updated). New `PromptCoordinationDebugViewModelTests` cover formatting and RMF reset without changing ownership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcb9e49d1c64ac7a474acdd6b682392416ce1ad1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->