### PR TITLE
Fix crash & keep the tab bar's item count in sync when an insert re-enters

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -1545,6 +1545,10 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
     }
 
     private var frozenLayout = false
+    /// Selection an in-flight insert is about to apply. `sizeForItemAt` runs synchronously
+    /// from `insertItems(at:)`, before the view model publishes the new `selectionIndex`, so
+    /// it consults this to size the inserted tab as selected and the outgoing one as not.
+    private var incomingSelectionIndex: TabIndex?
     @Published private var tabMode = TabMode.divided
 
     private func updateTabMode(for numberOfItems: Int? = nil, updateLayout: Bool? = nil) {
@@ -1951,8 +1955,22 @@ extension TabBarViewController: TabCollectionViewModelDelegate {
         let indexPathSet = Set(arrayLiteral: IndexPath(item: index.item))
         if selected {
             clearSelection(animated: true)
+            incomingSelectionIndex = index
         }
-        collectionView.animator().insertItems(at: indexPathSet)
+        defer { incomingSelectionIndex = nil }
+
+        // A mutation re-entering between the model update and this callback leaves the
+        // collection view's item count stale; an incremental insert would then raise
+        // NSInternalInconsistencyException, so reconcile with a full reload instead.
+        let modelCount = index.isPinnedTab
+            ? (tabCollectionViewModel.pinnedTabsCollection?.tabs.count ?? 0)
+            : tabCollectionViewModel.tabCollection.tabs.count
+        if collectionView.numberOfItems(inSection: 0) == modelCount - 1 {
+            collectionView.animator().insertItems(at: indexPathSet)
+        } else {
+            Logger.general.error("TabBarViewController: item count out of sync on insert, reloading")
+            collectionView.reloadData()
+        }
         if selected {
             collectionView.selectItems(at: indexPathSet, scrollPosition: .centeredHorizontally)
             collectionView.scrollToSelected()
@@ -2073,6 +2091,21 @@ extension TabBarViewController: TabCollectionViewModelDelegate {
 
         if selected {
             clearSelection()
+            incomingSelectionIndex = .unpinned(lastIndex)
+        }
+        defer { incomingSelectionIndex = nil }
+
+        // See `tabCollectionViewModelDidInsert(_:at:selected:)` on the count check.
+        guard collectionView.numberOfItems(inSection: 0) == tabCollectionViewModel.tabCollection.tabs.count - 1 else {
+            Logger.general.error("TabBarViewController: item count out of sync on append, reloading")
+            collectionView.reloadData()
+            if selected {
+                collectionView.selectItems(at: lastIndexPathSet, scrollPosition: .centeredHorizontally)
+            }
+            scrollCollectionViewToEnd()
+            updateEmptyTabArea()
+            hideTabPreview()
+            return
         }
 
         if tabMode == .divided {
@@ -2156,7 +2189,11 @@ extension TabBarViewController: NSCollectionViewDelegateFlowLayout {
         guard collectionView != pinnedTabsCollectionView else {
             return NSSize(width: pinnedTabWidth, height: pinnedTabHeight)
         }
-        let isItemSelected = tabCollectionViewModel.selectionIndex == .unpinned(indexPath.item)
+        // During an insert the view model's `selectionIndex` is not updated yet — the
+        // delegate is notified first so the item count stays in sync — so prefer the
+        // in-flight selection when there is one.
+        let selectionIndex = incomingSelectionIndex ?? tabCollectionViewModel.selectionIndex
+        let isItemSelected = selectionIndex == .unpinned(indexPath.item)
         return NSSize(width: self.currentTabWidth(selected: isItemSelected), height: standardTabHeight)
     }
 

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -2087,7 +2087,6 @@ extension TabBarViewController: TabCollectionViewModelDelegate {
         if frozenLayout {
             updateLayout()
         }
-        updateTabMode(for: collectionView.numberOfItems(inSection: 0) + 1)
 
         if selected {
             clearSelection()
@@ -2095,18 +2094,25 @@ extension TabBarViewController: TabCollectionViewModelDelegate {
         }
         defer { incomingSelectionIndex = nil }
 
+        let collectionViewItemCount = collectionView.numberOfItems(inSection: 0)
+        let modelItemCount = tabCollectionViewModel.tabCollection.tabs.count
+
         // See `tabCollectionViewModelDidInsert(_:at:selected:)` on the count check.
-        guard collectionView.numberOfItems(inSection: 0) == tabCollectionViewModel.tabCollection.tabs.count - 1 else {
+        guard collectionViewItemCount == modelItemCount - 1 else {
             Logger.general.error("TabBarViewController: item count out of sync on append, reloading")
             collectionView.reloadData()
+            updateTabMode(for: modelItemCount)
             if selected {
                 collectionView.selectItems(at: lastIndexPathSet, scrollPosition: .centeredHorizontally)
+            } else {
+                collectionView.scroll(to: IndexPath(item: lastIndex))
             }
-            scrollCollectionViewToEnd()
             updateEmptyTabArea()
             hideTabPreview()
             return
         }
+
+        updateTabMode(for: collectionViewItemCount + 1)
 
         if tabMode == .divided {
             collectionView.animator().insertItems(at: lastIndexPathSet)

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -446,10 +446,11 @@ final class TabCollectionViewModel: NSObject {
         tabCollection.append(tab: tab)
         handleNewTabPageSideEffects(for: tab)
         let insertionIndex = tabCollection.tabs.indices.index(before: tabCollection.tabs.endIndex)
+        // Notify the delegate before updating selection — see `insert(_:at:selected:)`.
+        delegate?.tabCollectionViewModelDidAppend(self, selected: selected)
         if selected {
             selectUnpinnedTab(at: insertionIndex, forceChange: forceChange)
         }
-        delegate?.tabCollectionViewModelDidAppend(self, selected: selected)
         return insertionIndex
     }
 
@@ -492,11 +493,12 @@ final class TabCollectionViewModel: NSObject {
         }
 
         tabCollection.append(tabs: tabsToAppend)
+        // Notify the delegate before updating selection — see `insert(_:at:selected:)`.
+        delegate?.tabCollectionViewModelDidMultipleChanges(self)
         if shouldSelectLastTab {
             let newSelectionIndex = tabCollection.tabs.count - 1
             selectUnpinnedTab(at: newSelectionIndex)
         }
-        delegate?.tabCollectionViewModelDidMultipleChanges(self)
     }
 
     func append(tabs: [Tab], andSelect shouldSelectLastTab: Bool) {
@@ -537,10 +539,16 @@ final class TabCollectionViewModel: NSObject {
         }()
 
         tabCollection.insert(tabToInsert, at: index.item)
+        // Notify the delegate before updating selection: setting `selectionIndex` publishes
+        // `selectedTabViewModel`, and a subscriber can synchronously insert another tab (a
+        // queued pop-up arriving at `createdChild` while the web view is attached on
+        // selection) while the collection view still holds the pre-insert item count,
+        // raising NSInternalInconsistencyException. The tab bar sizes the incoming tab from
+        // `index`/`selected` — see `TabBarViewController.incomingSelectionIndex`.
+        delegate?.tabCollectionViewModelDidInsert(self, at: index, selected: selected)
         if selected {
             select(at: index)
         }
-        delegate?.tabCollectionViewModelDidInsert(self, at: index, selected: selected)
     }
 
     func insert(_ tab: Tab, at index: TabIndex, selected: Bool = true) {
@@ -745,8 +753,9 @@ final class TabCollectionViewModel: NSObject {
 
             didRemoveTab(movedTab, at: fromIndex, withParent: parentTab)
 
-            otherViewModel.selectWithoutResettingState(at: toIndex)
+            // Notify the delegate before updating selection — see `insert(_:at:selected:)`.
             otherViewModel.delegate?.tabCollectionViewModelDidInsert(otherViewModel, at: toIndex, selected: true)
+            otherViewModel.selectWithoutResettingState(at: toIndex)
         }
     }
 
@@ -848,9 +857,9 @@ final class TabCollectionViewModel: NSObject {
         let newIndex = tabIndex.makeNext()
 
         tabCollection(for: tabIndex)?.insert(tabCopy, at: newIndex.item)
-        select(at: newIndex)
-
+        // Notify the delegate before updating selection — see `insert(_:at:selected:)`.
         delegate?.tabCollectionViewModelDidInsert(self, at: newIndex, selected: true)
+        select(at: newIndex)
     }
 
     func pinTab(at index: Int) {

--- a/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
+++ b/macOS/DuckDuckGo/TabBar/ViewModel/TabCollectionViewModel.swift
@@ -493,12 +493,12 @@ final class TabCollectionViewModel: NSObject {
         }
 
         tabCollection.append(tabs: tabsToAppend)
-        // Notify the delegate before updating selection — see `insert(_:at:selected:)`.
-        delegate?.tabCollectionViewModelDidMultipleChanges(self)
         if shouldSelectLastTab {
             let newSelectionIndex = tabCollection.tabs.count - 1
             selectUnpinnedTab(at: newSelectionIndex)
         }
+        // The delegate reloads the whole collection and needs the final selection for layout.
+        delegate?.tabCollectionViewModelDidMultipleChanges(self)
     }
 
     func append(tabs: [Tab], andSelect shouldSelectLastTab: Bool) {

--- a/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
@@ -338,8 +338,8 @@ final class TabCollectionViewModelTests: XCTestCase {
     }
 
     // Regression tests for APPLE-MACOS-BD7 and APPLE-MACOS-D57: setting `selectionIndex`
-    // from inside `insert`/`append` publishes `selectedTabViewModel`, and subscribers can
-    // synchronously re-enter and mutate tabs. The delegate must be notified before that
+    // from inside incremental `insert`/`append` publishes `selectedTabViewModel`, and subscribers
+    // can synchronously re-enter and mutate tabs. The delegate must be notified before that
     // publication so the collection view's item count stays in sync with the data source.
     // Cell sizing does not depend on this ordering — the tab bar sizes the incoming tab
     // from the `index`/`selected` arguments of the delegate call itself.
@@ -383,8 +383,10 @@ final class TabCollectionViewModelTests: XCTestCase {
         cancellable.cancel()
     }
 
+    // Bulk changes reload the whole collection, so the delegate needs the final selection
+    // rather than the incremental-update ordering asserted above.
     @MainActor
-    func testWhenAppendTabsWithSelectLast_ThenDelegateIsNotifiedBeforeSelectionPublishes() {
+    func testWhenAppendTabsWithSelectLast_ThenSelectionPublishesBeforeDelegateIsNotified() {
         let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
         let delegate = TabCollectionViewModelDelegateMock()
         tabCollectionViewModel.delegate = delegate
@@ -399,7 +401,9 @@ final class TabCollectionViewModelTests: XCTestCase {
 
         tabCollectionViewModel.append(tabs: [.loaded(Tab()), .loaded(Tab())], andSelect: true)
 
-        XCTAssertEqual(didMultipleChangesCalledWhenSelectionPublished, true)
+        XCTAssertEqual(didMultipleChangesCalledWhenSelectionPublished, false)
+        XCTAssertTrue(delegate.didMultipleChangesCalled)
+        XCTAssertEqual(tabCollectionViewModel.selectionIndex, .unpinned(tabCollectionViewModel.tabCollection.tabs.count - 1))
         cancellable.cancel()
     }
 

--- a/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabCollectionViewModelTests.swift
@@ -337,14 +337,14 @@ final class TabCollectionViewModelTests: XCTestCase {
         XCTAssert(tab === tabCollectionViewModel.tabViewModel(at: 2)?.tab)
     }
 
-    // Selection is published BEFORE the delegate notification on insert/append
-    // paths, so cell sizing in the tab bar (which reads `selectionIndex`) sees
-    // the correct value when `sizeForItemAt` runs from `insertItems`. The
-    // materialize-on-select crash this used to guard against is now prevented
-    // structurally by pre-materializing at the API boundary, and the
-    // lazy-loader re-entry is prevented by deferring its sink.
+    // Regression tests for APPLE-MACOS-BD7 and APPLE-MACOS-D57: setting `selectionIndex`
+    // from inside `insert`/`append` publishes `selectedTabViewModel`, and subscribers can
+    // synchronously re-enter and mutate tabs. The delegate must be notified before that
+    // publication so the collection view's item count stays in sync with the data source.
+    // Cell sizing does not depend on this ordering — the tab bar sizes the incoming tab
+    // from the `index`/`selected` arguments of the delegate call itself.
     @MainActor
-    func testWhenInsertWithSelected_ThenSelectionPublishesBeforeDelegate() {
+    func testWhenInsertWithSelected_ThenDelegateIsNotifiedBeforeSelectionPublishes() {
         let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
         let delegate = TabCollectionViewModelDelegateMock()
         tabCollectionViewModel.delegate = delegate
@@ -359,12 +359,12 @@ final class TabCollectionViewModelTests: XCTestCase {
 
         tabCollectionViewModel.insert(Tab(), at: .unpinned(0), selected: true)
 
-        XCTAssertEqual(didInsertCalledWhenSelectionPublished, false)
+        XCTAssertEqual(didInsertCalledWhenSelectionPublished, true)
         cancellable.cancel()
     }
 
     @MainActor
-    func testWhenAppendWithSelected_ThenSelectionPublishesBeforeDelegate() {
+    func testWhenAppendWithSelected_ThenDelegateIsNotifiedBeforeSelectionPublishes() {
         let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
         let delegate = TabCollectionViewModelDelegateMock()
         tabCollectionViewModel.delegate = delegate
@@ -379,12 +379,12 @@ final class TabCollectionViewModelTests: XCTestCase {
 
         tabCollectionViewModel.append(tab: Tab(), selected: true)
 
-        XCTAssertEqual(didAppendCalledWhenSelectionPublished, false)
+        XCTAssertEqual(didAppendCalledWhenSelectionPublished, true)
         cancellable.cancel()
     }
 
     @MainActor
-    func testWhenAppendTabsWithSelectLast_ThenSelectionPublishesBeforeDelegate() {
+    func testWhenAppendTabsWithSelectLast_ThenDelegateIsNotifiedBeforeSelectionPublishes() {
         let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
         let delegate = TabCollectionViewModelDelegateMock()
         tabCollectionViewModel.delegate = delegate
@@ -399,7 +399,36 @@ final class TabCollectionViewModelTests: XCTestCase {
 
         tabCollectionViewModel.append(tabs: [.loaded(Tab()), .loaded(Tab())], andSelect: true)
 
-        XCTAssertEqual(didMultipleChangesCalledWhenSelectionPublished, false)
+        XCTAssertEqual(didMultipleChangesCalledWhenSelectionPublished, true)
+        cancellable.cancel()
+    }
+
+    // Regression test for APPLE-MACOS-D57: a `selectedTabViewModel` subscriber inserting a
+    // tab (a queued pop-up reaching `createdChild` while the web view is attached on
+    // selection) must not find the collection view mid-update. Without the ordering above
+    // the nested insert reports one insertion while the model has grown by two, which is
+    // what NSCollectionView raises NSInternalInconsistencyException for.
+    @MainActor
+    func testWhenSelectionSubscriberInsertsAnotherTab_ThenCollectionViewCountStaysInSync() {
+        let tabCollectionViewModel = TabCollectionViewModel.aTabCollectionViewModel()
+        let initialCount = tabCollectionViewModel.tabCollection.tabs.count
+        let delegate = ItemCountMirroringDelegateMock(mirroring: tabCollectionViewModel)
+        tabCollectionViewModel.delegate = delegate
+
+        var hasReentered = false
+        let cancellable = tabCollectionViewModel.$selectedTabViewModel
+            .dropFirst()
+            .sink { [weak tabCollectionViewModel] _ in
+                guard !hasReentered, let tabCollectionViewModel else { return }
+                hasReentered = true
+                tabCollectionViewModel.insert(Tab(), at: .unpinned(tabCollectionViewModel.tabCollection.tabs.count), selected: false)
+            }
+
+        tabCollectionViewModel.insert(Tab(), at: .unpinned(0), selected: true)
+
+        XCTAssertTrue(hasReentered, "The selection subscriber never re-entered, so the test proves nothing")
+        XCTAssertEqual(delegate.violations, [])
+        XCTAssertEqual(tabCollectionViewModel.tabCollection.tabs.count, initialCount + 2)
         cancellable.cancel()
     }
 
@@ -1531,6 +1560,53 @@ fileprivate extension TabCollectionViewModel {
         let tabCollection = TabCollection()
         let provider = PinnedTabsManagerProvidingMock()
         return TabCollectionViewModel(tabCollection: tabCollection, pinnedTabsManagerProvider: provider)
+    }
+}
+
+/// Mirrors an `NSCollectionView`'s item count so a test can assert the invariant the real
+/// collection view enforces: the count it already knows about, plus the update it is being
+/// asked to perform, must equal the model's count at that moment.
+@MainActor
+private final class ItemCountMirroringDelegateMock: TabCollectionViewModelDelegate {
+
+    private(set) var violations: [String] = []
+    private var mirroredCount: Int
+
+    /// Seeded like a collection view that has already loaded its data.
+    init(mirroring tabCollectionViewModel: TabCollectionViewModel) {
+        mirroredCount = tabCollectionViewModel.tabCollection.tabs.count
+    }
+
+    func tabCollectionViewModelDidAppend(_ tabCollectionViewModel: TabCollectionViewModel, selected: Bool) {
+        apply(1, in: tabCollectionViewModel, from: "didAppend")
+    }
+
+    func tabCollectionViewModelDidInsert(_ tabCollectionViewModel: TabCollectionViewModel, at index: TabIndex, selected: Bool) {
+        guard index.isUnpinnedTab else { return }
+        apply(1, in: tabCollectionViewModel, from: "didInsert")
+    }
+
+    func tabCollectionViewModel(_ tabCollectionViewModel: TabCollectionViewModel,
+                                didRemoveTabAt removalIndex: Int,
+                                andSelectTabAt selectionIndex: Int?) {
+        apply(-1, in: tabCollectionViewModel, from: "didRemove")
+    }
+
+    func tabCollectionViewModelDidMultipleChanges(_ tabCollectionViewModel: TabCollectionViewModel) {
+        // The tab bar answers this one with `reloadData`, which resynchronises unconditionally.
+        mirroredCount = tabCollectionViewModel.tabCollection.tabs.count
+    }
+
+    func tabCollectionViewModel(_ tabCollectionViewModel: TabCollectionViewModel, didReplaceTabAt index: TabIndex) {}
+    func tabCollectionViewModel(_ tabCollectionViewModel: TabCollectionViewModel, didMoveTabAt index: TabIndex, to newIndex: TabIndex) {}
+    func tabCollectionViewModel(_ tabCollectionViewModel: TabCollectionViewModel, didSelectAt selectionIndex: Int?) {}
+
+    private func apply(_ change: Int, in tabCollectionViewModel: TabCollectionViewModel, from method: String) {
+        let modelCount = tabCollectionViewModel.tabCollection.tabs.count
+        if mirroredCount + change != modelCount {
+            violations.append("\(method): collection view had \(mirroredCount), model has \(modelCount), \(change) applied")
+        }
+        mirroredCount = modelCount
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1217529313084325?focus=true

### Description

A page opening a tab while another one is still opening can crash the window: the tab bar animates a single insertion while the tab list has already grown by two. Notifying the tab bar before the new selection publishes closes the window where that happens.

### Testing Steps

1. Open around twenty tabs so the tab bar enters overflow mode.
2. Press Cmd-T.
   The new tab appears at the full selected width, with no flicker.
3. Click the "+" button.
   The new tab appears at the full selected width, with no flicker.
4. Right-click a link and choose Open Link in New Tab.
   The new tab appears at the full selected width and is selected.
5. Turn off Switch to new tab when opened in Settings, then Cmd-click a link.
   The previously selected tab keeps its width and the new tab is at the unselected width.
6. Right-click a bookmark folder and choose Open All in Current Window.
   The last opened tab ends up selected at the correct width.
7. Right-click a tab and choose Duplicate Tab.
   The copy appears next to the original at the selected width and is selected.
8. Drag a tab out of the window and drop it onto another window.
   The tab arrives selected at the correct width in the destination window.
9. Open https://webbrowsertools.com/popup-blocker/ and allow pop-ups for the page.
   Several tabs open in sequence and the app does not crash.
10. Right-click a tab, choose Pin Tab, then right-click it again and choose Unpin Tab.
    The tab moves between the pinned and unpinned areas at the correct widths.
11. Relaunch with a saved many-tab session.
    The restored selected tab is at the correct width.

### Impact

Medium. The change touches the ordering between the tab model and the tab bar, so a mistake would show up as a wrong tab width, a selection landing on the wrong tab, or the crash it is meant to fix.

#### What could go wrong?

- Another re-entrant path could still reach the tab bar mid-update → the tab bar now compares its own item count against the model before animating and falls back to a full reload, so the worst case is a lost animation and a logged error rather than a crash.
- The incoming tab could be measured against a selection the view model has not applied yet → the tab bar uses the position and selection state passed to it for the duration of the insert, and steps 2 to 8 cover the visible widths.
- Opening several tabs at once could paint the selection on the wrong tab for a frame → the existing selection subscription reconciles it on the next pass; step 6 covers it.

### Quality Considerations

A unit test reproduces the crash by inserting a tab from a selection subscriber and asserting that the counts reported to the tab bar always add up. It fails without this change with the same numbers seen in the crash reports. The tab widths cannot be pinned the same way, because the tab bar view controller is not instantiable in the unit test target, so steps 2 to 8 are the check for those.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering between tab model selection and tab bar updates—a regression could cause wrong selection, tab widths, or reintroduce the collection view crash; mitigated by count checks and full reload fallback.
> 
> **Overview**
> Fixes crashes when a tab opens while another is still opening (e.g. queued pop-ups): the tab bar could animate one insert while the model had already grown by two, triggering `NSInternalInconsistencyException`.
> 
> **Model → tab bar ordering:** On insert, append, batch append, duplicate, and cross-window move, `TabCollectionViewModel` now calls the delegate **before** updating `selectionIndex`. Selection publishes `selectedTabViewModel`, and subscribers can synchronously add another tab; notifying the tab bar first keeps the collection view’s item count aligned with the model.
> 
> **Tab bar defenses:** `TabBarViewController` compares the collection view’s item count to the model before `insertItems`; on mismatch it logs and uses `reloadData()` instead of an incremental insert. **`incomingSelectionIndex`** lets `sizeForItemAt` treat the in-flight insert as selected during the synchronous layout pass before `selectionIndex` updates, avoiding width flicker.
> 
> Unit tests assert delegate-before-selection ordering and re-entrant insert via a count-mirroring delegate mock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 073c77bd263a3fdf2c3fff08dbf63d73fd9d835e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->