### PR TITLE
Always use simplified Fire Dialog for delete actions in History View

### DIFF
--- a/macOS/DuckDuckGo/Fire/View/FireCoordinator.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireCoordinator.swift
@@ -252,7 +252,7 @@ extension FireCoordinator {
             featureFlagger: self.featureFlagger,
             clearingOption: mode.shouldShowSegmentedControl ? nil /* last selected */ : .allData,
             includeTabsAndWindows: mode.shouldShowCloseTabsToggle ? nil /* last selected */ : false,
-            includeChatHistory: mode.shouldShowChatHistoryToggle ? nil /* last selected */ : false,
+            includeChatHistory: mode.shouldShowChatHistoryToggle(featureFlagger) ? nil /* last selected */ : false,
             mode: mode,
             settings: settings,
             scopeCookieDomains: scopeCookieDomains,

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -103,19 +103,19 @@ final class FireDialogViewModel: ObservableObject {
 
         var shouldShowVisitsToggle: Bool {
             switch self {
-            case .historyView(query: .visits):
+            case .historyView:
                 return false
             default:
                 return true
             }
         }
 
-        var shouldShowChatHistoryToggle: Bool {
+        func shouldShowChatHistoryToggle(_ featureFlagger: FeatureFlagger) -> Bool {
             switch self {
-            case .fireButton,
-                    .mainMenuAll,
-                    .historyView(query: .rangeFilter(.all)):
+            case .fireButton, .mainMenuAll:
                 return true
+            case .historyView(query: .rangeFilter(.all)):
+                return !featureFlagger.isFeatureOn(.fireDialogSimplified)
             case .historyView:
                 return false
             }
@@ -133,20 +133,36 @@ final class FireDialogViewModel: ObservableObject {
 
         /// Compute custom title for dialog based on mode (when applicable)
         var dialogTitle: String {
-            let title = switch self {
-            case .fireButton: UserText.fireDialogTitle
-            case .mainMenuAll,
-                 .historyView(query: .rangeFilter(.all)),
-                 .historyView(query: .rangeFilter(.allSites)): HistoryViewDeleteDialogModel.DeleteMode.all.title
-            case .historyView(query: .rangeFilter(.today)): HistoryViewDeleteDialogModel.DeleteMode.today.title
-            case .historyView(query: .rangeFilter(.yesterday)): HistoryViewDeleteDialogModel.DeleteMode.yesterday.title
-            case .historyView(query: .dateFilter(let date)): HistoryViewDeleteDialogModel.DeleteMode.date(date).title
-            case .historyView(query: .domainFilter(let domains)): HistoryViewDeleteDialogModel.DeleteMode.sites(domains).title
-            case .historyView(query: .rangeFilter(.older)): HistoryViewDeleteDialogModel.DeleteMode.older.title
-            case .historyView(query: .visits(let visits)): UserText.fireDialogHistoryItemsTitle(visits.uniqued(on: { $0.uuid }).count)
-            case .historyView: UserText.fireDialogTitle
-            }
-            return title.replacingOccurrences(of: #"\n"#, with: " ")
+            let title = {
+                switch self {
+                case .fireButton:
+                    return UserText.fireDialogTitle
+                case .mainMenuAll,
+                        .historyView(query: .rangeFilter(.all)),
+                        .historyView(query: .rangeFilter(.allSites)):
+                    return HistoryViewDeleteDialogModel.DeleteMode.all.title
+                case .historyView(query: .rangeFilter(.today)):
+                    return HistoryViewDeleteDialogModel.DeleteMode.today.title
+                case .historyView(query: .rangeFilter(.yesterday)):
+                    return HistoryViewDeleteDialogModel.DeleteMode.yesterday.title
+                case .historyView(query: .rangeFilter(.older)):
+                    return HistoryViewDeleteDialogModel.DeleteMode.older.title
+                case .historyView(query: .rangeFilter(let range)):
+                    guard let date = range.date(for: Date()) else {
+                        return UserText.fireDialogTitle
+                    }
+                    return HistoryViewDeleteDialogModel.DeleteMode.date(date).title
+                case .historyView(query: .dateFilter(let date)):
+                    return HistoryViewDeleteDialogModel.DeleteMode.date(date).title
+                case .historyView(query: .domainFilter(let domains)):
+                    return HistoryViewDeleteDialogModel.DeleteMode.sites(domains).title
+                case .historyView(query: .visits(let visits)):
+                    return UserText.fireDialogHistoryItemsTitle(visits.uniqued(on: { $0.uuid }).count)
+                case .historyView:
+                    return UserText.fireDialogTitle
+                }
+            }()
+            return title.replacingOccurrences(of: "\n", with: " ")
         }
     }
 
@@ -266,7 +282,7 @@ final class FireDialogViewModel: ObservableObject {
         // Only hide chats toggle when no chats in the new dialog, so default this to `true` when the flag is off.
         let hasChats = featureFlagger.isFeatureOn(.fireDialogSimplified) ? chats.count > 0 : true
         return aiChatHistoryCleaner.shouldDisplayCleanAIChatHistoryOption
-            && mode.shouldShowChatHistoryToggle
+            && mode.shouldShowChatHistoryToggle(featureFlagger)
             && (clearingOption.shouldShowChatHistoryToggle || isPresentedOnAIChatTab)
             && hasChats
     }

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -101,6 +101,13 @@ final class FireDialogViewModel: ObservableObject {
             return shouldShowVisitsToggle
         }
 
+        /// Show the History (visits) toggle?
+        ///
+        /// The compact dialog always deletes the records the History view scoped it to, so it offers
+        /// no way to exclude them.
+        ///
+        /// Only the compact dialog reads this. The legacy dialog always shows its History row and
+        /// reads the user's choice from `includeHistory`, so this needs no feature flag.
         var shouldShowVisitsToggle: Bool {
             switch self {
             case .historyView:
@@ -132,7 +139,19 @@ final class FireDialogViewModel: ObservableObject {
         }
 
         /// Compute custom title for dialog based on mode (when applicable)
-        var dialogTitle: String {
+        func dialogTitle(_ featureFlagger: FeatureFlagger) -> String {
+            guard featureFlagger.isFeatureOn(.fireDialogSimplified) else {
+                return legacyDialogTitle
+            }
+            return compactDialogTitle
+        }
+
+        /// Title of the compact dialog.
+        ///
+        /// The compact dialog is shorter than the legacy one and shows the title on a single line, so
+        /// it replaces the line break of the longer titles with a space. It also titles the weekday
+        /// sections of the History view, which each stand for a single date.
+        private var compactDialogTitle: String {
             let title = {
                 switch self {
                 case .fireButton:
@@ -140,22 +159,22 @@ final class FireDialogViewModel: ObservableObject {
                 case .mainMenuAll,
                         .historyView(query: .rangeFilter(.all)),
                         .historyView(query: .rangeFilter(.allSites)):
-                    return HistoryViewDeleteDialogModel.DeleteMode.all.title
+                    return HistoryViewDeleteDialogModel.DeleteMode.all.compactTitle
                 case .historyView(query: .rangeFilter(.today)):
-                    return HistoryViewDeleteDialogModel.DeleteMode.today.title
+                    return HistoryViewDeleteDialogModel.DeleteMode.today.compactTitle
                 case .historyView(query: .rangeFilter(.yesterday)):
-                    return HistoryViewDeleteDialogModel.DeleteMode.yesterday.title
+                    return HistoryViewDeleteDialogModel.DeleteMode.yesterday.compactTitle
                 case .historyView(query: .rangeFilter(.older)):
-                    return HistoryViewDeleteDialogModel.DeleteMode.older.title
+                    return HistoryViewDeleteDialogModel.DeleteMode.older.compactTitle
                 case .historyView(query: .rangeFilter(let range)):
                     guard let date = range.date(for: Date()) else {
                         return UserText.fireDialogTitle
                     }
-                    return HistoryViewDeleteDialogModel.DeleteMode.date(date).title
+                    return HistoryViewDeleteDialogModel.DeleteMode.date(date).compactTitle
                 case .historyView(query: .dateFilter(let date)):
-                    return HistoryViewDeleteDialogModel.DeleteMode.date(date).title
+                    return HistoryViewDeleteDialogModel.DeleteMode.date(date).compactTitle
                 case .historyView(query: .domainFilter(let domains)):
-                    return HistoryViewDeleteDialogModel.DeleteMode.sites(domains).title
+                    return HistoryViewDeleteDialogModel.DeleteMode.sites(domains).compactTitle
                 case .historyView(query: .visits(let visits)):
                     return UserText.fireDialogHistoryItemsTitle(visits.uniqued(on: { $0.uuid }).count)
                 case .historyView:
@@ -163,6 +182,35 @@ final class FireDialogViewModel: ObservableObject {
                 }
             }()
             return title.replacingOccurrences(of: "\n", with: " ")
+        }
+
+        /// Title of the legacy dialog.
+        ///
+        /// The legacy dialog spells dates out in full, keeps the line break of the longer titles, and
+        /// has no title for the weekday sections of the History view.
+        private var legacyDialogTitle: String {
+            switch self {
+            case .fireButton:
+                return UserText.fireDialogTitle
+            case .mainMenuAll,
+                    .historyView(query: .rangeFilter(.all)),
+                    .historyView(query: .rangeFilter(.allSites)):
+                return HistoryViewDeleteDialogModel.DeleteMode.all.title
+            case .historyView(query: .rangeFilter(.today)):
+                return HistoryViewDeleteDialogModel.DeleteMode.today.title
+            case .historyView(query: .rangeFilter(.yesterday)):
+                return HistoryViewDeleteDialogModel.DeleteMode.yesterday.title
+            case .historyView(query: .rangeFilter(.older)):
+                return HistoryViewDeleteDialogModel.DeleteMode.older.title
+            case .historyView(query: .dateFilter(let date)):
+                return HistoryViewDeleteDialogModel.DeleteMode.date(date).title
+            case .historyView(query: .domainFilter(let domains)):
+                return HistoryViewDeleteDialogModel.DeleteMode.sites(domains).title
+            case .historyView(query: .visits(let visits)):
+                return UserText.fireDialogHistoryItemsTitle(visits.uniqued(on: { $0.uuid }).count)
+            case .historyView:
+                return UserText.fireDialogTitle
+            }
         }
     }
 
@@ -274,7 +322,7 @@ final class FireDialogViewModel: ObservableObject {
         if case .historyView(query: .visits) = mode, !featureFlagger.isFeatureOn(.fireDialogSimplified) {
             return UserText.fireDialogTitle
         }
-        return mode.dialogTitle
+        return mode.dialogTitle(featureFlagger)
     }
 
     var shouldShowChatHistoryToggle: Bool {

--- a/macOS/DuckDuckGo/History/View/Dialogs/HistoryViewDeleteDialogModel.swift
+++ b/macOS/DuckDuckGo/History/View/Dialogs/HistoryViewDeleteDialogModel.swift
@@ -167,8 +167,7 @@ final class HistoryViewDeleteDialogModel: ObservableObject {
 
     static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateStyle = .full
-        formatter.timeStyle = .none
+        formatter.setLocalizedDateFormatFromTemplate("EEEEMMMMd")
         formatter.formattingContext = .middleOfSentence
         return formatter
     }()

--- a/macOS/DuckDuckGo/History/View/Dialogs/HistoryViewDeleteDialogModel.swift
+++ b/macOS/DuckDuckGo/History/View/Dialogs/HistoryViewDeleteDialogModel.swift
@@ -65,7 +65,20 @@ final class HistoryViewDeleteDialogModel: ObservableObject {
             return date
         }
 
+        /// Title that spells the date out in full, including the year.
         var title: String {
+            title(dateFormatter: HistoryViewDeleteDialogModel.dateFormatter)
+        }
+
+        /// Title that shortens the date to the weekday, the month and the day.
+        ///
+        /// The compact Fire dialog uses this title. It only titles dates from the last week, so the
+        /// year adds nothing and only made the title long enough to wrap onto a second line.
+        var compactTitle: String {
+            title(dateFormatter: HistoryViewDeleteDialogModel.compactDateFormatter)
+        }
+
+        private func title(dateFormatter: DateFormatter) -> String {
             switch self {
             case .all:
                 return UserText.deleteAllHistory
@@ -78,7 +91,7 @@ final class HistoryViewDeleteDialogModel: ObservableObject {
             case .unspecified:
                 return UserText.deleteHistory
             case .date(let date):
-                return UserText.deleteHistory(for: HistoryViewDeleteDialogModel.dateFormatter.string(from: date))
+                return UserText.deleteHistory(for: dateFormatter.string(from: date))
             case .sites(let domains) where domains.count == 1:
                 return UserText.deleteHistory(for: domains.first!)
             case .sites:
@@ -165,7 +178,17 @@ final class HistoryViewDeleteDialogModel: ObservableObject {
     private let mode: DeleteMode
     private let settingsPersistor: HistoryViewDeleteDialogSettingsPersisting
 
+    /// Spells the date out in full, including the year.
     static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .full
+        formatter.timeStyle = .none
+        formatter.formattingContext = .middleOfSentence
+        return formatter
+    }()
+
+    /// Shortens the date to the weekday, the month and the day, leaving the year out.
+    static let compactDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.setLocalizedDateFormatFromTemplate("EEEEMMMMd")
         formatter.formattingContext = .middleOfSentence

--- a/macOS/IntegrationTests/Fire/FireCoordinatorIntegrationTests.swift
+++ b/macOS/IntegrationTests/Fire/FireCoordinatorIntegrationTests.swift
@@ -17,10 +17,12 @@
 //
 
 import AppKit
+import FeatureFlags_macOS
 import History
 import HistoryView
 import Persistence
 import PersistenceTestingUtils
+import PrivacyConfig
 import SharedTestUtilities
 import PixelKitTestingUtilities
 import XCTest
@@ -85,7 +87,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Entry: History (All)
      Dialog config:
      - scopeSelector: hidden, selected: All
-     - tabs: visible, default=true; hist: visible, default=true; data: visible, default=true; chats: visible, default=false
+     - tabs: visible, default=true; hist: hidden (history is always deleted); data: visible, default=true; chats: visible, default=false
      - fireproof: visible; history link: hidden
      - title: "Delete all history?"
      - selectedDomains: [a.com, b.com, cook.ie, figma.com, date.com, c.com]
@@ -100,7 +102,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.all)),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -134,7 +136,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Entry: History (All)
      Dialog config:
      - scopeSelector: hidden, selected: All
-     - tabs: visible, default=true; hist: visible, default=true; data: visible, default=true; chats: visible, default=false
+     - tabs: visible, default=true; hist: hidden (history is always deleted); data: visible, default=true; chats: visible, default=false
      - fireproof: visible; history link: hidden
      - title: "Delete all history?"
      - selectedDomains: [a.com, b.com, cook.ie, figma.com, date.com, c.com]
@@ -149,7 +151,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.all)),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -183,7 +185,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Entry: History (All)
      Dialog config:
      - scopeSelector: hidden, selected: All
-     - tabs: visible, default=true; hist: visible, default=true; data: visible, default=true; chats: visible, default=false
+     - tabs: visible, default=true; hist: hidden (history is always deleted); data: visible, default=true; chats: visible, default=false
      - fireproof: visible; history link: hidden
      - title: "Delete all history?"
      - selectedDomains: [a.com, b.com]
@@ -198,7 +200,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.all)),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -239,7 +241,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Entry: History (All)
      Dialog config:
      - scopeSelector: hidden, selected: All
-     - tabs: visible, default=true; hist: visible, default=true; data: visible, default=true; chats: visible, default=false
+     - tabs: visible, default=true; hist: hidden (history is always deleted); data: visible, default=true; chats: visible, default=false
      - fireproof: visible; history link: hidden
      - title: "Delete all history?"
      - selectedDomains: [a.com, b.com, cook.ie, figma.com, x.com, example.com, test.com, date.com, close.me, c.com, z.com]
@@ -254,7 +256,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.all)),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -300,7 +302,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Dialog config:
      - scopeSelector: hidden, selected: All
      - tabs: visible, default=true
-     - hist: visible, default=true
+     - hist: hidden (history is always deleted)
      - data: visible, default=true
      - chats: not visible, default=false
      - fireproof: visible
@@ -325,7 +327,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.all)),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -371,7 +373,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Dialog config:
      - scopeSelector: hidden, selected: All
      - tabs: visible, default=true
-     - hist: visible, default=true
+     - hist: hidden (history is always deleted)
      - data: visible, default=true
      - chats: not visible, default=false
      - fireproof: visible
@@ -396,7 +398,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.all)),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -441,7 +443,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Entry: History (All)
      Dialog config:
      - scopeSelector: hidden, selected: All
-     - tabs: visible, default=true; hist: visible, default=true; data: visible, default=true; chats: not visible, default=false
+     - tabs: visible, default=true; hist: hidden (history is always deleted); data: visible, default=true; chats: not visible, default=false
      - fireproof: visible; history link: hidden
      - title: "Delete all history?"
      - selectedDomains: [a.com, b.com, cook.ie, figma.com, date.com, c.com]
@@ -457,7 +459,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .domainFilter(["cook.ie"])),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: false,
@@ -496,7 +498,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Entry: History (All)
      Dialog config:
      - scopeSelector: hidden, selected: All
