### PR TITLE
[iOS] Add regression test for Duck.ai prompt firing search experiment pixels

### DIFF
--- a/iOS/DuckDuckGoTests/StatisticsLoaderTests.swift
+++ b/iOS/DuckDuckGoTests/StatisticsLoaderTests.swift
@@ -98,6 +98,25 @@ class StatisticsLoaderTests: XCTestCase {
         XCTAssertFalse(firedOSDistributionMetrics.contains(.client))
     }
 
+    func testRefreshRetentionAtbOnDuckAIPromptSubmissionFiresSearchExperimentPixels() {
+        mockStatisticsStore.atb = "atb"
+        mockStatisticsStore.searchRetentionAtb = "searchretentionatb"
+        mockStatisticsStore.duckAIRetentionAtb = "retentionatb"
+        loadSuccessfulAtbStub()
+        loadSuccessfulExiStub()
+
+        let testExpectation = expectation(description: "refresh complete")
+        testee.refreshRetentionAtbOnDuckAIPromptSubmission {
+            testExpectation.fulfill()
+        }
+        wait(for: [testExpectation], timeout: 10.0)
+
+        // A Duck.ai prompt counts as a search, so it must fire the search experiment pixels
+        // (via refreshSearchRetentionAtb) in addition to the AI-prompt experiment pixels.
+        XCTAssertTrue(fireSearchExperimentPixelsCalled)
+        XCTAssertTrue(fireNewAIPromptExperimentPixelsCalled)
+    }
+
     override func tearDown() {
         HTTPStubs.removeAllStubs()
         PixelFiringMock.tearDown()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1216793387181016
CC:

### Description
A Duck.ai prompt counts as a search, so it should fire the search experiment pixels in addition to the dedicated Duck.ai metric. iOS already does this correctly, but there was no test locking in that behaviour on the Duck.ai prompt entrypoint.

### Testing Steps
1. Run `StatisticsLoaderTests.testRefreshRetentionAtbOnDuckAIPromptSubmissionFiresSearchExperimentPixels` → passes.

### Impact
None (test-only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or analytics pipeline modifications.
> 
> **Overview**
> Adds a **regression test** in `StatisticsLoaderTests` so Duck.ai prompt submission is locked in as firing **search experiment pixels** as well as AI-prompt experiment pixels.
> 
> The new `testRefreshRetentionAtbOnDuckAIPromptSubmissionFiresSearchExperimentPixels` exercises `refreshRetentionAtbOnDuckAIPromptSubmission` and asserts both `fireSearchExperimentPixels` and `fireNewAIPromptExperimentPixels` run—matching the product rule that a Duck.ai prompt counts as a search. **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a488cc215e765ada411464e9c2ea755a4d4b731e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->