### PR TITLE
Restore the Ask Duck.ai pill for users who had hidden only the Duck.ai button

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1914,6 +1914,7 @@
 		53C5FDE635F54E86A44EF5C6 /* DuckAIChromeButtonsPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E090D60EAB41E8BB22CA88 /* DuckAIChromeButtonsPreferences.swift */; };
 		541B2C4D448B4C109EF580A3 /* AIChatFloatingWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1812146DE841448CA4CE3FD1 /* AIChatFloatingWindowController.swift */; };
 		5601FECD29B7973D00068905 /* TabBarViewItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5601FECC29B7973D00068905 /* TabBarViewItemTests.swift */; };
+		7B4D2A112F1400000000AB01 /* DuckAIChromeButtonsVisibilityManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4D2A102F1400000000AB01 /* DuckAIChromeButtonsVisibilityManagerTests.swift */; };
 		5603D90629B7B746007F9F01 /* MockTabViewItemDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5603D90529B7B746007F9F01 /* MockTabViewItemDelegate.swift */; };
 		5603D90729B7B746007F9F01 /* MockTabViewItemDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5603D90529B7B746007F9F01 /* MockTabViewItemDelegate.swift */; };
 		560419442DD49BB600818414 /* PreferencesThreatProtectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560419432DD49BB600818414 /* PreferencesThreatProtectionView.swift */; };
@@ -2007,6 +2008,7 @@
 		5681ED462BDBAF6E00F59729 /* SyncErrorHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5681ED452BDBAF6E00F59729 /* SyncErrorHandlerTests.swift */; };
 		5681ED472BDBAF6E00F59729 /* SyncErrorHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5681ED452BDBAF6E00F59729 /* SyncErrorHandlerTests.swift */; };
 		5682C69429B79B57004DE3C8 /* TabBarViewItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5601FECC29B7973D00068905 /* TabBarViewItemTests.swift */; };
+		7B4D2A122F1400000000AB01 /* DuckAIChromeButtonsVisibilityManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4D2A102F1400000000AB01 /* DuckAIChromeButtonsVisibilityManagerTests.swift */; };
 		5687F6482F30CD1000A5C9B3 /* DefaultSubscriptionFlowsExecuter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5687F6472F30CD1000A5C9B3 /* DefaultSubscriptionFlowsExecuter.swift */; };
 		5687F6492F30CD1000A5C9B3 /* DefaultSubscriptionFlowsExecuter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5687F6472F30CD1000A5C9B3 /* DefaultSubscriptionFlowsExecuter.swift */; };
 		56A053FC2C19E8F7007D8FAB /* OnboardingActionsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A053FB2C19E8F7007D8FAB /* OnboardingActionsManager.swift */; };
@@ -5794,6 +5796,7 @@
 		51FEBFD485D01E6666551201 /* AutoplayPolicyTabExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoplayPolicyTabExtensionTests.swift; sourceTree = "<group>"; };
 		53E1C6F6843A455BA63258FB /* OnboardingChromeExtensionExperimentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingChromeExtensionExperimentTests.swift; sourceTree = "<group>"; };
 		5601FECC29B7973D00068905 /* TabBarViewItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarViewItemTests.swift; sourceTree = "<group>"; };
+		7B4D2A102F1400000000AB01 /* DuckAIChromeButtonsVisibilityManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIChromeButtonsVisibilityManagerTests.swift; sourceTree = "<group>"; };
 		5603D90529B7B746007F9F01 /* MockTabViewItemDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTabViewItemDelegate.swift; sourceTree = "<group>"; };
 		560419432DD49BB600818414 /* PreferencesThreatProtectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesThreatProtectionView.swift; sourceTree = "<group>"; };
 		560419482DD5FF3700818414 /* ContentScopeExperimentsEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentScopeExperimentsEndToEndTests.swift; sourceTree = "<group>"; };
@@ -9771,6 +9774,7 @@
 			children = (
 				5601FECC29B7973D00068905 /* TabBarViewItemTests.swift */,
 				5603D90529B7B746007F9F01 /* MockTabViewItemDelegate.swift */,
