### PR TITLE
[iOS][Onboarding Download Reason Experiment] Pixel Implementation

### DIFF
--- a/SharedPackages/Onboarding/Sources/Onboarding/Flow/OnboardingDownloadReason.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Flow/OnboardingDownloadReason.swift
@@ -43,3 +43,16 @@ public enum OnboardingDownloadReason: String, Equatable, CaseIterable {
     /// The user downloaded the app to block ads and trackers.
     case blockAds
 }
+
+public extension OnboardingDownloadReason {
+    /// The token used to identify the reason in pixel names and parameters
+    /// (e.g. the download-choice value and the per-reason experiment metrics).
+    var pixelToken: String {
+        switch self {
+        case .browserPrivately: "search"
+        case .privateAIChat: "ai-chat"
+        case .noAI: "no-ai"
+        case .blockAds: "ad-blocking"
+        }
+    }
+}

--- a/SharedPackages/Onboarding/Sources/Onboarding/Flow/OnboardingDownloadReason.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Flow/OnboardingDownloadReason.swift
@@ -43,16 +43,3 @@ public enum OnboardingDownloadReason: String, Equatable, CaseIterable {
     /// The user downloaded the app to block ads and trackers.
     case blockAds
 }
-
-public extension OnboardingDownloadReason {
-    /// The token used to identify the reason in pixel names and parameters
-    /// (e.g. the download-choice value and the per-reason experiment metrics).
-    var pixelToken: String {
-        switch self {
-        case .browserPrivately: "search"
-        case .privateAIChat: "ai-chat"
-        case .noAI: "no-ai"
-        case .blockAds: "ad-blocking"
-        }
-    }
-}

--- a/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
@@ -36,12 +36,6 @@ public extension OnboardingSharedPixelHandling {
         fire(event, source: nil, flow: nil, variant: nil)
     }
     #endif
