### PR TITLE
Enable M4 and M4 Pro Bitrise runners on PR checks

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -10,3 +10,6 @@ self-hosted-runner:
     - apple
     - xcode-27
     - bitrise:*
+    - image:osx-tahoe-26
+    - size:large
+    - size:xlarge

--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Override RUNS_ON
         if: runner.environment == 'self-hosted'
         run: |
-          if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+          if [[ "${{ contains(runner.name, 'm4pro') }}" == "true" ]]; then
             echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
           else
             echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
@@ -233,7 +233,7 @@ jobs:
       - name: Override RUNS_ON
         if: runner.environment == 'self-hosted'
         run: |
-          if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+          if [[ "${{ contains(runner.name, 'm4pro') }}" == "true" ]]; then
             echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
           else
             echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV

--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -36,7 +36,7 @@ jobs:
       needs: should-run-checks
       if: needs.should-run-checks.outputs.should_run == 'true'
 
-      runs-on: bitrise:macos26-m4
+      runs-on: [image:osx-tahoe-26, size:large]
       timeout-minutes: 45
 
       env:
@@ -58,6 +58,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Override RUNS_ON
+        if: runner.environment == 'self-hosted'
+        run: |
+          if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+            echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
+          else
+            echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
+          fi
 
       - name: Print macOS version
         run: sw_vers
@@ -202,7 +211,7 @@ jobs:
       needs: should-run-checks
       if: needs.should-run-checks.outputs.should_run == 'true'
 
-      runs-on: bitrise:macos26-m4
+      runs-on: [image:osx-tahoe-26, size:large]
       timeout-minutes: 45
 
       env:
@@ -220,6 +229,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Override RUNS_ON
+        if: runner.environment == 'self-hosted'
+        run: |
+          if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+            echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
+          else
+            echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
+          fi
 
       - name: Print macOS version
         run: sw_vers

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Override RUNS_ON
         if: runner.environment == 'self-hosted'
         run: |
-          if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+          if [[ "${{ contains(runner.name, 'm4pro') }}" == "true" ]]; then
             echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
           else
             echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
@@ -215,7 +215,7 @@ jobs:
       - name: Override RUNS_ON
         if: runner.environment == 'self-hosted'
         run: |
-          if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+          if [[ "${{ contains(runner.name, 'm4pro') }}" == "true" ]]; then
             echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
           else
             echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -36,7 +36,7 @@ jobs:
       needs: should-run-checks
       if: needs.should-run-checks.outputs.should_run == 'true'
 
-      runs-on: bitrise:macos26-m4
+      runs-on: [image:osx-tahoe-26, size:large]
       timeout-minutes: 30
 
       env:
@@ -58,6 +58,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Override RUNS_ON
+        if: runner.environment == 'self-hosted'
+        run: |
+          if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+            echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
+          else
+            echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
+          fi
 
       - name: Print macOS version
         run: sw_vers
@@ -185,7 +194,7 @@ jobs:
       needs: should-run-checks
       if: needs.should-run-checks.outputs.should_run == 'true'
 
-      runs-on: bitrise:macos26-m4
+      runs-on: [image:osx-tahoe-26, size:large]
       timeout-minutes: 30
 
       env:
@@ -202,6 +211,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+
+      - name: Override RUNS_ON
+        if: runner.environment == 'self-hosted'
+        run: |
+          if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+            echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
+          else
+            echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
+          fi
 
       - name: Print macOS version
         run: sw_vers

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -137,7 +137,7 @@ jobs:
     - name: Override RUNS_ON
       if: runner.environment == 'self-hosted'
       run: |
-        if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+        if [[ "${{ contains(runner.name, 'm4pro') }}" == "true" ]]; then
           echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
         else
           echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
@@ -367,7 +367,7 @@ jobs:
     - name: Override RUNS_ON
       if: runner.environment == 'self-hosted'
       run: |
-        if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+        if [[ "${{ contains(runner.name, 'm4pro') }}" == "true" ]]; then
           echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
         else
           echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -103,7 +103,7 @@ jobs:
     needs: should-run-checks
     if: needs.should-run-checks.outputs.should_run == 'true'
 
-    runs-on: bitrise:macos26-m4
+    runs-on: [image:osx-tahoe-26, size:large]
     timeout-minutes: 60 # temporary (vs original 20) to fix the issue with GHA slowness
 
     env:
@@ -133,6 +133,15 @@ jobs:
       with:
         submodules: recursive
         ref: ${{ inputs.branch || github.ref_name }}
+
+    - name: Override RUNS_ON
+      if: runner.environment == 'self-hosted'
+      run: |
+        if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+          echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
+        else
+          echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
+        fi
 
     - name: Print macOS version
       run: sw_vers
@@ -327,7 +336,7 @@ jobs:
       inputs.skip-release != true &&
       needs.should-run-checks.outputs.should_run == 'true'
 