-     - tabs: visible, default=false; hist: visible, default=true; data: visible, default=false; chats: not visible, default=false
+     - tabs: visible, default=false; hist: hidden (history is always deleted); data: visible, default=false; chats: not visible, default=false
      - fireproof: visible; history link: hidden
      - title: "Delete all history?"
      - selectedDomains: [onlyhistory.com]
@@ -512,7 +514,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .domainFilter(["test.com"])),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: false,
@@ -559,7 +561,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Dialog config:
      - scopeSelector: hidden, selected: All
      - tabs: visible, default=true
-     - hist: visible, default=true
+     - hist: hidden (history is always deleted)
      - data: visible, default=true
      - chats: not visible, default=false
      - fireproof: visible
@@ -582,7 +584,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.today)),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -627,7 +629,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      - Window 1: Tab a.com (active) history: today[a×2], yesterday[a×1]; Tab b.com history: today[b×1]
      - Window 2: Tab figma.com (active) history: yesterday[figma×2]; Tab cook.ie history: today[cook.ie×1]
      Entry: History (Today)
-     Dialog config: scopeSelector hidden (All), tabs visible default=true, hist visible default=true, data visible default=true; chats: not visible, default=false
+     Dialog config: scopeSelector hidden (All), tabs visible default=true, hist hidden (history is always deleted), data visible default=true; chats: not visible, default=false
      User input: all selected, tabs=true, hist=false, data=true
      Expectation: burnEntity(allWindows, selectedDomains=all, close=true), includingHistory=false
      */
