### PR TITLE
iOS: Duck.ai usage-warning footer behind the UTI

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1852,6 +1852,20 @@
 		AABB00010001000100010003 /* UTIRenderStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00010001000100010004 /* UTIRenderStateTests.swift */; };
 		AABB00010001000100010005 /* UTIViewConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00010001000100010006 /* UTIViewConfig.swift */; };
 		AABB00010001000100010007 /* UTIAttachmentPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00010001000100010008 /* UTIAttachmentPolicy.swift */; };
+		FC7EF0020000000000000001 /* UTIFooterWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0010000000000000001 /* UTIFooterWarning.swift */; };
+		FC7EF0020000000000000101 /* UTIFooterCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0010000000000000101 /* UTIFooterCardView.swift */; };
+		FC7EF0020000000000000102 /* UTIFooterUsageRingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0010000000000000102 /* UTIFooterUsageRingView.swift */; };
+		FC7EF0020000000000000002 /* UTIFooterWarningResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0010000000000000002 /* UTIFooterWarningResolver.swift */; };
+		FC7EF0020000000000000003 /* UTIFooterMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0010000000000000003 /* UTIFooterMessage.swift */; };
+		FC7EF0020000000000000004 /* UTIFooterMessageMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0010000000000000004 /* UTIFooterMessageMapper.swift */; };
+		FC7EF0020000000000000005 /* UTIFooterWarningProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0010000000000000005 /* UTIFooterWarningProviding.swift */; };
+		FC7EF0020000000000000006 /* DuckAiUsageLimitsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0010000000000000006 /* DuckAiUsageLimitsStore.swift */; };
+		FC7EF0020000000000000007 /* UTIFooterController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0010000000000000007 /* UTIFooterController.swift */; };
+		FC7EF0040000000000000001 /* UTIFooterWarningResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0030000000000000001 /* UTIFooterWarningResolverTests.swift */; };
+		FC7EF0040000000000000101 /* UTIFooterCardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0030000000000000101 /* UTIFooterCardViewTests.swift */; };
+		FC7EF0040000000000000002 /* UTIFooterMessageMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0030000000000000002 /* UTIFooterMessageMapperTests.swift */; };
+		FC7EF0040000000000000003 /* UTIFooterControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0030000000000000003 /* UTIFooterControllerTests.swift */; };
+		FC7EF0040000000000000004 /* DuckAiUsageLimitsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0030000000000000004 /* DuckAiUsageLimitsStoreTests.swift */; };
 		AABB00010001000100010009 /* UTIAttachmentPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0001000100010001000A /* UTIAttachmentPolicyTests.swift */; };
 		AABB0001000100010001000B /* UTIModelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0001000100010001000C /* UTIModelStore.swift */; };
 		AABB0001000100010001000D /* UTIModelStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB0001000100010001000E /* UTIModelStoreTests.swift */; };
@@ -4729,6 +4743,20 @@
 		AABB00010001000100010004 /* UTIRenderStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIRenderStateTests.swift; sourceTree = "<group>"; };
 		AABB00010001000100010006 /* UTIViewConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIViewConfig.swift; sourceTree = "<group>"; };
 		AABB00010001000100010008 /* UTIAttachmentPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIAttachmentPolicy.swift; sourceTree = "<group>"; };
+		FC7EF0010000000000000001 /* UTIFooterWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterWarning.swift; sourceTree = "<group>"; };
+		FC7EF0010000000000000101 /* UTIFooterCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterCardView.swift; sourceTree = "<group>"; };
+		FC7EF0010000000000000102 /* UTIFooterUsageRingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterUsageRingView.swift; sourceTree = "<group>"; };
+		FC7EF0010000000000000002 /* UTIFooterWarningResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterWarningResolver.swift; sourceTree = "<group>"; };
+		FC7EF0010000000000000003 /* UTIFooterMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterMessage.swift; sourceTree = "<group>"; };
+		FC7EF0010000000000000004 /* UTIFooterMessageMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterMessageMapper.swift; sourceTree = "<group>"; };
+		FC7EF0010000000000000005 /* UTIFooterWarningProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterWarningProviding.swift; sourceTree = "<group>"; };
+		FC7EF0010000000000000006 /* DuckAiUsageLimitsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAiUsageLimitsStore.swift; sourceTree = "<group>"; };
+		FC7EF0010000000000000007 /* UTIFooterController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterController.swift; sourceTree = "<group>"; };
+		FC7EF0030000000000000001 /* UTIFooterWarningResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterWarningResolverTests.swift; sourceTree = "<group>"; };
+		FC7EF0030000000000000101 /* UTIFooterCardViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterCardViewTests.swift; sourceTree = "<group>"; };
+		FC7EF0030000000000000002 /* UTIFooterMessageMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterMessageMapperTests.swift; sourceTree = "<group>"; };
+		FC7EF0030000000000000003 /* UTIFooterControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterControllerTests.swift; sourceTree = "<group>"; };
+		FC7EF0030000000000000004 /* DuckAiUsageLimitsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAiUsageLimitsStoreTests.swift; sourceTree = "<group>"; };
 		AABB0001000100010001000A /* UTIAttachmentPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIAttachmentPolicyTests.swift; sourceTree = "<group>"; };
 		AABB0001000100010001000C /* UTIModelStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIModelStore.swift; sourceTree = "<group>"; };
 		AABB0001000100010001000E /* UTIModelStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIModelStoreTests.swift; sourceTree = "<group>"; };
@@ -10279,6 +10307,7 @@
 				CB27DAF430063B4A00EEEADB /* AITabChromeDecision.swift */,
 				CB27DAFA30064B5100EEEADB /* UnifiedInputTextChangeGate.swift */,
 				CB781CD0301130BC008DCD60 /* Coordinator */,
+				FC7EF0050000000000000001 /* Footer */,
 				CB781CE33013BA7A008DCD60 /* UnifiedToggleInputDisplayState.swift */,
 			);
 			path = UnifiedToggleInput;
@@ -10311,6 +10340,7 @@
 				CB6D17A12FA397FC00ECD5AE /* UnifiedToggleInputPageContextChipViewModelTests.swift */,
 				CB22D7A12FC603EB00128979 /* MainViewControllerRefreshActionTests.swift */,
 				CBE77C732FD2F39800CB7C6D /* Suggestions */,
+				FC7EF0050000000000000002 /* Footer */,
 				2D09A21E8CF1A9B32BC45E19 /* UnifiedToggleInputReasoningMenuFactoryTests.swift */,
 				E71D2723FF8B5622E2904F40 /* DuckAISubscriptionUpsellPresenterTests.swift */,
 				8E7EE5FF3B14EBB6C0AAB71A /* IPadOmnibarReasoningPickerControllerTests.swift */,
@@ -10839,6 +10869,34 @@
 				CB6D17C12FB000000ECD5AE /* AIChatSyncPromoViewTests.swift */,
 			);
 			path = Suggestions;
