### PR TITLE
Prepare Fire Dialog for localization

### DIFF
--- a/.github/workflows/smartling.yml
+++ b/.github/workflows/smartling.yml
@@ -159,6 +159,7 @@ jobs:
         uses: ./.github/actions/select-xcode-version
 
       - name: Set up Python
+        if: runner.environment != 'self-hosted'
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'

--- a/.github/workflows/smartling.yml
+++ b/.github/workflows/smartling.yml
@@ -39,7 +39,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'pull_request' && (github.event.label.name == 'start ios translation' || github.event.label.name == 'start macos translation' || github.event.label.name == 'authorize translation' || github.event.label.name == 'download translations' || github.event.label.name == 'check translation status'))
-    runs-on: macos-26
+    runs-on: bitrise:macos26-m4-xlarge
     name: Smartling translation job
     permissions:
       contents: write

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -38,19 +38,19 @@ struct UserText {
     static let fireDialogTabsAndWindows = NSLocalizedString("fire.dialog.tabs.and.windows", value: "Tabs and windows", comment: "Section title. Refers to the scope option that affects open tabs and/or browser windows; keep short and title-cased.")
     static let fireDialogHistoryTitle = NSLocalizedString("fire.dialog.history.title", value: "History", comment: "Section title. Toggle that controls whether browsing history entries are deleted.")
     static let cookiesAndSiteDataTitle = NSLocalizedString("fire.dialog.cookies.title", value: "Cookies and site data", comment: "Section title. Toggle that controls whether website cookies and storage (site data) are deleted.")
-    static let fireDialogCookiesAndOtherData = NotLocalizedString("fire.dialog.cookies.and.other.data.title", value: "Cookies & other data", comment: "Section title. Toggle that controls whether website cookies and storage (site data) are deleted.")
-    static let fireDialogIncludeCookiesAndOtherData = NotLocalizedString("fire.dialog.include.cookies.and.other.data.title", value: "Include cookies & other data?", comment: "Section title. Toggle that controls whether website cookies and storage (site data) are deleted.")
+    static let fireDialogCookiesAndOtherData = NSLocalizedString("fire.dialog.cookies.and.other.data.title", value: "Cookies & other data", comment: "Section title. Toggle that controls whether website cookies and storage (site data) are deleted.")
+    static let fireDialogIncludeCookiesAndOtherData = NSLocalizedString("fire.dialog.include.cookies.and.other.data.title", value: "Include cookies & other data?", comment: "Section title. Toggle that controls whether website cookies and storage (site data) are deleted.")
     static let fireDialogCloseThisTab = NSLocalizedString("fire.dialog.close.this.tab", value: "Close this tab.", comment: "Subtitle shown under the Tabs and windows row when scope is ‘Tab’. Means: the currently active tab will be closed.")
     static let fireDialogCloseThisWindow = NSLocalizedString("fire.dialog.close.this.window", value: "Close this window.", comment: "Subtitle shown under the Tabs and windows row when scope is ‘Window’. Means: the current browser window (all tabs inside it) will be closed.")
     static let fireDialogCloseAllTabsWindows = NSLocalizedString("fire.dialog.close.all.tabs.windows", value: "Close all tabs and windows.", comment: "Subtitle shown under the Tabs and windows row when scope is ‘Everything’. Means: all browser tabs and windows will be closed.")
-    static let fireDialogCloseThisTabAfterDeleting = NotLocalizedString("fire.dialog.close.this.tab.after.deleting", value: "Close this tab after deleting, except if it's pinned.", comment: "Checkbox caption for when the data clearing scope is ‘Tab’. Means: the currently active tab will be closed, unless it's pinned.")
-    static let fireDialogCloseAllTabsWindowsAfterDeleting = NotLocalizedString("fire.dialog.close.all.windows.after.deleting", value: "Close all windows after deleting, except pinned tabs.", comment: "Checkbox caption for when the data clearing scope is ‘Everything’. Means: all browser tabs and windows will be closed, unless they contain pinned tabs in which case all regular tabs from a window will be closed and pinned tabs reloaeded.")
+    static let fireDialogCloseThisTabAfterDeleting = NSLocalizedString("fire.dialog.close.this.tab.after.deleting", value: "Close this tab after deleting, except if it's pinned.", comment: "Checkbox caption for when the data clearing scope is ‘Tab’. Means: the currently active tab will be closed, unless it's pinned.")
+    static let fireDialogCloseAllTabsWindowsAfterDeleting = NSLocalizedString("fire.dialog.close.all.windows.after.deleting", value: "Close all windows after deleting, except pinned tabs.", comment: "Checkbox caption for when the data clearing scope is ‘Everything’. Means: all browser tabs and windows will be closed, unless they contain pinned tabs in which case all regular tabs from a window will be closed and pinned tabs reloaeded.")
 
     static func fireDialogHistoryItemsTitle(_ count: Int) -> String {
-        let template = NotLocalizedString(
+        let template = NSLocalizedString(
             "fire.dialog.history.items.title",
-            value: "Delete %d History items?",
-            comment: "Dialog title. Shows the exact number of browsing history entries that will be deleted in this operation, using plural substitutions for the count and noun (%d)."
+            value: "Delete %#@historyItems@?",
+            comment: "Dialog title. Shows the exact number of browsing history entries that will be deleted in this operation, using plural substitutions for the count and noun (%#@historyItems@)."
         )
         return String.localizedStringWithFormat(template, count)
     }
@@ -90,14 +90,29 @@ struct UserText {
     }
 
     static func fireDialogHistoryItemsDetail(_ count: Int) -> String {
-        NotLocalizedString("fire.dialog.history.detail", value: count == 1 ? "1 item" : "\(count) items", comment: "Detail label next to the History toggle showing the number of history items that will be deleted.")
+        let template = NSLocalizedString(
+            "fire.dialog.history.detail",
+            value: "%d items",
+            comment: "Detail label next to the History toggle showing the number of history items that will be deleted."
+        )
+        return String.localizedStringWithFormat(template, count)
     }
     static func fireDialogCookiesSitesDetail(_ count: Int) -> String {
-        NotLocalizedString("fire.dialog.cookies.detail", value: count == 1 ? "1 site" : "\(count) sites", comment: "Detail label next to the Cookies toggle showing the number of sites whose cookies/site data will be deleted.")
+        let template = NSLocalizedString(
+            "fire.dialog.cookies.detail",
+            value: "%d sites",
+            comment: "Detail label next to the Cookies toggle showing the number of sites whose cookies/site data will be deleted."
+        )
+        return String.localizedStringWithFormat(template, count)
     }
-    static let fireDialogCookiesSignOutWarning = NotLocalizedString("fire.dialog.cookies.sign.out.warning", value: "May sign you out of accounts.", comment: "Subtitle shown under the Cookies row warning that deleting may sign the user out of accounts.")
+    static let fireDialogCookiesSignOutWarning = NSLocalizedString("fire.dialog.cookies.sign.out.warning", value: "May sign you out of accounts.", comment: "Subtitle shown under the Cookies row warning that deleting may sign the user out of accounts.")
     static func fireDialogChatsCountDetail(_ count: Int) -> String {
-        NotLocalizedString("fire.dialog.chats.detail", value: count == 1 ? "1 chat" : "\(count) chats", comment: "Detail label next to the Duck.ai chats toggle showing the number of chats that will be deleted.")
+        let template = NSLocalizedString(
+            "fire.dialog.chats.detail",
+            value: "%d chats",
+            comment: "Detail label next to the Duck.ai chats toggle showing the number of chats that will be deleted."
+        )
+        return String.localizedStringWithFormat(template, count)
     }
 
     static let fireDialogChatHistoryTitle = NSLocalizedString("fire.dialog.chats.title", value: "Duck.ai chats", comment: "Section title. Toggle that controls whether Duck.ai chat history is deleted.")
@@ -463,8 +478,8 @@ struct UserText {
     static let fireDialogFireproofSites = NSLocalizedString("fire.dialog.fireproof.sites", value: "Fireproof sites won't be cleared", comment: "Category of domains in fire button dialog")
     static let fireDialogClearSites = NSLocalizedString("fire.dialog.clear.sites", value: "Selected sites will be cleared", comment: "Category of domains in fire button dialog")
     static let fireDialogDeletingData = NSLocalizedString("fire.dialog.deliting.data", value: "Deleting browsing data…", comment: "Text shown in dialog while removing browsing data")
-    static let fireDialogDeletingDataFromThisTab = NotLocalizedString("fire.dialog.deleting.data.from.this.tab", value: "Deleting browsing data from this tab…", comment: "Text shown in dialog while removing browsing data of the current tab")
-    static let fireDialogDeletingAllData = NotLocalizedString("fire.dialog.deleting.all.data", value: "Deleting all browsing data…", comment: "Text shown in dialog while removing all browsing data")
+    static let fireDialogDeletingDataFromThisTab = NSLocalizedString("fire.dialog.deleting.data.from.this.tab", value: "Deleting browsing data from this tab…", comment: "Text shown in dialog while removing browsing data of the current tab")
+    static let fireDialogDeletingAllData = NSLocalizedString("fire.dialog.deleting.all.data", value: "Deleting all browsing data…", comment: "Text shown in dialog while removing all browsing data")
     static let fireInfoDialogTitle = NSLocalizedString("fire.info.dialog.title", value: "Leave No Trace", comment: "Title of the dialog that explains the Fire feature.")
     static let fireInfoDialogDescription = NSLocalizedString("fire.info.dialog.description", value: "Data, browsing history, and cookies can build up in your browser over time. Use the Fire Button to clear it all away.", comment: "Description in the dialog that explains the Fire feature.")
     static let fireDialogFireWindowTitle = NSLocalizedString("fire.dialog.fire-window.title", value: "Open New Fire Window", comment: "Title of the part of the dialog where the user can open a fire window.")
@@ -515,19 +530,19 @@ struct UserText {
     static let fireDialogSegmentWindow = NSLocalizedString("fire.dialog.segment.window", value: "Window", comment: "Segment label for Window scope")
     static let fireDialogSegmentEverything = NSLocalizedString("fire.dialog.segment.everything", value: "Everything", comment: "Segment label for Everything scope")
     static let fireDialogManageIndividualSitesLink = NSLocalizedString("fire.dialog.manage.individual.sites", value: "Delete individual sites and history.", comment: "Link row text to manage per-site deletions")
-    static let fireDialogMoreOptions = NotLocalizedString("fire.dialog.more.options", value: "More Options", comment: "Accessibility label for the toolbar button that reveals more Fire dialog options")
-    static let fireDialogDeleteAndClose = NotLocalizedString("fire.dialog.delete.and.close", value: "Delete & Close", comment: "Caption for the Fire dialog action button for deleting data and closing tabs and windows")
-    static let fireDialogMenuDeleteIndividualSites = NotLocalizedString("fire.dialog.menu.delete.individual.sites", value: "Delete Individual Sites", comment: "More Options menu item in the Fire dialog that opens the per-site data deletion view")
-    static let fireDialogMenuDataDeletionSettings = NotLocalizedString("fire.dialog.menu.data.deletion.settings", value: "Data Deletion Settings…", comment: "More Options menu item in the Fire dialog that opens the Data Clearing settings pane")
+    static let fireDialogMoreOptions = NSLocalizedString("fire.dialog.more.options", value: "More Options", comment: "Accessibility label for the toolbar button that reveals more Fire dialog options")
+    static let fireDialogDeleteAndClose = NSLocalizedString("fire.dialog.delete.and.close", value: "Delete & Close", comment: "Caption for the Fire dialog action button for deleting data and closing tabs and windows")
+    static let fireDialogMenuDeleteIndividualSites = NSLocalizedString("fire.dialog.menu.delete.individual.sites", value: "Delete Individual Sites", comment: "More Options menu item in the Fire dialog that opens the per-site data deletion view")
+    static let fireDialogMenuDataDeletionSettings = NSLocalizedString("fire.dialog.menu.data.deletion.settings", value: "Data Deletion Settings…", comment: "More Options menu item in the Fire dialog that opens the Data Clearing settings pane")
 
     // MARK: - Simplified Fire Dialog
-    static let fireDialogModeFromThisTab = NotLocalizedString("fire.dialog.mode.tab", value: "From this tab", comment: "Fire dialog mode for clearing data from current tab")
-    static let fireDialogModeAllData = NotLocalizedString("fire.dialog.mode.all.data", value: "All data", comment: "Fire dialog mode for clearing all browsing data")
-    static let fireDialogChooseWhatToDelete = NotLocalizedString("fire.dialog.choose.what.to.delete", value: "Choose what to delete", comment: "Fire dialog disclosure label that expands/collapses the data type toggles")
-    static let fireDialogFireproofExplanation = NotLocalizedString("fire.dialog.fireproof.explanation", value: "Fireproof site data won’t be deleted", comment: "Footnote below the Fire dialog data type toggles, explaining that data belonging to Fireproof sites is kept")
-    static let fireDialogAccessibilityDetailsExpanded = NotLocalizedString("fire.dialog.accessibility.details.expanded", value: "expanded", comment: "Accessiblity value - The fire dialog details are expanded")
-    static let fireDialogAccessibilityDetailsCollapsed = NotLocalizedString("fire.dialog.accessibility.details.collapsed", value: "collapsed", comment: "Accessiblity value - The fire dialog details are collapsed")
-    static let fireDialogAccessibilitySelected = NotLocalizedString("fire.dialog.accessibility.selected", value: "selected", comment: "Accessiblity value - The selected fire dialog mode")
+    static let fireDialogModeFromThisTab = NSLocalizedString("fire.dialog.mode.tab", value: "From this tab", comment: "Fire dialog mode for clearing data from current tab")
+    static let fireDialogModeAllData = NSLocalizedString("fire.dialog.mode.all.data", value: "All data", comment: "Fire dialog mode for clearing all browsing data")
+    static let fireDialogChooseWhatToDelete = NSLocalizedString("fire.dialog.choose.what.to.delete", value: "Choose what to delete", comment: "Fire dialog disclosure label that expands/collapses the data type toggles")
+    static let fireDialogFireproofExplanation = NSLocalizedString("fire.dialog.fireproof.explanation", value: "Fireproof site data won’t be deleted", comment: "Footnote below the Fire dialog data type toggles, explaining that data belonging to Fireproof sites is kept")
+    static let fireDialogAccessibilityDetailsExpanded = NSLocalizedString("fire.dialog.accessibility.details.expanded", value: "expanded", comment: "Accessiblity value - The fire dialog details are expanded")
+    static let fireDialogAccessibilityDetailsCollapsed = NSLocalizedString("fire.dialog.accessibility.details.collapsed", value: "collapsed", comment: "Accessiblity value - The fire dialog details are collapsed")
+    static let fireDialogAccessibilitySelected = NSLocalizedString("fire.dialog.accessibility.selected", value: "selected", comment: "Accessiblity value - The selected fire dialog mode")
 
     // MARK: - Fire dialog sites list sheet
     static let fireDialogSitesOverlayTitle = NSLocalizedString("fire.dialog.sites.overlay.title",
@@ -538,43 +553,37 @@ struct UserText {
                                                                   comment: "Subtitle above the list of domains in in-dialog overlay")
 
     // MARK: - Simplified Fire dialog sites list sheet
-    /// Bold-weight portion of the sites overlay title, e.g. "Cookies & other data from 7 sites"; combined with
-    /// `fireDialogSitesOverlayTitleRegular` to read "Cookies & other data from 7 sites will be deleted:"
-    static func fireDialogSitesOverlayTitleBold(_ count: Int) -> String {
-        NotLocalizedString("fire.dialog.sites.overlay.title.bold",
-                            value: count == 1 ? "Cookies & other data from 1 site" : "Cookies & other data from \(count) sites",
-                            comment: "Bold portion of the simplified Fire dialog's sites overlay title, stating the number of sites affected.")
+    static func fireDialogSitesOverlayTitle(_ count: Int) -> String {
+        let template = NSLocalizedString(
+            "fire.dialog.sites.overlay.title2",
+            value: "**Cookies & other data from %#@sites@** will be deleted:",
+            comment: "Simplified Fire dialog's sites overlay title, stating the number of sites affected."
+        )
+        return String(format: template, count)
     }
-    static let fireDialogSitesOverlayTitleRegular = NotLocalizedString("fire.dialog.sites.overlay.title.regular",
-                                                                        value: "will be deleted:",
-                                                                        comment: "Regular-weight portion of the simplified Fire dialog's sites overlay title, appended after fireDialogSitesOverlayTitleBold.")
 
     // MARK: - Simplified Fire dialog chats list sheet
-    /// Bold-weight portion of the chats overlay title, e.g. "5 Duck.ai chats"; combined with
-    /// `fireDialogChatsOverlayTitleRegular` to read "5 Duck.ai chats will be deleted:"
-    static func fireDialogChatsOverlayTitleBold(_ count: Int) -> String {
-        NotLocalizedString("fire.dialog.chats.overlay.title.bold",
-                            value: count == 1 ? "1 Duck.ai chat" : "\(count) Duck.ai chats",
-                            comment: "Bold portion of the simplified Fire dialog's chats overlay title, stating the number of chats affected.")
+    static func fireDialogChatsOverlayTitle(_ count: Int) -> String {
+        let template = NSLocalizedString(
+            "fire.dialog.chats.overlay.title2",
+            value: "**%#@chats@** will be deleted:",
+            comment: "Simplified Fire dialog's chats overlay title, stating the number of chats affected."
+        )
+        return String(format: template, count)
     }
-    static let fireDialogChatsOverlayTitleRegular = NotLocalizedString("fire.dialog.chats.overlay.title.regular",
-                                                                        value: "will be deleted:",
-                                                                        comment: "Regular-weight portion of the simplified Fire dialog's chats overlay title, appended after fireDialogChatsOverlayTitleBold.")
 
     // MARK: - Simplified Fire dialog history list sheet
-    /// Bold-weight portion of the history overlay title, e.g. "461 history items"; combined with
-    /// `fireDialogHistoryOverlayTitleRegular` to read "461 history items will be deleted:"
-    static func fireDialogHistoryOverlayTitleBold(_ count: Int) -> String {
-        NotLocalizedString("fire.dialog.history.overlay.title.bold",
-                            value: count == 1 ? "1 history item" : "\(count) history items",
-                            comment: "Bold portion of the simplified Fire dialog's history overlay title, stating the number of history items affected.")
+    static func fireDialogHistoryOverlayTitle(_ count: Int) -> String {
+        let template = NSLocalizedString(
+            "fire.dialog.history.overlay.title",
+            value: "**%#@items@** will be deleted:",
+            comment: "Simplified Fire dialog's history overlay title, stating the number of history items affected."
+        )
+        return String(format: template, count)
     }
-    static let fireDialogHistoryOverlayTitleRegular = NotLocalizedString("fire.dialog.history.overlay.title.regular",
-                                                                          value: "will be deleted:",
-                                                                          comment: "Regular-weight portion of the simplified Fire dialog's history overlay title, appended after fireDialogHistoryOverlayTitleBold.")
-    static let fireDialogShowAllHistory = NotLocalizedString("fire.dialog.history.overlay.show.all.history",
-                                                             value: "Show all history",
-                                                             comment: "Link button shown below the (capped) history overlay list, opens the full History View.")
+    static let fireDialogShowAllHistory = NSLocalizedString("fire.dialog.history.overlay.show.all.history",
+                                                            value: "Show all history",
+                                                            comment: "Link button shown below the (capped) history overlay list, opens the full History View.")
 
     // MARK: - Fire dialog single-entry contextual titles
     /// Title used when reusing the Fire dialog as a single entry point (from History, menu, etc.) with full-time range

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -559,7 +559,7 @@ struct UserText {
             value: "**Cookies & other data from %#@sites@** will be deleted:",
             comment: "Simplified Fire dialog's sites overlay title, stating the number of sites affected."
         )
-        return String(format: template, count)
+        return String.localizedStringWithFormat(template, count)
     }
 
     // MARK: - Simplified Fire dialog chats list sheet
@@ -569,7 +569,7 @@ struct UserText {
             value: "**%#@chats@** will be deleted:",
             comment: "Simplified Fire dialog's chats overlay title, stating the number of chats affected."
         )
-        return String(format: template, count)
+        return String.localizedStringWithFormat(template, count)
     }
 
     // MARK: - Simplified Fire dialog history list sheet
@@ -579,7 +579,7 @@ struct UserText {
             value: "**%#@items@** will be deleted:",
             comment: "Simplified Fire dialog's history overlay title, stating the number of history items affected."
         )
-        return String(format: template, count)
+        return String.localizedStringWithFormat(template, count)
     }
     static let fireDialogShowAllHistory = NSLocalizedString("fire.dialog.history.overlay.show.all.history",
                                                             value: "Show all history",

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -480,8 +480,7 @@ struct FireDialogView: ModalView {
     private var sitesOverlayHeader: some View {
         HStack(alignment: .center, spacing: 12) {
             VStack(alignment: .leading, spacing: 8) {
-                (Text(UserText.fireDialogSitesOverlayTitleBold(viewModel.selectable.count)).fontWeight(.semibold)
-                 + Text(" \(UserText.fireDialogSitesOverlayTitleRegular)"))
+                Text(.init(UserText.fireDialogSitesOverlayTitle(viewModel.selectable.count)))
                     .font(.system(size: 13))
                     .foregroundColor(Color(designSystemColor: .textPrimary))
                     .multilineTextAlignment(.leading)
@@ -603,8 +602,7 @@ struct FireDialogView: ModalView {
 
     private var chatsOverlayHeader: some View {
         HStack(alignment: .center, spacing: 12) {
-            (Text(UserText.fireDialogChatsOverlayTitleBold(viewModel.chats.count)).fontWeight(.semibold)
-             + Text(" \(UserText.fireDialogChatsOverlayTitleRegular)"))
+            Text(.init(UserText.fireDialogChatsOverlayTitle(viewModel.chats.count)))
                 .font(.system(size: 13))
                 .foregroundColor(Color(designSystemColor: .textPrimary))
                 .multilineTextAlignment(.leading)
@@ -694,8 +692,7 @@ struct FireDialogView: ModalView {
 
     private var historyOverlayHeader: some View {
         HStack(alignment: .center, spacing: 12) {
-            (Text(UserText.fireDialogHistoryOverlayTitleBold(viewModel.historyVisits.count)).fontWeight(.semibold)
-             + Text(" \(UserText.fireDialogHistoryOverlayTitleRegular)"))
+            Text(.init(UserText.fireDialogHistoryOverlayTitle(viewModel.historyVisits.count)))
                 .font(.system(size: 13))
                 .foregroundColor(Color(designSystemColor: .textPrimary))
                 .multilineTextAlignment(.leading)

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -45315,14 +45315,14 @@
             "plural" : {
               "few" : {
                 "stringUnit" : {
-                  "state" : "new",
-                  "value" : "%d chats"
+                  "state" : "translated",
+                  "value" : "%d чата"
                 }
               },
               "many" : {
                 "stringUnit" : {
-                  "state" : "new",
-                  "value" : "%d chats"
+                  "state" : "translated",
+                  "value" : "%d чатов"
                 }
               },
               "one" : {
@@ -46536,7 +46536,7 @@
                   "few" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg сайтов"
+                      "value" : "%arg сайта"
                     }
                   },
                   "many" : {
@@ -46728,14 +46728,14 @@
             "plural" : {
               "few" : {
                 "stringUnit" : {
-                  "state" : "new",
-                  "value" : "%d sites"
+                  "state" : "translated",
+                  "value" : "%d сайтов"
                 }
               },
               "many" : {
                 "stringUnit" : {
-                  "state" : "new",
-                  "value" : "%d sites"
+                  "state" : "translated",
+                  "value" : "%d сайтов"
                 }
               },
               "one" : {
@@ -74144,8 +74144,8 @@
                 "plural" : {
                   "few" : {
                     "stringUnit" : {
-                      "state" : "new",
-                      "value" : "%arg Trackers Blocked"
+                      "state" : "translated",
+                      "value" : "%arg zablokowane mechanizmy śledzące"
                     }
                   },
                   "many" : {
@@ -74218,8 +74218,8 @@
                 "plural" : {
                   "few" : {
                     "stringUnit" : {
-                      "state" : "new",
-                      "value" : "%arg Trackers Blocked"
+                      "state" : "translated",
+                      "value" : "Заблокировано трекеров: %arg"
                     }
                   },
                   "many" : {

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -45516,7 +45516,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zostaną usunięte czaty (**%#@chats@**):"
+            "value" : "**Czaty Duck.ai (%#@chats@)** zostaną usunięte:"
           },
           "substitutions" : {
             "chats" : {
@@ -45527,25 +45527,25 @@
                   "few" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "**%arg czaty Duck.ai** zostaną usunięte:"
+                      "value" : "%arg"
                     }
                   },
                   "many" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "**%arg czatów Duck.ai** zostanie usuniętych:"
+                      "value" : "%arg"
                     }
                   },
                   "one" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg czat Duck.ai"
+                      "value" : "%arg"
                     }
                   },
                   "other" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "Liczba czatów Duck.ai: %arg"
+                      "value" : "%arg"
                     }
                   }
                 }
@@ -45594,14 +45594,14 @@
                 "plural" : {
                   "few" : {
                     "stringUnit" : {
-                      "state" : "new",
-                      "value" : "%arg Duck.ai chats"
+                      "state" : "translated",
+                      "value" : "%arg чата Duck.ai"
                     }
                   },
                   "many" : {
                     "stringUnit" : {
-                      "state" : "new",
-                      "value" : "%arg Duck.ai chats"
+                      "state" : "translated",
+                      "value" : "%arg чатов Duck.ai"
                     }
                   },
                   "one" : {
@@ -48542,14 +48542,14 @@
             "plural" : {
               "few" : {
                 "stringUnit" : {
-                  "state" : "new",
-                  "value" : "%d items"
+                  "state" : "translated",
+                  "value" : "%d записи"
                 }
               },
               "many" : {
                 "stringUnit" : {
-                  "state" : "new",
-                  "value" : "%d items"
+                  "state" : "translated",
+                  "value" : "%d записей"
                 }
               },
               "one" : {
@@ -48772,7 +48772,7 @@
                   "other" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg elem. historii"
+                      "value" : "%arg elementów historii"
                     }
                   }
                 }
@@ -48821,14 +48821,14 @@
                 "plural" : {
                   "few" : {
                     "stringUnit" : {
-                      "state" : "new",
-                      "value" : "%arg History items"
+                      "state" : "translated",
+                      "value" : "%arg записи в истории"
                     }
                   },
                   "many" : {
                     "stringUnit" : {
-                      "state" : "new",
-                      "value" : "%arg History items"
+                      "state" : "translated",
+                      "value" : "%arg записей в истории"
                     }
                   },
                   "one" : {
@@ -49084,7 +49084,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zostaną usunięte elementy (**%#@items@**):"
+            "value" : "**Elementy historii (%#@items@)** zostaną usunięte:"
           },
           "substitutions" : {
             "items" : {
@@ -49095,25 +49095,25 @@
                   "few" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "**%arg elementy historii** zostaną usunięte:"
+                      "value" : "%arg"
                     }
                   },
                   "many" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "**%arg elementów historii** zostanie usuniętych:"
+                      "value" : "%arg"
                     }
                   },
                   "one" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg element historii"
+                      "value" : "%arg "
                     }
                   },
                   "other" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg elem. historii"
+                      "value" : "%arg"
                     }
                   }
                 }
@@ -49152,7 +49152,7 @@
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Из журнала будет удалено **%1$#@записей@**:"
+            "value" : "Из журнала будет удалено **%1$#@items@**:"
           },
           "substitutions" : {
             "items" : {
@@ -49162,14 +49162,14 @@
                 "plural" : {
                   "few" : {
                     "stringUnit" : {
-                      "state" : "new",
-                      "value" : "%arg history items"
+                      "state" : "translated",
+                      "value" : "%arg записи в истории"
                     }
                   },
                   "many" : {
                     "stringUnit" : {
-                      "state" : "new",
-                      "value" : "%arg history items"
+                      "state" : "translated",
+                      "value" : "%arg записей в истории"
                     }
                   },
                   "one" : {
@@ -50505,25 +50505,25 @@
                   "few" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg witryn"
+                      "value" : "%arg"
                     }
                   },
                   "many" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg witryn"
+                      "value" : "%arg"
                     }
                   },
                   "one" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg witryna"
+                      "value" : "%arg"
                     }
                   },
                   "other" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg witryn(y)"
+                      "value" : "%arg"
                     }
                   }
                 }
@@ -50562,7 +50562,7 @@
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "**Файлы cookie и прочие данные с %1$#@сайтов@** будут удалены:"
+            "value" : "**Файлы cookie и прочие данные с %#@sites@** будут удалены:"
           },
           "substitutions" : {
             "sites" : {
@@ -50572,20 +50572,20 @@
                 "plural" : {
                   "few" : {
                     "stringUnit" : {
-                      "state" : "new",
-                      "value" : "%arg sites"
+                      "state" : "translated",
+                      "value" : "%arg сайтов"
                     }
                   },
                   "many" : {
                     "stringUnit" : {
-                      "state" : "new",
-                      "value" : "%arg sites"
+                      "state" : "translated",
+                      "value" : "%arg сайтов"
                     }
                   },
                   "one" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg сайт"
+                      "value" : "%arg сайта"
                     }
                   },
                   "other" : {

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -45027,6 +45027,36 @@
               }
             }
           }
+        },
+        "pl" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d czaty"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d czatów"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d czat"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d czaty"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -45054,6 +45084,46 @@
                     "stringUnit" : {
                       "state" : "new",
                       "value" : "%arg Duck.ai chats"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%#@chats@"
+          },
+          "substitutions" : {
+            "chats" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "few" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "**%arg czaty Duck.ai** zostaną usunięte:"
+                    }
+                  },
+                  "many" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "**%arg czatów Duck.ai** zostanie usuniętych:"
+                    }
+                  },
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "**%arg czat Duck.ai** zostanie usunięty:"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "**%arg czatów Duck.ai** zostanie usuniętych:"
                     }
                   }
                 }
