### PR TITLE
[macOS] Prevent noise in unclean exit metric from App Store updates

### DIFF
--- a/macOS/DuckDuckGo/StateRestoration/AppStateRestorationManager.swift
+++ b/macOS/DuckDuckGo/StateRestoration/AppStateRestorationManager.swift
@@ -258,9 +258,14 @@ final class AppStateRestorationManager: NSObject, AppStateRestorationManaging {
 
         guard didCloseUnexpectedly else { return }
 
-        pixelFiring?.fire(SessionRestorePromptPixel.unexpectedAppTerminationDetected(
-            reason: restartSourceResolver.resolve(updateStatus: updateStatus)
-        ))
+        // Don't send the pixel if the restart had an unknown cause and coincided with an App Store update.
+        // App Store updates create noise in the metric by force quitting the app, which prevents
+        // using it for app health monitoring. However, this is a legitimate force quit so we still
+        // show the restore prompt when needed.
+        let restartSource = restartSourceResolver.resolve(updateStatus: updateStatus)
+        if restartSource != .unknownWithAppUpdate {
+            pixelFiring?.fire(SessionRestorePromptPixel.unexpectedAppTerminationDetected(reason: restartSource))
+        }
 
         guard !shouldSuppressUncleanExitRestorePrompt else { return }
 

--- a/macOS/PixelDefinitions/pixels/definitions/session_restore_prompt_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/session_restore_prompt_pixels.json5
@@ -1,6 +1,6 @@
 {
     "m_mac_unclean-exit_detected": {
-        "description": "Fired when an unexpected app termination is detected on app launch.",
+        "description": "Fired when an unexpected app termination is detected on app launch, except when it coincides with an App Store update.",
         "owners": ["rachelmcr"],
         "triggers": ["other"],
         "parameters": [
@@ -9,9 +9,9 @@
             "channel",
             {
                 "key": "restart-source-attribution",
-                "description": "Why the unclean exit and subsequent restart occurred. app_update is Sparkle-only (confirmed pending update). unknown_with_app_update is App Store-only (version changed; exit cause undetermined).",
+                "description": "Why the unclean exit and subsequent restart occurred. app_update is Sparkle-only (confirmed pending update).",
                 "type": "string",
-                "enum": ["crash", "app_update", "unknown_with_app_update", "unknown"]
+                "enum": ["crash", "app_update", "unknown"]
             }
         ]
     },

--- a/macOS/UnitTests/Common/FileSystem/AppStateRestorationManagerTests.swift
+++ b/macOS/UnitTests/Common/FileSystem/AppStateRestorationManagerTests.swift
@@ -249,13 +249,10 @@ final class AppStateRestorationManagerTests: XCTestCase {
     }
 
     @MainActor
-    func testWhenAppDidTerminateUnexpectedlyAfterUnknownWithAppUpdate_ThenPixelIsFiredAndPromptIsShown() throws {
+    func testWhenAppDidTerminateUnexpectedlyAfterUnknownWithAppUpdate_ThenPixelIsNotFiredAndPromptIsShown() throws {
         try mockKeyValueStore.set(false, forKey: terminationFlagKey)
         mockRestartSourceResolver.resolvedSource = .unknownWithAppUpdate
         addMockSessionData()
-        mockPixelKit.expectedFireCalls = [
-            .init(pixel: SessionRestorePromptPixel.unexpectedAppTerminationDetected(reason: .unknownWithAppUpdate), frequency: .standard)
-        ]
 
         appStateManager.applicationDidFinishLaunching()
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1215856248249961?focus=true
Tech Design URL:
CC:

### Description

There's noise in the unclean exit metric due to the App Store force quitting the app to perform an update (a real unclean exit but not caused by the app). This prevents it being useful for monitoring as an app health metric.

Since we can't detect when the App Store is updating the app (versus an update that happens after an unclean exit), we're suppressing the pixel in the `unknown_with_app_update` restart source case. This is documented as a known unmeasured case for this metric's monitoring.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Confirm checks pass (includes test that pixel is not fired in this case).

Optional manual testing:

1. Build and run the App Store build.
2. Kill the app (e.g. use the stop button in Xcode).
3. Run the app again and confirm `m_mac_unclean-exit_detected` is fired with the parameter `restart-source-attribution` with value `unknown` (no change in behavior).
4. Kill the app.
5. In `Version.xcconfig` change the version number.
6. Build and run the app and confirm `m_mac_unclean-exit_detected` is not fired.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change; restore prompt logic is untouched except for not emitting one pixel in a specific App Store update case.
> 
> **Overview**
> **Stops firing** `m_mac_unclean-exit_detected` when the unclean exit restart source is `unknownWithAppUpdate` (unclean exit on launch after an App Store version change). App Store updates force-quit the app and were inflating the metric without reflecting app health.
> 
> **Session restore behavior is unchanged:** the restore prompt still appears when appropriate; only telemetry is skipped in that case.
> 
> Pixel definitions drop the `unknown_with_app_update` value from `restart-source-attribution` and document the exception. Unit tests now assert no pixel fire for that resolver outcome while the prompt still shows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 432e332132877a219bc482b032b0512a66817145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->