### PR TITLE
Remove the vpnExcludeCGNATToggle feature flag

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/Settings/VPNSettings.swift
+++ b/SharedPackages/VPN/Sources/VPN/Settings/VPNSettings.swift
@@ -396,17 +396,6 @@ public final class VPNSettings {
         }
     }
 
-    /// Syncs `excludeCGNAT` against the feature-flag state. When the flag is off, the
-    /// value is forced to `false`. When on, the stored value is left alone (the storage
-    /// default produces the experimental on-by-default for users with the flag).
-    /// Call at app launch, tunnel start, and when the VPN settings screen appears so
-    /// readers of the raw value (tunnel, metadata) always see the effective value.
-    public func updateExcludeCGNAT(isFeatureEnabled: Bool) {
-        let effective = isFeatureEnabled ? excludeCGNAT : false
-        guard excludeCGNAT != effective else { return }
-        excludeCGNAT = effective
-    }
-
     // MARK: - Exclude APNs
 
     public var excludeAPNsPublisher: AnyPublisher<Bool, Never> {

--- a/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -392,8 +392,6 @@ final class NetworkProtectionTunnelController: VPNConnectionContextProvidingTunn
     }
 
     private func start(_ tunnelManager: NETunnelProviderManager) async throws {
-        settings.updateExcludeCGNAT(isFeatureEnabled: featureFlagger.isFeatureOn(.vpnExcludeCGNATToggle))
-
         var options = [String: NSObject]()
 
         if Self.shouldSimulateFailure {

--- a/iOS/DuckDuckGo/NetworkProtectionVPNSettingsView.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionVPNSettingsView.swift
@@ -71,11 +71,9 @@ struct NetworkProtectionVPNSettingsView: View {
                               footerText: UserText.netPExcludeLocalNetworksSettingFooter,
                               isOn: $viewModel.excludeLocalNetworks)
 
-                if viewModel.isExcludeCGNATAvailable {
-                    toggleSection(text: UserText.netPExcludeCGNATSettingTitle,
-                                  footerText: UserText.netPExcludeCGNATSettingFooter,
-                                  isOn: $viewModel.excludeCGNAT)
-                }
+                toggleSection(text: UserText.netPExcludeCGNATSettingTitle,
+                              footerText: UserText.netPExcludeCGNATSettingFooter,
+                              isOn: $viewModel.excludeCGNAT)
 
                 if viewModel.isStrictRoutingAvailable {
                     toggleSection(text: UserText.netPStrictRoutingSettingTitle,

--- a/iOS/DuckDuckGo/NetworkProtectionVPNSettingsViewModel.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionVPNSettingsViewModel.swift
@@ -42,10 +42,6 @@ final class NetworkProtectionVPNSettingsViewModel: ObservableObject {
 
     @Published private(set) var isStrictRoutingAvailable: Bool
 
-    var isExcludeCGNATAvailable: Bool {
-        featureFlagger.isFeatureOn(.vpnExcludeCGNATToggle)
-    }
-
     private var notificationsAuthorization: NotificationsAuthorizationControlling
     @Published var viewKind: NetworkProtectionNotificationsViewKind = .loading
 
@@ -149,7 +145,6 @@ final class NetworkProtectionVPNSettingsViewModel: ObservableObject {
 
     @MainActor
     func onViewAppeared() async {
-        settings.updateExcludeCGNAT(isFeatureEnabled: featureFlagger.isFeatureOn(.vpnExcludeCGNATToggle))
         let status = await notificationsAuthorization.authorizationStatus
         updateViewKind(for: status)
     }

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -239,10 +239,6 @@ public enum FeatureFlag: String {
     /// Gates the "Strict routing" VPN toggle.
     case vpnStrictRoutingToggle
 
-    /// Gates the "Exclude Carrier-Grade NAT" VPN toggle.
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214946884020610?focus=true
-    case vpnExcludeCGNATToggle
-
     /// Toggle for the Copy VPN Diagnostics button in the VPN status screen.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215794369750045
     case vpnShowCopyDiagnosticsButton
@@ -737,8 +733,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(PrivacyProSubfeature.vpnMenuItem))
         case .vpnStrictRoutingToggle:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(NetworkProtectionSubfeature.strictRoutingToggle))
-        case .vpnExcludeCGNATToggle:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(NetworkProtectionSubfeature.excludeCGNAT))
         case .vpnShowCopyDiagnosticsButton:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(NetworkProtectionSubfeature.showCopyDiagnosticsButton))
         case .forgetAllInSettings:

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
@@ -812,8 +812,6 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
 
     @MainActor
     private func start(_ tunnelManager: NETunnelProviderManager) async throws {
-        settings.updateExcludeCGNAT(isFeatureEnabled: featureFlagger.isFeatureOn(.vpnExcludeCGNATToggle))
-
         let options = try await prepareStartupOptions()
 
         if Self.simulationOptions.isEnabled(.controllerFailure) {

--- a/macOS/DuckDuckGo/Preferences/Model/VPNPreferencesModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/VPNPreferencesModel.swift
@@ -78,10 +78,6 @@ final class VPNPreferencesModel: ObservableObject {
         }
     }
 
-    var isExcludeCGNATAvailable: Bool {
-        featureFlagger.isFeatureOn(.vpnExcludeCGNATToggle)
-    }
-
     @Published var showInMenuBar: Bool {
         didSet {
             settings.showInMenuBar = showInMenuBar
@@ -332,11 +328,6 @@ final class VPNPreferencesModel: ObservableObject {
                 }
             }
             .store(in: &cancellables)
-    }
-
-    @MainActor
-    func onViewAppeared() {
-        settings.updateExcludeCGNAT(isFeatureEnabled: featureFlagger.isFeatureOn(.vpnExcludeCGNATToggle))
     }
 
     func reloadVPN() {

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesVPNView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesVPNView.swift
@@ -70,15 +70,13 @@ extension Preferences {
                         )
                     }
 
-                    if model.isExcludeCGNATAvailable {
-                        SpacedCheckbox {
-                            ToggleMenuItemWithDescription(
-                                UserText.vpnExcludeCGNATSettingTitle,
-                                UserText.vpnExcludeCGNATSettingDescription,
-                                isOn: $model.excludeCGNAT,
-                                spacing: 12
-                            )
-                        }
+                    SpacedCheckbox {
+                        ToggleMenuItemWithDescription(
+                            UserText.vpnExcludeCGNATSettingTitle,
+                            UserText.vpnExcludeCGNATSettingDescription,
+                            isOn: $model.excludeCGNAT,
+                            spacing: 12
+                        )
                     }
 
                     if model.isStrictRoutingAvailable {
@@ -235,9 +233,6 @@ extension Preferences {
                         }
                     }
                 }
-            }
-            .onAppear {
-                model.onViewAppeared()
             }
         }
 

--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -65,10 +65,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Gates the "Strict routing" VPN toggle.
     case vpnStrictRoutingToggle
 
-    /// Gates the "Exclude Carrier-Grade NAT" VPN toggle.
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214946884020610?focus=true
-    case vpnExcludeCGNATToggle
-
     /// Toggle for the Copy VPN Diagnostics button in VPN settings.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215794369750045
     case vpnShowCopyDiagnosticsButton
@@ -575,8 +571,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(NetworkProtectionSubfeature.appStoreSystemExtensionMessage), category: .vpn)
         case .vpnStrictRoutingToggle:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(NetworkProtectionSubfeature.strictRoutingToggle), category: .vpn)