-    runs-on: bitrise:macos26-m4
+    runs-on: [image:osx-tahoe-26, size:large]
     timeout-minutes: 60 # temporary (vs original 20) to fix the issue with GHA slowness
 
     env:
@@ -354,6 +363,15 @@ jobs:
       uses: actions/checkout@v6
       with:
         ref: ${{ inputs.branch || github.ref_name }}
+
+    - name: Override RUNS_ON
+      if: runner.environment == 'self-hosted'
+      run: |
+        if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+          echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
+        else
+          echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
+        fi
 
     - name: Print macOS version
       run: sw_vers

--- a/.github/workflows/macos_pir_end_to_end_tests.yml
+++ b/.github/workflows/macos_pir_end_to_end_tests.yml
@@ -38,10 +38,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [bitrise:macos26-m4]
+        runner: [image:osx-tahoe-26, size:large]
         include:
           - xcode-version: "26.4"
-            runner: bitrise:macos26-m4
+            runner: [image:osx-tahoe-26, size:large]
             runner-name: bitrise-macos26-m4 # runner label without reserved characters, for use in the artifact name
 
     concurrency:
@@ -231,6 +231,18 @@ jobs:
         path: macOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-pir-e2e-${{ steps.compilation-cache-hash.outputs.hash }}
 
+    - name: Set RUNS_ON
+      run: |
+        if [[ "${{ runner.environment }}" == "self-hosted" ]]; then
+          if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+            echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
+          else
+            echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
+          fi
+        else
+          echo "RUNS_ON=${{ matrix.runner }}" >> $GITHUB_ENV
+        fi
+
     - name: Report job duration
       if: success() || (always() && steps.run-tests.outcome == 'failure')
       continue-on-error: true
@@ -240,7 +252,7 @@ jobs:
         start-timestamp: ${{ steps.start-duration.outputs.start-timestamp }}
         pixel-name: m_ci_apple_duration_macos_pir_e2e_tests
         pixel-params: |
-          runner: ${{ matrix.runner }}
+          runner: ${{ env.RUNS_ON }}
 
     - name: Send Status Pixel
       if: always() && github.ref_name == 'main'

--- a/.github/workflows/macos_pir_end_to_end_tests.yml
+++ b/.github/workflows/macos_pir_end_to_end_tests.yml
@@ -38,10 +38,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [image:osx-tahoe-26, size:large]
+        runner: [bitrise:macos26-m4]
         include:
           - xcode-version: "26.4"
-            runner: '[image:osx-tahoe-26, size:large]'
+            runner: bitrise:macos26-m4
             runner-name: bitrise-macos26-m4 # runner label without reserved characters, for use in the artifact name
 
     concurrency:
@@ -231,18 +231,6 @@ jobs:
         path: macOS/DerivedData/CompilationCache.noindex
         key: xcode-compilation-cache-pir-e2e-${{ steps.compilation-cache-hash.outputs.hash }}
 
-    - name: Set RUNS_ON
-      run: |
-        if [[ "${{ runner.environment }}" == "self-hosted" ]]; then
-          if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
-            echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
-          else
-            echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
-          fi
-        else
-          echo "RUNS_ON=${{ matrix.runner }}" >> $GITHUB_ENV
-        fi
-
     - name: Report job duration
       if: success() || (always() && steps.run-tests.outcome == 'failure')
       continue-on-error: true
@@ -252,7 +240,7 @@ jobs:
         start-timestamp: ${{ steps.start-duration.outputs.start-timestamp }}
         pixel-name: m_ci_apple_duration_macos_pir_e2e_tests
         pixel-params: |
-          runner: ${{ env.RUNS_ON }}
+          runner: ${{ matrix.runner }}
 
     - name: Send Status Pixel
       if: always() && github.ref_name == 'main'

--- a/.github/workflows/macos_pir_end_to_end_tests.yml
+++ b/.github/workflows/macos_pir_end_to_end_tests.yml
@@ -41,7 +41,7 @@ jobs:
         runner: [image:osx-tahoe-26, size:large]
         include:
           - xcode-version: "26.4"
-            runner: [image:osx-tahoe-26, size:large]
+            runner: '[image:osx-tahoe-26, size:large]'
             runner-name: bitrise-macos26-m4 # runner label without reserved characters, for use in the artifact name
 
     concurrency:

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -445,7 +445,7 @@ jobs:
             echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
           fi
         else
-          echo "RUNS_ON=${{ matrix.runs-on }}" >> $GITHUB_ENV
+           echo "RUNS_ON=${{ join(matrix.runs-on, ',') }}" >> $GITHUB_ENV
         fi
 
     - name: Report job duration

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -457,7 +457,7 @@ jobs:
         start-timestamp: ${{ steps.start-duration-tests.outputs.start-timestamp }}
         pixel-name: m_ci_apple_duration_macos_${{ matrix.flavor }}_unit_tests
         pixel-params: |