@@ -45832,6 +45902,36 @@
               }
             }
           }
+        },
+        "pl" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d witryny"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d witryn"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d witryna"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d witryny"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -46549,7 +46649,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Usuń 1$#@items@."
+            "value" : "Usuń %#@items@"
           },
           "substitutions" : {
             "items" : {
@@ -46578,7 +46678,7 @@
                   "other" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "Liczba elementów: %arg"
+                      "value" : "%arg elementów"
                     }
                   }
                 }
@@ -46859,7 +46959,7 @@
                   "other" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "Liczba elementów: %arg"
+                      "value" : "%arg elementów"
                     }
                   }
                 }
@@ -47140,7 +47240,7 @@
                   "other" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg elem."
+                      "value" : "%arg elementów"
                     }
                   }
                 }
@@ -47238,6 +47338,36 @@
               }
             }
           }
+        },
+        "pl" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d elementy"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d elementów"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d element"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d elementów"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -47265,6 +47395,46 @@
                     "stringUnit" : {
                       "state" : "translated",
                       "value" : "%arg History items"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete %#@historyItems@?"
+          },
+          "substitutions" : {
+            "historyItems" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "few" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg elementy historii"
+                    }
+                  },
+                  "many" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg elementów historii"
+                    }
+                  },
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg element historii"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg elementów historii"
                     }
                   }
                 }