-        case .vpnExcludeCGNATToggle:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(NetworkProtectionSubfeature.excludeCGNAT), category: .vpn)
         case .vpnShowCopyDiagnosticsButton:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(NetworkProtectionSubfeature.showCopyDiagnosticsButton), category: .vpn)
         case .autoUpdateInDEBUG:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1217578715858522?focus=true

### Description
Exclude Carrier Services has been enabled for all users on current app versions and is working well, so its flag has done its job and can go. The setting stays exactly as users see it today, and the remote subfeature stays enabled for older app versions that still read it.

### Testing Steps

Just make sure the logic is sound, and the CGNAT toggle is visible in-App for both iOS and macOS.  The toggle is in VPN settings.

### Impact
Low. The setting, its default, and the routing it drives are unchanged; only the visibility check in front of it is gone.

#### What could go wrong?
Internal users lose the flag override that could hide the setting → the setting's own switch still turns the behaviour off.

### Quality Considerations
The routing tests already cover the setting in both states, and nothing in the test suites referenced the flag, so CI coverage is unchanged.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag cleanup only; excludeCGNAT behavior and defaults are unchanged. Internal users lose the flag override that could hide the setting.
> 
> **Overview**
> Removes the **`vpnExcludeCGNATToggle`** feature flag and all code that gated or synced the **Exclude Carrier-Grade NAT (CGNAT)** VPN setting behind it.
> 
> **Shared VPN settings:** Deletes `VPNSettings.updateExcludeCGNAT(isFeatureEnabled:)`, which previously forced `excludeCGNAT` to `false` when the flag was off and synced on launch, tunnel start, and when settings opened.
> 
> **iOS:** The CGNAT toggle in VPN settings is always shown (no `isExcludeCGNATAvailable` check). Removed flag checks from `NetworkProtectionTunnelController.start`, `NetworkProtectionVPNSettingsViewModel.onViewAppeared`, and the `vpnExcludeCGNATToggle` case from FeatureFlags-iOS.
> 
> **macOS:** Same always-visible CGNAT toggle in VPN preferences; removed `isExcludeCGNATAvailable`, `onViewAppeared` sync, tunnel-start `updateExcludeCGNAT`, and the flag from FeatureFlags-macOS.
> 
> The **`excludeCGNAT`** user setting, its defaults, and tunnel routing behavior are unchanged for users who already had the flag on; only the flag and visibility/sync plumbing are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b46dbf2413bb57f5e11c08ca0fcccb0640795661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->