+				7B4D2A102F1400000000AB01 /* DuckAIChromeButtonsVisibilityManagerTests.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -17279,6 +17283,7 @@
 				3707C72F294B5D4F00682A9F /* WebViewTests.swift in Sources */,
 				021EA0852BD6E0EB00772C9A /* TabsPreferencesTests.swift in Sources */,
 				5682C69429B79B57004DE3C8 /* TabBarViewItemTests.swift in Sources */,
+				7B4D2A122F1400000000AB01 /* DuckAIChromeButtonsVisibilityManagerTests.swift in Sources */,
 				37598EFA2D5A278400720EAF /* ArrayExtensionTests.swift in Sources */,
 				84C1007C2ECC6F3C0083AB11 /* PopupHandlingTabExtensionTests.swift in Sources */,
 				BB5555E7950EDE4C3EE58AD9 /* AutoplayPolicyTabExtensionTests.swift in Sources */,
@@ -19453,6 +19458,7 @@
 				843965152C737022004C8899 /* NSPasteboardExtension.swift in Sources */,
 				4B9292C22667103100AD2C21 /* BookmarkTests.swift in Sources */,
 				5601FECD29B7973D00068905 /* TabBarViewItemTests.swift in Sources */,
+				7B4D2A112F1400000000AB01 /* DuckAIChromeButtonsVisibilityManagerTests.swift in Sources */,
 				BB349A4E2E3B8B0E0028AFE1 /* MockDefaultBrowserProvider.swift in Sources */,
 				1D8C2FE52B70F4C4005E4BBD /* TabSnapshotExtensionTests.swift in Sources */,
 				E090E1D0B3C24239AC8CE35A /* TabSuspensionExtensionTests.swift in Sources */,

