### PR TITLE
Remove the legacy release notes parser equivalence test

### DIFF
--- a/macOS/LocalPackages/AppUpdater/Tests/AppUpdaterSharedTests/ReleaseNotesParserTests.swift
+++ b/macOS/LocalPackages/AppUpdater/Tests/AppUpdaterSharedTests/ReleaseNotesParserTests.swift
@@ -113,10 +113,8 @@ final class ReleaseNotesParserTests: XCTestCase {
         XCTAssertTrue(subscription.isEmpty)
     }
 
-    /// Behavioral note: the legacy regex/`NSAttributedString` parser silently dropped an unterminated
-    /// `<li>` item. The `XMLDocument` parser recovers it instead (libxml2 closes the tag), which is the
-    /// safer behavior. This is the one intentional divergence from the legacy parser and is excluded
-    /// from the equivalence test below.
+    /// An unterminated `<li>` item is recovered rather than dropped, because libxml2 closes the tag
+    /// while parsing.
     func testParseReleaseNotes_recoversUnterminatedListItem() {
         let description = """
         <h3>What's new</h3>
@@ -157,29 +155,6 @@ final class ReleaseNotesParserTests: XCTestCase {
         XCTAssertTrue(subscription.isEmpty)
     }
 
-    // MARK: - Equivalence with the legacy parser
-
-    /// Proves the new `XMLDocument` parser produces identical output to the original regex /
-    /// `NSAttributedString` implementation (reproduced verbatim as `LegacyReleaseNotesParser`)
-    /// for every well-formed input. The only known divergence — recovery of malformed/unterminated
-    /// list items — is covered separately by `testParseReleaseNotes_recoversUnterminatedListItem`.
-    func testParseReleaseNotes_matchesLegacyParserForWellFormedHTML() {
-        let fixtures = [
-            Self.realStandardOnly,
-            Self.realMultiItem,
-            Self.syntheticBothSections,
-            "<h3 style=\"font-size:14px\">What's new</h3><ul><li>Open Duck.ai with the ⌘+E shortcut &amp; enjoy it.</li></ul>",
-            "<p>No release notes here.</p>"
-        ]
-
-        for fixture in fixtures {
-            let new = ReleaseNotesParser.parseReleaseNotes(from: fixture)
-            let legacy = LegacyReleaseNotesParser.parseReleaseNotes(from: fixture)
-            XCTAssertEqual(new.0, legacy.0, "Standard notes differ for fixture:\n\(fixture)")
-            XCTAssertEqual(new.1, legacy.1, "Subscription notes differ for fixture:\n\(fixture)")
-        }
-    }
-
     // MARK: - Fixtures
 
     private static let realStandardOnly = """
@@ -198,83 +173,4 @@ final class ReleaseNotesParserTests: XCTestCase {
     <li>As usual, this update includes other bug fixes and improvements.</li>
     </ul>
     """
-
-    private static let syntheticBothSections = """
-    <h3>What's new</h3>
-    <ul>
-        <li>New feature A</li>
-        <li>Improvement B</li>
-    </ul>
-    <h3>For DuckDuckGo subscribers</h3>
-    <ul>
-        <li>Exclusive feature X</li>
-        <li>Exclusive improvement Y</li>
-    </ul>
-    """
-}
-
-/// Verbatim copy of the original `ReleaseNotesParser` implementation (regex + `NSAttributedString`),
-/// kept in the test target only, as the reference for the equivalence test above.
-private enum LegacyReleaseNotesParser {
-
-    static func parseReleaseNotes(from description: String?) -> ([String], [String]) {
-        guard let description else { return ([], []) }
-
-        var standardReleaseNotes = [String]()
-        var subscriptionReleaseNotes = [String]()
-
-        let standardPattern = "<h3[^>]*>What's new</h3>\\s*<ul>(.*?)</ul>"
-        let subscriptionPattern = "<h3[^>]*>For DuckDuckGo subscribers</h3>\\s*<ul>(.*?)</ul>"
-
-        do {
-            let standardRegex = try NSRegularExpression(pattern: standardPattern, options: .dotMatchesLineSeparators)
-            let subscriptionRegex = try NSRegularExpression(pattern: subscriptionPattern, options: .dotMatchesLineSeparators)
-
-            if let standardMatch = standardRegex.firstMatch(in: description, options: [], range: NSRange(location: 0, length: description.utf16.count)) {
-                if let range = Range(standardMatch.range(at: 1), in: description) {
-                    let standardList = String(description[range])
-                    standardReleaseNotes = extractListItems(from: standardList)
-                }
-            }
-
-            if let subscriptionMatch = subscriptionRegex.firstMatch(in: description, options: [], range: NSRange(location: 0, length: description.utf16.count)) {
-                if let range = Range(subscriptionMatch.range(at: 1), in: description) {
-                    let subscriptionList = String(description[range])
-                    subscriptionReleaseNotes = extractListItems(from: subscriptionList)
-                }
-            }
-        } catch {
-            assertionFailure("Error creating regular expression: \(error)")
-        }
-
-        return (standardReleaseNotes, subscriptionReleaseNotes)
-    }
-
-    private static func extractListItems(from list: String) -> [String] {
-        var items = [String]()
-        let pattern = "<li>(.*?)</li>"
-
-        do {
-            let regex = try NSRegularExpression(pattern: pattern, options: .dotMatchesLineSeparators)
-            let matches = regex.matches(in: list, options: [], range: NSRange(location: 0, length: list.utf16.count))
-
-            for match in matches {
-                if let range = Range(match.range(at: 1), in: list) {
-                    let item = String(list[range])
-
-                    if let data = item.data(using: .utf8),
-                       let attributedString = try? NSAttributedString(data: data,
-                                                                      options: [.documentType: NSAttributedString.DocumentType.html,
-                                                                                .characterEncoding: String.Encoding.utf8.rawValue],
-                                                                      documentAttributes: nil) {
-                        items.append(attributedString.string)
-                    }
-                }
-            }
-        } catch {
-            assertionFailure("Error creating regular expression: \(error)")
-        }
-
-        return items
-    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203108348835387/task/1216138442318450?focus=true

### Description

We're removing equivalence tests that are no longer necessary.

### Testing Steps

1. Run the AppUpdater package tests
   All tests pass.

### Impact

None — test-only change, no shipping code touched.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
