### PR TITLE
[iOS] Add pixel for dismissed Simplified Sync device-choice prompt

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1448,6 +1448,7 @@ extension Pixel {
         case settingsSyncRecoveryConfirmedTapped
         case settingsSyncAnotherDevicePromptShown
         case settingsSyncAnotherDevicePromptOptionTapped
+        case settingsSyncAnotherDevicePromptDismissed
         case settingsAppearanceOpen
         case settingsThemeSelectorPressed
         case settingsAddressBarTopSelected
@@ -2205,6 +2206,7 @@ extension Pixel.Event {
         case .settingsSyncRecoveryConfirmedTapped: return "m_settings_sync_recovery_confirmed_tapped"
         case .settingsSyncAnotherDevicePromptShown: return "m_settings_sync_another_device_prompt_shown"
         case .settingsSyncAnotherDevicePromptOptionTapped: return "m_settings_sync_another_device_prompt_option_tapped"
+        case .settingsSyncAnotherDevicePromptDismissed: return "m_settings_sync_another_device_prompt_dismissed"
         case .settingsAppearanceOpen: return "m_settings_appearance_open"
         case .settingsThemeSelectorPressed: return "m_settings_theme_selector_pressed"
         case .settingsAddressBarTopSelected: return "m_settings_address_bar_top_selected"

--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -2206,7 +2206,7 @@ extension Pixel.Event {
         case .settingsSyncRecoveryConfirmedTapped: return "m_settings_sync_recovery_confirmed_tapped"
         case .settingsSyncAnotherDevicePromptShown: return "m_settings_sync_another_device_prompt_shown"
         case .settingsSyncAnotherDevicePromptOptionTapped: return "m_settings_sync_another_device_prompt_option_tapped"
-        case .settingsSyncAnotherDevicePromptDismissed: return "m_settings_sync_another_device_prompt_dismissed"
+        case .settingsSyncAnotherDevicePromptDismissed: return "settings_sync_another_device_prompt_dismissed"
         case .settingsAppearanceOpen: return "m_settings_appearance_open"
         case .settingsThemeSelectorPressed: return "m_settings_theme_selector_pressed"
         case .settingsAddressBarTopSelected: return "m_settings_address_bar_top_selected"

--- a/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
+++ b/iOS/DuckDuckGo/SyncSettingsViewController+SyncDelegate.swift
@@ -476,6 +476,11 @@ extension SyncSettingsViewController: SyncManagementViewModelDelegate {
             Pixel.fire(pixel: .settingsSyncAnotherDevicePromptOptionTapped,
                        withAdditionalParameters: parameters,
                        includedParameters: [.appVersion])
+        case .anotherDevicePromptDismissed:
+            pixelFiring.fire(.settingsSyncAnotherDevicePromptDismissed,
+                             withAdditionalParameters: uiVersionParameters,
+                             includedParameters: [.appVersion],
+                             onComplete: { _ in })
         }
     }
 

--- a/iOS/DuckDuckGoTests/SyncSettingsViewControllerPixelTests.swift
+++ b/iOS/DuckDuckGoTests/SyncSettingsViewControllerPixelTests.swift
@@ -106,6 +106,20 @@ final class SyncSettingsViewControllerPixelTests {
         })
     }
 
