### PR TITLE
Constrain origin and page_type on UTI submission pixels

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -3,8 +3,6 @@
 // from the Duck.ai tab and the address bar. `voice_tapped` carries the same values under its pre-existing
 // `source` key. The subscription-funnel `origin` on the picker/upsell pixels intentionally folds the
 // contextual sheet into the Duck.ai bucket (keeps the funnel origin / subscription redirect URL stable).
-// `origin` on prompt_submitted is unrelated to those: it is an m_aichat_entry_point source value, not a
-// subscription-funnel origin.
 {
     "m_aichat_unified_input_image_generation_selected": {
         "description": "Fires when the user activates Create Image from the tools menu in the Unified Toggle Input. Does not fire when the toggle is rejected by an unsupporting model.",

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -3,6 +3,8 @@
 // from the Duck.ai tab and the address bar. `voice_tapped` carries the same values under its pre-existing
 // `source` key. The subscription-funnel `origin` on the picker/upsell pixels intentionally folds the
 // contextual sheet into the Duck.ai bucket (keeps the funnel origin / subscription redirect URL stable).
+// `origin` on prompt_submitted is unrelated to those: it is an m_aichat_entry_point source value, not a
+// subscription-funnel origin.
 {
     "m_aichat_unified_input_image_generation_selected": {
         "description": "Fires when the user activates Create Image from the tools menu in the Unified Toggle Input. Does not fire when the toggle is rejected by an unsupporting model.",
@@ -363,11 +365,7 @@
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "page_type",
-                "description": "The page the user was on when submitting: ntp, serp, website, duck_ai, contextual, or unknown",
-                "type": "string"
-            },
+            "unified_input_page_type",
             {
                 "key": "default_mode",
                 "description": "The user's Opening-mode setting, for telling an accepted default apart from a switch. Absent on iPad's address-bar toggle path, which has no Search-side counterpart — filter on it being present for any Search-vs-Duck.ai ratio.",
@@ -376,8 +374,35 @@
             },
             {
                 "key": "origin",
-                "description": "How the user reached the surface the prompt was typed on, as an m_aichat_entry_point source value. Absent when the entry is unknown.",
-                "type": "string"
+                "description": "How the user reached the surface the prompt was typed on, as an m_aichat_entry_point source value — same value set as that pixel's source param and the duckai-prompt wide event's feature.data.ext.prompt.origin. Not a subscription-funnel origin. Absent when the entry is unknown.",
+                "type": "string",
+                "enum": [
+                    "address_bar_prompt",
+                    "address_bar_icon",
+                    "address_bar_shortcut_chip",
+                    "address_bar_editing_state",
+                    "suggestion_ask_ai",
+                    "ipad_toggle_prompt",
+                    "browsing_menu_ntp",
+                    "browsing_menu_webpage",
+                    "tab_switcher",
+                    "tabs_bar_button",
+                    "chat_history_new_chat",
+                    "chat_history_open_chat",
+                    "voice",
+                    "onboarding",
+                    "direct_url",
+                    "serp",
+                    "icon_shortcut",
+                    "contextual_chat",
+                    "widget_quick_actions",
+                    "widget_quick_actions_medium",
+                    "widget_favorite",
+                    "widget_lock_screen",
+                    "widget_control_center",
+                    "siri",
+                    "deep_link_other"
+                ]
             },
             "unified_input_surface",
             {
@@ -421,11 +446,7 @@
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": [
             "appVersion",
-            {
-                "key": "page_type",
-                "description": "The page the user was on when submitting: ntp, serp, website, duck_ai, contextual, or unknown",
-                "type": "string"
-            },
+            "unified_input_page_type",
             {
                 "key": "default_mode",
                 "description": "The user's Opening-mode setting, for telling an accepted default apart from a switch.",

--- a/iOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/iOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -21,6 +21,12 @@
         "description": "The Unified Toggle Input surface the pixel was fired from, distinguishing the contextual chat sheet from the Duck.ai tab and the address bar.",
         "enum": ["address_bar", "duck_ai", "contextual_chat"]
     },
+    "unified_input_page_type": {
+        "key": "page_type",
+        "type": "string",
+        "description": "The page the user was on when submitting through the Unified Toggle Input, one value per case of the UnifiedToggleInputPromptPageType Swift enum. `contextual` is the contextual chat sheet; `unknown` is a submission whose page could not be resolved, e.g. no current tab.",
+        "enum": ["ntp", "serp", "website", "duck_ai", "contextual", "unknown"]
+    },
     "cookie_popup_preference": {
         "key": "cookie_popup_preference",
         "type": "string",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201188456623839/task/1217540623808834?focus=true
Tech Design URL:
CC:

### Description
Update pixel definition

### Testing Steps
1. From `iOS/`, run `npm ci` then `npm run pixel-lint` → reports all files match Prettier style.
2. Run `npm run validate-defs-without-formatting` → exits 0 with no validation errors.
3. Run `npm run check-wide-events` → both the consistency and schema-immutability checks pass.

### Impact
None

#### What could go wrong?
An entry point that sends an `origin` value outside the declared enum would fail live pixel validation → mitigated by deriving the list from every case of `AIChatEntryPointSource`, which is the only type the firing code accepts.

### Quality Considerations
The `origin` key on these pixels is an entry-point label, not the `funnel_*` subscription-attribution `origin` that the model-picker and upsell pixels in the same file carry. Both the param description and the file header now say so explicitly.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSON5 pixel-definition-only changes; enums mirror existing Swift types, so runtime behavior is unchanged aside from stricter validation if a new origin were sent without updating definitions.
> 
> **Overview**
> Tightens **Unified Toggle Input** submission pixel schemas so live validation matches what the app actually sends.
> 
> Adds a shared **`unified_input_page_type`** entry in `params_dictionary.json5` (key `page_type`, enum `ntp`, `serp`, `website`, `duck_ai`, `contextual`, `unknown`) and wires **`m_aichat_unified_input_prompt_submitted`** and **`m_aichat_unified_input_query_submitted`** to use it instead of inline `page_type` blocks.
> 
> On **`m_aichat_unified_input_prompt_submitted`**, **`origin`** is now an explicit enum aligned with **`m_aichat_entry_point`** / **`AIChatEntryPointSource`** (address bar, widgets, Siri, etc.), with description clarifying it is **not** the subscription-funnel `funnel_*` **`origin`** used on model-picker pixels in the same file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d4578192a61cf8e92d6a59407821808c0e45c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->