@@ -637,7 +639,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.today)),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -684,7 +686,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Dialog config:
      - scopeSelector: hidden, selected: All
      - tabs: visible, default=true
-     - hist: visible, default=true
+     - hist: hidden (history is always deleted)
      - data: visible, default=true
      - chats: not visible, default=false
      - fireproof: visible
@@ -708,7 +710,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.today)),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -755,7 +757,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Dialog config:
      - scopeSelector: hidden, selected: All
      - tabs: hidden, default=nil
-     - hist: visible, default=true
+     - hist: hidden (history is always deleted)
      - data: visible, default=false
      - fireproof: visible
      - history link: hidden
@@ -779,7 +781,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.today)),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: true,
             showFireproofSection: true,
@@ -823,7 +825,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Dialog config:
      - scopeSelector: hidden, selected: All
      - tabs: hidden, default=nil
-     - hist: visible, default=true
+     - hist: hidden (history is always deleted)
      - data: visible, default=false
      - chats: not visible, default=false
      - fireproof: visible
@@ -861,7 +863,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .rangeFilter(.yesterday)),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: true,
@@ -916,7 +918,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Dialog config:
      - scopeSelector: hidden, selected: All
      - tabs: hidden, default=nil
-     - hist: visible, default=true
+     - hist: hidden (history is always deleted)
      - data: visible, default=true
      - chats: not visible, default=false
      - fireproof: visible
@@ -940,7 +942,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .dateFilter(date)),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: true,
@@ -986,7 +988,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Dialog config:
      - scopeSelector: hidden, selected: All
      - tabs: hidden, default=nil
-     - hist: visible, default=true
+     - hist: hidden (history is always deleted)
      - data: visible, default=true
      - chats: not visible, default=false
      - fireproof: visible
@@ -1010,7 +1012,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .dateFilter(date)),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: true,
@@ -1058,7 +1060,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Dialog config:
      - scopeSelector: hidden, selected: All
      - tabs: hidden, default=nil
-     - hist: visible, default=true
+     - hist: hidden (history is always deleted)
      - data: visible, default=true
      - chats: not visible, default=false
      - fireproof: hidden
@@ -1082,7 +1084,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .domainFilter(["figma.com"])),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: false,
@@ -1126,7 +1128,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Dialog config:
      - scopeSelector: hidden, selected: All
      - tabs: hidden, default=nil
-     - hist: visible, default=true
+     - hist: hidden (history is always deleted)
      - data: visible, default=true
      - chats: not visible, default=false
      - fireproof: hidden
@@ -1150,7 +1152,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .domainFilter(["example.com"])),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: false,
@@ -1195,7 +1197,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Dialog config:
      - scopeSelector: hidden, selected: All
      - tabs: hidden, default=nil
-     - hist: visible, default=true
+     - hist: hidden (history is always deleted)
      - data: visible, default=true
      - chats: not visible, default=false
      - fireproof: hidden
@@ -1219,7 +1221,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .domainFilter(["a.com"])),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: false,
@@ -1264,7 +1266,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Dialog config:
      - scopeSelector: hidden, selected: All
      - tabs: hidden, default=nil
-     - hist: visible, default=false
+     - hist: hidden (history is always deleted)
      - data: visible, default=true
      - chats: not visible, default=false
      - fireproof: hidden
@@ -1287,7 +1289,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .domainFilter(["a.com", "b.com"])),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: false,
@@ -1333,7 +1335,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
      Dialog config:
      - scopeSelector: hidden, selected: All
      - tabs: hidden, default=nil
-     - hist: visible, default=false
+     - hist: hidden (history is always deleted)
      - data: visible, default=true
      - chats: not visible, default=false
      - fireproof: hidden
@@ -1358,7 +1360,7 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
         dialogExpectedInput = DialogExpectedInput(
             mode: .historyView(query: .domainFilter(["a.com", "b.com"])),
-            showVisitsToggle: true,
+            showVisitsToggle: false,
             showSegmentedControl: false,
             showCloseWindowsAndTabsToggle: false,
             showFireproofSection: false,
@@ -3112,6 +3114,149 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
         XCTAssertFalse(call.includingHistory)
     }
 