-
-    func fire(_ event: OnboardingSharedPixelEvent,
-              source: OnboardingPixelParameter.Source?,
-              flow: OnboardingPixelParameter.Flow?) {
-        fire(event, source: source, flow: flow, variant: nil)
-    }
 }
 
 public enum OnboardingPixelParameter {

--- a/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
@@ -211,6 +211,7 @@ public enum OnboardingSharedPixelEvent: PixelKit.Event, Equatable {
     case trackersBlocked(EngagementEvent)
     case fireButton(EngagementEvent)
     case end(EngagementEvent)
+    case endTryDuckAI(EngagementEvent) // iOS only — the Try Duck.ai end-of-journey dialog
     case subscriptionPromo(EngagementEvent) // iOS only
 
     // Segmented onboarding (download-reason) events — iOS only
@@ -409,6 +410,7 @@ private extension OnboardingSharedPixelEvent {
         case .trackersBlocked: return "trackers-blocked"
         case .fireButton: return "fire-button"
         case .end: return "end"
+        case .endTryDuckAI: return "end-try-duckai"
         case .subscriptionPromo: return "subscription-promo"
         case .downloadChoice: return "download-choice"
         case .preferencesSerp: return "preferences_serp"
@@ -441,6 +443,7 @@ private extension OnboardingSharedPixelEvent {
                 .trackersBlocked(let event),
                 .fireButton(let event),
                 .end(let event),
+                .endTryDuckAI(let event),
                 .subscriptionPromo(let event):
             switch event {
             case .shown:
@@ -559,6 +562,7 @@ private extension OnboardingSharedPixelEvent {
                 .trackersBlocked(let event),
                 .fireButton(let event),
                 .end(let event),
+                .endTryDuckAI(let event),
                 .subscriptionPromo(let event):
             switch event {
             case .shown, .confirmed:

--- a/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
@@ -213,6 +213,15 @@ public enum OnboardingSharedPixelEvent: PixelKit.Event, Equatable {
     case end(EngagementEvent)
     case subscriptionPromo(EngagementEvent) // iOS only
 
+    // Segmented onboarding (download-reason) events — iOS only
+    case downloadChoice(DownloadChoiceEvent)
+    case preferencesSerp(SerpEngagementEvent)
+    case preferencesAIModel(AIModelEvent)
+    case preferencesAIToggleMode(AIToggleModeEvent)
+    case preferencesAISearch(AISearchEngagementEvent)
+    case preferencesDuckAI(DuckAIEvent)
+    case preferencesYoutube(YoutubeEngagementEvent)
+
     public enum EngagementEvent: Equatable {
         public enum Value: String {
             case engage
@@ -294,6 +303,60 @@ public enum OnboardingSharedPixelEvent: PixelKit.Event, Equatable {
         case shown
         case clicked(Value)
     }
+
+    /// The download-reason selection screen. `Value` records the reason the user chose.
+    public enum DownloadChoiceEvent: Equatable {
+        public enum Value: String {
+            case search
+            case aiChat = "ai-chat"
+            case noAI = "no-ai"
+            case adBlocking = "ad-blocking"
+        }
+
+        case shown
+        case clicked(Value)
+    }
+
+    /// The SERP preferences screen.
+    public enum SerpEngagementEvent: Equatable {
+        case shown
+        case clicked(recentlyVisitedSitesEnabled: Bool, safeSearchEnabled: Bool)
+    }
+
+    /// The AI search settings screen.
+    public enum AISearchEngagementEvent: Equatable {
+        case shown
+        case clicked(searchAssistEnabled: Bool, aiGeneratedImagesEnabled: Bool)
+    }
+
+    /// The YouTube (Duck Player) preferences screen.
+    public enum YoutubeEngagementEvent: Equatable {
+        case shown
+        case clicked(youTubeAdBlockingEnabled: Bool, duckPlayerEnabled: Bool)
+    }
+
+    /// The AI model picker. The selected model as a coarse label (e.g. "claude", "chatgpt")
+    public enum AIModelEvent: Equatable {
+        case shown
+        case clicked(model: String)
+    }
+
+    /// The Search/AI address-bar toggle-mode screen.
+    public enum AIToggleModeEvent: Equatable {
+        case shown
+        case clicked(enabled: Bool)
+    }
+
+    /// The "Keep Duck.ai on / Turn Duck.ai off" screen.
+    public enum DuckAIEvent: Equatable {
+        public enum Value: String {
+            case on
+            case off
+        }
+
+        case shown
+        case clicked(Value)
+    }
 }
 
 public extension OnboardingSharedPixelEvent {
@@ -309,6 +372,8 @@ public extension OnboardingSharedPixelEvent {
         if let value {
             parameters["value"] = value
         }
+
+        parameters.merge(extraParameters) { _, new in new }
 
         return parameters
     }
@@ -345,6 +410,13 @@ private extension OnboardingSharedPixelEvent {
         case .fireButton: return "fire-button"
         case .end: return "end"
         case .subscriptionPromo: return "subscription-promo"
+        case .downloadChoice: return "download-choice"
+        case .preferencesSerp: return "preferences_serp"
+        case .preferencesAIModel: return "preferences_ai-model"
+        case .preferencesAIToggleMode: return "preferences_ai-toggle-mode"
+        case .preferencesAISearch: return "preferences_ai-search"
+        case .preferencesDuckAI: return "preferences_duck-ai"
+        case .preferencesYoutube: return "preferences_youtube"
         }
     }
 
@@ -415,6 +487,55 @@ private extension OnboardingSharedPixelEvent {
                 return ParameterValues.clicked
             }
         case .searchChatToggle(let event):
+            switch event {
+            case .shown:
+                return ParameterValues.shown
+            case .clicked:
+                return ParameterValues.clicked
+            }
+        case .downloadChoice(let event):
+            switch event {
+            case .shown:
+                return ParameterValues.shown
+            case .clicked:
+                return ParameterValues.clicked
+            }
+        case .preferencesSerp(let event):
+            switch event {
+            case .shown:
+                return ParameterValues.shown
+            case .clicked:
+                return ParameterValues.clicked
+            }
+        case .preferencesAISearch(let event):
+            switch event {
+            case .shown:
+                return ParameterValues.shown
+            case .clicked:
+                return ParameterValues.clicked
+            }
+        case .preferencesYoutube(let event):
+            switch event {
+            case .shown:
+                return ParameterValues.shown
+            case .clicked:
+                return ParameterValues.clicked
+            }
+        case .preferencesAIModel(let event):
+            switch event {
+            case .shown:
+                return ParameterValues.shown
+            case .clicked:
+                return ParameterValues.clicked
+            }
+        case .preferencesAIToggleMode(let event):
+            switch event {
+            case .shown:
+                return ParameterValues.shown
+            case .clicked:
+                return ParameterValues.clicked
+            }
+        case .preferencesDuckAI(let event):
             switch event {
             case .shown:
                 return ParameterValues.shown
@@ -492,6 +613,73 @@ private extension OnboardingSharedPixelEvent {
             case .clicked(let value):
                 return value.rawValue
             }
+        case .downloadChoice(let event):
+            switch event {
+            case .shown:
+                return nil
+            case .clicked(let value):
+                return value.rawValue
+            }
+        case .preferencesSerp(let event):
+            switch event {
+            case .shown, .clicked:
+                // Toggle states are emitted via `extraParameters`, not as `value`.
+                return nil
+            }
+        case .preferencesAISearch(let event):
+            switch event {
+            case .shown, .clicked:
+                return nil
+            }
+        case .preferencesYoutube(let event):
+            switch event {
+            case .shown, .clicked:
+                return nil
+            }
+        case .preferencesAIModel(let event):
+            switch event {
+            case .shown:
+                return nil
+            case .clicked(let model):
+                return model
+            }
+        case .preferencesAIToggleMode(let event):
+            switch event {
+            case .shown:
+                return nil
+            case .clicked(let enabled):
+                return String(enabled)
+            }
+        case .preferencesDuckAI(let event):
+            switch event {
+            case .shown:
+                return nil
+            case .clicked(let value):
+                return value.rawValue
+            }
+        }
+    }
+
+    // Screen-specific toggle states emitted as their own pixel parameters (in addition to `event`/`value`).
+    var extraParameters: [String: String] {
+        switch self {
+        case .preferencesSerp(.clicked(let recentlyVisitedSitesEnabled, let safeSearchEnabled)):
+            return [
+                "recently_visited_sites_enabled": String(recentlyVisitedSitesEnabled),
+                "safe_search_enabled": String(safeSearchEnabled)
+            ]
+        case .preferencesAISearch(.clicked(let searchAssistEnabled, let aiGeneratedImagesEnabled)):
+            return [
+                "search_assist_enabled": String(searchAssistEnabled),
+                "ai_generated_images_enabled": String(aiGeneratedImagesEnabled)
+            ]
+        case .preferencesYoutube(.clicked(let youTubeAdBlockingEnabled, let duckPlayerEnabled)):
+            return [
+                "youtube_ad_blocking_enabled": String(youTubeAdBlockingEnabled),
+                "duck_player_enabled": String(duckPlayerEnabled)
+            ]
+        default:
+            return [:]
         }
     }
 }

--- a/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
@@ -55,13 +55,31 @@ public enum OnboardingPixelParameter {
     public enum Flow: String {
         case `default` = "default"
         case duckAI = "duckai"
-        case tailoredByDownloadReason = "tailored_download_reason"
+        case tailoredByDownloadReason = "tailored_by_download_reason"
     }
 
     /// Pixel parameter for the variant of the onboarding flow the user enters after a branching step during onboarding.
     public enum Variant: String {
         case duckAISearch = "search_plus_duckai-search"
         case duckAIChat = "search_plus_duckai-chat"
+        // Records the download reason the user selected, passed to every pixel after the choice for internal cohort segmentation.
+        case downloadReasonSearch = "download_reason_search"
+        case downloadReasonAIChat = "download_reason_ai-chat"
+        case downloadReasonNoAI = "download_reason_no-ai"
+        case downloadReasonAdBlocking = "download_reason_ad-blocking"
+    }
+}
+
+public extension OnboardingPixelParameter.Variant {
+    /// Maps the domain download reason to its pixel variant, so the selected reason can be
+    /// recorded on the segmented-onboarding pixels for cohort segmentation.
+    init(_ reason: OnboardingDownloadReason) {
+        switch reason {
+        case .browserPrivately: self = .downloadReasonSearch
+        case .privateAIChat:    self = .downloadReasonAIChat
+        case .noAI:             self = .downloadReasonNoAI
+        case .blockAds:         self = .downloadReasonAdBlocking
+        }
     }
 }
 

--- a/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
+++ b/SharedPackages/Onboarding/Sources/Onboarding/Pixels/OnboardingSharedPixels.swift
@@ -344,7 +344,7 @@ public enum OnboardingSharedPixelEvent: PixelKit.Event, Equatable {
     /// The Search/AI address-bar toggle-mode screen.
     public enum AIToggleModeEvent: Equatable {
         case shown
-        case clicked(enabled: Bool)
+        case clicked(openNewTabsWithAIChat: Bool)
     }
 
     /// The "Keep Duck.ai on / Turn Duck.ai off" screen.
@@ -647,8 +647,8 @@ private extension OnboardingSharedPixelEvent {
             switch event {
             case .shown:
                 return nil
-            case .clicked(let enabled):
-                return String(enabled)
+            case .clicked(let openNewTabsWithAIChat):
+                return String(openNewTabsWithAIChat)
             }
         case .preferencesDuckAI(let event):
             switch event {

--- a/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSharedPixelTests.swift
+++ b/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSharedPixelTests.swift
@@ -73,6 +73,63 @@ final class OnboardingSharedPixelTests: XCTestCase {
         XCTAssertEqual(event.additionalParameters?["variant"], "search_plus_duckai-search")
     }
 
+    func testWhenFlowIsTailoredByDownloadReasonThenUsesTailoredByDownloadReasonValue() throws {
+        // GIVEN
+        let pixelFiring = PixelKitMock()
+        let pixelHandler = makeHandler(pixelFiring: pixelFiring)
+
+        // WHEN
+        pixelHandler.fire(.welcome(.shown),
+                          source: .default,
+                          flow: .tailoredByDownloadReason,
+                          variant: nil)
+
+        // THEN
+        let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+        XCTAssertEqual(event.additionalParameters?["flow"], "tailored_by_download_reason")
+    }
+
+    func testWhenVariantIsDownloadReasonThenUsesDownloadReasonValue() throws {
+        // GIVEN
+        let expectedValues: [OnboardingPixelParameter.Variant: String] = [
+            .downloadReasonSearch: "download_reason_search",
+            .downloadReasonAIChat: "download_reason_ai-chat",
+            .downloadReasonNoAI: "download_reason_no-ai",
+            .downloadReasonAdBlocking: "download_reason_ad-blocking"
+        ]
+
+        // WHEN
+        for (variant, expectedValue) in expectedValues {
+            let pixelFiring = PixelKitMock()
+            let pixelHandler = makeHandler(pixelFiring: pixelFiring)
+
+            pixelHandler.fire(.welcome(.shown),
+                              source: .default,
+                              flow: .tailoredByDownloadReason,
+                              variant: variant)
+
+            // THEN
+            let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+            XCTAssertEqual(event.additionalParameters?["variant"], expectedValue, "Failed for variant \(variant)")
+        }
+    }
+
+    func testWhenVariantInitFromDownloadReasonThenMapsToExpectedVariant() {
+        // GIVEN
+        let expectedMappings: [OnboardingDownloadReason: OnboardingPixelParameter.Variant] = [
+            .browserPrivately: .downloadReasonSearch,
+            .privateAIChat: .downloadReasonAIChat,
+            .noAI: .downloadReasonNoAI,
+            .blockAds: .downloadReasonAdBlocking
+        ]
+
+        // WHEN
+        for (reason, expectedVariant) in expectedMappings {
+            // THEN
+            XCTAssertEqual(OnboardingPixelParameter.Variant(reason), expectedVariant, "Failed for reason \(reason)")
+        }
+    }
+
     func testWhenFiringPixelEventThenFrequencyIsUniqueByNameAndParameters() throws {
         let pixelFiring = PixelKitMock()
         let pixelHandler = makeHandler(pixelFiring: pixelFiring)

--- a/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSharedPixelTests.swift
+++ b/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSharedPixelTests.swift
@@ -495,7 +495,7 @@ final class OnboardingSharedPixelTests: XCTestCase {
             let pixelHandler = makeHandler(pixelFiring: pixelFiring)
 
             // WHEN
-            pixelHandler.fire(.preferencesAIToggleMode(.clicked(enabled: enabled)))
+            pixelHandler.fire(.preferencesAIToggleMode(.clicked(openNewTabsWithAIChat: enabled)))
 
             // THEN
             let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)

--- a/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSharedPixelTests.swift
+++ b/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSharedPixelTests.swift
@@ -524,6 +524,29 @@ final class OnboardingSharedPixelTests: XCTestCase {
             XCTAssertEqual(event.pixel.parameters?["value"], expectedValue, "Failed for \(value)")
         }
     }
+
+    func testWhenEndTryDuckAIEventThenUsesExpectedNameAndValue() throws {
+        // GIVEN
+        let cases: [(OnboardingSharedPixelEvent, String, String?)] = [
+            (.endTryDuckAI(.shown), "shown", nil),
+            (.endTryDuckAI(.clicked(.engage)), "clicked", "engage"),
+            (.endTryDuckAI(.clicked(.dismiss)), "clicked", "dismiss")
+        ]
+
+        for (pixelEvent, expectedEvent, expectedValue) in cases {
+            let pixelFiring = PixelKitMock()
+            let pixelHandler = makeHandler(pixelFiring: pixelFiring)
+
+            // WHEN
+            pixelHandler.fire(pixelEvent)
+
+            // THEN
+            let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+            XCTAssertEqual(event.pixel.name, "onboarding_end-try-duckai")
+            XCTAssertEqual(event.pixel.parameters?["event"], expectedEvent, "Failed for \(pixelEvent)")
+            XCTAssertEqual(event.pixel.parameters?["value"], expectedValue, "Failed for \(pixelEvent)")
+        }
+    }
 }
 
 private extension OnboardingSharedPixelHandling {

--- a/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSharedPixelTests.swift
+++ b/SharedPackages/Onboarding/Sources/OnboardingTests/OnboardingSharedPixelTests.swift
@@ -368,6 +368,162 @@ final class OnboardingSharedPixelTests: XCTestCase {
         let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)
         XCTAssertEqual(event.pixel.parameters?["value"], "bottom")
     }
+
+    // MARK: - Segmented onboarding (download-reason) events
+
+    func testWhenSegmentedOnboardingImpressionThenUsesExpectedNameAndNoValue() throws {
+        // GIVEN
+        let cases: [(OnboardingSharedPixelEvent, String)] = [
+            (.downloadChoice(.shown), "onboarding_download-choice"),
+            (.preferencesSerp(.shown), "onboarding_preferences_serp"),
+            (.preferencesAIModel(.shown), "onboarding_preferences_ai-model"),
+            (.preferencesAIToggleMode(.shown), "onboarding_preferences_ai-toggle-mode"),
+            (.preferencesAISearch(.shown), "onboarding_preferences_ai-search"),
+            (.preferencesDuckAI(.shown), "onboarding_preferences_duck-ai"),
+            (.preferencesYoutube(.shown), "onboarding_preferences_youtube")
+        ]
+
+        for (pixelEvent, expectedName) in cases {
+            let pixelFiring = PixelKitMock()
+            let pixelHandler = makeHandler(pixelFiring: pixelFiring)
+
+            // WHEN
+            pixelHandler.fire(pixelEvent)
+
+            // THEN
+            let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+            XCTAssertEqual(event.pixel.name, expectedName, "Failed for \(expectedName)")
+            XCTAssertEqual(event.pixel.parameters?["event"], "shown", "Failed for \(expectedName)")
+            XCTAssertNil(event.pixel.parameters?["value"], "Failed for \(expectedName)")
+        }
+    }
+
+    func testWhenDownloadChoiceClickedThenUsesReasonValue() throws {
+        // GIVEN
+        let expectedValues: [OnboardingSharedPixelEvent.DownloadChoiceEvent.Value: String] = [
+            .search: "search",
+            .aiChat: "ai-chat",
+            .noAI: "no-ai",
+            .adBlocking: "ad-blocking"
+        ]
+
+        for (value, expectedValue) in expectedValues {
+            let pixelFiring = PixelKitMock()
+            let pixelHandler = makeHandler(pixelFiring: pixelFiring)
+
+            // WHEN
+            pixelHandler.fire(.downloadChoice(.clicked(value)))
+
+            // THEN
+            let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+            XCTAssertEqual(event.pixel.name, "onboarding_download-choice")
+            XCTAssertEqual(event.pixel.parameters?["event"], "clicked")
+            XCTAssertEqual(event.pixel.parameters?["value"], expectedValue, "Failed for \(value)")
+        }
+    }
+
+    func testWhenPreferencesSerpClickedThenSendsToggleParametersAndNoValue() throws {
+        // GIVEN
+        let pixelFiring = PixelKitMock()
+        let pixelHandler = makeHandler(pixelFiring: pixelFiring)
+
+        // WHEN
+        pixelHandler.fire(.preferencesSerp(.clicked(recentlyVisitedSitesEnabled: true, safeSearchEnabled: false)))
+
+        // THEN
+        let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+        XCTAssertEqual(event.pixel.name, "onboarding_preferences_serp")
+        XCTAssertEqual(event.pixel.parameters?["event"], "clicked")
+        XCTAssertNil(event.pixel.parameters?["value"])
+        XCTAssertEqual(event.pixel.parameters?["recently_visited_sites_enabled"], "true")
+        XCTAssertEqual(event.pixel.parameters?["safe_search_enabled"], "false")
+    }
+
+    func testWhenPreferencesAISearchClickedThenSendsToggleParametersAndNoValue() throws {
+        // GIVEN
+        let pixelFiring = PixelKitMock()
+        let pixelHandler = makeHandler(pixelFiring: pixelFiring)
+
+        // WHEN
+        pixelHandler.fire(.preferencesAISearch(.clicked(searchAssistEnabled: false, aiGeneratedImagesEnabled: true)))
+
+        // THEN
+        let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+        XCTAssertEqual(event.pixel.name, "onboarding_preferences_ai-search")
+        XCTAssertEqual(event.pixel.parameters?["event"], "clicked")
+        XCTAssertNil(event.pixel.parameters?["value"])
+        XCTAssertEqual(event.pixel.parameters?["search_assist_enabled"], "false")
+        XCTAssertEqual(event.pixel.parameters?["ai_generated_images_enabled"], "true")
+    }
+
+    func testWhenPreferencesYoutubeClickedThenSendsToggleParametersAndNoValue() throws {
+        // GIVEN
+        let pixelFiring = PixelKitMock()
+        let pixelHandler = makeHandler(pixelFiring: pixelFiring)
+
+        // WHEN
+        pixelHandler.fire(.preferencesYoutube(.clicked(youTubeAdBlockingEnabled: true, duckPlayerEnabled: false)))
+
+        // THEN
+        let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+        XCTAssertEqual(event.pixel.name, "onboarding_preferences_youtube")
+        XCTAssertEqual(event.pixel.parameters?["event"], "clicked")
+        XCTAssertNil(event.pixel.parameters?["value"])
+        XCTAssertEqual(event.pixel.parameters?["youtube_ad_blocking_enabled"], "true")
+        XCTAssertEqual(event.pixel.parameters?["duck_player_enabled"], "false")
+    }
+
+    func testWhenPreferencesAIModelClickedThenUsesModelValue() throws {
+        // GIVEN
+        let pixelFiring = PixelKitMock()
+        let pixelHandler = makeHandler(pixelFiring: pixelFiring)
+
+        // WHEN
+        pixelHandler.fire(.preferencesAIModel(.clicked(model: "claude")))
+
+        // THEN
+        let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+        XCTAssertEqual(event.pixel.name, "onboarding_preferences_ai-model")
+        XCTAssertEqual(event.pixel.parameters?["event"], "clicked")
+        XCTAssertEqual(event.pixel.parameters?["value"], "claude")
+    }
+
+    func testWhenPreferencesAIToggleModeClickedThenUsesEnabledValue() throws {
+        for (enabled, expectedValue) in [(true, "true"), (false, "false")] {
+            // GIVEN
+            let pixelFiring = PixelKitMock()
+            let pixelHandler = makeHandler(pixelFiring: pixelFiring)
+
+            // WHEN
+            pixelHandler.fire(.preferencesAIToggleMode(.clicked(enabled: enabled)))
+
+            // THEN
+            let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+            XCTAssertEqual(event.pixel.name, "onboarding_preferences_ai-toggle-mode")
+            XCTAssertEqual(event.pixel.parameters?["value"], expectedValue, "Failed for \(enabled)")
+        }
+    }
+
+    func testWhenPreferencesDuckAIClickedThenUsesOnOffValue() throws {
+        // GIVEN
+        let expectedValues: [OnboardingSharedPixelEvent.DuckAIEvent.Value: String] = [
+            .on: "on",
+            .off: "off"
+        ]
+
+        for (value, expectedValue) in expectedValues {
+            let pixelFiring = PixelKitMock()
+            let pixelHandler = makeHandler(pixelFiring: pixelFiring)
+
+            // WHEN
+            pixelHandler.fire(.preferencesDuckAI(.clicked(value)))
+
+            // THEN
+            let event = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+            XCTAssertEqual(event.pixel.name, "onboarding_preferences_duck-ai")
+            XCTAssertEqual(event.pixel.parameters?["value"], expectedValue, "Failed for \(value)")
+        }
+    }
 }
 
 private extension OnboardingSharedPixelHandling {

--- a/iOS/Core/OnboardingDownloadReasonStore.swift
+++ b/iOS/Core/OnboardingDownloadReasonStore.swift
@@ -35,9 +35,9 @@ public enum OnboardingDownloadReasonStore {
 
     /// Maps a persisted `OnboardingDownloadReason` raw value to its pixel token.
     ///
-    /// Deliberately duplicates `OnboardingDownloadReason.pixelToken` so Core stays free of the
-    /// `Onboarding` module (importing it would invert the Core → Onboarding layering). Acceptable
-    /// because this is a temporary experiment; keep the two mappings in sync until it's removed.
+    /// Kept here (keyed on the raw value) so Core stays free of the `Onboarding` module — importing it
+    /// would invert the Core → Onboarding layering. Mirrors the download-reason tokens in the Onboarding
+    /// pixel layer (`DownloadChoiceEvent.Value`); keep them in sync while the experiment is live.
     private static func pixelToken(forRawValue rawValue: String) -> String? {
         switch rawValue {
         case "browserPrivately": "search"

--- a/iOS/Core/OnboardingDownloadReasonStore.swift
+++ b/iOS/Core/OnboardingDownloadReasonStore.swift
@@ -1,0 +1,50 @@
+//
+//  OnboardingDownloadReasonStore.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Core-visible reader for the onboarding download reason the user selected.
+///
+/// The value is persisted by the app layer (`DefaultTutorialSettings`) as the reason's raw value in
+/// `UserDefaults.app`. This store owns the storage key so the app (writer) and Core consumers (e.g.
+/// `StatisticsLoader`, which fires the per-reason retention experiment pixels) share a single source of
+/// truth without Core having to depend on the `Onboarding` module.
+public enum OnboardingDownloadReasonStore {
+    public static let key = "com.duckduckgo.tutorials.onboardingDownloadReason"
+
+    /// The pixel token for the selected download reason (e.g. `"search"`, `"ad-blocking"`), or `nil` if none.
+    public static func currentPixelToken(_ userDefaults: UserDefaults = .app) -> String? {
+        userDefaults.string(forKey: key).flatMap(pixelToken(forRawValue:))
+    }
+
+    /// Maps a persisted `OnboardingDownloadReason` raw value to its pixel token.
+    ///
+    /// Deliberately duplicates `OnboardingDownloadReason.pixelToken` so Core stays free of the
+    /// `Onboarding` module (importing it would invert the Core → Onboarding layering). Acceptable
+    /// because this is a temporary experiment; keep the two mappings in sync until it's removed.
+    private static func pixelToken(forRawValue rawValue: String) -> String? {
+        switch rawValue {
+        case "browserPrivately": "search"
+        case "privateAIChat": "ai-chat"
+        case "noAI": "no-ai"
+        case "blockAds": "ad-blocking"
+        default: nil
+        }
+    }
+}

--- a/iOS/Core/StatisticsLoader.swift
+++ b/iOS/Core/StatisticsLoader.swift
@@ -57,6 +57,7 @@ public class StatisticsLoader {
             PixelKit.fireSearchExperimentPixels()
             StatisticsLoader.fireLegacySearchRetentionExperimentPixels()
             StatisticsLoader.fireSearchTokenExperimentPixels(metric: "search")
+            StatisticsLoader.fireOnboardingByDownloadReasonSearchExperimentPixels()
          },
          fireNewAIPromptExperimentPixels: @escaping () -> Void = PixelKit.fireNewAIPromptExperimentPixels,
          fireOSDistributionPixel: @escaping (OSDistributionPixel.Metric) -> Void = PixelKit.fireOSDistributionPixel(metric:),
@@ -80,6 +81,21 @@ public class StatisticsLoader {
                 for: iOSBrowserConfigSubfeature.searchTokenExperimentV3.rawValue,
                 metric: metric,
                 conversionWindowDays: 1...4,
+                threshold: threshold
+            )
+        }
+    }
+
+    // Temporary: per-download-reason d5-7 search retention for the onboarding-by-download-reason experiment.
+    // No-op for users who haven't selected a reason or aren't enrolled (fireExperimentPixelIfThresholdReached guards both).
+    static func fireOnboardingByDownloadReasonSearchExperimentPixels() {
+        guard let pixelToken = OnboardingDownloadReasonStore.currentPixelToken() else { return }
+        let metric = "download_reason_search_retention_\(pixelToken)"
+        for threshold in [1, 4, 6, 11, 21, 30] {
+            PixelKit.fireExperimentPixelIfThresholdReached(
+                for: iOSBrowserConfigSubfeature.onboardingFlowByDownloadReasonExperiment.rawValue,
+                metric: metric,
+                conversionWindowDays: 5...7,
                 threshold: threshold
             )
         }

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1531,6 +1531,7 @@
 		9F3668762EAF0A7600AA8670 /* MockContextualOnboardingStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3668742EAF0A6900AA8670 /* MockContextualOnboardingStatusProvider.swift */; };
 		9F3668772EAF0A7600AA8670 /* MockContextualOnboardingStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3668742EAF0A6900AA8670 /* MockContextualOnboardingStatusProvider.swift */; };
 		9F3668782EAF0A7600AA8670 /* MockContextualOnboardingStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3668742EAF0A6900AA8670 /* MockContextualOnboardingStatusProvider.swift */; };
+		9F371806302DB47A0071F761 /* OnboardingDownloadReasonStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F371805302DB47A0071F761 /* OnboardingDownloadReasonStore.swift */; };
 		9F387DD82EA86CE3006861F8 /* PromptCooldownStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DD72EA86CE3006861F8 /* PromptCooldownStoreTests.swift */; };
 		9F387DDA2EA87C0F006861F8 /* PromptCooldownManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DD92EA87C0F006861F8 /* PromptCooldownManagerTests.swift */; };
 		9F387DDD2EA881D1006861F8 /* PromptCooldownMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F387DDC2EA881C7006861F8 /* PromptCooldownMocks.swift */; };
@@ -4475,6 +4476,7 @@
 		9F3361BB2F2B394500E0C21A /* ContextualOnboardingDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualOnboardingDelegateMock.swift; sourceTree = "<group>"; };
 		9F3361C02F2B3A0500E0C21A /* MockContextualDaxDialogsFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockContextualDaxDialogsFactory.swift; sourceTree = "<group>"; };
 		9F3668742EAF0A6900AA8670 /* MockContextualOnboardingStatusProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockContextualOnboardingStatusProvider.swift; sourceTree = "<group>"; };
+		9F371805302DB47A0071F761 /* OnboardingDownloadReasonStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDownloadReasonStore.swift; sourceTree = "<group>"; };
 		9F387DD72EA86CE3006861F8 /* PromptCooldownStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownStoreTests.swift; sourceTree = "<group>"; };
 		9F387DD92EA87C0F006861F8 /* PromptCooldownManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownManagerTests.swift; sourceTree = "<group>"; };
 		9F387DDC2EA881C7006861F8 /* PromptCooldownMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownMocks.swift; sourceTree = "<group>"; };
@@ -11435,6 +11437,7 @@
 		F1134EA91F3E2BA700B73467 /* Store */ = {
 			isa = PBXGroup;
 			children = (
+				9F371805302DB47A0071F761 /* OnboardingDownloadReasonStore.swift */,
 				F1134EA51F3E2AF400B73467 /* StatisticsStore.swift */,
 				F1134EAA1F3E2C6A00B73467 /* StatisticsUserDefaults.swift */,
 			);
@@ -15903,6 +15906,7 @@
 				CBAA195A27BFE15600A4BD49 /* NSManagedObjectContextExtension.swift in Sources */,
 				F124B95A2F2CC20C00B29447 /* BuildFlags.swift in Sources */,
 				85BDC3192436161C0053DB07 /* LoginFormDetectionUserScript.swift in Sources */,
+				9F371806302DB47A0071F761 /* OnboardingDownloadReasonStore.swift in Sources */,
 				F143C3291E4A9A0E00CFDE3A /* URLExtension.swift in Sources */,
 				C1C1FF4A2D085A4C0017ACCE /* AutofillInterfaceEmailTruncator.swift in Sources */,
 				C1C1FF4B2D085A4C0017ACCE /* TextMasker.swift in Sources */,

--- a/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/NewTabDaxDialogFactory.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/NewTabDaxDialogFactory.swift
@@ -175,9 +175,16 @@ extension NewTabDaxDialogFactory {
                 ScrollView(.vertical, showsIndicators: false) {
                     OnboardingRebranding.OnboardingEndOfJourneyDialog(content: content) { [weak self] action in
                         switch action {
-                        case .completeAndActivateSearch, .tryDuckAI:
+                        case .completeAndActivateSearch:
                             self?.onboardingPixelReporter.measureEndOfJourneyDialogCTAAction()
-                        case .skip, .manualDismiss:
+                        case .tryDuckAI:
+                            self?.onboardingPixelReporter.measureEndOfJourneyDialogCTAAction()
+                            // Try Duck.ai EOJ CTA — surface-scoped pixel for CTR (only the Try-AI variant emits `.tryDuckAI`).
+                            self?.onboardingPixelReporter.measureEndOfJourneyTryDuckAICTAAction()
+                        case .skip:
+                            self?.onboardingPixelReporter.measureEndOfJourneyDialogNewTabDismissButtonTapped()
+                            self?.onboardingPixelReporter.measureEndOfJourneyTryDuckAISkipAction()
+                        case .manualDismiss:
                             self?.onboardingPixelReporter.measureEndOfJourneyDialogNewTabDismissButtonTapped()
                         }
                         onAction(action)
@@ -190,6 +197,10 @@ extension NewTabDaxDialogFactory {
                 self?.daxDialogsFlowCoordinator.setFinalOnboardingDialogSeen()
                 self?.onboardingPixelReporter.measureScreenImpression(event: .daxDialogsEndOfJourneyNewTabUnique)
                 self?.onboardingPixelReporter.measureScreenImpression(.end(.shown))
+                // Try Duck.ai EOJ impression — surface-scoped pixel for CTR, only for the Try-AI variant.
+                if content.primaryAction == .tryDuckAI {
+                    self?.onboardingPixelReporter.measureEndOfJourneyTryDuckAIImpression()
+                }
             }
         )
     }

--- a/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/NewTabDaxDialogFactory.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/ContextualOnboarding/NewTabDaxDialogFactory.swift
@@ -178,11 +178,9 @@ extension NewTabDaxDialogFactory {
                         case .completeAndActivateSearch:
                             self?.onboardingPixelReporter.measureEndOfJourneyDialogCTAAction()
                         case .tryDuckAI:
-                            self?.onboardingPixelReporter.measureEndOfJourneyDialogCTAAction()
                             // Try Duck.ai EOJ CTA — surface-scoped pixel for CTR (only the Try-AI variant emits `.tryDuckAI`).
                             self?.onboardingPixelReporter.measureEndOfJourneyTryDuckAICTAAction()
                         case .skip:
-                            self?.onboardingPixelReporter.measureEndOfJourneyDialogNewTabDismissButtonTapped()
                             self?.onboardingPixelReporter.measureEndOfJourneyTryDuckAISkipAction()
                         case .manualDismiss:
                             self?.onboardingPixelReporter.measureEndOfJourneyDialogNewTabDismissButtonTapped()
@@ -196,10 +194,11 @@ extension NewTabDaxDialogFactory {
             .onFirstAppear { [weak self] in
                 self?.daxDialogsFlowCoordinator.setFinalOnboardingDialogSeen()
                 self?.onboardingPixelReporter.measureScreenImpression(event: .daxDialogsEndOfJourneyNewTabUnique)
-                self?.onboardingPixelReporter.measureScreenImpression(.end(.shown))
                 // Try Duck.ai EOJ impression — surface-scoped pixel for CTR, only for the Try-AI variant.
                 if content.primaryAction == .tryDuckAI {
-                    self?.onboardingPixelReporter.measureEndOfJourneyTryDuckAIImpression()
+                    self?.onboardingPixelReporter.measureScreenImpression(.endTryDuckAI(.shown))
+                } else {
+                    self?.onboardingPixelReporter.measureScreenImpression(.end(.shown))
                 }
             }
         )

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingIntroViewModel.swift
@@ -290,7 +290,7 @@ final class OnboardingIntroViewModel: ObservableObject {
 
         postDownloadSelectionPersonalizationSetup(for: reason)
 
-        // TODO: pixel for the selected download reason. https://app.asana.com/1/137249556945/task/1216200647629938
+        pixelReporter.measureDownloadReasonSelection(reason)
         let remainingSteps = onboardingManager.selectDownloadReason(reason)
         if let currentStepIndex = introSteps.firstIndex(of: currentIntroStep) {
             introSteps.insert(contentsOf: remainingSteps, at: currentStepIndex + 1)
@@ -299,33 +299,51 @@ final class OnboardingIntroViewModel: ObservableObject {
         makeNextViewState()
     }
 
-    // NA Experiment: per-step actions for the reason-tailored screens. They only advance for now;
-    // the UI task adds each screen's real behaviour (persisting the setting, pixels, etc.).
+    // NA Experiment: per-step actions for the reason-tailored screens.
     func searchPrivacySettingsContinueAction() {
+        pixelReporter.measureSearchPrivacySettingsSelection(
+            recentlyVisitedSitesEnabled: personalizationManager.isRecentlyVisitedSitesEnabled,
+            safeSearchEnabled: personalizationManager.isSafeSearchEnabled
+        )
         makeNextViewState()
     }
 
     func aiSearchSettingsContinueAction() {
+        pixelReporter.measureAISearchSettingsSelection(
+            searchAssistEnabled: personalizationManager.isSearchAssistEnabled,
+            aiGeneratedImagesEnabled: !personalizationManager.areAIGeneratedImagesHidden
+        )
         makeNextViewState()
     }
 
     func aiModelContinueAction() {
+        // Report the model's provider (e.g. "openai") rather than the specific model id — coarser and
+        // more privacy-preserving.
+        let selectedModelID = personalizationManager.selectedAIChatModelID
+        let provider = aiModelsPrefetcher.resolvedModel.models.first { $0.id == selectedModelID }?.provider
+        pixelReporter.measureAIModelSelection(model: provider?.rawValue ?? "unknown")
         makeNextViewState()
     }
 
     func toggleInputModeContinueAction(opensWithAIChat: Bool) {
         personalizationManager.setNewTabOpensWithAIChat(opensWithAIChat)
+        pixelReporter.measureToggleInputModeSelection(openNewTabsWithAIChat: personalizationManager.doesNewTabOpenWithAIChat)
         makeNextViewState()
     }
 
-    func keepDuckAIContinueAction(isEnabled: Bool) {
-        personalizationManager.setDuckAIEnabled(isEnabled)
-        onboardingSearchExperienceProvider.storeAIChatSearchInputDuringOnboardingChoice(enable: isEnabled)
+    func keepDuckAIContinueAction(shouldKeep: Bool) {
+        personalizationManager.setDuckAIEnabled(shouldKeep)
+        onboardingSearchExperienceProvider.storeAIChatSearchInputDuringOnboardingChoice(enable: shouldKeep)
+        pixelReporter.measureKeepDuckAISelection(shouldKeep: shouldKeep)
 
         makeNextViewState()
     }
 
     func duckPlayerContinueAction() {
+        pixelReporter.measureDuckPlayerSelection(
+            youTubeAdBlockingEnabled: personalizationManager.isYouTubeAdBlockingEnabled,
+            duckPlayerEnabled: personalizationManager.isDuckPlayerEnabled
+        )
         makeNextViewState()
     }
 
@@ -658,10 +676,19 @@ private extension OnboardingIntroViewModel {
         case .duckAIQueryDialog:
             pixelReporter.measureDuckAIQuerySelectionImpression()
         case .downloadReasonDialog:
-            break // TODO: Download Screen impression pixel. https://app.asana.com/1/137249556945/task/1216200647629938
-        case .searchPrivacySettingsDialog, .aiSearchSettingsDialog, .aiModelDialog,
-             .toggleInputModeDialog, .keepDuckAIDialog, .duckPlayerDialog:
-            break // TODO: impression pixels for the reason-tailored steps (UI task).
+            pixelReporter.measureDownloadReasonImpression()
+        case .searchPrivacySettingsDialog:
+            pixelReporter.measureSearchPrivacySettingsImpression()
+        case .aiSearchSettingsDialog:
+            pixelReporter.measureAISearchSettingsImpression()
+        case .aiModelDialog:
+            pixelReporter.measureAIModelImpression()
+        case .toggleInputModeDialog:
+            pixelReporter.measureToggleInputModeImpression()
+        case .keepDuckAIDialog:
+            pixelReporter.measureKeepDuckAIImpression()
+        case .duckPlayerDialog:
+            pixelReporter.measureDuckPlayerImpression()
         }
     }
 

--- a/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/LinearOnboarding/OnboardingView.swift
@@ -559,12 +559,12 @@ extension OnboardingView {
                 isVisible: $showBubbleContent,
                 primaryAction: {
                     animateContentTransition {
-                        model.keepDuckAIContinueAction(isEnabled: true)
+                        model.keepDuckAIContinueAction(shouldKeep: true)
                     }
                 },
                 secondaryAction: {
                     animateContentTransition {
-                        model.keepDuckAIContinueAction(isEnabled: false)
+                        model.keepDuckAIContinueAction(shouldKeep: false)
                     }
                 }
             )

--- a/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
@@ -262,14 +262,16 @@ extension OnboardingPixelReporter: OnboardingIntroPixelReporting {
         fire(event: .onboardingIntroComparisonChartShownUnique, unique: true)
         sharedPixelHandler.fire(.setDefault(.shown),
                                 source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+                                flow: sharedPixelsStorage.onboardingFlow,
+                                variant: sharedPixelsStorage.onboardingVariant)
     }
 
     func measureChooseBrowserCTAAction() {
         fire(event: .onboardingIntroChooseBrowserCTAPressed, unique: false)
         sharedPixelHandler.fire(.setDefault(.clicked(.engage)),
                                 source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+                                flow: sharedPixelsStorage.onboardingFlow,
+                                variant: sharedPixelsStorage.onboardingVariant)
     }
 
     func measureAiIntroImpression() {
@@ -388,7 +390,8 @@ extension OnboardingPixelReporter: OnboardingIntroPixelReporting {
     func measureSetDefaultBrowserSkipped() {
         sharedPixelHandler.fire(.setDefault(.clicked(.dismiss)),
                                 source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+                                flow: sharedPixelsStorage.onboardingFlow,
+                                variant: sharedPixelsStorage.onboardingVariant)
     }
 
 }

--- a/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
@@ -107,6 +107,9 @@ protocol OnboardingDaxDialogsReporting {
     func measureEndOfJourneyDialogDismissButtonTapped()
     func measureSubscriptionDialogNewTabDismissButtonTapped()
     func measureEndOfJourneyDialogCTAAction()
+    func measureEndOfJourneyTryDuckAIImpression()
+    func measureEndOfJourneyTryDuckAICTAAction()
+    func measureEndOfJourneyTryDuckAISkipAction()
 }
 
 
@@ -182,6 +185,14 @@ final class OnboardingPixelReporter {
         } else {
             pixel.fire(pixel: event, withAdditionalParameters: additionalParameters, includedParameters: includedParameters)
         }
+    }
+
+    // Fires a shared onboarding pixel with the current stored context (source, flow and variant).
+    private func fireSharedPixel(_ event: OnboardingSharedPixelEvent) {
+        sharedPixelHandler.fire(event,
+                                source: sharedPixelsStorage.onboardingSource,
+                                flow: sharedPixelsStorage.onboardingFlow,
+                                variant: sharedPixelsStorage.onboardingVariant)
     }
 
 }
@@ -444,10 +455,7 @@ extension OnboardingPixelReporter: OnboardingDaxDialogsReporting {
     }
 
     func measureScreenImpression(_ event: OnboardingSharedPixelEvent) {
-        sharedPixelHandler.fire(event,
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(event)
     }
 
     func measureSearchResultsDialogGotItAction() {
@@ -605,6 +613,18 @@ extension OnboardingPixelReporter: OnboardingDaxDialogsReporting {
                                 variant: sharedPixelsStorage.onboardingVariant)
     }
 
+    func measureEndOfJourneyTryDuckAIImpression() {
+        fireSharedPixel(.endTryDuckAI(.shown))
+    }
+
+    func measureEndOfJourneyTryDuckAICTAAction() {
+        fireSharedPixel(.endTryDuckAI(.clicked(.engage)))
+    }
+
+    func measureEndOfJourneyTryDuckAISkipAction() {
+        fireSharedPixel(.endTryDuckAI(.clicked(.dismiss)))
+    }
+
 }
 
 // MARK: - OnboardingPixelReporter + Add To Dock
@@ -670,59 +690,51 @@ extension OnboardingPixelReporter: OnboardingDownloadReasonPixelReporting {
     }
 
     func measureSearchPrivacySettingsImpression() {
-        fireTailoredStepPixel(.preferencesSerp(.shown))
+        fireSharedPixel(.preferencesSerp(.shown))
     }
 
     func measureSearchPrivacySettingsSelection(recentlyVisitedSitesEnabled: Bool, safeSearchEnabled: Bool) {
-        fireTailoredStepPixel(.preferencesSerp(.clicked(recentlyVisitedSitesEnabled: recentlyVisitedSitesEnabled, safeSearchEnabled: safeSearchEnabled)))
+        fireSharedPixel(.preferencesSerp(.clicked(recentlyVisitedSitesEnabled: recentlyVisitedSitesEnabled, safeSearchEnabled: safeSearchEnabled)))
     }
 
     func measureAIModelImpression() {
-        fireTailoredStepPixel(.preferencesAIModel(.shown))
+        fireSharedPixel(.preferencesAIModel(.shown))
     }
 
     func measureAIModelSelection(model: String) {
-        fireTailoredStepPixel(.preferencesAIModel(.clicked(model: model)))
+        fireSharedPixel(.preferencesAIModel(.clicked(model: model)))
     }
 
     func measureToggleInputModeImpression() {
-        fireTailoredStepPixel(.preferencesAIToggleMode(.shown))
+        fireSharedPixel(.preferencesAIToggleMode(.shown))
     }
 
     func measureToggleInputModeSelection(openNewTabsWithAIChat: Bool) {
-        fireTailoredStepPixel(.preferencesAIToggleMode(.clicked(openNewTabsWithAIChat: openNewTabsWithAIChat)))
+        fireSharedPixel(.preferencesAIToggleMode(.clicked(openNewTabsWithAIChat: openNewTabsWithAIChat)))
     }
 
     func measureAISearchSettingsImpression() {
-        fireTailoredStepPixel(.preferencesAISearch(.shown))
+        fireSharedPixel(.preferencesAISearch(.shown))
     }
 
     func measureAISearchSettingsSelection(searchAssistEnabled: Bool, aiGeneratedImagesEnabled: Bool) {
-        fireTailoredStepPixel(.preferencesAISearch(.clicked(searchAssistEnabled: searchAssistEnabled, aiGeneratedImagesEnabled: aiGeneratedImagesEnabled)))
+        fireSharedPixel(.preferencesAISearch(.clicked(searchAssistEnabled: searchAssistEnabled, aiGeneratedImagesEnabled: aiGeneratedImagesEnabled)))
     }
 
     func measureKeepDuckAIImpression() {
-        fireTailoredStepPixel(.preferencesDuckAI(.shown))
+        fireSharedPixel(.preferencesDuckAI(.shown))
     }
 
     func measureKeepDuckAISelection(shouldKeep: Bool) {
-        fireTailoredStepPixel(.preferencesDuckAI(.clicked(shouldKeep ? .on : .off)))
+        fireSharedPixel(.preferencesDuckAI(.clicked(shouldKeep ? .on : .off)))
     }
 
     func measureDuckPlayerImpression() {
-        fireTailoredStepPixel(.preferencesYoutube(.shown))
+        fireSharedPixel(.preferencesYoutube(.shown))
     }
 
     func measureDuckPlayerSelection(youTubeAdBlockingEnabled: Bool, duckPlayerEnabled: Bool) {
-        fireTailoredStepPixel(.preferencesYoutube(.clicked(youTubeAdBlockingEnabled: youTubeAdBlockingEnabled, duckPlayerEnabled: duckPlayerEnabled)))
-    }
-
-    // Fires a tailored-step pixel with the source, flow and the stored download-reason variant.
-    private func fireTailoredStepPixel(_ event: OnboardingSharedPixelEvent) {
-        sharedPixelHandler.fire(event,
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.preferencesYoutube(.clicked(youTubeAdBlockingEnabled: youTubeAdBlockingEnabled, duckPlayerEnabled: duckPlayerEnabled)))
     }
 
 }

--- a/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
@@ -23,6 +23,10 @@ import Core
 import PrivacyConfig
 import Onboarding
 import Persistence
+import PixelKit
+import PixelExperimentKit
+import FeatureFlags_iOS
+
 // MARK: - Pixel Fire Interface
 
 protocol OnboardingPixelFiring {
@@ -107,7 +111,6 @@ protocol OnboardingDaxDialogsReporting {
     func measureEndOfJourneyDialogDismissButtonTapped()
     func measureSubscriptionDialogNewTabDismissButtonTapped()
     func measureEndOfJourneyDialogCTAAction()
-    func measureEndOfJourneyTryDuckAIImpression()
     func measureEndOfJourneyTryDuckAICTAAction()
     func measureEndOfJourneyTryDuckAISkipAction()
 }
@@ -154,6 +157,7 @@ final class OnboardingPixelReporter {
     private let sharedPixelHandler: OnboardingSharedPixelHandling
     private let sharedPixelsStorage: any KeyedStoring<OnboardingSharedPixelsKeys>
     private let siteVisitedUserDefaultsKey = "com.duckduckgo.ios.site-visited"
+    private let downloadReasonExperimentMetric: OnboardingDownloadReasonExperimentMetric
 
     init(
         pixel: OnboardingPixelFiring.Type = Pixel.self,
@@ -163,7 +167,8 @@ final class OnboardingPixelReporter {
         dateProvider: @escaping () -> Date = Date.init,
         userDefaults: UserDefaults = UserDefaults.app,
         sharedPixelHandler: OnboardingSharedPixelHandling? = nil,
-        sharedPixelsStorage: (any KeyedStoring<OnboardingSharedPixelsKeys>)? = nil
+        sharedPixelsStorage: (any KeyedStoring<OnboardingSharedPixelsKeys>)? = nil,
+        downloadReasonExperimentMetric: OnboardingDownloadReasonExperimentMetric = OnboardingDownloadReasonExperimentMetric()
     ) {
         self.pixel = pixel
         self.uniquePixel = uniquePixel
@@ -177,6 +182,7 @@ final class OnboardingPixelReporter {
             installDateProvider: { statisticsStore.installDate }
         )
         self.sharedPixelsStorage = if let sharedPixelsStorage { sharedPixelsStorage } else { UserDefaults.app.keyedStoring() }
+        self.downloadReasonExperimentMetric = downloadReasonExperimentMetric
     }
 
     private func fire(event: Pixel.Event, unique: Bool, additionalParameters: [String: String] = [:], includedParameters: [Pixel.QueryParameters] = [.appVersion]) {
@@ -455,6 +461,10 @@ extension OnboardingPixelReporter: OnboardingDaxDialogsReporting {
     }
 
     func measureScreenImpression(_ event: OnboardingSharedPixelEvent) {
+        if event == .end(.shown) || event == .endTryDuckAI(.shown) {
+            downloadReasonExperimentMetric.measureDownloadReasonExperimentOnboardingCompleted()
+        }
+
         fireSharedPixel(event)
     }
 
@@ -613,10 +623,6 @@ extension OnboardingPixelReporter: OnboardingDaxDialogsReporting {
                                 variant: sharedPixelsStorage.onboardingVariant)
     }
 
-    func measureEndOfJourneyTryDuckAIImpression() {
-        fireSharedPixel(.endTryDuckAI(.shown))
-    }
-
     func measureEndOfJourneyTryDuckAICTAAction() {
         fireSharedPixel(.endTryDuckAI(.clicked(.engage)))
     }
@@ -687,6 +693,7 @@ extension OnboardingPixelReporter: OnboardingDownloadReasonPixelReporting {
                                 flow: sharedPixelsStorage.onboardingFlow)
         // Persist the chosen reason as the variant so every subsequent tailored-step pixel carries it.
         sharedPixelsStorage.onboardingVariant = OnboardingPixelParameter.Variant(reason)
+        downloadReasonExperimentMetric.measureDownloadReasonSelected(reason)
     }
 
     func measureSearchPrivacySettingsImpression() {
@@ -748,6 +755,73 @@ private extension OnboardingSharedPixelEvent.DownloadChoiceEvent.Value {
         case .noAI: self = .noAI
         case .blockAds: self = .adBlocking
         }
+    }
+
+}
+
+// MARK: - OnboardingPixelReporter + OnboardingDownloadReasonExperiment
+
+protocol ExperimentPixelFiring {
+    /// Fires an experiment pixel with the specified parameters.
+    ///
+    /// - Parameters:
+    ///   - subfeatureID: The unique identifier of the subfeature associated with the experiment.
+    ///   - metric: The name of the metric being tracked (e.g., impressions, clicks, conversions).
+    ///   - conversionWindowDays: The time range (in days) to associate the pixel with conversion events.
+    ///   - value: A string representing the value associated with the metric, such as counts or statuses.
+    static func fireExperimentPixel(for subfeatureID: SubfeatureID,
+                                    metric: String,
+                                    conversionWindowDays: ConversionWindow,
+                                    value: String)
+}
+
+/// Conforming `PixelKit` to the `ExperimentPixelFiring` protocol.
+///
+/// `PixelKit` provides the concrete implementation for firing experiment pixels. By extending
+/// `PixelKit` to conform to `ExperimentPixelFiring`, its functionality can be injected and mocked
+/// for testing purposes.
+extension PixelKit: ExperimentPixelFiring {}
+
+struct OnboardingDownloadReasonExperimentMetric {
+    private enum Name: String {
+        case onboardingCompleted = "onboarding_completed"
+        case downloadReasonSelectedSearch = "download_reason_selected_search"
+        case downloadReasonSelectedAIChat = "download_reason_selected_ai-chat"
+        case downloadReasonSelectedNoAI = "download_reason_selected_no-ai"
+        case downloadReasonSelectedAdBlocking = "download_reason_selected_ad-blocking"
+    }
+
+    private static let conversionWindowD0: ConversionWindow = 0...0
+
+    private let experimentPixelFiring: ExperimentPixelFiring.Type
+
+    init(experimentPixelFiring: ExperimentPixelFiring.Type = PixelKit.self) {
+        self.experimentPixelFiring = experimentPixelFiring
+    }
+
+    func measureDownloadReasonExperimentOnboardingCompleted() {
+        fire(metric: .onboardingCompleted)
+    }
+
+    /// Fires the per-reason "selected" metric (one metric per option, empty value, d0) when the user
+    /// picks a download reason.
+    func measureDownloadReasonSelected(_ reason: OnboardingDownloadReason) {
+        let metric: Name = switch reason {
+        case .browserPrivately: .downloadReasonSelectedSearch
+        case .privateAIChat: .downloadReasonSelectedAIChat
+        case .noAI: .downloadReasonSelectedNoAI
+        case .blockAds: .downloadReasonSelectedAdBlocking
+        }
+        fire(metric: metric)
+    }
+
+    private func fire(metric: Name) {
+        experimentPixelFiring.fireExperimentPixel(
+            for: iOSBrowserConfigSubfeature.onboardingFlowByDownloadReasonExperiment.rawValue,
+            metric: metric.rawValue,
+            conversionWindowDays: Self.conversionWindowD0,
+            value: ""
+        )
     }
 
 }

--- a/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
@@ -658,11 +658,6 @@ protocol ExperimentPixelFiring {
                                     value: String)
 }
 
-/// Conforming `PixelKit` to the `ExperimentPixelFiring` protocol.
-///
-/// `PixelKit` provides the concrete implementation for firing experiment pixels. By extending
-/// `PixelKit` to conform to `ExperimentPixelFiring`, its functionality can be injected and mocked
-/// for testing purposes.
 extension PixelKit: ExperimentPixelFiring {}
 
 struct OnboardingDownloadReasonExperimentMetric {

--- a/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
@@ -201,6 +201,13 @@ final class OnboardingPixelReporter {
                                 variant: sharedPixelsStorage.onboardingVariant)
     }
 
+    // Records the onboarding variant only if one hasn't been set yet, so the first branching
+    // choice wins and a later step can't overwrite it.
+    private func setVariantIfNotAlreadySet(_ variant: OnboardingPixelParameter.Variant) {
+        guard sharedPixelsStorage.onboardingVariant == nil else { return }
+        sharedPixelsStorage.onboardingVariant = variant
+    }
+
 }
 
 enum DuckAIQueryPromptSource: String {
@@ -230,30 +237,22 @@ extension AppIcon {
 extension OnboardingPixelReporter: OnboardingIntroPixelReporting {
 
     func measureStartOnboardingCTAAction() {
-        sharedPixelHandler.fire(.welcome(.clicked(.engage)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.welcome(.clicked(.engage)))
     }
 
     func measureSkipOnboardingCTAAction() {
         fire(event: .onboardingIntroSkipOnboardingCTAPressed, unique: false)
-        sharedPixelHandler.fire(.welcome(.clicked(.dismiss)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.welcome(.clicked(.dismiss)))
     }
 
     func measureConfirmSkipOnboardingCTAAction() {
         fire(event: .onboardingIntroConfirmSkipOnboardingCTAPressed, unique: false)
-        sharedPixelHandler.fire(.skipOnboarding(.clicked(.engage)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.skipOnboarding(.clicked(.engage)))
     }
 
     func measureResumeOnboardingCTAAction() {
         fire(event: .onboardingIntroResumeOnboardingCTAPressed, unique: false)
-        sharedPixelHandler.fire(.skipOnboarding(.clicked(.dismiss)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.skipOnboarding(.clicked(.dismiss)))
     }
 
     func measureAutoRestoreOnboardingPromptShown() {
@@ -270,102 +269,72 @@ extension OnboardingPixelReporter: OnboardingIntroPixelReporting {
 
     func measureOnboardingIntroImpression() {
         fire(event: .onboardingIntroShownUnique, unique: true)
-        sharedPixelHandler.fire(.welcome(.shown),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.welcome(.shown))
     }
 
     func measureSetDefaultBrowserImpression() {
         fire(event: .onboardingIntroComparisonChartShownUnique, unique: true)
-        sharedPixelHandler.fire(.setDefault(.shown),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.setDefault(.shown))
     }
 
     func measureChooseBrowserCTAAction() {
         fire(event: .onboardingIntroChooseBrowserCTAPressed, unique: false)
-        sharedPixelHandler.fire(.setDefault(.clicked(.engage)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.setDefault(.clicked(.engage)))
     }
 
     func measureAiIntroImpression() {
-        sharedPixelHandler.fire(.aiIntro(.shown),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.aiIntro(.shown))
     }
 
     func measureAiIntroCTAAction() {
-        sharedPixelHandler.fire(.aiIntro(.clicked(.engage)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.aiIntro(.clicked(.engage)))
     }
 
     func measureChooseAppIconImpression() {
         fire(event: .onboardingIntroChooseAppIconImpressionUnique, unique: true)
-        sharedPixelHandler.fire(.appIconColor(.shown),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.appIconColor(.shown))
     }
 
     func measureChooseAppIconColor(_ color: AppIcon) {
         if color != .defaultAppIcon {
             fire(event: .onboardingIntroChooseCustomAppIconColorCTAPressed, unique: false)
         }
-        sharedPixelHandler.fire(.appIconColor(.clicked(color.pixelValue)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.appIconColor(.clicked(color.pixelValue)))
     }
 
     func measureAddressBarPositionSelectionImpression() {
         fire(event: .onboardingIntroChooseAddressBarImpressionUnique, unique: true)
-        sharedPixelHandler.fire(.addressBarPosition(.shown),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.addressBarPosition(.shown))
     }
 
     func measureChooseAddressBarPosition(_ position: AddressBarPosition) {
         switch position {
         case .top:
-            sharedPixelHandler.fire(.addressBarPosition(.clicked(.top)),
-                                    source: sharedPixelsStorage.onboardingSource,
-                                    flow: sharedPixelsStorage.onboardingFlow)
+            fireSharedPixel(.addressBarPosition(.clicked(.top)))
         case .bottom:
             fire(event: .onboardingIntroBottomAddressBarSelected, unique: false)
-            sharedPixelHandler.fire(.addressBarPosition(.clicked(.bottom)),
-                                    source: sharedPixelsStorage.onboardingSource,
-                                    flow: sharedPixelsStorage.onboardingFlow)
+            fireSharedPixel(.addressBarPosition(.clicked(.bottom)))
         }
     }
 
     func measureSearchExperienceSelectionImpression() {
         fire(event: .onboardingIntroChooseSearchExperienceImpressionUnique, unique: true)
-        sharedPixelHandler.fire(.searchExperience(.shown),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.searchExperience(.shown))
     }
 
     func measureChooseAIChat() {
         fire(event: .onboardingIntroAIChatSelected, unique: false)
-        sharedPixelHandler.fire(.searchExperience(.clicked(.searchPlusDuckAI)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.searchExperience(.clicked(.searchPlusDuckAI)))
     }
 
     func measureChooseSearchOnly() {
         fire(event: .onboardingIntroSearchOnlySelected, unique: false)
-        sharedPixelHandler.fire(.searchExperience(.clicked(.searchOnly)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.searchExperience(.clicked(.searchOnly)))
     }
 
     func measureDuckAIQuerySelectionImpression() {
         fire(event: .onboardingIntroDuckAIToggleImpressionUnique, unique: true)
-        sharedPixelHandler.fire(.searchChatToggle(.shown),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.searchChatToggle(.shown))
     }
 
     func measureDuckAIQueryChooseSearchOnly() {
@@ -379,36 +348,23 @@ extension OnboardingPixelReporter: OnboardingIntroPixelReporting {
     func measureDuckAIQuerySubmission(selection: DuckAIQueryMode, promptSource: DuckAIQueryPromptSource) {
         switch (promptSource, selection) {
         case (.custom, .duckAI):
-            sharedPixelHandler.fire(.searchChatToggle(.clicked(.customChat)),
-                                    source: sharedPixelsStorage.onboardingSource,
-                                    flow: sharedPixelsStorage.onboardingFlow)
+            fireSharedPixel(.searchChatToggle(.clicked(.customChat)))
         case (.custom, .search):
-            sharedPixelHandler.fire(.searchChatToggle(.clicked(.customSearch)),
-                                    source: sharedPixelsStorage.onboardingSource,
-                                    flow: sharedPixelsStorage.onboardingFlow)
+            fireSharedPixel(.searchChatToggle(.clicked(.customSearch)))
         case (_, .duckAI):
-            sharedPixelHandler.fire(.searchChatToggle(.clicked(.suggestedChat)),
-                                    source: sharedPixelsStorage.onboardingSource,
-                                    flow: sharedPixelsStorage.onboardingFlow)
+            fireSharedPixel(.searchChatToggle(.clicked(.suggestedChat)))
         case (_, .search):
-            sharedPixelHandler.fire(.searchChatToggle(.clicked(.suggestedSearch)),
-                                    source: sharedPixelsStorage.onboardingSource,
-                                    flow: sharedPixelsStorage.onboardingFlow)
+            fireSharedPixel(.searchChatToggle(.clicked(.suggestedSearch)))
         }
-        sharedPixelsStorage.onboardingVariant = OnboardingPixelParameter.Variant(selection)
+        setVariantIfNotAlreadySet(OnboardingPixelParameter.Variant(selection))
     }
 
     func measureSkipOnboardingScreenImpression() {
-        sharedPixelHandler.fire(.skipOnboarding(.shown),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.skipOnboarding(.shown))
     }
 
     func measureSetDefaultBrowserSkipped() {
-        sharedPixelHandler.fire(.setDefault(.clicked(.dismiss)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.setDefault(.clicked(.dismiss)))
     }
 
 }
@@ -419,18 +375,12 @@ extension OnboardingPixelReporter: OnboardingCustomInteractionPixelReporting {
 
     func measureCustomSearch() {
         fire(event: .onboardingContextualSearchCustomUnique, unique: true)
-        sharedPixelHandler.fire(.search(.clicked(.custom)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.search(.clicked(.custom)))
     }
     
     func measureCustomSite() {
         fire(event: .onboardingContextualSiteCustomUnique, unique: true)
-        sharedPixelHandler.fire(.visitSite(.clicked(.custom)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.visitSite(.clicked(.custom)))
     }
     
     func measureSecondSiteVisit() {
@@ -469,107 +419,65 @@ extension OnboardingPixelReporter: OnboardingDaxDialogsReporting {
     }
 
     func measureSearchResultsDialogGotItAction() {
-        sharedPixelHandler.fire(.searchResults(.clicked(.engage)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.searchResults(.clicked(.engage)))
     }
 
     func measureTrackersDialogGotItAction() {
-        sharedPixelHandler.fire(.trackersBlocked(.clicked(.engage)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.trackersBlocked(.clicked(.engage)))
     }
 
     func measureSubscriptionPromoDialogShown() {
-        sharedPixelHandler.fire(.subscriptionPromo(.shown),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.subscriptionPromo(.shown))
     }
 
     func measureSubscriptionPromoEngageCTAAction() {
-        sharedPixelHandler.fire(.subscriptionPromo(.clicked(.engage)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.subscriptionPromo(.clicked(.engage)))
     }
 
     func measureFireButtonOnboardingDeleteConfirmed() {
-        sharedPixelHandler.fire(.fireButton(.clicked(.engage)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.fireButton(.clicked(.engage)))
     }
 
     func measureFireButtonOnboardingDismissButtonTapped() {
-        sharedPixelHandler.fire(.fireButton(.clicked(.dismiss)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.fireButton(.clicked(.dismiss)))
     }
 
     func measureTrySearchDialogSuggestedSearchTapped() {
-        sharedPixelHandler.fire(.search(.clicked(.suggested)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.search(.clicked(.suggested)))
     }
 
     func measureTrySearchDialogNewTabDismissButtonTapped() {
         fire(event: .onboardingTrySearchDialogNewTabDismissButtonTapped, unique: false)
-        sharedPixelHandler.fire(.search(.clicked(.dismiss)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.search(.clicked(.dismiss)))
     }
 
     func measureSearchResultDialogDismissButtonTapped() {
         fire(event: .onboardingSearchResultDialogDismissButtonTapped, unique: false)
-        sharedPixelHandler.fire(.searchResults(.clicked(.dismiss)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.searchResults(.clicked(.dismiss)))
     }
 
     func measureTryVisitSiteDialogSuggestedSiteTapped() {
-        sharedPixelHandler.fire(.visitSite(.clicked(.suggested)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.visitSite(.clicked(.suggested)))
     }
 
     func measureTryVisitSiteDialogNewTabDismissButtonTapped() {
         fire(event: .onboardingTryVisitSiteDialogNewTabDismissButtonTapped, unique: false)
-        sharedPixelHandler.fire(.visitSite(.clicked(.dismiss)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.visitSite(.clicked(.dismiss)))
     }
 
     func measureTryVisitSiteDialogDismissButtonTapped() {
         fire(event: .onboardingTryVisitSiteDialogDismissButtonTapped, unique: false)
-        sharedPixelHandler.fire(.visitSite(.clicked(.dismiss)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.visitSite(.clicked(.dismiss)))
     }
 
     func measureTrackersDialogDismissButtonTapped() {
         fire(event: .onboardingTrackersDialogDismissButtonTapped, unique: false)
-        sharedPixelHandler.fire(.trackersBlocked(.clicked(.dismiss)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.trackersBlocked(.clicked(.dismiss)))
     }
 
     func measureFireDialogDismissButtonTapped() {
         fire(event: .onboardingFireDialogDismissButtonTapped, unique: false)
-        sharedPixelHandler.fire(.fireButton(.clicked(.dismiss)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.fireButton(.clicked(.dismiss)))
     }
 
     func measureDuckAIFireButtonCTAAction() {
@@ -585,42 +493,27 @@ extension OnboardingPixelReporter: OnboardingDaxDialogsReporting {
     }
 
     func measureDuckAIFinalDialogCTAAction() {
-        sharedPixelHandler.fire(.end(.clicked(.engage)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.end(.clicked(.engage)))
     }
 
     func measureEndOfJourneyDialogNewTabDismissButtonTapped() {
         fire(event: .onboardingEndOfJourneyDialogNewTabDismissButtonTapped, unique: false)
-        sharedPixelHandler.fire(.end(.clicked(.dismiss)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.end(.clicked(.dismiss)))
     }
 
     func measureEndOfJourneyDialogDismissButtonTapped() {
         fire(event: .onboardingEndOfJourneyDialogDismissButtonTapped, unique: false)
-        sharedPixelHandler.fire(.end(.clicked(.dismiss)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.end(.clicked(.dismiss)))
     }
 
     func measureSubscriptionDialogNewTabDismissButtonTapped() {
         fire(event: .onboardingSubscriptionDialogDismissButtonTapped, unique: false)
-        sharedPixelHandler.fire(.subscriptionPromo(.clicked(.dismiss)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.subscriptionPromo(.clicked(.dismiss)))
     }
 
     func measureEndOfJourneyDialogCTAAction() {
         fire(event: .daxDialogsEndOfJourneyDismissed, unique: false)
-        sharedPixelHandler.fire(.end(.clicked(.engage)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow,
-                                variant: sharedPixelsStorage.onboardingVariant)
+        fireSharedPixel(.end(.clicked(.engage)))
     }
 
     func measureEndOfJourneyTryDuckAICTAAction() {
@@ -639,23 +532,17 @@ extension OnboardingPixelReporter: OnboardingAddToDockReporting {
    
     func measureAddToDockPromoImpression() {
         fire(event: .onboardingAddToDockPromoImpressionsUnique, unique: true)
-        sharedPixelHandler.fire(.addToDock(.shown),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.addToDock(.shown))
     }
     
     func measureAddToDockPromoShowTutorialCTAAction() {
         fire(event: .onboardingAddToDockPromoShowTutorialCTATapped, unique: false)
-        sharedPixelHandler.fire(.addToDock(.clicked(.engage)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.addToDock(.clicked(.engage)))
     }
     
     func measureAddToDockPromoDismissCTAAction() {
         fire(event: .onboardingAddToDockPromoDismissCTATapped, unique: false)
-        sharedPixelHandler.fire(.addToDock(.clicked(.dismiss)),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.addToDock(.clicked(.dismiss)))
     }
     
     func measureAddToDockTutorialDismissCTAAction() {
@@ -682,17 +569,13 @@ extension OnboardingPixelParameter.Variant {
 extension OnboardingPixelReporter: OnboardingDownloadReasonPixelReporting {
 
     func measureDownloadReasonImpression() {
-        sharedPixelHandler.fire(.downloadChoice(.shown),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.downloadChoice(.shown))
     }
 
     func measureDownloadReasonSelection(_ reason: OnboardingDownloadReason) {
-        sharedPixelHandler.fire(.downloadChoice(.clicked(.init(reason))),
-                                source: sharedPixelsStorage.onboardingSource,
-                                flow: sharedPixelsStorage.onboardingFlow)
+        fireSharedPixel(.downloadChoice(.clicked(.init(reason))))
         // Persist the chosen reason as the variant so every subsequent tailored-step pixel carries it.
-        sharedPixelsStorage.onboardingVariant = OnboardingPixelParameter.Variant(reason)
+        setVariantIfNotAlreadySet(OnboardingPixelParameter.Variant(reason))
         downloadReasonExperimentMetric.measureDownloadReasonSelected(reason)
     }
 

--- a/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
@@ -117,7 +117,26 @@ protocol OnboardingAddToDockReporting {
     func measureAddToDockTutorialDismissCTAAction()
 }
 
-typealias LinearOnboardingPixelReporting = OnboardingIntroPixelReporting & OnboardingAddToDockReporting
+/// Reporting for the download-reason segmented onboarding flow (treatment cohort only): the download-reason
+/// screen and the tailored preferences steps that follow it.
+protocol OnboardingDownloadReasonPixelReporting {
+    func measureDownloadReasonImpression()
+    func measureDownloadReasonSelection(_ reason: OnboardingDownloadReason)
+    func measureSearchPrivacySettingsImpression()
+    func measureSearchPrivacySettingsSelection(recentlyVisitedSitesEnabled: Bool, safeSearchEnabled: Bool)
+    func measureAIModelImpression()
+    func measureAIModelSelection(model: String)
+    func measureToggleInputModeImpression()
+    func measureToggleInputModeSelection(openNewTabsWithAIChat: Bool)
+    func measureAISearchSettingsImpression()
+    func measureAISearchSettingsSelection(searchAssistEnabled: Bool, aiGeneratedImagesEnabled: Bool)
+    func measureKeepDuckAIImpression()
+    func measureKeepDuckAISelection(isEnabled: Bool)
+    func measureDuckPlayerImpression()
+    func measureDuckPlayerSelection(youTubeAdBlockingEnabled: Bool, duckPlayerEnabled: Bool)
+}
+
+typealias LinearOnboardingPixelReporting = OnboardingIntroPixelReporting & OnboardingAddToDockReporting & OnboardingDownloadReasonPixelReporting
 typealias OnboardingPixelReporting = LinearOnboardingPixelReporting & OnboardingCustomInteractionPixelReporting & OnboardingDaxDialogsReporting
 
 // MARK: - Implementation
@@ -624,6 +643,95 @@ extension OnboardingPixelParameter.Variant {
             self = .duckAIChat
         case .search:
             self = .duckAISearch
+        }
+    }
+
+}
+
+// MARK: - OnboardingPixelReporter + Download Reason Segmented Flow
+
+extension OnboardingPixelReporter: OnboardingDownloadReasonPixelReporting {
+
+    func measureDownloadReasonImpression() {
+        sharedPixelHandler.fire(.downloadChoice(.shown),
+                                source: sharedPixelsStorage.onboardingSource,
+                                flow: sharedPixelsStorage.onboardingFlow)
+    }
+
+    func measureDownloadReasonSelection(_ reason: OnboardingDownloadReason) {
+        sharedPixelHandler.fire(.downloadChoice(.clicked(.init(reason))),
+                                source: sharedPixelsStorage.onboardingSource,
+                                flow: sharedPixelsStorage.onboardingFlow)
+        // Persist the chosen reason as the variant so every subsequent tailored-step pixel carries it.
+        sharedPixelsStorage.onboardingVariant = OnboardingPixelParameter.Variant(reason)
+    }
+
+    func measureSearchPrivacySettingsImpression() {
+        fireTailoredStepPixel(.preferencesSerp(.shown))
+    }
+
+    func measureSearchPrivacySettingsSelection(recentlyVisitedSitesEnabled: Bool, safeSearchEnabled: Bool) {
+        fireTailoredStepPixel(.preferencesSerp(.clicked(recentlyVisitedSitesEnabled: recentlyVisitedSitesEnabled, safeSearchEnabled: safeSearchEnabled)))
+    }
+
+    func measureAIModelImpression() {
+        fireTailoredStepPixel(.preferencesAIModel(.shown))
+    }
+
+    func measureAIModelSelection(model: String) {
+        fireTailoredStepPixel(.preferencesAIModel(.clicked(model: model)))
+    }
+
+    func measureToggleInputModeImpression() {
+        fireTailoredStepPixel(.preferencesAIToggleMode(.shown))
+    }
+
+    func measureToggleInputModeSelection(openNewTabsWithAIChat: Bool) {
+        fireTailoredStepPixel(.preferencesAIToggleMode(.clicked(openNewTabsWithAIChat: openNewTabsWithAIChat)))
+    }
+
+    func measureAISearchSettingsImpression() {
+        fireTailoredStepPixel(.preferencesAISearch(.shown))
+    }
+
+    func measureAISearchSettingsSelection(searchAssistEnabled: Bool, aiGeneratedImagesEnabled: Bool) {
+        fireTailoredStepPixel(.preferencesAISearch(.clicked(searchAssistEnabled: searchAssistEnabled, aiGeneratedImagesEnabled: aiGeneratedImagesEnabled)))
+    }
+
+    func measureKeepDuckAIImpression() {
+        fireTailoredStepPixel(.preferencesDuckAI(.shown))
+    }
+
+    func measureKeepDuckAISelection(isEnabled: Bool) {
+        fireTailoredStepPixel(.preferencesDuckAI(.clicked(isEnabled ? .on : .off)))
+    }
+
+    func measureDuckPlayerImpression() {
+        fireTailoredStepPixel(.preferencesYoutube(.shown))
+    }
+
+    func measureDuckPlayerSelection(youTubeAdBlockingEnabled: Bool, duckPlayerEnabled: Bool) {
+        fireTailoredStepPixel(.preferencesYoutube(.clicked(youTubeAdBlockingEnabled: youTubeAdBlockingEnabled, duckPlayerEnabled: duckPlayerEnabled)))
+    }
+
+    // Fires a tailored-step pixel with the source, flow and the stored download-reason variant.
+    private func fireTailoredStepPixel(_ event: OnboardingSharedPixelEvent) {
+        sharedPixelHandler.fire(event,
+                                source: sharedPixelsStorage.onboardingSource,
+                                flow: sharedPixelsStorage.onboardingFlow,
+                                variant: sharedPixelsStorage.onboardingVariant)
+    }
+
+}
+
+private extension OnboardingSharedPixelEvent.DownloadChoiceEvent.Value {
+
+    init(_ reason: OnboardingDownloadReason) {
+        switch reason {
+        case .browserPrivately: self = .search
+        case .privateAIChat: self = .aiChat
+        case .noAI: self = .noAI
+        case .blockAds: self = .adBlocking
         }
     }
 

--- a/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
+++ b/iOS/DuckDuckGo/OnboardingFlow/Pixels/OnboardingPixelReporter.swift
@@ -131,7 +131,7 @@ protocol OnboardingDownloadReasonPixelReporting {
     func measureAISearchSettingsImpression()
     func measureAISearchSettingsSelection(searchAssistEnabled: Bool, aiGeneratedImagesEnabled: Bool)
     func measureKeepDuckAIImpression()
-    func measureKeepDuckAISelection(isEnabled: Bool)
+    func measureKeepDuckAISelection(shouldKeep: Bool)
     func measureDuckPlayerImpression()
     func measureDuckPlayerSelection(youTubeAdBlockingEnabled: Bool, duckPlayerEnabled: Bool)
 }
@@ -705,8 +705,8 @@ extension OnboardingPixelReporter: OnboardingDownloadReasonPixelReporting {
         fireTailoredStepPixel(.preferencesDuckAI(.shown))
     }
 
-    func measureKeepDuckAISelection(isEnabled: Bool) {
-        fireTailoredStepPixel(.preferencesDuckAI(.clicked(isEnabled ? .on : .off)))
+    func measureKeepDuckAISelection(shouldKeep: Bool) {
+        fireTailoredStepPixel(.preferencesDuckAI(.clicked(shouldKeep ? .on : .off)))
     }
 
     func measureDuckPlayerImpression() {

--- a/iOS/DuckDuckGo/TutorialSettings.swift
+++ b/iOS/DuckDuckGo/TutorialSettings.swift
@@ -59,7 +59,7 @@ final class DefaultTutorialSettings: TutorialSettings {
         static let hasSeenOnboarding = "com.duckduckgo.tutorials.hasSeenOnboarding"
         static let hasSkippedOnboarding = "com.duckduckgo.tutorials.hasSkippedOnboarding"
         static let onboardingFlowType = "com.duckduckgo.tutorials.onboardingFlowType"
-        static let onboardingDownloadReason = "com.duckduckgo.tutorials.onboardingDownloadReason"
+        static let onboardingDownloadReason = OnboardingDownloadReasonStore.key
     }
 
     private func userDefaults() -> UserDefaults {

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -1529,7 +1529,7 @@ extension OnboardingIntroViewModelTests {
         let sut = makeSUT(currentOnboardingStep: .keepDuckAISelection, personalizationManager: personalizationManager)
 
         // WHEN
-        sut.keepDuckAIContinueAction(isEnabled: true)
+        sut.keepDuckAIContinueAction(shouldKeep: true)
 
         // THEN
         XCTAssertTrue(personalizationManager.isDuckAIEnabled)
@@ -1543,7 +1543,7 @@ extension OnboardingIntroViewModelTests {
         let sut = makeSUT(currentOnboardingStep: .keepDuckAISelection, personalizationManager: personalizationManager)
 
         // WHEN
-        sut.keepDuckAIContinueAction(isEnabled: false)
+        sut.keepDuckAIContinueAction(shouldKeep: false)
 
         // THEN
         XCTAssertFalse(personalizationManager.isDuckAIEnabled)
@@ -1732,7 +1732,7 @@ extension OnboardingIntroViewModelTests {
         sut.onAppear()
 
         // WHEN
-        sut.keepDuckAIContinueAction(isEnabled: true)
+        sut.keepDuckAIContinueAction(shouldKeep: true)
 
         // THEN
         XCTAssertTrue(searchExperienceProvider.storeAIChatSearchInputDuringOnboardingChoiceCalled)
@@ -1748,7 +1748,7 @@ extension OnboardingIntroViewModelTests {
         sut.onAppear()
 
         // WHEN
-        sut.keepDuckAIContinueAction(isEnabled: false)
+        sut.keepDuckAIContinueAction(shouldKeep: false)
 
         // THEN
         XCTAssertTrue(searchExperienceProvider.storeAIChatSearchInputDuringOnboardingChoiceCalled)
@@ -1842,7 +1842,7 @@ extension OnboardingIntroViewModelTests {
         sut.aiSearchSettingsContinueAction()
         XCTAssertEqual(sut.state.intro?.type, .keepDuckAIDialog(content: .mock))
 
-        sut.keepDuckAIContinueAction(isEnabled: true)
+        sut.keepDuckAIContinueAction(shouldKeep: true)
         XCTAssertEqual(sut.state.intro?.type, .chooseAddressBarPositionDialog(content: .mock))
 
         sut.selectAddressBarPositionAction()
@@ -1880,6 +1880,166 @@ extension OnboardingIntroViewModelTests {
 
         sut.appIconPickerContinueAction()
         XCTAssertEqual(sut.state.intro?.type, .duckAIQueryDialog(content: .mock))
+    }
+}
+
+// MARK: - Download Reason Segmented Flow Pixels
+
+extension OnboardingIntroViewModelTests {
+
+    func testWhenTailoredStepAppearsThenItsImpressionPixelFires() {
+        makeSUT(currentOnboardingStep: .downloadReasonSelection).onAppear()
+        XCTAssertTrue(pixelReporterMock.didCallMeasureDownloadReasonImpression)
+
+        makeSUT(currentOnboardingStep: .searchPrivacySettingsSelection).onAppear()
+        XCTAssertTrue(pixelReporterMock.didCallMeasureSearchPrivacySettingsImpression)
+
+        makeSUT(currentOnboardingStep: .aiSearchSettingsSelection).onAppear()
+        XCTAssertTrue(pixelReporterMock.didCallMeasureAISearchSettingsImpression)
+
+        makeSUT(currentOnboardingStep: .aiModelSelection).onAppear()
+        XCTAssertTrue(pixelReporterMock.didCallMeasureAIModelImpression)
+
+        makeSUT(currentOnboardingStep: .toggleInputModeSelection).onAppear()
+        XCTAssertTrue(pixelReporterMock.didCallMeasureToggleInputModeImpression)
+
+        makeSUT(currentOnboardingStep: .keepDuckAISelection).onAppear()
+        XCTAssertTrue(pixelReporterMock.didCallMeasureKeepDuckAIImpression)
+
+        makeSUT(currentOnboardingStep: .duckPlayerSelection).onAppear()
+        XCTAssertTrue(pixelReporterMock.didCallMeasureDuckPlayerImpression)
+    }
+
+    func testWhenSelectDownloadReasonThenSelectionPixelFiresWithChosenReason() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = [.introDialog(isReturningUser: false), .downloadReasonSelection]
+        onboardingManagerMock.stubbedRemainingSteps = [.setDefaultBrowser]
+        let sut = makeSUT(currentOnboardingStep: .downloadReasonSelection)
+
+        // WHEN
+        sut.selectDownloadReasonAction(.privateAIChat)
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureDownloadReasonSelection)
+        XCTAssertEqual(pixelReporterMock.didCaptureDownloadReasonSelection, .privateAIChat)
+    }
+
+    func testWhenSearchPrivacySettingsContinueThenFirePixelWithCorrectParameters() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = [.searchPrivacySettingsSelection]
+        let personalizationManager = MockOnboardingPersonalizationManager()
+        personalizationManager.isRecentlyVisitedSitesEnabled = true
+        personalizationManager.isSafeSearchEnabled = false
+        let sut = makeSUT(currentOnboardingStep: .searchPrivacySettingsSelection, personalizationManager: personalizationManager)
+
+        // WHEN
+        sut.searchPrivacySettingsContinueAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureSearchPrivacySettingsSelection)
+        XCTAssertEqual(pixelReporterMock.didCaptureSearchPrivacySettingsSelection?.recentlyVisitedSitesEnabled, true)
+        XCTAssertEqual(pixelReporterMock.didCaptureSearchPrivacySettingsSelection?.safeSearchEnabled, false)
+    }
+
+    func testWhenAISearchSettingsContinueThenFirePixelWithCorrectParameters() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = [.aiSearchSettingsSelection]
+        let personalizationManager = MockOnboardingPersonalizationManager()
+        personalizationManager.isSearchAssistEnabled = true
+        personalizationManager.areAIGeneratedImagesHidden = true
+        let sut = makeSUT(currentOnboardingStep: .aiSearchSettingsSelection, personalizationManager: personalizationManager)
+
+        // WHEN
+        sut.aiSearchSettingsContinueAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureAISearchSettingsSelection)
+        XCTAssertEqual(pixelReporterMock.didCaptureAISearchSettingsSelection?.searchAssistEnabled, true)
+        XCTAssertEqual(pixelReporterMock.didCaptureAISearchSettingsSelection?.aiGeneratedImagesEnabled, false) // opposite of areAIGeneratedImagesHidden
+    }
+
+    func testWhenAIModelContinueThenFirePixelWithProvider() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = [.aiModelSelection]
+        let prefetcher = MockOnboardingAIModelsPrefetcher()
+        prefetcher.resolvedModel = OnboardingAIModelResponse(
+            models: [OnboardingAIModelOption(id: "claude-1", provider: .anthropic, modelShortName: "Claude")],
+            defaultModelId: "claude-1"
+        )
+        let personalizationManager = MockOnboardingPersonalizationManager()
+        personalizationManager.selectedAIChatModelID = "claude-1"
+        let sut = makeSUT(currentOnboardingStep: .aiModelSelection, personalizationManager: personalizationManager, aiModelsPrefetcher: prefetcher)
+
+        // WHEN
+        sut.aiModelContinueAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureAIModelSelection)
+        XCTAssertEqual(pixelReporterMock.didCaptureAIModelSelection, "anthropic")
+    }
+
+    func testWhenAIModelContinueAndSelectedModelNotInCatalogThenSelectionPixelReportsUnknown() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = [.aiModelSelection]
+        let prefetcher = MockOnboardingAIModelsPrefetcher()
+        prefetcher.resolvedModel = OnboardingAIModelResponse(
+            models: [OnboardingAIModelOption(id: "claude-1", provider: .anthropic, modelShortName: "Claude")],
+            defaultModelId: "claude-1"
+        )
+        let personalizationManager = MockOnboardingPersonalizationManager()
+        personalizationManager.selectedAIChatModelID = "not-in-catalog"
+        let sut = makeSUT(currentOnboardingStep: .aiModelSelection, personalizationManager: personalizationManager, aiModelsPrefetcher: prefetcher)
+
+        // WHEN
+        sut.aiModelContinueAction()
+
+        // THEN
+        XCTAssertEqual(pixelReporterMock.didCaptureAIModelSelection, "unknown")
+    }
+
+    func testWhenToggleInputModeContinueThenFirePixelWithCorrectParameters() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = [.toggleInputModeSelection]
+        let personalizationManager = MockOnboardingPersonalizationManager()
+        personalizationManager.doesNewTabOpenWithAIChat = true
+        let sut = makeSUT(currentOnboardingStep: .toggleInputModeSelection, personalizationManager: personalizationManager)
+
+        // WHEN
+        sut.toggleInputModeContinueAction(opensWithAIChat: true)
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureToggleInputModeSelection)
+        XCTAssertEqual(pixelReporterMock.didCaptureToggleInputModeSelection, true)
+    }
+
+    func testWhenKeepDuckAIContinueThenFirePixelWithCorrectParameters() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = [.keepDuckAISelection]
+        let sut = makeSUT(currentOnboardingStep: .keepDuckAISelection)
+
+        // WHEN
+        sut.keepDuckAIContinueAction(shouldKeep: false)
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureKeepDuckAISelection)
+        XCTAssertEqual(pixelReporterMock.didCaptureKeepDuckAISelection, false)
+    }
+
+    func testWhenDuckPlayerContinueThenFirePixelWithCorrectParameters() {
+        // GIVEN
+        onboardingManagerMock.onboardingSteps = [.duckPlayerSelection]
+        let personalizationManager = MockOnboardingPersonalizationManager()
+        personalizationManager.isYouTubeAdBlockingEnabled = true
+        personalizationManager.isDuckPlayerEnabled = false
+        let sut = makeSUT(currentOnboardingStep: .duckPlayerSelection, personalizationManager: personalizationManager)
+
+        // WHEN
+        sut.duckPlayerContinueAction()
+
+        // THEN
+        XCTAssertTrue(pixelReporterMock.didCallMeasureDuckPlayerSelection)
+        XCTAssertEqual(pixelReporterMock.didCaptureDuckPlayerSelection?.youTubeAdBlockingEnabled, true)
+        XCTAssertEqual(pixelReporterMock.didCaptureDuckPlayerSelection?.duckPlayerEnabled, false)
     }
 }
 

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -23,6 +23,7 @@ import Onboarding
 import Persistence
 import PersistenceTestingUtils
 import PrivacyConfig
+import PixelExperimentKit
 @testable import DuckDuckGo
 
 final class OnboardingPixelReporterTests: XCTestCase {
@@ -43,7 +44,8 @@ final class OnboardingPixelReporterTests: XCTestCase {
         userDefaultsMock = UserDefaults(suiteName: Self.suiteName)
         sharedPixelHandlerMock = MockOnboardingSharedPixelHandling()
         initSharedPixelsStorageMock()
-        sut = OnboardingPixelReporter(pixel: OnboardingPixelFireMock.self, uniquePixel: OnboardingUniquePixelFireMock.self, statisticsStore: statisticsStoreMock, calendar: calendar, dateProvider: { self.now }, userDefaults: userDefaultsMock, sharedPixelHandler: sharedPixelHandlerMock, sharedPixelsStorage: sharedPixelsStorageMock)
+        MockExperimentPixelFiring.reset()
+        sut = OnboardingPixelReporter(pixel: OnboardingPixelFireMock.self, uniquePixel: OnboardingUniquePixelFireMock.self, statisticsStore: statisticsStoreMock, calendar: calendar, dateProvider: { self.now }, userDefaults: userDefaultsMock, sharedPixelHandler: sharedPixelHandlerMock, sharedPixelsStorage: sharedPixelsStorageMock, downloadReasonExperimentMetric: OnboardingDownloadReasonExperimentMetric(experimentPixelFiring: MockExperimentPixelFiring.self))
         try super.setUpWithError()
     }
 
@@ -1263,16 +1265,40 @@ final class OnboardingPixelReporterTests: XCTestCase {
 
     // MARK: - Try Duck.ai End of Journey
 
-    func testWhenMeasureEndOfJourneyTryDuckAIImpressionThenEndOfJourneyTryDuckAIShownFiresWithVariant() {
+    func testWhenMeasureScreenImpressionEndTryDuckAIShownThenSharedPixelFiresWithVariant() {
         // GIVEN
         sharedPixelsStorageMock.onboardingVariant = .downloadReasonSearch
 
         // WHEN
-        sut.measureEndOfJourneyTryDuckAIImpression()
+        sut.measureScreenImpression(.endTryDuckAI(.shown))
 
         // THEN
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.endTryDuckAI(.shown)])
         XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .downloadReasonSearch)
+    }
+
+    func testWhenMeasureScreenImpressionEndShownThenOnboardingCompletedExperimentMetricFires() {
+        // WHEN
+        sut.measureScreenImpression(.end(.shown))
+
+        // THEN
+        XCTAssertTrue(MockExperimentPixelFiring.firedMetrics.contains("onboarding_completed"))
+    }
+
+    func testWhenMeasureScreenImpressionEndTryDuckAIShownThenOnboardingCompletedExperimentMetricFires() {
+        // WHEN
+        sut.measureScreenImpression(.endTryDuckAI(.shown))
+
+        // THEN
+        XCTAssertTrue(MockExperimentPixelFiring.firedMetrics.contains("onboarding_completed"))
+    }
+
+    func testWhenMeasureScreenImpressionOtherSharedEventThenOnboardingCompletedExperimentMetricDoesNotFire() {
+        // WHEN
+        sut.measureScreenImpression(.welcome(.shown))
+
+        // THEN
+        XCTAssertFalse(MockExperimentPixelFiring.firedMetrics.contains("onboarding_completed"))
     }
 
     func testWhenMeasureEndOfJourneyTryDuckAICTAActionThenEndOfJourneyTryDuckAIEngageFires() {
@@ -1420,6 +1446,26 @@ final class OnboardingPixelReporterTests: XCTestCase {
         }
     }
 
+    func testWhenMeasureDownloadReasonSelectionThenSelectionExperimentMetricFires() {
+        let expectedMetrics: [(OnboardingDownloadReason, String)] = [
+            (.browserPrivately, "download_reason_selected_search"),
+            (.privateAIChat, "download_reason_selected_ai-chat"),
+            (.noAI, "download_reason_selected_no-ai"),
+            (.blockAds, "download_reason_selected_ad-blocking")
+        ]
+
+        for (reason, expectedMetric) in expectedMetrics {
+            // GIVEN
+            MockExperimentPixelFiring.reset()
+
+            // WHEN
+            sut.measureDownloadReasonSelection(reason)
+
+            // THEN
+            XCTAssertTrue(MockExperimentPixelFiring.firedMetrics.contains(expectedMetric), "Failed for reason \(reason)")
+        }
+    }
+
     func testWhenMeasureSearchPrivacySettingsSelectionThenSerpClickedFires() {
         // WHEN
         sut.measureSearchPrivacySettingsSelection(recentlyVisitedSitesEnabled: true, safeSearchEnabled: false)
@@ -1492,5 +1538,20 @@ private final class MockOnboardingSharedPixelHandling: OnboardingSharedPixelHand
         receivedSource = source
         receivedFlow = flow
         receivedVariant = variant
+    }
+}
+
+private enum MockExperimentPixelFiring: ExperimentPixelFiring {
+    private(set) static var firedMetrics: [String] = []
+
+    static func fireExperimentPixel(for subfeatureID: SubfeatureID,
+                                    metric: String,
+                                    conversionWindowDays: ConversionWindow,
+                                    value: String) {
+        firedMetrics.append(metric)
+    }
+
+    static func reset() {
+        firedMetrics = []
     }
 }

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -1261,6 +1261,36 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
+    // MARK: - Try Duck.ai End of Journey
+
+    func testWhenMeasureEndOfJourneyTryDuckAIImpressionThenEndOfJourneyTryDuckAIShownFiresWithVariant() {
+        // GIVEN
+        sharedPixelsStorageMock.onboardingVariant = .downloadReasonSearch
+
+        // WHEN
+        sut.measureEndOfJourneyTryDuckAIImpression()
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.endTryDuckAI(.shown)])
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .downloadReasonSearch)
+    }
+
+    func testWhenMeasureEndOfJourneyTryDuckAICTAActionThenEndOfJourneyTryDuckAIEngageFires() {
+        // WHEN
+        sut.measureEndOfJourneyTryDuckAICTAAction()
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.endTryDuckAI(.clicked(.engage))])
+    }
+
+    func testWhenMeasureEndOfJourneyTryDuckAISkipActionThenEndOfJourneyTryDuckAIDismissFires() {
+        // WHEN
+        sut.measureEndOfJourneyTryDuckAISkipAction()
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.endTryDuckAI(.clicked(.dismiss))])
+    }
+
     // MARK: - Download Reason Segmented Flow
 
     func testWhenMeasureTailoredStepImpressionsThenCorrectShownPixelsFire() {

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -1261,6 +1261,155 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
+    // MARK: - Download Reason Segmented Flow
+
+    func testWhenMeasureTailoredStepImpressionsThenCorrectShownPixelsFire() {
+        // WHEN
+        sut.measureDownloadReasonImpression()
+        sut.measureSearchPrivacySettingsImpression()
+        sut.measureAIModelImpression()
+        sut.measureToggleInputModeImpression()
+        sut.measureAISearchSettingsImpression()
+        sut.measureKeepDuckAIImpression()
+        sut.measureDuckPlayerImpression()
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [
+            .downloadChoice(.shown),
+            .preferencesSerp(.shown),
+            .preferencesAIModel(.shown),
+            .preferencesAIToggleMode(.shown),
+            .preferencesAISearch(.shown),
+            .preferencesDuckAI(.shown),
+            .preferencesYoutube(.shown)
+        ])
+    }
+
+    func testWhenMeasureDownloadReasonImpressionThenNoVariantIsCarried() {
+        // WHEN
+        sut.measureDownloadReasonImpression()
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.downloadChoice(.shown)])
+        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+    }
+
+    func testWhenMeasureTailoredStepImpressionThenStoredVariantIsCarried() {
+        // GIVEN
+        sharedPixelsStorageMock.onboardingVariant = .downloadReasonSearch
+
+        // WHEN
+        sut.measureSearchPrivacySettingsImpression()
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.preferencesSerp(.shown)])
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .downloadReasonSearch)
+    }
+
+    func testWhenSegmentedFlowStepFiresThenCarriesTreatmentSourceAndFlow() {
+        // GIVEN
+        sharedPixelsStorageMock.onboardingSource = .default
+        sharedPixelsStorageMock.onboardingFlow = .tailoredByDownloadReason
+
+        // WHEN
+        sut.measureDownloadReasonImpression()
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .default)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .tailoredByDownloadReason)
+    }
+
+    func testWhenMeasureDownloadReasonSelectionThenDownloadChoiceClickedFiresWithMappedReason() {
+        // WHEN
+        sut.measureDownloadReasonSelection(.browserPrivately)
+        sut.measureDownloadReasonSelection(.privateAIChat)
+        sut.measureDownloadReasonSelection(.noAI)
+        sut.measureDownloadReasonSelection(.blockAds)
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [
+            .downloadChoice(.clicked(.search)),
+            .downloadChoice(.clicked(.aiChat)),
+            .downloadChoice(.clicked(.noAI)),
+            .downloadChoice(.clicked(.adBlocking))
+        ])
+        // The download-choice pixel itself carries no variant (the variant is set from this choice).
+        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+    }
+
+    func testWhenMeasureDownloadReasonSelectionThenChosenReasonPersistedAsVariant() {
+        let expectedVariants: [(OnboardingDownloadReason, OnboardingPixelParameter.Variant)] = [
+            (.browserPrivately, .downloadReasonSearch),
+            (.privateAIChat, .downloadReasonAIChat),
+            (.noAI, .downloadReasonNoAI),
+            (.blockAds, .downloadReasonAdBlocking)
+        ]
+
+        for (reason, expectedVariant) in expectedVariants {
+            // WHEN
+            sut.measureDownloadReasonSelection(reason)
+
+            // THEN
+            XCTAssertEqual(sharedPixelsStorageMock.onboardingVariant, expectedVariant, "Failed for reason \(reason)")
+        }
+    }
+
+    func testWhenMeasureSearchPrivacySettingsSelectionThenSerpClickedFires() {
+        // WHEN
+        sut.measureSearchPrivacySettingsSelection(recentlyVisitedSitesEnabled: true, safeSearchEnabled: false)
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.preferencesSerp(.clicked(recentlyVisitedSitesEnabled: true, safeSearchEnabled: false))])
+    }
+
+    func testWhenMeasureAIModelSelectionThenAIModelClickedFires() {
+        // WHEN
+        sut.measureAIModelSelection(model: "claude")
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.preferencesAIModel(.clicked(model: "claude"))])
+    }
+
+    func testWhenMeasureToggleInputModeSelectionThenToggleModeClickedFires() {
+        // WHEN
+        sut.measureToggleInputModeSelection(openNewTabsWithAIChat: true)
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.preferencesAIToggleMode(.clicked(openNewTabsWithAIChat: true))])
+    }
+
+    func testWhenMeasureAISearchSettingsSelectionThenAISearchClickedFires() {
+        // WHEN
+        sut.measureAISearchSettingsSelection(searchAssistEnabled: false, aiGeneratedImagesEnabled: true)
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.preferencesAISearch(.clicked(searchAssistEnabled: false, aiGeneratedImagesEnabled: true))])
+    }
+
+    func testWhenMeasureKeepDuckAISelectionEnabledThenDuckAIOnClickedFires() {
+        // WHEN
+        sut.measureKeepDuckAISelection(isEnabled: true)
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.preferencesDuckAI(.clicked(.on))])
+    }
+
+    func testWhenMeasureKeepDuckAISelectionDisabledThenDuckAIOffClickedFires() {
+        // WHEN
+        sut.measureKeepDuckAISelection(isEnabled: false)
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.preferencesDuckAI(.clicked(.off))])
+    }
+
+    func testWhenMeasureDuckPlayerSelectionThenYoutubeClickedFires() {
+        // WHEN
+        sut.measureDuckPlayerSelection(youTubeAdBlockingEnabled: true, duckPlayerEnabled: false)
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.preferencesYoutube(.clicked(youTubeAdBlockingEnabled: true, duckPlayerEnabled: false))])
+    }
+
 }
 
 private final class MockOnboardingSharedPixelHandling: OnboardingSharedPixelHandling {

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -1424,7 +1424,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
 
     func testWhenMeasureKeepDuckAISelectionEnabledThenDuckAIOnClickedFires() {
         // WHEN
-        sut.measureKeepDuckAISelection(isEnabled: true)
+        sut.measureKeepDuckAISelection(shouldKeep: true)
 
         // THEN
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.preferencesDuckAI(.clicked(.on))])
@@ -1432,7 +1432,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
 
     func testWhenMeasureKeepDuckAISelectionDisabledThenDuckAIOffClickedFires() {
         // WHEN
-        sut.measureKeepDuckAISelection(isEnabled: false)
+        sut.measureKeepDuckAISelection(shouldKeep: false)
 
         // THEN
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.preferencesDuckAI(.clicked(.off))])

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -190,7 +190,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.setDefault(.shown)])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertNotNil(sharedPixelHandlerMock.receivedVariant)
     }
 
     func testWhenMeasureChooseBrowserCTAActionThenLegacyChooseBrowserPressedAndSetDefaultEngageSharedPixelsFire() {
@@ -215,7 +215,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.setDefault(.clicked(.engage))])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertNotNil(sharedPixelHandlerMock.receivedVariant)
     }
 
     func testWhenMeasureAiComparisonImpressionThenAiComparisonShownSharedPixelFires() {
@@ -336,7 +336,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.setDefault(.clicked(.dismiss))])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertNotNil(sharedPixelHandlerMock.receivedVariant)
     }
 
     // MARK: - Custom Interactions
@@ -1317,6 +1317,42 @@ final class OnboardingPixelReporterTests: XCTestCase {
         // THEN
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .default)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .tailoredByDownloadReason)
+    }
+
+    func testWhenMeasureSetDefaultBrowserImpressionThenCarriesStoredDownloadReasonVariant() {
+        // GIVEN — a download reason was selected earlier in the tailored flow.
+        sharedPixelsStorageMock.onboardingVariant = .downloadReasonAdBlocking
+
+        // WHEN
+        sut.measureSetDefaultBrowserImpression()
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.setDefault(.shown)])
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .downloadReasonAdBlocking)
+    }
+
+    func testWhenMeasureChooseBrowserCTAActionThenCarriesStoredDownloadReasonVariant() {
+        // GIVEN — a download reason was selected earlier in the tailored flow.
+        sharedPixelsStorageMock.onboardingVariant = .downloadReasonSearch
+
+        // WHEN
+        sut.measureChooseBrowserCTAAction()
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.setDefault(.clicked(.engage))])
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .downloadReasonSearch)
+    }
+
+    func testWhenMeasureSetDefaultBrowserSkippedThenCarriesStoredDownloadReasonVariant() {
+        // GIVEN — a download reason was selected earlier in the tailored flow.
+        sharedPixelsStorageMock.onboardingVariant = .downloadReasonNoAI
+
+        // WHEN
+        sut.measureSetDefaultBrowserSkipped()
+
+        // THEN
+        XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.setDefault(.clicked(.dismiss))])
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .downloadReasonNoAI)
     }
 
     func testWhenMeasureDownloadReasonSelectionThenDownloadChoiceClickedFiresWithMappedReason() {

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -92,7 +92,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.welcome(.shown)])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureSkipOnboardingCTAIsCalledThenLegacySkipPressedAndWelcomeDismissSharedPixelsFire() {
@@ -117,7 +117,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.welcome(.clicked(.dismiss))])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureConfirmSkipOnboardingCTAIsCalledThenLegacyConfirmSkipPressedAndSkipOnboardingEngageSharedPixelsFire() {
@@ -142,7 +142,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.skipOnboarding(.clicked(.engage))])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureCancelSkipOnboardingCTAIsCalledThenLegacyResumePressedAndSkipOnboardingDismissSharedPixelsFire() {
@@ -167,7 +167,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.skipOnboarding(.clicked(.dismiss))])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureBrowserComparisonImpressionThenLegacyComparisonChartShownUniqueAndSetDefaultShownSharedPixelsFire() {
@@ -235,7 +235,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.aiIntro(.shown)])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureAiComparisonCTAActionThenAiComparisonEngageSharedPixelFires() {
@@ -253,7 +253,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.aiIntro(.clicked(.engage))])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureStartOnboardingCTAActionThenWelcomeEngageSharedPixelFires() {
@@ -272,7 +272,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.welcome(.clicked(.engage))])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureAutoRestoreOnboardingRestoreCTAActionThenLegacyRestoreTappedUniquePixelFires() {
@@ -324,7 +324,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.skipOnboarding(.shown)])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureSetDefaultBrowserSkippedThenSetDefaultDismissSharedPixelFires() {
@@ -701,7 +701,8 @@ final class OnboardingPixelReporterTests: XCTestCase {
     // MARK: - Duck AI query selection (linear onboarding)
 
     func testWhenMeasureDuckAIQuerySelectionImpressionThenLegacyToggleImpressionUniqueAndSearchShownSharedPixelsFire() {
-        // GIVEN
+        // GIVEN — the toggle is the branching point; it fires before a variant is set.
+        sharedPixelsStorageMock.onboardingVariant = nil
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [])
 
         // WHEN
@@ -979,7 +980,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.appIconColor(.shown)])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureChooseNonDefaultAppIconIsCalledThenLegacyChooseCustomIconColorPressedAndAppIconColorClickedSharedPixelsFire() {
@@ -1002,7 +1003,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.appIconColor(.clicked(.green))])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureChooseDefaultAppIconIsCalledThenOnlySharedOnboardingPixelFires() {
@@ -1020,7 +1021,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.appIconColor(.clicked(.red))])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureAddressBarPositionSelectionImpressionIsCalledThenLegacyChooseAddressBarImpressionUniqueAndAddressBarPositionShownSharedPixelsFire() {
@@ -1043,7 +1044,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.addressBarPosition(.shown)])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureChooseBottomAddressBarPositionIsCalledThenLegacyBottomAddressBarSelectedAndAddressBarBottomSharedPixelsFire() {
@@ -1066,7 +1067,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.addressBarPosition(.clicked(.bottom))])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureChooseTopAddressBarPositionIsCalledThenOnlySharedOnboardingPixelFires() {
@@ -1084,7 +1085,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.addressBarPosition(.clicked(.top))])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     // MARK: Add To Dock Experiment
@@ -1109,7 +1110,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.addToDock(.shown)])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureAddToDockPromoShowTutorialCTAActionIsCalledThenLegacyShowTutorialTappedAndAddToDockEngageSharedPixelsFire() {
@@ -1132,7 +1133,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.addToDock(.clicked(.engage))])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureAddToDockPromoDismissCTAActionThenLegacyPromoDismissTappedAndAddToDockDismissSharedPixelsFire() {
@@ -1155,7 +1156,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.addToDock(.clicked(.dismiss))])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureAddToDockTutorialDismissCTAActionIsCalledThenonboardingAddToDockTutorialDismissCTAPixelFires() {
@@ -1199,7 +1200,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.searchExperience(.shown)])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureChooseAIChatIsCalledThenLegacyAIChatSelectedAndSearchExperienceSearchPlusDuckAISharedPixelsFire() {
@@ -1222,7 +1223,7 @@ final class OnboardingPixelReporterTests: XCTestCase {
         XCTAssertEqual(sharedPixelHandlerMock.eventsFired, [.searchExperience(.clicked(.searchPlusDuckAI))])
         XCTAssertEqual(sharedPixelHandlerMock.receivedSource, .duckAICustomProductPage)
         XCTAssertEqual(sharedPixelHandlerMock.receivedFlow, .duckAI)
-        XCTAssertNil(sharedPixelHandlerMock.receivedVariant)
+        XCTAssertEqual(sharedPixelHandlerMock.receivedVariant, .duckAISearch)
     }
 
     func testWhenMeasureChooseSearchOnlyIsCalledThenLegacySearchOnlySelectedAndSearchExperienceSearchOnlySharedPixelsFire() {
@@ -1342,6 +1343,9 @@ final class OnboardingPixelReporterTests: XCTestCase {
     }
 
     func testWhenMeasureDownloadReasonImpressionThenNoVariantIsCarried() {
+        // GIVEN
+        sharedPixelsStorageMock.onboardingVariant = nil
+
         // WHEN
         sut.measureDownloadReasonImpression()
 
@@ -1413,9 +1417,13 @@ final class OnboardingPixelReporterTests: XCTestCase {
 
     func testWhenMeasureDownloadReasonSelectionThenDownloadChoiceClickedFiresWithMappedReason() {
         // WHEN
+        sharedPixelsStorageMock.onboardingVariant = nil // reset the variant before each selection so every choice fires from a clean state
         sut.measureDownloadReasonSelection(.browserPrivately)
+        sharedPixelsStorageMock.onboardingVariant = nil
         sut.measureDownloadReasonSelection(.privateAIChat)
+        sharedPixelsStorageMock.onboardingVariant = nil
         sut.measureDownloadReasonSelection(.noAI)
+        sharedPixelsStorageMock.onboardingVariant = nil
         sut.measureDownloadReasonSelection(.blockAds)
 
         // THEN
@@ -1438,12 +1446,26 @@ final class OnboardingPixelReporterTests: XCTestCase {
         ]
 
         for (reason, expectedVariant) in expectedVariants {
+            // GIVEN
+            sharedPixelsStorageMock.onboardingVariant = nil
+
             // WHEN
             sut.measureDownloadReasonSelection(reason)
 
             // THEN
             XCTAssertEqual(sharedPixelsStorageMock.onboardingVariant, expectedVariant, "Failed for reason \(reason)")
         }
+    }
+
+    func testWhenVariantAlreadySetThenLaterSelectionDoesNotOverwriteIt() {
+        // GIVEN a variant already set (e.g. by the download-reason screen)
+        sharedPixelsStorageMock.onboardingVariant = .downloadReasonSearch
+
+        // WHEN a later branching step tries to set another variant
+        sut.measureDuckAIQuerySubmission(selection: .duckAI, promptSource: .custom)
+
+        // THEN the first variant wins and is not overwritten
+        XCTAssertEqual(sharedPixelsStorageMock.onboardingVariant, .downloadReasonSearch)
     }
 
     func testWhenMeasureDownloadReasonSelectionThenSelectionExperimentMetricFires() {

--- a/iOS/PixelDefinitions/pixels/definitions/onboarding_shared.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/onboarding_shared.json5
@@ -362,9 +362,8 @@
             "onboardingEventType",
             {
                 "key": "value",
-                "type": "string",
-                "description": "On the engagement (clicked) event: whether new tabs open with AI chat: true or false",
-                "enum": ["true", "false"]
+                "type": "boolean",
+                "description": "On the engagement (clicked) event: whether new tabs open with AI chat: true or false"
             },
             "onboardingInstallType",
             "onboardingDaysSinceInstall",

--- a/iOS/PixelDefinitions/pixels/definitions/onboarding_shared.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/onboarding_shared.json5
@@ -11,7 +11,8 @@
             "onboardingInstallType",
             "onboardingDaysSinceInstall",
             "onboardingSource",
-            "onboardingFlow"
+            "onboardingFlow",
+            "onboardingFlowVariant"
         ]
     },
     "m_ios_onboarding_skip-onboarding": {
@@ -26,7 +27,8 @@
             "onboardingInstallType",
             "onboardingDaysSinceInstall",
             "onboardingSource",
-            "onboardingFlow"
+            "onboardingFlow",
+            "onboardingFlowVariant"
         ]
     },
     "m_ios_onboarding_set-default": {
@@ -41,7 +43,8 @@
             "onboardingInstallType",
             "onboardingDaysSinceInstall",
             "onboardingSource",
-            "onboardingFlow"
+            "onboardingFlow",
+            "onboardingFlowVariant"
         ]
     },
     "m_ios_onboarding_ai-intro": {
@@ -56,7 +59,8 @@
             "onboardingInstallType",
             "onboardingDaysSinceInstall",
             "onboardingSource",
-            "onboardingFlow"
+            "onboardingFlow",
+            "onboardingFlowVariant"
         ]
     },
     "m_ios_onboarding_add-to-dock": {
@@ -71,7 +75,8 @@
             "onboardingInstallType",
             "onboardingDaysSinceInstall",
             "onboardingSource",
-            "onboardingFlow"
+            "onboardingFlow",
+            "onboardingFlowVariant"
         ]
     },
     "m_ios_onboarding_app-icon-color": {
@@ -91,7 +96,8 @@
             "onboardingInstallType",
             "onboardingDaysSinceInstall",
             "onboardingSource",
-            "onboardingFlow"
+            "onboardingFlow",
+            "onboardingFlowVariant"
         ]
     },
     "m_ios_onboarding_address-bar-position": {
@@ -111,7 +117,8 @@
             "onboardingInstallType",
             "onboardingDaysSinceInstall",
             "onboardingSource",
-            "onboardingFlow"
+            "onboardingFlow",
+            "onboardingFlowVariant"
         ]
     },
     "m_ios_onboarding_search-experience": {
@@ -131,7 +138,8 @@
             "onboardingInstallType",
             "onboardingDaysSinceInstall",
             "onboardingSource",
-            "onboardingFlow"
+            "onboardingFlow",
+            "onboardingFlowVariant"
         ]
     },
     "m_ios_onboarding_search-chat-toggle": {
@@ -151,7 +159,8 @@
             "onboardingInstallType",
             "onboardingDaysSinceInstall",
             "onboardingSource",
-            "onboardingFlow"
+            "onboardingFlow",
+            "onboardingFlowVariant"
         ]
     },
     "m_ios_onboarding_search": {
@@ -293,7 +302,8 @@
             "onboardingInstallType",
             "onboardingDaysSinceInstall",
             "onboardingSource",
-            "onboardingFlow"
+            "onboardingFlow",
+            "onboardingFlowVariant"
         ]
     },
     "m_ios_onboarding_preferences_serp": {

--- a/iOS/PixelDefinitions/pixels/definitions/onboarding_shared.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/onboarding_shared.json5
@@ -275,5 +275,179 @@
             "onboardingFlow",
             "onboardingFlowVariant"
         ]