@@ -47310,6 +47480,46 @@
                     "stringUnit" : {
                       "state" : "new",
                       "value" : "%arg history items"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%#@items@"
+          },
+          "substitutions" : {
+            "items" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "few" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "**%arg elementy historii** zostaną usunięte:"
+                    }
+                  },
+                  "many" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "**%arg elementów historii** zostanie usuniętych:"
+                    }
+                  },
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "**%arg element historii** zostanie usunięty:"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "**%arg elementów historii** zostanie usuniętych:"
                     }
                   }
                 }
@@ -48184,6 +48394,46 @@
                     "stringUnit" : {
                       "state" : "new",
                       "value" : "%arg sites"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Cookies & other data from %#@sites@** will be deleted:"
+          },
+          "substitutions" : {
+            "sites" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "few" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg witryn"
+                    }
+                  },
+                  "many" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg witryn"
+                    }
+                  },
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg witryny"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg witryn"
                     }
                   }
                 }

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -44911,6 +44911,42 @@
         }
       }
     },
+    "fire.dialog.accessibility.details.collapsed" : {
+      "comment" : "Accessiblity value - The fire dialog details are collapsed",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "collapsed"
+          }
+        }
+      }
+    },
+    "fire.dialog.accessibility.details.expanded" : {
+      "comment" : "Accessiblity value - The fire dialog details are expanded",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "expanded"
+          }
+        }
+      }
+    },
+    "fire.dialog.accessibility.selected" : {
+      "comment" : "Accessiblity value - The selected fire dialog mode",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "selected"
+          }
+        }
+      }
+    },
     "fire.dialog.all-windows-will-close" : {
       "comment" : "Warning label shown in an expanded view of the fire popover",
       "extractionState" : "extracted_with_value",
@@ -44967,6 +45003,62 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Все окна будут закрыты."
+          }
+        }
+      }
+    },
+    "fire.dialog.chats.detail" : {
+      "comment" : "Detail label next to the Duck.ai chats toggle showing the number of chats that will be deleted.",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%d chat"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%d chats"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "fire.dialog.chats.overlay.title2" : {
+      "comment" : "Simplified Fire dialog's chats overlay title, stating the number of chats affected.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "**%#@chats@** will be deleted:"
+          },
+          "substitutions" : {
+            "chats" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "new",
+                      "value" : "%arg Duck.ai chat"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "new",
+                      "value" : "%arg Duck.ai chats"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -45087,6 +45179,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Чаты Duck.ai"
+          }
+        }
+      }
+    },
+    "fire.dialog.choose.what.to.delete" : {
+      "comment" : "Fire dialog disclosure label that expands/collapses the data type toggles",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose what to delete"
           }
         }
       }