+    // MARK: - Compact dialog (Fire Dialog Simplified on)
+
+    /// The tests above run with the flag the app ships with, which currently selects the legacy
+    /// dialog. These use their own coordinator with the flag on, so the compact dialog rules for the
+    /// History view are covered end to end as well.
+    private func makeCompactDialogCoordinator() -> FireCoordinator {
+        let featureFlagger = MockFeatureFlagger(featuresStub: [FeatureFlag.fireDialogSimplified.rawValue: true])
+        return makeCoordinator(with: fire, featureFlagger: featureFlagger)
+    }
+
+    /**
+     Entry: History (All), compact dialog
+     Dialog config:
+     - scopeSelector: hidden, selected: All
+     - tabs: visible, default=true
+     - hist: hidden (history is always deleted)
+     - data: visible, default=true
+     - chats: hidden (the compact dialog deletes browsing data only)
+     - fireproof: visible; history link: hidden
+     - title: "Delete all history?"
+     Expectation:
+     - burnAll
+     */
+    func testCompactDialog_HistoryAll_HidesTheHistoryAndChatToggles() async throws {
+        let coordinator = makeCompactDialogCoordinator()
+        let expectedVisits = await mockHistoryProvider.visits(matching: .rangeFilter(.all))
+
+        dialogExpectedInput = DialogExpectedInput(
+            mode: .historyView(query: .rangeFilter(.all)),
+            showVisitsToggle: false,
+            showSegmentedControl: false,
+            showCloseWindowsAndTabsToggle: true,
+            showFireproofSection: true,
+            customTitle: "Delete all history?",
+            showIndividualSitesLink: false,
+            expectedClearingOption: .allData,
+            expectedIncludeTabsAndWindows: true,
+            expectedIncludeHistory: true,
+            expectedIncludeCookiesAndSiteData: true,
+            expectedIncludeChatHistory: false,
+            expectedSelectable: allCookieDomains(except: fireproofDomains),
+            expectedFireproofed: visitedFireproofDomains,
+            expectedSelected: allCookieDomains(except: fireproofDomains).indices,
+            expectedHistoryVisits: expectedVisits
+        )
+        dialogConfirmedOptions = .init(clearingOption: .allData,
+                                       includeHistory: true,
+                                       includeTabsAndWindows: true,
+                                       includeCookiesAndSiteData: true,
+                                       includeChatHistory: false)
+
+        let response = await coordinator.presentFireDialog(mode: .historyView(query: .rangeFilter(.all)), in: window, settings: mockSettings.keyedStoring())
+        if case .burn(let opts?) = response { XCTAssertTrue(opts.includeTabsAndWindows) } else { XCTFail("Expected burn response, got \(String(describing: response))") }
+        _ = try XCTUnwrap(fire.burnAllCalls.onlyValue)
+    }
+
+    /**
+     Entry: History (Date), compact dialog
+     Dialog config:
+     - hist: hidden (history is always deleted)
+     - title: "Delete all history from Wednesday, May 15?" — one line, and no year
+     */
+    func testCompactDialog_HistoryDate_ShortensTheDateAndKeepsTheTitleOnOneLine() async throws {
+        let coordinator = makeCompactDialogCoordinator()
+        let date = ISO8601DateFormatter().date(from: "2024-05-15T12:00:00Z") ?? Date(timeIntervalSince1970: 1715774400)
+        let expectedVisits = await mockHistoryProvider.visits(matching: .dateFilter(date))
+        let expectedDomains = await mockHistoryProvider.cookieDomains(matching: .dateFilter(date))
+
+        dialogExpectedInput = DialogExpectedInput(
+            mode: .historyView(query: .dateFilter(date)),
+            showVisitsToggle: false,
+            showSegmentedControl: false,
+            showCloseWindowsAndTabsToggle: false,
+            showFireproofSection: true,
+            customTitle: "Delete all history from Wednesday, May 15?",
+            showIndividualSitesLink: false,
+            expectedClearingOption: .allData,
+            expectedIncludeTabsAndWindows: false,
+            expectedIncludeHistory: true,
+            expectedIncludeCookiesAndSiteData: true,
+            expectedIncludeChatHistory: false,
+            expectedSelectable: expectedDomains.sorted(),
+            expectedFireproofed: [],
+            expectedSelected: Set(expectedDomains.sorted().indices),
+            expectedHistoryVisits: expectedVisits
+        )
+        dialogConfirmedOptions = .init(clearingOption: .allData,
+                                       includeHistory: true,
+                                       includeTabsAndWindows: false,
+                                       includeCookiesAndSiteData: true,
+                                       includeChatHistory: false,
+                                       selectedCookieDomains: nil,
+                                       selectedVisits: [],
+                                       isToday: false)
+
+        _ = await coordinator.presentFireDialog(mode: .historyView(query: .dateFilter(date)), in: window, settings: mockSettings.keyedStoring())
+        let call = try XCTUnwrap(fire.burnEntityCalls.onlyValue)
+        XCTAssertTrue(call.includingHistory)
+    }
+
+    /**
+     Entry: History (Site), compact dialog
+     Dialog config:
+     - hist: hidden (history is always deleted); fireproof: hidden
+     - title: "Delete all history from figma.com?" — one line
+     */
+    func testCompactDialog_HistorySite_KeepsTheTitleOnOneLine() async throws {
+        let coordinator = makeCompactDialogCoordinator()
+        let expectedVisits = await mockHistoryProvider.visits(matching: .domainFilter(["figma.com"]))
+        let expectedDomains = await mockHistoryProvider.cookieDomains(matching: .domainFilter(["figma.com"]))
+
+        dialogExpectedInput = DialogExpectedInput(
+            mode: .historyView(query: .domainFilter(["figma.com"])),
+            showVisitsToggle: false,
+            showSegmentedControl: false,
+            showCloseWindowsAndTabsToggle: false,
+            showFireproofSection: false,
+            customTitle: "Delete all history from figma.com?",
+            showIndividualSitesLink: false,
+            expectedClearingOption: .allData,
+            expectedIncludeTabsAndWindows: false,
+            expectedIncludeHistory: true,
+            expectedIncludeCookiesAndSiteData: true,
+            expectedIncludeChatHistory: false,
+            expectedSelectable: expectedDomains.sorted(),
+            expectedFireproofed: [],
+            expectedSelected: Set(expectedDomains.sorted().indices),
+            expectedHistoryVisits: expectedVisits
+        )
+        dialogConfirmedOptions = .init(clearingOption: .allData,
+                                       includeHistory: true,
+                                       includeTabsAndWindows: false,
+                                       includeCookiesAndSiteData: true,
+                                       includeChatHistory: false,
+                                       selectedCookieDomains: nil,
+                                       selectedVisits: [],
+                                       isToday: false)
+
+        _ = await coordinator.presentFireDialog(mode: .historyView(query: .domainFilter(["figma.com"])), in: window, settings: mockSettings.keyedStoring())
+        let call = try XCTUnwrap(fire.burnEntityCalls.onlyValue)
+        XCTAssertTrue(call.includingHistory)
+    }
+
     // MARK: - Helpers
 
     private func makeEntry(_ urlString: String) -> HistoryEntry {
@@ -3130,12 +3275,13 @@ final class FireCoordinatorIntegrationTests: XCTestCase {
 
     private func makeCoordinator(
         with fire: FireProtocol,
+        featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger,
         customPresenterAction: ((NSWindow?, @escaping () -> Void) -> Void)? = nil
     ) -> FireCoordinator {
         let vm = FireViewModel(fire: fire)
         return FireCoordinator(
             tld: Application.appDelegate.tld,
-            featureFlagger: Application.appDelegate.featureFlagger,
+            featureFlagger: featureFlagger,
             historyCoordinating: Application.appDelegate.historyCoordinator,
             visualizeFireAnimationDecider: nil,
             onboardingContextualDialogsManager: nil,

--- a/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
+++ b/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
@@ -1641,6 +1641,96 @@ final class FireDialogViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldShowChatHistoryToggle)
     }
 
+    // MARK: - Chat history toggle per mode
+
+    /// History view entry points scoped to less than the whole history.
+    private static let scopedHistoryViewModes: [FireDialogViewModel.Mode] = [
+        .historyView(query: .rangeFilter(.allSites)),
+        .historyView(query: .rangeFilter(.today)),
+        .historyView(query: .rangeFilter(.yesterday)),
+        .historyView(query: .rangeFilter(.monday)),
+        .historyView(query: .rangeFilter(.older)),
+        .historyView(query: .dateFilter(Date())),
+        .historyView(query: .searchTerm("duck")),
+        .historyView(query: .domainFilter(["example.com"])),
+        .historyView(query: .visits([]))
+    ]
+
+    @MainActor func testFireButtonAndMainMenuAlwaysOfferTheChatHistoryToggle() {
+        // Scenario: The dialog is opened from the fire button or the main menu.
+        // Expectation: Both offer the chat history toggle, whichever dialog the flag selects.
+
+        for isSimplified in [false, true] {
+            let featureFlagger = MockFeatureFlagger(featuresStub: [FeatureFlag.fireDialogSimplified.rawValue: isSimplified])
+
+            XCTAssertTrue(FireDialogViewModel.Mode.fireButton.shouldShowChatHistoryToggle(featureFlagger),
+                          "fireButton, simplified: \(isSimplified)")
+            XCTAssertTrue(FireDialogViewModel.Mode.mainMenuAll.shouldShowChatHistoryToggle(featureFlagger),
+                          "mainMenuAll, simplified: \(isSimplified)")
+        }
+    }
+
+    @MainActor func testWhenSimplifiedDialogIsOff_ThenDeletingAllHistoryOffersTheChatHistoryToggle() {
+        // Scenario: The user deletes all history from the History view while the simplified dialog
+        // is off.
+        // Expectation: The legacy dialog keeps offering the chat history toggle for this entry point.
+
+        let featureFlagger = MockFeatureFlagger(featuresStub: [FeatureFlag.fireDialogSimplified.rawValue: false])
+
+        XCTAssertTrue(FireDialogViewModel.Mode.historyView(query: .rangeFilter(.all)).shouldShowChatHistoryToggle(featureFlagger))
+    }
+
+    @MainActor func testWhenSimplifiedDialogIsOn_ThenDeletingAllHistoryDoesNotOfferTheChatHistoryToggle() {
+        // Scenario: The user deletes all history from the History view while the simplified dialog
+        // is on. The History view now uses the compact dialog for every scope, and that dialog
+        // deletes browsing data only.
+        // Expectation: The mode does not offer the chat history toggle.
+
+        let featureFlagger = MockFeatureFlagger(featuresStub: [FeatureFlag.fireDialogSimplified.rawValue: true])
+
+        XCTAssertFalse(FireDialogViewModel.Mode.historyView(query: .rangeFilter(.all)).shouldShowChatHistoryToggle(featureFlagger))
+    }
+
+    @MainActor func testScopedHistoryViewModesNeverOfferTheChatHistoryToggle() {
+        // Scenario: The user deletes a section, a site, or selected items in the History view.
+        // Expectation: None of these modes offers the chat history toggle, whichever dialog the flag
+        // selects. The chats cannot be narrowed to the same scope.
+
+        for isSimplified in [false, true] {
+            let featureFlagger = MockFeatureFlagger(featuresStub: [FeatureFlag.fireDialogSimplified.rawValue: isSimplified])
+
+            for mode in Self.scopedHistoryViewModes {
+                XCTAssertFalse(mode.shouldShowChatHistoryToggle(featureFlagger), "\(mode), simplified: \(isSimplified)")
+            }
+        }
+    }
+
+    @MainActor func testWhenSimplifiedDialogIsOn_ThenDeletingAllHistoryHidesTheChatHistoryToggleAndClearsNoChats() {
+        // Scenario: Chats exist and the user turned the chat history setting on in an earlier dialog,
+        // then deletes all history from the History view with the simplified dialog on.
+        // Expectation: The dialog hides the toggle and clears no chats. The stored setting must not
+        // delete the chats behind the user's back.
+
+        let viewModel = makeViewModelWithChats(mode: .historyView(query: .rangeFilter(.all)),
+                                               isFireDialogSimplified: true,
+                                               settings: MockFireDialogViewSettings(lastIncludeChatHistoryState: true))
+
+        XCTAssertFalse(viewModel.shouldShowChatHistoryToggle)
+        XCTAssertFalse(viewModel.includeChatHistory, "A hidden toggle must not clear the chats")
+    }
+
+    @MainActor func testWhenSimplifiedDialogIsOff_ThenDeletingAllHistoryShowsTheChatHistoryToggleAndKeepsTheSetting() {
+        // Scenario: The same dialog, with the simplified dialog off.
+        // Expectation: The legacy dialog shows the toggle and honours the stored setting.
+
+        let viewModel = makeViewModelWithChats(mode: .historyView(query: .rangeFilter(.all)),
+                                               isFireDialogSimplified: false,
+                                               settings: MockFireDialogViewSettings(lastIncludeChatHistoryState: true))
+
+        XCTAssertTrue(viewModel.shouldShowChatHistoryToggle)
+        XCTAssertTrue(viewModel.includeChatHistory)
+    }
+
     // MARK: - Settings Persistence Tests
 
     @MainActor func testWhenClearingOptionChanged_ThenSettingIsPersisted() {
@@ -2214,7 +2304,11 @@ final class FireDialogViewModelTests: XCTestCase {
     /// Modes where the user can choose whether the browsing history is deleted.
     private static let modesWithVisitsToggle: [FireDialogViewModel.Mode] = [
         .fireButton,
-        .mainMenuAll,
+        .mainMenuAll
+    ]
+
+    /// Modes opened from the History view, where the records in scope are always deleted.
+    private static let modesWithoutVisitsToggle: [FireDialogViewModel.Mode] = [
         .historyView(query: .rangeFilter(.all)),
         .historyView(query: .rangeFilter(.allSites)),
         .historyView(query: .rangeFilter(.today)),
@@ -2224,18 +2318,19 @@ final class FireDialogViewModelTests: XCTestCase {
         .historyView(query: .dateFilter(Date())),
         .historyView(query: .searchTerm("duck")),
         .historyView(query: .domainFilter(["example.com"])),
-        .historyView(query: .domainFilter(["example.com", "duckduckgo.com"]))
-    ]
-
-    /// Modes scoped to records the user picked, where those records are always deleted.
-    private static let modesWithoutVisitsToggle: [FireDialogViewModel.Mode] = [
+        .historyView(query: .domainFilter(["example.com", "duckduckgo.com"])),
         .historyView(query: .visits([])),
         .historyView(query: .visits([VisitIdentifier(uuid: UUID().uuidString, url: URL(string: "https://example.com")!, date: Date())]))
     ]
 
-    @MainActor func testWhenModeIsNotAHistoryItemSelection_ThenVisitsToggleIsShown() {
-        // Scenario: The dialog is opened from the fire button, the main menu, or a History view
-        // section, all of which delete a whole part of the history.
+    /// All modes the dialog supports.
+    private static var allModes: [FireDialogViewModel.Mode] {
+        modesWithVisitsToggle + modesWithoutVisitsToggle
+    }
+
+    @MainActor func testWhenModeIsFireButtonOrMainMenu_ThenVisitsToggleIsShown() {
+        // Scenario: The dialog is opened from the fire button or the main menu, neither of which is
+        // scoped to a part of the history.
         // Expectation: The History toggle is visible, so the user can exclude the browsing history
         // and delete only the site data.
 
@@ -2244,10 +2339,10 @@ final class FireDialogViewModelTests: XCTestCase {
         }
     }
 
-    @MainActor func testWhenModeIsAHistoryItemSelection_ThenVisitsToggleIsHidden() {
-        // Scenario: The user selects history items in the History view and deletes them.
-        // Expectation: The History toggle is hidden, because the selected items are the subject
-        // of the deletion and cannot be excluded from it.
+    @MainActor func testWhenModeComesFromTheHistoryView_ThenVisitsToggleIsHidden() {
+        // Scenario: The user deletes a section, a site, or selected items in the History view.
+        // Expectation: The History toggle is hidden. The records in scope are the subject of the
+        // deletion, so the user cannot exclude them from it.
 
         for mode in Self.modesWithoutVisitsToggle {
             XCTAssertFalse(mode.shouldShowVisitsToggle, "\(mode) should not show the History toggle")
@@ -2256,8 +2351,8 @@ final class FireDialogViewModelTests: XCTestCase {
 
     @MainActor func testWhenVisitsToggleIsHidden_ThenHistoryIsDeletedRegardlessOfThePersistedSetting() {
         // Scenario: The user turned the History toggle off in an earlier dialog, then deletes
-        // selected items in the History view.
-        // Expectation: The selected items are deleted. The dialog shows no History toggle, so the
+        // a section, a site, or selected items in the History view.
+        // Expectation: The records in scope are deleted. The dialog shows no History toggle, so the
         // earlier choice must not silently reduce the deletion to the site data.
 
         let mockSettings = MockFireDialogViewSettings(lastIncludeHistoryState: false)
@@ -2266,7 +2361,7 @@ final class FireDialogViewModelTests: XCTestCase {
             let viewModel = makeViewModel(settings: mockSettings, mode: mode)
 
             XCTAssertFalse(viewModel.includeHistory, "\(mode) should keep the persisted setting")
-            XCTAssertTrue(viewModel.shouldDeleteHistory, "\(mode) should delete the selected items anyway")
+            XCTAssertTrue(viewModel.shouldDeleteHistory, "\(mode) should delete the records in scope anyway")
         }
     }
 
@@ -2288,7 +2383,7 @@ final class FireDialogViewModelTests: XCTestCase {
         // Expectation: The "Choose what to delete" disclosure control appears only together with
         // the History toggle. Without it, too few rows remain to make the sections worth hiding.
 
-        for mode in Self.modesWithVisitsToggle + Self.modesWithoutVisitsToggle {
+        for mode in Self.allModes {
             XCTAssertEqual(mode.shouldShowDetailsDisclosure, mode.shouldShowVisitsToggle, "\(mode)")
         }
     }
@@ -2542,8 +2637,8 @@ final class FireDialogViewModelTests: XCTestCase {
             makeVisitIdentifier(url: "https://spreadprivacy.com")
         ]))
 
-        XCTAssertEqual(mode.dialogTitle, UserText.fireDialogHistoryItemsTitle(3))
-        XCTAssertEqual(mode.dialogTitle, "Delete 3 History items?")
+        XCTAssertEqual(mode.titleInCompactDialog, UserText.fireDialogHistoryItemsTitle(3))
+        XCTAssertEqual(mode.titleInCompactDialog, "Delete 3 History items?")
     }
 
     @MainActor func testWhenModeIsSingleSelectedVisit_ThenDialogTitleShowsOneItem() {
@@ -2554,7 +2649,7 @@ final class FireDialogViewModelTests: XCTestCase {
             makeVisitIdentifier(url: "https://example.com")
         ]))
 
-        XCTAssertEqual(mode.dialogTitle, UserText.fireDialogHistoryItemsTitle(1))
+        XCTAssertEqual(mode.titleInCompactDialog, UserText.fireDialogHistoryItemsTitle(1))
     }
 
     @MainActor func testWhenSelectedVisitsShareHistoryEntry_ThenDialogTitleCountsTheEntryOnce() {
@@ -2569,7 +2664,7 @@ final class FireDialogViewModelTests: XCTestCase {
             makeVisitIdentifier(url: "https://duckduckgo.com")
         ]))
 
-        XCTAssertEqual(mode.dialogTitle, UserText.fireDialogHistoryItemsTitle(2))
+        XCTAssertEqual(mode.titleInCompactDialog, UserText.fireDialogHistoryItemsTitle(2))
     }
 
     @MainActor func testWhenNoVisitsAreSelected_ThenDialogTitleShowsZeroItems() {
@@ -2578,7 +2673,7 @@ final class FireDialogViewModelTests: XCTestCase {
 
         let mode = FireDialogViewModel.Mode.historyView(query: .visits([]))
 
-        XCTAssertEqual(mode.dialogTitle, UserText.fireDialogHistoryItemsTitle(0))
+        XCTAssertEqual(mode.titleInCompactDialog, UserText.fireDialogHistoryItemsTitle(0))
     }
 
     @MainActor func testWhenSimplifiedDialogIsOff_ThenSelectedVisitsKeepTheGenericDialogTitle() {
@@ -2610,16 +2705,17 @@ final class FireDialogViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.dialogTitle, UserText.fireDialogHistoryItemsTitle(2))
     }
 
-    @MainActor func testDialogTitleOfOtherModesDoesNotDependOnTheSimplifiedDialogFlag() {
+    @MainActor func testDialogTitleFollowsTheDialogTheFlagSelects() {
         // Scenario: Any mode other than a history item selection.
-        // Expectation: Both dialogs show the title of the mode, so the flag changes nothing.
+        // Expectation: Each dialog shows the title of its own kind. The view model must not hand the
+        // legacy dialog a title that only the compact dialog defines.
 
-        for mode in Self.modesWithVisitsToggle {
+        for mode in Self.allModes where !mode.isVisitsSelection {
             let legacy = makeViewModel(settings: MockFireDialogViewSettings(), mode: mode, isFireDialogSimplified: false)
-            XCTAssertEqual(legacy.dialogTitle, mode.dialogTitle, "\(mode)")
+            XCTAssertEqual(legacy.dialogTitle, mode.titleInLegacyDialog, "\(mode)")
 
             let simplified = makeViewModel(settings: MockFireDialogViewSettings(), mode: mode, isFireDialogSimplified: true)
-            XCTAssertEqual(simplified.dialogTitle, mode.dialogTitle, "\(mode)")
+            XCTAssertEqual(simplified.dialogTitle, mode.titleInCompactDialog, "\(mode)")
         }
     }
 
@@ -2627,14 +2723,188 @@ final class FireDialogViewModelTests: XCTestCase {
         // Scenario: The other History view entry points.
         // Expectation: Their titles keep using the History view delete dialog titles.
 
-        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .rangeFilter(.all)).dialogTitle,
+        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .rangeFilter(.all)).titleInCompactDialog,
                        HistoryViewDeleteDialogModel.DeleteMode.all.title)
-        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .rangeFilter(.today)).dialogTitle,
+        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .rangeFilter(.allSites)).titleInCompactDialog,
+                       HistoryViewDeleteDialogModel.DeleteMode.all.title)
+        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .rangeFilter(.today)).titleInCompactDialog,
                        HistoryViewDeleteDialogModel.DeleteMode.today.title)
