### PR TITLE
iOS: Help users choose the right AI model - part 3

### DIFF
--- a/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
@@ -52,15 +52,17 @@ final class IPadOmnibarModelPickerController {
         upsellPresenter: DuckAISubscriptionUpselling = DuckAISubscriptionUpsellPresenter(),
         updatedModelPickerFeature: UpdatedModelPickerFeatureProviding = UpdatedModelPickerFeature()
     ) {
+        let isUpdatedModelPickerEnabled = updatedModelPickerFeature.isAvailable
         self.upsellPresenter = upsellPresenter
-        self.menuFactory = UnifiedToggleInputModelMenuFactory(isUpdatedModelPickerEnabled: updatedModelPickerFeature.isAvailable)
+        self.menuFactory = UnifiedToggleInputModelMenuFactory(isUpdatedModelPickerEnabled: isUpdatedModelPickerEnabled)
         store = UTIModelStore(
             modelsService: modelsService ?? AIChatModelsService(
                 baseURL: aiChatModelsBaseURL(forChatURL: aiChatSettings.aiChatURL),
                 accessTokenProvider: subscriptionManager
             ),
             preferences: preferences,
-            subscriptionManager: subscriptionManager
+            subscriptionManager: subscriptionManager,
+            isUpdatedModelPickerEnabled: isUpdatedModelPickerEnabled
         )
         store.onModelsUpdated = { [weak self] in
             self?.onModelsUpdated?()

--- a/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarModelPickerController.swift
@@ -91,6 +91,7 @@ final class IPadOmnibarModelPickerController {
             models: store.models,
             selectedId: store.persistedModelId,
             userTier: store.subscriptionState.userTier,
+            freeTrialEligibility: store.freeTrialEligibility,
             onSelect: onSelect
         )
     }

--- a/iOS/DuckDuckGo/IPadOmnibarReasoningPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarReasoningPickerController.swift
@@ -74,6 +74,7 @@ final class IPadOmnibarReasoningPickerController {
             model: model,
             selectedMode: currentReasoningMode,
             userTier: store.subscriptionState.userTier,
+            freeTrialEligibility: store.freeTrialEligibility,
             onSelect: onSelect
         )
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIModelSelector.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIModelSelector.swift
@@ -271,6 +271,7 @@ final class UTIModelSelector {
             models: modelStore.models,
             selectedId: selectedId,
             userTier: modelStore.subscriptionState.userTier,
+            freeTrialEligibility: modelStore.freeTrialEligibility,
             onSelect: onSelect
         )
     }
@@ -301,6 +302,7 @@ final class UTIModelSelector {
             model: selectedModel,
             selectedMode: resolvedSelectedReasoningMode,
             userTier: modelStore.subscriptionState.userTier,
+            freeTrialEligibility: modelStore.freeTrialEligibility,
             onSelect: onSelect
         )
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
@@ -18,8 +18,16 @@
 //
 
 import AIChat
+import Combine
 import os.log
 import Subscription
