### PR TITLE
iOS: Mapping CSS 16.9

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "c7e7dadeb9a426d0a35255a45c066c5b3805f449b532def4b0b374c8c1736434",
+  "originHash" : "a8590e9229381dfd67207a8633935d1e6b2fe560750a82711b8801007b762334",
   "pins" : [
     {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "9bb13ba44c2e73f97ebe45c8ce77c238578f3ce5",
-        "version" : "16.8.0"
+        "revision" : "21aec4d902338cb10c422e091eb6a8c9f38a9be1",
+        "version" : "16.9.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),
         .package(url: "https://github.com/vapor/jwt-kit.git", exact: "4.13.5"),
         .package(url: "https://github.com/pointfreeco/swift-clocks.git", exact: "1.0.6"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "16.8.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "16.9.0"),
         .package(path: "../URLPredictor"),
         .package(path: "../Infrastructure/SystemFrameworksExtensions"),
     ],

--- a/SharedPackages/DataBrokerProtectionCore/Package.resolved
+++ b/SharedPackages/DataBrokerProtectionCore/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "9bb13ba44c2e73f97ebe45c8ce77c238578f3ce5",
-        "version" : "16.8.0"
+        "revision" : "21aec4d902338cb10c422e091eb6a8c9f38a9be1",
+        "version" : "16.9.0"
       }
     },
     {

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d1911e821037e18b93f63e9987a032bec5718a78bb265398182ef96b8d8a54ec",
+  "originHash" : "79e8346d2affdb376c7e99d3b674b35e87a36ed978d9e40ef67267d401e714ec",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "9bb13ba44c2e73f97ebe45c8ce77c238578f3ce5",
-        "version" : "16.8.0"
+        "revision" : "21aec4d902338cb10c422e091eb6a8c9f38a9be1",
+        "version" : "16.9.0"
       }
     },
     {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "efb9fcd0467068838457999f2886c03e71fbb5bc900ad58b8a3540db0becaf6e",
+  "originHash" : "11403115d8e598baff4aae3409a2eaf35860fdaa061e7f58fbca4dabc6fcadc9",
   "pins" : [
     {
       "identity" : "apple-toolbox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "9bb13ba44c2e73f97ebe45c8ce77c238578f3ce5",
-        "version" : "16.8.0"
+        "revision" : "21aec4d902338cb10c422e091eb6a8c9f38a9be1",
+        "version" : "16.9.0"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1217491870935694
Tech Design URL:
CC:

### Description
This PR bumps our CSS dependency to 16.9, in the iOS 7.234 branch.

### Testing Steps
- [ ] Verify the CI is green

### Impact
Medium: Could disrupt specific features or user flows

#### What could go wrong?
The Maestro regression could not really be fixed

### Quality Considerations
Nothing in particular

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change but content-scope-scripts affects in-page privacy and content scripts broadly; regressions could break Maestro or site-specific behavior without compile-time signal.
> 
> **Overview**
> Bumps the **content-scope-scripts** (CSS) dependency from **16.8.0** to **16.9.0** for the macOS 1.204 mapping work.
> 
> `BrowserServicesKit/Package.swift` pins the package at `exact: "16.9.0"`, and matching **Package.resolved** updates land in BrowserServicesKit, DataBrokerProtectionCore, iOS, and macOS Xcode workspaces (revision `21aec4d902338cb10c422e091eb6a8c9f38a9be1`). No app or library source changes—only SPM lockfiles and the version constraint.
> 
> This pulls in whatever script and privacy-feature updates ship in CSS 16.9 (injected via `ContentScopeScripts` on BrowserServicesKit targets such as SpecialErrorPages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a06f47fe3b1a865e596ce9b263965f55495d9e53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->