### PR TITLE
iOS: Fix iPad tab hover flicker from excessive tab bar reloads

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2626,7 +2626,7 @@ class MainViewController: UIViewController {
             attachTab(tab: tab)
         }
         themeColorManager.updateThemeColor()
-        tabsBarController?.refresh(tabsModel: tabManager.currentTabsModel, scrollToSelected: true)
+        tabsBarController?.refreshStyleInPlace(tabsModel: tabManager.currentTabsModel, scrollToSelected: true)
         bindAIChatChromeChipToCurrentTab()
         swipeTabsCoordinator?.refresh(tabsModel: tabManager.currentTabsModel, scrollToSelected: true)
         if daxDialogsManager.shouldShowFireButtonPulse {
@@ -6982,7 +6982,8 @@ extension MainViewController: TabSwitcherDelegate {
 
     func closeTab(_ tab: Tab,
                   behavior: TabClosingBehavior = .onlyClose,
-                  clearTabHistory: Bool = true) {
+                  clearTabHistory: Bool = true,
+                  refreshInPlace: Bool = false) {
         
         func replaceTabWith(newTab: Tab) {
             tabManager.replace(tab: tab, withNewTab: newTab, clearTabHistory: clearTabHistory)
@@ -6999,6 +7000,9 @@ extension MainViewController: TabSwitcherDelegate {
         hideSuggestionTray()
         hideNotificationBarIfBrokenSitePromptShown()
         themeColorManager.updateThemeColor()
+
+        // Captured before removal so the tabs bar can delete exactly this cell in place.
+        let removedIndex = tabManager.currentTabsModel.indexOf(tab: tab)
 
         switch behavior {
         case .createEmptyTabAtSamePosition:
@@ -7020,8 +7024,15 @@ extension MainViewController: TabSwitcherDelegate {
             tabManager.remove(tab: tab, clearTabHistory: clearTabHistory)
         }
 
-        updateCurrentTab()
-        refreshTabBar()
+        // In-place close: delete the cell before updateCurrentTab() so the follow-up restyle stays in
+        // place instead of reloading (a reload flashes the hover highlight on the wrong tab).
+        if refreshInPlace, behavior == .onlyClose, let removedIndex {
+            tabsBarController?.removeTab(at: removedIndex, tabsModel: tabManager.currentTabsModel)
+            updateCurrentTab()
+        } else {
+            updateCurrentTab()
+            refreshTabBar()
+        }
     }
 
     func tabSwitcherDidRequestForgetAll(tabSwitcher: TabSwitcherViewController, fireRequest: FireRequest) {

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -349,23 +349,57 @@ class TabsBarViewController: UIViewController {
 
     func refresh(tabsModel: TabsModelManaging?, scrollToSelected: Bool = false) {
         self.tabsModel = tabsModel
-
-        tabSwitcherButton.isAccessibilityElement = true
-        tabSwitcherButton.accessibilityLabel = UserText.tabSwitcherAccessibilityLabel
-        tabSwitcherButton.accessibilityHint = UserText.numberOfTabs(tabsCount)
-
         recomputeItemSize()
         reloadData()
         fireUsageDailyPixels()
+        if scrollToSelected { scrollToSelectedTab() }
+    }
 
-        if scrollToSelected {
-            DispatchQueue.main.async {
-                if let currentIndex = self.currentIndex {
-                    self.collectionView.scrollToItem(at: IndexPath(row: currentIndex, section: 0), at: [], animated: true)
-                }
-            }
+    /// Restyles visible cells in place instead of reloading (a reload recycles cells hosting the pointer
+    /// effect and flashes the hover highlight on the wrong tab). Falls back to `refresh` on add/remove.
+    func refreshStyleInPlace(tabsModel: TabsModelManaging?, scrollToSelected: Bool = false) {
+        guard let tabsModel, tabsModel.count == collectionView.numberOfItems(inSection: 0) else {
+            refresh(tabsModel: tabsModel, scrollToSelected: scrollToSelected)
+            return
         }
+        self.tabsModel = tabsModel
+        refreshVisibleCellStyles()
+        refreshTabSwitcherButton()
+        if scrollToSelected { scrollToSelectedTab() }
+    }
 
+    /// Deletes one cell instead of reloading, so surviving cells keep their pointer state. Must run
+    /// before `updateCurrentTab()` on the close path so the follow-up restyle stays in place.
+    func removeTab(at index: Int, tabsModel: TabsModelManaging?) {
+        let displayedCount = collectionView.numberOfItems(inSection: 0)
+        guard let tabsModel, index < displayedCount, tabsModel.count == displayedCount - 1 else {
+            refresh(tabsModel: tabsModel, scrollToSelected: true)
+            return
+        }
+        self.tabsModel = tabsModel
+        recomputeItemSize()
+        // deleteItems animates by default; suppress it to match reloadData()'s instant update.
+        UIView.performWithoutAnimation {
+            collectionView.deleteItems(at: [IndexPath(item: index, section: 0)])
+        }
+        refreshVisibleCellStyles()
+        refreshTabSwitcherButton()
+    }
+
+    private func refreshTabSwitcherButton() {
+        tabSwitcherButton.isAccessibilityElement = true
+        tabSwitcherButton.accessibilityLabel = UserText.tabSwitcherAccessibilityLabel
+        tabSwitcherButton.accessibilityHint = UserText.numberOfTabs(tabsCount)
+        tabSwitcherButton.tabCount = tabsCount
+        tabSwitcherButton.isFireMode = (tabManager?.currentBrowsingMode ?? .normal) == .fire
+        tabSwitcherButton.hasUnread = hasUnread
+    }
+
+    private func scrollToSelectedTab() {
+        DispatchQueue.main.async {
+            guard let currentIndex = self.currentIndex else { return }
+            self.collectionView.scrollToItem(at: IndexPath(row: currentIndex, section: 0), at: [], animated: true)
+        }
     }
 
     /// After a resize/rotation reflows the strip, nudge the current tab fully into view, but only if
@@ -453,9 +487,7 @@ class TabsBarViewController: UIViewController {
 
     private func reloadData() {
         collectionView.reloadData()
-        tabSwitcherButton.tabCount = tabsCount
-        tabSwitcherButton.isFireMode = (tabManager?.currentBrowsingMode ?? .normal) == .fire
-        tabSwitcherButton.hasUnread = hasUnread
+        refreshTabSwitcherButton()
         flareBackground.update()
     }
 
@@ -914,7 +946,7 @@ extension MainViewController: TabsBarDelegate {
     
     func tabsBar(_ controller: TabsBarViewController, didRemoveTabAtIndex index: Int) {
         if let tab = tabManager.currentTabsModel.get(tabAt: index) {
-            closeTab(tab)
+            closeTab(tab, refreshInPlace: true)
         }
     }
 

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -377,11 +377,11 @@ class TabsBarViewController: UIViewController {
             return
         }
         self.tabsModel = tabsModel
-        recomputeItemSize()
         // deleteItems animates by default; suppress it to match reloadData()'s instant update.
         UIView.performWithoutAnimation {
             collectionView.deleteItems(at: [IndexPath(item: index, section: 0)])
         }
+        recomputeItemSize()
         refreshVisibleCellStyles()
         refreshTabSwitcherButton()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213902367836299

### Description

On iPad with a hardware trackpad, the pointer-hover highlight on tabs would flash on the wrong tabs when selecting a tab and jump around when closing one. The root cause is that both actions triggered a full `collectionView.reloadData()`, which recycles the cells that host the `UIPointerInteraction` hover effect — the recycled cell briefly renders a stale highlight under the stationary pointer before UIKit re-resolves it.

This replaces the unnecessary reloads on those two paths with in-place updates:

- **Selecting a tab** (`transitionTo`) now calls a new `refreshStyleInPlace(...)`, which restyles the visible cells without a reload when the tab set is unchanged, and falls back to `refresh()` when the count changed (add/remove).
- **Closing a tab from the tabs bar** propagates a new `refreshInPlace` flag down to `closeTab`, which deletes just the removed cell via `deleteItems` (animation suppressed to match the old instant behavior) before `updateCurrentTab()`, so the follow-up restyle stays in place instead of reloading.

Also refactors the shared tab-switcher-button and scroll-to-selected logic into helpers (`refreshTabSwitcherButton()`, `scrollToSelectedTab()`) to remove duplication introduced by the new methods.

### Testing Steps

1. Run the iOS app on an iPad (simulator with pointer, or a device with a hardware trackpad/mouse).
2. Open several tabs so the tabs bar is visible.
3. Hover the pointer over the tabs, then click between different tabs. **Expected:** the hover highlight only appears on the tab actually under the pointer — no brief flash on adjacent/random tabs when switching.
4. Hover over a tab and close a middle tab (via its close button). **Expected:** the closed tab's cell is removed instantly and the remaining tabs close the gap without the hover highlight skidding to another tab and back.
5. Add new tabs and close tabs until the strip overflows (scrolls); repeat steps 3–4 to confirm behavior holds when the strip is overflowing.
6. Confirm no regressions in normal tab operations: opening new tabs, reordering via drag, closing the current tab, and "close other tabs".

### Impact and Risks

**Low.** iPad-only, scoped to the tabs bar. The change swaps full reloads for in-place updates on the select/close paths, with a guard that falls back to the original `refresh()`/reload whenever the tab count doesn't match (add/remove/desync), so worst case is the pre-existing behavior. No data model or persistence changes. Main risk area is collection-view consistency on the close path (deleting a cell before `updateCurrentTab()`), mitigated by the count guard and the existing placeholder fallback in `cellForItemAt`.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> iPad tabs bar UI only; count-mismatch guards fall back to the previous full reload path, with no model or persistence changes.
> 
> **Overview**
> Fixes **iPad trackpad pointer hover** flashing on the wrong tab when switching tabs or closing one from the tabs bar. Those paths used **`collectionView.reloadData()`**, which recycles cells that host **`UIPointerInteraction`** and briefly shows a stale hover highlight.
> 
> **Tab selection** (`transitionTo`) now calls **`refreshStyleInPlace`**, which restyles visible cells when the tab count is unchanged and falls back to full **`refresh`** on add/remove.
> 
> **Closing from the tabs bar** passes **`refreshInPlace: true`** into **`closeTab`**. For **`onlyClose`**, it removes the cell with **`removeTab`** ( **`deleteItems`** without animation) before **`updateCurrentTab()`**, so the follow-up update stays in place instead of reloading.
> 
> Shared tab-switcher button updates and scroll-to-selected behavior are consolidated into **`refreshTabSwitcherButton()`** and **`scrollToSelectedTab()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9433126ba21ce36335aa2ad6349acd55fe05b20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->