### PR TITLE
iOS: Help users choose the right AI model - part 3 (pixels)

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1880,6 +1880,7 @@ extension Pixel {
         case unifiedToggleInputCustomizeResponsesSelected
         case unifiedToggleInputModelSelected
         case unifiedToggleInputModelPickerShown
+        case unifiedToggleInputUnknownModelLabelDebug
         case unifiedToggleInputReasoningEffortSelected
         case unifiedToggleInputReasoningEffortPickerShown
         case unifiedToggleInputImageAttached
@@ -3795,6 +3796,7 @@ extension Pixel.Event {
         case .unifiedToggleInputCustomizeResponsesSelected: return "m_aichat_unified_input_customize_responses_selected"
         case .unifiedToggleInputModelSelected: return "m_aichat_unified_input_model_selected"
         case .unifiedToggleInputModelPickerShown: return "m_aichat_unified_input_model_picker_shown"
+        case .unifiedToggleInputUnknownModelLabelDebug: return "debug_aichat_unified_input_unknown_model_label"
         case .unifiedToggleInputReasoningEffortSelected: return "m_aichat_unified_input_reasoning_effort_selected"
         case .unifiedToggleInputReasoningEffortPickerShown: return "m_aichat_unified_input_reasoning_effort_picker_shown"
         case .unifiedToggleInputImageAttached: return "m_aichat_unified_input_image_attached"

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1074,6 +1074,7 @@
 		97C00D062F97ACD100593A53 /* DaxLogoManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C00D052F97ACD100593A53 /* DaxLogoManagerTests.swift */; };
 		97C00D0C2F98EEE300593A53 /* UnifiedInputContentContainerViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C00D0B2F98EEE300593A53 /* UnifiedInputContentContainerViewControllerTests.swift */; };
 		97D45F48302B5F59002388C8 /* UpdatedModelPickerFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D45F47302B5F59002388C8 /* UpdatedModelPickerFeature.swift */; };
+		97D45F52302B6000002388C8 /* UnknownModelLabelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D45F51302B6000002388C8 /* UnknownModelLabelReporter.swift */; };
 		97D45F4C302B5FC2002388C8 /* UpdatedModelPickerFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D45F4B302B5FC2002388C8 /* UpdatedModelPickerFeatureTests.swift */; };
 		97D99E622F741FE900EE34E7 /* AIVoiceChatIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D99E612F741FE900EE34E7 /* AIVoiceChatIntent.swift */; };
 		97D99E642F7420A900EE34E7 /* AIVoiceChatIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D99E632F7420A900EE34E7 /* AIVoiceChatIntentTests.swift */; };
@@ -3927,6 +3928,7 @@
 		97C00D052F97ACD100593A53 /* DaxLogoManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaxLogoManagerTests.swift; sourceTree = "<group>"; };
 		97C00D0B2F98EEE300593A53 /* UnifiedInputContentContainerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedInputContentContainerViewControllerTests.swift; sourceTree = "<group>"; };
 		97D45F47302B5F59002388C8 /* UpdatedModelPickerFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatedModelPickerFeature.swift; sourceTree = "<group>"; };
+		97D45F51302B6000002388C8 /* UnknownModelLabelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownModelLabelReporter.swift; sourceTree = "<group>"; };
 		97D45F4B302B5FC2002388C8 /* UpdatedModelPickerFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatedModelPickerFeatureTests.swift; sourceTree = "<group>"; };
 		97D99E612F741FE900EE34E7 /* AIVoiceChatIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIVoiceChatIntent.swift; sourceTree = "<group>"; };
 		97D99E632F7420A900EE34E7 /* AIVoiceChatIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIVoiceChatIntentTests.swift; sourceTree = "<group>"; };
@@ -10184,6 +10186,7 @@
 				C18390C32F4F73AE001939B9 /* UnifiedToggleInputHandler.swift */,
 				C18390BA2F4F6F54001939B9 /* UnifiedToggleInputCoordinator.swift */,
 				97D45F47302B5F59002388C8 /* UpdatedModelPickerFeature.swift */,
+				97D45F51302B6000002388C8 /* UnknownModelLabelReporter.swift */,
 				977C2D422FC06B6100C39A04 /* UnifiedToggleInputCoordinatorPixelHelper.swift */,
 				BBA0000000000000000A0001 /* TabInputState.swift */,
 				BBA0000000000000000B0001 /* UnifiedInputStateStoring.swift */,
@@ -14286,6 +14289,7 @@
 				CBD4F13C279EBF4A00B20FD7 /* HomeMessage.swift in Sources */,
 				6FB2A67E2C2DAFB4004D20C8 /* NewTabPageGridView.swift in Sources */,
 				97D45F48302B5F59002388C8 /* UpdatedModelPickerFeature.swift in Sources */,
+				97D45F52302B6000002388C8 /* UnknownModelLabelReporter.swift in Sources */,
 				80A09D4E2F6B80B900AACDEE /* WebsiteDataFireWorker.swift in Sources */,
 				31D4CD4B2D4D1C2D00BC27C6 /* ToolbarStateHandling.swift in Sources */,
 				1DEAADEC2BA45B4500E25A97 /* SettingsAccessibilityView.swift in Sources */,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
