### PR TITLE
Retire the vpnShowCopyDiagnosticsButton feature flag

### DIFF
--- a/iOS/DuckDuckGo/NetworkProtectionVPNSettingsView.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionVPNSettingsView.swift
@@ -50,10 +50,6 @@ struct NetworkProtectionVPNSettingsView: View {
 
     private let strictRoutingRowID = "strictRoutingRow"
 
-    private var showsCopyDiagnosticsButton: Bool {
-        AppDependencyProvider.shared.featureFlagger.isFeatureOn(.vpnShowCopyDiagnosticsButton)
-    }
-
     var body: some View {
         VStack {
             ScrollViewReader { proxy in
@@ -86,9 +82,7 @@ struct NetworkProtectionVPNSettingsView: View {
 
                 dnsSection()
 
-                if showsCopyDiagnosticsButton {
-                    diagnostics()
-                }
+                diagnostics()
             }
             .onAppear {
                 Task {

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -243,10 +243,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214946884020610?focus=true
     case vpnExcludeCGNATToggle
 
-    /// Toggle for the Copy VPN Diagnostics button in the VPN status screen.
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215794369750045
-    case vpnShowCopyDiagnosticsButton
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866614199859
     case forgetAllInSettings
 
@@ -739,8 +735,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .internalOnly, source: .remoteReleasable(NetworkProtectionSubfeature.strictRoutingToggle))
         case .vpnExcludeCGNATToggle:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(NetworkProtectionSubfeature.excludeCGNAT))
-        case .vpnShowCopyDiagnosticsButton:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(NetworkProtectionSubfeature.showCopyDiagnosticsButton))
         case .forgetAllInSettings:
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.forgetAllInSettings))
         case .fullDuckAIMode:

--- a/macOS/DuckDuckGo/Preferences/Model/VPNPreferencesModel.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/VPNPreferencesModel.swift
@@ -127,10 +127,6 @@ final class VPNPreferencesModel: ObservableObject {
 
     @Published private(set) var copySupportInfoState: CopySupportInfoState = .idle
 
-    var showsCopyDiagnosticsButton: Bool {
-        featureFlagger.isFeatureOn(.vpnShowCopyDiagnosticsButton)
-    }
-
     private var onboardingStatus: OnboardingStatus {
         didSet {
             Task { @MainActor in

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesVPNView.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesVPNView.swift
@@ -209,27 +209,23 @@ extension Preferences {
 
                 // SECTION: Troubleshooting
 
-                if model.showsCopyDiagnosticsButton || model.showUninstallVPN {
-                    PreferencePaneSection(UserText.vpnTroubleshootingTitle) {
-                        if model.showsCopyDiagnosticsButton {
-                            PreferencePaneSubSection {
-                                Button(copyDiagnosticsButtonTitle) {
-                                    Task { @MainActor in
-                                        await model.copySupportInfo()
-                                    }
-                                }
-                                .disabled(model.copySupportInfoState != .idle)
-
-                                TextMenuItemCaption(UserText.vpnSettingsCopyDiagnosticsCaption)
+                PreferencePaneSection(UserText.vpnTroubleshootingTitle) {
+                    PreferencePaneSubSection {
+                        Button(copyDiagnosticsButtonTitle) {
+                            Task { @MainActor in
+                                await model.copySupportInfo()
                             }
                         }
+                        .disabled(model.copySupportInfoState != .idle)
 
-                        if model.showUninstallVPN {
-                            PreferencePaneSubSection {
-                                Button(UserText.uninstallVPNButtonTitle) {
-                                    Task { @MainActor in
-                                        await model.uninstallVPN()
-                                    }
+                        TextMenuItemCaption(UserText.vpnSettingsCopyDiagnosticsCaption)
+                    }
+
+                    if model.showUninstallVPN {
+                        PreferencePaneSubSection {
+                            Button(UserText.uninstallVPNButtonTitle) {
+                                Task { @MainActor in
+                                    await model.uninstallVPN()
                                 }
                             }
                         }

--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -69,10 +69,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214946884020610?focus=true
     case vpnExcludeCGNATToggle
 
-    /// Toggle for the Copy VPN Diagnostics button in VPN settings.
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215794369750045
-    case vpnShowCopyDiagnosticsButton
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866615719736
     case autoUpdateInDEBUG
 
@@ -580,8 +576,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .internalOnly, source: .remoteReleasable(NetworkProtectionSubfeature.strictRoutingToggle), category: .vpn)
         case .vpnExcludeCGNATToggle:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(NetworkProtectionSubfeature.excludeCGNAT), category: .vpn)
-        case .vpnShowCopyDiagnosticsButton:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(NetworkProtectionSubfeature.showCopyDiagnosticsButton), category: .vpn)
         case .autoUpdateInDEBUG:
             Config(source: .disabled, category: .updates)
         case .autoUpdateInREVIEW:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1217636464766365?focus=true
Tech Design URL:
CC:

### Description
Retires the `vpnShowCopyDiagnosticsButton` feature flag now that the Copy VPN Diagnostics action has been available long enough to remove the gate. The action remains enabled on iOS and macOS with no user-visible default change.

### Testing Steps
1. Open VPN preferences on macOS → Copy VPN Diagnostics action is present.
2. Open VPN settings on iOS → Copy VPN Diagnostics action is present.

### Impact
None: internal feature flag cleanup, no user-visible behavior change.

### Quality Considerations
None.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal feature-flag cleanup with no intended user-visible behavior change for builds where the flag was already enabled.
> 
> **Overview**
> Removes the **`vpnShowCopyDiagnosticsButton`** gate on iOS and macOS so **Copy VPN Diagnostics** is always shown in VPN settings/preferences.
> 
> On iOS, the diagnostics troubleshooting section is always included in the settings list. On macOS, the troubleshooting pane always includes the copy action; **Uninstall VPN** remains conditional on `showUninstallVPN`.
> 
> The flag case and remote config mapping are deleted from **FeatureFlags-iOS** and **FeatureFlags-macOS**; related view/model helpers that read the flag are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 901fea38dfc172536b4698995da5effa217eb7bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->