### PR TITLE
Fix tab switcher E2E flows by making the floating UI flag override apply

### DIFF
--- a/.maestro/shared/setup.yaml
+++ b/.maestro/shared/setup.yaml
@@ -16,4 +16,5 @@ appId: com.duckduckgo.mobile.ios
         currentAppVariant: ${APP_VARIANT} # Renaming `currentAppVariant` requires to update LaunchOptionsHandler `currentAppVariant` key
         isRunningUITests: true
         isInternalUser: ${INTERNAL_USER_MODE}
-        ff.floatingUIAugust2026: false
+        # Keep quoted — LaunchOptionsHandler silently ignores unquoted YAML booleans.
+        ff.floatingUIAugust2026: "false"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1217515498353359?focus=true
Tech Design URL:
CC:

### Description

Three iPhone release E2E flows (`tabswitcher`, `tab-switcher-selection`, `bookmarks-multi`) have been failing on the nightly `E2E: release - internal` leg since 14 Aug, all with `Element not found: Text matching regex: Edit`.

The updated tab switcher was switched on by default for internal users, and its menu button is icon-only with no "Edit" label, so the flows can no longer find it. A shared setup file already tried to pin the flows to the previous tab switcher by turning the flag off — but the value was written as an unquoted YAML boolean, and unquoted booleans are silently discarded when launch arguments are read back, so the override never applied.

Quoting the value makes the existing override work as intended. Every other feature-flag override across the Maestro suite was already quoted; this was the only one that wasn't.

### Testing Steps

1. Run the three flows against an internal-mode build on iPhone (iOS 18.2), e.g. `maestro test -e ONBOARDING_COMPLETED=true -e INTERNAL_USER_MODE=true .maestro/release_tests/tabswitcher.yaml` → passes
2. Repeat for `.maestro/release_tests/tab-switcher-selection.yaml` → passes
3. Repeat for `.maestro/release_tests/bookmarks-multi.yaml` → passes
4. Open the tab switcher manually in the same build → the previous tab switcher is shown, with the labelled "Edit" button

All three were verified locally against the exact binary from the failing CI run (run 31926170808 / 31993898668), on iPhone 16 / iOS 18.2 — the same device and OS the failing job uses. Before the change all three failed; after it all three pass.

### Impact

None — test tooling only. No app code changes. It restores E2E coverage that has been red for four days.

#### What could go wrong?

* The flows are now genuinely pinned to the previous tab switcher, so they no longer exercise the updated one → when the flag reaches 100% these three flows need rewriting against the new chrome, which restructured several controls (grid/list became menu actions, a dedicated close-tabs button replaced the menu item, and Select All/Deselect All moved out of the multi-select menu).

### Quality Considerations

Worth being aware of two things this uncovered, both left out of scope here:

* Unquoted values in these overrides fail **silently** — the flag simply stays at its default with no warning. That is what let this sit red for four days. Making the launch-argument parsing tolerant of non-string values (or warning on them) would close the whole class.
* The updated tab switcher's menu buttons have no accessibility label at all, which is a VoiceOver gap for internal users independent of the tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Maestro test configuration only; no production app code changes.
> 
> **Overview**
> Fixes three failing iPhone release E2E flows (`tabswitcher`, `tab-switcher-selection`, `bookmarks-multi`) that look for an **Edit** label on the tab switcher.
> 
> In `.maestro/shared/setup.yaml`, `ff.floatingUIAugust2026` is changed from an unquoted YAML boolean to the quoted string `"false"`, with a comment that **LaunchOptionsHandler** ignores unquoted booleans. The override was already intended to keep the previous tab switcher chrome during tests; quoting makes that launch argument actually register.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b736e234632009c78ee41785af66f1c7b435ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->