@@ -31,6 +31,7 @@ final class UTIModelStore {
     private let modelsService: AIChatModelsProviding
     private(set) var preferences: AIChatPreferencesPersisting
     private let subscriptionManager: any SubscriptionManager
+    private let unknownLabelReporter: UnknownModelLabelReporting
     private var modelsFetchTask: Task<Void, Never>?
 
     private var liveModelId: String?
@@ -40,11 +41,13 @@ final class UTIModelStore {
     init(
         modelsService: AIChatModelsProviding,
         preferences: AIChatPreferencesPersisting,
-        subscriptionManager: any SubscriptionManager
+        subscriptionManager: any SubscriptionManager,
+        unknownLabelReporter: UnknownModelLabelReporting? = nil
     ) {
         self.modelsService = modelsService
         self.preferences = preferences
         self.subscriptionManager = subscriptionManager
+        self.unknownLabelReporter = unknownLabelReporter ?? UnknownModelLabelReporter()
     }
 
     var persistedModelId: String? {
@@ -119,6 +122,7 @@ final class UTIModelStore {
                 let response = try await modelsService.fetchModels()
                 guard !Task.isCancelled else { return }
                 self.models = Self.resolveModels(from: response.models, userTier: state.userTier)
+                self.unknownLabelReporter.reportUnknownLabels(in: self.models)
                 self.attachmentLimits = response.attachmentLimits?.limits(for: state.userTier)
                 self.clearStaleModelSelectionIfNeeded()
                 self.clearStaleReasoningModeIfNeeded()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnknownModelLabelReporter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnknownModelLabelReporter.swift
@@ -1,0 +1,64 @@
+//
+//  UnknownModelLabelReporter.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import Foundation
+
+@MainActor
+protocol UnknownModelLabelReporting {
+    func reportUnknownLabels(in models: [AIChatModel])
+}
+
+/// Reports `/v1/models` recommendation labels the updated model picker doesn't recognise. An unknown
+/// label renders as a model row with no subline, so a new backend label is otherwise invisible on the
+/// client — this is the debug signal that one shipped.
+@MainActor
+final class UnknownModelLabelReporter: UnknownModelLabelReporting {
+    private let firing: UTIPixelFiring
+    private let isUpdatedModelPickerEnabled: () -> Bool
+    /// Labels already reported by this instance. The same unknown label repeats on every `/models`
+    /// refresh, and this is a monitoring signal — one report per label per app run is enough.
+    private var reportedLabels: Set<String> = []
+
+    init(firing: UTIPixelFiring = .live, isUpdatedModelPickerEnabled: @escaping () -> Bool = { UpdatedModelPickerFeature().isAvailable }) {
+        self.firing = firing
+        self.isUpdatedModelPickerEnabled = isUpdatedModelPickerEnabled
+    }
+
+    func reportUnknownLabels(in models: [AIChatModel]) {
+        guard isUpdatedModelPickerEnabled() else { return }
+
+        let labels = Set(models.compactMap { Self.unrecognisedRawLabel(of: $0) })
+        let unreportedLabels = labels.subtracting(reportedLabels)
+        reportedLabels.formUnion(unreportedLabels)
+
+        unreportedLabels.forEach {
+            firing.fire(.unifiedToggleInputUnknownModelLabelDebug, ["label": $0])
+        }
+    }
+
+    private static func unrecognisedRawLabel(of model: AIChatModel) -> String? {
+        switch model.label {
+        case .some(.unknown(let rawValue)):
+            return rawValue
+        case .some(.everydayUse), .some(.usesLimitsFaster), .none:
+            return nil
+        }
+    }
+}

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -475,5 +475,19 @@
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": ["appVersion"]
+    },
+    "debug_aichat_unified_input_unknown_model_label": {
+        "description": "Fires when the /v1/models response carries a recommendation label the client doesn't recognise, so it renders as a model row with no subline.",
+        "owners": ["pikorddg"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "label",
+                "description": "The unrecognised label exactly as returned by the API, so it can be added to the client's known labels verbatim. Values come from a server-side enum, not from user input.",
+                "type": "string"
+            }
+        ]
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1217159579063402?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->
Adds one debug pixels that allows to report missing backend key.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. In Xcode filter console logs with unknown.model.label
2. In Proxyman filter for `v1/models`
3. Tap on address bar to see running endpoint -> confirm no pixel is fired
4. Using Map Local tool in Proxyman, modify `v1/models` to have some unsupported label. For example, for Haiku model
```json
    {
      "id": "claude-haiku-4-5",
      "label": "USES_LIMITS_FASTER_TEMP"
    },
```
5. Top address bar again to run the endpoint. Ensure in Proxyman your mocked response was applied. 
6. Confirm in Xcode logs that pixel `Pixel fired debug.aichat.unified.input.unknown.model.label ["label": “USES_LIMITS_FASTER_TEMP”]` fired

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
7. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low, telemetry

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->
- Pixel volume for a new backend label may be high after the new label is introduced.
- The label value is sent verbatim from the backend.

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only change gated on the updated model picker feature; label values are server enum strings, not user input.
> 
> **Overview**
> Adds **debug telemetry** so the team can spot when `/v1/models` returns recommendation labels the updated model picker does not recognise—those rows show **no subline**, which is easy to miss without a signal.
> 
> After a successful models fetch in **`UTIModelStore`**, **`UnknownModelLabelReporter`** scans models whose label is `.unknown(rawValue)` and fires **`debug_aichat_unified_input_unknown_model_label`** with a `label` parameter (API string). Reporting runs only when **`UpdatedModelPickerFeature`** is available, and each distinct label is reported **once per app run** to limit noise on repeated refreshes.
> 
> Registers the new **`PixelEvent`** case and **`ai_chat_unified_input.json5`** pixel definition alongside the existing unified-input analytics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1735a58bebf30fb26758228092b9969c70254b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->