@@ -45271,6 +45375,18 @@
         }
       }
     },
+    "fire.dialog.close.all.windows.after.deleting" : {
+      "comment" : "Checkbox caption for when the data clearing scope is ‘Everything’. Means: all browser tabs and windows will be closed, unless they contain pinned tabs in which case all regular tabs from a window will be closed and pinned tabs reloaeded.",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close all windows after deleting, except pinned tabs."
+          }
+        }
+      }
+    },
     "fire.dialog.close.this.tab" : {
       "comment" : "Subtitle shown under the Tabs and windows row when scope is ‘Tab’. Means: the currently active tab will be closed.",
       "extractionState" : "extracted_with_value",
@@ -45331,6 +45447,18 @@
         }
       }
     },
+    "fire.dialog.close.this.tab.after.deleting" : {
+      "comment" : "Checkbox caption for when the data clearing scope is ‘Tab’. Means: the currently active tab will be closed, unless it's pinned.",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Close this tab after deleting, except if it's pinned."
+          }
+        }
+      }
+    },
     "fire.dialog.close.this.window" : {
       "comment" : "Subtitle shown under the Tabs and windows row when scope is ‘Window’. Means: the current browser window (all tabs inside it) will be closed.",
       "extractionState" : "extracted_with_value",
@@ -45387,6 +45515,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Закрыть это окно"
+          }
+        }
+      }
+    },
+    "fire.dialog.cookies.and.other.data.title" : {
+      "comment" : "Section title. Toggle that controls whether website cookies and storage (site data) are deleted.",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cookies & other data"
           }
         }
       }