+
+/// Free trial eligibility used to label gated models and reasoning efforts.
+enum FreeTrialEligibility: Equatable {
+    case unknown
+    case eligible
+    case ineligible
+}
 
 @MainActor
 final class UTIModelStore {
@@ -27,11 +35,13 @@ final class UTIModelStore {
     var models: [AIChatModel] = []
     var subscriptionState: SubscriptionState = .free
     var attachmentLimits: AIChatAttachmentTierLimits?
+    private(set) var freeTrialEligibility: FreeTrialEligibility = .unknown
 
     private let modelsService: AIChatModelsProviding
     private(set) var preferences: AIChatPreferencesPersisting
     private let subscriptionManager: any SubscriptionManager
     private var modelsFetchTask: Task<Void, Never>?
+    private var cancellables = Set<AnyCancellable>()
 
     private var liveModelId: String?
 
@@ -45,6 +55,7 @@ final class UTIModelStore {
         self.modelsService = modelsService
         self.preferences = preferences
         self.subscriptionManager = subscriptionManager
+        subscribeToAppStoreProductAvailability()
     }
 
     var persistedModelId: String? {
@@ -109,6 +120,7 @@ final class UTIModelStore {
     }
 
     func fetchModels() {
+        updateFreeTrialEligibilityFromSubscriptionCache(notifyOnChange: false)
         modelsFetchTask?.cancel()
         modelsFetchTask = Task { [weak self] in
             guard let self else { return }
@@ -129,6 +141,31 @@ final class UTIModelStore {
                 self.onModelsUpdated?()
                 os_log(.error, "Failed to fetch models: %{public}@", error.localizedDescription)
             }
+        }
+    }
+
+    private func subscribeToAppStoreProductAvailability() {
+        subscriptionManager.hasAppStoreProductsAvailablePublisher
+            .sink { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.updateFreeTrialEligibilityFromSubscriptionCache(notifyOnChange: true)
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    private func updateFreeTrialEligibilityFromSubscriptionCache(notifyOnChange: Bool) {
+        let updatedEligibility: FreeTrialEligibility
+        if !subscriptionManager.isSubscriptionPurchaseEligible {
+            updatedEligibility = .unknown
+        } else {
+            updatedEligibility = subscriptionManager.isUserEligibleForFreeTrial() ? .eligible : .ineligible
+        }
+
+        guard updatedEligibility != freeTrialEligibility else { return }
+        freeTrialEligibility = updatedEligibility
+        if notifyOnChange {
+            onModelsUpdated?()
         }
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
@@ -40,6 +40,7 @@ final class UTIModelStore {
     private let modelsService: AIChatModelsProviding
     private(set) var preferences: AIChatPreferencesPersisting
     private let subscriptionManager: any SubscriptionManager
+    private let isUpdatedModelPickerEnabled: Bool
     private var modelsFetchTask: Task<Void, Never>?
     private var cancellables = Set<AnyCancellable>()
 
@@ -50,12 +51,17 @@ final class UTIModelStore {
     init(
         modelsService: AIChatModelsProviding,
         preferences: AIChatPreferencesPersisting,
-        subscriptionManager: any SubscriptionManager
+        subscriptionManager: any SubscriptionManager,
+        isUpdatedModelPickerEnabled: Bool
     ) {
         self.modelsService = modelsService
         self.preferences = preferences
         self.subscriptionManager = subscriptionManager
-        subscribeToAppStoreProductAvailability()
+        self.isUpdatedModelPickerEnabled = isUpdatedModelPickerEnabled
+        if isUpdatedModelPickerEnabled {
+            // Only the updated picker labels gated models and reasoning efforts based on trial eligibility.
+            subscribeToAppStoreProductAvailability()
+        }
     }
 
     var persistedModelId: String? {
@@ -120,7 +126,9 @@ final class UTIModelStore {
     }
 
     func fetchModels() {
-        updateFreeTrialEligibilityFromSubscriptionCache(notifyOnChange: false)
+        if isUpdatedModelPickerEnabled {
+            updateFreeTrialEligibilityFromSubscriptionCache(notifyOnChange: false)
+        }
         modelsFetchTask?.cancel()
         modelsFetchTask = Task { [weak self] in
             guard let self else { return }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -303,6 +303,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         placesAttachmentsAboveInput: Bool = false,
         updatedModelPickerFeature: UpdatedModelPickerFeatureProviding = UpdatedModelPickerFeature()
     ) {
+        let isUpdatedModelPickerEnabled = updatedModelPickerFeature.isAvailable
         self.host = host
         self.isToggleEnabled = isToggleEnabled
         self.hidesToggleOnDuckAITab = hidesToggleOnDuckAITab
@@ -324,7 +325,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
                 accessTokenProvider: subscriptionManager
             ),
             preferences: preferences,
-            subscriptionManager: subscriptionManager
+            subscriptionManager: subscriptionManager,
+            isUpdatedModelPickerEnabled: isUpdatedModelPickerEnabled
         )
         self.lastUsedModelProvider = lastUsedModelProvider
             ?? duckAiNativeStorageHandler.map { DuckAiLastUsedModelProvider(storage: $0, pixelFiring: duckAiNativeStoragePixelFiring) }
@@ -411,7 +413,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
                 clearSubmitRecoveryBlock: { [weak self] in self?.isSubmitBlockedByRecoveryCard = false },
                 onModelApplied: { [weak self] in self?.notifyFrontendOfActiveChatModelChange($0) }
             ),
-            isUpdatedModelPickerEnabled: updatedModelPickerFeature.isAvailable
+            isUpdatedModelPickerEnabled: isUpdatedModelPickerEnabled
         )
         attachmentController = UTIAttachmentController(
             pixelReporter: pixelReporter,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputModelMenuFactory.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputModelMenuFactory.swift
@@ -21,6 +21,18 @@ import AIChat
 import DesignResourcesKitIcons
 import UIKit
 
+enum UnifiedToggleInputGatedSectionTitleResolver {
+    static func title(for userTier: AIChatUserTier, freeTrialEligibility: FreeTrialEligibility) -> String {
+        if userTier == .plus {
+            return UserText.aiChatModelPickerProPlanExclusive
+        }
+        if freeTrialEligibility == .ineligible {
+            return UserText.aiChatModelPickerSubscriberExclusive
+        }
+        return UserText.aiChatModelPickerTryFree
+    }
+}
+
 struct UnifiedToggleInputModelMenuFactory {
 
     private let isUpdatedModelPickerEnabled: Bool
@@ -33,10 +45,16 @@ struct UnifiedToggleInputModelMenuFactory {
         models: [AIChatModel],
         selectedId: String?,
         userTier: AIChatUserTier,
+        freeTrialEligibility: FreeTrialEligibility = .unknown,
         onSelect: @escaping (String) -> Void
     ) -> UIMenu {
         if isUpdatedModelPickerEnabled {
-            return makeUpdatedMenu(models: models, selectedId: selectedId, userTier: userTier, onSelect: onSelect)
+            return makeUpdatedMenu(
+                models: models,
+                selectedId: selectedId,
+                userTier: userTier,
+                freeTrialEligibility: freeTrialEligibility,
+                onSelect: onSelect)
         }
 
         return makeLegacyMenu(models: models, selectedId: selectedId, onSelect: onSelect)
@@ -84,6 +102,7 @@ struct UnifiedToggleInputModelMenuFactory {
         models: [AIChatModel],
         selectedId: String?,
         userTier: AIChatUserTier,
+        freeTrialEligibility: FreeTrialEligibility,
         onSelect: @escaping (String) -> Void
     ) -> UIMenu {
         let groupedModels = AIChatModelSectionBuilder.groupByAccess(models: models)
@@ -107,7 +126,9 @@ struct UnifiedToggleInputModelMenuFactory {
                     onSelect: onSelect
                 )
             }
-            let gatedSectionTitle = userTier == .plus ? UserText.aiChatModelPickerProPlanExclusive : UserText.aiChatModelPickerTryFree
+            let gatedSectionTitle = UnifiedToggleInputGatedSectionTitleResolver.title(
+                for: userTier,
+                freeTrialEligibility: freeTrialEligibility)
             children.append(UIMenu(title: gatedSectionTitle, options: .displayInline, children: gatedActions))
         }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputModelMenuFactory.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputModelMenuFactory.swift
@@ -107,7 +107,7 @@ struct UnifiedToggleInputModelMenuFactory {
                     onSelect: onSelect
                 )
             }
-            let gatedSectionTitle = userTier == .plus ? UserText.aiChatModelPickerAvailableWithPro : UserText.aiChatModelPickerTryFree
+            let gatedSectionTitle = userTier == .plus ? UserText.aiChatModelPickerProPlanExclusive : UserText.aiChatModelPickerTryFree
             children.append(UIMenu(title: gatedSectionTitle, options: .displayInline, children: gatedActions))
         }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputReasoningMenuFactory.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputReasoningMenuFactory.swift
@@ -33,10 +33,16 @@ struct UnifiedToggleInputReasoningMenuFactory {
         model: AIChatModel,
         selectedMode: AIChatReasoningMode?,
         userTier: AIChatUserTier,
+        freeTrialEligibility: FreeTrialEligibility = .unknown,
         onSelect: @escaping (AIChatReasoningMode) -> Void
     ) -> UIMenu? {
         if isUpdatedModelPickerEnabled {
-            return makeUpdatedMenu(model: model, selectedMode: selectedMode, userTier: userTier, onSelect: onSelect)
+            return makeUpdatedMenu(
+                model: model,
+                selectedMode: selectedMode,
+                userTier: userTier,
+                freeTrialEligibility: freeTrialEligibility,
+                onSelect: onSelect)
         }
 
         return makeLegacyMenu(model: model, selectedMode: selectedMode, onSelect: onSelect)
@@ -67,6 +73,7 @@ struct UnifiedToggleInputReasoningMenuFactory {
         model: AIChatModel,
         selectedMode: AIChatReasoningMode?,
         userTier: AIChatUserTier,
+        freeTrialEligibility: FreeTrialEligibility,
         onSelect: @escaping (AIChatReasoningMode) -> Void
     ) -> UIMenu? {
         guard model.supportsReasoningPicker else { return nil }
@@ -81,7 +88,9 @@ struct UnifiedToggleInputReasoningMenuFactory {
             let gatedActions = gatedModes.map { mode in
                 makeUpdatedAction(mode: mode, selectedMode: selectedMode, isGated: true, onSelect: onSelect)
             }
-            let gatedSectionTitle = userTier == .plus ? UserText.aiChatModelPickerProPlanExclusive : UserText.aiChatModelPickerTryFree
+            let gatedSectionTitle = UnifiedToggleInputGatedSectionTitleResolver.title(
+                for: userTier,
+                freeTrialEligibility: freeTrialEligibility)
             children.append(UIMenu(title: gatedSectionTitle, options: .displayInline, children: gatedActions))
         }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputReasoningMenuFactory.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputReasoningMenuFactory.swift
@@ -81,7 +81,7 @@ struct UnifiedToggleInputReasoningMenuFactory {
             let gatedActions = gatedModes.map { mode in
                 makeUpdatedAction(mode: mode, selectedMode: selectedMode, isGated: true, onSelect: onSelect)
             }
-            let gatedSectionTitle = userTier == .plus ? UserText.aiChatModelPickerAvailableWithPro : UserText.aiChatModelPickerTryFree
+            let gatedSectionTitle = userTier == .plus ? UserText.aiChatModelPickerProPlanExclusive : UserText.aiChatModelPickerTryFree
             children.append(UIMenu(title: gatedSectionTitle, options: .displayInline, children: gatedActions))
         }
 

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2344,6 +2344,7 @@ public struct UserText {
     public static let aiChatPlusModelsSectionHeader = NotLocalizedString("aichat.model-picker.plus-section-header", value: "Plus", comment: "Section header in the model picker menu for models available from the DuckDuckGo Plus tier")
     public static let aiChatProModelsSectionHeader = NotLocalizedString("aichat.model-picker.pro-section-header", value: "Pro", comment: "Section header in the model picker menu for models available from the DuckDuckGo Pro tier")
     public static let aiChatModelPickerTryFree = NotLocalizedString("aichat.model-picker.try-free", value: "Try Free for 7 Days", comment: "Section header for subscription models shown to free users")
+    public static let aiChatModelPickerSubscriberExclusive = NotLocalizedString("aichat.model-picker.subscriber-exclusive", value: "Subscriber Exclusive", comment: "Section header for subscription models shown to users who are not eligible for a free trial")
     public static let aiChatModelPickerProPlanExclusive = NotLocalizedString("aichat.model-picker.pro-plan-exclusive", value: "Pro Plan Exclusive", comment: "Section header for Pro-only models shown to DuckDuckGo Plus subscribers")
     public static let aiChatModelPickerEffortTitle = NotLocalizedString(
         "aichat.model-picker.effort-title",

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2344,7 +2344,7 @@ public struct UserText {
     public static let aiChatPlusModelsSectionHeader = NotLocalizedString("aichat.model-picker.plus-section-header", value: "Plus", comment: "Section header in the model picker menu for models available from the DuckDuckGo Plus tier")
     public static let aiChatProModelsSectionHeader = NotLocalizedString("aichat.model-picker.pro-section-header", value: "Pro", comment: "Section header in the model picker menu for models available from the DuckDuckGo Pro tier")
     public static let aiChatModelPickerTryFree = NotLocalizedString("aichat.model-picker.try-free", value: "Try Free for 7 Days", comment: "Section header for subscription models shown to free users")
-    public static let aiChatModelPickerAvailableWithPro = NotLocalizedString("aichat.model-picker.available-with-pro", value: "Available with Pro", comment: "Section header for Pro-only models shown to DuckDuckGo Plus subscribers")
+    public static let aiChatModelPickerProPlanExclusive = NotLocalizedString("aichat.model-picker.pro-plan-exclusive", value: "Pro Plan Exclusive", comment: "Section header for Pro-only models shown to DuckDuckGo Plus subscribers")
     public static let aiChatModelPickerEffortTitle = NotLocalizedString(
         "aichat.model-picker.effort-title",
         value: "Effort",

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2343,7 +2343,7 @@ public struct UserText {
     public static let aiChatBasicModelsSectionHeader = NotLocalizedString("aichat.model-picker.subscribed-basic-section-header", value: "Basic Models", comment: "Section header in the model picker menu for basic/free models when the user has an active subscription")
     public static let aiChatPlusModelsSectionHeader = NotLocalizedString("aichat.model-picker.plus-section-header", value: "Plus", comment: "Section header in the model picker menu for models available from the DuckDuckGo Plus tier")
     public static let aiChatProModelsSectionHeader = NotLocalizedString("aichat.model-picker.pro-section-header", value: "Pro", comment: "Section header in the model picker menu for models available from the DuckDuckGo Pro tier")
-    public static let aiChatModelPickerTryFree = NotLocalizedString("aichat.model-picker.try-free", value: "Try Free for 7 Days", comment: "Section header for subscription models shown to free users")
+    public static let aiChatModelPickerTryFree = NotLocalizedString("aichat.model-picker.try-free", value: "Try for free", comment: "Section header for subscription models shown to free users")
     public static let aiChatModelPickerSubscriberExclusive = NotLocalizedString("aichat.model-picker.subscriber-exclusive", value: "Subscriber Exclusive", comment: "Section header for subscription models shown to users who are not eligible for a free trial")
     public static let aiChatModelPickerProPlanExclusive = NotLocalizedString("aichat.model-picker.pro-plan-exclusive", value: "Pro Plan Exclusive", comment: "Section header for Pro-only models shown to DuckDuckGo Plus subscribers")
     public static let aiChatModelPickerEffortTitle = NotLocalizedString(

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarAttachmentControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarAttachmentControllerTests.swift
@@ -38,7 +38,8 @@ final class IPadOmnibarAttachmentControllerTests: XCTestCase {
         store = UTIModelStore(
             modelsService: StubAttachmentModelsService(),
             preferences: preferences,
-            subscriptionManager: SubscriptionManagerMock()
+            subscriptionManager: SubscriptionManagerMock(),
+            isUpdatedModelPickerEnabled: false
         )
         // In production the models fetch also returns attachment limits; without them the validator
         // treats the per-turn image allowance as 0, so `canAttachImages` (and the attach menu) is

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarModelPickerControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarModelPickerControllerTests.swift
@@ -128,7 +128,7 @@ final class IPadOmnibarModelPickerControllerTests: XCTestCase {
         XCTAssertEqual(gatedSection?.title, UserText.aiChatModelPickerTryFree)
     }
 
-    func testWhenUpdatedModelPickerIsEnabledForPlusUserThenGatedSectionUsesProTitle() throws {
+    func testWhenUpdatedModelPickerIsEnabledForPlusUserThenGatedSectionUsesProPlanExclusiveTitle() throws {
         sut = makeSUTWithUpdatedModelPickerEnabled(userTier: .plus)
         sut.modelStore.models = [
             makeModel(id: "pro", shortName: "Pro", entityHasAccess: false, accessTier: ["pro"])
@@ -137,7 +137,7 @@ final class IPadOmnibarModelPickerControllerTests: XCTestCase {
         let menu = try XCTUnwrap(sut.makeMenu { _ in })
         let gatedSection = menu.children.compactMap { $0 as? UIMenu }.first
 
-        XCTAssertEqual(gatedSection?.title, UserText.aiChatModelPickerAvailableWithPro)
+        XCTAssertEqual(gatedSection?.title, UserText.aiChatModelPickerProPlanExclusive)
     }
 
     @available(iOS 16.0, *)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarReasoningPickerControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarReasoningPickerControllerTests.swift
@@ -38,7 +38,8 @@ final class IPadOmnibarReasoningPickerControllerTests: XCTestCase {
         store = UTIModelStore(
             modelsService: StubModelsService(),
             preferences: preferences,
-            subscriptionManager: SubscriptionManagerMock()
+            subscriptionManager: SubscriptionManagerMock(),
+            isUpdatedModelPickerEnabled: false
         )
         upsellPresenter = MockUpsellPresenter()
         sut = IPadOmnibarReasoningPickerController(

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarToolPickerControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarToolPickerControllerTests.swift
@@ -37,7 +37,8 @@ final class IPadOmnibarToolPickerControllerTests: XCTestCase {
         store = UTIModelStore(
             modelsService: StubModelsService(),
             preferences: preferences,
-            subscriptionManager: SubscriptionManagerMock()
+            subscriptionManager: SubscriptionManagerMock(),
+            isUpdatedModelPickerEnabled: false
         )
         sut = IPadOmnibarToolPickerController(store: store)
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIModelStoreTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIModelStoreTests.swift
@@ -36,12 +36,7 @@ final class UTIModelStoreTests: XCTestCase {
         preferences = StubPreferences()
         modelsService = StubModelsService()
         subscriptionManager = SubscriptionManagerMock()
-        sut = UTIModelStore(
-            modelsService: modelsService,
-            preferences: preferences,
-            subscriptionManager: subscriptionManager,
-            isUpdatedModelPickerEnabled: false
-        )
+        sut = makeSUT(isUpdatedModelPickerEnabled: false)
     }
 
     override func tearDown() {
@@ -428,7 +423,77 @@ final class UTIModelStoreTests: XCTestCase {
         XCTAssertEqual(sut.subscriptionState.userTier, .free)
     }
 
+    // MARK: - Free Trial Eligibility
+
+    func test_fetchModels_whenUpdatedModelPickerIsDisabled_keepsTrialEligibilityUnknown() {
+        subscriptionManager.isEligibleForFreeTrialResult = true
+
+        sut.fetchModels()
+
+        XCTAssertEqual(sut.freeTrialEligibility, .unknown)
+    }
+
+    func test_whenUpdatedModelPickerIsDisabled_productAvailabilityDoesNotChangeTrialEligibility() async {
+        subscriptionManager.hasAppStoreProductsAvailable = false
+        subscriptionManager.isEligibleForFreeTrialResult = true
+        sut = makeSUT(isUpdatedModelPickerEnabled: false)
+
+        subscriptionManager.hasAppStoreProductsAvailable = true
+        await Task.yield()
+
+        XCTAssertEqual(sut.freeTrialEligibility, .unknown)
+    }
+
+    func test_fetchModels_whenCachedTrialEligibilityChanges_updatesTrialEligibility() {
+        sut = makeSUT(isUpdatedModelPickerEnabled: true)
+        subscriptionManager.isEligibleForFreeTrialResult = true
+
+        sut.fetchModels()
+        XCTAssertEqual(sut.freeTrialEligibility, .eligible)
+
+        subscriptionManager.isEligibleForFreeTrialResult = false
+        sut.fetchModels()
+
+        XCTAssertEqual(sut.freeTrialEligibility, .ineligible)
+    }
+
+    func test_fetchModels_whenPurchasePlatformIsStripe_usesCachedTrialEligibility() {
+        subscriptionManager.currentEnvironment = .init(serviceEnvironment: .staging, purchasePlatform: .stripe)
+        subscriptionManager.hasAppStoreProductsAvailable = false
+        subscriptionManager.isEligibleForFreeTrialResult = false
+        sut = makeSUT(isUpdatedModelPickerEnabled: true)
+
+        sut.fetchModels()
+
+        XCTAssertEqual(sut.freeTrialEligibility, .ineligible)
+    }
+
+    func test_whenAppStoreProductsBecomeAvailable_updatesTrialEligibilityAndNotifies() async {
+        subscriptionManager.hasAppStoreProductsAvailable = false
+        subscriptionManager.isEligibleForFreeTrialResult = true
+        sut = makeSUT(isUpdatedModelPickerEnabled: true)
+        let didUpdate = expectation(description: "trial eligibility updated")
+        sut.onModelsUpdated = {
+            didUpdate.fulfill()
+        }
+
+        XCTAssertEqual(sut.freeTrialEligibility, .unknown)
+        subscriptionManager.hasAppStoreProductsAvailable = true
+
+        await fulfillment(of: [didUpdate], timeout: 1)
+        XCTAssertEqual(sut.freeTrialEligibility, .eligible)
+    }
+
     // MARK: - Helpers
+
+    private func makeSUT(isUpdatedModelPickerEnabled: Bool) -> UTIModelStore {
+        UTIModelStore(
+            modelsService: modelsService,
+            preferences: preferences,
+            subscriptionManager: subscriptionManager,
+            isUpdatedModelPickerEnabled: isUpdatedModelPickerEnabled
+        )
+    }
 
     private func makeLimits() -> AIChatAttachmentTierLimits {
         AIChatAttachmentTierLimits(

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIModelStoreTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIModelStoreTests.swift
@@ -39,7 +39,8 @@ final class UTIModelStoreTests: XCTestCase {
         sut = UTIModelStore(
             modelsService: modelsService,
             preferences: preferences,
-            subscriptionManager: subscriptionManager
+            subscriptionManager: subscriptionManager,
+            isUpdatedModelPickerEnabled: false
         )
     }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputModelMenuTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputModelMenuTests.swift
@@ -178,19 +178,41 @@ final class UnifiedToggleInputModelMenuTests: XCTestCase {
         XCTAssertEqual(availableActions(in: menu).first?.title, "plus")
     }
 
-    func testWhenUpdatedMenuFreeUserHasGatedModelsThenUsesTryFreeTitle() {
+    func testWhenUpdatedMenuFreeUserTrialEligibilityIsUnknownThenUsesTryFreeTitle() {
         let menu = makeUpdatedMenu(
             models: [makeFakeModel(id: "plus", accessTier: ["plus"], hasAccess: false)],
-            userTier: .free
+            userTier: .free,
+            freeTrialEligibility: .unknown
         )
 
         XCTAssertEqual(gatedSection(in: menu)?.title, UserText.aiChatModelPickerTryFree)
     }
 
+    func testWhenUpdatedMenuFreeUserIsEligibleForTrialThenUsesTryFreeTitle() {
+        let menu = makeUpdatedMenu(
+            models: [makeFakeModel(id: "plus", accessTier: ["plus"], hasAccess: false)],
+            userTier: .free,
+            freeTrialEligibility: .eligible
+        )
+
+        XCTAssertEqual(gatedSection(in: menu)?.title, UserText.aiChatModelPickerTryFree)
+    }
+
+    func testWhenUpdatedMenuFreeUserIsIneligibleForTrialThenUsesSubscriberExclusiveTitle() {
+        let menu = makeUpdatedMenu(
+            models: [makeFakeModel(id: "plus", accessTier: ["plus"], hasAccess: false)],
+            userTier: .free,
+            freeTrialEligibility: .ineligible
+        )
+
+        XCTAssertEqual(gatedSection(in: menu)?.title, UserText.aiChatModelPickerSubscriberExclusive)
+    }
+
     func testWhenUpdatedMenuPlusUserHasGatedModelsThenUsesProPlanExclusiveTitle() {
         let menu = makeUpdatedMenu(
             models: [makeFakeModel(id: "pro", accessTier: ["pro"], hasAccess: false)],
-            userTier: .plus
+            userTier: .plus,
+            freeTrialEligibility: .ineligible
         )
 
         XCTAssertEqual(gatedSection(in: menu)?.title, UserText.aiChatModelPickerProPlanExclusive)
@@ -250,12 +272,14 @@ final class UnifiedToggleInputModelMenuTests: XCTestCase {
     private func makeUpdatedMenu(
         models: [AIChatModel],
         selectedId: String? = nil,
-        userTier: AIChatUserTier = .free
+        userTier: AIChatUserTier = .free,
+        freeTrialEligibility: FreeTrialEligibility = .unknown
     ) -> UIMenu {
         UnifiedToggleInputModelMenuFactory(isUpdatedModelPickerEnabled: true).makeMenu(
             models: models,
             selectedId: selectedId,
             userTier: userTier,
+            freeTrialEligibility: freeTrialEligibility,
             onSelect: { _ in }
         )
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputModelMenuTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputModelMenuTests.swift
@@ -187,13 +187,13 @@ final class UnifiedToggleInputModelMenuTests: XCTestCase {
         XCTAssertEqual(gatedSection(in: menu)?.title, UserText.aiChatModelPickerTryFree)
     }
 
-    func testWhenUpdatedMenuPlusUserHasGatedModelsThenUsesAvailableWithProTitle() {
+    func testWhenUpdatedMenuPlusUserHasGatedModelsThenUsesProPlanExclusiveTitle() {
         let menu = makeUpdatedMenu(
             models: [makeFakeModel(id: "pro", accessTier: ["pro"], hasAccess: false)],
             userTier: .plus
         )
 
-        XCTAssertEqual(gatedSection(in: menu)?.title, UserText.aiChatModelPickerAvailableWithPro)
+        XCTAssertEqual(gatedSection(in: menu)?.title, UserText.aiChatModelPickerProPlanExclusive)
     }
 
     func testWhenUpdatedMenuAvailableModelsHaveMixedRecommendationLabelsThenDoesNotAddSectionSeparator() {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputReasoningMenuFactoryTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputReasoningMenuFactoryTests.swift
@@ -75,17 +75,14 @@ final class UnifiedToggleInputReasoningMenuFactoryTests: XCTestCase {
 
     func testWhenUpdatedModelPickerIsEnabledThenMenuGroupsGatedModes() throws {
         sut = UnifiedToggleInputReasoningMenuFactory(isUpdatedModelPickerEnabled: true)
-        let model = makeReasoningModel(
-            id: "gpt-5.2",
-            supportedReasoningEffort: [.none, .low, .medium],
-            reasoningEffortAccess: [
-                AIChatReasoningEffortAccess(effort: .none, accessTier: ["free"], entityHasAccess: true),
-                AIChatReasoningEffortAccess(effort: .low, accessTier: ["free"], entityHasAccess: true),
-                AIChatReasoningEffortAccess(effort: .medium, accessTier: ["plus"], entityHasAccess: false)
-            ]
-        )
+        let model = makeModelWithGatedExtendedReasoning()
 
-        let menu = try XCTUnwrap(sut.makeMenu(model: model, selectedMode: .fast, userTier: .free) { _ in })
+        let menu = try XCTUnwrap(sut.makeMenu(
+            model: model,
+            selectedMode: .fast,
+            userTier: .free,
+            freeTrialEligibility: .unknown,
+            onSelect: { _ in }))
         let availableActions = menu.children.compactMap { $0 as? UIAction }
         let gatedSection = try XCTUnwrap(menu.children.compactMap { $0 as? UIMenu }.first)
 
@@ -94,7 +91,34 @@ final class UnifiedToggleInputReasoningMenuFactoryTests: XCTestCase {
         XCTAssertEqual(gatedSection.children.compactMap { ($0 as? UIAction)?.title }, ["Extended Reasoning…"])
     }
 
+    func testWhenUpdatedMenuFreeUserIsIneligibleForTrialThenUsesSubscriberExclusiveTitle() throws {
+        sut = UnifiedToggleInputReasoningMenuFactory(isUpdatedModelPickerEnabled: true)
+        let model = makeModelWithGatedExtendedReasoning()
+
+        let menu = try XCTUnwrap(sut.makeMenu(
+            model: model,
+            selectedMode: .fast,
+            userTier: .free,
+            freeTrialEligibility: .ineligible,
+            onSelect: { _ in }))
+        let gatedSection = try XCTUnwrap(menu.children.compactMap { $0 as? UIMenu }.first)
+
+        XCTAssertEqual(gatedSection.title, UserText.aiChatModelPickerSubscriberExclusive)
+    }
+
     // MARK: - Helpers
+
+    private func makeModelWithGatedExtendedReasoning() -> AIChatModel {
+        makeReasoningModel(
+            id: "gpt-5.2",
+            supportedReasoningEffort: [.none, .low, .medium],
+            reasoningEffortAccess: [
+                AIChatReasoningEffortAccess(effort: .none, accessTier: ["free"], entityHasAccess: true),
+                AIChatReasoningEffortAccess(effort: .low, accessTier: ["free"], entityHasAccess: true),
+                AIChatReasoningEffortAccess(effort: .medium, accessTier: ["plus"], entityHasAccess: false)
+            ]
+        )
+    }
 
     private func makeReasoningModel(
         id: String,


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1217486676313049?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

Adds support for different gated model section header title, based on trial eligibility.
  - Free tier, trial available -> header is `Try Free for 7 Days` for both model + picker
  - Free tier, trial unavilable -> `Subscriber Exclusive` for both model + picker
  - Plus tier -> `Pro Plan Exclusive` for both model + picker
  
Eligibility starts in an unknown state and preserves existing `Try Free for 7 Days` copy until subscription information becomes available. Subscription availability is observed only while `updatedModelPicker` is enabled, leaving legacy picker behavior unchanged.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->

Pick one of the options. Option 2 is sufficient. I tested this using Option 1 and it was working correctly.

#### Option 1: Sandbox account
Setup: use Sandbox tester account that previously completed purchases for this app.

1. Install and launch `iOS Browser Alpha` on physical device with `updatedModelPicker` enabled.
2. Verify device is signed in to same Sandbox tester account for App Store purchases.
3. Tap address bar and open model picker.
4. Find gated model section → header displays `Subscriber Exclusive` (trial unavailable because previously a purchase with this account was made)
5. Open reasoning picker for model with gated reasoning effort → gated section header displays `Subscriber Exclusive`.
6. In App Store Connect, go to **Users and Access → Sandbox → Testers** and select your tester.
7. Tap **Clear Purchase History** at top of tester page and confirm reset.
8. Terminate and relaunch `iOS Browser Alpha`.
9. Tap address bar and open model picker → gated section header displays `Try Free for 7 Days`.
10. Open reasoning picker for model with gated reasoning effort → gated section header displays `Try Free for 7 Days`

#### Option 2: Local eligibility override

1. In `StorePurchaseManager.swift`, temporarily make `DefaultStorePurchaseManager.isUserEligibleForFreeTrial()` return `true`.
2. Launch `iOS Browser Alpha` with `updatedModelPicker` enabled.
3. Tap address bar and open model picker → gated section header displays `Try Free for 7 Days`.
4. Open reasoning picker for model with gated reasoning effort → gated section header displays `Try Free for 7 Days`.
5. Change temporary return value to `false` and relaunch app.
6. Open model picker → gated section header displays `Subscriber Exclusive`.
7. Open reasoning picker for model with gated reasoning effort → gated section header displays `Subscriber Exclusive`.
8. Remove local override before finishing review.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low. Change affects section-header copy in updated model and reasoning pickers for gated content.


#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->
- Stale eligibility could show incorrect gated-section copy → existing subscription product updates and each model fetch refresh cached eligibility, with state transitions covered by unit tests.
- Legacy picker could react to subscription product updates unnecessarily → subscription observation is limited to `updatedModelPicker`, with disabled-flag behavior covered by unit tests.
- Unknown eligibility intentionally retains `Try Free for 7 Days` to preserve current behavior while subscription data loads.
- Existing Subscription package remains source of truth for App Store and Stripe eligibility.
- No new subscription request, user data collection, or measurement is introduced.

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UX in a feature-flagged picker; eligibility uses existing subscription APIs with no new data collection or purchase flows.
> 
> **Overview**
> When the **updated model picker** is on, gated sections in the model and reasoning menus now use **trial eligibility** from the existing subscription manager—not only Plus vs free tier.
> 
> **`UTIModelStore`** tracks `FreeTrialEligibility` (`unknown`, `eligible`, `ineligible`), refreshes it on model fetch and when App Store product availability changes, and notifies pickers so menus can rebuild. Legacy picker paths keep eligibility **unknown** and skip subscription observation.
> 
> **`UnifiedToggleInputGatedSectionTitleResolver`** centralizes section titles: Plus → **Pro Plan Exclusive**; free + ineligible → **Subscriber Exclusive**; otherwise **Try for free** (updated string; unknown stays on try-free copy until subscription data loads). iPhone omnibar, iPad omnibar, and UTI coordinators pass `freeTrialEligibility` into the menu factories.
> 
> Unit tests cover eligibility transitions, Stripe cache behavior, and the new title matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e78480b67b4bcd4ff2053c15e37e7d61ede0402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->