### PR TITLE
[iOS] Reduce authentication-related hangs on the passwords screen

### DIFF
--- a/iOS/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/iOS/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -80,6 +80,7 @@ class AutofillLoginListViewModel: ObservableObject {
     private var showBreakageReporter: Bool = false
     private let extensionPromotionManager: AutofillExtensionPromotionManaging
     private let featureFlagger: FeatureFlagger
+    private var authenticationAvailable: Bool?
 
     private lazy var reporterDateFormatter = {
         let dateFormatter = DateFormatter()
@@ -211,11 +212,16 @@ class AutofillLoginListViewModel: ObservableObject {
 
         isAuthenticating = true
 
-        if !authenticator.canAuthenticate() {
+        let authenticationAvailable = authenticator.canAuthenticate()
+        self.authenticationAvailable = authenticationAvailable
+
+        if !authenticationAvailable {
             viewState = .noAuthAvailable
             completion(nil)
             return
         }
+
+        updateViewState()
 
         if viewState != .authLocked {
             completion(nil)
@@ -523,9 +529,9 @@ class AutofillLoginListViewModel: ObservableObject {
     private func updateViewState() {
         var newViewState: AutofillLoginListViewModel.ViewState
         
-        if !authenticator.canAuthenticate() {
+        if authenticationAvailable == false {
             newViewState = .noAuthAvailable
-        } else if authenticator.state == .loggedOut && !authenticationNotRequired {
+        } else if authenticator.state != .loggedIn && !authenticationNotRequired {
             newViewState = .authLocked
         } else if isSearching {
             if sections.count == 0 {

--- a/iOS/DuckDuckGo/AutofillLoginListViewModel.swift
+++ b/iOS/DuckDuckGo/AutofillLoginListViewModel.swift
@@ -520,8 +520,19 @@ class AutofillLoginListViewModel: ObservableObject {
     private func setupCancellables() {
         authenticator.$state
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                self?.updateViewState()
+            .sink { [weak self] state in
+                guard let self else { return }
+
+                switch state {
+                case .loggedIn:
+                    authenticationAvailable = true
+                case .notAvailable:
+                    authenticationAvailable = false
+                case .loggedOut:
+                    break
+                }
+
+                updateViewState()
             }
             .store(in: &cancellables)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462886803403/task/1217579031816069?focus=true
Tech Design URL:
CC:

### Description
Avoids repeatedly checking device authentication availability whenever the passwords screen updates. This removes the main-thread work seen in the hang report while preserving credential protection and re-authentication behaviour.

Hang report: 
<img width="815" height="237" alt="image" src="https://github.com/user-attachments/assets/675799a9-11c2-45d6-8155-a2bee280b1f0" />

### Testing Steps
1. Open Settings → Passwords with saved credentials → the credentials remain hidden and the authentication prompt appears.
2. Authenticate successfully → the saved credentials appear.
3. Search the credentials list → results update normally and the screen remains responsive.
4. Open Control Center, then return to the app → authentication is required again and credentials remain hidden until it succeeds.
5. Minimise the app, then return to foreground → authentication is required again and credentials remain hidden until it succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches autofill lock/unlock UI logic; wrong caching could briefly show the wrong screen before auth is checked, but credential protection still depends on the authenticator and vault.
> 
> **Overview**
> Reduces main-thread hangs on the passwords list by **not calling** `canAuthenticate()` every time `updateViewState()` runs (e.g. when sections refresh).
> 
> **`AutofillLoginListViewModel`** now keeps a cached `authenticationAvailable` flag: it is set once when `authenticate()` runs, and updated from `authenticator.$state` (`loggedIn` → available, `notAvailable` → unavailable). View state uses that cache for `.noAuthAvailable` instead of re-querying LocalAuthentication, and treats the lock screen when the user is not `.loggedIn` rather than only when `.loggedOut`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 857d7b71b969288e81b5142b2dd49fe796da16db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->