### PR TITLE
[macOS] Update UI tests to use new Fire Dialog

### DIFF
--- a/macOS/UITests/AutocompleteTests.swift
+++ b/macOS/UITests/AutocompleteTests.swift
@@ -39,7 +39,7 @@ class AutocompleteTests: UITestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         continueAfterFailure = false
-        app = XCUIApplication.setUp(featureFlags: ["fireDialogSimplified": false])
+        app = XCUIApplication.setUp()
         addBookmarkButton = app.buttons["BookmarkDialogButtonsView.defaultButton"]
         resetBookMarksMenuItem = app.menuItems["MainMenu.resetBookmarks"]
         historyMenuBarItem = app.menuBarItems["History"]
@@ -191,8 +191,14 @@ private extension AutocompleteTests {
             "Fire dialog didn't appear in a reasonable timeframe."
         )
 
-        // Select "Everything" scope to clear all history
-        app.fireDialogSegmentedControl.buttons["Everything"].click()
+        // Select "All data" scope to clear all history
+        app.fireDialogSegmentedControl.buttons["All data"].click()
+
+        // Expand Fire Dialog details
+        let detailsDisclosureButton = app.fireDialogDetailsDisclosureButton
+        if (detailsDisclosureButton.value as? String) != "expanded" {
+            detailsDisclosureButton.click()
+        }
 
         // Ensure history, cookies, and tabs toggles are enabled
         let fireDialogHistoryToggle = app.fireDialogHistoryToggle