@@ -45672,6 +45812,41 @@
         }
       }
     },
+    "fire.dialog.cookies.detail" : {
+      "comment" : "Detail label next to the Cookies toggle showing the number of sites whose cookies/site data will be deleted.",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%d site"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%d sites"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "fire.dialog.cookies.sign.out.warning" : {
+      "comment" : "Subtitle shown under the Cookies row warning that deleting may sign the user out of accounts.",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "May sign you out of accounts."
+          }
+        }
+      }
+    },
     "fire.dialog.cookies.title" : {
       "comment" : "Section title. Toggle that controls whether website cookies and storage (site data) are deleted.",
       "extractionState" : "extracted_with_value",
@@ -45728,6 +45903,42 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Куки-файлы и данные сайтов"
+          }
+        }
+      }
+    },
+    "fire.dialog.delete.and.close" : {
+      "comment" : "Caption for the Fire dialog action button for deleting data and closing tabs and windows",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete & Close"
+          }
+        }
+      }
+    },
+    "fire.dialog.deleting.all.data" : {
+      "comment" : "Text shown in dialog while removing all browsing data",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Deleting all browsing data…"
+          }
+        }
+      }
+    },
+    "fire.dialog.deleting.data.from.this.tab" : {
+      "comment" : "Text shown in dialog while removing browsing data of the current tab",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Deleting browsing data from this tab…"
           }
         }
       }
@@ -46088,6 +46299,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Открыть новое окно Fire Window"
+          }
+        }
+      }
+    },
+    "fire.dialog.fireproof.explanation" : {
+      "comment" : "Footnote below the Fire dialog data type toggles, explaining that data belonging to Fireproof sites is kept",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fireproof site data won’t be deleted"
           }
         }
       }
@@ -46995,6 +47218,107 @@
         }
       }
     },
+    "fire.dialog.history.detail" : {
+      "comment" : "Detail label next to the History toggle showing the number of history items that will be deleted.",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%d item"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%d items"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "fire.dialog.history.items.title" : {
+      "comment" : "Dialog title. Shows the exact number of browsing history entries that will be deleted in this operation, using plural substitutions for the count and noun (%#@historyItems@).",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete %#@historyItems@?"
+          },
+          "substitutions" : {
+            "historyItems" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg History item"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg History items"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "fire.dialog.history.overlay.show.all.history" : {
+      "comment" : "Link button shown below the (capped) history overlay list, opens the full History View.",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Show all history"
+          }
+        }
+      }
+    },
+    "fire.dialog.history.overlay.title" : {
+      "comment" : "Simplified Fire dialog's history overlay title, stating the number of history items affected.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "**%#@items@** will be deleted:"
+          },
+          "substitutions" : {
+            "items" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "new",
+                      "value" : "%arg history item"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "new",
+                      "value" : "%arg history items"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "fire.dialog.history.title" : {
       "comment" : "Section title. Toggle that controls whether browsing history entries are deleted.",
       "localizations" : {
@@ -47050,6 +47374,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "История"
+          }
+        }
+      }
+    },
+    "fire.dialog.include.cookies.and.other.data.title" : {
+      "comment" : "Section title. Toggle that controls whether website cookies and storage (site data) are deleted.",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Include cookies & other data?"
           }
         }
       }
@@ -47169,6 +47505,66 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Удалить отдельные сайты и записи"
+          }
+        }
+      }
+    },
+    "fire.dialog.menu.data.deletion.settings" : {
+      "comment" : "More Options menu item in the Fire dialog that opens the Data Clearing settings pane",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Data Deletion Settings…"
+          }
+        }
+      }
+    },
+    "fire.dialog.menu.delete.individual.sites" : {
+      "comment" : "More Options menu item in the Fire dialog that opens the per-site data deletion view",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete Individual Sites"
+          }
+        }
+      }
+    },
+    "fire.dialog.mode.all.data" : {
+      "comment" : "Fire dialog mode for clearing all browsing data",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "All data"
+          }
+        }
+      }
+    },
+    "fire.dialog.mode.tab" : {
+      "comment" : "Fire dialog mode for clearing data from current tab",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "From this tab"
+          }
+        }
+      }
+    },
+    "fire.dialog.more.options" : {
+      "comment" : "Accessibility label for the toolbar button that reveals more Fire dialog options",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "More Options"
           }
         }
       }
@@ -47760,6 +48156,39 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Подробнее о сайте"
+          }
+        }
+      }
+    },
+    "fire.dialog.sites.overlay.title2" : {
+      "comment" : "Simplified Fire dialog's sites overlay title, stating the number of sites affected.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "**Cookies & other data from %#@sites@** will be deleted:"
+          },
+          "substitutions" : {
+            "sites" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "new",
+                      "value" : "%arg site"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "new",
+                      "value" : "%arg sites"
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -44915,10 +44915,58 @@
       "comment" : "Accessiblity value - The fire dialog details are collapsed",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eingeklappt"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "collapsed"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "contraído"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "réduit"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "compresso"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ingeklapt"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zwinięte"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "recolhido"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "свернуто"
           }
         }
       }
@@ -44927,10 +44975,58 @@
       "comment" : "Accessiblity value - The fire dialog details are expanded",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "erweitert"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "expanded"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "expandido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "développé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "espanso"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "uitgevouwen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "rozwinięte"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "expandido"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "развернуто"
           }
         }
       }
@@ -44939,10 +45035,58 @@
       "comment" : "Accessiblity value - The selected fire dialog mode",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ausgewählt"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "selected"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "seleccionado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sélectionné"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "selezionato"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "geselecteerd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "wybrano"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecionado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "выбрано"
           }
         }
       }
@@ -45010,6 +45154,24 @@
     "fire.dialog.chats.detail" : {
       "comment" : "Detail label next to the Duck.ai chats toggle showing the number of chats that will be deleted.",
       "localizations" : {
+        "de" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d Chat"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d Chats"
+                }
+              }
+            }
+          }
+        },
         "en" : {
           "variations" : {
             "plural" : {
@@ -45022,6 +45184,78 @@
               "other" : {
                 "stringUnit" : {
                   "state" : "new",
+                  "value" : "%d chats"
+                }
+              }
+            }
+          }
+        },
+        "es" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d chat"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d chats"
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d discussion"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d discussions"
+                }
+              }
+            }
+          }
+        },
+        "it" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d chat"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d chat"
+                }
+              }
+            }
+          }
+        },
+        "nl" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d chat"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
                   "value" : "%d chats"
                 }
               }
@@ -45052,7 +45286,55 @@
               "other" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "%d czaty"
+                  "value" : "%d czaty(-ów)"
+                }
+              }
+            }
+          }
+        },
+        "pt" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d conversas"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d conversas"
+                }
+              }
+            }
+          }
+        },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%d chats"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%d chats"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d чат"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d чатов"
                 }
               }
             }
@@ -45063,6 +45345,34 @@
     "fire.dialog.chats.overlay.title2" : {
       "comment" : "Simplified Fire dialog's chats overlay title, stating the number of chats affected.",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%#@chats@** werden gelöscht:"
+          },
+          "substitutions" : {
+            "chats" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg Duck.ai-Chat"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg Duck.ai-Chats"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
@@ -45091,10 +45401,122 @@
             }
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%#@chats@** se borrarán:"
+          },
+          "substitutions" : {
+            "chats" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg chat de Duck.ai"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg chats de Duck.ai"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%#@chats@** seront supprimées :"
+          },
+          "substitutions" : {
+            "chats" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg discussion Duck.ai"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg discussions Duck.ai"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%#@chats@** verranno eliminate:"
+          },
+          "substitutions" : {
+            "chats" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg chat di Duck.ai"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg chat di Duck.ai"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%#@chats@** worden verwijderd:"
+          },
+          "substitutions" : {
+            "chats" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg Duck.ai-chat"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg Duck.ai-chats"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%#@chats@"
+            "value" : "Zostaną usunięte czaty (**%#@chats@**):"
           },
           "substitutions" : {
             "chats" : {
@@ -45117,13 +45539,81 @@
                   "one" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "**%arg czat Duck.ai** zostanie usunięty:"
+                      "value" : "%arg czat Duck.ai"
                     }
                   },
                   "other" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "**%arg czatów Duck.ai** zostanie usuniętych:"
+                      "value" : "Liczba czatów Duck.ai: %arg"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%#@chats@** serão eliminados:"
+          },
+          "substitutions" : {
+            "chats" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg conversa do Duck.ai"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg conversas do Duck.ai"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%#@chats@** будут удалены:"
+          },
+          "substitutions" : {
+            "chats" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "few" : {
+                    "stringUnit" : {
+                      "state" : "new",
+                      "value" : "%arg Duck.ai chats"
+                    }
+                  },
+                  "many" : {
+                    "stringUnit" : {
+                      "state" : "new",
+                      "value" : "%arg Duck.ai chats"
+                    }
+                  },
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg чат Duck.ai"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg чатов Duck.ai"
                     }
                   }
                 }