-          runner: $RUNS_ON
+          runner: ${{ env.RUNS_ON }}
 
     - name: Send Unit Tests Status Pixel
       if: always() && github.ref_name == 'main'

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -579,6 +579,7 @@ jobs:
           echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
         else
           echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
+        fi
 
     - name: Print macOS version
       run: sw_vers

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -439,7 +439,7 @@ jobs:
     - name: Set RUNS_ON
       run: |
         if [[ "${{ runner.environment }}" == "self-hosted" ]]; then
-          if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+          if [[ "${{ contains(runner.name, 'm4pro') }}" == "true" ]]; then
             echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
           else
             echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
@@ -575,7 +575,7 @@ jobs:
     - name: Override RUNS_ON
       if: runner.environment == 'self-hosted'
       run: |
-        if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+        if [[ "${{ contains(runner.name, 'm4pro') }}" == "true" ]]; then
           echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
         else
           echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -161,9 +161,9 @@ jobs:
             flavor: Non-Sandbox
           - cache-key: sandbox-
             flavor: Sandbox
-          - runs-on: bitrise:macos26-m4
+          - runs-on: [image:osx-tahoe-26, size:large]
             flavor: Non-Sandbox
-          - runs-on: bitrise:macos26-m4-xlarge
+          - runs-on: [image:osx-tahoe-26, size:xlarge]
             flavor: Sandbox
 
     runs-on: ${{ matrix.runs-on }}
@@ -436,6 +436,18 @@ jobs:
             | xargs -L 1 ${{ github.workspace }}/scripts/report-failed-unit-test.sh -s ${{ vars.APPLE_CI_FAILING_TESTS_MACOS_FAILED_TESTS_SECTION_ID }}
         done
 
+    - name: Set RUNS_ON
+      run: |
+        if [[ "${{ runner.environment }}" == "self-hosted" ]]; then
+          if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+            echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
+          else
+            echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
+          fi
+        else
+          echo "RUNS_ON=${{ matrix.runs-on }}" >> $GITHUB_ENV
+        fi
+
     - name: Report job duration
       if: success() || (always() && steps.run-integration-tests.outcome == 'failure')
       continue-on-error: true
@@ -445,7 +457,7 @@ jobs:
         start-timestamp: ${{ steps.start-duration-tests.outputs.start-timestamp }}
         pixel-name: m_ci_apple_duration_macos_${{ matrix.flavor }}_unit_tests
         pixel-params: |
-          runner: ${{ matrix.runs-on }}
+          runner: $RUNS_ON
 
     - name: Send Unit Tests Status Pixel
       if: always() && github.ref_name == 'main'
@@ -539,7 +551,7 @@ jobs:
       inputs.skip-release-build != true &&
       needs.should-run-checks.outputs.should_run == 'true'
 
-    runs-on: bitrise:macos26-m4
+    runs-on: [image:osx-tahoe-26, size:large]
     timeout-minutes: 60
     env:
       RUNS_ON: bitrise:macos26-m4 # keep this in sync with runs-on above
@@ -559,6 +571,14 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: recursive
+
+    - name: Override RUNS_ON
+      if: runner.environment == 'self-hosted'
+      run: |
+        if [[ "${{ contains(runner.os, 'm4pro') }}" == "true" ]]; then
+          echo "RUNS_ON=bitrise:macos26-m4pro" >> $GITHUB_ENV
+        else
+          echo "RUNS_ON=bitrise:macos26-m4" >> $GITHUB_ENV
 
     - name: Print macOS version
       run: sw_vers


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1217529050598187?focus=true

### Description
This change adjusts runner labels to include both M4 and M4 Pro pools for runner selection for PR checks runs.
It will allow us to compare performance of M4 vs M4 Pro in the wild.

### Testing Steps
1. Verify that CI is green.
2. Verify that when [an M4 Pro runner is selected](https://github.com/duckduckgo/apple-browsers/actions/runs/32034107003/job/95400416051?pr=6380#step:1:2), then [RUNS_ON=bitrise:macos26-m4pro is set](https://github.com/duckduckgo/apple-browsers/actions/runs/32034107003/job/95400416051?pr=6380#step:5:3)

### Impact
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions runner labels and CI telemetry env vars; no application or security logic is touched.
> 
> **Overview**
> PR check macOS jobs now target Bitrise via **`image:osx-tahoe-26`** with **`size:large`** or **`size:xlarge`** instead of fixed **`bitrise:macos26-m4`** labels, so scheduling can draw from both M4 and M4 Pro pools. **actionlint** is updated to accept those custom labels.
> 
> After checkout, self-hosted jobs run an **Override RUNS_ON** (or **Set RUNS_ON** on the macOS test matrix) step that sets **`RUNS_ON`** to **`bitrise:macos26-m4pro`** when **`runner.name`** contains **`m4pro`**, otherwise **`bitrise:macos26-m4`**, so duration pixels and metrics reflect the actual hardware. The macOS matrix job still records matrix label strings when not on self-hosted runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebcbe50d3d87724bac6c258d9152343a8a52edb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->