+    @available(iOS 16, macOS 13, *)
+    @Test("Another-device prompt dismissal fires the dismissed pixel", .timeLimit(.minutes(1)))
+    func anotherDevicePromptDismissalFiresDismissedPixel() {
+        let vc = makeViewController(source: "test_source", enabledFeatureFlags: [.simplifiedSyncSetupV2])
+
+        vc.fireSyncSetupPixel(event: .anotherDevicePromptDismissed)
+
+        #expect(PixelFiringMock.allPixelsFired.contains {
+            $0.pixelName == Pixel.Event.settingsSyncAnotherDevicePromptDismissed.name &&
+            $0.params == ["ui_version": "v2"] &&
+            $0.includedParams == [.appVersion]
+        })
+    }
+
     private func makeViewController(source: String?, enabledFeatureFlags: [FeatureFlag]) -> SyncSettingsViewController {
         SyncSettingsViewController(
             syncService: ddgSyncing,

--- a/iOS/DuckDuckGoTests/SyncUI/SyncSettingsViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/SyncUI/SyncSettingsViewModelTests.swift
@@ -704,6 +704,49 @@ final class SyncSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(delegate.firedSyncSetupPixelEvents, [.anotherDevicePromptOptionTapped(.thisDeviceOnly)])
     }
 
+    func testWhenAnotherDevicePromptIsDismissedWithoutSelectionThenFiresPromptDismissedPixel() {
+        let delegate = MockSyncSettingsViewModelDelegate()
+        let sut = makeSut(autoRestoreProvider: MockSyncAutoRestoreHandler(), delegate: delegate)
+        sut.connectingSheetPhase = .syncAnotherDevice(isConnecting: false)
+        sut.anotherDevicePromptAppeared()
+
+        sut.dismissAnotherDevicePrompt()
+        sut.connectingSheetDidDismiss()
+
+        XCTAssertEqual(delegate.firedSyncSetupPixelEvents, [.anotherDevicePromptShown, .anotherDevicePromptDismissed])
+    }
+
+    func testWhenSyncAnotherDeviceOptionIsSelectedThenDoesNotFirePromptDismissedPixel() {
+        let delegate = MockSyncSettingsViewModelDelegate()
+        let sut = makeSut(autoRestoreProvider: MockSyncAutoRestoreHandler(), delegate: delegate)
+        sut.connectingSheetPhase = .syncAnotherDevice(isConnecting: false)
+        sut.anotherDevicePromptAppeared()
+
+        sut.syncAnotherDeviceFromConnectingSheet()
+        sut.connectingSheetDidDismiss()
+
+        XCTAssertEqual(delegate.firedSyncSetupPixelEvents, [
+            .anotherDevicePromptShown,
+            .anotherDevicePromptOptionTapped(.syncAnotherDevice)
+        ])
+    }
+
+    func testWhenThisDeviceOnlyOptionIsSelectedThenDoesNotFirePromptDismissedPixel() {
+        let delegate = MockSyncSettingsViewModelDelegate()
+        let sut = makeSut(autoRestoreProvider: MockSyncAutoRestoreHandler(), delegate: delegate)
+        sut.connectingSheetPhase = .syncAnotherDevice(isConnecting: false)
+        sut.anotherDevicePromptAppeared()
+
+        sut.syncThisDeviceOnlyFromConnectingSheet()
+        sut.dismissConnectingSheet()
+        sut.connectingSheetDidDismiss()
+
+        XCTAssertEqual(delegate.firedSyncSetupPixelEvents, [
+            .anotherDevicePromptShown,
+            .anotherDevicePromptOptionTapped(.thisDeviceOnly)
+        ])
+    }
+
     private func makeSut(autoRestoreProvider: MockSyncAutoRestoreHandler,
                          delegate: MockSyncSettingsViewModelDelegate? = nil) -> SyncSettingsViewModel {
         let model = SyncSettingsViewModel(

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/SyncSettingsViewModel.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/ViewModels/SyncSettingsViewModel.swift
@@ -136,6 +136,7 @@ public class SyncSettingsViewModel: ObservableObject {
         case recoveryConfirmedTapped
         case anotherDevicePromptShown
         case anotherDevicePromptOptionTapped(SyncAnotherDeviceOption)
+        case anotherDevicePromptDismissed
     }
 
     public enum SyncAnotherDeviceOption: String {
@@ -486,6 +487,12 @@ public class SyncSettingsViewModel: ObservableObject {
 
     public func doneFromConnectingSheet() {
         connectingSheetPhase = nil
+    }
+
+    public func dismissAnotherDevicePrompt() {
+        guard connectingSheetPhase == .syncAnotherDevice(isConnecting: false) else { return }
+        delegate?.fireSyncSetupPixel(event: .anotherDevicePromptDismissed)
+        dismissConnectingSheet()
     }
 
     public func dismissConnectingSheet(then action: (() -> Void)? = nil) {

--- a/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncAnotherDevicePromptViewV2.swift
+++ b/iOS/LocalPackages/SyncUI-iOS/Sources/SyncUI-iOS/Views/SyncAnotherDevicePromptViewV2.swift
@@ -84,7 +84,7 @@ struct SyncAnotherDevicePromptViewV2: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {
-                        model.dismissConnectingSheet()
+                        model.dismissAnotherDevicePrompt()
                     } label: {
                         Image(uiImage: DesignSystemImages.Glyphs.Size24.close)
                     }

--- a/iOS/PixelDefinitions/pixels/definitions/settings_sync.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/settings_sync.json5
@@ -65,5 +65,12 @@
                 "enum": ["this_device_only", "sync_another_device"]
             }
         ]
+    },
+    "m_settings_sync_another_device_prompt_dismissed": {
+        "description": "Fired when the user dismisses the Sync Another Device prompt (simplifiedSyncSetupV2) without choosing an option.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": ["appVersion", "ui_version"]
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/settings_sync.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/settings_sync.json5
@@ -66,7 +66,7 @@
             }
         ]
     },
-    "m_settings_sync_another_device_prompt_dismissed": {
+    "settings_sync_another_device_prompt_dismissed": {
         "description": "Fired when the user dismisses the Sync Another Device prompt (simplifiedSyncSetupV2) without choosing an option.",
         "owners": ["pballart"],
         "triggers": ["other"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462886803403/task/1217550980600752?focus=true
Tech Design URL:
CC: @hanyutang-sandra 

### Description
Adds an explicit analytics pixel when a user closes the Simplified Sync device-choice prompt without selecting either option. Selecting “Sync another device” or “Set up this device only” does not fire the dismissal pixel.

### Testing Steps
Prerequisite: Turn off Sync if already enabled
1. Open Settings → Sync & Backup
2. Turn on the Sync toggle and complete device authentication → the device-choice prompt appears.
3. Close the prompt without selecting an option → the prompt dismisses and pixel `settings_sync_another_device_prompt_dismissed` fires once.
4. Open the prompt again and select "Sync With Another Device" → the pairing flow opens and the dismissal pixel does not fire.
5. Open the prompt again and select "Sync This Device Only" → setup begins and the dismissal pixel does not fire.

<img width="758" height="799" alt="image" src="https://github.com/user-attachments/assets/d132f6b4-758b-4af7-9c0b-2d8ca6428ce3" />


### Impact
What's the impact on users if something goes wrong?

Low: Minor visual changes, small bug fixes, improvement to existing features

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change on sync setup UI with no sync logic or data handling changes; wrong pixel naming would affect metrics only.
> 
> **Overview**
> Adds **`settings_sync_another_device_prompt_dismissed`** analytics when users close the Simplified Sync v2 “sync another device” choice sheet via the toolbar close button **without** picking “Sync another device” or “Set up this device only.”
> 
> **`SyncSettingsViewModel.dismissAnotherDevicePrompt()`** fires the new setup pixel event (only while the sheet is in the non-connecting another-device phase) and then dismisses the sheet. The v2 prompt’s close action now calls that path instead of a generic dismiss.
> 
> Delegate wiring in **`SyncSettingsViewController+SyncDelegate`** and **`PixelEvent`** / **`settings_sync.json5`** register the event with `appVersion` and `ui_version`. Tests cover delegate firing and that option taps still emit only the existing option-tapped pixel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 800010b4876f64f4202510572f6ac997043d74de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->