@@ -45257,10 +45747,58 @@
       "comment" : "Fire dialog disclosure label that expands/collapses the data type toggles",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wähle, was du löschen möchtest"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Choose what to delete"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elige qué eliminar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir le contenu à supprimer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scegli cosa eliminare"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kies wat je wilt verwijderen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybierz, co chcesz usunąć"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escolhe o que apagar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите, что удалить"
           }
         }
       }
@@ -45449,10 +45987,58 @@
       "comment" : "Checkbox caption for when the data clearing scope is ‘Everything’. Means: all browser tabs and windows will be closed, unless they contain pinned tabs in which case all regular tabs from a window will be closed and pinned tabs reloaeded.",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Fenster nach dem Löschen schließen, außer angeheftete Tabs."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close all windows after deleting, except pinned tabs."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cierra todas las ventanas después de borrar, excepto las pestañas fijadas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer toutes les fenêtres après la suppression, sauf les onglets épinglés."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiudi tutte le finestre dopo l'eliminazione, tranne le schede bloccate."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sluit alle vensters na het verwijderen, behalve vastgezette tabbladen."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zamknij wszystkie okna po usunięciu, z wyjątkiem przypiętych kart."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fechar todas as janelas após eliminar, exceto os separadores afixados."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрыть все окна после удаления, кроме закрепленных вкладок."
           }
         }
       }
@@ -45521,10 +46107,58 @@
       "comment" : "Checkbox caption for when the data clearing scope is ‘Tab’. Means: the currently active tab will be closed, unless it's pinned.",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diesen Tab nach dem Löschen schließen, außer wenn er angepinnt ist."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Close this tab after deleting, except if it's pinned."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cierra esta pestaña después de borrar, excepto si está anclada."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer cet onglet après la suppression, sauf s’il est épinglé."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiudi questa scheda dopo l’eliminazione, a meno che non sia bloccata."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sluit dit tabblad na het verwijderen, behalve als het is vastgezet."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zamknij tę kartę po usunięciu, chyba że jest przypięta."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fechar este separador após eliminar, exceto se estiver afixado."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрыть эту вкладку после удаления, если она не закреплена."
           }
         }
       }
@@ -45593,10 +46227,58 @@
       "comment" : "Section title. Toggle that controls whether website cookies and storage (site data) are deleted.",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cookies & andere Daten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Cookies & other data"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cookies y otros datos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cookies et autres données"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cookie e altri dati"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cookies & andere gegevens"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pliki cookie i inne dane"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cookies e outros dados"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Файлы cookie и прочие данные"
           }
         }
       }
@@ -45885,6 +46567,24 @@
     "fire.dialog.cookies.detail" : {
       "comment" : "Detail label next to the Cookies toggle showing the number of sites whose cookies/site data will be deleted.",
       "localizations" : {
+        "de" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d Website"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d Websites"
+                }
+              }
+            }
+          }
+        },
         "en" : {
           "variations" : {
             "plural" : {
@@ -45897,6 +46597,78 @@
               "other" : {
                 "stringUnit" : {
                   "state" : "new",
+                  "value" : "%d sites"
+                }
+              }
+            }
+          }
+        },
+        "es" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d sitio"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d sitios"
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d site"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d sites"
+                }
+              }
+            }
+          }
+        },
+        "it" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d sito"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d siti"
+                }
+              }
+            }
+          }
+        },
+        "nl" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d site"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
                   "value" : "%d sites"
                 }
               }
@@ -45927,7 +46699,55 @@
               "other" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "%d witryny"
+                  "value" : "%d witryn(y)"
+                }
+              }
+            }
+          }
+        },
+        "pt" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d site"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d sites"
+                }
+              }
+            }
+          }
+        },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%d sites"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%d sites"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d сайт"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d сайтов"
                 }
               }
             }
@@ -45939,10 +46759,58 @@
       "comment" : "Subtitle shown under the Cookies row warning that deleting may sign the user out of accounts.",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du wirst möglicherweise von Konten abgemeldet."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "May sign you out of accounts."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puede que cierre sesión en tus cuentas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Peut vous déconnecter des comptes."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Potrebbe disconnetterti dagli account."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Je kan worden uitgelogd bij accounts."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Może nastąpić wylogowanie z kont."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podes terminar a tua sessão nas contas."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Операция может сопровождаться выходом из учетных записей."
           }
         }
       }
@@ -46011,10 +46879,58 @@
       "comment" : "Caption for the Fire dialog action button for deleting data and closing tabs and windows",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Löschen & schließen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Delete & Close"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar y cerrar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer et fermer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina & chiudi"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwijder & sluit"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuń i zamknij"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar e fechar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить и закрыть"
           }
         }
       }
@@ -46023,10 +46939,58 @@
       "comment" : "Text shown in dialog while removing all browsing data",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Browserdaten werden gelöscht …"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Deleting all browsing data…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminando todos los datos de navegación…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suppression de toutes les données de navigation…"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminazione di tutti i dati di navigazione…"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle browsegegevens verwijderen…"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuwanie wszystkich danych przeglądania…"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A eliminar todos os dados de navegação…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удаление всех данных о посещении сайтов…"
           }
         }
       }
@@ -46035,10 +46999,58 @@
       "comment" : "Text shown in dialog while removing browsing data of the current tab",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lösche von Browsing-Daten aus diesem Tab ..."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Deleting browsing data from this tab…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminando los datos de navegación de esta pestaña…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suppression des données de navigation de cet onglet…"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminazione dei dati di navigazione da questa scheda…"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browsegegevens van dit tabblad verwijderen…"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuwanie danych przeglądania z tej karty…"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A eliminar dados de navegação deste separador…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удаление данных о посещениях с этой вкладки…"
           }
         }
       }
@@ -46407,10 +47419,58 @@
       "comment" : "Footnote below the Fire dialog data type toggles, explaining that data belonging to Fireproof sites is kept",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daten einer „Fireproof“-Website werden nicht gelöscht."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Fireproof site data won’t be deleted"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los datos del sitio Fireproof no se eliminarán"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les données des sites Fireproof ne seront pas supprimées"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I dati dei siti Fireproof non saranno eliminati"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fireproof sitegegevens worden niet verwijderd"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dane witryn oznaczonych jako Fireproof nie zostaną usunięte"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Os dados dos sites Fireproof não serão eliminados"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Данные fireproof-сайтов не будут удалены"
           }
         }
       }
@@ -46649,7 +47709,7 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Usuń %#@items@"
+            "value" : "Usuń 1$#@items@."
           },
           "substitutions" : {
             "items" : {
@@ -46678,7 +47738,7 @@
                   "other" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg elementów"
+                      "value" : "Liczba elementów: %arg"
                     }
                   }
                 }
@@ -46959,7 +48019,7 @@
                   "other" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg elementów"
+                      "value" : "Liczba elementów: %arg"
                     }
                   }
                 }
@@ -47240,7 +48300,7 @@
                   "other" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg elementów"
+                      "value" : "%arg elem."
                     }
                   }
                 }
@@ -47321,6 +48381,24 @@
     "fire.dialog.history.detail" : {
       "comment" : "Detail label next to the History toggle showing the number of history items that will be deleted.",
       "localizations" : {
+        "de" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d Element"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d Elemente"
+                }
+              }
+            }
+          }
+        },
         "en" : {
           "variations" : {
             "plural" : {
@@ -47333,6 +48411,78 @@
               "other" : {
                 "stringUnit" : {
                   "state" : "new",
+                  "value" : "%d items"
+                }
+              }
+            }
+          }
+        },
+        "es" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d artículo"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d artículos"
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d élément"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d éléments"
+                }
+              }
+            }
+          }
+        },
+        "it" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d elemento"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d elementi"
+                }
+              }
+            }
+          }
+        },
+        "nl" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d item"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
                   "value" : "%d items"
                 }
               }
@@ -47363,7 +48513,55 @@
               "other" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "%d elementów"
+                  "value" : "%d elementy(-ów)"
+                }
+              }
+            }
+          }
+        },
+        "pt" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d item"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d itens"
+                }
+              }
+            }
+          }
+        },
+        "ru" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%d items"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "%d items"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d запись"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d записей"
                 }
               }
             }