+    },
+    "m_ios_onboarding_download-choice": {
+        "description": "Fired during linear onboarding on the Download Reason screen of the download-reason segmented flow (treatment cohort). The variant is not carried here because it is set by this choice.",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "onboardingEventType",
+            {
+                "key": "value",
+                "type": "string",
+                "description": "On the engagement (clicked) event: the download reason the user selected",
+                "enum": ["search", "ai-chat", "no-ai", "ad-blocking"]
+            },
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingSource",
+            "onboardingFlow"
+        ]
+    },
+    "m_ios_onboarding_preferences_serp": {
+        "description": "Fired during linear onboarding on the SERP preferences step of the download-reason segmented flow (treatment cohort).",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "onboardingEventType",
+            {
+                "key": "recently_visited_sites_enabled",
+                "type": "boolean",
+                "description": "On the engagement (clicked) event: whether recently visited sites is enabled: true or false"
+            },
+            {
+                "key": "safe_search_enabled",
+                "type": "boolean",
+                "description": "On the engagement (clicked) event: whether safe search is enabled: true or false"
+            },
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingSource",
+            "onboardingFlow",
+            "onboardingFlowVariant"
+        ]
+    },
+    "m_ios_onboarding_preferences_ai-model": {
+        "description": "Fired during linear onboarding on the AI model picker step of the download-reason segmented flow (treatment cohort).",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "onboardingEventType",
+            {
+                "key": "value",
+                "type": "string",
+                "description": "On the engagement (clicked) event: the provider of the selected AI model",
+                "enum": ["anthropic", "openai", "mistral", "unknown"]
+            },
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingSource",
+            "onboardingFlow",
+            "onboardingFlowVariant"
+        ]
+    },
+    "m_ios_onboarding_preferences_ai-toggle-mode": {
+        "description": "Fired during linear onboarding on the Search/AI address-bar toggle-mode step of the download-reason segmented flow (treatment cohort).",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "onboardingEventType",
+            {
+                "key": "value",
+                "type": "string",
+                "description": "On the engagement (clicked) event: whether new tabs open with AI chat: true or false",
+                "enum": ["true", "false"]
+            },
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingSource",
+            "onboardingFlow",
+            "onboardingFlowVariant"
+        ]
+    },
+    "m_ios_onboarding_preferences_ai-search": {
+        "description": "Fired during linear onboarding on the AI search settings step of the download-reason segmented flow (treatment cohort).",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "onboardingEventType",
+            {
+                "key": "search_assist_enabled",
+                "type": "boolean",
+                "description": "On the engagement (clicked) event: whether search assist is enabled: true or false"
+            },
+            {
+                "key": "ai_generated_images_enabled",
+                "type": "boolean",
+                "description": "On the engagement (clicked) event: whether AI-generated images are enabled (shown): true or false"
+            },
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingSource",
+            "onboardingFlow",
+            "onboardingFlowVariant"
+        ]
+    },
+    "m_ios_onboarding_preferences_duck-ai": {
+        "description": "Fired during linear onboarding on the 'Keep Duck.ai on/off' step of the download-reason segmented flow (treatment cohort).",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "onboardingEventType",
+            {
+                "key": "value",
+                "type": "string",
+                "description": "On the engagement (clicked) event: whether the user chose to keep Duck.ai on or off",
+                "enum": ["on", "off"]
+            },
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingSource",
+            "onboardingFlow",
+            "onboardingFlowVariant"
+        ]
+    },
+    "m_ios_onboarding_preferences_youtube": {
+        "description": "Fired during linear onboarding on the YouTube (Duck Player) preferences step of the download-reason segmented flow (treatment cohort).",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "onboardingEventType",
+            {
+                "key": "youtube_ad_blocking_enabled",
+                "type": "boolean",
+                "description": "On the engagement (clicked) event: whether YouTube ad blocking is enabled: true or false"
+            },
+            {
+                "key": "duck_player_enabled",
+                "type": "boolean",
+                "description": "On the engagement (clicked) event: whether Duck Player is enabled: true or false"
+            },
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingSource",
+            "onboardingFlow",
+            "onboardingFlowVariant"
+        ]
+    },
+    "m_ios_onboarding_end-try-duckai": {
+        "description": "Fired on the 'Try Duck.ai' end-of-journey dialog (new-tab surface) of the download-reason segmented flow, to measure the Try Duck.ai CTA CTR (shown vs engage/dismiss).",
+        "owners": ["alessandroboron"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "onboardingEventType",
+            "onboardingClickedValue",
+            "onboardingInstallType",
+            "onboardingDaysSinceInstall",
+            "onboardingSource",
+            "onboardingFlow",
+            "onboardingFlowVariant"
+        ]
     }
 }