--- a/macOS/UITests/BrowsingHistoryTests.swift
+++ b/macOS/UITests/BrowsingHistoryTests.swift
@@ -29,11 +29,12 @@ class BrowsingHistoryTests: UITestCase {
     private var fireDialogCookiesToggle: XCUIElement { app.fireDialogCookiesToggle }
     private var fireDialogTabsToggle: XCUIElement { app.fireDialogTabsToggle }
     private var fireDialogBurnButton: XCUIElement { app.fireDialogBurnButton }
+    private var fireDialogDetailsDisclosureButton: XCUIElement { app.fireDialogDetailsDisclosureButton }
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         continueAfterFailure = false
-        app = XCUIApplication.setUp(featureFlags: ["fireDialogSimplified": false])
+        app = XCUIApplication.setUp()
         app.enforceSingleWindow()
 
         // Clear history using Fire Dialog
@@ -56,7 +57,12 @@ class BrowsingHistoryTests: UITestCase {
         )
 
         // Select "Everything" scope to clear all history
-        app.fireDialogSegmentedControl.buttons["Everything"].click()
+        app.fireDialogSegmentedControl.buttons["All data"].click()
+
+        // Expand Fire Dialog details
+        if (fireDialogDetailsDisclosureButton.value as? String) != "expanded" {
+            fireDialogDetailsDisclosureButton.click()
+        }
 
         // Ensure history toggle is enabled
         fireDialogHistoryToggle.toggleCheckboxIfNeeded(to: true, ensureHittable: { _ in })

--- a/macOS/UITests/Common/XCUIApplicationExtension.swift
+++ b/macOS/UITests/Common/XCUIApplicationExtension.swift
@@ -94,6 +94,7 @@ extension XCUIApplication {
 
         static let fireDialogTitle = "FireDialogView.title"
         static let fireDialogSegmentedControl = "FireDialogView.segmentedControl"
+        static let fireDialogDetailsDisclosureButton = "FireDialogView.detailsDisclosureButton"
         static let fireDialogTabsToggle = "FireDialogView.tabsToggle"
         static let fireDialogHistoryToggle = "FireDialogView.historyToggle"
         static let fireDialogCookiesToggle = "FireDialogView.cookiesToggle"
@@ -822,6 +823,10 @@ extension XCUIApplication {
 
     var fireDialogSegmentedControl: XCUIElement {
         groups[AccessibilityIdentifiers.fireDialogSegmentedControl]
+    }
+
+    var fireDialogDetailsDisclosureButton: XCUIElement {
+        buttons[AccessibilityIdentifiers.fireDialogDetailsDisclosureButton]
     }
 
     var fireDialogTabsToggle: XCUIElement {

--- a/macOS/UITests/NewPermissionViewTests.swift
+++ b/macOS/UITests/NewPermissionViewTests.swift
@@ -53,7 +53,7 @@ class NewPermissionViewTests: UITestCase {
         app.resetAuthorizationStatus(for: .microphone)
 
         // Now set up and launch the app
-        app = XCUIApplication.setUp(featureFlags: ["fireDialogSimplified": false])
+        app = XCUIApplication.setUp()
         addressBarTextField = app.addressBar
         app.enforceSingleWindow()
 
@@ -77,7 +77,12 @@ class NewPermissionViewTests: UITestCase {
         )
 
         // Select "Everything" scope to clear all history
-        app.fireDialogSegmentedControl.buttons["Everything"].click()
+        app.fireDialogSegmentedControl.buttons["All data"].click()
+
+        // Expand Fire Dialog details
+        if (app.fireDialogDetailsDisclosureButton.value as? String) != "expanded" {
+            app.fireDialogDetailsDisclosureButton.click()
+        }
 
         // Ensure toggles are enabled
         fireDialogHistoryToggle.toggleCheckboxIfNeeded(to: true, ensureHittable: { _ in })
@@ -740,7 +745,6 @@ final class NewPermissionViewPopupTests: UITestCase {
             ],
             featureFlags: [
                 "popupBlocking": true,
-                "fireDialogSimplified": false,
             ]
         )
 
@@ -752,7 +756,13 @@ final class NewPermissionViewPopupTests: UITestCase {
     override func tearDown() {
         // Burn all data to clear permissions between tests
         app.fireButton.click()
-        app.fireDialogSegmentedControl.buttons["Everything"].click()
+        app.fireDialogSegmentedControl.buttons["All data"].click()
+
+        // Expand Fire Dialog details
+        if (app.fireDialogDetailsDisclosureButton.value as? String) != "expanded" {
+            app.fireDialogDetailsDisclosureButton.click()
+        }
+
         app.fireDialogTabsToggle.toggleCheckboxIfNeeded(to: true, ensureHittable: { _ in })
         app.fireDialogHistoryToggle.toggleCheckboxIfNeeded(to: true, ensureHittable: { _ in })
         app.fireDialogCookiesToggle.toggleCheckboxIfNeeded(to: true, ensureHittable: { _ in })


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1217623969156564?focus=true

### Description
Adjust non-Fire-Dialog UI tests to use the new Fire Dialog.
Fire Dialog UI tests will be adjusted in a separate PR.

### Testing Steps
Verify that [this UI tests workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/32187186351) is green for the following tests:
* AutocompleteTests
* BrowsingHistoryTests
* NewPermissionViewTests

### Impact
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to UI automation helpers and setup flows; no production app logic or secrets in the diff.
> 
> **Overview**
> Updates **macOS UI test** setup and teardown that clear data via **History → Clear all history** or the Fire button so they target the **new Fire Dialog** instead of forcing the legacy UI with `fireDialogSimplified: false`.
> 
> Tests now pick the **All data** scope (replacing **Everything**), **expand the details disclosure** when toggles are collapsed, then enable history/cookies/tabs and burn as before. Shared helpers add the `FireDialogView.detailsDisclosureButton` accessibility id and `fireDialogDetailsDisclosureButton` on `XCUIApplication`.
> 
> **AutocompleteTests**, **BrowsingHistoryTests**, **NewPermissionViewTests** (including popup tearDown), and **XCUIApplicationExtension** are updated; dedicated Fire Dialog UI tests are left for a follow-up PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15af5841be004463a1a3d43cd395aed0ba6a2bc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->