### PR TITLE
[iOS] Fix flaky Dax dialog test

### DIFF
--- a/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
+++ b/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
@@ -324,7 +324,7 @@ class CapturingNewTabDaxDialogProvider: NewTabDaxDialogProviding {
     func createEndOfJourneyDialog(content: OnboardingEndOfJourneyContent, onAction: @escaping (OnboardingEndOfJourneyAction) -> Void) -> AnyView {
         endOfJourneyContent = content
         onEndOfJourneyAction = onAction
-        AnyView(EmptyView())
+        return AnyView(EmptyView())
     }
 }
 

--- a/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
+++ b/iOS/SharedStateTests/NewTabPageControllerDaxDialogTests.swift
@@ -177,9 +177,9 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
         XCTAssertEqual(store.capturedTriggerFilter, .specific(.afterIdle))
     }
 
-    func testWhenViewDidAppear_CorrectTypePassedToDialogFactory() throws {
+    func testWhenViewDidAppearWithInitialSpecThenDaxDialogIsCreated() throws {
         // GIVEN
-        let expectedSpec = randomDialogType()
+        let expectedSpec = DaxDialogs.HomeScreenSpec.initial
         specProvider.specToReturn = expectedSpec
 
         // WHEN
@@ -190,11 +190,12 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
         XCTAssertTrue(self.specProvider.nextHomeScreenMessageNewCalled)
         XCTAssertEqual(self.dialogFactory.homeDialog, expectedSpec)
         XCTAssertNotNil(self.dialogFactory.onDismiss)
+        XCTAssertNil(self.dialogFactory.endOfJourneyContent)
     }
 
-    func testWhenOnboardingComplete_CorrectTypePassedToDialogFactory() throws {
+    func testWhenOnboardingCompletesWithInitialSpecThenDaxDialogIsCreated() throws {
         // GIVEN
-        let expectedSpec = randomDialogType()
+        let expectedSpec = DaxDialogs.HomeScreenSpec.initial
         specProvider.specToReturn = expectedSpec
 
         // WHEN
@@ -205,6 +206,23 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
         XCTAssertTrue(self.specProvider.nextHomeScreenMessageNewCalled)
         XCTAssertEqual(self.dialogFactory.homeDialog, expectedSpec)
         XCTAssertNotNil(self.dialogFactory.onDismiss)
+        XCTAssertNil(self.dialogFactory.endOfJourneyContent)
+    }
+
+    func testWhenOnboardingCompletesWithFinalSpecThenEndOfJourneyDialogIsCreated() throws {
+        // GIVEN
+        specProvider.specToReturn = .final
+
+        // WHEN
+        hvc.onboardingCompleted()
+
+        // THEN
+        XCTAssertFalse(specProvider.nextHomeScreenMessageCalled)
+        XCTAssertTrue(specProvider.nextHomeScreenMessageNewCalled)
+        XCTAssertNil(dialogFactory.homeDialog)
+        XCTAssertNil(dialogFactory.onDismiss)
+        XCTAssertNotNil(dialogFactory.endOfJourneyContent)
+        XCTAssertNotNil(dialogFactory.onEndOfJourneyAction)
     }
 
     func testWhenShowNextDaxDialog_AndShouldShowDaxDialogs_ThenReturnTrue() {
@@ -271,11 +289,6 @@ final class NewTabPageControllerDaxDialogTests: XCTestCase {
         // a stray `.initial`/`.subsequent` dialog could leak into the Duck.ai onboarding completion UX.
         XCTAssertFalse(specProvider.nextHomeScreenMessageNewCalled)
     }
-
-    private func randomDialogType() -> DaxDialogs.HomeScreenSpec {
-        let specs: [DaxDialogs.HomeScreenSpec] = [.initial, .subsequent, .final, .addFavorite]
-        return specs.randomElement()!
-    }
 }
 
 class CapturingVariantManager: VariantManager {
@@ -295,6 +308,9 @@ class CapturingVariantManager: VariantManager {
 class CapturingNewTabDaxDialogProvider: NewTabDaxDialogProviding {
     var homeDialog: DaxDialogs.HomeScreenSpec?
     var onDismiss: ((_ activateSearch: Bool) -> Void)?
+    var endOfJourneyContent: OnboardingEndOfJourneyContent?
+    var onEndOfJourneyAction: ((OnboardingEndOfJourneyAction) -> Void)?
+
     func createDaxDialog(for homeDialog: DaxDialogs.HomeScreenSpec, onCompletion: @escaping (_ activateSearch: Bool) -> Void, onManualDismiss: @escaping () -> Void) -> some View {
         self.homeDialog = homeDialog
         self.onDismiss = onCompletion
@@ -306,6 +322,8 @@ class CapturingNewTabDaxDialogProvider: NewTabDaxDialogProviding {
     }
 
     func createEndOfJourneyDialog(content: OnboardingEndOfJourneyContent, onAction: @escaping (OnboardingEndOfJourneyAction) -> Void) -> AnyView {
+        endOfJourneyContent = content
+        onEndOfJourneyAction = onAction
         AnyView(EmptyView())
     }
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1217576331966649?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

This PR fixes a test that can fail because of random chance.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Check that CI is green

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code in the diff; impact is CI reliability, not app behavior.
> 
> **Overview**
> **Removes flaky randomness** in `NewTabPageControllerDaxDialogTests` by dropping `randomDialogType()` and asserting against fixed specs instead of a random `HomeScreenSpec`.
> 
> **Splits and tightens dialog routing checks:** `viewDidAppear` and onboarding completion with `.initial` now assert the standard Dax path (`createDaxDialog`, dismiss handler set, no end-of-journey). A new case for `.final` on onboarding completion asserts the end-of-journey path (`createEndOfJourneyDialog` via captured `endOfJourneyContent` / `onEndOfJourneyAction`, with standard Dax factory fields nil).
> 
> **Updates `CapturingNewTabDaxDialogProvider`** so `createEndOfJourneyDialog` records content and action callbacks instead of returning an empty stub only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c50406d07311ef8abd3c7dde7682956c8d7e39c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->