@@ -47374,6 +48572,34 @@
     "fire.dialog.history.items.title" : {
       "comment" : "Dialog title. Shows the exact number of browsing history entries that will be deleted in this operation, using plural substitutions for the count and noun (%#@historyItems@).",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%#@historyItems@ löschen?"
+          },
+          "substitutions" : {
+            "historyItems" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg Verlaufseintrag"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg Verlaufseinträge"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
@@ -47402,10 +48628,122 @@
             }
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Eliminar %#@historyItems@?"
+          },
+          "substitutions" : {
+            "historyItems" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg elemento del historial"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg elementos del historial"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer %#@historyItems@ ?"
+          },
+          "substitutions" : {
+            "historyItems" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg élément d'historique"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg éléments d'historique"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina %#@historyItems@?"
+          },
+          "substitutions" : {
+            "historyItems" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg elemento della cronologia"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg elementi della cronologia"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwijder %#@historyItems@?"
+          },
+          "substitutions" : {
+            "historyItems" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg geschiedenisitem"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg geschiedenisitems"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Delete %#@historyItems@?"
+            "state" : "translated",
+            "value" : "Usunąć %#@historyItems@?"
           },
           "substitutions" : {
             "historyItems" : {
@@ -47434,7 +48772,75 @@
                   "other" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg elementów historii"
+                      "value" : "%arg elem. historii"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar %#@historyItems@?"
+          },
+          "substitutions" : {
+            "historyItems" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg item do histórico"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg itens do histórico"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить %#@historyItems@?"
+          },
+          "substitutions" : {
+            "historyItems" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "few" : {
+                    "stringUnit" : {
+                      "state" : "new",
+                      "value" : "%arg History items"
+                    }
+                  },
+                  "many" : {
+                    "stringUnit" : {
+                      "state" : "new",
+                      "value" : "%arg History items"
+                    }
+                  },
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg запись в истории"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg записей в истории"
                     }
                   }
                 }
@@ -47448,10 +48854,58 @@
       "comment" : "Link button shown below the (capped) history overlay list, opens the full History View.",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesamten Verlauf anzeigen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Show all history"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar todo el historial"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher tout l'historique"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra tutta la cronologia"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle geschiedenis tonen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokaż całą historię"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar todo o histórico"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отобразить всю историю"
           }
         }
       }
@@ -47459,6 +48913,34 @@
     "fire.dialog.history.overlay.title" : {
       "comment" : "Simplified Fire dialog's history overlay title, stating the number of history items affected.",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%#@items@** werden gelöscht:"
+          },
+          "substitutions" : {
+            "items" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg Verlaufseintrag"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg Verlaufseinträge"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
@@ -47487,10 +48969,122 @@
             }
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se eliminará **%#@items@**:"
+          },
+          "substitutions" : {
+            "items" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg artículo del historial"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg elementos del historial"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%#@items@** seront supprimés :"
+          },
+          "substitutions" : {
+            "items" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg élément d'historique"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg éléments d'historique"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%#@items@** verranno eliminati:"
+          },
+          "substitutions" : {
+            "items" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg elemento della cronologia"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg elementi della cronologia"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%#@items@** worden verwijderd:"
+          },
+          "substitutions" : {
+            "items" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg geschiedenisitem"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg geschiedenisitems"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%#@items@"
+            "value" : "Zostaną usunięte elementy (**%#@items@**):"
           },
           "substitutions" : {
             "items" : {
@@ -47513,13 +49107,81 @@
                   "one" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "**%arg element historii** zostanie usunięty:"
+                      "value" : "%arg element historii"
                     }
                   },
                   "other" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "**%arg elementów historii** zostanie usuniętych:"
+                      "value" : "%arg elem. historii"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%#@items@** serão eliminados:"
+          },
+          "substitutions" : {
+            "items" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg item do histórico"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg itens do histórico"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Из журнала будет удалено **%1$#@записей@**:"
+          },
+          "substitutions" : {
+            "items" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "few" : {
+                    "stringUnit" : {
+                      "state" : "new",
+                      "value" : "%arg history items"
+                    }
+                  },
+                  "many" : {
+                    "stringUnit" : {
+                      "state" : "new",
+                      "value" : "%arg history items"
+                    }
+                  },
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg запись в истории"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg записей в истории"
                     }
                   }
                 }
@@ -47592,10 +49254,58 @@
       "comment" : "Section title. Toggle that controls whether website cookies and storage (site data) are deleted.",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cookies & andere Daten einbeziehen?"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Include cookies & other data?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Incluir cookies y otros datos?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inclure les cookies et autres données ?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Includere cookie e altri dati?"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inclusief cookies en andere gegevens?"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uwzględnić pliki cookie i inne dane?"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incluir cookies e outros dados?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Также удалить cookie и другие данные?"
           }
         }
       }
@@ -47723,10 +49433,58 @@
       "comment" : "More Options menu item in the Fire dialog that opens the Data Clearing settings pane",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen zur Datenlöschung ..."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Data Deletion Settings…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes de eliminación de datos…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres de suppression des données…"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impostazioni di eliminazione dati…"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instellingen voor gegevensverwijdering…"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ustawienia usuwania danych…"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Definições de eliminação de dados…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки удаления данных…"
           }
         }
       }
@@ -47735,10 +49493,58 @@
       "comment" : "More Options menu item in the Fire dialog that opens the per-site data deletion view",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einzelne Websites löschen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Delete Individual Sites"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar sitios individuales"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer les sites individuels"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina singoli siti"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afzonderlijke sites verwijderen"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuń poszczególne witryny"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar sites individuais"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить отдельные сайты"
           }
         }
       }
@@ -47747,10 +49553,58 @@
       "comment" : "Fire dialog mode for clearing all browsing data",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Daten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "All data"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos los datos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toutes les données"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutti i dati"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle gegevens"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wszystkie dane"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos os dados"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все данные"
           }
         }
       }
@@ -47759,10 +49613,58 @@
       "comment" : "Fire dialog mode for clearing data from current tab",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aus dieser Registerkarte"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "From this tab"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De esta pestaña"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De cet onglet"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da questa scheda"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uit dit tabblad"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Z tej karty"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A partir deste separador"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "С этой вкладки"
           }
         }
       }
@@ -47771,10 +49673,58 @@
       "comment" : "Accessibility label for the toolbar button that reveals more Fire dialog options",
       "extractionState" : "extracted_with_value",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weitere Optionen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "More Options"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más opciones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus d'options"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altre opzioni"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meer opties"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Więcej opcji"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mais opções"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Другие параметры"
           }
         }
       }
@@ -48373,6 +50323,34 @@
     "fire.dialog.sites.overlay.title2" : {
       "comment" : "Simplified Fire dialog's sites overlay title, stating the number of sites affected.",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Cookies & andere Daten von %#@sites@** werden gelöscht:"
+          },
+          "substitutions" : {
+            "sites" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg Website"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg Websites"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
@@ -48401,10 +50379,122 @@
             }
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Las cookies y otros datos de %#@sites@** se eliminarán:"
+          },
+          "substitutions" : {
+            "sites" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg sitio"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg sitios"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les **cookies et autres données de %#@sites@** seront supprimés :"
+          },
+          "substitutions" : {
+            "sites" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg site"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg sites"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**I cookie e gli altri dati di %#@sites@** saranno eliminati:"
+          },
+          "substitutions" : {
+            "sites" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg sito"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg siti"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Cookies & andere gegevens van %#@sites@** worden verwijderd:"
+          },
+          "substitutions" : {
+            "sites" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg site"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg sites"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "**Cookies & other data from %#@sites@** will be deleted:"
+            "value" : "**Pliki cookie i inne dane witryn (%#@sites@)** zostaną usunięte:"
           },
           "substitutions" : {
             "sites" : {
@@ -48427,13 +50517,81 @@
                   "one" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg witryny"
+                      "value" : "%arg witryna"
                     }
                   },
                   "other" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg witryn"
+                      "value" : "%arg witryn(y)"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Os cookies e outros dados de %#@sites@** serão eliminados:"
+          },
+          "substitutions" : {
+            "sites" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg site"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg sites"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Файлы cookie и прочие данные с %1$#@сайтов@** будут удалены:"
+          },
+          "substitutions" : {
+            "sites" : {
+              "argNum" : 1,
+              "formatSpecifier" : "d",
+              "variations" : {
+                "plural" : {
+                  "few" : {
+                    "stringUnit" : {
+                      "state" : "new",
+                      "value" : "%arg sites"
+                    }
+                  },
+                  "many" : {
+                    "stringUnit" : {
+                      "state" : "new",
+                      "value" : "%arg sites"
+                    }
+                  },
+                  "one" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg сайт"
+                    }
+                  },
+                  "other" : {
+                    "stringUnit" : {
+                      "state" : "translated",
+                      "value" : "%arg сайтов"
                     }
                   }
                 }

--- a/macOS/DuckDuckGo/Localization/Localizable.xcstrings
+++ b/macOS/DuckDuckGo/Localization/Localizable.xcstrings
@@ -49107,7 +49107,7 @@
                   "one" : {
                     "stringUnit" : {
                       "state" : "translated",
-                      "value" : "%arg "
+                      "value" : "%arg"
                     }
                   },
                   "other" : {

--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -560,7 +560,7 @@ extension FeatureFlag: FeatureFlagDescribing {
                    cohortType: OnboardingSubscriptionUpsellCohort.self,
                    category: .subscription)
         case .fireDialogSimplified:
-            Config(defaultValue: .disabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.fireDialogSimplified))
+            Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.fireDialogSimplified))
         case .unknownUsernameCategorization:
             Config(source: .remoteReleasable(AutofillSubfeature.unknownUsernameCategorization), supportsLocalOverriding: false)
         case .credentialsImportPromotionForExistingUsers:

--- a/macOS/UITests/AutocompleteTests.swift
+++ b/macOS/UITests/AutocompleteTests.swift
@@ -39,7 +39,7 @@ class AutocompleteTests: UITestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         continueAfterFailure = false
-        app = XCUIApplication.setUp()
+        app = XCUIApplication.setUp(featureFlags: ["fireDialogSimplified": false])
         addBookmarkButton = app.buttons["BookmarkDialogButtonsView.defaultButton"]
         resetBookMarksMenuItem = app.menuItems["MainMenu.resetBookmarks"]
         historyMenuBarItem = app.menuBarItems["History"]

--- a/macOS/UITests/BrowsingHistoryTests.swift
+++ b/macOS/UITests/BrowsingHistoryTests.swift
@@ -33,7 +33,7 @@ class BrowsingHistoryTests: UITestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         continueAfterFailure = false
-        app = XCUIApplication.setUp()
+        app = XCUIApplication.setUp(featureFlags: ["fireDialogSimplified": false])
         app.enforceSingleWindow()
 
         // Clear history using Fire Dialog

--- a/macOS/UITests/Fire/FireDialogUITestsBase.swift
+++ b/macOS/UITests/Fire/FireDialogUITestsBase.swift
@@ -34,7 +34,7 @@ extension FireDialogUITests {
 
     func setUpFireDialogUITests() {
         continueAfterFailure = false
-        app = XCUIApplication.setUp()
+        app = XCUIApplication.setUp(featureFlags: ["fireDialogSimplified": false])
         // Clear the Local Network permission prompt if it surfaced during launch, before the
         // debug-menu / fire-button clicks below (which it would otherwise intercept).
         XCUIApplication.dismissLocalNetworkPromptIfPresent()

--- a/macOS/UITests/NewPermissionViewTests.swift
+++ b/macOS/UITests/NewPermissionViewTests.swift
@@ -53,7 +53,7 @@ class NewPermissionViewTests: UITestCase {
         app.resetAuthorizationStatus(for: .microphone)
 
         // Now set up and launch the app
-        app = XCUIApplication.setUp()
+        app = XCUIApplication.setUp(featureFlags: ["fireDialogSimplified": false])
         addressBarTextField = app.addressBar
         app.enforceSingleWindow()
 
@@ -740,6 +740,7 @@ final class NewPermissionViewPopupTests: UITestCase {
             ],
             featureFlags: [
                 "popupBlocking": true,
+                "fireDialogSimplified": false,
             ]
         )
 

--- a/macOS/UITests/NextStepsListUITests.swift
+++ b/macOS/UITests/NextStepsListUITests.swift
@@ -25,7 +25,7 @@ final class NextStepsListUITests: UITestCase {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
-        app = XCUIApplication.setUp()
+        app = XCUIApplication.setUp(featureFlags: ["fireDialogSimplified": false])
         app.enforceSingleWindow()
         resetNextSteps()
         webView = app.webViews.firstMatch

--- a/macOS/UITests/TabNavigationInterfaceTests.swift
+++ b/macOS/UITests/TabNavigationInterfaceTests.swift
@@ -29,7 +29,7 @@ final class TabNavigationInterfaceTests: UITestCase, TabNavigationTestHelpers {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
-        app = XCUIApplication.setUp()
+        app = XCUIApplication.setUp(featureFlags: ["fireDialogSimplified": false])
     }
 
     // MARK: - Link Navigation Tests

--- a/macOS/UITests/TabNavigationPopupTests.swift
+++ b/macOS/UITests/TabNavigationPopupTests.swift
@@ -29,7 +29,7 @@ final class TabNavigationPopupTests: UITestCase, TabNavigationTestHelpers {
 
     override func setUpWithError() throws {
         continueAfterFailure = false
-        app = XCUIApplication.setUp()
+        app = XCUIApplication.setUp(featureFlags: ["fireDialogSimplified": false])
     }
 
     // MARK: - Popup Window Navigation Tests

--- a/scripts/translation-pr-checks/check_new_string_translations.py
+++ b/scripts/translation-pr-checks/check_new_string_translations.py
@@ -42,28 +42,75 @@ TranslationIssue = Tuple[str, str, Set[str], str]
 # .xcstrings (String Catalog) Handling
 # =============================================================================
 
+def flatten_localization(entry: Dict, prefix: str = "") -> Dict[str, Dict]:
+    """
+    Flatten one .xcstrings localization entry to {subpath: stringUnit}.
+
+    Recurses through stringUnit, variations (plural/device), and substitutions
+    (named plural arguments, which themselves nest variations), so every
+    translatable leaf is captured. A plural string keeps one stringUnit per
+    category instead of a single one at the top level.
+    """
+    leaves: Dict[str, Dict] = {}
+    if not isinstance(entry, dict):
+        return leaves
+    string_unit = entry.get("stringUnit")
+    if isinstance(string_unit, dict):
+        leaves[prefix] = string_unit
+    variations = entry.get("variations")
+    if isinstance(variations, dict):
+        for kind, cases in variations.items():
+            if not isinstance(cases, dict):
+                continue
+            for case_name, case_entry in cases.items():
+                key = f"{prefix}.{kind}.{case_name}" if prefix else f"{kind}.{case_name}"
+                leaves.update(flatten_localization(case_entry, key))
+    substitutions = entry.get("substitutions")
+    if isinstance(substitutions, dict):
+        for name, sub_entry in substitutions.items():
+            key = f"{prefix}.sub:{name}" if prefix else f"sub:{name}"
+            leaves.update(flatten_localization(sub_entry, key))
+    return leaves
+
 def get_string_unit_value(string_entry: Dict) -> str:
-    """Extract source string value from a .xcstrings string entry."""
+    """
+    Extract the source string value from a .xcstrings string entry.
+
+    The value of every leaf is included, so a change to one plural category
+    counts as a change to the source string.
+    """
     if not isinstance(string_entry, dict):
         return ""
-    # The source string is stored in localizations['en']['stringUnit']['value']
+    # The source string is stored in localizations['en']
     localizations = string_entry.get("localizations", {})
-    if isinstance(localizations, dict):
-        en_localization = localizations.get("en", {})
-        if isinstance(en_localization, dict):
-            string_unit = en_localization.get("stringUnit", {})
-            if isinstance(string_unit, dict):
-                return string_unit.get("value", "")
-    return ""
+    if not isinstance(localizations, dict):
+        return ""
+    leaves = flatten_localization(localizations.get("en", {}))
+    if not leaves:
+        return ""
+    return "\n".join(
+        f"{subpath}={leaves[subpath].get('value', '')}" for subpath in sorted(leaves)
+    )
 
 def get_string_unit_state(localization_entry: Dict) -> Optional[str]:
-    """Extract state from a .xcstrings localization entry."""
-    if not isinstance(localization_entry, dict):
+    """
+    Extract the effective state from a .xcstrings localization entry.
+
+    A plural string holds one state per category, so the leaf states are
+    combined into the least complete one: an untranslated category outranks
+    needs_review, and needs_review outranks translated. Returns None when the
+    entry holds no leaf at all.
+    """
+    leaves = flatten_localization(localization_entry)
+    if not leaves:
         return None
-    string_unit = localization_entry.get("stringUnit", {})
-    if isinstance(string_unit, dict):
-        return string_unit.get("state")
-    return None
+    states = [leaves[subpath].get("state") for subpath in sorted(leaves)]
+    for state in states:
+        if state != "translated" and state != "needs_review":
+            return state
+    if "needs_review" in states:
+        return "needs_review"
+    return "translated"
 
 def get_changed_string_keys(old_data: Dict, new_data: Dict) -> Set[str]:
     """Get keys that have changed in new_data compared to old_data."""


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1217529278319869?focus=true

### Description
Update UserText to better support translations and remove NotLocalizedString from Fire Dialog strings.

### Testing Steps
Smoke test fire dialog - there should be no changes to the copy.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localization-only string and presentation changes with intended English parity; no auth, data deletion logic, or security surface changes beyond CI runner configuration.
> 
> **Overview**
> Prepares **macOS Fire dialog** copy for translation by replacing `NotLocalizedString` with `NSLocalizedString` across Fire-related `UserText` entries, including progress strings, simplified dialog labels, and overlay actions.
> 
> **Pluralized counts** now use `String.localizedStringWithFormat` with `%#@…@` plural rules (history items, sites, chats) instead of hand-built English singular/plural branches. Overlay headers for sites, chats, and history are **single localized templates** with `**markdown**` emphasis, replacing separate bold/regular string pairs.
> 
> `FireDialogView` renders those headers via `Text(.init(...))` so bold segments come from the localized string rather than SwiftUI `Text` concatenation.
> 
> The **Smartling workflow** runs on `bitrise:macos26-m4-xlarge` and skips `actions/setup-python` when `runner.environment == 'self-hosted'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed0fd5f79c7ec36823945567de5e9538f0c70ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->