### PR TITLE
[iOS] Purge app switcher snapshots on Fire

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		05F1108C822949F08BF3A2D6 /* AppSwitcherSnapshotCleanerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2CD0727DF6499698C2C9B6 /* AppSwitcherSnapshotCleanerTests.swift */; };
+		A11F1F0030B1000000000001 /* FireButtonAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11F1F0130B1000000000001 /* FireButtonAnimatorTests.swift */; };
 		6B8037F2CB054FEFA71D9805 /* AppSwitcherSnapshotCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B201258F344468FA92BB7D2 /* AppSwitcherSnapshotCleaner.swift */; };
 		02025664298818B200E694E7 /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02025663298818B100E694E7 /* NetworkExtension.framework */; };
 		021440742C7FAB1900426724 /* ConfigurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021440732C7FAB1900426724 /* ConfigurationManager.swift */; };
@@ -2957,6 +2958,7 @@
 /* Begin PBXFileReference section */
 		3B201258F344468FA92BB7D2 /* AppSwitcherSnapshotCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSwitcherSnapshotCleaner.swift; sourceTree = "<group>"; };
 		5D2CD0727DF6499698C2C9B6 /* AppSwitcherSnapshotCleanerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSwitcherSnapshotCleanerTests.swift; sourceTree = "<group>"; };
+		A11F1F0130B1000000000001 /* FireButtonAnimatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireButtonAnimatorTests.swift; sourceTree = "<group>"; };
 		02025662298818B100E694E7 /* PacketTunnelProvider.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = PacketTunnelProvider.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		02025663298818B100E694E7 /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = System/Library/Frameworks/NetworkExtension.framework; sourceTree = SDKROOT; };
 		02025668298818B200E694E7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -7780,6 +7782,7 @@
 			isa = PBXGroup;
 			children = (
 				5D2CD0727DF6499698C2C9B6 /* AppSwitcherSnapshotCleanerTests.swift */,
+				A11F1F0130B1000000000001 /* FireButtonAnimatorTests.swift */,
 				36F6195F2F686F3300CBF121 /* DataClearingWideEventServiceTests.swift */,
 				36F6195B2F68657100CBF121 /* DataClearingPixelsReporterTests.swift */,
 				80437D6C2EFB3BD600D3E896 /* AutoClearSettingsViewModelTests.swift */,
@@ -15286,6 +15289,7 @@
 				805898353006C5BA00A4EA69 /* SerpSearchTokenInterceptorTests.swift in Sources */,
 				80E8D5D32EEA655900820EB0 /* FireExecutorTests.swift in Sources */,
 				05F1108C822949F08BF3A2D6 /* AppSwitcherSnapshotCleanerTests.swift in Sources */,
+				A11F1F0030B1000000000001 /* FireButtonAnimatorTests.swift in Sources */,
 				8582D7282E58A11D00A356FD /* AutocompleteViewModelTests.swift in Sources */,
 				981FED7422046017008488D7 /* AutoClearTests.swift in Sources */,
 				319BE1092D47EBE300E510A4 /* AIChatUserScriptHandlerTests.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05F1108C822949F08BF3A2D6 /* AppSwitcherSnapshotCleanerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D2CD0727DF6499698C2C9B6 /* AppSwitcherSnapshotCleanerTests.swift */; };
+		6B8037F2CB054FEFA71D9805 /* AppSwitcherSnapshotCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B201258F344468FA92BB7D2 /* AppSwitcherSnapshotCleaner.swift */; };
 		02025664298818B200E694E7 /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02025663298818B100E694E7 /* NetworkExtension.framework */; };
 		021440742C7FAB1900426724 /* ConfigurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021440732C7FAB1900426724 /* ConfigurationManager.swift */; };
 		021440762C7FAB4100426724 /* ConfigurationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021440752C7FAB4100426724 /* ConfigurationStore.swift */; };