--- a/macOS/DuckDuckGo/TabBar/View/DuckAIChromeButtonsPreferences.swift
+++ b/macOS/DuckDuckGo/TabBar/View/DuckAIChromeButtonsPreferences.swift
@@ -24,6 +24,7 @@ struct DuckAIChromeButtonsUserDefaultsPersistor {
     enum Key: String {
         case isDuckAIButtonHidden = "duck-ai-chrome.title-button.hidden"
         case isSidebarButtonHidden = "duck-ai-chrome.sidebar-button.hidden"
+        case didMigrateMenuButtonLayoutVisibility = "duck-ai-chrome.menu-button-layout.visibility-migrated"
     }
 
     private let keyValueStore: KeyValueStoring
@@ -40,6 +41,11 @@ struct DuckAIChromeButtonsUserDefaultsPersistor {
     var isSidebarButtonHidden: Bool {
         get { boolValue(for: .isSidebarButtonHidden) }
         set { set(newValue, for: .isSidebarButtonHidden) }
+    }
+
+    var didMigrateMenuButtonLayoutVisibility: Bool {
+        get { boolValue(for: .didMigrateMenuButtonLayoutVisibility) }
+        set { set(newValue, for: .didMigrateMenuButtonLayoutVisibility) }
     }
 
     private func boolValue(for key: Key) -> Bool {

--- a/macOS/DuckDuckGo/TabBar/View/DuckAIChromeButtonsVisibilityManager.swift
+++ b/macOS/DuckDuckGo/TabBar/View/DuckAIChromeButtonsVisibilityManager.swift
@@ -27,6 +27,9 @@ protocol DuckAIChromeButtonsVisibilityManaging {
     func isHidden(_ button: DuckAIChromeButtonType) -> Bool
     func toggleVisibility(for button: DuckAIChromeButtonType)
     func setHidden(_ hidden: Bool, for button: DuckAIChromeButtonType)
+
+    /// Call when the menu-button layout is applied. See the implementation for what it migrates.
+    func migrateVisibilityForMenuButtonLayoutIfNeeded()
 }
 
 final class LocalDuckAIChromeButtonsVisibilityManager: DuckAIChromeButtonsVisibilityManaging {
@@ -48,6 +51,21 @@ final class LocalDuckAIChromeButtonsVisibilityManager: DuckAIChromeButtonsVisibi
 
     func toggleVisibility(for button: DuckAIChromeButtonType) {
         setHidden(!isHidden(button), for: button)
+    }
+
+    /// The split control had two independently hidable halves; the menu pill has one. Hiding only the
+    /// Duck.ai half used to leave the sidebar button — and so the whole control — visible, meaning that
+    /// stored state was never a request to empty the tab bar. The pill reads the same flag as "hide
+    /// everything", so those users silently lose the control on update. Clear it once for that one
+    /// combination; the flag is stamped either way so a later deliberate hide is never undone.
+    ///
+    /// Only meaningful in the menu-button layout — in the split layout that state is still coherent.
+    func migrateVisibilityForMenuButtonLayoutIfNeeded() {
+        guard !persistor.didMigrateMenuButtonLayoutVisibility else { return }
+        persistor.didMigrateMenuButtonLayoutVisibility = true
+
+        guard isHidden(.duckAI), !isHidden(.sidebar) else { return }
+        setHidden(false, for: .duckAI)
     }
 
     func setHidden(_ hidden: Bool, for button: DuckAIChromeButtonType) {

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -627,6 +627,9 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
 
         // Menu-button layout: a single "Ask Duck.ai" pill; the sidebar sub-button and divider never render.
         if isMenuButtonLayout {
+            // Runs at most once, here rather than at launch because the layout can flip on a config
+            // fetch. Reading the flag straight after picks up the migrated value, so there's no flicker.
+            duckAIChromeButtonsVisibilityManager.migrateVisibilityForMenuButtonLayoutIfNeeded()
             let duckAIHidden = duckAIChromeButtonsVisibilityManager.isHidden(.duckAI)
             titleButton.isHidden = duckAIHidden
             sidebarButton.isHidden = true

--- a/macOS/UnitTests/TabBar/View/DuckAIChromeButtonsVisibilityManagerTests.swift
+++ b/macOS/UnitTests/TabBar/View/DuckAIChromeButtonsVisibilityManagerTests.swift
@@ -1,0 +1,112 @@
+//
+//  DuckAIChromeButtonsVisibilityManagerTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+@testable import DuckDuckGo_Privacy_Browser
+
+final class DuckAIChromeButtonsVisibilityManagerTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test_\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    private func makeManager() -> LocalDuckAIChromeButtonsVisibilityManager {
+        LocalDuckAIChromeButtonsVisibilityManager(
+            persistor: DuckAIChromeButtonsUserDefaultsPersistor(keyValueStore: defaults)
+        )
+    }
+
+    // MARK: - Menu-button layout migration
+
+    func testWhenOnlyDuckAIButtonWasHiddenThenMigrationRestoresIt() {
+        let manager = makeManager()
+        manager.setHidden(true, for: .duckAI)
+
+        manager.migrateVisibilityForMenuButtonLayoutIfNeeded()
+
+        XCTAssertFalse(manager.isHidden(.duckAI))
+    }
+
+    func testWhenBothButtonsWereHiddenThenMigrationLeavesThemHidden() {
+        let manager = makeManager()
+        manager.setHidden(true, for: .duckAI)
+        manager.setHidden(true, for: .sidebar)
+
+        manager.migrateVisibilityForMenuButtonLayoutIfNeeded()
+
+        XCTAssertTrue(manager.isHidden(.duckAI))
+        XCTAssertTrue(manager.isHidden(.sidebar))
+    }
+
+    func testWhenNothingWasHiddenThenMigrationChangesNothing() {
+        let manager = makeManager()
+
+        manager.migrateVisibilityForMenuButtonLayoutIfNeeded()
+
+        XCTAssertFalse(manager.isHidden(.duckAI))
+        XCTAssertFalse(manager.isHidden(.sidebar))
+    }
+
+    func testWhenMigrationAlreadyRanThenLaterDeliberateHideIsPreserved() {
+        let manager = makeManager()
+        manager.setHidden(true, for: .duckAI)
+        manager.migrateVisibilityForMenuButtonLayoutIfNeeded()
+        XCTAssertFalse(manager.isHidden(.duckAI))
+
+        // The user hides the pill on purpose, then the layout is applied again.
+        manager.setHidden(true, for: .duckAI)
+        manager.migrateVisibilityForMenuButtonLayoutIfNeeded()
+
+        XCTAssertTrue(manager.isHidden(.duckAI))
+    }
+
+    func testWhenMigrationRunsRepeatedlyThenItIsIdempotent() {
+        let manager = makeManager()
+        manager.setHidden(true, for: .duckAI)
+
+        for _ in 0..<3 {
+            manager.migrateVisibilityForMenuButtonLayoutIfNeeded()
+        }
+
+        XCTAssertFalse(manager.isHidden(.duckAI))
+    }
+
+    func testWhenMigrationRunsThenItIsNotRepeatedOnAFreshManagerSharingStorage() {
+        makeManager().migrateVisibilityForMenuButtonLayoutIfNeeded()
+
+        // A second window builds its own manager over the same storage.
+        let other = makeManager()
+        other.setHidden(true, for: .duckAI)
+        other.migrateVisibilityForMenuButtonLayoutIfNeeded()
+
+        XCTAssertTrue(other.isHidden(.duckAI))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1217577226377839?focus=true

### Description

This PR fixes the state where "Ask Duck.ai" button in tab bar was hidden for users who disabled Duck.ai pill but kept sidebar button.

### Testing Steps

Use a channel whose defaults have never run this build (Alpha or Review) — the migration is one-shot per bundle id, so running the fixed build first burns the attempt.

1. Checkout `release/macos/1.204.0` branch
2. Run the app
3. Debug → Feature Flags → turn off `aiChatChromeMenuButton` → the split Duck.ai control appears.
4. Right-click the Duck.ai title button → Hide Duck.ai Button → the sidebar button stays visible.
5. Debug → Feature Flags → turn on `aiChatChromeMenuButton` → the whole control disappears. This is the bug.
5. Quit.

Checkout `tom/duck-ai-pill-visibility-migration`

6. Build and run the same scheme → the **Ask Duck.ai pill is present**, and Settings → AI Chat shows the tab-bar toggle on.
8. Quit and relaunch → the pill stays pesent

### Impact

Low — restores a tab-bar affordance for a subset of users, guarded to run once and only for one stored-state combination.

#### What could go wrong?

- A deliberate hide is undone on every launch → mitigated by recording the migration before the condition check; covered by `testWhenMigrationAlreadyRanThenLaterDeliberateHideIsPreserved`.
- Users who deliberately hid both buttons get the pill forced back → mitigated by requiring the sidebar button to be visible; covered by `testWhenBothButtonsWereHiddenThenMigrationLeavesThemHidden`.

### Quality Considerations

The migration reuses the existing visibility setter, so the change propagates to other windows and to the Settings model through the notification they already observe. That observer hops through the main queue, so there is no re-entry into the layout pass that triggered it.

Users already on 1.202.0–1.204.x stay affected until they update to a build containing this; there is no remote lever that reaches them without reverting the pill layout for everyone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UserDefaults migration and tab-bar visibility only; one-shot guard limits behavior change to a specific legacy stored-state combination.
> 
> **Overview**
> Fixes users who **hid only the Duck.ai half** of the split tab-bar control and then lost the whole **Ask Duck.ai** pill when the menu-button layout shipped. The pill treats the same UserDefaults flag as “hide the entire control,” which was never what that stored state meant in the split UI.
> 
> Adds a **one-shot migration** (`migrateVisibilityForMenuButtonLayoutIfNeeded`) that runs when the menu-button layout is applied in `TabBarViewController` (not at launch, so a mid-session feature-flag flip still migrates before visibility is read). It clears the Duck.ai hidden flag only when Duck.ai was hidden but the sidebar half was still visible; users who hid both stay hidden. A `didMigrateMenuButtonLayoutVisibility` stamp ensures deliberate hides after migration are preserved.
> 
> Persistence and protocol updates live in `DuckAIChromeButtonsPreferences` / `LocalDuckAIChromeButtonsVisibilityManager`; coverage is in new `DuckAIChromeButtonsVisibilityManagerTests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee6118bfe27494e7a83a1c4b5eabc309063a2654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->