-        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .rangeFilter(.older)).dialogTitle,
+        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .rangeFilter(.yesterday)).titleInCompactDialog,
+                       HistoryViewDeleteDialogModel.DeleteMode.yesterday.title)
+        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .rangeFilter(.older)).titleInCompactDialog,
                        HistoryViewDeleteDialogModel.DeleteMode.older.title)
-        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .domainFilter(["example.com"])).dialogTitle,
+    }
+
+    @MainActor func testWhenModeIsASearchTerm_ThenDialogTitleIsGeneric() {
+        // Scenario: The user deletes the results of a History view search.
+        // Expectation: The dialog falls back to the generic title. A search term has no title of
+        // its own that would describe the scope of the deletion.
+
+        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .searchTerm("duck")).titleInCompactDialog,
+                       UserText.fireDialogTitle)
+    }
+
+    // MARK: - Dialog title for History view day sections
+
+    @MainActor func testWhenModeIsAWeekdaySection_ThenDialogTitleShowsThatDay() {
+        // Scenario: The user deletes one of the weekday sections of the History view. Those sections
+        // cover the 2-7 days before today, so each of them stands for a single date.
+        // Expectation: The title names that date, the same way the History view delete dialog does.
+        // Before, every weekday section fell back to the generic "Delete Browsing Data" title.
+
+        let weekdays: [DataModel.HistoryRange] = [.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]
+
+        for weekday in weekdays {
+            guard let date = weekday.date(for: Date()) else {
+                XCTFail("\(weekday) should stand for a single date")
+                continue
+            }
+
+            XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .rangeFilter(weekday)).titleInCompactDialog,
+                           singleLine(HistoryViewDeleteDialogModel.DeleteMode.date(date).compactTitle),
+                           "\(weekday)")
+        }
+    }
+
+    @MainActor func testWhenModeIsAWeekdaySection_ThenDialogTitleMatchesTheHistoryViewDeleteDialog() {
+        // Scenario: The user deletes the same weekday section from the History view and from the
+        // Fire dialog.
+        // Expectation: Both dialogs name the same date, so the two entry points cannot disagree.
+
+        for weekday in [DataModel.HistoryRange.monday, .friday] {
+            let deleteMode = DataModel.HistoryQueryKind.rangeFilter(weekday).deleteMode
+
+            XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .rangeFilter(weekday)).titleInCompactDialog,
+                           singleLine(deleteMode.compactTitle),
+                           "\(weekday)")
+        }
+    }
+
+    @MainActor func testWhenModeIsADate_ThenDialogTitleNamesThatDate() {
+        // Scenario: The user deletes a dated History view section.
+        // Expectation: The title names the date.
+
+        let date = Date(timeIntervalSince1970: 1715774400)
+        let mode = FireDialogViewModel.Mode.historyView(query: .dateFilter(date))
+
+        XCTAssertEqual(mode.titleInCompactDialog, singleLine(HistoryViewDeleteDialogModel.DeleteMode.date(date).compactTitle))
+    }
+
+    @MainActor func testWhenModeIsASingleSite_ThenDialogTitleNamesTheSite() {
+        // Scenario: The user deletes the history of one site.
+        // Expectation: The title names the site.
+
+        let mode = FireDialogViewModel.Mode.historyView(query: .domainFilter(["example.com"]))
+
+        XCTAssertEqual(mode.titleInCompactDialog, singleLine(HistoryViewDeleteDialogModel.DeleteMode.sites(["example.com"]).compactTitle))
+        XCTAssertEqual(mode.titleInCompactDialog, "Delete all history from example.com?")
+    }
+
+    @MainActor func testWhenModeIsSeveralSites_ThenDialogTitleIsGeneric() {
+        // Scenario: The user deletes the history of more than one site.
+        // Expectation: The title stays generic, because it cannot name every site.
+
+        let mode = FireDialogViewModel.Mode.historyView(query: .domainFilter(["example.com", "duckduckgo.com"]))
+
+        XCTAssertEqual(mode.titleInCompactDialog, HistoryViewDeleteDialogModel.DeleteMode.sites(["example.com", "duckduckgo.com"]).title)
+    }
+
+    @MainActor func testDialogTitleAlwaysRendersOnASingleLine() {
+        // Scenario: Any dialog mode. The History view delete dialog breaks its date and site titles
+        // into two lines.
+        // Expectation: No title contains a line break. The Fire dialog shows the title on one line,
+        // and a stray line break would push the dialog content out of shape.
+
+        for mode in Self.allModes {
+            XCTAssertFalse(mode.titleInCompactDialog.contains("\n"), "\(mode) should render its title on one line")
+        }
+    }
+
+    @MainActor func testDateAndSiteTitlesLoseTheirLineBreak() {
+        // Scenario: The date and site titles are the only ones that carry a line break.
+        // Expectation: The Fire dialog replaces the break with a space, so the words stay apart.
+        // The earlier code matched a literal backslash-n and left the real break in place.
+
+        let date = Date(timeIntervalSince1970: 1715774400)
+
+        let titlesWithLineBreak = [
+            HistoryViewDeleteDialogModel.DeleteMode.date(date).compactTitle,
+            HistoryViewDeleteDialogModel.DeleteMode.sites(["example.com"]).compactTitle
+        ]
+        for title in titlesWithLineBreak {
+            XCTAssertTrue(title.contains("\n"), "This test is only meaningful while the title breaks lines: \(title)")
+        }
+
+        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .dateFilter(date)).titleInCompactDialog,
+                       titlesWithLineBreak[0].replacingOccurrences(of: "\n", with: " "))
+        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .domainFilter(["example.com"])).titleInCompactDialog,
+                       titlesWithLineBreak[1].replacingOccurrences(of: "\n", with: " "))
+    }
+
+    // MARK: - Dialog title: the legacy dialog is unchanged
+
+    @MainActor func testLegacyDialogHasNoTitleForWeekdaySections() {
+        // Scenario: The Fire Dialog Simplified flag is off and the user deletes a weekday section of
+        // the History view.
+        // Expectation: The legacy dialog keeps its generic title. Naming the date is a compact dialog
+        // change and must not reach the legacy one.
+
+        let weekdays: [DataModel.HistoryRange] = [.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]
+
+        for weekday in weekdays {
+            XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .rangeFilter(weekday)).titleInLegacyDialog,
+                           UserText.fireDialogTitle,
+                           "\(weekday)")
+        }
+    }
+
+    @MainActor func testLegacyDialogTitlesKeepTheirLineBreak() {
+        // Scenario: The legacy dialog titles a date or a single site.
+        // Expectation: The line break stays. The legacy dialog is tall enough to show the title on
+        // two lines, and replacing the break is a compact dialog change.
+
+        let date = Date(timeIntervalSince1970: 1715774400)
+
+        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .dateFilter(date)).titleInLegacyDialog,
+                       HistoryViewDeleteDialogModel.DeleteMode.date(date).title)
+        XCTAssertEqual(FireDialogViewModel.Mode.historyView(query: .domainFilter(["example.com"])).titleInLegacyDialog,
                        HistoryViewDeleteDialogModel.DeleteMode.sites(["example.com"]).title)
