### PR TITLE
[macOS] Further Fire Dialog Ship Review feedback

### DIFF
--- a/macOS/DuckDuckGo/Fire/View/FireCoordinator.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireCoordinator.swift
@@ -33,6 +33,10 @@ import AIChat
 protocol FireDialogViewPresenting {
     @MainActor
     func present(in window: NSWindow, completion: (() -> Void)?)
+
+    /// Closes the presented dialog, and does nothing when it is not presented any more.
+    @MainActor
+    func dismiss()
 }
 
 struct FireDialogViewConfig {
@@ -43,11 +47,29 @@ struct FireDialogViewConfig {
 
 typealias FireDialogViewFactory = (_ config: FireDialogViewConfig) -> FireDialogViewPresenting
 
-private struct DefaultFireDialogPresenter: FireDialogViewPresenting {
-    let view: any ModalView
+private final class DefaultFireDialogPresenter: FireDialogViewPresenting {
+    private let view: any ModalView
+    private weak var window: NSWindow?
+    private var isPresented = false
+
+    init(view: any ModalView) {
+        self.view = view
+    }
+
     @MainActor
     func present(in window: NSWindow, completion: (() -> Void)?) {
-        view.show(in: window, completion: completion)
+        self.window = window
+        isPresented = true
+        view.show(in: window) { [weak self] in
+            self?.isPresented = false
+            completion?()
+        }
+    }
+
+    @MainActor
+    func dismiss() {
+        guard isPresented, let window, let sheet = window.attachedSheet else { return }
+        window.endSheet(sheet)
     }
 }
 
@@ -263,6 +285,8 @@ extension FireCoordinator {
             pixelFiring: self.pixelFiring
         )
 
+        var tabsChangedCancellable: AnyCancellable?
+
         let response: FireDialogView.Response = await withCheckedContinuation { (continuation: CheckedContinuation<FireDialogView.Response, Never>) in
             var didResume = false
             func resumeOnce(returning value: FireDialogView.Response) {
@@ -281,10 +305,25 @@ extension FireCoordinator {
                     }
                 )
             )
+
+            // The tabs of the window can change while the dialog is open, without the user doing it
+            // in the browser: a link opened from another app adds a tab and selects it. Let's close the
+            // dialog then.
+            tabsChangedCancellable = tabCollectionViewModel.tabCollection.$tabs
+                .dropFirst()
+                .map { _ in () }
+                .merge(with: tabCollectionViewModel.$selectedTabViewModel.dropFirst().map { _ in () })
+                .sink { _ in
+                    presenter.dismiss()
+                }
+
             presenter.present(in: parentWindow) {
                 resumeOnce(returning: .noAction)
             }
         }
+
+        // The dialog is closed here, so a later change of the tabs is none of its business.
+        tabsChangedCancellable?.cancel()
 
         switch response {
         case .noAction:

--- a/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
+++ b/macOS/DuckDuckGo/Fire/View/FireDialogView.swift
@@ -931,22 +931,22 @@ struct FireDialogView: ModalView {
     private var deleteButtonBackground: LinearGradient {
         LinearGradient(
             stops: [
-                .init(color: Color(singleUseColor: .fireButtonGradientStart), location: 0.116),
+                .init(color: Color(singleUseColor: .fireButtonGradientStart), location: 0),
                 .init(color: Color(singleUseColor: .fireButtonGradientEnd), location: 1.0)
             ],
-            startPoint: UnitPoint(x: 0, y: 0.37),
-            endPoint: UnitPoint(x: 1, y: 0.63)
+            startPoint: UnitPoint(x: -0.20, y: 0),
+            endPoint: UnitPoint(x: 1.20, y: 1)
         )
     }
 
     private var deleteButtonPressedBackground: LinearGradient {
         LinearGradient(
             stops: [
-                .init(color: Color(singleUseColor: .fireButtonPressedGradientStart), location: 0.116),
+                .init(color: Color(singleUseColor: .fireButtonPressedGradientStart), location: 0),
                 .init(color: Color(singleUseColor: .fireButtonPressedGradientEnd), location: 1.0)
             ],
-            startPoint: UnitPoint(x: 0, y: 0.37),
-            endPoint: UnitPoint(x: 1, y: 0.63)
+            startPoint: UnitPoint(x: -0.20, y: 0),
+            endPoint: UnitPoint(x: 1.20, y: 1)
         )
     }
 

--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -302,6 +302,13 @@ final class FireDialogViewModel: ObservableObject {
 
     private static func isCurrentTabOptionEnabled(for tab: Tab?) -> Bool {
         guard let tab else { return true }
+
+        // This check is here to catch cases when Fire Dialog is opened for a freshly burned tab that wasn't closed.
+        // In that case such tab isn't recorded in history and we're unable to present a history item for it,
+        // and effectively burning a tab wouldn't delete any history items.
+        let hasVisitWithHistoryItems = tab.localHistory.contains(where: { $0.historyEntry != nil })
+        guard hasVisitWithHistoryItems else { return false }
+
         return tab.content.isExternalUrl || tab.canGoBack || tab.canGoForward
     }
 
@@ -553,7 +560,7 @@ final class FireDialogViewModel: ObservableObject {
         case .allData:
             self.historyVisits = scopeVisits ?? historyCoordinating.allHistoryVisits ?? []
         case .currentTab:
-            self.historyVisits = tabCollectionViewModel?.selectedTabViewModel?.tab.localHistory ?? []
+            self.historyVisits = tabCollectionViewModel?.selectedTabViewModel?.tab.localHistory.filter({ $0.historyEntry != nil }) ?? []
         case .currentWindow:
             self.historyVisits = tabCollectionViewModel?.localHistory ?? []
         }

--- a/macOS/IntegrationTests/Fire/FireCoordinatorIntegrationTests.swift
+++ b/macOS/IntegrationTests/Fire/FireCoordinatorIntegrationTests.swift
@@ -3368,6 +3368,7 @@ private final class TestPresenter: FireDialogViewPresenting {
     private let handler: (NSWindow?, (() -> Void)?) -> Void
     init(handler: @escaping (NSWindow?, (() -> Void)?) -> Void) { self.handler = handler }
     func present(in window: NSWindow, completion: (() -> Void)?) { handler(window, completion) }
+    func dismiss() {}
 }
 
 // Expected dialog configuration to validate against when presenter is invoked

--- a/macOS/UnitTests/Fire/FireCoordinatorTests.swift
+++ b/macOS/UnitTests/Fire/FireCoordinatorTests.swift
@@ -374,6 +374,56 @@ struct FireCoordinatorTests {
         #expect(mockFireReporting.measureFireDialogDismissedCallCount == 0)
     }
 
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1))) func testPresentFireDialog_whenTabIsAddedWhileDialogIsOpen_thenDialogIsClosed() async throws {
+        // Scenario: A link opened from another app adds a tab to the window while the dialog is open.
+        // Expectation: The dialog is closed, and it deletes nothing, because what it shows was read
+        // when it opened and no longer matches the tabs of the window.
+
+        var presenter: SheetLikeFireDialogPresenter?
+        var wasClosedByTabsChange = false
+        let factory: FireDialogViewFactory = { _ in
+            let sheetLikePresenter = SheetLikeFireDialogPresenter { [self] in
+                _ = tabCollectionViewModel.append(tab: Tab(content: .newtab))
+                wasClosedByTabsChange = (presenter?.dismissCallCount ?? 0) >= 1
+                // Finish the presentation, so that a regression fails here and not on the time limit.
+                presenter?.complete()
+            }
+            presenter = sheetLikePresenter
+            return sheetLikePresenter
+        }
+        let coordinator = makeCoordinator(fireDialogViewFactory: factory)
+
+        let response = await coordinator.presentFireDialog(mode: .fireButton, in: MockWindow(isVisible: false), settings: nil)
+
+        #expect(wasClosedByTabsChange, "The dialog should be closed when a tab is added")
+        if case .burn = response {
+            Issue.record("A closed dialog should delete nothing")
+        }
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test(.timeLimit(.minutes(1))) func testPresentFireDialog_whenTabIsAddedAfterDialogIsClosed_thenNothingIsDismissed() async throws {
+        // Scenario: The tabs of the window change after the dialog was closed, which is what burning
+        // the data does itself.
+        // Expectation: The closed dialog no longer watches the tabs.
+
+        var presenter: SheetLikeFireDialogPresenter?
+        let factory: FireDialogViewFactory = { config in
+            let sheetLikePresenter = SheetLikeFireDialogPresenter {
+                config.onConfirm(.noAction)
+            }
+            presenter = sheetLikePresenter
+            return sheetLikePresenter
+        }
+        let coordinator = makeCoordinator(fireDialogViewFactory: factory)
+
+        _ = await coordinator.presentFireDialog(mode: .fireButton, in: MockWindow(isVisible: false), settings: nil)
+        _ = tabCollectionViewModel.append(tab: Tab(content: .newtab))
+
+        #expect(presenter?.dismissCallCount == 0, "The dialog was closed by the user, so nothing should dismiss it again")
+    }
+
 }
 
 private final class MockTabCleanupPreparer: TabCleanupPreparing {
@@ -382,6 +432,7 @@ private final class MockTabCleanupPreparer: TabCleanupPreparing {
 
 private final class TestPresenter: FireDialogViewPresenting {
     func present(in window: NSWindow, completion: (() -> Void)?) { }
+    func dismiss() { }
 }
 
 private final class CallbackFireDialogPresenter: FireDialogViewPresenting {
@@ -393,6 +444,36 @@ private final class CallbackFireDialogPresenter: FireDialogViewPresenting {
 
     func present(in window: NSWindow, completion: (() -> Void)?) {
         onPresent()
+    }
+
+    func dismiss() { }
+}
+
+/// A presenter that stays presented until it is dismissed, like the sheet of the real dialog does.
+private final class SheetLikeFireDialogPresenter: FireDialogViewPresenting {
+    private let onPresent: () -> Void
+    private var completion: (() -> Void)?
+    private(set) var dismissCallCount = 0
+
+    init(onPresent: @escaping () -> Void = {}) {
+        self.onPresent = onPresent
+    }
+
+    func present(in window: NSWindow, completion: (() -> Void)?) {
+        self.completion = completion
+        onPresent()
+    }
+
+    func dismiss() {
+        dismissCallCount += 1
+        complete()
+    }
+
+    /// Finishes the presentation, like the sheet does when it closes. Does nothing when finished.
+    func complete() {
+        let completion = self.completion
+        self.completion = nil
+        completion?()
     }
 }
 

--- a/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
+++ b/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
@@ -49,6 +49,12 @@ final class FireDialogViewModelTests: XCTestCase {
 
     private var fireDialogViewResponse: FireDialogView.Response!
 
+    /// Keeps the made history entries alive, because `Visit` refers to its history entry weakly.
+    ///
+    /// An entry that the test does not hold is deallocated at once, and its visit then looks like
+    /// a visit of an already burned tab, which is not what most of the tests here set up.
+    private var historyEntries: [HistoryEntry] = []
+
     @MainActor
     override func setUp() {
         schemeHandler = TestSchemeHandler()
@@ -117,6 +123,7 @@ final class FireDialogViewModelTests: XCTestCase {
         aiChatHistoryCleaner = nil
         dataClearingPreferences = nil
         pixelFiringMock = nil
+        historyEntries = []
     }
 
     @MainActor func testOnBurn_OnboardingContextualDialogsManagerFireButtonUsedCalled() {
@@ -2502,6 +2509,45 @@ final class FireDialogViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.clearingOption, .currentTab, "The dialog should keep the user choice")
     }
 
+    @MainActor func testWhenCurrentTabWasAlreadyBurned_ThenTheScopeIsDisabledAndAllDataIsUsed() {
+        // Scenario: The fire button is used again on a tab that was burned, and that stayed open.
+        // The visits of such a tab are no longer in history, so the scope has no history item to
+        // show, and deleting it would delete nothing.
+        // Expectation: The scope is disabled, the dialog uses All data, and the stored choice stays.
+
+        let mockSettings = MockFireDialogViewSettings(lastSelectedClearingOption: .currentTab)
+        let historyMock = HistoryTabExtensionMock()
+        historyMock.localHistory = [Visit(date: Date(), identifier: "https://example.com".url!, historyEntry: nil)]
+        tabCollectionVM.append(tab: makeTab(url: "https://example.com".url!, historyMock: historyMock))
+        tabCollectionVM.select(at: .unpinned(1))
+
+        let viewModel = makeViewModel(tabCollectionViewModel: tabCollectionVM, settings: mockSettings)
+
+        XCTAssertFalse(viewModel.isCurrentTabOptionEnabled, "The burned tab holds no history item to delete")
+        XCTAssertEqual(viewModel.clearingOption, .allData, "The dialog should use All data")
+        XCTAssertEqual(mockSettings.lastSelectedClearingOption, .currentTab, "The user choice should stay stored")
+    }
+
+    @MainActor func testWhenCurrentTabHasVisitsWithoutHistoryItems_ThenOnlyTheOtherVisitsAreCounted() {
+        // Scenario: A tab that was burned, and that was then used to visit another website. The
+        // burned visits are no longer in history, and the new visit is.
+        // Expectation: The current tab scope counts the new visit only.
+
+        let historyMock = HistoryTabExtensionMock()
+        let entry = makeHistoryEntry(url: "https://example.com")
+        historyMock.localHistory = [
+            Visit(date: Date(), identifier: "https://burned.com".url!, historyEntry: nil),
+            Visit(date: Date(), identifier: entry.url, historyEntry: entry)
+        ]
+        tabCollectionVM.append(tab: makeTab(url: "https://example.com".url!, historyMock: historyMock))
+        tabCollectionVM.select(at: .unpinned(1))
+
+        let viewModel = makeViewModel(with: tabCollectionVM, clearingOption: .currentTab)
+
+        XCTAssertEqual(viewModel.historyItemsCountForCurrentScope, 1, "A visit without a history item should not be counted")
+        XCTAssertEqual(viewModel.historyVisits.first?.historyEntry?.url, entry.url)
+    }
+
     @MainActor func testWhenCurrentTabHasNoDataToDeleteAndAllDataWasSelected_ThenNothingChanges() {
         // Scenario: The user already chose All data, then uses the fire button on a new tab page.
         // Expectation: The scope is disabled, and the stored choice stays as it is.
@@ -3203,15 +3249,17 @@ final class FireDialogViewModelTests: XCTestCase {
     }
 
     private func makeHistoryEntry(url: String) -> HistoryEntry {
-        HistoryEntry(identifier: UUID(),
-                     url: URL(string: url)!,
-                     failedToLoad: false,
-                     numberOfTotalVisits: 1,
-                     lastVisit: Date(),
-                     visits: [],
-                     numberOfTrackersBlocked: 0,
-                     blockedTrackingEntities: [],
-                     trackersFound: false)
+        let entry = HistoryEntry(identifier: UUID(),
+                                 url: URL(string: url)!,
+                                 failedToLoad: false,
+                                 numberOfTotalVisits: 1,
+                                 lastVisit: Date(),
+                                 visits: [],
+                                 numberOfTrackersBlocked: 0,
+                                 blockedTrackingEntities: [],
+                                 trackersFound: false)
+        historyEntries.append(entry)
+        return entry
     }
 
     @MainActor

--- a/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
+++ b/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
@@ -3366,4 +3366,5 @@ private final class TestPresenter: FireDialogViewPresenting {
     private let handler: (NSWindow?, (() -> Void)?) -> Void
     init(handler: @escaping (NSWindow?, (() -> Void)?) -> Void) { self.handler = handler }
     func present(in window: NSWindow, completion: (() -> Void)?) { handler(window, completion) }
+    func dismiss() {}
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1217605079684315?focus=true

### Description
3 changes:
* Delete button gradient got updated
* When you try to burn a freshly burned tab, the "From this tab" mode is not available
* When Fire Dialog is shown and you open a link from an external app, the dialog will now close.

### Testing Steps
1. Verify that the delete button gradient is beautiful 💅 
2. Open a new tab and navigate somewhere. Then burn the current tab without closing it. Then press Fire Button again and verify that "From this tab" mode is not available.
3. Set the browser as default. Open Fire Dialog, and then activate a link from an external app. Verify that a new tab is opened and Fire Dialog gets dismissed.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### Notes
I enabled closing Fire Dialog on activating a link on both Fire Dialog modes: legacy and new one, because it's a nice bug fix.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Fire UI and dialog lifecycle fixes; no changes to core burn execution paths beyond scope eligibility and auto-dismiss behavior.
> 
> **Overview**
> Addresses **ship review feedback** on the macOS Fire dialog with three focused changes.
> 
> **Delete button** — Updates the normal and pressed **linear gradient** on the delete/destructive action (gradient stop positions and diagonal span).
> 
> **“From this tab” after a burn** — When Fire is opened on a tab that was already burned but left open, visits may lack linked **history entries**. The view model now treats **“From this tab”** as disabled (falls back to **All data**) and only counts/lists visits that still have a `historyEntry` for the current-tab scope.
> 
> **Dialog vs. external links** — While the Fire sheet is open, **tab list** or **selected tab** changes (e.g. a link from another app adds and selects a tab) **dismiss the dialog** via a new `dismiss()` on the presenter abstraction, so stale scope is not confirmed. The tab subscription is cancelled once the dialog flow completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa14dc619a827031a5bd2baae53ce9eab0a436cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->