--- a/iOS/PixelDefinitions/pixels/native_experiments.json5
+++ b/iOS/PixelDefinitions/pixels/native_experiments.json5
@@ -1,5 +1,47 @@
 {
     // This file defines pixels sent by the native experiments framework
     "defaultSuffixes": [],
-    "activeExperiments": {}
+    "activeExperiments": {
+        "onboardingFlowByDownloadReasonExperiment": {
+            "cohorts": ["control", "treatment"],
+            "metrics": {
+                "onboarding_completed": {
+                    "description": "User reached the end-of-journey dialog (onboarding completed)",
+                    "enum": [""]
+                },
+                "download_reason_selected_search": {
+                    "description": "User selected the 'search' download reason",
+                    "enum": [""]
+                },
+                "download_reason_selected_ai-chat": {
+                    "description": "User selected the 'ai-chat' download reason",
+                    "enum": [""]
+                },
+                "download_reason_selected_no-ai": {
+                    "description": "User selected the 'no-ai' download reason",
+                    "enum": [""]
+                },
+                "download_reason_selected_ad-blocking": {
+                    "description": "User selected the 'ad-blocking' download reason",
+                    "enum": [""]
+                },
+                "download_reason_search_retention_search": {
+                    "description": "D5-7 search retention for the 'search' download-reason segment",
+                    "enum": ["1", "4", "6", "11", "21", "30"]
+                },
+                "download_reason_search_retention_ai-chat": {
+                    "description": "D5-7 search retention for the 'ai-chat' download-reason segment",
+                    "enum": ["1", "4", "6", "11", "21", "30"]
+                },
+                "download_reason_search_retention_no-ai": {
+                    "description": "D5-7 search retention for the 'no-ai' download-reason segment",
+                    "enum": ["1", "4", "6", "11", "21", "30"]
+                },
+                "download_reason_search_retention_ad-blocking": {
+                    "description": "D5-7 search retention for the 'ad-blocking' download-reason segment",
+                    "enum": ["1", "4", "6", "11", "21", "30"]
+                }
+            }
+        }
+    }
 }

