### PR TITLE
Sync: Self-heal current-device metadata after device-list fallback

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -246,9 +246,10 @@ public class DDGSync: DDGSyncing {
             throw SyncError.accountNotFound
         }
 
+        let wasDeviceInfoMigrationRunning = deviceInfoMigrationTask != nil
         do {
             let result = try await dependencies.account.fetchDevicesForAccount(account)
-            if result.needsCurrentDeviceInfoRepair {
+            if result.needsCurrentDeviceInfoRepair && !wasDeviceInfoMigrationRunning {
                 scheduleCurrentDeviceInfoRepair(for: account)
             }
             return result.devices
@@ -731,6 +732,7 @@ public class DDGSync: DDGSyncing {
 
     private func scheduleCurrentDeviceInfoRepair(for account: SyncAccount) {
         guard dependencies.syncFeatureFlags.canWriteUnifiedDeviceList(),
+              deviceInfoMigrationTask == nil,
               currentDeviceInfoRepairTask == nil,
               !hasAttemptedCurrentDeviceInfoRepair else {
             return

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -247,14 +247,18 @@ public class DDGSync: DDGSyncing {
         }
 
         do {
-            return try await dependencies.account.fetchDevicesForAccount(account).devices
+            let result = try await dependencies.account.fetchDevicesForAccount(account)
+            if result.needsCurrentDeviceInfoRepair {
+                scheduleCurrentDeviceInfoRepair(for: account)
+            }
+            return result.devices
         } catch {
             throw handleUnauthenticatedAndMap(error)
         }
     }
 
     public func updateDeviceName(_ name: String) async throws -> [RegisteredDevice] {
-        await cancelDeviceInfoMigrationAndWait()
+        await cancelDeviceInfoUpdatesAndWait()
 
         guard let account = try dependencies.secureStore.account() else {
             throw SyncError.accountNotFound
@@ -522,6 +526,10 @@ public class DDGSync: DDGSyncing {
                 deviceInfoMigrationTask?.cancel()
                 deviceInfoMigrationTask = nil
                 deviceInfoMigrationTaskID = nil
+                currentDeviceInfoRepairTask?.cancel()
+                currentDeviceInfoRepairTask = nil
+                currentDeviceInfoRepairTaskID = nil
+                hasAttemptedCurrentDeviceInfoRepair = false
                 try dependencies.secureStore.removeAccount()
                 clearAccountInfoKeyCache(for: storedAccount)
                 deviceInfoMigrationCoordinator.reset()
@@ -721,6 +729,27 @@ public class DDGSync: DDGSyncing {
         }
     }
 
+    private func scheduleCurrentDeviceInfoRepair(for account: SyncAccount) {
+        guard dependencies.syncFeatureFlags.canWriteUnifiedDeviceList(),
+              currentDeviceInfoRepairTask == nil,
+              !hasAttemptedCurrentDeviceInfoRepair else {
+            return
+        }
+        let deviceInfoMigrationCoordinator = deviceInfoMigrationCoordinator
+        let taskID = UUID()
+        currentDeviceInfoRepairTaskID = taskID
+        // A failed best-effort repair retries on a later app launch, not on every device-list poll.
+        hasAttemptedCurrentDeviceInfoRepair = true
+        let task = Task {
+            await deviceInfoMigrationCoordinator.repairCurrentDeviceInfo(for: account)
+        }
+        currentDeviceInfoRepairTask = task
+        Task { [weak self] in
+            await task.value
+            self?.clearCompletedCurrentDeviceInfoRepairTask(withID: taskID)
+        }
+    }
+
     private func clearCompletedDeviceInfoMigrationTask(withID taskID: UUID) {
         guard deviceInfoMigrationTaskID == taskID else {
             return
@@ -729,14 +758,26 @@ public class DDGSync: DDGSyncing {
         deviceInfoMigrationTaskID = nil
     }
 
-    private func cancelDeviceInfoMigrationAndWait() async {
-        guard let deviceInfoMigrationTask else {
+    private func clearCompletedCurrentDeviceInfoRepairTask(withID taskID: UUID) {
+        guard currentDeviceInfoRepairTaskID == taskID else {
             return
         }
-        deviceInfoMigrationTask.cancel()
-        await deviceInfoMigrationTask.value
+        currentDeviceInfoRepairTask = nil
+        currentDeviceInfoRepairTaskID = nil
+    }
+
+    private func cancelDeviceInfoUpdatesAndWait() async {
+        let deviceInfoMigrationTask = deviceInfoMigrationTask
+        let currentDeviceInfoRepairTask = currentDeviceInfoRepairTask
+        deviceInfoMigrationTask?.cancel()
+        currentDeviceInfoRepairTask?.cancel()
+        await deviceInfoMigrationTask?.value
+        await currentDeviceInfoRepairTask?.value
         self.deviceInfoMigrationTask = nil
         deviceInfoMigrationTaskID = nil
+        self.currentDeviceInfoRepairTask = nil
+        currentDeviceInfoRepairTaskID = nil
+        hasAttemptedCurrentDeviceInfoRepair = false
     }
 
     private func persistRecoveredThirdPartyScopedPasswordIfAvailable(from accessCredentials: [AccessCredential]?, account: SyncAccount) {
@@ -803,6 +844,10 @@ public class DDGSync: DDGSyncing {
         deviceInfoMigrationTask?.cancel()
         deviceInfoMigrationTask = nil
         deviceInfoMigrationTaskID = nil
+        currentDeviceInfoRepairTask?.cancel()
+        currentDeviceInfoRepairTask = nil
+        currentDeviceInfoRepairTaskID = nil
+        hasAttemptedCurrentDeviceInfoRepair = false
         dependencies.scheduler.isEnabled = false
         startSyncCancellable?.cancel()
         syncQueueCancellable?.cancel()
@@ -870,4 +915,7 @@ public class DDGSync: DDGSyncing {
     private var syncQueueRequestErrorCancellable: AnyCancellable?
     private var deviceInfoMigrationTask: Task<Void, Never>?
     private var deviceInfoMigrationTaskID: UUID?
+    private var currentDeviceInfoRepairTask: Task<Void, Never>?
+    private var currentDeviceInfoRepairTaskID: UUID?
+    private var hasAttemptedCurrentDeviceInfoRepair = false
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -732,6 +732,9 @@ public class DDGSync: DDGSyncing {
 
     private func scheduleCurrentDeviceInfoRepair(for account: SyncAccount) {
         guard dependencies.syncFeatureFlags.canWriteUnifiedDeviceList(),
+              let currentAccount = try? dependencies.secureStore.account(),
+              currentAccount.userId == account.userId,
+              currentAccount.deviceId == account.deviceId,
               deviceInfoMigrationTask == nil,
               currentDeviceInfoRepairTask == nil,
               !hasAttemptedCurrentDeviceInfoRepair else {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -259,6 +259,8 @@ public class DDGSync: DDGSyncing {
     }
 
     public func updateDeviceName(_ name: String) async throws -> [RegisteredDevice] {
+        isDeviceRenameInProgress = true
+        defer { isDeviceRenameInProgress = false }
         await cancelDeviceInfoUpdatesAndWait()
 
         guard let account = try dependencies.secureStore.account() else {
@@ -737,6 +739,7 @@ public class DDGSync: DDGSyncing {
               currentAccount.deviceId == account.deviceId,
               deviceInfoMigrationTask == nil,
               currentDeviceInfoRepairTask == nil,
+              !isDeviceRenameInProgress,
               !hasAttemptedCurrentDeviceInfoRepair else {
             return
         }
@@ -923,5 +926,6 @@ public class DDGSync: DDGSyncing {
     private var deviceInfoMigrationTaskID: UUID?
     private var currentDeviceInfoRepairTask: Task<Void, Never>?
     private var currentDeviceInfoRepairTaskID: UUID?
+    private var isDeviceRenameInProgress = false
     private var hasAttemptedCurrentDeviceInfoRepair = false
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -737,6 +737,7 @@ public class DDGSync: DDGSyncing {
               !hasAttemptedCurrentDeviceInfoRepair else {
             return
         }
+        Logger.sync.debug("Sync-UnifiedDevices: scheduling current device_info repair")
         let deviceInfoMigrationCoordinator = deviceInfoMigrationCoordinator
         let taskID = UUID()
         currentDeviceInfoRepairTaskID = taskID

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -747,7 +747,7 @@ public class DDGSync: DDGSyncing {
         // A failed best-effort repair retries on a later app launch, not on every device-list poll.
         hasAttemptedCurrentDeviceInfoRepair = true
         let task = Task {
-            await deviceInfoMigrationCoordinator.repairCurrentDeviceInfo(for: account)
+            await deviceInfoMigrationCoordinator.repairCurrentDeviceInfo(for: currentAccount)
         }
         currentDeviceInfoRepairTask = task
         Task { [weak self] in

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
@@ -22,6 +22,7 @@ import Persistence
 
 protocol DeviceInfoMigrationCoordinating {
     func migrateCurrentDeviceIfNeeded(for account: SyncAccount) async
+    func repairCurrentDeviceInfo(for account: SyncAccount) async
     func hasCompletedMigration(for account: SyncAccount) -> Bool
     func reset()
 }
@@ -84,7 +85,21 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
             return
         }
         Logger.sync.debug("Sync-UnifiedDevices: migrating current device_info")
+        await updateCurrentDeviceInfo(for: account, identity: identity)
+    }
 
+    func repairCurrentDeviceInfo(for account: SyncAccount) async {
+        let identity = DeviceInfoMigrationIdentity(account: account)
+        guard canWriteUnifiedDeviceList(),
+              currentAccount(matching: identity) != nil,
+              !Task.isCancelled else {
+            return
+        }
+        await updateCurrentDeviceInfo(for: account, identity: identity)
+    }
+
+    private func updateCurrentDeviceInfo(for account: SyncAccount,
+                                         identity: DeviceInfoMigrationIdentity) async {
         do {
             let protectedKey = try await prepareAccountInfoProtectedKey(for: account,
                                                                         identity: identity)
@@ -123,8 +138,8 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
             guard !Task.isCancelled else {
                 return
             }
-            let errorType = String(describing: type(of: error))
-            Logger.sync.error("Sync-UnifiedDevices: failed to migrate current device_info: \(errorType)")
+            let errorType = String(describing: Swift.type(of: error))
+            Logger.sync.error("Sync-UnifiedDevices: failed to update current device_info: \(errorType)")
         }
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -159,6 +159,7 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
         if initialMappings.contains(where: { $0.unifiedDeviceInfoFailure == .staleKey }),
            let accountInfoKeys,
            let refreshedAccountInfoKey = try? await accountInfoKeys.refreshKey(for: account) {
+            Logger.sync.debug("Sync-UnifiedDevices: refreshed account_info key after stale device_info")
             finalMappings = entries.map {
                 registeredDevice(from: $0,
                                  account: account,

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -1006,6 +1006,78 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertTrue(migrationCoordinator.calls.isEmpty)
     }
 
+    func testWhenRepairingFetchCompletesDuringRenameThenRepairWaitsForNextPoll() async throws {
+        dependencies.canWriteUnifiedDeviceList = { true }
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        let deviceFetchStarted = expectation(description: "Device fetch started")
+        let renameStarted = expectation(description: "Device rename started")
+        let migrationFinished = expectation(description: "Device info migration finished")
+        let unexpectedRepair = expectation(description: "Current device info repair not scheduled during rename")
+        unexpectedRepair.isInverted = true
+        let (deviceFetchGate, deviceFetchGateContinuation) = AsyncStream<Void>.makeStream()
+        let (renameGate, renameGateContinuation) = AsyncStream<Void>.makeStream()
+        defer {
+            deviceFetchGateContinuation.finish()
+            renameGateContinuation.finish()
+        }
+        accountManager.fetchDevicesForAccountHandler = { _ in
+            deviceFetchStarted.fulfill()
+            for await _ in deviceFetchGate {}
+            return RegisteredDeviceMappingResult(devices: [.mock], needsCurrentDeviceInfoRepair: true)
+        }
+        accountManager.refreshTokenHandler = { account, deviceName in
+            renameStarted.fulfill()
+            for await _ in renameGate {}
+            let renamedAccount = SyncAccount(
+                deviceId: account.deviceId,
+                deviceName: deviceName,
+                deviceType: account.deviceType,
+                userId: account.userId,
+                primaryKey: account.primaryKey,
+                secretKey: account.secretKey,
+                token: account.token,
+                state: account.state)
+            return LoginResult(account: renamedAccount, devices: [.mock])
+        }
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.migrateCurrentDeviceHandler = {
+            migrationFinished.fulfill()
+        }
+        migrationCoordinator.repairCurrentDeviceInfoHandler = {
+            unexpectedRepair.fulfill()
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        async let fetchedDevices = syncService.fetchDevices()
+        await fulfillment(of: [deviceFetchStarted], timeout: 1)
+        async let renamedDevices = syncService.updateDeviceName("Renamed Device")
+        await fulfillment(of: [renameStarted], timeout: 1)
+        deviceFetchGateContinuation.finish()
+        _ = try await fetchedDevices
+        await fulfillment(of: [unexpectedRepair], timeout: 0.1)
+        renameGateContinuation.finish()
+        _ = try await renamedDevices
+        await fulfillment(of: [migrationFinished], timeout: 1)
+        await Task.yield()
+
+        XCTAssertTrue(migrationCoordinator.repairCalls.isEmpty)
+
+        let repairScheduledOnNextPoll = expectation(description: "Current device info repair scheduled on next poll")
+        migrationCoordinator.repairCurrentDeviceInfoHandler = {
+            repairScheduledOnNextPoll.fulfill()
+        }
+        accountManager.fetchDevicesForAccountHandler = nil
+        accountManager.fetchDevicesForAccountStub = RegisteredDeviceMappingResult(
+            devices: [.mock],
+            needsCurrentDeviceInfoRepair: true)
+
+        _ = try await syncService.fetchDevices()
+        await fulfillment(of: [repairScheduledOnNextPoll], timeout: 1)
+
+        XCTAssertEqual(migrationCoordinator.repairCalls.map(\.account.deviceId), [SyncAccount.mock.deviceId])
+    }
+
     func testWhenRefreshResponseContainsRecoverableScopedPasswordThenScopedPasswordIsCached() async throws {
         let scopedPassword = Data(repeating: 7, count: 32)
         (dependencies.account as? AccountManagingMock)?.refreshTokenStub = LoginResult(

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -795,6 +795,51 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(migrationCoordinator.repairCalls.map(\.account.deviceId), [replacementAccount.deviceId])
     }
 
+    func testWhenStoredAccountIsRefreshedDuringDeviceFetchThenRepairUsesLatestAccount() async throws {
+        dependencies.canWriteUnifiedDeviceList = { true }
+        let secureStore = try XCTUnwrap(dependencies.secureStore as? SecureStorageStub)
+        let originalAccount = SyncAccount.mock
+        let refreshedAccount = SyncAccount(
+            deviceId: originalAccount.deviceId,
+            deviceName: "refreshedDeviceName",
+            deviceType: originalAccount.deviceType,
+            userId: originalAccount.userId,
+            primaryKey: Data("refreshedPrimaryKey".utf8),
+            secretKey: Data("refreshedSecretKey".utf8),
+            token: "refreshedToken",
+            state: .active)
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        let deviceFetchStarted = expectation(description: "Device fetch started")
+        let (deviceFetchGate, deviceFetchGateContinuation) = AsyncStream<Void>.makeStream()
+        defer { deviceFetchGateContinuation.finish() }
+        accountManager.fetchDevicesForAccountHandler = { _ in
+            deviceFetchStarted.fulfill()
+            for await _ in deviceFetchGate {}
+            return RegisteredDeviceMappingResult(devices: [.mock], needsCurrentDeviceInfoRepair: true)
+        }
+        let repairScheduled = expectation(description: "Current device info repair scheduled")
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.repairCurrentDeviceInfoHandler = {
+            repairScheduled.fulfill()
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        async let devices = syncService.fetchDevices()
+        await fulfillment(of: [deviceFetchStarted], timeout: 1)
+        secureStore.theAccount = refreshedAccount
+        deviceFetchGateContinuation.finish()
+        _ = try await devices
+        await fulfillment(of: [repairScheduled], timeout: 1)
+
+        XCTAssertEqual(migrationCoordinator.repairCalls.count, 1)
+        let repairAccount = try XCTUnwrap(migrationCoordinator.repairCalls.first?.account)
+        XCTAssertEqual(repairAccount.deviceName, refreshedAccount.deviceName)
+        XCTAssertEqual(repairAccount.primaryKey, refreshedAccount.primaryKey)
+        XCTAssertEqual(repairAccount.secretKey, refreshedAccount.secretKey)
+        XCTAssertEqual(repairAccount.token, refreshedAccount.token)
+    }
+
     func testWhenFetchedCurrentDeviceNeedsInfoRepairButWriteIsDisabledThenRepairIsNotScheduled() async throws {
         let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
         accountManager.fetchDevicesForAccountStub = RegisteredDeviceMappingResult(

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -661,6 +661,50 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(migrationCoordinator.resetCallCount, 1)
     }
 
+    func testWhenFetchedCurrentDeviceNeedsInfoRepairThenRepairIsScheduledOncePerSession() async throws {
+        dependencies.canWriteUnifiedDeviceList = { true }
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        accountManager.fetchDevicesForAccountStub = RegisteredDeviceMappingResult(
+            devices: [.mock],
+            needsCurrentDeviceInfoRepair: true)
+        let repairScheduled = expectation(description: "Current device info repair scheduled")
+        let repairFinished = expectation(description: "Current device info repair finished")
+        let (repairGate, repairGateContinuation) = AsyncStream<Void>.makeStream()
+        defer { repairGateContinuation.finish() }
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.repairCurrentDeviceInfoHandler = {
+            repairScheduled.fulfill()
+            for await _ in repairGate {}
+            repairFinished.fulfill()
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        let devices = try await syncService.fetchDevices()
+        await fulfillment(of: [repairScheduled], timeout: 1)
+        repairGateContinuation.finish()
+        await fulfillment(of: [repairFinished], timeout: 1)
+        await Task.yield()
+        _ = try await syncService.fetchDevices()
+
+        XCTAssertEqual(devices.map(\.id), [RegisteredDevice.mock.id])
+        XCTAssertEqual(migrationCoordinator.repairCalls.map(\.account.deviceId), [SyncAccount.mock.deviceId])
+    }
+
+    func testWhenFetchedCurrentDeviceNeedsInfoRepairButWriteIsDisabledThenRepairIsNotScheduled() async throws {
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        accountManager.fetchDevicesForAccountStub = RegisteredDeviceMappingResult(
+            devices: [.mock],
+            needsCurrentDeviceInfoRepair: true)
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        _ = try await syncService.fetchDevices()
+
+        XCTAssertTrue(migrationCoordinator.repairCalls.isEmpty)
+    }
+
     func testWhenScopedPasswordRecoveryFailsDuringLoginThenNativeLoginStillSucceeds() async throws {
         (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil
         (dependencies.secureStore as? SecureStorageStub)?.theScopedPassword = Data(repeating: 9, count: 32)

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -661,6 +661,67 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(migrationCoordinator.resetCallCount, 1)
     }
 
+    func testWhenMigrationCompletesDuringDeviceFetchThenStaleResultDoesNotScheduleRepairUntilNextPoll() async throws {
+        dependencies.canWriteUnifiedDeviceList = { true }
+        (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        let migrationStarted = expectation(description: "Device info migration started")
+        let migrationFinished = expectation(description: "Device info migration finished")
+        let deviceFetchStarted = expectation(description: "Device fetch started")
+        let unexpectedRepair = expectation(description: "Current device info repair not scheduled")
+        unexpectedRepair.isInverted = true
+        let (migrationGate, migrationGateContinuation) = AsyncStream<Void>.makeStream()
+        let (deviceFetchGate, deviceFetchGateContinuation) = AsyncStream<Void>.makeStream()
+        defer {
+            migrationGateContinuation.finish()
+            deviceFetchGateContinuation.finish()
+        }
+        accountManager.fetchDevicesForAccountHandler = { _ in
+            deviceFetchStarted.fulfill()
+            for await _ in deviceFetchGate {}
+            return RegisteredDeviceMappingResult(devices: [.mock], needsCurrentDeviceInfoRepair: true)
+        }
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.migrateCurrentDeviceHandler = {
+            migrationStarted.fulfill()
+            for await _ in migrationGate {}
+            migrationFinished.fulfill()
+        }
+        migrationCoordinator.repairCurrentDeviceInfoHandler = {
+            unexpectedRepair.fulfill()
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        try await syncService.createAccount(deviceName: "iPhone", deviceType: "iOS")
+        await fulfillment(of: [migrationStarted], timeout: 1)
+        async let fetchedDevices = syncService.fetchDevices()
+        await fulfillment(of: [deviceFetchStarted], timeout: 1)
+        migrationGateContinuation.finish()
+        await fulfillment(of: [migrationFinished], timeout: 1)
+        await Task.yield()
+        deviceFetchGateContinuation.finish()
+        let devices = try await fetchedDevices
+        await fulfillment(of: [unexpectedRepair], timeout: 0.1)
+
+        XCTAssertEqual(devices.map(\.id), [RegisteredDevice.mock.id])
+        XCTAssertTrue(migrationCoordinator.repairCalls.isEmpty)
+
+        let repairScheduledOnNextPoll = expectation(description: "Current device info repair scheduled on next poll")
+        migrationCoordinator.repairCurrentDeviceInfoHandler = {
+            repairScheduledOnNextPoll.fulfill()
+        }
+        accountManager.fetchDevicesForAccountHandler = nil
+        accountManager.fetchDevicesForAccountStub = RegisteredDeviceMappingResult(
+            devices: [.mock],
+            needsCurrentDeviceInfoRepair: true)
+
+        _ = try await syncService.fetchDevices()
+        await fulfillment(of: [repairScheduledOnNextPoll], timeout: 1)
+
+        XCTAssertEqual(migrationCoordinator.repairCalls.map(\.account.deviceId), [SyncAccount.mock.deviceId])
+    }
+
     func testWhenFetchedCurrentDeviceNeedsInfoRepairThenRepairIsScheduledOncePerSession() async throws {
         dependencies.canWriteUnifiedDeviceList = { true }
         let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -752,6 +752,49 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(migrationCoordinator.repairCalls.map(\.account.deviceId), [SyncAccount.mock.deviceId])
     }
 
+    func testWhenAccountChangesDuringDeviceFetchThenOldResultDoesNotConsumeRepairAttempt() async throws {
+        dependencies.canWriteUnifiedDeviceList = { true }
+        let secureStore = try XCTUnwrap(dependencies.secureStore as? SecureStorageStub)
+        let originalAccount = SyncAccount.mock
+        let replacementAccount = SyncAccount(
+            deviceId: "replacementDeviceId",
+            deviceName: "replacementDeviceName",
+            deviceType: originalAccount.deviceType,
+            userId: "replacementUserId",
+            primaryKey: originalAccount.primaryKey,
+            secretKey: originalAccount.secretKey,
+            token: originalAccount.token,
+            state: .active)
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        let originalFetchStarted = expectation(description: "Original account device fetch started")
+        let (originalFetchGate, originalFetchGateContinuation) = AsyncStream<Void>.makeStream()
+        defer { originalFetchGateContinuation.finish() }
+        accountManager.fetchDevicesForAccountHandler = { account in
+            if account.deviceId == originalAccount.deviceId {
+                originalFetchStarted.fulfill()
+                for await _ in originalFetchGate {}
+            }
+            return RegisteredDeviceMappingResult(devices: [.mock], needsCurrentDeviceInfoRepair: true)
+        }
+        let repairScheduled = expectation(description: "Replacement account device info repair scheduled")
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.repairCurrentDeviceInfoHandler = {
+            repairScheduled.fulfill()
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        async let originalDevices = syncService.fetchDevices()
+        await fulfillment(of: [originalFetchStarted], timeout: 1)
+        secureStore.theAccount = replacementAccount
+        originalFetchGateContinuation.finish()
+        _ = try await originalDevices
+        _ = try await syncService.fetchDevices()
+        await fulfillment(of: [repairScheduled], timeout: 1)
+
+        XCTAssertEqual(migrationCoordinator.repairCalls.map(\.account.deviceId), [replacementAccount.deviceId])
+    }
+
     func testWhenFetchedCurrentDeviceNeedsInfoRepairButWriteIsDisabledThenRepairIsNotScheduled() async throws {
         let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
         accountManager.fetchDevicesForAccountStub = RegisteredDeviceMappingResult(

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
@@ -99,6 +99,16 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.count, 1)
     }
 
+    func testWhenMigrationAlreadyCompletedThenRepairStillPatchesCurrentDevice() async {
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+
+        await coordinator.repairCurrentDeviceInfo(for: .mock)
+
+        XCTAssertEqual(accountManager.updateDeviceCalls.count, 2)
+        XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.count, 2)
+        XCTAssertTrue(coordinator.hasCompletedMigration(for: .mock))
+    }
+
     func testWhenCompletedMigrationIsResetAfterRenameThenCurrentDeviceIsPatchedAgainWithLatestName() async throws {
         await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
         let renamedAccount = SyncAccount(

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -94,9 +94,13 @@ class AccountManagingMock: AccountManaging {
 
     var refreshTokenStub: LoginResult?
     var refreshTokenError: Error?
+    var refreshTokenHandler: ((SyncAccount, String) async throws -> LoginResult)?
     var refreshTokenCalled: Bool = false
     func refreshToken(_ account: SyncAccount, deviceName: String) async throws -> LoginResult {
         refreshTokenCalled = true
+        if let refreshTokenHandler {
+            return try await refreshTokenHandler(account, deviceName)
+        }
         if let refreshTokenError {
             throw refreshTokenError
         }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -595,6 +595,7 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
 
     private let lock = NSLock()
     private var recordedCalls: [Call] = []
+    private var recordedRepairCalls: [Call] = []
     private var recordedResetCallCount = 0
     var hasCompletedMigrationStub = false
     var calls: [Call] {
@@ -602,15 +603,26 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
         defer { lock.unlock() }
         return recordedCalls
     }
+    var repairCalls: [Call] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedRepairCalls
+    }
     var resetCallCount: Int {
         lock.lock()
         defer { lock.unlock() }
         return recordedResetCallCount
     }
     var migrateCurrentDeviceHandler: (() async -> Void)?
+    var repairCurrentDeviceInfoHandler: (() async -> Void)?
 
     func migrateCurrentDeviceIfNeeded(for account: SyncAccount) async {
         let handler = record(Call(account: account))
+        await handler?()
+    }
+
+    func repairCurrentDeviceInfo(for account: SyncAccount) async {
+        let handler = recordRepair(Call(account: account))
         await handler?()
     }
 
@@ -628,6 +640,14 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
         lock.lock()
         recordedCalls.append(call)
         let handler = migrateCurrentDeviceHandler
+        lock.unlock()
+        return handler
+    }
+
+    private func recordRepair(_ call: Call) -> (() async -> Void)? {
+        lock.lock()
+        recordedRepairCalls.append(call)
+        let handler = repairCurrentDeviceInfoHandler
         lock.unlock()
         return handler
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1217605006097875?focus=true
Tech Design URL:
CC:

### Description
Unified device lists use encrypted device_info so all clients can share a device’s name and type. When that metadata is missing or cannot be read, Apple still displays the device using its legacy name and type.

This PR makes that fallback self-healing for the current Apple device. When the device list falls back to legacy data for this device, the app recreates and uploads its unified metadata in the background so future refreshes can use device_info again.

Repair requires unified-device writes and is attempted at most once per app session to avoid repeatedly updating the server during device-list polling. It does not delay or block the device list, and it never attempts to repair another device. Work based on an outdated account or overlapping migration is safely ignored without consuming the session’s repair attempt.

### Testing Steps
Prerequisite: Test on iOS because it provides the device-list diagnostics in Debug > Sync. Start with Sync disabled and create a brand-new account. Keep the app running while changing the flags so launch-time migration does not populate the metadata first.

1. Ensure both feature flags `syncCanReadUnifiedDeviceList` & `syncCanWriteUnifiedDeviceList` are disabled
2. Enable Sync → account creation succeeds without unified device metadata.
3. Enable `syncCanReadUnifiedDeviceList`, leaving `syncCanWriteUnifiedDeviceList` disabled.
4. Open the Sync screen → the current device remains visible with its correct legacy name and type.
5. Open Debug > Sync and tap to refresh the device list → the current device reports the legacy source and a missing `device_info` issue.
6. In the Xcode console, filter for `Sync-UnifiedDevices`.
7. Enable `syncCanWriteUnifiedDeviceList`.
8. Return to the Sync settings screen → the device remains visible while the console reports that current-device repair was scheduled and completed.
9. Return to Debug > Sync and refresh the device list → the current device reports `device_info` as its source with no device-info issue.
10. Return to the Sync settings screen again → the device remains correct and no additional repair is scheduled in logs


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Background server updates to device metadata and new concurrency guards around migration/rename; scoped to the current device and feature-flagged writes, but touches core sync device-list flows.
> 
> **Overview**
> Adds **self-healing for the current device’s unified `device_info`** when the device list had to fall back to legacy name/type for this device.
> 
> After `fetchDevices()`, if the mapper reports `needsCurrentDeviceInfoRepair` and launch migration wasn’t in flight, `DDGSync` schedules a **best-effort background repair** (unified writes enabled only, **once per app session**, non-blocking). Repair is skipped during rename, while migration/repair tasks run, or when the stored account no longer matches the fetch; rename now cancels **both** migration and repair via `cancelDeviceInfoUpdatesAndWait()`.
> 
> `DeviceInfoMigrationCoordinator` gains `repairCurrentDeviceInfo`, sharing upload logic with migration but **without** requiring migration to be incomplete. Account teardown clears repair state. Mapper adds a debug log when refreshing `account_info` after stale `device_info`. Tests cover scheduling edge cases (migration overlap, account swap, rename, write flag off).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdb65500612d58c45bb74e8ef2ed489cd01d6441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->