@@ -2953,6 +2955,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3B201258F344468FA92BB7D2 /* AppSwitcherSnapshotCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSwitcherSnapshotCleaner.swift; sourceTree = "<group>"; };
+		5D2CD0727DF6499698C2C9B6 /* AppSwitcherSnapshotCleanerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSwitcherSnapshotCleanerTests.swift; sourceTree = "<group>"; };
 		02025662298818B100E694E7 /* PacketTunnelProvider.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = PacketTunnelProvider.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		02025663298818B100E694E7 /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = System/Library/Frameworks/NetworkExtension.framework; sourceTree = SDKROOT; };
 		02025668298818B200E694E7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -7775,6 +7779,7 @@
 		8097AA582EE652CF00E995F9 /* Fire */ = {
 			isa = PBXGroup;
 			children = (
+				5D2CD0727DF6499698C2C9B6 /* AppSwitcherSnapshotCleanerTests.swift */,
 				36F6195F2F686F3300CBF121 /* DataClearingWideEventServiceTests.swift */,
 				36F6195B2F68657100CBF121 /* DataClearingPixelsReporterTests.swift */,
 				80437D6C2EFB3BD600D3E896 /* AutoClearSettingsViewModelTests.swift */,
@@ -7790,6 +7795,7 @@
 			isa = PBXGroup;
 			children = (
 				80A09D612F6BA07500AACDEE /* AIChatDeleter.swift */,
+				3B201258F344468FA92BB7D2 /* AppSwitcherSnapshotCleaner.swift */,
 				806DF4082F3B89BD00FBCA3F /* DataClearingCapability.swift */,
 				F1000FEA2FA3B25D00D96ED0 /* Fire.xcassets */,
 				809F9D112EE12CF600943E8A /* FireConfirmationPresenter.swift */,
@@ -13539,6 +13545,7 @@
 				C12726F02A5FF89900215B02 /* EmailSignupPromptViewModel.swift in Sources */,
 				31669B9A28020A460071CC18 /* SaveLoginViewModel.swift in Sources */,
 				8065741D2ED917410001497A /* FireExecutor.swift in Sources */,
+				6B8037F2CB054FEFA71D9805 /* AppSwitcherSnapshotCleaner.swift in Sources */,
 				312BF6EF2E6B2CAF00411CF9 /* NewAddressBarPickerDisplayValidator.swift in Sources */,
 				EE4FB1882A28D11900E5CBA7 /* NetworkProtectionStatusViewModel.swift in Sources */,
 				4B67012B2E3BE3660066176A /* LogViewerDataSource.swift in Sources */,
@@ -15278,6 +15285,7 @@
 				9FA0AF282EB844C800713387 /* MockParameterRandomiser.swift in Sources */,
 				805898353006C5BA00A4EA69 /* SerpSearchTokenInterceptorTests.swift in Sources */,
 				80E8D5D32EEA655900820EB0 /* FireExecutorTests.swift in Sources */,
+				05F1108C822949F08BF3A2D6 /* AppSwitcherSnapshotCleanerTests.swift in Sources */,
 				8582D7282E58A11D00A356FD /* AutocompleteViewModelTests.swift in Sources */,
 				981FED7422046017008488D7 /* AutoClearTests.swift in Sources */,
 				319BE1092D47EBE300E510A4 /* AIChatUserScriptHandlerTests.swift in Sources */,

--- a/iOS/DuckDuckGo/Fire/AppSwitcherSnapshotCleaner.swift
+++ b/iOS/DuckDuckGo/Fire/AppSwitcherSnapshotCleaner.swift
@@ -20,12 +20,12 @@
 import Common
 import Foundation
 
-protocol AppSwitcherSnapshotClearing {
+protocol AppSwitcherSnapshotClearing: Sendable {
     /// Deletes the OS-cached app switcher and launch snapshots in Library/SplashBoard/Snapshots.
     func clearSnapshots() async
 }
 
-struct AppSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing {
+actor AppSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing {
 
     private let fileManager: FileManager
     private let libraryDirectoryOverride: URL?
@@ -37,41 +37,36 @@ struct AppSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing {
     }
 
     func clearSnapshots() async {
-        let fileManager = fileManager
-        let libraryDirectoryOverride = libraryDirectoryOverride
+        guard let libraryDirectory = libraryDirectoryOverride ?? fileManager.urls(for: .libraryDirectory, in: .userDomainMask).first else {
+            return
+        }
 
-        await Task.detached(priority: .utility) {
-            guard let libraryDirectory = libraryDirectoryOverride ?? fileManager.urls(for: .libraryDirectory, in: .userDomainMask).first else {
-                return
-            }
+        let snapshotsDirectory = libraryDirectory
+            .appendingPathComponent("SplashBoard", isDirectory: true)
+            .appendingPathComponent("Snapshots", isDirectory: true)
 
-            let snapshotsDirectory = libraryDirectory
-                .appendingPathComponent("SplashBoard", isDirectory: true)
-                .appendingPathComponent("Snapshots", isDirectory: true)
+        guard fileManager.fileExists(atPath: snapshotsDirectory.path) else {
+            return
+        }
 
-            guard fileManager.fileExists(atPath: snapshotsDirectory.path) else {
-                return
-            }
+        let snapshotItems: [URL]
+        do {
+            snapshotItems = try fileManager.contentsOfDirectory(at: snapshotsDirectory,
+                                                                includingPropertiesForKeys: nil,
+                                                                options: [])
+        } catch {
+            Logger.general.error("Failed to read app switcher snapshots: \(error.localizedDescription, privacy: .public)")
+            return
+        }
 
-            let snapshotItems: [URL]
+        for snapshotItem in snapshotItems {
             do {
-                snapshotItems = try fileManager.contentsOfDirectory(at: snapshotsDirectory,
-                                                                    includingPropertiesForKeys: nil,
-                                                                    options: [])
+                try fileManager.removeItem(at: snapshotItem)
             } catch {
-                Logger.general.error("Failed to read app switcher snapshots: \(error.localizedDescription, privacy: .public)")
-                return
+                let itemName = snapshotItem.lastPathComponent
+                let errorDescription = error.localizedDescription
+                Logger.general.error("Failed to remove snapshot \(itemName, privacy: .public): \(errorDescription, privacy: .public)")
             }
-
-            for snapshotItem in snapshotItems {
-                do {
-                    try fileManager.removeItem(at: snapshotItem)
-                } catch {
-                    let itemName = snapshotItem.lastPathComponent
-                    let errorDescription = error.localizedDescription
-                    Logger.general.error("Failed to remove snapshot \(itemName, privacy: .public): \(errorDescription, privacy: .public)")
-                }
-            }
-        }.value
+        }
     }
 }

--- a/iOS/DuckDuckGo/Fire/AppSwitcherSnapshotCleaner.swift
+++ b/iOS/DuckDuckGo/Fire/AppSwitcherSnapshotCleaner.swift
@@ -20,13 +20,7 @@
 import Common
 import Foundation
 
-protocol AppSwitcherSnapshotClearing: Sendable {
-    /// Best-effort deletes the contents of Library/SplashBoard/Snapshots while preserving the directory itself.
-    /// Missing directories and deletion failures are ignored so cleanup never prevents a Fire operation from completing.
-    func clearSnapshots() async
-}
-
-actor AppSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing {
+actor AppSwitcherSnapshotCleaner {
 
     private let fileManager: FileManager
     private let libraryDirectoryOverride: URL?
@@ -46,19 +40,9 @@ actor AppSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing {
             .appendingPathComponent("SplashBoard", isDirectory: true)
             .appendingPathComponent("Snapshots", isDirectory: true)
 
-        guard fileManager.fileExists(atPath: snapshotsDirectory.path) else {
-            return
-        }
-
-        let snapshotItems: [URL]
-        do {
-            snapshotItems = try fileManager.contentsOfDirectory(at: snapshotsDirectory,
-                                                                includingPropertiesForKeys: nil,
-                                                                options: [])
-        } catch {
-            Logger.general.error("Failed to read app switcher snapshots: \(error.localizedDescription, privacy: .public)")
-            return
-        }
+        let snapshotItems = (try? fileManager.contentsOfDirectory(at: snapshotsDirectory,
+                                                                  includingPropertiesForKeys: nil,
+                                                                  options: [])) ?? []
 
         for snapshotItem in snapshotItems {
             do {

--- a/iOS/DuckDuckGo/Fire/AppSwitcherSnapshotCleaner.swift
+++ b/iOS/DuckDuckGo/Fire/AppSwitcherSnapshotCleaner.swift
@@ -21,7 +21,8 @@ import Common
 import Foundation
 
 protocol AppSwitcherSnapshotClearing: Sendable {
-    /// Deletes the OS-cached app switcher and launch snapshots in Library/SplashBoard/Snapshots.
+    /// Best-effort deletes the contents of Library/SplashBoard/Snapshots while preserving the directory itself.
+    /// Missing directories and deletion failures are ignored so cleanup never prevents a Fire operation from completing.
     func clearSnapshots() async
 }
 

--- a/iOS/DuckDuckGo/Fire/AppSwitcherSnapshotCleaner.swift
+++ b/iOS/DuckDuckGo/Fire/AppSwitcherSnapshotCleaner.swift
@@ -1,0 +1,77 @@
+//
+//  AppSwitcherSnapshotCleaner.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Common
+import Foundation
+
+protocol AppSwitcherSnapshotClearing {
+    /// Deletes the OS-cached app switcher and launch snapshots in Library/SplashBoard/Snapshots.
+    func clearSnapshots() async
+}
+
+struct AppSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing {
+
+    private let fileManager: FileManager
+    private let libraryDirectoryOverride: URL?
+
+    init(fileManager: FileManager = .default,
+         libraryDirectoryOverride: URL? = nil) {
+        self.fileManager = fileManager
+        self.libraryDirectoryOverride = libraryDirectoryOverride
+    }
+
+    func clearSnapshots() async {
+        let fileManager = fileManager
+        let libraryDirectoryOverride = libraryDirectoryOverride
+
+        await Task.detached(priority: .utility) {
+            guard let libraryDirectory = libraryDirectoryOverride ?? fileManager.urls(for: .libraryDirectory, in: .userDomainMask).first else {
+                return
+            }
+
+            let snapshotsDirectory = libraryDirectory
+                .appendingPathComponent("SplashBoard", isDirectory: true)
+                .appendingPathComponent("Snapshots", isDirectory: true)
+
+            guard fileManager.fileExists(atPath: snapshotsDirectory.path) else {
+                return
+            }
+
+            let snapshotItems: [URL]
+            do {
+                snapshotItems = try fileManager.contentsOfDirectory(at: snapshotsDirectory,
+                                                                    includingPropertiesForKeys: nil,
+                                                                    options: [])
+            } catch {
+                Logger.general.error("Failed to read app switcher snapshots: \(error.localizedDescription, privacy: .public)")
+                return
+            }
+
+            for snapshotItem in snapshotItems {
+                do {
+                    try fileManager.removeItem(at: snapshotItem)
+                } catch {
+                    let itemName = snapshotItem.lastPathComponent
+                    let errorDescription = error.localizedDescription
+                    Logger.general.error("Failed to remove snapshot \(itemName, privacy: .public): \(errorDescription, privacy: .public)")
+                }
+            }
+        }.value
+    }
+}

--- a/iOS/DuckDuckGo/Fire/FireExecutor.swift
+++ b/iOS/DuckDuckGo/Fire/FireExecutor.swift
@@ -83,6 +83,7 @@ protocol FireExecutorDelegate: AnyObject {
     func didFinishBurningData(fireRequest: FireRequest)
     func willStartBurningAIHistory(fireRequest: FireRequest)
     func didFinishBurningAIHistory(fireRequest: FireRequest)
+    func willClearAppSwitcherSnapshots(fireRequest: FireRequest)
     func didFinishBurning(fireRequest: FireRequest)
 }
 
@@ -304,6 +305,8 @@ class FireExecutor: FireExecuting {
         }
 
         if featureFlagger.isFeatureOn(.appSwitcherSnapshotClearing) {
+            // Remove any retained pre-burn UI before purging so it cannot be captured again.
+            delegate?.willClearAppSwitcherSnapshots(fireRequest: request)
             await appSwitcherSnapshotCleaner.clearSnapshots()
         }
 

--- a/iOS/DuckDuckGo/Fire/FireExecutor.swift
+++ b/iOS/DuckDuckGo/Fire/FireExecutor.swift
@@ -83,7 +83,6 @@ protocol FireExecutorDelegate: AnyObject {
     func didFinishBurningData(fireRequest: FireRequest)
     func willStartBurningAIHistory(fireRequest: FireRequest)
     func didFinishBurningAIHistory(fireRequest: FireRequest)
-    func willClearAppSwitcherSnapshots(fireRequest: FireRequest)
     func didFinishBurning(fireRequest: FireRequest)
 }
 
@@ -305,8 +304,6 @@ class FireExecutor: FireExecuting {
         }
 
         if featureFlagger.isFeatureOn(.appSwitcherSnapshotClearing) {
-            // Remove any retained pre-burn UI before purging so it cannot be captured again.
-            delegate?.willClearAppSwitcherSnapshots(fireRequest: request)
             await appSwitcherSnapshotCleaner.clearSnapshots()
         }
 

--- a/iOS/DuckDuckGo/Fire/FireExecutor.swift
+++ b/iOS/DuckDuckGo/Fire/FireExecutor.swift
@@ -138,7 +138,7 @@ class FireExecutor: FireExecuting {
     private let aiChatDeleter: AIChatDeleting
     private let idManager: DataStoreIDManaging
     private let fireModeStorageController: FireModeNativeStorageController?
-    private let appSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing
+    private let clearAppSwitcherSnapshots: @MainActor () async -> Void
 
     weak var delegate: FireExecutorDelegate?
     private(set) var burnInProgress = false
@@ -171,7 +171,9 @@ class FireExecutor: FireExecuting {
          pixelsReporter: DataClearingPixelsReporter = DataClearingPixelsReporter(),
          wideEvent: WideEventManaging? = nil,
          idManager: DataStoreIDManaging = DataStoreIDManager.shared,
-         appSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing = AppSwitcherSnapshotCleaner()) {
+         clearAppSwitcherSnapshots: @escaping @MainActor () async -> Void = {
+             await AppSwitcherSnapshotCleaner().clearSnapshots()
+         }) {
         self.tabManager = tabManager
         self.downloadManager = downloadManager
         self.favicons = favicons
@@ -194,7 +196,7 @@ class FireExecutor: FireExecuting {
         self.appSettings = appSettings
         self.aiChatSyncCleaner = aiChatSyncCleaner
         self.fireModeStorageController = fireModeStorageController
-        self.appSwitcherSnapshotCleaner = appSwitcherSnapshotCleaner
+        self.clearAppSwitcherSnapshots = clearAppSwitcherSnapshots
         self.pixelsReporter = pixelsReporter
         self.dataClearingWideEventService = wideEvent.map { DataClearingWideEventService(wideEvent: $0) }
         let aiChatDeleter = AIChatDeleter(historyCleanerProvider: self.historyCleanerProvider,
@@ -269,7 +271,7 @@ class FireExecutor: FireExecuting {
 
         // Notify delegate that we're starting
         delegate?.willStartBurning(fireRequest: request)
-
+        
         // Compute flags
         let shouldBurnTabs = request.options.contains(.tabs)
         let shouldBurnData = request.options.contains(.data)
@@ -304,7 +306,7 @@ class FireExecutor: FireExecuting {
         }
 
         if featureFlagger.isFeatureOn(.appSwitcherSnapshotClearing) {
-            await appSwitcherSnapshotCleaner.clearSnapshots()
+            await clearAppSwitcherSnapshots()
         }
 
         // Notify delegate that we finished

--- a/iOS/DuckDuckGo/Fire/FireExecutor.swift
+++ b/iOS/DuckDuckGo/Fire/FireExecutor.swift
@@ -270,10 +270,6 @@ class FireExecutor: FireExecuting {
         // Notify delegate that we're starting
         delegate?.willStartBurning(fireRequest: request)
 
-        if featureFlagger.isFeatureOn(.appSwitcherSnapshotClearing) {
-            await appSwitcherSnapshotCleaner.clearSnapshots()
-        }
-        
         // Compute flags
         let shouldBurnTabs = request.options.contains(.tabs)
         let shouldBurnData = request.options.contains(.data)
@@ -305,6 +301,10 @@ class FireExecutor: FireExecuting {
         // currentFireModeID. No-op for non-data burns (ID hasn't changed).
         if shouldBurnData {
             fireModeStorageController?.syncWithCurrentFireModeID()
+        }
+
+        if featureFlagger.isFeatureOn(.appSwitcherSnapshotClearing) {
+            await appSwitcherSnapshotCleaner.clearSnapshots()
         }
 
         // Notify delegate that we finished

--- a/iOS/DuckDuckGo/Fire/FireExecutor.swift
+++ b/iOS/DuckDuckGo/Fire/FireExecutor.swift
@@ -138,6 +138,7 @@ class FireExecutor: FireExecuting {
     private let aiChatDeleter: AIChatDeleting
     private let idManager: DataStoreIDManaging
     private let fireModeStorageController: FireModeNativeStorageController?
+    private let appSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing
 
     weak var delegate: FireExecutorDelegate?
     private(set) var burnInProgress = false
@@ -169,7 +170,8 @@ class FireExecutor: FireExecuting {
          fireModeStorageController: FireModeNativeStorageController? = nil,
          pixelsReporter: DataClearingPixelsReporter = DataClearingPixelsReporter(),
          wideEvent: WideEventManaging? = nil,
-         idManager: DataStoreIDManaging = DataStoreIDManager.shared) {
+         idManager: DataStoreIDManaging = DataStoreIDManager.shared,
+         appSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing = AppSwitcherSnapshotCleaner()) {
         self.tabManager = tabManager
         self.downloadManager = downloadManager
         self.favicons = favicons
@@ -192,6 +194,7 @@ class FireExecutor: FireExecuting {
         self.appSettings = appSettings
         self.aiChatSyncCleaner = aiChatSyncCleaner
         self.fireModeStorageController = fireModeStorageController
+        self.appSwitcherSnapshotCleaner = appSwitcherSnapshotCleaner
         self.pixelsReporter = pixelsReporter
         self.dataClearingWideEventService = wideEvent.map { DataClearingWideEventService(wideEvent: $0) }
         let aiChatDeleter = AIChatDeleter(historyCleanerProvider: self.historyCleanerProvider,
@@ -298,6 +301,10 @@ class FireExecutor: FireExecuting {
         // currentFireModeID. No-op for non-data burns (ID hasn't changed).
         if shouldBurnData {
             fireModeStorageController?.syncWithCurrentFireModeID()
+        }
+
+        if featureFlagger.isFeatureOn(.appSwitcherSnapshotClearing) {
+            await appSwitcherSnapshotCleaner.clearSnapshots()
         }
 
         // Notify delegate that we finished

--- a/iOS/DuckDuckGo/Fire/FireExecutor.swift
+++ b/iOS/DuckDuckGo/Fire/FireExecutor.swift
@@ -270,8 +270,9 @@ class FireExecutor: FireExecuting {
         // Notify delegate that we're starting
         delegate?.willStartBurning(fireRequest: request)
 
-        let shouldClearAppSwitcherSnapshots = featureFlagger.isFeatureOn(.appSwitcherSnapshotClearing)
-        async let snapshotCleanupTask: Void = shouldClearAppSwitcherSnapshots ? appSwitcherSnapshotCleaner.clearSnapshots() : ()
+        if featureFlagger.isFeatureOn(.appSwitcherSnapshotClearing) {
+            await appSwitcherSnapshotCleaner.clearSnapshots()
+        }
         
         // Compute flags
         let shouldBurnTabs = request.options.contains(.tabs)
@@ -298,7 +299,7 @@ class FireExecutor: FireExecuting {
         }
         
         // Await async tasks
-        _ = await (dataTask, aiTask, snapshotCleanupTask)
+        _ = await (dataTask, aiTask)
 
         // Realign the fire-mode native store after WebsiteDataFireWorker has rotated
         // currentFireModeID. No-op for non-data burns (ID hasn't changed).

--- a/iOS/DuckDuckGo/Fire/FireExecutor.swift
+++ b/iOS/DuckDuckGo/Fire/FireExecutor.swift
@@ -305,9 +305,7 @@ class FireExecutor: FireExecuting {
             fireModeStorageController?.syncWithCurrentFireModeID()
         }
 
-        if featureFlagger.isFeatureOn(.appSwitcherSnapshotClearing) {
-            await clearAppSwitcherSnapshots()
-        }
+        await clearAppSwitcherSnapshotsIfNeeded()
 
         // Notify delegate that we finished
         await didFinishBurning(fireRequest: request)
@@ -345,19 +343,35 @@ class FireExecutor: FireExecuting {
     @discardableResult
     @MainActor
     func burnChat(chatID: String, isFireMode: Bool) async -> Result<Void, Error> {
-        await aiChatDeleter.deleteChat(chatID: chatID, isFireMode: isFireMode)
+        let result = await aiChatDeleter.deleteChat(chatID: chatID, isFireMode: isFireMode)
+        return await clearAppSwitcherSnapshotsIfNeeded(after: result)
     }
 
     @discardableResult
     @MainActor
     func burnChats(chatIDs: [String], isFireMode: Bool) async -> Result<Void, Error> {
-        await aiChatDeleter.deleteChats(chatIDs: chatIDs, isFireMode: isFireMode)
+        let result = await aiChatDeleter.deleteChats(chatIDs: chatIDs, isFireMode: isFireMode)
+        return await clearAppSwitcherSnapshotsIfNeeded(after: result)
     }
 
     @discardableResult
     @MainActor
     func burnAllChats(isFireMode: Bool) async -> Result<Void, Error> {
-        await aiChatDeleter.deleteAllChats(isFireMode: isFireMode)
+        let result = await aiChatDeleter.deleteAllChats(isFireMode: isFireMode)
+        return await clearAppSwitcherSnapshotsIfNeeded(after: result)
+    }
+
+    @MainActor
+    private func clearAppSwitcherSnapshotsIfNeeded() async {
+        guard featureFlagger.isFeatureOn(.appSwitcherSnapshotClearing) else { return }
+        await clearAppSwitcherSnapshots()
+    }
+
+    @MainActor
+    private func clearAppSwitcherSnapshotsIfNeeded(after result: Result<Void, Error>) async -> Result<Void, Error> {
+        guard case .success = result else { return result }
+        await clearAppSwitcherSnapshotsIfNeeded()
+        return result
     }
 
     @MainActor

--- a/iOS/DuckDuckGo/Fire/FireExecutor.swift
+++ b/iOS/DuckDuckGo/Fire/FireExecutor.swift
@@ -269,6 +269,9 @@ class FireExecutor: FireExecuting {
 
         // Notify delegate that we're starting
         delegate?.willStartBurning(fireRequest: request)
+
+        let shouldClearAppSwitcherSnapshots = featureFlagger.isFeatureOn(.appSwitcherSnapshotClearing)
+        async let snapshotCleanupTask: Void = shouldClearAppSwitcherSnapshots ? appSwitcherSnapshotCleaner.clearSnapshots() : ()
         
         // Compute flags
         let shouldBurnTabs = request.options.contains(.tabs)
@@ -295,16 +298,12 @@ class FireExecutor: FireExecuting {
         }
         
         // Await async tasks
-        _ = await (dataTask, aiTask)
+        _ = await (dataTask, aiTask, snapshotCleanupTask)
 
         // Realign the fire-mode native store after WebsiteDataFireWorker has rotated
         // currentFireModeID. No-op for non-data burns (ID hasn't changed).
         if shouldBurnData {
             fireModeStorageController?.syncWithCurrentFireModeID()
-        }
-
-        if featureFlagger.isFeatureOn(.appSwitcherSnapshotClearing) {
-            await appSwitcherSnapshotCleaner.clearSnapshots()
         }
 
         // Notify delegate that we finished

--- a/iOS/DuckDuckGo/FireButtonAnimator.swift
+++ b/iOS/DuckDuckGo/FireButtonAnimator.swift
@@ -114,13 +114,11 @@ enum FireButtonAnimationType: String, CaseIterable, Identifiable, CustomStringCo
 class FireButtonAnimator {
     
     private let appSettings: AppSettings
-    private let notificationCenter: NotificationCenter
     private var preLoadedComposition: LottieAnimation?
     private weak var preBurnSnapshot: UIView?
 
     init(appSettings: AppSettings, notificationCenter: NotificationCenter = .default) {
         self.appSettings = appSettings
-        self.notificationCenter = notificationCenter
         reloadPreLoadedComposition()
                 
         notificationCenter.addObserver(self,
@@ -168,11 +166,8 @@ class FireButtonAnimator {
 
         let duration = Double(composition.duration) / speed
         let delay = duration * currentAnimation.transition
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
             snapshot.removeFromSuperview()
-            if self?.preBurnSnapshot === snapshot {
-                self?.preBurnSnapshot = nil
-            }
             Task { @MainActor in
                 await onTransitionCompleted()
             }

--- a/iOS/DuckDuckGo/FireButtonAnimator.swift
+++ b/iOS/DuckDuckGo/FireButtonAnimator.swift
@@ -110,20 +110,27 @@ enum FireButtonAnimationType: String, CaseIterable, Identifiable, CustomStringCo
 
 }
 
+@MainActor
 class FireButtonAnimator {
     
     private let appSettings: AppSettings
+    private let notificationCenter: NotificationCenter
     private var preLoadedComposition: LottieAnimation?
     private weak var preBurnSnapshot: UIView?
 
-    init(appSettings: AppSettings) {
+    init(appSettings: AppSettings, notificationCenter: NotificationCenter = .default) {
         self.appSettings = appSettings
+        self.notificationCenter = notificationCenter
         reloadPreLoadedComposition()
                 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(onFireButtonAnimationChange),
-                                               name: AppUserDefaults.Notifications.currentFireButtonAnimationChange,
-                                               object: nil)
+        notificationCenter.addObserver(self,
+                                       selector: #selector(onFireButtonAnimationChange),
+                                       name: AppUserDefaults.Notifications.currentFireButtonAnimationChange,
+                                       object: nil)
+        notificationCenter.addObserver(self,
+                                       selector: #selector(onApplicationWillResignActive),
+                                       name: UIApplication.willResignActiveNotification,
+                                       object: nil)
     }
         
     func animate(onAnimationStart: @escaping () async -> Void, onTransitionCompleted: @escaping () async -> Void, completion: @escaping () async -> Void) {
@@ -185,13 +192,17 @@ class FireButtonAnimator {
         }
     }
 
-    func removePreBurnSnapshot() {
+    private func removePreBurnSnapshot() {
         preBurnSnapshot?.removeFromSuperview()
         preBurnSnapshot = nil
     }
     
     @objc func onFireButtonAnimationChange() {
         reloadPreLoadedComposition()
+    }
+
+    @objc private func onApplicationWillResignActive() {
+        removePreBurnSnapshot()
     }
     
     private func reloadPreLoadedComposition() {

--- a/iOS/DuckDuckGo/FireButtonAnimator.swift
+++ b/iOS/DuckDuckGo/FireButtonAnimator.swift
@@ -114,6 +114,7 @@ class FireButtonAnimator {
     
     private let appSettings: AppSettings
     private var preLoadedComposition: LottieAnimation?
+    private weak var preBurnSnapshot: UIView?
 
     init(appSettings: AppSettings) {
         self.appSettings = appSettings
@@ -126,6 +127,7 @@ class FireButtonAnimator {
     }
         
     func animate(onAnimationStart: @escaping () async -> Void, onTransitionCompleted: @escaping () async -> Void, completion: @escaping () async -> Void) {
+        removePreBurnSnapshot()
 
         guard let window = UIApplication.shared.firstKeyWindow,
               let snapshot = window.snapshotView(afterScreenUpdates: false) else {
@@ -147,6 +149,7 @@ class FireButtonAnimator {
         }
         
         window.addSubview(snapshot)
+        preBurnSnapshot = snapshot
         
         let animationView = LottieAnimationView(animation: composition)
         let currentAnimation = appSettings.currentFireButtonAnimation
@@ -158,8 +161,11 @@ class FireButtonAnimator {
 
         let duration = Double(composition.duration) / speed
         let delay = duration * currentAnimation.transition
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
             snapshot.removeFromSuperview()
+            if self?.preBurnSnapshot === snapshot {
+                self?.preBurnSnapshot = nil
+            }
             Task { @MainActor in
                 await onTransitionCompleted()
             }
@@ -177,6 +183,11 @@ class FireButtonAnimator {
                 await onAnimationStart()
             }
         }
+    }
+
+    func removePreBurnSnapshot() {
+        preBurnSnapshot?.removeFromSuperview()
+        preBurnSnapshot = nil
     }
     
     @objc func onFireButtonAnimationChange() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -7621,7 +7621,7 @@ extension MainViewController: FireExecutorDelegate {
             return
         }
     }
-
+    
     func didFinishBurning(fireRequest: FireRequest) {
         // Trigger sync if needed after data and aichats finish
         // because data could potentially delete a contextual chat that needs syncing

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -7621,6 +7621,11 @@ extension MainViewController: FireExecutorDelegate {
             return
         }
     }
+
+    func willClearAppSwitcherSnapshots(fireRequest: FireRequest) {
+        guard fireRequest.trigger == .manualFire else { return }
+        fireButtonAnimator.removePreBurnSnapshot()
+    }
     
     func didFinishBurning(fireRequest: FireRequest) {
         // Trigger sync if needed after data and aichats finish

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -7622,11 +7622,6 @@ extension MainViewController: FireExecutorDelegate {
         }
     }
 
-    func willClearAppSwitcherSnapshots(fireRequest: FireRequest) {
-        guard fireRequest.trigger == .manualFire else { return }
-        fireButtonAnimator.removePreBurnSnapshot()
-    }
-    
     func didFinishBurning(fireRequest: FireRequest) {
         // Trigger sync if needed after data and aichats finish
         // because data could potentially delete a contextual chat that needs syncing

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -67,7 +67,7 @@ final class SettingsViewModel: ObservableObject {
     private(set) lazy var appSettings = AppDependencyProvider.shared.appSettings
     private(set) var privacyStore = PrivacyUserDefaults()
     lazy var featureFlagger = AppDependencyProvider.shared.featureFlagger
-    private lazy var animator: FireButtonAnimator = FireButtonAnimator(appSettings: AppUserDefaults())
+    @MainActor private lazy var animator: FireButtonAnimator = FireButtonAnimator(appSettings: AppUserDefaults())
     private var legacyViewProvider: SettingsLegacyViewProvider
     private lazy var versionProvider: AppVersion = AppVersion.shared
     private let voiceSearchHelper: VoiceSearchHelperProtocol

--- a/iOS/DuckDuckGo/SettingsViewModel.swift
+++ b/iOS/DuckDuckGo/SettingsViewModel.swift
@@ -67,7 +67,6 @@ final class SettingsViewModel: ObservableObject {
     private(set) lazy var appSettings = AppDependencyProvider.shared.appSettings
     private(set) var privacyStore = PrivacyUserDefaults()
     lazy var featureFlagger = AppDependencyProvider.shared.featureFlagger
-    @MainActor private lazy var animator: FireButtonAnimator = FireButtonAnimator(appSettings: AppUserDefaults())
     private var legacyViewProvider: SettingsLegacyViewProvider
     private lazy var versionProvider: AppVersion = AppVersion.shared
     private let voiceSearchHelper: VoiceSearchHelperProtocol

--- a/iOS/DuckDuckGo/TabManager.swift
+++ b/iOS/DuckDuckGo/TabManager.swift
@@ -145,6 +145,7 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
     private let contextualOnboardingLogic: ContextualOnboardingLogic
     private let onboardingPixelReporter: OnboardingPixelReporting
     private let featureFlagger: FeatureFlagger
+    private let clearAppSwitcherSnapshots: @MainActor () async -> Void
     private let tabTerminationTelemetry: any TabTerminationTelemetry
     private let tabTerminationErrorPageDetector: any TabTerminationErrorPageDetecting
     private let tabEvictionSettings: TabEvictionSettings
@@ -239,7 +240,10 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
          tabTerminationTelemetry: (any TabTerminationTelemetry)? = nil,
          tabTerminationErrorPageDetector: (any TabTerminationErrorPageDetecting)? = nil,
          applicationState: (@MainActor () -> UIApplication.State)? = nil,
-         isPad: Bool? = nil
+         isPad: Bool? = nil,
+         clearAppSwitcherSnapshots: @escaping @MainActor () async -> Void = {
+             await AppSwitcherSnapshotCleaner().clearSnapshots()
+         }
     ) {
         self.duckAiNativeStorageHandler = duckAiNativeStorageHandler
         self.duckAiFireModeStorageHandler = duckAiFireModeStorageHandler
@@ -257,6 +261,7 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
         self.contextualOnboardingLogic = contextualOnboardingLogic
         self.onboardingPixelReporter = onboardingPixelReporter
         self.featureFlagger = featureFlagger
+        self.clearAppSwitcherSnapshots = clearAppSwitcherSnapshots
         let tabEvictionSettings = TabEvictionSettings(privacyConfigurationManager: privacyConfigurationManager)
         self.tabEvictionSettings = tabEvictionSettings
         self.tabTerminationTelemetry = tabTerminationTelemetry ?? DefaultTabTerminationTelemetry(
@@ -892,6 +897,12 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
         }
         if clearTabHistory {
             removeTabHistory(for: tabIDs)
+        }
+
+        if featureFlagger.isFeatureOn(.appSwitcherSnapshotClearing) {
+            Task {
+                await clearAppSwitcherSnapshots()
+            }
         }
 
         tabsCacheNeedsCleanup = true

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -191,6 +191,10 @@ final class MainCoordinator {
         )
         self.privacyStats = PrivacyStats(databaseProvider: PrivacyStatsDatabase())
         let toggleModeStorage: ToggleModeStoring = ToggleModeStorage()
+        let appSwitcherSnapshotCleaner = AppSwitcherSnapshotCleaner()
+        let clearAppSwitcherSnapshots: @MainActor () async -> Void = {
+            await appSwitcherSnapshotCleaner.clearSnapshots()
+        }
         tabManager = TabManager(tabsModelProvider: tabsModelProvider,
                                 previewsSource: previewsSource,
                                 interactionStateSource: interactionStateSource,
@@ -228,7 +232,8 @@ final class MainCoordinator {
                                 duckAiFireModeStorageHandler: contentBlockingService.duckAiFireModeStorageHandler,
                                 toggleModeStorage: toggleModeStorage,
                                 adBlockingAvailability: contentBlockingService.adBlockingAvailability,
-                                eventHub: eventHub)
+                                eventHub: eventHub,
+                                clearAppSwitcherSnapshots: clearAppSwitcherSnapshots)
         let fireExecutor = FireExecutor(tabManager: tabManager,
                                         websiteDataManager: websiteDataManager,
                                         daxDialogsManager: daxDialogsManager,
@@ -246,7 +251,8 @@ final class MainCoordinator {
                                         aiChatSyncCleaner: syncService.aiChatSyncCleaner,
                                         duckAiNativeStorageHandler: contentBlockingService.duckAiNativeStorageHandler,
                                         fireModeStorageController: contentBlockingService.fireModeStorageController,
-                                        wideEvent: wideEvent)
+                                        wideEvent: wideEvent,
+                                        clearAppSwitcherSnapshots: clearAppSwitcherSnapshots)
         let syncAutoRestoreHandler = SyncAutoRestoreHandler(
             decisionManager: syncAutoRestoreDecisionManager,
             syncService: syncService.sync

--- a/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
@@ -1,0 +1,100 @@
+//
+//  AppSwitcherSnapshotCleanerTests.swift
+//  DuckDuckGoTests
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import DuckDuckGo
+
+final class AppSwitcherSnapshotCleanerTests: XCTestCase {
+
+    func testClearSnapshotsRemovesContentsAndKeepsSnapshotsDirectory() async throws {
+        let libraryDirectory = makeTemporaryLibraryDirectory()
+        defer { try? FileManager.default.removeItem(at: libraryDirectory) }
+
+        let snapshotsDirectory = libraryDirectory
+            .appendingPathComponent("SplashBoard", isDirectory: true)
+            .appendingPathComponent("Snapshots", isDirectory: true)
+        let sceneDirectory = snapshotsDirectory.appendingPathComponent("scene", isDirectory: true)
+        try FileManager.default.createDirectory(at: sceneDirectory, withIntermediateDirectories: true)
+        try Data("snapshot".utf8).write(to: sceneDirectory.appendingPathComponent("portrait.ktx"))
+
+        let cleaner = AppSwitcherSnapshotCleaner(libraryDirectoryOverride: libraryDirectory)
+        await cleaner.clearSnapshots()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: snapshotsDirectory.path))
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(at: snapshotsDirectory,
+                                                                   includingPropertiesForKeys: nil), [])
+    }
+
+    func testClearSnapshotsWhenSnapshotsDirectoryIsMissingDoesNothing() async {
+        let libraryDirectory = makeTemporaryLibraryDirectory()
+        defer { try? FileManager.default.removeItem(at: libraryDirectory) }
+
+        let cleaner = AppSwitcherSnapshotCleaner(libraryDirectoryOverride: libraryDirectory)
+        await cleaner.clearSnapshots()
+
+        let snapshotsDirectory = libraryDirectory
+            .appendingPathComponent("SplashBoard", isDirectory: true)
+            .appendingPathComponent("Snapshots", isDirectory: true)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: snapshotsDirectory.path))
+    }
+
+    func testClearSnapshotsContinuesAfterAnItemCannotBeRemoved() async throws {
+        let libraryDirectory = makeTemporaryLibraryDirectory()
+        defer { try? FileManager.default.removeItem(at: libraryDirectory) }
+
+        let snapshotsDirectory = libraryDirectory
+            .appendingPathComponent("SplashBoard", isDirectory: true)
+            .appendingPathComponent("Snapshots", isDirectory: true)
+        let protectedSceneDirectory = snapshotsDirectory.appendingPathComponent("protected-scene", isDirectory: true)
+        let removableSceneDirectory = snapshotsDirectory.appendingPathComponent("removable-scene", isDirectory: true)
+        try FileManager.default.createDirectory(at: protectedSceneDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: removableSceneDirectory, withIntermediateDirectories: true)
+
+        let fileManager = SelectivelyFailingFileManager(failingItemName: protectedSceneDirectory.lastPathComponent)
+        let cleaner = AppSwitcherSnapshotCleaner(fileManager: fileManager, libraryDirectoryOverride: libraryDirectory)
+        await cleaner.clearSnapshots()
+
+        XCTAssertTrue(fileManager.fileExists(atPath: protectedSceneDirectory.path))
+        XCTAssertFalse(fileManager.fileExists(atPath: removableSceneDirectory.path))
+        XCTAssertTrue(fileManager.fileExists(atPath: snapshotsDirectory.path))
+    }
+
+    private func makeTemporaryLibraryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("AppSwitcherSnapshotCleanerTests-\(UUID().uuidString)", isDirectory: true)
+    }
+}
+
+private final class SelectivelyFailingFileManager: FileManager, @unchecked Sendable {
+
+    private let failingItemName: String
+
+    init(failingItemName: String) {
+        self.failingItemName = failingItemName
+        super.init()
+    }
+
+    override func removeItem(at URL: URL) throws {
+        guard URL.lastPathComponent != failingItemName else {
+            throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileWriteNoPermission.rawValue)
+        }
+        try super.removeItem(at: URL)
+    }
+}

--- a/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
@@ -74,6 +74,7 @@ final class AppSwitcherSnapshotCleanerTests: XCTestCase {
         XCTAssertTrue(fileManager.fileExists(atPath: protectedSceneDirectory.path))
         XCTAssertFalse(fileManager.fileExists(atPath: removableSceneDirectory.path))
         XCTAssertTrue(fileManager.fileExists(atPath: snapshotsDirectory.path))
+        XCTAssertEqual(fileManager.removalAttempts.map(\.lastPathComponent), ["protected-scene", "removable-scene"])
     }
 
     private func makeTemporaryLibraryDirectory() -> URL {
@@ -85,13 +86,26 @@ final class AppSwitcherSnapshotCleanerTests: XCTestCase {
 private final class SelectivelyFailingFileManager: FileManager, @unchecked Sendable {
 
     private let failingItemName: String
+    private(set) var removalAttempts: [URL] = []
 
     init(failingItemName: String) {
         self.failingItemName = failingItemName
         super.init()
     }
 
+    override func contentsOfDirectory(at url: URL,
+                                      includingPropertiesForKeys keys: [URLResourceKey]?,
+                                      options mask: DirectoryEnumerationOptions = []) throws -> [URL] {
+        var items = try super.contentsOfDirectory(at: url, includingPropertiesForKeys: keys, options: mask)
+        guard let failingItemIndex = items.firstIndex(where: { $0.lastPathComponent == failingItemName }) else {
+            return items
+        }
+        let failingItem = items.remove(at: failingItemIndex)
+        return [failingItem] + items.sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
     override func removeItem(at URL: URL) throws {
+        removalAttempts.append(URL)
         guard URL.lastPathComponent != failingItemName else {
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileWriteNoPermission.rawValue)
         }

--- a/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
@@ -62,19 +62,20 @@ final class AppSwitcherSnapshotCleanerTests: XCTestCase {
         let snapshotsDirectory = libraryDirectory
             .appendingPathComponent("SplashBoard", isDirectory: true)
             .appendingPathComponent("Snapshots", isDirectory: true)
-        let protectedSceneDirectory = snapshotsDirectory.appendingPathComponent("protected-scene", isDirectory: true)
-        let removableSceneDirectory = snapshotsDirectory.appendingPathComponent("removable-scene", isDirectory: true)
-        try FileManager.default.createDirectory(at: protectedSceneDirectory, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: removableSceneDirectory, withIntermediateDirectories: true)
+        let firstSceneDirectory = snapshotsDirectory.appendingPathComponent("scene-1", isDirectory: true)
+        let secondSceneDirectory = snapshotsDirectory.appendingPathComponent("scene-2", isDirectory: true)
+        try FileManager.default.createDirectory(at: firstSceneDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: secondSceneDirectory, withIntermediateDirectories: true)
 
-        let fileManager = SelectivelyFailingFileManager(failingItemName: protectedSceneDirectory.lastPathComponent)
+        let fileManager = FailFirstRemovalFileManager()
         let cleaner = AppSwitcherSnapshotCleaner(fileManager: fileManager, libraryDirectoryOverride: libraryDirectory)
         await cleaner.clearSnapshots()
 
-        XCTAssertTrue(fileManager.fileExists(atPath: protectedSceneDirectory.path))
-        XCTAssertFalse(fileManager.fileExists(atPath: removableSceneDirectory.path))
-        XCTAssertTrue(fileManager.fileExists(atPath: snapshotsDirectory.path))
-        XCTAssertEqual(fileManager.removalAttempts.map(\.lastPathComponent), ["protected-scene", "removable-scene"])
+        XCTAssertEqual(fileManager.removalAttempts.count, 2)
+        let failedItem = try XCTUnwrap(fileManager.removalAttempts.first)
+        let laterItem = try XCTUnwrap(fileManager.removalAttempts.dropFirst().first)
+        XCTAssertTrue(fileManager.fileExists(atPath: failedItem.path))
+        XCTAssertFalse(fileManager.fileExists(atPath: laterItem.path))
     }
 
     private func makeTemporaryLibraryDirectory() -> URL {
@@ -83,30 +84,12 @@ final class AppSwitcherSnapshotCleanerTests: XCTestCase {
     }
 }
 
-private final class SelectivelyFailingFileManager: FileManager, @unchecked Sendable {
-
-    private let failingItemName: String
+private final class FailFirstRemovalFileManager: FileManager, @unchecked Sendable {
     private(set) var removalAttempts: [URL] = []
-
-    init(failingItemName: String) {
-        self.failingItemName = failingItemName
-        super.init()
-    }
-
-    override func contentsOfDirectory(at url: URL,
-                                      includingPropertiesForKeys keys: [URLResourceKey]?,
-                                      options mask: DirectoryEnumerationOptions = []) throws -> [URL] {
-        var items = try super.contentsOfDirectory(at: url, includingPropertiesForKeys: keys, options: mask)
-        guard let failingItemIndex = items.firstIndex(where: { $0.lastPathComponent == failingItemName }) else {
-            return items
-        }
-        let failingItem = items.remove(at: failingItemIndex)
-        return [failingItem] + items.sorted { $0.lastPathComponent < $1.lastPathComponent }
-    }
 
     override func removeItem(at URL: URL) throws {
         removalAttempts.append(URL)
-        guard URL.lastPathComponent != failingItemName else {
+        guard removalAttempts.count > 1 else {
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileWriteNoPermission.rawValue)
         }
         try super.removeItem(at: URL)

--- a/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
@@ -71,7 +71,6 @@ final class AppSwitcherSnapshotCleanerTests: XCTestCase {
         let cleaner = AppSwitcherSnapshotCleaner(fileManager: fileManager, libraryDirectoryOverride: libraryDirectory)
         await cleaner.clearSnapshots()
 
-        XCTAssertEqual(fileManager.removalAttempts.count, 2)
         let failedItem = try XCTUnwrap(fileManager.removalAttempts.first)
         let laterItem = try XCTUnwrap(fileManager.removalAttempts.dropFirst().first)
         XCTAssertTrue(fileManager.fileExists(atPath: failedItem.path))

--- a/iOS/DuckDuckGoTests/Fire/FireButtonAnimatorTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/FireButtonAnimatorTests.swift
@@ -41,7 +41,6 @@ final class FireButtonAnimatorTests: XCTestCase {
         defer { addedSubviews.forEach { $0.removeFromSuperview() } }
 
         let snapshot = try XCTUnwrap(addedSubviews.first)
-        XCTAssertTrue(snapshot.superview === window)
 
         notificationCenter.post(name: UIApplication.willResignActiveNotification, object: nil)
 

--- a/iOS/DuckDuckGoTests/Fire/FireButtonAnimatorTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/FireButtonAnimatorTests.swift
@@ -1,0 +1,50 @@
+//
+//  FireButtonAnimatorTests.swift
+//  DuckDuckGoTests
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+import XCTest
+@testable import DuckDuckGo
+
+@MainActor
+final class FireButtonAnimatorTests: XCTestCase {
+
+    func testWhenApplicationWillResignActiveThenRetainedPreBurnSnapshotIsRemoved() throws {
+        let window = try XCTUnwrap(UIApplication.shared.firstKeyWindow)
+        let notificationCenter = NotificationCenter()
+        let animator = FireButtonAnimator(appSettings: AppSettingsMock(), notificationCenter: notificationCenter)
+        let existingSubviews = window.subviews
+
+        animator.animate {
+        } onTransitionCompleted: {
+        } completion: {
+        }
+
+        let addedSubviews = window.subviews.filter { subview in
+            !existingSubviews.contains(where: { $0 === subview })
+        }
+        defer { addedSubviews.forEach { $0.removeFromSuperview() } }
+
+        let snapshot = try XCTUnwrap(addedSubviews.first)
+        XCTAssertTrue(snapshot.superview === window)
+
+        notificationCenter.post(name: UIApplication.willResignActiveNotification, object: nil)
+
+        XCTAssertNil(snapshot.superview)
+    }
+}

--- a/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
@@ -269,18 +269,19 @@ final class FireExecutorTests: XCTestCase {
 
     // MARK: - App Switcher Snapshot Tests
 
-    func testBurnCompletesAppSwitcherSnapshotCleanupBeforeTabDomainLookupWhenFeatureIsEnabled() async {
+    func testBurnClearsAppSwitcherSnapshotsAfterCoreWorkAndBeforeCompletionWhenFeatureIsEnabled() async {
         mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
         let snapshotCleaner = MockAppSwitcherSnapshotCleaner {
-            XCTAssertTrue(self.mockHistoryManager.tabHistoryCalls.isEmpty)
+            XCTAssertTrue(self.mockDelegate.didFinishBurningTabsCalled)
+            XCTAssertTrue(self.mockDelegate.didFinishBurningDataCalled)
+            XCTAssertTrue(self.mockDelegate.didFinishBurningAIHistoryCalled)
+            XCTAssertFalse(self.mockDelegate.didFinishBurningCalled)
         }
         let executor = makeFireExecutor(appSwitcherSnapshotCleaner: snapshotCleaner)
-        let request = makeFireRequest(options: .tabs, scope: .tab(viewModel: makeTabViewModel()))
 
-        await executor.burn(request: request, applicationState: .unknown)
+        await executor.burn(request: makeFireRequest(options: .all), applicationState: .unknown)
 
         XCTAssertEqual(snapshotCleaner.clearSnapshotsCallCount, 1)
-        XCTAssertEqual(mockHistoryManager.tabHistoryCalls, ["test-tab-uid"])
     }
 
     func testBurnDoesNotClearAppSwitcherSnapshotsWhenFeatureIsDisabled() async {

--- a/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
@@ -47,7 +47,6 @@ final class FireExecutorTests: XCTestCase {
         private(set) var willStartBurningFireRequest: FireRequest?
         private(set) var didFinishBurningCalled = false
         private(set) var didFinishBurningFireRequest: FireRequest?
-        var didFinishBurningHandler: (() -> Void)?
         
         func willStartBurning(fireRequest: FireRequest) {
             willStartBurningCalled = true
@@ -81,7 +80,6 @@ final class FireExecutorTests: XCTestCase {
         func didFinishBurning(fireRequest: FireRequest) {
             didFinishBurningCalled = true
             didFinishBurningFireRequest = fireRequest
-            didFinishBurningHandler?()
         }
     }
     
@@ -124,21 +122,6 @@ final class FireExecutorTests: XCTestCase {
         func cancelCleaningSchedule() {}
     }
 
-    @MainActor
-    private final class MockAppSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing {
-        private(set) var clearSnapshotsCallCount = 0
-        private let onCompletion: (() -> Void)?
-
-        init(onCompletion: (() -> Void)? = nil) {
-            self.onCompletion = onCompletion
-        }
-
-        func clearSnapshots() async {
-            clearSnapshotsCallCount += 1
-            onCompletion?()
-        }
-    }
-    
     // MARK: - Setup
     
     private var mockTabManager: MockTabManager!
@@ -157,7 +140,6 @@ final class FireExecutorTests: XCTestCase {
     private var mockDelegate: MockFireExecutorDelegate!
     private var mockAppSettings: AppSettingsMock!
     private var mockAIChatSyncCleaner: MockAIChatSyncCleaning!
-    private var mockAppSwitcherSnapshotCleaner: MockAppSwitcherSnapshotCleaner!
     
     private var normalTextZoomCoordinator: MockTextZoomCoordinator {
         mockTextZoomCoordinatorProvider.normalCoordinator
@@ -182,7 +164,6 @@ final class FireExecutorTests: XCTestCase {
         mockAppSettings = AppSettingsMock()
         mockAppSettings.autoClearAIChatHistory = true
         mockAIChatSyncCleaner = MockAIChatSyncCleaning()
-        mockAppSwitcherSnapshotCleaner = MockAppSwitcherSnapshotCleaner()
     }
     
     override func tearDown() {
@@ -203,7 +184,6 @@ final class FireExecutorTests: XCTestCase {
         mockDelegate = nil
         mockAppSettings = nil
         mockAIChatSyncCleaner = nil
-        mockAppSwitcherSnapshotCleaner = nil
         super.tearDown()
     }
     
@@ -211,7 +191,7 @@ final class FireExecutorTests: XCTestCase {
         syncService: DDGSyncing? = nil,
         bookmarksDatabaseCleaner: (any BookmarkDatabaseCleaning)? = nil,
         fireproofing: Fireproofing? = nil,
-        appSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing? = nil
+        clearAppSwitcherSnapshots: @escaping @MainActor () async -> Void = {}
     ) -> FireExecutor {
         let executor = FireExecutor(
             tabManager: mockTabManager,
@@ -236,7 +216,7 @@ final class FireExecutorTests: XCTestCase {
             appSettings: mockAppSettings,
             aiChatSyncCleaner: mockAIChatSyncCleaner,
             wideEvent: WideEventMock(),
-            appSwitcherSnapshotCleaner: appSwitcherSnapshotCleaner ?? mockAppSwitcherSnapshotCleaner
+            clearAppSwitcherSnapshots: clearAppSwitcherSnapshots
         )
         executor.delegate = mockDelegate
         return executor
@@ -271,50 +251,30 @@ final class FireExecutorTests: XCTestCase {
 
     // MARK: - App Switcher Snapshot Tests
 
-    func testWhenFeatureIsEnabledThenAppSwitcherSnapshotCleanupFollowsCoreWorkAndPrecedesCompletion() async {
+    func testWhenFeatureIsEnabledAndSingleTabIsBurnedThenAppSwitcherSnapshotCleanupFollowsTabWorkAndPrecedesCompletion() async {
         mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
-        var events: [String] = []
-        mockDelegate.didFinishBurningHandler = {
-            events.append("didFinishBurning")
-        }
-        let snapshotCleaner = MockAppSwitcherSnapshotCleaner {
+        var didClearSnapshots = false
+        let executor = makeFireExecutor {
             XCTAssertTrue(self.mockDelegate.didFinishBurningTabsCalled)
-            XCTAssertTrue(self.mockDelegate.didFinishBurningDataCalled)
-            XCTAssertTrue(self.mockDelegate.didFinishBurningAIHistoryCalled)
             XCTAssertFalse(self.mockDelegate.didFinishBurningCalled)
-            events.append("clearSnapshots")
+            didClearSnapshots = true
         }
-        let executor = makeFireExecutor(appSwitcherSnapshotCleaner: snapshotCleaner)
 
-        await executor.burn(request: makeFireRequest(options: .all), applicationState: .unknown)
+        await executor.burn(request: makeFireRequest(options: .tabs, scope: .tab(viewModel: makeTabViewModel())), applicationState: .unknown)
 
-        XCTAssertEqual(snapshotCleaner.clearSnapshotsCallCount, 1)
-        XCTAssertEqual(events, ["clearSnapshots", "didFinishBurning"])
+        XCTAssertTrue(didClearSnapshots)
+        XCTAssertTrue(mockDelegate.didFinishBurningCalled)
     }
 
     func testWhenFeatureIsDisabledThenBurnDoesNotClearAppSwitcherSnapshots() async {
-        let executor = makeFireExecutor()
+        var didClearSnapshots = false
+        let executor = makeFireExecutor {
+            didClearSnapshots = true
+        }
 
         await executor.burn(request: makeFireRequest(options: .tabs), applicationState: .unknown)
 
-        XCTAssertEqual(mockAppSwitcherSnapshotCleaner.clearSnapshotsCallCount, 0)
-    }
-
-    func testWhenFeatureIsEnabledThenRepresentativeBurnRequestsClearAppSwitcherSnapshots() async {
-        mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
-        let requests = [
-            makeFireRequest(options: .tabs, scope: .tab(viewModel: makeTabViewModel())),
-            makeFireRequest(options: .data, trigger: .autoClearOnLaunch)
-        ]
-
-        for request in requests {
-            let snapshotCleaner = MockAppSwitcherSnapshotCleaner()
-            let executor = makeFireExecutor(appSwitcherSnapshotCleaner: snapshotCleaner)
-
-            await executor.burn(request: request, applicationState: .unknown)
-
-            XCTAssertEqual(snapshotCleaner.clearSnapshotsCallCount, 1)
-        }
+        XCTAssertFalse(didClearSnapshots)
     }
 
     private func makeTabViewModel(chatID: String, fireTab: Bool) -> TabViewModel {

--- a/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
@@ -45,9 +45,9 @@ final class FireExecutorTests: XCTestCase {
         private(set) var didFinishBurningAIHistoryCalled = false
         private(set) var willStartBurningCalled = false
         private(set) var willStartBurningFireRequest: FireRequest?
-        private(set) var willClearAppSwitcherSnapshotsCalled = false
         private(set) var didFinishBurningCalled = false
         private(set) var didFinishBurningFireRequest: FireRequest?
+        var didFinishBurningHandler: (() -> Void)?
         
         func willStartBurning(fireRequest: FireRequest) {
             willStartBurningCalled = true
@@ -78,13 +78,10 @@ final class FireExecutorTests: XCTestCase {
             didFinishBurningAIHistoryCalled = true
         }
 
-        func willClearAppSwitcherSnapshots(fireRequest: FireRequest) {
-            willClearAppSwitcherSnapshotsCalled = true
-        }
-        
         func didFinishBurning(fireRequest: FireRequest) {
             didFinishBurningCalled = true
             didFinishBurningFireRequest = fireRequest
+            didFinishBurningHandler?()
         }
     }
     
@@ -274,42 +271,50 @@ final class FireExecutorTests: XCTestCase {
 
     // MARK: - App Switcher Snapshot Tests
 
-    func testBurnClearsAppSwitcherSnapshotsAfterCoreWorkAndBeforeCompletionWhenFeatureIsEnabled() async {
+    func testWhenFeatureIsEnabledThenAppSwitcherSnapshotCleanupFollowsCoreWorkAndPrecedesCompletion() async {
         mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
+        var events: [String] = []
+        mockDelegate.didFinishBurningHandler = {
+            events.append("didFinishBurning")
+        }
         let snapshotCleaner = MockAppSwitcherSnapshotCleaner {
             XCTAssertTrue(self.mockDelegate.didFinishBurningTabsCalled)
             XCTAssertTrue(self.mockDelegate.didFinishBurningDataCalled)
             XCTAssertTrue(self.mockDelegate.didFinishBurningAIHistoryCalled)
             XCTAssertFalse(self.mockDelegate.didFinishBurningCalled)
+            events.append("clearSnapshots")
         }
         let executor = makeFireExecutor(appSwitcherSnapshotCleaner: snapshotCleaner)
 
         await executor.burn(request: makeFireRequest(options: .all), applicationState: .unknown)
 
         XCTAssertEqual(snapshotCleaner.clearSnapshotsCallCount, 1)
+        XCTAssertEqual(events, ["clearSnapshots", "didFinishBurning"])
     }
 
-    func testBurnDoesNotClearAppSwitcherSnapshotsWhenFeatureIsDisabled() async {
+    func testWhenFeatureIsDisabledThenBurnDoesNotClearAppSwitcherSnapshots() async {
         let executor = makeFireExecutor()
 
         await executor.burn(request: makeFireRequest(options: .tabs), applicationState: .unknown)
 
         XCTAssertEqual(mockAppSwitcherSnapshotCleaner.clearSnapshotsCallCount, 0)
-        XCTAssertFalse(mockDelegate.willClearAppSwitcherSnapshotsCalled)
     }
 
-    func testTabsOnlyBurnNotifiesDelegateBeforeClearingAppSwitcherSnapshots() async {
+    func testWhenFeatureIsEnabledThenRepresentativeBurnRequestsClearAppSwitcherSnapshots() async {
         mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
-        let snapshotCleaner = MockAppSwitcherSnapshotCleaner {
-            XCTAssertTrue(self.mockDelegate.willClearAppSwitcherSnapshotsCalled)
-            XCTAssertFalse(self.mockDelegate.didFinishBurningCalled)
+        let requests = [
+            makeFireRequest(options: .tabs, scope: .tab(viewModel: makeTabViewModel())),
+            makeFireRequest(options: .data, trigger: .autoClearOnLaunch)
+        ]
+
+        for request in requests {
+            let snapshotCleaner = MockAppSwitcherSnapshotCleaner()
+            let executor = makeFireExecutor(appSwitcherSnapshotCleaner: snapshotCleaner)
+
+            await executor.burn(request: request, applicationState: .unknown)
+
+            XCTAssertEqual(snapshotCleaner.clearSnapshotsCallCount, 1)
         }
-        let executor = makeFireExecutor(appSwitcherSnapshotCleaner: snapshotCleaner)
-        let request = makeFireRequest(options: .tabs, scope: .tab(viewModel: makeTabViewModel()))
-
-        await executor.burn(request: request, applicationState: .unknown)
-
-        XCTAssertEqual(snapshotCleaner.clearSnapshotsCallCount, 1)
     }
 
     private func makeTabViewModel(chatID: String, fireTab: Bool) -> TabViewModel {

--- a/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
@@ -121,6 +121,14 @@ final class FireExecutorTests: XCTestCase {
         func scheduleRegularCleaning() {}
         func cancelCleaningSchedule() {}
     }
+
+    actor MockAppSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing {
+        private(set) var clearSnapshotsCallCount = 0
+
+        func clearSnapshots() async {
+            clearSnapshotsCallCount += 1
+        }
+    }
     
     // MARK: - Setup
     
@@ -140,6 +148,7 @@ final class FireExecutorTests: XCTestCase {
     private var mockDelegate: MockFireExecutorDelegate!
     private var mockAppSettings: AppSettingsMock!
     private var mockAIChatSyncCleaner: MockAIChatSyncCleaning!
+    private var mockAppSwitcherSnapshotCleaner: MockAppSwitcherSnapshotCleaner!
     
     private var normalTextZoomCoordinator: MockTextZoomCoordinator {
         mockTextZoomCoordinatorProvider.normalCoordinator
@@ -164,6 +173,7 @@ final class FireExecutorTests: XCTestCase {
         mockAppSettings = AppSettingsMock()
         mockAppSettings.autoClearAIChatHistory = true
         mockAIChatSyncCleaner = MockAIChatSyncCleaning()
+        mockAppSwitcherSnapshotCleaner = MockAppSwitcherSnapshotCleaner()
     }
     
     override func tearDown() {
@@ -184,13 +194,15 @@ final class FireExecutorTests: XCTestCase {
         mockDelegate = nil
         mockAppSettings = nil
         mockAIChatSyncCleaner = nil
+        mockAppSwitcherSnapshotCleaner = nil
         super.tearDown()
     }
     
     private func makeFireExecutor(
         syncService: DDGSyncing? = nil,
         bookmarksDatabaseCleaner: (any BookmarkDatabaseCleaning)? = nil,
-        fireproofing: Fireproofing? = nil
+        fireproofing: Fireproofing? = nil,
+        appSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing? = nil
     ) -> FireExecutor {
         let executor = FireExecutor(
             tabManager: mockTabManager,
@@ -214,7 +226,8 @@ final class FireExecutorTests: XCTestCase {
             },
             appSettings: mockAppSettings,
             aiChatSyncCleaner: mockAIChatSyncCleaner,
-            wideEvent: WideEventMock()
+            wideEvent: WideEventMock(),
+            appSwitcherSnapshotCleaner: appSwitcherSnapshotCleaner ?? mockAppSwitcherSnapshotCleaner
         )
         executor.delegate = mockDelegate
         return executor
@@ -245,6 +258,48 @@ final class FireExecutorTests: XCTestCase {
         let tab = Tab(uid: "test-tab-with-contextual-chat")
         tab.contextualChatURL = "https://duckduckgo.com/?ia=chat&duckai=4&chatID=\(contextualChatID)"
         return TabViewModel(tab: tab, historyManager: mockHistoryManager)
+    }
+
+    // MARK: - App Switcher Snapshot Tests
+
+    func testBurnAllOptionsClearsAppSwitcherSnapshotsWhenFeatureIsEnabled() async {
+        mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
+        let executor = makeFireExecutor()
+
+        await executor.burn(request: makeFireRequest(options: .all), applicationState: .unknown)
+
+        let callCount = await mockAppSwitcherSnapshotCleaner.clearSnapshotsCallCount
+        XCTAssertEqual(callCount, 1)
+    }
+
+    func testBurnTabsOnlyClearsAppSwitcherSnapshotsWhenFeatureIsEnabled() async {
+        mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
+        let executor = makeFireExecutor()
+
+        await executor.burn(request: makeFireRequest(options: .tabs), applicationState: .unknown)
+
+        let callCount = await mockAppSwitcherSnapshotCleaner.clearSnapshotsCallCount
+        XCTAssertEqual(callCount, 1)
+    }
+
+    func testBurnTabScopeClearsAppSwitcherSnapshotsWhenFeatureIsEnabled() async {
+        mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
+        let executor = makeFireExecutor()
+        let tabViewModel = makeTabViewModel()
+
+        await executor.burn(request: makeFireRequest(options: .tabs, scope: .tab(viewModel: tabViewModel)), applicationState: .unknown)
+
+        let callCount = await mockAppSwitcherSnapshotCleaner.clearSnapshotsCallCount
+        XCTAssertEqual(callCount, 1)
+    }
+
+    func testBurnDoesNotClearAppSwitcherSnapshotsWhenFeatureIsDisabled() async {
+        let executor = makeFireExecutor()
+
+        await executor.burn(request: makeFireRequest(options: .tabs), applicationState: .unknown)
+
+        let callCount = await mockAppSwitcherSnapshotCleaner.clearSnapshotsCallCount
+        XCTAssertEqual(callCount, 0)
     }
 
     private func makeTabViewModel(chatID: String, fireTab: Bool) -> TabViewModel {

--- a/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
@@ -277,6 +277,33 @@ final class FireExecutorTests: XCTestCase {
         XCTAssertFalse(didClearSnapshots)
     }
 
+    func testWhenFeatureIsEnabledAndDirectAIChatBurnsSucceedThenAppSwitcherSnapshotsAreCleared() async {
+        mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
+        var cleanupCallCount = 0
+        let executor = makeFireExecutor {
+            cleanupCallCount += 1
+        }
+
+        _ = await executor.burnChat(chatID: "chat", isFireMode: false)
+        _ = await executor.burnChats(chatIDs: ["chat-1", "chat-2"], isFireMode: false)
+        _ = await executor.burnAllChats(isFireMode: false)
+
+        XCTAssertEqual(cleanupCallCount, 3)
+    }
+
+    func testWhenDirectAIChatBurnFailsThenAppSwitcherSnapshotsAreNotCleared() async {
+        mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
+        mockHistoryCleaner.deleteAIChatResult = .failure(NSError(domain: "test", code: 1))
+        var didClearSnapshots = false
+        let executor = makeFireExecutor {
+            didClearSnapshots = true
+        }
+
+        _ = await executor.burnChat(chatID: "chat", isFireMode: false)
+
+        XCTAssertFalse(didClearSnapshots)
+    }
+
     private func makeTabViewModel(chatID: String, fireTab: Bool) -> TabViewModel {
         let tab = Tab(uid: "test-tab-\(fireTab ? "fire" : "normal")", fireTab: fireTab)
         let aiURL = URL(string: "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=4&chatID=\(chatID)")!

--- a/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
@@ -124,9 +124,15 @@ final class FireExecutorTests: XCTestCase {
 
     actor MockAppSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing {
         private(set) var clearSnapshotsCallCount = 0
+        private let clearSnapshotsStartedExpectation: XCTestExpectation?
+
+        init(clearSnapshotsStartedExpectation: XCTestExpectation? = nil) {
+            self.clearSnapshotsStartedExpectation = clearSnapshotsStartedExpectation
+        }
 
         func clearSnapshots() async {
             clearSnapshotsCallCount += 1
+            clearSnapshotsStartedExpectation?.fulfill()
         }
     }
     
@@ -300,6 +306,26 @@ final class FireExecutorTests: XCTestCase {
 
         let callCount = await mockAppSwitcherSnapshotCleaner.clearSnapshotsCallCount
         XCTAssertEqual(callCount, 0)
+    }
+
+    func testBurnStartsAppSwitcherSnapshotCleanupBeforeTabDomainLookupCompletes() async {
+        mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
+        let tabHistoryStartedExpectation = expectation(description: "Tab history lookup started")
+        let snapshotCleanupStartedExpectation = expectation(description: "Snapshot cleanup started")
+        let blockingHistoryManager = BlockingHistoryManager(tabHistoryStartedExpectation: tabHistoryStartedExpectation)
+        mockHistoryManager = blockingHistoryManager
+        let snapshotCleaner = MockAppSwitcherSnapshotCleaner(clearSnapshotsStartedExpectation: snapshotCleanupStartedExpectation)
+        let executor = makeFireExecutor(appSwitcherSnapshotCleaner: snapshotCleaner)
+        let request = makeFireRequest(options: .tabs, scope: .tab(viewModel: makeTabViewModel()))
+
+        let burnTask = Task {
+            await executor.burn(request: request, applicationState: .unknown)
+        }
+
+        await fulfillment(of: [tabHistoryStartedExpectation], timeout: 1.0)
+        await fulfillment(of: [snapshotCleanupStartedExpectation], timeout: 1.0)
+        await blockingHistoryManager.resumeTabHistory()
+        await burnTask.value
     }
 
     private func makeTabViewModel(chatID: String, fireTab: Bool) -> TabViewModel {
@@ -968,5 +994,47 @@ final class FireExecutorTests: XCTestCase {
         await executor.burn(request: makeFireRequest(options: .aiChats, scope: .normalMode), applicationState: .unknown)
 
         XCTAssertEqual(mockHistoryCleaner.lastIsFireMode, false, "Normal-mode burn must route through normal native storage")
+    }
+}
+
+private final class BlockingHistoryManager: MockHistoryManager {
+
+    private let tabHistoryStartedExpectation: XCTestExpectation
+    private let tabHistoryGate = AsyncGate()
+
+    init(tabHistoryStartedExpectation: XCTestExpectation) {
+        self.tabHistoryStartedExpectation = tabHistoryStartedExpectation
+        super.init(historyCoordinator: NullHistoryCoordinator(), isEnabledByUser: false, historyFeatureEnabled: false)
+    }
+
+    override func tabHistory(tabID: String) async throws -> [URL] {
+        tabHistoryStartedExpectation.fulfill()
+        await tabHistoryGate.wait()
+        return []
+    }
+
+    func resumeTabHistory() async {
+        await tabHistoryGate.open()
+    }
+}
+
+private actor AsyncGate {
+
+    private var isOpen = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        guard !isOpen else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func open() {
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
     }
 }

--- a/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
@@ -122,17 +122,18 @@ final class FireExecutorTests: XCTestCase {
         func cancelCleaningSchedule() {}
     }
 
-    actor MockAppSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing {
+    @MainActor
+    private final class MockAppSwitcherSnapshotCleaner: AppSwitcherSnapshotClearing {
         private(set) var clearSnapshotsCallCount = 0
-        private let clearSnapshotsStartedExpectation: XCTestExpectation?
+        private let onCompletion: (() -> Void)?
 
-        init(clearSnapshotsStartedExpectation: XCTestExpectation? = nil) {
-            self.clearSnapshotsStartedExpectation = clearSnapshotsStartedExpectation
+        init(onCompletion: (() -> Void)? = nil) {
+            self.onCompletion = onCompletion
         }
 
         func clearSnapshots() async {
             clearSnapshotsCallCount += 1
-            clearSnapshotsStartedExpectation?.fulfill()
+            onCompletion?()
         }
     }
     
@@ -268,35 +269,18 @@ final class FireExecutorTests: XCTestCase {
 
     // MARK: - App Switcher Snapshot Tests
 
-    func testBurnAllOptionsClearsAppSwitcherSnapshotsWhenFeatureIsEnabled() async {
+    func testBurnCompletesAppSwitcherSnapshotCleanupBeforeTabDomainLookupWhenFeatureIsEnabled() async {
         mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
-        let executor = makeFireExecutor()
+        let snapshotCleaner = MockAppSwitcherSnapshotCleaner {
+            XCTAssertTrue(self.mockHistoryManager.tabHistoryCalls.isEmpty)
+        }
+        let executor = makeFireExecutor(appSwitcherSnapshotCleaner: snapshotCleaner)
+        let request = makeFireRequest(options: .tabs, scope: .tab(viewModel: makeTabViewModel()))
 
-        await executor.burn(request: makeFireRequest(options: .all), applicationState: .unknown)
+        await executor.burn(request: request, applicationState: .unknown)
 
-        let callCount = await mockAppSwitcherSnapshotCleaner.clearSnapshotsCallCount
-        XCTAssertEqual(callCount, 1)
-    }
-
-    func testBurnTabsOnlyClearsAppSwitcherSnapshotsWhenFeatureIsEnabled() async {
-        mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
-        let executor = makeFireExecutor()
-
-        await executor.burn(request: makeFireRequest(options: .tabs), applicationState: .unknown)
-
-        let callCount = await mockAppSwitcherSnapshotCleaner.clearSnapshotsCallCount
-        XCTAssertEqual(callCount, 1)
-    }
-
-    func testBurnTabScopeClearsAppSwitcherSnapshotsWhenFeatureIsEnabled() async {
-        mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
-        let executor = makeFireExecutor()
-        let tabViewModel = makeTabViewModel()
-
-        await executor.burn(request: makeFireRequest(options: .tabs, scope: .tab(viewModel: tabViewModel)), applicationState: .unknown)
-
-        let callCount = await mockAppSwitcherSnapshotCleaner.clearSnapshotsCallCount
-        XCTAssertEqual(callCount, 1)
+        XCTAssertEqual(snapshotCleaner.clearSnapshotsCallCount, 1)
+        XCTAssertEqual(mockHistoryManager.tabHistoryCalls, ["test-tab-uid"])
     }
 
     func testBurnDoesNotClearAppSwitcherSnapshotsWhenFeatureIsDisabled() async {
@@ -304,28 +288,7 @@ final class FireExecutorTests: XCTestCase {
 
         await executor.burn(request: makeFireRequest(options: .tabs), applicationState: .unknown)
 
-        let callCount = await mockAppSwitcherSnapshotCleaner.clearSnapshotsCallCount
-        XCTAssertEqual(callCount, 0)
-    }
-
-    func testBurnStartsAppSwitcherSnapshotCleanupBeforeTabDomainLookupCompletes() async {
-        mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
-        let tabHistoryStartedExpectation = expectation(description: "Tab history lookup started")
-        let snapshotCleanupStartedExpectation = expectation(description: "Snapshot cleanup started")
-        let blockingHistoryManager = BlockingHistoryManager(tabHistoryStartedExpectation: tabHistoryStartedExpectation)
-        mockHistoryManager = blockingHistoryManager
-        let snapshotCleaner = MockAppSwitcherSnapshotCleaner(clearSnapshotsStartedExpectation: snapshotCleanupStartedExpectation)
-        let executor = makeFireExecutor(appSwitcherSnapshotCleaner: snapshotCleaner)
-        let request = makeFireRequest(options: .tabs, scope: .tab(viewModel: makeTabViewModel()))
-
-        let burnTask = Task {
-            await executor.burn(request: request, applicationState: .unknown)
-        }
-
-        await fulfillment(of: [tabHistoryStartedExpectation], timeout: 1.0)
-        await fulfillment(of: [snapshotCleanupStartedExpectation], timeout: 1.0)
-        await blockingHistoryManager.resumeTabHistory()
-        await burnTask.value
+        XCTAssertEqual(mockAppSwitcherSnapshotCleaner.clearSnapshotsCallCount, 0)
     }
 
     private func makeTabViewModel(chatID: String, fireTab: Bool) -> TabViewModel {
@@ -994,47 +957,5 @@ final class FireExecutorTests: XCTestCase {
         await executor.burn(request: makeFireRequest(options: .aiChats, scope: .normalMode), applicationState: .unknown)
 
         XCTAssertEqual(mockHistoryCleaner.lastIsFireMode, false, "Normal-mode burn must route through normal native storage")
-    }
-}
-
-private final class BlockingHistoryManager: MockHistoryManager {
-
-    private let tabHistoryStartedExpectation: XCTestExpectation
-    private let tabHistoryGate = AsyncGate()
-
-    init(tabHistoryStartedExpectation: XCTestExpectation) {
-        self.tabHistoryStartedExpectation = tabHistoryStartedExpectation
-        super.init(historyCoordinator: NullHistoryCoordinator(), isEnabledByUser: false, historyFeatureEnabled: false)
-    }
-
-    override func tabHistory(tabID: String) async throws -> [URL] {
-        tabHistoryStartedExpectation.fulfill()
-        await tabHistoryGate.wait()
-        return []
-    }
-
-    func resumeTabHistory() async {
-        await tabHistoryGate.open()
-    }
-}
-
-private actor AsyncGate {
-
-    private var isOpen = false
-    private var continuation: CheckedContinuation<Void, Never>?
-
-    func wait() async {
-        guard !isOpen else {
-            return
-        }
-        await withCheckedContinuation { continuation in
-            self.continuation = continuation
-        }
-    }
-
-    func open() {
-        isOpen = true
-        continuation?.resume()
-        continuation = nil
     }
 }

--- a/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
@@ -45,6 +45,7 @@ final class FireExecutorTests: XCTestCase {
         private(set) var didFinishBurningAIHistoryCalled = false
         private(set) var willStartBurningCalled = false
         private(set) var willStartBurningFireRequest: FireRequest?
+        private(set) var willClearAppSwitcherSnapshotsCalled = false
         private(set) var didFinishBurningCalled = false
         private(set) var didFinishBurningFireRequest: FireRequest?
         
@@ -75,6 +76,10 @@ final class FireExecutorTests: XCTestCase {
         
         func didFinishBurningAIHistory(fireRequest: FireRequest) {
             didFinishBurningAIHistoryCalled = true
+        }
+
+        func willClearAppSwitcherSnapshots(fireRequest: FireRequest) {
+            willClearAppSwitcherSnapshotsCalled = true
         }
         
         func didFinishBurning(fireRequest: FireRequest) {
@@ -290,6 +295,21 @@ final class FireExecutorTests: XCTestCase {
         await executor.burn(request: makeFireRequest(options: .tabs), applicationState: .unknown)
 
         XCTAssertEqual(mockAppSwitcherSnapshotCleaner.clearSnapshotsCallCount, 0)
+        XCTAssertFalse(mockDelegate.willClearAppSwitcherSnapshotsCalled)
+    }
+
+    func testTabsOnlyBurnNotifiesDelegateBeforeClearingAppSwitcherSnapshots() async {
+        mockFeatureFlagger.enabledFeatureFlags.append(.appSwitcherSnapshotClearing)
+        let snapshotCleaner = MockAppSwitcherSnapshotCleaner {
+            XCTAssertTrue(self.mockDelegate.willClearAppSwitcherSnapshotsCalled)
+            XCTAssertFalse(self.mockDelegate.didFinishBurningCalled)
+        }
+        let executor = makeFireExecutor(appSwitcherSnapshotCleaner: snapshotCleaner)
+        let request = makeFireRequest(options: .tabs, scope: .tab(viewModel: makeTabViewModel()))
+
+        await executor.burn(request: request, applicationState: .unknown)
+
+        XCTAssertEqual(snapshotCleaner.clearSnapshotsCallCount, 1)
     }
 
     private func makeTabViewModel(chatID: String, fireTab: Bool) -> TabViewModel {

--- a/iOS/DuckDuckGoTests/TabManagerTests.swift
+++ b/iOS/DuckDuckGoTests/TabManagerTests.swift
@@ -74,6 +74,21 @@ final class TabManagerTests: XCTestCase {
         XCTAssertEqual(0, tabsModel.currentIndex)
     }
 
+    func testWhenTabRemovedAndSnapshotClearingIsEnabledThenAppSwitcherSnapshotsAreCleared() async throws {
+        let tabsModel = TabsModel(desktop: false)
+        let tab = try XCTUnwrap(tabsModel.tabs.first)
+        let featureFlagger = MockFeatureFlagger()
+        featureFlagger.enabledFeatureFlags = [.appSwitcherSnapshotClearing]
+        let snapshotsCleared = expectation(description: "App switcher snapshots cleared")
+        let manager = try makeManager(tabsModel,
+                                      featureFlagger: featureFlagger,
+                                      clearAppSwitcherSnapshots: { snapshotsCleared.fulfill() })
+
+        manager.remove(tab: tab)
+
+        await fulfillment(of: [snapshotsCleared], timeout: 1.0)
+    }
+
     func testWhenAppBecomesActiveAndExcessPreviewsThenCleanUpHappens() async throws {
         let mock = MockTabPreviewsSource(totalStoredPreviews: 5)
         let tabsModel = TabsModel(desktop: false)
@@ -651,7 +666,8 @@ final class TabManagerTests: XCTestCase {
                      tabTerminationErrorPageDetector: (any TabTerminationErrorPageDetecting)? = nil,
                      privacyConfigurationManager: PrivacyConfigurationManaging = MockPrivacyConfigurationManager(),
                      applicationState: (@MainActor () -> UIApplication.State)? = nil,
-                     isPad: Bool = false) throws -> TabManager {
+                     isPad: Bool = false,
+                     clearAppSwitcherSnapshots: @escaping @MainActor () async -> Void = {}) throws -> TabManager {
         FireModeCapability.resolve(using: featureFlagger)
         let normalStore = try normalStore ?? MockKeyValueFileStore(throwOnInit: nil)
         let tabsPersistence = TabsModelPersistence(normalStore: normalStore,
@@ -696,7 +712,8 @@ final class TabManagerTests: XCTestCase {
                           tabTerminationTelemetry: tabTerminationTelemetry,
                           tabTerminationErrorPageDetector: tabTerminationErrorPageDetector,
                           applicationState: applicationState,
-                          isPad: isPad)
+                          isPad: isPad,
+                          clearAppSwitcherSnapshots: clearAppSwitcherSnapshots)
     }
 
     private func makePrivacyConfigurationManager(settings: String) -> MockPrivacyConfigurationManager {

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -439,7 +439,7 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213433942918287?focus=true
     case duckAIVoiceShortcut
 
-    /// https://app.asana.com/1/137249556945/project/414709148257752/task/1217575998563977
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217683061875234?focus=true
     case appSwitcherSnapshotClearing
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213813585476250?focus=true

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -439,6 +439,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213433942918287?focus=true
     case duckAIVoiceShortcut
 
+    /// https://app.asana.com/1/137249556945/project/414709148257752/task/1217575998563977
+    case appSwitcherSnapshotClearing
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213813585476250?focus=true
     case screenTimeCleaning
 
@@ -864,6 +867,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.omnibarDefaultPosition))
         case .duckAIVoiceShortcut:
             Config(source: .remoteReleasable(AIChatSubfeature.voiceShortcut))
+        case .appSwitcherSnapshotClearing:
+            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.appSwitcherSnapshotClearing))
         case .screenTimeCleaning:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.screenTimeCleaning))
         case .bottomBarViewportFixedElementsWorkaround:

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
@@ -79,6 +79,9 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
 
     case crashReportOptInStatusResetting
 
+    /// https://app.asana.com/1/137249556945/project/414709148257752/task/1217575998563977
+    case appSwitcherSnapshotClearing
+
     case screenTimeCleaning
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215448831345663?focus=true

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
@@ -79,7 +79,7 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
 
     case crashReportOptInStatusResetting
 
-    /// https://app.asana.com/1/137249556945/project/414709148257752/task/1217575998563977
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217683061875234?focus=true
     case appSwitcherSnapshotClearing
 
     case screenTimeCleaning


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1217575998563977

### Description
Deletes OS-cached app-switcher snapshots after every Fire request so snapshots captured in another orientation cannot reveal burned content. It also clears snapshots after successful Duck.ai chat deletions that use the Fire Button animation—including deleting one chat, selected chats, or all chats—and when tabs are closed. This prevents a snapshot captured in one orientation from showing content that was later deleted in another orientation. The cleanup is default-on behind a remotely releasable kill switch.

### Testing Steps
1. Load a website in portrait.
2. Background the app to capture a portrait snapshot.
3. Reopen the app and rotate to landscape.
4. Tap the Fire Button.
5. Background the app to capture the post-fire landscape snapshot.
6. Rotate the device to portrait and open the app switcher → the burned website is not visible.
7. Reopen the app → the burned website does not flash during the launch animation.
8. Repeat with portrait and landscape swapped.
9. Repeat steps 1–3, close the tab normally instead of using Fire, then background and open the app switcher in the original orientation → the closed tab is not visible.
10. Repeat the orientation sequence in Duck.ai, delete one chat, selected chats, or all chats using the Fire Button flow, then open the app switcher in the original orientation → deleted chat content is not visible.

### Impact
Medium: stale app-switcher snapshots can expose content the user burned.

#### What could go wrong?
Snapshot cleanup could fail or OS storage behavior could change → failures are isolated per item, never fail the burn, and the remotely releasable feature flag can disable cleanup.

### Quality Considerations
The cleaner removes only the contents of Library/SplashBoard/Snapshots and preserves the OS-owned directory. File I/O runs off the main actor. Missing directories are a silent no-op. Physical-device validation is still required because SpringBoard snapshot behavior cannot be fully confirmed by unit tests or the simulator.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches privacy-sensitive data clearing and deletes files under Library/SplashBoard/Snapshots. Failures are isolated and gated by a remotely releasable default-on flag.
> 
> **Overview**
> Clears iOS app-switcher snapshots after Fire, successful Duck.ai chat deletion, and tab close so a snapshot captured in another orientation cannot show content the user already burned.
> 
> Adds `AppSwitcherSnapshotCleaner`, which removes items under `Library/SplashBoard/Snapshots` while keeping the OS directory. `FireExecutor` and `TabManager` invoke it behind the new default-on, remotely releasable `appSwitcherSnapshotClearing` flag. Chat burns only clear snapshots on success.
> 
> Also drops the Fire animation’s pre-burn window snapshot when the app resigns active, so that overlay cannot leak into a new switcher snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c63b5f622b4c1aea45cd9fad9b03404a189b781. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