+			sourceTree = "<group>";
+		};
+		FC7EF0050000000000000001 /* Footer */ = {
+			isa = PBXGroup;
+			children = (
+				FC7EF0010000000000000001 /* UTIFooterWarning.swift */,
+				FC7EF0010000000000000101 /* UTIFooterCardView.swift */,
+				FC7EF0010000000000000102 /* UTIFooterUsageRingView.swift */,
+				FC7EF0010000000000000002 /* UTIFooterWarningResolver.swift */,
+				FC7EF0010000000000000003 /* UTIFooterMessage.swift */,
+				FC7EF0010000000000000004 /* UTIFooterMessageMapper.swift */,
+				FC7EF0010000000000000005 /* UTIFooterWarningProviding.swift */,
+				FC7EF0010000000000000006 /* DuckAiUsageLimitsStore.swift */,
+				FC7EF0010000000000000007 /* UTIFooterController.swift */,
+			);
+			path = Footer;
+			sourceTree = "<group>";
+		};
+		FC7EF0050000000000000002 /* Footer */ = {
+			isa = PBXGroup;
+			children = (
+				FC7EF0030000000000000001 /* UTIFooterWarningResolverTests.swift */,
+				FC7EF0030000000000000101 /* UTIFooterCardViewTests.swift */,
+				FC7EF0030000000000000002 /* UTIFooterMessageMapperTests.swift */,
+				FC7EF0030000000000000003 /* UTIFooterControllerTests.swift */,
+				FC7EF0030000000000000004 /* DuckAiUsageLimitsStoreTests.swift */,
+			);
+			path = Footer;
 			sourceTree = "<group>";
 		};
 		CB781CD0301130BC008DCD60 /* Coordinator */ = {
@@ -14241,6 +14299,15 @@
 				FA57E0030003000300030003 /* UnifiedToggleInputPasteHandler.swift in Sources */,
 				F2B8A10736AA100000C0DE01 /* UnifiedToggleInputAttachment.swift in Sources */,
 				AABB00010001000100010007 /* UTIAttachmentPolicy.swift in Sources */,
+				FC7EF0020000000000000001 /* UTIFooterWarning.swift in Sources */,
+				FC7EF0020000000000000101 /* UTIFooterCardView.swift in Sources */,
+				FC7EF0020000000000000102 /* UTIFooterUsageRingView.swift in Sources */,
+				FC7EF0020000000000000002 /* UTIFooterWarningResolver.swift in Sources */,
+				FC7EF0020000000000000003 /* UTIFooterMessage.swift in Sources */,
+				FC7EF0020000000000000004 /* UTIFooterMessageMapper.swift in Sources */,
+				FC7EF0020000000000000005 /* UTIFooterWarningProviding.swift in Sources */,
+				FC7EF0020000000000000006 /* DuckAiUsageLimitsStore.swift in Sources */,
+				FC7EF0020000000000000007 /* UTIFooterController.swift in Sources */,
 				CB27DAE72FFFE65200EEEADB /* WebViewTransitionGeometry.swift in Sources */,
 				AABB0001000100010001000B /* UTIModelStore.swift in Sources */,
 				AABB0001000100010001000F /* UTIToolsController.swift in Sources */,
@@ -15241,6 +15308,11 @@
 				A1B2C3D4E5F60014A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift in Sources */,
 				F101D53CD31E95F9C9FE2AC1 /* UnifiedToggleInputCoordinatorAttachmentLimitsTests.swift in Sources */,
 				AABB00010001000100010009 /* UTIAttachmentPolicyTests.swift in Sources */,
+				FC7EF0040000000000000001 /* UTIFooterWarningResolverTests.swift in Sources */,
+				FC7EF0040000000000000101 /* UTIFooterCardViewTests.swift in Sources */,
+				FC7EF0040000000000000002 /* UTIFooterMessageMapperTests.swift in Sources */,
+				FC7EF0040000000000000003 /* UTIFooterControllerTests.swift in Sources */,
+				FC7EF0040000000000000004 /* DuckAiUsageLimitsStoreTests.swift in Sources */,
 				AABB00010001000100010101 /* UnifiedToggleInputViewTests.swift in Sources */,
 				AABB00010001000100010201 /* UnifiedToggleInputToggleViewTests.swift in Sources */,
 				6F6446202FDBEE2A00D699B9 /* SuggestionListKeyboardSelectionTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -731,7 +731,8 @@ private extension AIChatContextualSheetCoordinator {
             isFireTab: isFireTab,
             lastUsedModelProvider: duckAiLastUsedModelProvider,
             floatingInputFeature: floatingInputFeature,
-            start: start
+            start: start,
+            footerWarningProvider: duckAiFooterWarningProvider
         )
         host.onAttachRequested = { [weak self] in
             self?.requestManualPageContextAttach()
@@ -956,6 +957,13 @@ private extension AIChatContextualSheetCoordinator {
         let storageHandler = isFireTab ? duckAiFireModeStorageHandler : duckAiNativeStorageHandler
         return storageHandler.map {
             DuckAiLastUsedModelProvider(storage: $0, pixelFiring: DuckAiNativeStoragePixelAdapter())
+        }
+    }
+
+    var duckAiFooterWarningProvider: UTIFooterWarningProviding? {
+        let storageHandler = isFireTab ? duckAiFireModeStorageHandler : duckAiNativeStorageHandler
+        return storageHandler.map {
+            UTIFooterWarningProvider(limitsStore: DuckAiUsageLimitsStore(storageHandler: $0))
         }
     }
     

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -73,7 +73,8 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate, AIChatContextua
         voiceShortcutFeature: DuckAIVoiceShortcutFeatureProviding = DuckAIVoiceShortcutFeature(),
         unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature(),
         floatingInputFeature: AIChatContextualFloatingInputFeatureProviding = AIChatContextualFloatingInputFeature(),
-        start: ContextualInputStart = .expandedOnExistingChat
+        start: ContextualInputStart = .expandedOnExistingChat,
+        footerWarningProvider: UTIFooterWarningProviding? = nil
     ) {
         let isFloatingInputAvailable = floatingInputFeature.isAvailable
         self.hasActiveChat = hasActiveChat
@@ -93,7 +94,8 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate, AIChatContextua
             duckAIWideEventFlowScope: duckAIWideEventFlowScope,
             contextualStart: start,
             attachmentPasteEnabled: unifiedToggleInputFeature.isAttachmentPasteEnabled,
-            placesAttachmentsAboveInput: isFloatingInputAvailable
+            placesAttachmentsAboveInput: isFloatingInputAvailable,
+            footerWarningProvider: footerWarningProvider
         )
         self.chipViewModel = UnifiedToggleInputPageContextChipViewModel(
             originatingURLPublisher: originatingURLPublisher,

--- a/iOS/DuckDuckGo/AIChatDebugView.swift
+++ b/iOS/DuckDuckGo/AIChatDebugView.swift
@@ -17,11 +17,11 @@
 //  limitations under the License.
 //
 
-
 import SwiftUI
 import Combine
 import AIChat
 import AIChatDebugServer
+import os.log
 import DebugServer
 
 struct AIChatDebugView: View {
@@ -35,6 +35,8 @@ struct AIChatDebugView: View {
     var body: some View {
         List {
             AIChatStorageServerSection(duckAiNativeStorageHandler: duckAiNativeStorageHandler)
+
+            AIChatUsageWarningsSection(duckAiNativeStorageHandler: duckAiNativeStorageHandler)
 
             Section(footer: Text("Stored Hostname: \(viewModel.enteredHostname)")) {
                 NavigationLink(destination: AIChatDebugHostnameEntryView(viewModel: viewModel)) {
@@ -299,6 +301,82 @@ private struct AIChatDebugSessionTimerEntryView: View {
             if let seconds = viewModel.contextualSessionTimerSeconds {
                 secondsText = "\(seconds)"
             }
+        }
+    }
+}
+
+private struct AIChatUsageWarningsSection: View {
+
+    private static let presets: [(label: String, weekly: Double?, daily: Double?, hoursUntilReset: Double)] = [
+        ("Weekly 50%", 50, nil, 48),
+        ("Weekly 75%", 75, nil, 48),
+        ("Weekly 90%", 90, nil, 48),
+        ("Weekly limit reached", 100, nil, 168),
+        ("Daily 90%", nil, 90, 5),
+    ]
+
+    let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
+
+    @State private var status: String?
+
+    var body: some View {
+        Section(header: Text(verbatim: "Duck.ai Usage Warnings"),
+                footer: Text(verbatim: status ?? "Writes a synthetic snapshot to the reserved `usageLimits` entry — the same one the web app writes — so the real read path drives the footer. Needs the utiDuckAIWarnings flag on, and is picked up the next time a Duck.ai input is opened.")) {
+            ForEach(Self.presets, id: \.label) { preset in
+                Button {
+                    seed(weekly: preset.weekly, daily: preset.daily, hoursUntilReset: preset.hoursUntilReset)
+                    status = "Seeded \(preset.label) (override + storage). Reopen the Duck.ai input."
+                } label: {
+                    Text(verbatim: preset.label)
+                }
+                .foregroundColor(.primary)
+            }
+
+            Button {
+                clear()
+            } label: {
+                Text(verbatim: "Clear snapshot")
+            }
+            .foregroundColor(.red)
+        }
+    }
+
+    private func seed(weekly: Double?, daily: Double?, hoursUntilReset: Double) {
+        let resetsAtDate = Date().addingTimeInterval(hoursUntilReset * 60 * 60)
+        DuckAiUsageLimitsStore.debugOverride = DuckAiUsageLimits(
+            daily: daily.map { DuckAiUsageLimitWindow(percentUsed: $0, resetsAt: resetsAtDate) },
+            weekly: weekly.map { DuckAiUsageLimitWindow(percentUsed: $0, resetsAt: resetsAtDate) }
+        )
+        guard let duckAiNativeStorageHandler else {
+            status = "Override set; native storage unavailable so nothing was written to it."
+            return
+        }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let resetsAt = formatter.string(from: resetsAtDate)
+        let windows = [("weekly", weekly), ("daily", daily)]
+            .compactMap { name, percent -> String? in
+                guard let percent else { return nil }
+                return "\"\(name)\":{\"percentUsed\":\(percent),\"resetsAt\":\"\(resetsAt)\"}"
+            }
+        let json = "{\(windows.joined(separator: ","))}"
+        do {
+            try duckAiNativeStorageHandler.putEntry(key: DuckAiNativeStorageReservedEntryKeys.usageLimits.rawValue, value: json)
+            Logger.duckAIUsageWarnings.debug("[UsageWarnings] debug seeded usageLimits=\(json, privacy: .public)")
+        } catch {
+            status = "Failed to seed: \(error)"
+            Logger.duckAIUsageWarnings.error("[UsageWarnings] debug seed failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func clear() {
+        DuckAiUsageLimitsStore.debugOverride = nil
+        do {
+            try duckAiNativeStorageHandler?.deleteEntry(key: DuckAiNativeStorageReservedEntryKeys.usageLimits.rawValue)
+            status = "Snapshot cleared."
+            Logger.duckAIUsageWarnings.debug("[UsageWarnings] debug cleared usageLimits")
+        } catch {
+            status = "Failed to clear: \(error)"
         }
     }
 }

--- a/iOS/DuckDuckGo/AIChatDebugView.swift
+++ b/iOS/DuckDuckGo/AIChatDebugView.swift
@@ -36,7 +36,9 @@ struct AIChatDebugView: View {
         List {
             AIChatStorageServerSection(duckAiNativeStorageHandler: duckAiNativeStorageHandler)
 
+#if DEBUG || ALPHA
             AIChatUsageWarningsSection(duckAiNativeStorageHandler: duckAiNativeStorageHandler)
+#endif
 
             Section(footer: Text("Stored Hostname: \(viewModel.enteredHostname)")) {
                 NavigationLink(destination: AIChatDebugHostnameEntryView(viewModel: viewModel)) {
@@ -305,6 +307,8 @@ private struct AIChatDebugSessionTimerEntryView: View {
     }
 }
 
+#if DEBUG || ALPHA
+// Matches the `debugOverride` gate in DuckAiUsageLimitsStore — Release must not carry the override.
 private struct AIChatUsageWarningsSection: View {
 
     private static let presets: [(label: String, weekly: Double?, daily: Double?, hoursUntilReset: Double)] = [
@@ -380,6 +384,7 @@ private struct AIChatUsageWarningsSection: View {
         }
     }
 }
+#endif
 
 private struct AIChatStorageServerSection: View {
     let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/DuckAiUsageLimitsStore.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/DuckAiUsageLimitsStore.swift
@@ -1,0 +1,71 @@
+//
+//  DuckAiUsageLimitsStore.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import Core
+import FeatureFlags_iOS
+import Foundation
+import os.log
+import PrivacyConfig
+
+struct DuckAiUsageLimitsStore {
+
+#if DEBUG || ALPHA
+    @MainActor static var debugOverride: DuckAiUsageLimits?
+#endif
+
+    private let provider: DuckAiUsageLimitsProviding?
+    private let featureFlagger: FeatureFlagger
+
+    init(storageHandler: DuckAiNativeStorageHandling?,
+         featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
+         dateProvider: @escaping () -> Date = Date.init) {
+        self.provider = storageHandler.map {
+            DuckAiUsageLimitsProvider(storage: $0,
+                                      pixelFiring: DuckAiNativeStoragePixelAdapter(),
+                                      dateProvider: dateProvider)
+        }
+        self.featureFlagger = featureFlagger
+    }
+
+    func currentLimits() -> DuckAiUsageLimits? {
+        guard featureFlagger.isFeatureOn(.utiDuckAIWarnings) else {
+            Logger.duckAIUsageWarnings.debug("[UsageWarnings] store inactive: utiDuckAIWarnings flag is off")
+            return nil
+        }
+#if DEBUG || ALPHA
+        if let override = MainActor.assumeIsolated({ Self.debugOverride }) {
+            Logger.duckAIUsageWarnings.debug("[UsageWarnings] using debug override snapshot")
+            return override
+        }
+#endif
+        guard let provider else {
+            Logger.duckAIUsageWarnings.debug("[UsageWarnings] store inactive: no native-storage bridge")
+            return nil
+        }
+        let limits = provider.currentUsageLimits()
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] limits read: daily=\(Self.describe(limits.daily), privacy: .private) weekly=\(Self.describe(limits.weekly), privacy: .private)")
+        return limits
+    }
+
+    private static func describe(_ usage: DuckAiUsageLimitWindow?) -> String {
+        guard let usage else { return "none" }
+        return "\(usage.percentUsed)% resets \(usage.resetsAt)"
+    }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterCardView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterCardView.swift
@@ -1,0 +1,227 @@
+//
+//  UTIFooterCardView.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DesignResourcesKit
+import DesignResourcesKitIcons
+import UIKit
+
+final class UTIFooterCardView: UIView {
+
+    static let overlap: CGFloat = 44
+
+    private enum Constants {
+        static let cornerRadius: CGFloat = 28
+        static let contentTopGap: CGFloat = 12
+        static let contentBottom: CGFloat = 12
+        static let contentLeading: CGFloat = 16
+        static let contentTrailing: CGFloat = 12
+        static let iconSize: CGFloat = 16
+        static let iconTextGap: CGFloat = 10
+        static let textSpacing: CGFloat = 1
+        static let actionSpacing: CGFloat = 8
+        static let primaryButtonHeight: CGFloat = 34
+        static let primaryButtonHorizontalPadding: CGFloat = 14
+        static let dismissSize: CGFloat = 32
+        static let primaryButtonStrokeWidth: CGFloat = 0.5
+    }
+
+    var onPrimaryTap: (() -> Void)?
+    var onDismissTap: (() -> Void)?
+
+    let contentView = UIView()
+
+    private let usageRing = UTIFooterUsageRingView()
+    private let alertIcon = UIImageView(image: DesignSystemImages.Glyphs.Size16.alertRecolorable)
+    private let titleLabel = UILabel()
+    private let subtitleLabel = UILabel()
+    private let primaryButton = UIButton(type: .system)
+    private let dismissButton = UIButton(type: .system)
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with message: UTIFooterMessage, animateIcon: Bool) {
+        switch message.icon {
+        case .usageRing(let progress):
+            usageRing.isHidden = false
+            alertIcon.isHidden = true
+            usageRing.setProgress(progress, animated: animateIcon)
+        case .alert:
+            usageRing.isHidden = true
+            alertIcon.isHidden = false
+        }
+
+        titleLabel.text = message.title
+        subtitleLabel.text = message.subtitle
+        subtitleLabel.isHidden = message.subtitle?.isEmpty ?? true
+
+        if let primaryAction = message.primaryAction {
+            primaryButton.isHidden = false
+            primaryButton.configuration?.title = primaryAction.title
+        } else {
+            primaryButton.isHidden = true
+            primaryButton.configuration?.title = nil
+        }
+
+        dismissButton.isHidden = !message.isDismissible
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            applyColors()
+        }
+    }
+
+    @objc private func primaryTapped() {
+        onPrimaryTap?()
+    }
+
+    @objc private func dismissTapped() {
+        onDismissTap?()
+    }
+}
+
+// MARK: - Setup
+
+private extension UTIFooterCardView {
+
+    func setupUI() {
+        layer.cornerRadius = Constants.cornerRadius
+        layer.cornerCurve = .continuous
+        layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        clipsToBounds = true
+
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(contentView)
+
+        [usageRing, alertIcon].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            $0.setContentHuggingPriority(.required, for: .horizontal)
+            $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+            contentView.addSubview($0)
+        }
+        alertIcon.contentMode = .scaleAspectFit
+        alertIcon.isHidden = true
+
+        for label in [titleLabel, subtitleLabel] {
+            label.numberOfLines = 1
+            label.lineBreakMode = .byTruncatingTail
+            label.adjustsFontForContentSizeCategory = true
+            label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        }
+        titleLabel.font = .daxFootnoteSemibold()
+        subtitleLabel.font = .daxCaption1()
+
+        let textStack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+        textStack.axis = .vertical
+        textStack.alignment = .leading
+        textStack.spacing = Constants.textSpacing
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(textStack)
+
+        primaryButton.translatesAutoresizingMaskIntoConstraints = false
+                primaryButton.configuration = Self.makePrimaryButtonConfiguration()
+        primaryButton.setContentHuggingPriority(.required, for: .horizontal)
+        primaryButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+        primaryButton.addTarget(self, action: #selector(primaryTapped), for: .primaryActionTriggered)
+        contentView.addSubview(primaryButton)
+
+        dismissButton.translatesAutoresizingMaskIntoConstraints = false
+        dismissButton.setImage(DesignSystemImages.Glyphs.Size16.close, for: .normal)
+        dismissButton.accessibilityLabel = UserText.utiDuckAIWarningsDismissAccessibilityLabel
+        dismissButton.setContentHuggingPriority(.required, for: .horizontal)
+        dismissButton.addTarget(self, action: #selector(dismissTapped), for: .primaryActionTriggered)
+        contentView.addSubview(dismissButton)
+
+        let contentTop = contentView.topAnchor.constraint(equalTo: topAnchor, constant: Self.overlap + Constants.contentTopGap)
+        contentTop.priority = .defaultHigh
+
+        NSLayoutConstraint.activate([
+            contentTop,
+            contentView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.contentLeading),
+            contentView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.contentTrailing),
+            contentView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.contentBottom),
+
+            usageRing.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            usageRing.centerYAnchor.constraint(equalTo: textStack.centerYAnchor),
+            usageRing.widthAnchor.constraint(equalToConstant: Constants.iconSize),
+            usageRing.heightAnchor.constraint(equalToConstant: Constants.iconSize),
+
+            alertIcon.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            alertIcon.centerYAnchor.constraint(equalTo: textStack.centerYAnchor),
+            alertIcon.widthAnchor.constraint(equalToConstant: Constants.iconSize),
+            alertIcon.heightAnchor.constraint(equalToConstant: Constants.iconSize),
+
+            textStack.leadingAnchor.constraint(equalTo: usageRing.trailingAnchor, constant: Constants.iconTextGap),
+            textStack.topAnchor.constraint(equalTo: contentView.topAnchor),
+            textStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+
+            textStack.trailingAnchor.constraint(equalTo: primaryButton.leadingAnchor, constant: -Constants.actionSpacing),
+            primaryButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            primaryButton.heightAnchor.constraint(equalToConstant: Constants.primaryButtonHeight),
+            primaryButton.trailingAnchor.constraint(equalTo: dismissButton.leadingAnchor, constant: -Constants.actionSpacing),
+            primaryButton.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor),
+            primaryButton.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor),
+
+            dismissButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            dismissButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            dismissButton.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor),
+            dismissButton.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor),
+            dismissButton.widthAnchor.constraint(equalToConstant: Constants.dismissSize),
+            dismissButton.heightAnchor.constraint(equalToConstant: Constants.dismissSize),
+        ])
+
+        applyColors()
+    }
+
+    static func makePrimaryButtonConfiguration() -> UIButton.Configuration {
+        var configuration = UIButton.Configuration.plain()
+        configuration.cornerStyle = .capsule
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 0,
+                                                              leading: Constants.primaryButtonHorizontalPadding,
+                                                              bottom: 0,
+                                                              trailing: Constants.primaryButtonHorizontalPadding)
+        configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var outgoing = incoming
+            outgoing.font = .daxFootnoteRegular()
+            return outgoing
+        }
+        return configuration
+    }
+
+    func applyColors() {
+        backgroundColor = UIColor(designSystemColor: .surfaceSecondary)
+        titleLabel.textColor = UIColor(designSystemColor: .textPrimary)
+        subtitleLabel.textColor = UIColor(designSystemColor: .textSecondary)
+        alertIcon.tintColor = UIColor(designSystemColor: .icons)
+        dismissButton.tintColor = UIColor(designSystemColor: .iconsSecondary)
+        primaryButton.configuration?.baseForegroundColor = UIColor(designSystemColor: .textPrimary)
+        primaryButton.configuration?.background.backgroundColor = UIColor(designSystemColor: .surfaceCanvas)
+        primaryButton.configuration?.background.strokeColor = UIColor(designSystemColor: .lines)
+        primaryButton.configuration?.background.strokeWidth = Constants.primaryButtonStrokeWidth
+    }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
@@ -1,0 +1,133 @@
+//
+//  UTIFooterController.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import os.log
+import UIKit
+
+@MainActor
+protocol UTIFooterPresenting: AnyObject {
+    func applyFooterMessage(_ message: UTIFooterMessage?)
+}
+
+@MainActor
+final class UTIFooterController {
+
+    typealias Animator = (_ changes: @escaping () -> Void) -> Void
+
+    private enum Constants {
+        static let duration: TimeInterval = 0.4
+        static let damping: CGFloat = 0.85
+    }
+
+    weak var presenter: UTIFooterPresenting?
+
+    var onAction: ((UTIFooterAction) -> Void)?
+
+    private let provider: UTIFooterWarningProviding
+    private let mapper: UTIFooterMessageMapper
+    private let dateProvider: () -> Date
+    private let animator: Animator
+
+    private var lastWarning: UTIFooterWarning?
+    private var dismissedWarnings: Set<UTIFooterWarning> = []
+    private var isSuppressed = false
+
+    private(set) var currentMessage: UTIFooterMessage?
+
+    init(provider: UTIFooterWarningProviding,
+         mapper: UTIFooterMessageMapper = UTIFooterMessageMapper(),
+         dateProvider: @escaping () -> Date = Date.init,
+         animator: Animator? = nil) {
+        self.provider = provider
+        self.mapper = mapper
+        self.dateProvider = dateProvider
+        self.animator = animator ?? Self.springAnimator
+    }
+
+    func refresh() {
+        lastWarning = provider.currentWarning()
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] controller refresh → warning=\(String(describing: self.lastWarning), privacy: .public) suppressed=\(self.isSuppressed, privacy: .public)")
+        applyCurrentState()
+    }
+
+    func resetForPoseChange() {
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] controller reset for pose change")
+        lastWarning = nil
+        currentMessage = nil
+    }
+
+    func setSuppressed(_ suppressed: Bool) {
+        guard isSuppressed != suppressed else { return }
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] controller suppressed=\(suppressed, privacy: .public)")
+        isSuppressed = suppressed
+        applyCurrentState()
+    }
+
+    func dismissCurrent() {
+        guard let lastWarning else { return }
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] controller dismissed \(String(describing: lastWarning), privacy: .public)")
+        dismissedWarnings.insert(lastWarning)
+        applyCurrentState()
+    }
+
+    func performPrimaryAction() {
+        guard let action = currentMessage?.primaryAction?.action else { return }
+        onAction?(action)
+    }
+
+    private func applyCurrentState() {
+        let message = resolveMessage()
+        guard message != currentMessage else {
+            Logger.duckAIUsageWarnings.debug("[UsageWarnings] controller no-op: message unchanged (\(message == nil ? "nil" : "visible", privacy: .public))")
+            return
+        }
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] controller applying: \(message?.title ?? "nil", privacy: .public)")
+        currentMessage = message
+        animator { [weak self] in
+            self?.presenter?.applyFooterMessage(message)
+        }
+    }
+
+    private func resolveMessage() -> UTIFooterMessage? {
+        guard !isSuppressed else {
+            Logger.duckAIUsageWarnings.debug("[UsageWarnings] nothing to show: suppressed (editing or Search mode)")
+            return nil
+        }
+        guard let lastWarning else { return nil }
+        guard !dismissedWarnings.contains(lastWarning) else {
+            Logger.duckAIUsageWarnings.debug("[UsageWarnings] nothing to show: warning was dismissed this session")
+            return nil
+        }
+        return mapper.message(for: lastWarning, now: dateProvider())
+    }
+
+    static let springAnimator: Animator = { changes in
+        guard !UIAccessibility.isReduceMotionEnabled else {
+            changes()
+            return
+        }
+        UIView.animate(withDuration: Constants.duration,
+                       delay: 0,
+                       usingSpringWithDamping: Constants.damping,
+                       initialSpringVelocity: 0,
+                       options: [.beginFromCurrentState, .allowUserInteraction],
+                       animations: changes)
+    }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
@@ -24,6 +24,8 @@ import UIKit
 @MainActor
 protocol UTIFooterPresenting: AnyObject {
     func applyFooterMessage(_ message: UTIFooterMessage?)
+    /// State-only drop of a stored-but-unapplied message; must not touch layout or animate.
+    func clearPendingFooterMessage()
 }
 
 @MainActor
@@ -71,6 +73,9 @@ final class UTIFooterController {
         Logger.duckAIUsageWarnings.debug("[UsageWarnings] controller reset for pose change")
         lastWarning = nil
         currentMessage = nil
+        // Keeps the view's copy in lockstep — otherwise a later refresh that resolves to no
+        // warning no-ops (nil == nil) and the view resurrects the stale card on the next expand.
+        presenter?.clearPendingFooterMessage()
     }
 
     func setSuppressed(_ suppressed: Bool) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterMessage.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterMessage.swift
@@ -1,0 +1,69 @@
+//
+//  UTIFooterMessage.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+enum UTIFooterAction: Equatable {
+    case reduceUsage
+    case switchModel
+}
+
+struct UTIFooterMessage: Equatable {
+
+    enum Icon: Equatable {
+        case usageRing(progress: Double)
+        case alert
+    }
+
+    struct PrimaryAction: Equatable {
+        let title: String
+        let action: UTIFooterAction
+    }
+
+    let icon: Icon
+    let title: String
+    let subtitle: String?
+    let primaryAction: PrimaryAction?
+    let isDismissible: Bool
+}
+
+struct UTIFooterResetDescriber {
+
+    private let formatter: DateComponentsFormatter
+
+    init(locale: Locale = .current) {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = locale
+        let formatter = DateComponentsFormatter()
+        formatter.calendar = calendar
+        formatter.unitsStyle = .full
+        formatter.allowedUnits = [.day, .hour, .minute]
+        formatter.maximumUnitCount = 1
+        self.formatter = formatter
+    }
+
+    func describe(until resetsAt: Date, from now: Date) -> String {
+        let remaining = max(resetsAt.timeIntervalSince(now), Constants.minimumRemaining)
+        return formatter.string(from: remaining) ?? ""
+    }
+
+    private enum Constants {
+        static let minimumRemaining: TimeInterval = 60
+    }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterMessageMapper.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterMessageMapper.swift
@@ -1,0 +1,68 @@
+//
+//  UTIFooterMessageMapper.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+struct UTIFooterMessageMapper {
+
+    private let resetDescriber: UTIFooterResetDescriber
+
+    init(resetDescriber: UTIFooterResetDescriber = UTIFooterResetDescriber()) {
+        self.resetDescriber = resetDescriber
+    }
+
+    func message(for warning: UTIFooterWarning, now: Date) -> UTIFooterMessage {
+        switch warning {
+        case .usageThreshold(let window, let threshold, let resetsAt):
+            UTIFooterMessage(
+                icon: .usageRing(progress: Double(threshold.rawValue) / 100),
+                title: Self.thresholdTitle(percent: threshold.rawValue, window: window),
+                subtitle: subtitle(resetsAt: resetsAt, now: now),
+                primaryAction: .init(title: UserText.utiDuckAIWarningsReduceUsage, action: .reduceUsage),
+                isDismissible: true
+            )
+        case .limitReached(let window, let resetsAt):
+            UTIFooterMessage(
+                icon: .alert,
+                title: Self.limitReachedTitle(window: window),
+                subtitle: subtitle(resetsAt: resetsAt, now: now),
+                primaryAction: .init(title: UserText.utiDuckAIWarningsSwitch, action: .switchModel),
+                isDismissible: true
+            )
+        }
+    }
+
+    private func subtitle(resetsAt: Date, now: Date) -> String {
+        String(format: UserText.utiDuckAIWarningsResetsIn, resetDescriber.describe(until: resetsAt, from: now))
+    }
+
+    private static func thresholdTitle(percent: Int, window: UTIFooterUsageWindow) -> String {
+        switch window {
+        case .weekly: String(format: UserText.utiDuckAIWarningsWeeklyUsageTitle, percent)
+        case .daily: String(format: UserText.utiDuckAIWarningsDailyUsageTitle, percent)
+        }
+    }
+
+    private static func limitReachedTitle(window: UTIFooterUsageWindow) -> String {
+        switch window {
+        case .weekly: UserText.utiDuckAIWarningsWeeklyLimitReached
+        case .daily: UserText.utiDuckAIWarningsDailyLimitReached
+        }
+    }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterUsageRingView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterUsageRingView.swift
@@ -1,0 +1,102 @@
+//
+//  UTIFooterUsageRingView.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DesignResourcesKit
+import UIKit
+
+final class UTIFooterUsageRingView: UIView {
+
+    private enum Constants {
+        static let size: CGFloat = 16
+        static let lineWidth: CGFloat = 2
+        static let progressChangeDuration: TimeInterval = 0.25
+    }
+
+    private let trackLayer = CAShapeLayer()
+    private let progressLayer = CAShapeLayer()
+
+    private var progress: Double = 0
+
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: Constants.size, height: Constants.size)
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isUserInteractionEnabled = false
+        for shape in [trackLayer, progressLayer] {
+            shape.fillColor = UIColor.clear.cgColor
+            shape.lineWidth = Constants.lineWidth
+            shape.lineCap = .round
+            layer.addSublayer(shape)
+        }
+        progressLayer.strokeEnd = 0
+        applyColors()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setProgress(_ progress: Double, animated: Bool) {
+        let clamped = min(max(progress, 0), 1)
+        guard clamped != self.progress else { return }
+        self.progress = clamped
+        guard animated else {
+            progressLayer.removeAnimation(forKey: "strokeEnd")
+            progressLayer.strokeEnd = clamped
+            return
+        }
+        let animation = CABasicAnimation(keyPath: "strokeEnd")
+        animation.fromValue = progressLayer.presentation()?.value(forKey: "strokeEnd") ?? progressLayer.strokeEnd
+        animation.toValue = clamped
+        animation.duration = Constants.progressChangeDuration
+        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        progressLayer.strokeEnd = clamped
+        progressLayer.add(animation, forKey: "strokeEnd")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let inset = Constants.lineWidth / 2
+        let rect = bounds.insetBy(dx: inset, dy: inset)
+        let path = UIBezierPath(arcCenter: CGPoint(x: rect.midX, y: rect.midY),
+                                radius: min(rect.width, rect.height) / 2,
+                                startAngle: -.pi / 2,
+                                endAngle: 3 * .pi / 2,
+                                clockwise: true).cgPath
+        for shape in [trackLayer, progressLayer] {
+            shape.frame = bounds
+            shape.path = path
+        }
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            applyColors()
+        }
+    }
+
+    private func applyColors() {
+        trackLayer.strokeColor = UIColor(designSystemColor: .lines).cgColor
+        progressLayer.strokeColor = UIColor(designSystemColor: .icons).cgColor
+    }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterWarning.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterWarning.swift
@@ -1,5 +1,5 @@
 //
-//  Logger+UnifiedInputState.swift
+//  UTIFooterWarning.swift
 //  DuckDuckGo
 //
 //  Copyright © 2026 DuckDuckGo. All rights reserved.
@@ -18,9 +18,19 @@
 //
 
 import Foundation
-import os.log
 
-extension Logger {
-    static let unifiedInputState = Logger(subsystem: "UnifiedInputState", category: "PerTab")
-    static let duckAIUsageWarnings = Logger(subsystem: "UsageWarnings", category: "UTIFooter")
+enum UTIFooterUsageWindow: Equatable, Hashable {
+    case daily
+    case weekly
+}
+
+enum UTIFooterUsageThreshold: Int, Equatable, Hashable, CaseIterable {
+    case fifty = 50
+    case seventyFive = 75
+    case ninety = 90
+}
+
+enum UTIFooterWarning: Equatable, Hashable {
+    case usageThreshold(window: UTIFooterUsageWindow, threshold: UTIFooterUsageThreshold, resetsAt: Date)
+    case limitReached(window: UTIFooterUsageWindow, resetsAt: Date)
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterWarningProviding.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterWarningProviding.swift
@@ -1,0 +1,43 @@
+//
+//  UTIFooterWarningProviding.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import os.log
+
+protocol UTIFooterWarningProviding {
+    func currentWarning() -> UTIFooterWarning?
+}
+
+struct UTIFooterWarningProvider: UTIFooterWarningProviding {
+
+    private let limitsStore: DuckAiUsageLimitsStore
+    private let resolver: UTIFooterWarningResolver
+
+    init(limitsStore: DuckAiUsageLimitsStore, resolver: UTIFooterWarningResolver = UTIFooterWarningResolver()) {
+        self.limitsStore = limitsStore
+        self.resolver = resolver
+    }
+
+    func currentWarning() -> UTIFooterWarning? {
+        guard let limits = limitsStore.currentLimits() else { return nil }
+        let warning = resolver.resolve(limits: limits)
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] resolved warning: \(String(describing: warning), privacy: .public)")
+        return warning
+    }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterWarningProviding.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterWarningProviding.swift
@@ -41,3 +41,16 @@ struct UTIFooterWarningProvider: UTIFooterWarningProviding {
         return warning
     }
 }
+
+/// Picks the burner or persistent snapshot per read: one omnibar coordinator serves both
+/// normal and fire tabs, so a fire tab must never surface normal-session usage (or vice versa).
+struct UTIFireTabAwareFooterWarningProvider: UTIFooterWarningProviding {
+
+    let normalTabProvider: UTIFooterWarningProviding?
+    let fireTabProvider: UTIFooterWarningProviding?
+    let isFireTab: () -> Bool
+
+    func currentWarning() -> UTIFooterWarning? {
+        (isFireTab() ? fireTabProvider : normalTabProvider)?.currentWarning()
+    }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterWarningResolver.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterWarningResolver.swift
@@ -1,0 +1,51 @@
+//
+//  UTIFooterWarningResolver.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import Foundation
+
+struct UTIFooterWarningResolver {
+
+    func resolve(limits: DuckAiUsageLimits) -> UTIFooterWarning? {
+        let candidates = [
+            warning(for: limits.weekly, window: .weekly),
+            warning(for: limits.daily, window: .daily)
+        ].compactMap { $0 }
+
+        return candidates.max { Self.rank(of: $0) < Self.rank(of: $1) }
+    }
+
+    private func warning(for usage: DuckAiUsageLimitWindow?, window: UTIFooterUsageWindow) -> UTIFooterWarning? {
+        guard let usage else { return nil }
+        guard usage.percentUsed < 100 else {
+            return .limitReached(window: window, resetsAt: usage.resetsAt)
+        }
+        guard let threshold = UTIFooterUsageThreshold.allCases.last(where: { Double($0.rawValue) <= usage.percentUsed }) else {
+            return nil
+        }
+        return .usageThreshold(window: window, threshold: threshold, resetsAt: usage.resetsAt)
+    }
+
+    private static func rank(of warning: UTIFooterWarning) -> Int {
+        switch warning {
+        case .limitReached: 100
+        case .usageThreshold(_, let threshold, _): threshold.rawValue
+        }
+    }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -79,6 +79,7 @@ extension MainViewController {
             isFireTab: isCurrentTabFireTab(),
             hidesToggleOnDuckAITab: unifiedToggleInputFeature.isToggleHiddenOnDuckAITab,
             duckAiNativeStorageHandler: duckAiNativeStorageHandler,
+            duckAiFireModeStorageHandler: duckAiFireModeStorageHandler,
             preferences: aiChatPreferences,
             toggleModeStorage: toggleModeStorage,
             stateStore: stateStore,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -291,6 +291,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         isFireTab: Bool = false,
         hidesToggleOnDuckAITab: Bool = false,
         duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = nil,
+        duckAiFireModeStorageHandler: DuckAiNativeStorageHandling? = nil,
         duckAiNativeStoragePixelFiring: DuckAiNativeStoragePixelFiring = DuckAiNativeStoragePixelAdapter(),
         lastUsedModelProvider: DuckAiLastUsedModelProviding? = nil,
         lastUsedReasoningModeProvider: DuckAiLastUsedReasoningModeProviding? = nil,
@@ -345,14 +346,16 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         self.lastUsedReasoningModeProvider = lastUsedReasoningModeProvider
             ?? duckAiNativeStorageHandler.map { DuckAiLastUsedReasoningModeProvider(storage: $0, pixelFiring: duckAiNativeStoragePixelFiring) }
         self.duckAIWideEventFlowScope = duckAIWideEventFlowScope
-        let resolvedFooterProvider = footerWarningProvider ?? duckAiNativeStorageHandler.map { handler in
-            UTIFooterWarningProvider(limitsStore: DuckAiUsageLimitsStore(storageHandler: handler,
-                                                                        featureFlagger: featureFlagger))
-        }
-        self.footerController = resolvedFooterProvider.map { UTIFooterController(provider: $0) }
         viewController = UnifiedToggleInputViewController(isToggleEnabled: isToggleEnabled,
                                                          isFireTab: isFireTab,
                                                          placesAttachmentsAboveInput: placesAttachmentsAboveInput)
+        let resolvedFooterProvider = footerWarningProvider ?? Self.makeStorageBackedFooterProvider(
+            normalTabStorageHandler: duckAiNativeStorageHandler,
+            fireTabStorageHandler: duckAiFireModeStorageHandler,
+            featureFlagger: featureFlagger,
+            isFireTab: { [handler = viewController.handler] in handler.isFireTab }
+        )
+        self.footerController = resolvedFooterProvider.map { UTIFooterController(provider: $0) }
         contentViewController = UnifiedInputContentContainerViewController(
             switchBarHandler: viewController.handler,
             duckAiNativeStorageHandler: duckAiNativeStorageHandler,
@@ -880,6 +883,26 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     }
 
     // MARK: - Footer Warning
+
+    /// One coordinator serves normal and fire tabs, so the usage snapshot source is
+    /// picked per read rather than bound at init (a fire tab must never read the normal one).
+    private static func makeStorageBackedFooterProvider(normalTabStorageHandler: DuckAiNativeStorageHandling?,
+                                                        fireTabStorageHandler: DuckAiNativeStorageHandling?,
+                                                        featureFlagger: FeatureFlagger,
+                                                        isFireTab: @escaping () -> Bool) -> UTIFooterWarningProviding? {
+        func makeProvider(_ storageHandler: DuckAiNativeStorageHandling?) -> UTIFooterWarningProviding? {
+            storageHandler.map {
+                UTIFooterWarningProvider(limitsStore: DuckAiUsageLimitsStore(storageHandler: $0,
+                                                                             featureFlagger: featureFlagger))
+            }
+        }
+        let normalTabProvider = makeProvider(normalTabStorageHandler)
+        let fireTabProvider = makeProvider(fireTabStorageHandler)
+        guard normalTabProvider != nil || fireTabProvider != nil else { return nil }
+        return UTIFireTabAwareFooterWarningProvider(normalTabProvider: normalTabProvider,
+                                                    fireTabProvider: fireTabProvider,
+                                                    isFireTab: isFireTab)
+    }
 
     private func refreshFooterSuppression() {
         let suppressed = isEditing || inputMode != .aiChat

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -23,6 +23,7 @@ import Combine
 import Core
 import DDGSync
 import os.log
+import PrivacyConfig
 import Subscription
 import UIKit
 import UniformTypeIdentifiers
@@ -280,6 +281,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
     private let duckAIWideEventFlowScope: DuckAIWideEventFlowScope?
 
+    private let footerController: UTIFooterController?
+
     // MARK: - Initialization
 
     init(
@@ -308,7 +311,9 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         contextualStart: ContextualInputStart = .expandedOnExistingChat,
         attachmentPasteEnabled: Bool = false,
         placesAttachmentsAboveInput: Bool = false,
-        updatedModelPickerFeature: UpdatedModelPickerFeatureProviding = UpdatedModelPickerFeature()
+        updatedModelPickerFeature: UpdatedModelPickerFeatureProviding = UpdatedModelPickerFeature(),
+        footerWarningProvider: UTIFooterWarningProviding? = nil,
+        featureFlagger: FeatureFlagger = AppDependencyProvider.shared.featureFlagger
     ) {
         let isUpdatedModelPickerEnabled = updatedModelPickerFeature.isAvailable
         self.host = host
@@ -340,6 +345,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         self.lastUsedReasoningModeProvider = lastUsedReasoningModeProvider
             ?? duckAiNativeStorageHandler.map { DuckAiLastUsedReasoningModeProvider(storage: $0, pixelFiring: duckAiNativeStoragePixelFiring) }
         self.duckAIWideEventFlowScope = duckAIWideEventFlowScope
+        let resolvedFooterProvider = footerWarningProvider ?? duckAiNativeStorageHandler.map { handler in
+            UTIFooterWarningProvider(limitsStore: DuckAiUsageLimitsStore(storageHandler: handler,
+                                                                        featureFlagger: featureFlagger))
+        }
+        self.footerController = resolvedFooterProvider.map { UTIFooterController(provider: $0) }
         viewController = UnifiedToggleInputViewController(isToggleEnabled: isToggleEnabled,
                                                          isFireTab: isFireTab,
                                                          placesAttachmentsAboveInput: placesAttachmentsAboveInput)
@@ -353,6 +363,10 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         floatingReturnKeyViewController = UnifiedToggleInputFloatingReturnKeyViewController()
         super.init()
         viewController.delegate = self
+        footerController?.presenter = viewController
+        footerController?.onAction = { [weak self] action in
+            self?.handleFooterAction(action)
+        }
         textModel = UTITextModel(sideEffects: .init(
             applyTextToView: { [weak self] in self?.viewController.text = $0 },
             persistDraft: { [weak self] in self?.persistDraftToStore() },
@@ -733,6 +747,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         // Pose deferred to the intent handler so the morph animates in sync with the keyboard.
         applyToolbarPresentation()
         viewController.deactivateInput()
+        footerController?.resetForPoseChange()
         intentSubject.send(.showCollapsed(from: previousDisplayState))
     }
 
@@ -758,6 +773,9 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             textModel.markPrefilledSelected()
         }
         updateFloatingReturnKeyState()
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] showExpanded host=\(String(describing: self.host), privacy: .public) mode=\(String(describing: self.inputMode), privacy: .public) controller=\(self.footerController == nil ? "nil" : "present", privacy: .public)")
+        refreshFooterSuppression()
+        footerController?.refresh()
 
         intentSubject.send(.showExpanded(from: previousDisplayState))
         guard activatesInput else { return }
@@ -857,7 +875,20 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
     private func applyEditMode() {
         viewController.setEditMode(isEditing, showsReplaceDisclaimer: isEditing && editHasResponsesToLose)
+        refreshFooterSuppression()
         delegate?.unifiedToggleInputDidChangeEditMode(isEditing)
+    }
+
+    // MARK: - Footer Warning
+
+    private func refreshFooterSuppression() {
+        let suppressed = isEditing || inputMode != .aiChat
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] suppression inputs: isEditing=\(self.isEditing, privacy: .public) mode=\(String(describing: self.inputMode), privacy: .public) → \(suppressed, privacy: .public)")
+        footerController?.setSuppressed(suppressed)
+    }
+
+    private func handleFooterAction(_ action: UTIFooterAction) {
+        Logger.aiChat.debug("[UsageWarnings] footer action: \(String(describing: action), privacy: .public)")
     }
 
     func hide() {
@@ -887,6 +918,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         viewController.apply(renderState.viewConfig, animated: false)
         applyToolbarPresentation()
         viewController.deactivateInput()
+        footerController?.resetForPoseChange()
         intentSubject.send(.hide)
     }
 
@@ -908,6 +940,9 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         resetToolsSelection()
         modelSelector.updateModelChipVisibility()
         syncHasSubmittedPromptToHandler()
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] omnibar session starting mode=\(String(describing: self.inputMode), privacy: .public)")
+        refreshFooterSuppression()
+        footerController?.refresh()
 
         viewController.applyCardLayout(.collapsed, animated: false)
         let renderState = computeRenderState()
@@ -1079,6 +1114,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         if didModeChange {
             attachmentController.syncValidationErrorForCurrentMode()
             recordUserChoiceToStore()
+            refreshFooterSuppression()
         }
     }
 
@@ -1720,6 +1756,14 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
         attachmentsChangeSubject.send()
         updateImageButtonEnabledState()
         updateFloatingReturnKeyState()
+    }
+
+    func unifiedToggleInputVCDidTapFooterPrimaryAction(_ vc: UnifiedToggleInputViewController) {
+        footerController?.performPrimaryAction()
+    }
+
+    func unifiedToggleInputVCDidDismissFooter(_ vc: UnifiedToggleInputViewController) {
+        footerController?.dismissCurrent()
     }
 
     func unifiedToggleInputVCDidChangeHeight(_ vc: UnifiedToggleInputViewController) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -404,6 +404,11 @@ final class UnifiedToggleInputView: UIView {
         return true
     }
 
+    /// State-only: the visual slot release stays inside the pose animation.
+    func clearPendingFooterMessage() {
+        pendingFooterMessage = nil
+    }
+
     private func applyFooterForCardLayout(expanded: Bool) {
         guard expanded else {
             if bottomCardSlot == .footer {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -22,6 +22,7 @@ import Combine
 import DesignResourcesKit
 import DesignResourcesKitIcons
 import UIComponents
+import os.log
 import UIKit
 
 // MARK: - Delegate Protocol
@@ -131,6 +132,9 @@ final class UnifiedToggleInputView: UIView {
         /// Spacing between the inline dismiss button and the field's leading content when the
         /// dismiss shares the field row (toggle disabled, top position).
         static let fieldRowInlineDismissSpacing: CGFloat = 4
+
+        static let footerContentFadeDelay: TimeInterval = 0.06
+        static let footerContentFadeDuration: TimeInterval = 0.15
 
         static let editDisclaimerOverlap: CGFloat = 44
         static let editDisclaimerTopGap: CGFloat = 12
@@ -347,6 +351,8 @@ final class UnifiedToggleInputView: UIView {
     var onAttachmentRemoved: ((UUID, UnifiedToggleInputAttachment, Bool) -> Void)?
     var onInlineDismissTapped: (() -> Void)?
     var onAIChatShortcutTapped: (() -> Void)?
+    var onFooterPrimaryTapped: (() -> Void)?
+    var onFooterDismissTapped: (() -> Void)?
 
     // MARK: - Attachment API
 
@@ -362,10 +368,82 @@ final class UnifiedToggleInputView: UIView {
 
     private func setEditReplaceDisclaimerCardVisible(_ visible: Bool) {
         editReplaceDisclaimerCard.isHidden = !visible
-        cardBottomConstraint.isActive = !visible
-        cardEditBottomConstraint.isActive = visible
-        expandedShadowBottomConstraint.isActive = !visible
-        expandedShadowEditBottomConstraint.isActive = visible
+        applyBottomSlot(visible ? .editDisclaimer : .none)
+    }
+
+    // MARK: - Footer Warning Card
+
+    private enum BottomCardSlot {
+        case none
+        case editDisclaimer
+        case footer
+    }
+
+    private var bottomCardSlot: BottomCardSlot = .none
+
+    private var pendingFooterMessage: UTIFooterMessage?
+
+    @discardableResult
+    func setFooterMessage(_ message: UTIFooterMessage?) -> Bool {
+        pendingFooterMessage = message
+        guard let message else {
+            let wasShowingFooter = bottomCardSlot == .footer
+            Logger.duckAIUsageWarnings.debug("[UsageWarnings] view clearing footer (wasShowing=\(wasShowingFooter, privacy: .public))")
+            applyBottomSlot(editReplaceDisclaimerCard.isHidden ? .none : .editDisclaimer)
+            return wasShowingFooter
+        }
+        guard editReplaceDisclaimerCard.isHidden else {
+            Logger.duckAIUsageWarnings.debug("[UsageWarnings] view rejected: edit disclaimer owns the slot")
+            return false
+        }
+        guard isExpanded else {
+            Logger.duckAIUsageWarnings.debug("[UsageWarnings] view deferred: card not expanded yet (layout=\(String(describing: self.currentLayout), privacy: .public)) — the pose animation will pick it up")
+            return false
+        }
+        applyPendingFooterMessage(message)
+        return true
+    }
+
+    private func applyFooterForCardLayout(expanded: Bool) {
+        guard expanded else {
+            if bottomCardSlot == .footer {
+                Logger.duckAIUsageWarnings.debug("[UsageWarnings] view releasing slot: card no longer expanded")
+                applyBottomSlot(.none)
+            }
+            return
+        }
+        guard let pending = pendingFooterMessage,
+              bottomCardSlot != .footer,
+              editReplaceDisclaimerCard.isHidden else { return }
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] view joining expand animation with pending message")
+        applyPendingFooterMessage(pending)
+        onNeedsHierarchyLayout?()
+    }
+
+    private func applyPendingFooterMessage(_ message: UTIFooterMessage) {
+        let wasVisible = bottomCardSlot == .footer
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] view showing footer '\(message.title, privacy: .public)' (wasVisible=\(wasVisible, privacy: .public))")
+        footerCard.configure(with: message, animateIcon: wasVisible)
+        applyBottomSlot(.footer)
+        guard !wasVisible else { return }
+        footerCard.contentView.alpha = 0
+        UIView.animate(withDuration: Constants.footerContentFadeDuration,
+                       delay: Constants.footerContentFadeDelay,
+                       options: [.curveLinear, .beginFromCurrentState]) {
+            self.footerCard.contentView.alpha = 1
+        }
+    }
+
+    private func applyBottomSlot(_ slot: BottomCardSlot) {
+        bottomCardSlot = slot
+        cardBottomConstraint.isActive = slot == .none
+        cardEditBottomConstraint.isActive = slot == .editDisclaimer
+        cardFooterBottomConstraint.isActive = slot == .footer
+        expandedShadowBottomConstraint.isActive = slot == .none
+        expandedShadowEditBottomConstraint.isActive = slot == .editDisclaimer
+        expandedShadowFooterBottomConstraint.isActive = slot == .footer
+        footerCollapsedHeightConstraint.isActive = slot != .footer
+        footerCard.alpha = slot == .footer ? 1 : 0
     }
 
     private static func makeEditReplaceDisclaimerCard() -> UIView {
@@ -481,6 +559,7 @@ final class UnifiedToggleInputView: UIView {
     private let toolsToolbar = UnifiedToggleInputToolbarView()
 
     private lazy var editReplaceDisclaimerCard = Self.makeEditReplaceDisclaimerCard()
+    private let footerCard = UTIFooterCardView()
     private var pageContextChipCancellables = Set<AnyCancellable>()
 
     private lazy var aiTabCollapsedFireButton: UIButton = {
@@ -614,8 +693,11 @@ final class UnifiedToggleInputView: UIView {
     private var cardTrailingFlankedConstraint: NSLayoutConstraint!
     private var cardBottomConstraint: NSLayoutConstraint!
     private var cardEditBottomConstraint: NSLayoutConstraint!
+    private var cardFooterBottomConstraint: NSLayoutConstraint!
     private var expandedShadowBottomConstraint: NSLayoutConstraint!
     private var expandedShadowEditBottomConstraint: NSLayoutConstraint!
+    private var expandedShadowFooterBottomConstraint: NSLayoutConstraint!
+    private var footerCollapsedHeightConstraint: NSLayoutConstraint!
     private var cardPinnedHeightConstraint: NSLayoutConstraint!
     private var toggleTopConstraint: NSLayoutConstraint!
     private var toggleLeadingConstraint: NSLayoutConstraint!
@@ -1023,6 +1105,7 @@ final class UnifiedToggleInputView: UIView {
             self.toolbarHeightConstraint.constant = showToolbar ? Constants.toolbarHeight : 0
             self.toolsToolbar.alpha = showToolbar ? 1 : 0
             self.updateAttachmentsStripLayout()
+            self.applyFooterForCardLayout(expanded: expanded)
         }
 
         if animated {
@@ -1488,12 +1571,19 @@ private extension UnifiedToggleInputView {
         cardView.isUserInteractionEnabled = false
         addSubview(cardView)
         insertSubview(editReplaceDisclaimerCard, belowSubview: cardView)
+        footerCard.translatesAutoresizingMaskIntoConstraints = false
+        footerCard.alpha = 0
+        footerCard.onPrimaryTap = { [weak self] in self?.onFooterPrimaryTapped?() }
+        footerCard.onDismissTap = { [weak self] in self?.onFooterDismissTapped?() }
+        insertSubview(footerCard, belowSubview: cardView)
         addSubview(aiTabCollapsedFireButton)
         addSubview(aiTabCollapsedMenuButton)
 
         expandedShadowBottomConstraint = expandedShadowView.bottomAnchor.constraint(equalTo: cardView.bottomAnchor)
         expandedShadowEditBottomConstraint = expandedShadowView.bottomAnchor.constraint(equalTo: editReplaceDisclaimerCard.bottomAnchor)
         expandedShadowEditBottomConstraint.isActive = false
+        expandedShadowFooterBottomConstraint = expandedShadowView.bottomAnchor.constraint(equalTo: footerCard.bottomAnchor)
+        expandedShadowFooterBottomConstraint.isActive = false
         NSLayoutConstraint.activate([
             expandedShadowView.leadingAnchor.constraint(equalTo: cardView.leadingAnchor),
             expandedShadowView.trailingAnchor.constraint(equalTo: cardView.trailingAnchor),
@@ -1607,6 +1697,10 @@ private extension UnifiedToggleInputView {
         cardBottomConstraint = cardView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.collapsedCardBottomMargin)
         cardEditBottomConstraint = cardView.bottomAnchor.constraint(equalTo: editReplaceDisclaimerCard.topAnchor, constant: Constants.editDisclaimerOverlap)
         cardEditBottomConstraint.isActive = false
+        cardFooterBottomConstraint = cardView.bottomAnchor.constraint(equalTo: footerCard.topAnchor, constant: UTIFooterCardView.overlap)
+        cardFooterBottomConstraint.isActive = false
+        footerCollapsedHeightConstraint = footerCard.heightAnchor.constraint(equalToConstant: UTIFooterCardView.overlap)
+        footerCollapsedHeightConstraint.isActive = true
         cardPinnedHeightConstraint = cardView.heightAnchor.constraint(equalToConstant: Constants.collapsedCardHeight)
         cardPinnedHeightConstraint.priority = .defaultHigh
         cardPinnedHeightConstraint.isActive = true
@@ -1637,6 +1731,10 @@ private extension UnifiedToggleInputView {
             cardLeadingConstraint,
             cardTrailingConstraint,
             cardBottomConstraint,
+
+            footerCard.leadingAnchor.constraint(equalTo: cardView.leadingAnchor),
+            footerCard.trailingAnchor.constraint(equalTo: cardView.trailingAnchor),
+            footerCard.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.cardVerticalMarginBottom),
 
             editReplaceDisclaimerCard.leadingAnchor.constraint(equalTo: cardView.leadingAnchor),
             editReplaceDisclaimerCard.trailingAnchor.constraint(equalTo: cardView.trailingAnchor),

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -483,6 +483,10 @@ extension UnifiedToggleInputViewController: UTIFooterPresenting {
         delegate?.unifiedToggleInputVCDidChangeHeight(self)
         view.superview?.layoutIfNeeded()
     }
+
+    func clearPendingFooterMessage() {
+        inputBarView.clearPendingFooterMessage()
+    }
 }
 
 // MARK: - UnifiedToggleInputViewDelegate

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -20,6 +20,7 @@
 import AIChat
 import DesignResourcesKit
 import DesignResourcesKitIcons
+import os.log
 import UIKit
 
 // MARK: - Delegate Protocol
@@ -44,6 +45,8 @@ protocol UnifiedToggleInputViewControllerDelegate: AnyObject {
     func unifiedToggleInputVCDidTapReturnKey(_ vc: UnifiedToggleInputViewController)
     func unifiedToggleInputVCDidShowModelPicker(_ vc: UnifiedToggleInputViewController)
     func unifiedToggleInputVCDidShowReasoningPicker(_ vc: UnifiedToggleInputViewController)
+    func unifiedToggleInputVCDidTapFooterPrimaryAction(_ vc: UnifiedToggleInputViewController)
+    func unifiedToggleInputVCDidDismissFooter(_ vc: UnifiedToggleInputViewController)
 }
 
 // MARK: - View Controller
@@ -449,6 +452,14 @@ final class UnifiedToggleInputViewController: UIViewController {
             guard let self else { return }
             delegate?.unifiedToggleInputVCDidTapAIChatShortcut(self)
         }
+        barView.onFooterPrimaryTapped = { [weak self] in
+            guard let self else { return }
+            delegate?.unifiedToggleInputVCDidTapFooterPrimaryAction(self)
+        }
+        barView.onFooterDismissTapped = { [weak self] in
+            guard let self else { return }
+            delegate?.unifiedToggleInputVCDidDismissFooter(self)
+        }
         let containerView = UnifiedToggleInputContainerView(inputView: barView)
         containerView.cardPosition = barView.cardPosition
         if let attachmentValidationMessage {
@@ -459,6 +470,18 @@ final class UnifiedToggleInputViewController: UIViewController {
 
     private func notifyHeightDidChange() {
         delegate?.unifiedToggleInputVCDidChangeHeight(self)
+    }
+}
+
+// MARK: - UTIFooterPresenting
+
+extension UnifiedToggleInputViewController: UTIFooterPresenting {
+
+    func applyFooterMessage(_ message: UTIFooterMessage?) {
+        guard inputBarView.setFooterMessage(message) else { return }
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] pushing new bar height to host")
+        delegate?.unifiedToggleInputVCDidChangeHeight(self)
+        view.superview?.layoutIfNeeded()
     }
 }
 

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2331,6 +2331,19 @@ public struct UserText {
     public static let aiChatHeaderCloseTabAccessibilityLabel = NotLocalizedString("aichat.header.closeTab.a11y", value: "Close tab", comment: "Accessibility label for the close-tab button in the Duck.ai tab header")
     public static let aiChatHeaderNewChatAccessibilityLabel = NotLocalizedString("aichat.header.newChat.a11y", value: "New chat", comment: "Accessibility label for the new-chat button in the Duck.ai tab header")
     public static let aiChatHeaderPlusMenuAccessibilityLabel = NSLocalizedString("aichat.header.plusMenu.a11y", value: "New", comment: "Accessibility label for the Plus (+) button in the Duck.ai tab header that opens a menu of new-chat and new-tab actions")
+
+    // MARK: - Duck.ai usage warnings (unified toggle input footer)
+    // NotLocalizedString while the copy is being finalised behind `utiDuckAIWarnings`; these must
+    // become NSLocalizedString with .xcstrings entries before the feature ships externally.
+
+    public static let utiDuckAIWarningsWeeklyUsageTitle = NotLocalizedString("aichat.usageWarnings.weeklyUsage.title", value: "%d%% of weekly limit", comment: "Title of the Duck.ai input footer warning, telling the user what share of their weekly message limit is used. %d is a percentage")
+    public static let utiDuckAIWarningsDailyUsageTitle = NotLocalizedString("aichat.usageWarnings.dailyUsage.title", value: "%d%% of daily limit", comment: "Title of the Duck.ai input footer warning, telling the user what share of their daily message limit is used. %d is a percentage")
+    public static let utiDuckAIWarningsWeeklyLimitReached = NotLocalizedString("aichat.usageWarnings.weeklyLimitReached.title", value: "Weekly limit reached", comment: "Title of the Duck.ai input footer warning shown once the user's weekly message limit is used up")
+    public static let utiDuckAIWarningsDailyLimitReached = NotLocalizedString("aichat.usageWarnings.dailyLimitReached.title", value: "Daily limit reached", comment: "Title of the Duck.ai input footer warning shown once the user's daily message limit is used up")
+    public static let utiDuckAIWarningsResetsIn = NotLocalizedString("aichat.usageWarnings.resetsIn", value: "Resets in %@", comment: "Subtitle of the Duck.ai input footer warning saying how long until the usage limit resets. %@ is a duration such as '2 days'")
+    public static let utiDuckAIWarningsReduceUsage = NotLocalizedString("aichat.usageWarnings.action.reduceUsage", value: "Reduce Usage", comment: "Button in the Duck.ai input footer warning that shows the user how to use fewer messages")
+    public static let utiDuckAIWarningsSwitch = NotLocalizedString("aichat.usageWarnings.action.switch", value: "Switch", comment: "Button in the Duck.ai input footer warning that switches the user to a model they still have messages for")
+    public static let utiDuckAIWarningsDismissAccessibilityLabel = NotLocalizedString("aichat.usageWarnings.dismiss.a11y", value: "Dismiss", comment: "Accessibility label for the button that dismisses the Duck.ai input footer warning")
     public static let aiChatHeaderNewVoiceChatTitle = NSLocalizedString("aichat.header.plusMenu.newVoiceChat", value: "New Voice Chat", comment: "Title for the New Voice Chat row in the Duck.ai tab header Plus (+) menu")
     public static let aiChatHeaderNewImageTitle = NSLocalizedString("aichat.header.plusMenu.newImage", value: "New Image", comment: "Title for the New Image row in the Duck.ai tab header Plus (+) menu — opens Duck.ai in image generation mode")
     public static let aiChatHeaderNewTabTitle = NSLocalizedString("aichat.header.plusMenu.newTab", value: "New Tab", comment: "Title for the New Tab row in the Duck.ai tab header Plus (+) menu")

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/DuckAiUsageLimitsStoreTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/DuckAiUsageLimitsStoreTests.swift
@@ -1,0 +1,130 @@
+//
+//  DuckAiUsageLimitsStoreTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import XCTest
+@testable import DuckDuckGo
+
+final class DuckAiUsageLimitsStoreTests: XCTestCase {
+
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func test_currentLimits_isNilWhenTheFeatureFlagIsOff() {
+        let sut = makeStore(storage: seededStorage(weeklyPercent: 80), isFeatureOn: false)
+
+        XCTAssertNil(sut.currentLimits())
+    }
+
+    func test_currentLimits_isNilWhenThereIsNoStorageBridge() {
+        let sut = makeStore(storage: nil)
+
+        XCTAssertNil(sut.currentLimits())
+    }
+
+    func test_currentLimits_readsTheSnapshotWrittenByTheWebApp() {
+        let sut = makeStore(storage: seededStorage(weeklyPercent: 80, resetsAt: now.addingTimeInterval(172_800)))
+
+        let limits = sut.currentLimits()
+
+        XCTAssertEqual(limits?.weekly?.percentUsed, 80)
+        XCTAssertEqual(limits?.weekly?.resetsAt.timeIntervalSince1970 ?? 0,
+                       now.addingTimeInterval(172_800).timeIntervalSince1970,
+                       accuracy: 1)
+    }
+
+    func test_currentLimits_isNoDataWhenStorageHoldsNothing() {
+        let sut = makeStore(storage: DuckAiNativeMemoryStorageHandler())
+
+        XCTAssertEqual(sut.currentLimits(), .noData)
+    }
+
+    func test_currentLimits_dropsAWindowThatHasAlreadyReset() {
+        let sut = makeStore(storage: seededStorage(weeklyPercent: 80, resetsAt: now.addingTimeInterval(-60)))
+
+        XCTAssertEqual(sut.currentLimits(), .noData)
+    }
+
+    // MARK: - Helpers
+
+    private func makeStore(storage: DuckAiNativeStorageHandling?, isFeatureOn: Bool = true) -> DuckAiUsageLimitsStore {
+        DuckAiUsageLimitsStore(storageHandler: storage,
+                               featureFlagger: MockFeatureFlagger(enabledFeatureFlags: isFeatureOn ? [.utiDuckAIWarnings] : []),
+                               dateProvider: { [unowned self] in now })
+    }
+
+    private func seededStorage(weeklyPercent: Double, resetsAt: Date? = nil) -> DuckAiNativeStorageHandling {
+        let storage = DuckAiNativeMemoryStorageHandler()
+        try? storage.putEntry(key: DuckAiNativeStorageReservedEntryKeys.usageLimits.rawValue,
+                              value: Self.snapshotJSON(weeklyPercent: weeklyPercent,
+                                                       resetsAt: resetsAt ?? now.addingTimeInterval(172_800)))
+        return storage
+    }
+
+    private static func snapshotJSON(weeklyPercent: Double, resetsAt: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return """
+        {"weekly":{"percentUsed":\(weeklyPercent),"resetsAt":"\(formatter.string(from: resetsAt))"}}
+        """
+    }
+}
+
+final class UTIFooterWarningProviderTests: XCTestCase {
+
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func test_currentWarning_resolvesTheSnapshotHeldInNativeStorage() {
+        let sut = makeProvider(weeklyPercent: 80)
+
+        let warning = sut.currentWarning()
+
+        guard case .usageThreshold(let window, let threshold, _) = warning else {
+            return XCTFail("Expected a usage threshold, got \(String(describing: warning))")
+        }
+        XCTAssertEqual(window, .weekly)
+        XCTAssertEqual(threshold, .seventyFive)
+    }
+
+    func test_currentWarning_isNilWhenTheFeatureIsInactive() {
+        let sut = makeProvider(weeklyPercent: 80, isFeatureOn: false)
+
+        XCTAssertNil(sut.currentWarning())
+    }
+
+    func test_currentWarning_isNilWhenUsageIsBelowEveryThreshold() {
+        let sut = makeProvider(weeklyPercent: 20)
+
+        XCTAssertNil(sut.currentWarning())
+    }
+
+    private func makeProvider(weeklyPercent: Double, isFeatureOn: Bool = true) -> UTIFooterWarningProvider {
+        let storage = DuckAiNativeMemoryStorageHandler()
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let json = """
+        {"weekly":{"percentUsed":\(weeklyPercent),"resetsAt":"\(formatter.string(from: now.addingTimeInterval(172_800)))"}}
+        """
+        try? storage.putEntry(key: DuckAiNativeStorageReservedEntryKeys.usageLimits.rawValue, value: json)
+
+        let store = DuckAiUsageLimitsStore(storageHandler: storage,
+                                           featureFlagger: MockFeatureFlagger(enabledFeatureFlags: isFeatureOn ? [.utiDuckAIWarnings] : []),
+                                           dateProvider: { [unowned self] in now })
+        return UTIFooterWarningProvider(limitsStore: store)
+    }
+}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/DuckAiUsageLimitsStoreTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/DuckAiUsageLimitsStoreTests.swift
@@ -128,3 +128,54 @@ final class UTIFooterWarningProviderTests: XCTestCase {
         return UTIFooterWarningProvider(limitsStore: store)
     }
 }
+
+final class UTIFireTabAwareFooterWarningProviderTests: XCTestCase {
+
+    private let normalWarning = UTIFooterWarning.usageThreshold(window: .weekly,
+                                                                threshold: .ninety,
+                                                                resetsAt: Date(timeIntervalSince1970: 1_800_172_800))
+    private let fireWarning = UTIFooterWarning.usageThreshold(window: .daily,
+                                                              threshold: .fifty,
+                                                              resetsAt: Date(timeIntervalSince1970: 1_800_086_400))
+
+    func test_currentWarning_readsTheNormalTabSourceOutsideAFireTab() {
+        let sut = makeProvider(isFireTab: { false })
+
+        XCTAssertEqual(sut.currentWarning(), normalWarning)
+    }
+
+    func test_currentWarning_readsTheFireTabSourceOnAFireTab() {
+        let sut = makeProvider(isFireTab: { true })
+
+        XCTAssertEqual(sut.currentWarning(), fireWarning)
+    }
+
+    func test_currentWarning_isNilOnAFireTabWithNoFireTabSource() {
+        let sut = UTIFireTabAwareFooterWarningProvider(normalTabProvider: StubUTIFooterWarningProvider(warning: normalWarning),
+                                                       fireTabProvider: nil,
+                                                       isFireTab: { true })
+
+        XCTAssertNil(sut.currentWarning())
+    }
+
+    func test_currentWarning_followsTheFireTabStateAcrossReads() {
+        var isFireTab = false
+        let sut = makeProvider(isFireTab: { isFireTab })
+
+        XCTAssertEqual(sut.currentWarning(), normalWarning)
+        isFireTab = true
+        XCTAssertEqual(sut.currentWarning(), fireWarning)
+    }
+
+    private func makeProvider(isFireTab: @escaping () -> Bool) -> UTIFireTabAwareFooterWarningProvider {
+        UTIFireTabAwareFooterWarningProvider(normalTabProvider: StubUTIFooterWarningProvider(warning: normalWarning),
+                                             fireTabProvider: StubUTIFooterWarningProvider(warning: fireWarning),
+                                             isFireTab: isFireTab)
+    }
+}
+
+private struct StubUTIFooterWarningProvider: UTIFooterWarningProviding {
+    let warning: UTIFooterWarning?
+
+    func currentWarning() -> UTIFooterWarning? { warning }
+}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterCardViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterCardViewTests.swift
@@ -1,0 +1,79 @@
+//
+//  UTIFooterCardViewTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+import XCTest
+@testable import DuckDuckGo
+
+@MainActor
+final class UTIFooterCardViewTests: XCTestCase {
+
+    private let phoneWidth: CGFloat = 390
+
+    func test_cardHeight_isUnchangedByALongTitle() {
+        let sut = UTIFooterCardView()
+
+        sut.configure(with: makeMessage(title: "90% of weekly limit"), animateIcon: false)
+        let compact = height(of: sut)
+
+        sut.configure(with: makeMessage(title: "90% of weekly limit for advanced models on this plan"), animateIcon: false)
+        let long = height(of: sut)
+
+        XCTAssertEqual(compact, long, accuracy: 0.5)
+    }
+
+    func test_cardHeight_isUnchangedByALongSubtitle() {
+        let sut = UTIFooterCardView()
+
+        sut.configure(with: makeMessage(subtitle: "Resets in 2 days"), animateIcon: false)
+        let compact = height(of: sut)
+
+        sut.configure(with: makeMessage(subtitle: "Resets in 2 days, 4 hours and 13 minutes from now"), animateIcon: false)
+        let long = height(of: sut)
+
+        XCTAssertEqual(compact, long, accuracy: 0.5)
+    }
+
+    func test_cardHeight_leavesRoomForTheControls() {
+        let sut = UTIFooterCardView()
+        sut.configure(with: makeMessage(), animateIcon: false)
+
+        XCTAssertGreaterThan(height(of: sut), UTIFooterCardView.overlap + 34)
+    }
+
+    // MARK: - Helpers
+
+    private func height(of view: UTIFooterCardView) -> CGFloat {
+        view.frame = CGRect(x: 0, y: 0, width: phoneWidth, height: 0)
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        return view.systemLayoutSizeFitting(CGSize(width: phoneWidth, height: UIView.layoutFittingCompressedSize.height),
+                                            withHorizontalFittingPriority: .required,
+                                            verticalFittingPriority: .fittingSizeLevel).height
+    }
+
+    private func makeMessage(title: String = "90% of weekly limit",
+                             subtitle: String? = "Resets in 2 days") -> UTIFooterMessage {
+        UTIFooterMessage(icon: .usageRing(progress: 0.9),
+                         title: title,
+                         subtitle: subtitle,
+                         primaryAction: .init(title: "Reduce Usage", action: .reduceUsage),
+                         isDismissible: true)
+    }
+}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterControllerTests.swift
@@ -159,7 +159,7 @@ final class UTIFooterControllerTests: XCTestCase {
 
     // MARK: - Pose changes
 
-    func test_resetForPoseChange_leavesTheViewAlone() {
+    func test_resetForPoseChange_neverAppliesOrAnimatesAMessage() {
         provider.warning = fiftyPercent
         sut.refresh()
 
@@ -167,6 +167,29 @@ final class UTIFooterControllerTests: XCTestCase {
 
         XCTAssertEqual(presenter.appliedMessages.count, 1)
         XCTAssertEqual(animationCount, 1)
+    }
+
+    func test_resetForPoseChange_dropsTheViewsPendingMessage() {
+        provider.warning = fiftyPercent
+        sut.refresh()
+
+        sut.resetForPoseChange()
+
+        XCTAssertEqual(presenter.pendingClearCount, 1)
+    }
+
+    func test_refresh_afterAPoseResetWithTheWarningGone_hasNothingLeftToResurrect() {
+        provider.warning = fiftyPercent
+        sut.refresh()
+        sut.resetForPoseChange()
+
+        provider.warning = nil
+        sut.refresh()
+
+        // No second apply is needed precisely because the reset already dropped the view's pending copy.
+        XCTAssertEqual(presenter.appliedMessages.count, 1)
+        XCTAssertEqual(presenter.pendingClearCount, 1)
+        XCTAssertNil(sut.currentMessage)
     }
 
     func test_resetForPoseChange_reappliesTheWarningOnTheNextRefresh() {
@@ -218,8 +241,13 @@ private final class FakeUTIFooterWarningProvider: UTIFooterWarningProviding {
 @MainActor
 private final class SpyUTIFooterPresenter: UTIFooterPresenting {
     private(set) var appliedMessages: [UTIFooterMessage?] = []
+    private(set) var pendingClearCount = 0
 
     func applyFooterMessage(_ message: UTIFooterMessage?) {
         appliedMessages.append(message)
+    }
+
+    func clearPendingFooterMessage() {
+        pendingClearCount += 1
     }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterControllerTests.swift
@@ -1,0 +1,225 @@
+//
+//  UTIFooterControllerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+@MainActor
+final class UTIFooterControllerTests: XCTestCase {
+
+    private var provider: FakeUTIFooterWarningProvider!
+    private var presenter: SpyUTIFooterPresenter!
+    private var animationCount = 0
+    private var sut: UTIFooterController!
+
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private lazy var fiftyPercent = UTIFooterWarning.usageThreshold(window: .weekly, threshold: .fifty, resetsAt: now.addingTimeInterval(172_800))
+    private lazy var seventyFivePercent = UTIFooterWarning.usageThreshold(window: .weekly, threshold: .seventyFive, resetsAt: now.addingTimeInterval(172_800))
+
+    override func setUp() {
+        super.setUp()
+        provider = FakeUTIFooterWarningProvider()
+        presenter = SpyUTIFooterPresenter()
+        animationCount = 0
+        sut = UTIFooterController(provider: provider,
+                                  dateProvider: { [unowned self] in now },
+                                  animator: { [unowned self] changes in
+                                      animationCount += 1
+                                      changes()
+                                  })
+        sut.presenter = presenter
+    }
+
+    override func tearDown() {
+        sut = nil
+        presenter = nil
+        provider = nil
+        super.tearDown()
+    }
+
+    // MARK: - Refresh
+
+    func test_refresh_presentsAMessageForTheResolvedWarning() {
+        provider.warning = fiftyPercent
+
+        sut.refresh()
+
+        XCTAssertEqual(presenter.appliedMessages.count, 1)
+        XCTAssertTrue(presenter.appliedMessages.last??.title.contains("50%") ?? false)
+    }
+
+    func test_refresh_presentsNothingWhenThereIsNoWarning() {
+        provider.warning = nil
+
+        sut.refresh()
+
+        XCTAssertTrue(presenter.appliedMessages.isEmpty)
+    }
+
+    func test_refresh_doesNotReapplyAnUnchangedMessage() {
+        provider.warning = fiftyPercent
+
+        sut.refresh()
+        sut.refresh()
+
+        XCTAssertEqual(presenter.appliedMessages.count, 1)
+        XCTAssertEqual(animationCount, 1)
+    }
+
+    func test_refresh_animatesEveryVisibleChange() {
+        provider.warning = fiftyPercent
+        sut.refresh()
+
+        provider.warning = seventyFivePercent
+        sut.refresh()
+
+        XCTAssertEqual(animationCount, 2)
+    }
+
+    // MARK: - Dismissal
+
+    func test_dismissCurrent_hidesTheFooter() {
+        provider.warning = fiftyPercent
+        sut.refresh()
+
+        sut.dismissCurrent()
+
+        XCTAssertEqual(presenter.appliedMessages.last, .some(nil))
+    }
+
+    func test_dismissCurrent_keepsTheSameWarningHiddenOnTheNextRefresh() {
+        provider.warning = fiftyPercent
+        sut.refresh()
+        sut.dismissCurrent()
+
+        sut.refresh()
+
+        XCTAssertEqual(presenter.appliedMessages.last, .some(nil))
+    }
+
+    func test_dismissCurrent_doesNotHideADifferentWarning() {
+        provider.warning = fiftyPercent
+        sut.refresh()
+        sut.dismissCurrent()
+
+        provider.warning = seventyFivePercent
+        sut.refresh()
+
+        XCTAssertTrue(presenter.appliedMessages.last??.title.contains("75%") ?? false)
+    }
+
+    // MARK: - Suppression
+
+    func test_setSuppressed_hidesTheFooterWithoutForgettingTheWarning() {
+        provider.warning = fiftyPercent
+        sut.refresh()
+
+        sut.setSuppressed(true)
+
+        XCTAssertEqual(presenter.appliedMessages.last, .some(nil))
+    }
+
+    func test_setSuppressed_restoresTheWarningWithoutReadingTheProviderAgain() {
+        provider.warning = fiftyPercent
+        sut.refresh()
+        sut.setSuppressed(true)
+        provider.readCount = 0
+
+        sut.setSuppressed(false)
+
+        XCTAssertEqual(provider.readCount, 0)
+        XCTAssertTrue(presenter.appliedMessages.last??.title.contains("50%") ?? false)
+    }
+
+    func test_refresh_presentsNothingWhileSuppressed() {
+        sut.setSuppressed(true)
+        provider.warning = fiftyPercent
+
+        sut.refresh()
+
+        XCTAssertTrue(presenter.appliedMessages.allSatisfy { $0 == nil })
+    }
+
+    // MARK: - Pose changes
+
+    func test_resetForPoseChange_leavesTheViewAlone() {
+        provider.warning = fiftyPercent
+        sut.refresh()
+
+        sut.resetForPoseChange()
+
+        XCTAssertEqual(presenter.appliedMessages.count, 1)
+        XCTAssertEqual(animationCount, 1)
+    }
+
+    func test_resetForPoseChange_reappliesTheWarningOnTheNextRefresh() {
+        provider.warning = fiftyPercent
+        sut.refresh()
+        sut.resetForPoseChange()
+
+        sut.refresh()
+
+        XCTAssertEqual(presenter.appliedMessages.count, 2)
+        XCTAssertTrue(presenter.appliedMessages.last??.title.contains("50%") ?? false)
+    }
+
+    // MARK: - Actions
+
+    func test_performPrimaryAction_forwardsTheMappedAction() {
+        var received: [UTIFooterAction] = []
+        sut.onAction = { received.append($0) }
+        provider.warning = .limitReached(window: .weekly, resetsAt: now.addingTimeInterval(604_800))
+        sut.refresh()
+
+        sut.performPrimaryAction()
+
+        XCTAssertEqual(received, [.switchModel])
+    }
+
+    func test_performPrimaryAction_doesNothingWithoutAMessage() {
+        var received: [UTIFooterAction] = []
+        sut.onAction = { received.append($0) }
+
+        sut.performPrimaryAction()
+
+        XCTAssertTrue(received.isEmpty)
+    }
+}
+
+// MARK: - Test doubles
+
+private final class FakeUTIFooterWarningProvider: UTIFooterWarningProviding {
+    var warning: UTIFooterWarning?
+    var readCount = 0
+
+    func currentWarning() -> UTIFooterWarning? {
+        readCount += 1
+        return warning
+    }
+}
+
+@MainActor
+private final class SpyUTIFooterPresenter: UTIFooterPresenting {
+    private(set) var appliedMessages: [UTIFooterMessage?] = []
+
+    func applyFooterMessage(_ message: UTIFooterMessage?) {
+        appliedMessages.append(message)
+    }
+}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterMessageMapperTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterMessageMapperTests.swift
@@ -1,0 +1,108 @@
+//
+//  UTIFooterMessageMapperTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+final class UTIFooterMessageMapperTests: XCTestCase {
+
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+    private lazy var sut = UTIFooterMessageMapper(resetDescriber: UTIFooterResetDescriber(locale: Locale(identifier: "en_US")))
+
+    // MARK: - Usage threshold
+
+    func test_message_usageThresholdShowsTheRingFilledToTheThreshold() {
+        let message = sut.message(for: .usageThreshold(window: .weekly, threshold: .seventyFive, resetsAt: now.addingTimeInterval(.days(2))), now: now)
+
+        XCTAssertEqual(message.icon, .usageRing(progress: 0.75))
+    }
+
+    func test_message_usageThresholdTitleCarriesThePercentageAndWindow() {
+        let message = sut.message(for: .usageThreshold(window: .weekly, threshold: .fifty, resetsAt: now.addingTimeInterval(.days(2))), now: now)
+
+        XCTAssertTrue(message.title.contains("50%"), message.title)
+        XCTAssertTrue(message.title.lowercased().contains("weekly"), message.title)
+    }
+
+    func test_message_usageThresholdOffersReduceUsage() {
+        let message = sut.message(for: .usageThreshold(window: .daily, threshold: .ninety, resetsAt: now.addingTimeInterval(.days(2))), now: now)
+
+        XCTAssertEqual(message.primaryAction?.action, .reduceUsage)
+        XCTAssertFalse(message.primaryAction?.title.isEmpty ?? true)
+    }
+
+    // MARK: - Limit reached
+
+    func test_message_limitReachedShowsTheAlertIcon() {
+        let message = sut.message(for: .limitReached(window: .weekly, resetsAt: now.addingTimeInterval(.days(7))), now: now)
+
+        XCTAssertEqual(message.icon, .alert)
+    }
+
+    func test_message_limitReachedOffersSwitch() {
+        let message = sut.message(for: .limitReached(window: .weekly, resetsAt: now.addingTimeInterval(.days(7))), now: now)
+
+        XCTAssertEqual(message.primaryAction?.action, .switchModel)
+    }
+
+    func test_message_everyStateIsDismissible() {
+        let threshold = sut.message(for: .usageThreshold(window: .weekly, threshold: .fifty, resetsAt: now), now: now)
+        let reached = sut.message(for: .limitReached(window: .weekly, resetsAt: now), now: now)
+
+        XCTAssertTrue(threshold.isDismissible)
+        XCTAssertTrue(reached.isDismissible)
+    }
+
+    // MARK: - Reset description
+
+    func test_message_subtitleDescribesWholeDaysUntilReset() {
+        let message = sut.message(for: .usageThreshold(window: .weekly, threshold: .fifty, resetsAt: now.addingTimeInterval(.days(2) + .hours(3))), now: now)
+
+        XCTAssertTrue(message.subtitle?.contains("2 days") ?? false, message.subtitle ?? "nil")
+    }
+
+    func test_message_subtitleUsesTheSingularDay() {
+        let message = sut.message(for: .usageThreshold(window: .weekly, threshold: .fifty, resetsAt: now.addingTimeInterval(.days(1) + .hours(1))), now: now)
+
+        XCTAssertTrue(message.subtitle?.contains("1 day") ?? false, message.subtitle ?? "nil")
+    }
+
+    func test_message_subtitleFallsBackToHoursWithinADay() {
+        let message = sut.message(for: .usageThreshold(window: .daily, threshold: .fifty, resetsAt: now.addingTimeInterval(.hours(5))), now: now)
+
+        XCTAssertTrue(message.subtitle?.contains("5 hours") ?? false, message.subtitle ?? "nil")
+    }
+
+    func test_message_subtitleFallsBackToMinutesWithinAnHour() {
+        let message = sut.message(for: .usageThreshold(window: .daily, threshold: .fifty, resetsAt: now.addingTimeInterval(12 * 60)), now: now)
+
+        XCTAssertTrue(message.subtitle?.contains("12 minutes") ?? false, message.subtitle ?? "nil")
+    }
+
+    func test_message_subtitleHandlesAResetThatHasAlreadyPassed() {
+        let message = sut.message(for: .usageThreshold(window: .daily, threshold: .fifty, resetsAt: now.addingTimeInterval(-60)), now: now)
+
+        XCTAssertNotNil(message.subtitle)
+    }
+}
+
+private extension TimeInterval {
+    static func days(_ count: Double) -> TimeInterval { count * 24 * 60 * 60 }
+    static func hours(_ count: Double) -> TimeInterval { count * 60 * 60 }
+}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterWarningResolverTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterWarningResolverTests.swift
@@ -1,0 +1,92 @@
+//
+//  UTIFooterWarningResolverTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import XCTest
+@testable import DuckDuckGo
+
+final class UTIFooterWarningResolverTests: XCTestCase {
+
+    private let sut = UTIFooterWarningResolver()
+    private let weeklyReset = Date(timeIntervalSince1970: 1_800_000_000)
+    private let dailyReset = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - Nothing to warn about
+
+    func test_resolve_returnsNilWhenThereIsNoData() {
+        XCTAssertNil(sut.resolve(limits: .noData))
+    }
+
+    func test_resolve_returnsNilBelowTheFirstThreshold() {
+        XCTAssertNil(sut.resolve(limits: makeLimits(weekly: 49.9)))
+    }
+
+    // MARK: - Thresholds
+
+    func test_resolve_returnsFiftyThresholdAtTheExactBoundary() {
+        XCTAssertEqual(sut.resolve(limits: makeLimits(weekly: 50)),
+                       .usageThreshold(window: .weekly, threshold: .fifty, resetsAt: weeklyReset))
+    }
+
+    func test_resolve_bucketsDownToTheHighestCrossedThreshold() {
+        XCTAssertEqual(sut.resolve(limits: makeLimits(weekly: 76)),
+                       .usageThreshold(window: .weekly, threshold: .seventyFive, resetsAt: weeklyReset))
+    }
+
+    func test_resolve_returnsNinetyThresholdBelowTheLimit() {
+        XCTAssertEqual(sut.resolve(limits: makeLimits(weekly: 99.9)),
+                       .usageThreshold(window: .weekly, threshold: .ninety, resetsAt: weeklyReset))
+    }
+
+    func test_resolve_returnsLimitReachedAtFullUsage() {
+        XCTAssertEqual(sut.resolve(limits: makeLimits(weekly: 100)),
+                       .limitReached(window: .weekly, resetsAt: weeklyReset))
+    }
+
+    // MARK: - Choosing between windows
+
+    func test_resolve_picksTheWindowWithTheHigherThreshold() {
+        XCTAssertEqual(sut.resolve(limits: makeLimits(daily: 92, weekly: 55)),
+                       .usageThreshold(window: .daily, threshold: .ninety, resetsAt: dailyReset))
+    }
+
+    func test_resolve_picksTheBlockedWindowOverAThresholdInTheOther() {
+        XCTAssertEqual(sut.resolve(limits: makeLimits(daily: 100, weekly: 90)),
+                       .limitReached(window: .daily, resetsAt: dailyReset))
+    }
+
+    func test_resolve_prefersWeeklyWhenBothWindowsRankTheSame() {
+        XCTAssertEqual(sut.resolve(limits: makeLimits(daily: 55, weekly: 51)),
+                       .usageThreshold(window: .weekly, threshold: .fifty, resetsAt: weeklyReset))
+    }
+
+    func test_resolve_ignoresAWindowThatHasNotCrossedAThreshold() {
+        XCTAssertEqual(sut.resolve(limits: makeLimits(daily: 10, weekly: 80)),
+                       .usageThreshold(window: .weekly, threshold: .seventyFive, resetsAt: weeklyReset))
+    }
+
+    // MARK: - Helpers
+
+    private func makeLimits(daily: Double? = nil, weekly: Double? = nil) -> DuckAiUsageLimits {
+        DuckAiUsageLimits(
+            daily: daily.map { DuckAiUsageLimitWindow(percentUsed: $0, resetsAt: dailyReset) },
+            weekly: weekly.map { DuckAiUsageLimitWindow(percentUsed: $0, resetsAt: weeklyReset) }
+        )
+    }
+}

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -491,6 +491,10 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216000794365770?focus=true
     case iPadDuckAIBarControls
 
+    /// Warns Duck.ai users in the unified toggle input as they approach their usage limits, using the
+    /// snapshot the web app writes into the reserved `usageLimits` native-storage entry.
+    case utiDuckAIWarnings
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215359554019438?focus=true
     case floatingUIAugust2026
 
@@ -741,6 +745,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.fullDuckAIMode))
         case .iPadDuckAIBarControls:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.iPadDuckAIBarControls))
+        case .utiDuckAIWarnings:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.usageWarnings))
         case .attributedMetrics:
             Config(defaultValue: .enabled, source: .remoteReleasable(AttributedMetricsSubfeature.featureEnabled))
         case .onboardingDuckAIFlow:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1216355909736641?focus=true
Tech Design URL:
CC:

### Description
Adds a message card that sits behind the unified toggle input and slides out below it to warn Duck.ai users as they approach a usage limit, reading the privacy-safe usage snapshot the web app writes into native storage. It appears in the Duck.ai input and in the address bar when the toggle is on Duck.ai, and carries a primary action plus a dismiss. Behind the internal-only `utiDuckAIWarnings` flag; the actions are not wired to real destinations yet and the copy is not final.

### Testing Steps
1. Debug ▸ AI Chat ▸ Duck.ai Usage Warnings → tap **Weekly 90%**, then go back.
2. Open a Duck.ai tab and focus the input → the card grows out from behind it in one motion, showing "90% of weekly limit / Resets in 2 days"; dismiss it with ✕ and confirm it stays gone for that window but returns after seeding a different percentage.
3. Tap the address bar with the toggle on **Duck.ai** → same card; flip the toggle to **Search** → it hides, flip back → it returns.

### Impact
Low

#### What could go wrong?
The card shares the slot behind the input with the edit-replace disclaimer and changes the bar's height → mitigated by a single-occupant slot the disclaimer always wins, and by unit tests pinning the card to one line per label so a long string can never grow the bar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches unified-input layout and height (shared slot with the edit disclaimer) and reads usage from native storage, but the feature is internal-only and primary actions are not wired yet.
> 
> **Overview**
> Adds a **Duck.ai usage-warning footer** that slides out behind the unified toggle input when daily/weekly usage hits 50/75/90% or the limit. It reads the privacy-safe `usageLimits` snapshot the web app already writes to native storage, and is gated by the internal-only `utiDuckAIWarnings` flag.
> 
> The card appears in Duck.ai input and in the omnibar when the toggle is on Duck.ai; it hides in Search mode, while editing, and when collapsed. Fire tabs use a separate storage snapshot so usage never leaks across modes. Dismiss is session-scoped per warning; **Reduce Usage** / **Switch** buttons are present but not connected to destinations yet. Copy is still `NotLocalizedString`.
> 
> Debug/Alpha can seed snapshots from AI Chat debug settings. Unit tests cover threshold ranking, mapping, controller suppression/dismiss, fire-tab routing, and single-line card height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6919dbf24054db8c0f84baf446fa0b22dab98bbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->