--- a/iOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/iOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -404,13 +404,13 @@
         "key": "flow",
         "type": "string",
         "description": "Version of the onboarding flow the user entered",
-        "enum": ["default", "duckai"]
+        "enum": ["default", "duckai", "tailored_by_download_reason"]
     },
     "onboardingFlowVariant": {
         "key": "variant",
         "type": "string",
-        "description": "Variant of the onboarding flow the user selected after branching on the 'Try a search or AI chat' step",
-        "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
+        "description": "Variant of the onboarding flow the user selected after branching (the 'Try a search or AI chat' step, or the download-reason screen)",
+        "enum": ["search_plus_duckai-search", "search_plus_duckai-chat", "download_reason_search", "download_reason_ai-chat", "download_reason_no-ai", "download_reason_ad-blocking"]
     },
     "tabCount": {
         "key": "tab_count",

--- a/iOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/iOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -410,7 +410,14 @@
         "key": "variant",
         "type": "string",
         "description": "Variant of the onboarding flow the user selected after branching (the 'Try a search or AI chat' step, or the download-reason screen)",
-        "enum": ["search_plus_duckai-search", "search_plus_duckai-chat", "download_reason_search", "download_reason_ai-chat", "download_reason_no-ai", "download_reason_ad-blocking"]
+        "enum": [
+            "search_plus_duckai-search",
+            "search_plus_duckai-chat",
+            "download_reason_search",
+            "download_reason_ai-chat",
+            "download_reason_no-ai",
+            "download_reason_ad-blocking"
+        ]
     },
     "tabCount": {
         "key": "tab_count",

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingPixelReporterMock.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingPixelReporterMock.swift
@@ -429,13 +429,8 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
 
     // MARK: - Try Duck.ai End of Journey
 
-    private(set) var didCallMeasureEndOfJourneyTryDuckAIImpression = false
     private(set) var didCallMeasureEndOfJourneyTryDuckAICTAAction = false
     private(set) var didCallMeasureEndOfJourneyTryDuckAISkipAction = false
-
-    func measureEndOfJourneyTryDuckAIImpression() {
-        didCallMeasureEndOfJourneyTryDuckAIImpression = true
-    }
 
     func measureEndOfJourneyTryDuckAICTAAction() {
         didCallMeasureEndOfJourneyTryDuckAICTAAction = true

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingPixelReporterMock.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingPixelReporterMock.swift
@@ -22,7 +22,7 @@ import Core
 import Onboarding
 @testable import DuckDuckGo
 
-final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, OnboardingCustomInteractionPixelReporting, OnboardingDaxDialogsReporting, OnboardingAddToDockReporting {
+final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, OnboardingCustomInteractionPixelReporting, OnboardingDaxDialogsReporting, OnboardingAddToDockReporting, OnboardingDownloadReasonPixelReporting {
 
     private(set) var didCallMeasureOnboardingIntroImpression = false
     private(set) var didCallMeasureSkipOnboardingCTAAction = false
@@ -338,5 +338,92 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
 
     func measureSubscriptionDialogNewTabDismissButtonTapped() {
         didCallMeasureSubscriptionPromoDialogNewTabDismissButtonTapped = true
+    }
+
+    // MARK: - Download Reason Segmented Flow
+
+    private(set) var didCallMeasureDownloadReasonImpression = false
+    private(set) var didCallMeasureDownloadReasonSelection = false
+    private(set) var didCaptureDownloadReasonSelection: OnboardingDownloadReason?
+    private(set) var didCallMeasureSearchPrivacySettingsImpression = false
+    private(set) var didCallMeasureSearchPrivacySettingsSelection = false
+    private(set) var didCaptureSearchPrivacySettingsSelection: (recentlyVisitedSitesEnabled: Bool, safeSearchEnabled: Bool)?
+    private(set) var didCallMeasureAIModelImpression = false
+    private(set) var didCallMeasureAIModelSelection = false
+    private(set) var didCaptureAIModelSelection: String?
+    private(set) var didCallMeasureToggleInputModeImpression = false
+    private(set) var didCallMeasureToggleInputModeSelection = false
+    private(set) var didCaptureToggleInputModeSelection: Bool?
+    private(set) var didCallMeasureAISearchSettingsImpression = false
+    private(set) var didCallMeasureAISearchSettingsSelection = false
+    private(set) var didCaptureAISearchSettingsSelection: (searchAssistEnabled: Bool, aiGeneratedImagesEnabled: Bool)?
+    private(set) var didCallMeasureKeepDuckAIImpression = false
+    private(set) var didCallMeasureKeepDuckAISelection = false
+    private(set) var didCaptureKeepDuckAISelection: Bool?
+    private(set) var didCallMeasureDuckPlayerImpression = false
+    private(set) var didCallMeasureDuckPlayerSelection = false
+    private(set) var didCaptureDuckPlayerSelection: (youTubeAdBlockingEnabled: Bool, duckPlayerEnabled: Bool)?
+
+    func measureDownloadReasonImpression() {
+        didCallMeasureDownloadReasonImpression = true
+    }
+
+    func measureDownloadReasonSelection(_ reason: OnboardingDownloadReason) {
+        didCallMeasureDownloadReasonSelection = true
+        didCaptureDownloadReasonSelection = reason
+    }
+
+    func measureSearchPrivacySettingsImpression() {
+        didCallMeasureSearchPrivacySettingsImpression = true
+    }
+
+    func measureSearchPrivacySettingsSelection(recentlyVisitedSitesEnabled: Bool, safeSearchEnabled: Bool) {
+        didCallMeasureSearchPrivacySettingsSelection = true
+        didCaptureSearchPrivacySettingsSelection = (recentlyVisitedSitesEnabled, safeSearchEnabled)
+    }
+
+    func measureAIModelImpression() {
+        didCallMeasureAIModelImpression = true
+    }
+
+    func measureAIModelSelection(model: String) {
+        didCallMeasureAIModelSelection = true
+        didCaptureAIModelSelection = model
+    }
+
+    func measureToggleInputModeImpression() {
+        didCallMeasureToggleInputModeImpression = true
+    }
+
+    func measureToggleInputModeSelection(openNewTabsWithAIChat: Bool) {
+        didCallMeasureToggleInputModeSelection = true
+        didCaptureToggleInputModeSelection = openNewTabsWithAIChat
+    }
+
+    func measureAISearchSettingsImpression() {
+        didCallMeasureAISearchSettingsImpression = true
+    }
+
+    func measureAISearchSettingsSelection(searchAssistEnabled: Bool, aiGeneratedImagesEnabled: Bool) {
+        didCallMeasureAISearchSettingsSelection = true
+        didCaptureAISearchSettingsSelection = (searchAssistEnabled, aiGeneratedImagesEnabled)
+    }
+
+    func measureKeepDuckAIImpression() {
+        didCallMeasureKeepDuckAIImpression = true
+    }
+
+    func measureKeepDuckAISelection(isEnabled: Bool) {
+        didCallMeasureKeepDuckAISelection = true
+        didCaptureKeepDuckAISelection = isEnabled
+    }
+
+    func measureDuckPlayerImpression() {
+        didCallMeasureDuckPlayerImpression = true
+    }
+
+    func measureDuckPlayerSelection(youTubeAdBlockingEnabled: Bool, duckPlayerEnabled: Bool) {
+        didCallMeasureDuckPlayerSelection = true
+        didCaptureDuckPlayerSelection = (youTubeAdBlockingEnabled, duckPlayerEnabled)
     }
 }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingPixelReporterMock.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingPixelReporterMock.swift
@@ -413,9 +413,9 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
         didCallMeasureKeepDuckAIImpression = true
     }
 
-    func measureKeepDuckAISelection(isEnabled: Bool) {
+    func measureKeepDuckAISelection(shouldKeep: Bool) {
         didCallMeasureKeepDuckAISelection = true
-        didCaptureKeepDuckAISelection = isEnabled
+        didCaptureKeepDuckAISelection = shouldKeep
     }
 
     func measureDuckPlayerImpression() {

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingPixelReporterMock.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tutorials/Onboarding/OnboardingPixelReporterMock.swift
@@ -426,4 +426,22 @@ final class OnboardingPixelReporterMock: OnboardingIntroPixelReporting, Onboardi
         didCallMeasureDuckPlayerSelection = true
         didCaptureDuckPlayerSelection = (youTubeAdBlockingEnabled, duckPlayerEnabled)
     }
+
+    // MARK: - Try Duck.ai End of Journey
+
+    private(set) var didCallMeasureEndOfJourneyTryDuckAIImpression = false
+    private(set) var didCallMeasureEndOfJourneyTryDuckAICTAAction = false
+    private(set) var didCallMeasureEndOfJourneyTryDuckAISkipAction = false
+
+    func measureEndOfJourneyTryDuckAIImpression() {
+        didCallMeasureEndOfJourneyTryDuckAIImpression = true
+    }
+
+    func measureEndOfJourneyTryDuckAICTAAction() {
+        didCallMeasureEndOfJourneyTryDuckAICTAAction = true
+    }
+
+    func measureEndOfJourneyTryDuckAISkipAction() {
+        didCallMeasureEndOfJourneyTryDuckAISkipAction = true
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216200647629938
Tech Design URL:
CC:

### Description
Adds pixel instrumentation for the download-reason segmented onboarding flow. 

The chosen download reason is recorded as a variant that rides on every subsequent onboarding pixel for cohort segmentation. 

Also adds the per-reason experiment metrics for download reason selection and search-retention

### Testing Steps

Notes:  [Pixel Definitions](https://app.asana.com/1/137249556945/project/1206329551987282/task/1216556967361534?focus=true)

1. Add return `.treatment` in `OnboardingManager.swift` line 416
2. Fresh install the app and start onboarding.
3. Verify that on the download-reason screen → `download-choice` fires (shown on appear)
4. Select a reason and verify that `download-choice` clicked fires, and `download_reason_selected_<reason>` experiment metric fires.
5. Step through the two tailored steps for that reason (each fires shown on appear + clicked on continue
| Download reason | Step 1 → pixel | Step 2 → pixel |
   |---|---|---|
   | Browse privately (`search`)   | Search privacy → `preferences_serp`        | Search experience → `search-experience` |
   | Private AI chat (`ai-chat`)   | AI model → `preferences_ai-model`          | Toggle input mode → `preferences_ai-toggle-mode` |
   | No AI (`no-ai`)               | AI search settings → `preferences_ai-search` | Keep Duck.ai → `preferences_duck-ai` |
   | Block ads (`ad-blocking`)     | Duck Player → `preferences_ad-blocking`        | Search experience → `search-experience` |
6. Confirm every pixel from step 4 onward carries `variant=download_reason_<reason>`.
6. Reach the end-of-journey dialog → `end-try-duckai` fires (shown, then engage/dismiss).

### Impact
**Low:** Analytics only, no user-facing behavior change. Gated behind the experiment cohort

#### What could go wrong?
- A later step overwriting the segment variant → prevented by the first-writer-wins guard (unit-tested).
- Pixels emitting an undeclared `onboardingFlowVariant` → every onboarding pixel definition now declares it.

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable —>

—
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes behind the experiment cohort; no user-facing behavior. Variant overwrite is guarded and tested; pixel enums are declared in definitions.
> 
> **Overview**
> Adds **analytics instrumentation** for the iOS download-reason segmented onboarding experiment (treatment cohort): new shared onboarding pixel events, wiring from linear onboarding and contextual EOJ, and experiment metrics for selection and D5–7 search retention.
> 
> **Shared pixel layer** extends `OnboardingPixelParameter` with flow `tailored_by_download_reason`, download-reason **variants** (`download_reason_search`, etc.), and new events (`download-choice`, `preferences_serp`, `preferences_ai-model`, `preferences_ai-toggle-mode`, `preferences_ai-search`, `preferences_duck-ai`, `preferences_youtube`, `end-try-duckai`). Preference **clicked** events send toggle states via `extraParameters` (not only `value`). The chosen reason is mapped from `OnboardingDownloadReason` and persisted as **variant** on later pixels for cohort segmentation.
> 
> **App wiring**: `OnboardingPixelReporter` centralizes shared-pixel firing with stored source/flow/variant; **first-writer-wins** when setting variant so download-reason choice is not overwritten by later branching. Download-reason selection also fires per-reason **d0 experiment metrics**; EOJ shown fires `onboarding_completed`. `OnboardingIntroViewModel` and `NewTabDaxDialogFactory` call the new reporter methods on appear/continue. **`OnboardingDownloadReasonStore`** in Core reads the persisted reason for **`StatisticsLoader`** to fire per-segment `download_reason_search_retention_*` experiment pixels.
> 
> Pixel definition JSON5 and unit tests cover names, parameters, variants, and experiment firing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eaca1634d94f945f562c9fae137285f30a99015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->