+
+        XCTAssertTrue(FireDialogViewModel.Mode.historyView(query: .dateFilter(date)).titleInLegacyDialog.contains("\n"))
+        XCTAssertTrue(FireDialogViewModel.Mode.historyView(query: .domainFilter(["example.com"])).titleInLegacyDialog.contains("\n"))
+    }
+
+    @MainActor func testLegacyDialogSpellsTheDateOutInFull() {
+        // Scenario: The legacy dialog titles a date.
+        // Expectation: The date still names the year. Shortening the date is a compact dialog change.
+
+        let date = Date(timeIntervalSince1970: 1715774400)
+        let year = Calendar.autoupdatingCurrent.component(.year, from: date)
+        let title = FireDialogViewModel.Mode.historyView(query: .dateFilter(date)).titleInLegacyDialog
+
+        XCTAssertTrue(title.contains(String(year)), "Expected \(title) to name the year \(year)")
+    }
+
+    @MainActor func testLegacyDialogTitlesOfTheOtherHistoryViewModesMatchTheCompactOnes() {
+        // Scenario: The History view sections that carry neither a date nor a site name.
+        // Expectation: Both dialogs title them the same way. Those titles never changed, so a
+        // difference here would mean the gating went too far.
+
+        let modes: [FireDialogViewModel.Mode] = [
+            .fireButton,
+            .mainMenuAll,
+            .historyView(query: .rangeFilter(.all)),
+            .historyView(query: .rangeFilter(.allSites)),
+            .historyView(query: .rangeFilter(.today)),
+            .historyView(query: .rangeFilter(.yesterday)),
+            .historyView(query: .rangeFilter(.older)),
+            .historyView(query: .searchTerm("duck")),
+            .historyView(query: .domainFilter(["example.com", "duckduckgo.com"]))
+        ]
+
+        for mode in modes {
+            XCTAssertEqual(mode.titleInLegacyDialog, mode.titleInCompactDialog, "\(mode)")
+        }
     }
 
     // MARK: - Simplified Fire Dialog: currentWindow folding
@@ -2898,6 +3168,40 @@ final class FireDialogViewModelTests: XCTestCase {
         VisitIdentifier(uuid: UUID().uuidString, url: URL(string: url)!, date: date)
     }
 
+    /// Makes a view model that has Duck.ai chats to delete.
+    ///
+    /// The simplified dialog also hides the chat history toggle when there are no chats, so the chats
+    /// keep that rule from hiding the toggle and let the tests observe the mode on its own.
+    @MainActor
+    private func makeViewModelWithChats(mode: FireDialogViewModel.Mode,
+                                        isFireDialogSimplified: Bool,
+                                        settings: any KeyedStoring<FireDialogViewSettings>) -> FireDialogViewModel {
+        let aiChatHistoryCleaner = MockAIChatHistoryCleaner(showCleanOption: true)
+        aiChatHistoryCleaner.allChatsStub = [(chatId: "chat-1", title: "A chat")]
+
+        return FireDialogViewModel(
+            fireViewModel: .init(fire: fire),
+            tabCollectionViewModel: tabCollectionVM,
+            historyCoordinating: historyCoordinator,
+            aiChatHistoryCleaner: aiChatHistoryCleaner,
+            fireproofDomains: fireproofDomains,
+            faviconManagement: fire.faviconManagement,
+            featureFlagger: MockFeatureFlagger(featuresStub: [FeatureFlag.fireDialogSimplified.rawValue: isFireDialogSimplified]),
+            clearingOption: .allData,
+            mode: mode,
+            settings: settings,
+            tld: TLD(),
+            windowControllersManager: windowControllersManager,
+            dataClearingPreferences: dataClearingPreferences,
+            pixelFiring: pixelFiringMock
+        )
+    }
+
+    /// Converts a History view delete dialog title to the single line that the Fire dialog shows.
+    private func singleLine(_ title: String) -> String {
+        title.replacingOccurrences(of: "\n", with: " ")
+    }
+
     private func makeHistoryEntry(url: String) -> HistoryEntry {
         HistoryEntry(identifier: UUID(),
                      url: URL(string: url)!,
@@ -2946,6 +3250,30 @@ func MockFireDialogViewSettings(
     storage.lastSectionsExpandedState = lastSectionsExpandedState
 
     return storage
+}
+
+private extension FireDialogViewModel.Mode {
+    /// Whether the mode deletes history items that the user picked in the History view.
+    var isVisitsSelection: Bool {
+        if case .historyView(query: .visits) = self {
+            return true
+        }
+        return false
+    }
+
+    /// Title the compact dialog gives this mode.
+    var titleInCompactDialog: String {
+        dialogTitle(Self.featureFlagger(isFireDialogSimplified: true))
+    }
+
+    /// Title the legacy dialog gives this mode.
+    var titleInLegacyDialog: String {
+        dialogTitle(Self.featureFlagger(isFireDialogSimplified: false))
+    }
+
+    static func featureFlagger(isFireDialogSimplified: Bool) -> MockFeatureFlagger {
+        MockFeatureFlagger(featuresStub: [FeatureFlag.fireDialogSimplified.rawValue: isFireDialogSimplified])
+    }
 }
 
 class CapturingContextualOnboardingStateUpdater: ContextualOnboardingStateUpdater {

--- a/macOS/UnitTests/History/View/HistoryQueryKindExtensionTests.swift
+++ b/macOS/UnitTests/History/View/HistoryQueryKindExtensionTests.swift
@@ -50,6 +50,68 @@ final class HistoryQueryKindExtensionTests: XCTestCase {
         XCTAssertTrue(DataModel.HistoryQueryKind.rangeFilter(.saturday).deleteMode.isDate)
     }
 
+    // MARK: - Date title format
+
+    func testCompactDateFormatNamesTheWeekdayMonthAndDayWithoutTheYear() {
+        // Scenario: A History view section that covers a single date, titled by the compact dialog.
+        // Expectation: The format names the weekday, the month and the day, and leaves the year out.
+        // These sections only reach back one week, so the year adds nothing and only made the title
+        // long enough to wrap onto a second line.
+        //
+        // The format is asserted instead of a formatted string, because the wording and the order of
+        // the parts depend on the locale of the machine running the test.
+
+        let format = HistoryViewDeleteDialogModel.compactDateFormatter.dateFormat ?? ""
+
+        XCTAssertFalse(format.contains("y"), "The compact date must not name the year, got format \(format)")
+        XCTAssertFalse(format.contains("Y"), "The compact date must not name the year, got format \(format)")
+        XCTAssertTrue(format.contains("EEEE"), "The compact date must name the weekday, got format \(format)")
+        // Some locales resolve the month of a template to its standalone form.
+        XCTAssertTrue(format.contains("MMMM") || format.contains("LLLL"),
+                      "The compact date must name the month, got format \(format)")
+        XCTAssertTrue(format.contains("d"), "The compact date must name the day, got format \(format)")
+    }
+
+    func testFullDateFormatStillNamesTheYear() {
+        // Scenario: The legacy dialog titles a section that covers a single date.
+        // Expectation: The date still names the year. Shortening the date belongs to the compact
+        // dialog, and must not reach the legacy one.
+
+        let format = HistoryViewDeleteDialogModel.dateFormatter.dateFormat ?? ""
+
+        XCTAssertTrue(format.contains("y") || format.contains("Y"),
+                      "The full date must name the year, got format \(format)")
+    }
+
+    func testDateTitlesEmbedTheFormattedDate() {
+        // Scenario: Each dialog titles a section that covers a single date.
+        // Expectation: Each title carries the date in its own format, so the user can see which day
+        // is deleted, and the two titles differ.
+
+        let date = Date(timeIntervalSince1970: 1715774400)
+        let fullDate = HistoryViewDeleteDialogModel.dateFormatter.string(from: date)
+        let compactDate = HistoryViewDeleteDialogModel.compactDateFormatter.string(from: date)
+
+        XCTAssertTrue(HistoryViewDeleteDialogModel.DeleteMode.date(date).title.contains(fullDate),
+                      "Expected the title to contain \(fullDate)")
+        XCTAssertTrue(HistoryViewDeleteDialogModel.DeleteMode.date(date).compactTitle.contains(compactDate),
+                      "Expected the compact title to contain \(compactDate)")
+        XCTAssertNotEqual(fullDate, compactDate)
+    }
+
+    func testTitlesWithoutADateAreTheSameInBothFormats() {
+        // Scenario: The delete modes that carry no date.
+        // Expectation: The compact title matches the full one, because only the date is shortened.
+
+        let modes: [HistoryViewDeleteDialogModel.DeleteMode] = [
+            .all, .today, .yesterday, .older, .unspecified, .sites(["example.com"]), .sites(["a.com", "b.com"])
+        ]
+
+        for mode in modes {
+            XCTAssertEqual(mode.compactTitle, mode.title, "\(mode)")
+        }
+    }
+
     func testShouldSkipDeleteDialog() {
         XCTAssertFalse(DataModel.HistoryQueryKind.rangeFilter(.all).shouldSkipDeleteDialog)
         XCTAssertFalse(DataModel.HistoryQueryKind.rangeFilter(.today).shouldSkipDeleteDialog)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1217574717932085?focus=true

### Description
All delete actions in History View are now scoped to history items only (+ optionally site data), with no option
to clear AI chats. They become "delete history" rather than "delete browsing data" actions.

### Testing Steps
1. Enable `fireDialogSimplified` feature flag
2. Populate History if needed. Debug Menu -> History -> Add 10 history visits each day
3. Test various delete actions (top of the view, sidebar, multi-select) and verify that all present compact Fire Dialog: no expand/collapse button, no mode selector, only the toggle to delete site data. Verify that for weekdays the dialog title includes date:
<img width="445" height="327" alt="Screenshot 2026-08-17 at 23 33 14" src="https://github.com/user-attachments/assets/9fcc4dcf-a8c3-4c37-beb5-e35af171e6e5" />

5. Click Fire Button and verify that it displays the full Fire Dialog.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Fire dialog presentation and delete-option defaults in History View, with broad test coverage and no changes to core burn/clearing execution paths beyond what the user confirms in the dialog.
> 
> **Overview**
> History View delete entry points now follow **compact Fire dialog** rules when `fireDialogSimplified` is on: scoped history is always cleared (no History/visits toggle), and **Delete all history** from History no longer offers the AI chat toggle. Fire button and main menu still expose chat history when appropriate.
> 
> Dialog titles are **gated by the flag**: the compact path uses single-line titles, weekday section labels, and `compactTitle` dates (weekday/month/day, no year) via a new `compactDateFormatter` on `HistoryViewDeleteDialogModel`; the legacy path keeps full dates, line breaks, and generic titles for weekday sections.
> 
> `FireCoordinator` and `FireDialogViewModel.Mode` now pass `FeatureFlagger` into `shouldShowChatHistoryToggle` and `dialogTitle`. Integration and unit tests were updated for hidden history toggles in History flows and new compact-dialog scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 619e7f04d082f346cfb40413699dac3d6b2067a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->