### PR TITLE
Fix upgradedHttps false positives in iOS breakage reports

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		18EB298166184F06B6A87190 /* OnboardingSearchAIToggleGrey.lottie in Resources */ = {isa = PBXBuildFile; fileRef = 17BA504D98D84DB79BDE168D /* OnboardingSearchAIToggleGrey.lottie */; };
 		1A2B3C4D5E6F708192A3B402 /* MainViewController+AIChatHistoryViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F708192A3B401 /* MainViewController+AIChatHistoryViewModelDelegate.swift */; };
 		1AD965E390AC1B7FDE09D956 /* OnboardingView+ComparisonContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8693FFCAC02CE4A85D0BD62C /* OnboardingView+ComparisonContent.swift */; };
+		1CBBE38A74610DD6C6CF7524 /* TabViewControllerHTTPSForcedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BC30682612C1D398C8629A /* TabViewControllerHTTPSForcedTests.swift */; };
 		1D116C11AE6EDE0456EE23B3 /* SubscriptionPromoExistingUserCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DEC03128C893FD62A15EF4A /* SubscriptionPromoExistingUserCoordinatorTests.swift */; };
 		1D200C972BA3157A00108701 /* SettingsNextStepsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D200C962BA3157A00108701 /* SettingsNextStepsView.swift */; };
 		1D200C992BA3176D00108701 /* SettingsOthersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D200C982BA3176D00108701 /* SettingsOthersView.swift */; };
@@ -6587,6 +6588,7 @@
 			children = (
 				317045BF2858C6B90016ED1F /* AutofillInterfaceEmailTruncatorTests.swift */,
 				C14E2F7629DE14EA002AC515 /* AutofillInterfaceUsernameTruncatorTests.swift */,
+				00BC30682612C1D398C8629A /* TabViewControllerHTTPSForcedTests.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -15385,6 +15387,7 @@
 				AA10B5022FA0000100AB12CD /* WebExtensionAvailabilityTests.swift in Sources */,
 				39BD5432CF6280442CDE88F0 /* DBPIOSContentBlockingTests.swift in Sources */,
 				B7A97190FB026429E034DB99 /* TabViewControllerSiteLoadingPixelTests.swift in Sources */,
+				1CBBE38A74610DD6C6CF7524 /* TabViewControllerHTTPSForcedTests.swift in Sources */,
 				A627D8C9C6C477E0A51B89E5 /* NavigationPixelNavigationResponderTests.swift in Sources */,
 				9F032A343019A1AA00F8D5E9 /* OnboardingPersonalizationToggleBindingTests.swift in Sources */,
 				88CED5F7656BFDD8D99B3CA0 /* UnifiedToggleInputReasoningMenuFactoryTests.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -29,7 +29,6 @@
 		18EB298166184F06B6A87190 /* OnboardingSearchAIToggleGrey.lottie in Resources */ = {isa = PBXBuildFile; fileRef = 17BA504D98D84DB79BDE168D /* OnboardingSearchAIToggleGrey.lottie */; };
 		1A2B3C4D5E6F708192A3B402 /* MainViewController+AIChatHistoryViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F708192A3B401 /* MainViewController+AIChatHistoryViewModelDelegate.swift */; };
 		1AD965E390AC1B7FDE09D956 /* OnboardingView+ComparisonContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8693FFCAC02CE4A85D0BD62C /* OnboardingView+ComparisonContent.swift */; };
-		1CBBE38A74610DD6C6CF7524 /* TabViewControllerHTTPSForcedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BC30682612C1D398C8629A /* TabViewControllerHTTPSForcedTests.swift */; };
 		1D116C11AE6EDE0456EE23B3 /* SubscriptionPromoExistingUserCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DEC03128C893FD62A15EF4A /* SubscriptionPromoExistingUserCoordinatorTests.swift */; };
 		1D200C972BA3157A00108701 /* SettingsNextStepsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D200C962BA3157A00108701 /* SettingsNextStepsView.swift */; };
 		1D200C992BA3176D00108701 /* SettingsOthersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D200C982BA3176D00108701 /* SettingsOthersView.swift */; };
@@ -714,6 +713,7 @@
 		7BFD5FD92C9DBC24000FF959 /* VPNSnoozeTip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFD5FD82C9DBC24000FF959 /* VPNSnoozeTip.swift */; };
 		7C728F7CD1A6080BA2CF4C3E /* IPadOmnibarAttachmentControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9978912B1022C989EF9C224 /* IPadOmnibarAttachmentControllerTests.swift */; };
 		7C8A1B2D3E4F506172839405 /* AIChatTabChatHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E5D6C7A8F9012345678901 /* AIChatTabChatHeaderViewTests.swift */; };
+		8012B4A43035E438002EA94C /* TabViewControllerHTTPSForcedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8012B4A33035E438002EA94C /* TabViewControllerHTTPSForcedTests.swift */; };
 		801870A92F86CD6800E2DC44 /* LastActiveTabStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801870A82F86CD6800E2DC44 /* LastActiveTabStore.swift */; };
 		8026361E2F983C2A009FD281 /* TabSwitcherTitleBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8026361D2F983C2A009FD281 /* TabSwitcherTitleBarView.swift */; };
 		80273AB82ED3E22E00EA03A1 /* SpyDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80273AB72ED3E22B00EA03A1 /* SpyDownloadManager.swift */; };
@@ -3579,6 +3579,7 @@
 		7BFD5FD42C9DA310000FF959 /* VPNAddWidgetTip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNAddWidgetTip.swift; sourceTree = "<group>"; };
 		7BFD5FD62C9DB9D7000FF959 /* VPNGeoswitchingTip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNGeoswitchingTip.swift; sourceTree = "<group>"; };
 		7BFD5FD82C9DBC24000FF959 /* VPNSnoozeTip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNSnoozeTip.swift; sourceTree = "<group>"; };
+		8012B4A33035E438002EA94C /* TabViewControllerHTTPSForcedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewControllerHTTPSForcedTests.swift; sourceTree = "<group>"; };
 		801870A82F86CD6800E2DC44 /* LastActiveTabStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastActiveTabStore.swift; sourceTree = "<group>"; };
 		8026361D2F983C2A009FD281 /* TabSwitcherTitleBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherTitleBarView.swift; sourceTree = "<group>"; };
 		80273AB72ED3E22B00EA03A1 /* SpyDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpyDownloadManager.swift; sourceTree = "<group>"; };
@@ -6588,7 +6589,6 @@
 			children = (
 				317045BF2858C6B90016ED1F /* AutofillInterfaceEmailTruncatorTests.swift */,
 				C14E2F7629DE14EA002AC515 /* AutofillInterfaceUsernameTruncatorTests.swift */,
-				00BC30682612C1D398C8629A /* TabViewControllerHTTPSForcedTests.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -11706,6 +11706,7 @@
 		F13B4BF71F18C9E800814661 /* Tabs */ = {
 			isa = PBXGroup;
 			children = (
+				8012B4A33035E438002EA94C /* TabViewControllerHTTPSForcedTests.swift */,
 				854D678E2F6D4C71008707A3 /* TabSwitcherMenuBuilderTests.swift */,
 				5B4F88C32F465B70003999E2 /* TabExternalLaunchTests.swift */,
 				5B4F88C22F465B0D003999E2 /* TabManagerExternalLaunchTests.swift */,
@@ -15136,6 +15137,7 @@
 				9FF967B92E0E6ADE00E45B54 /* DefaultBrowserPromptFeatureFlagAdapterTests.swift in Sources */,
 				98E563F12DE8B32D00E6E75F /* MockPrivacyConfiguration.swift in Sources */,
 				98E563F22DE8B32D00E6E75F /* MockSecureVault.swift in Sources */,
+				8012B4A43035E438002EA94C /* TabViewControllerHTTPSForcedTests.swift in Sources */,
 				98E563F32DE8B32D00E6E75F /* MockVariantManager.swift in Sources */,
 				9FF967B42E0E270300E45B54 /* DefaultBrowserPromptUserTypeStoreTests.swift in Sources */,
 				C14CA6492E589F6A0060FA7B /* DaxEasterEggLogoCacheTests.swift in Sources */,
@@ -15387,7 +15389,6 @@
 				AA10B5022FA0000100AB12CD /* WebExtensionAvailabilityTests.swift in Sources */,
 				39BD5432CF6280442CDE88F0 /* DBPIOSContentBlockingTests.swift in Sources */,
 				B7A97190FB026429E034DB99 /* TabViewControllerSiteLoadingPixelTests.swift in Sources */,
-				1CBBE38A74610DD6C6CF7524 /* TabViewControllerHTTPSForcedTests.swift in Sources */,
 				A627D8C9C6C477E0A51B89E5 /* NavigationPixelNavigationResponderTests.swift in Sources */,
 				9F032A343019A1AA00F8D5E9 /* OnboardingPersonalizationToggleBindingTests.swift in Sources */,
 				88CED5F7656BFDD8D99B3CA0 /* UnifiedToggleInputReasoningMenuFactoryTests.swift in Sources */,

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2239,10 +2239,15 @@ extension TabViewController: WKNavigationDelegate {
 
     /// Whether the committed page was reached via an HTTPS upgrade.
     ///
-    /// Guards on `lastUpgradedURL` so an upgrade is only reported when one actually happened.
+    /// Needs both an upgrade on record and an HTTPS commit: `lastUpgradedURL` isn't reset across
+    /// same-domain navigations, so without the scheme check a later HTTP commit on the same domain
+    /// would be mis-flagged. Mirrors macOS's `connectionUpgradedTo != nil`.
     static func isHTTPSForced(lastUpgradedURL: URL?, currentURL: URL?, tld: TLD) -> Bool {
-        guard let lastUpgradedURL else { return false }
-        return tld.domain(lastUpgradedURL.host) == tld.domain(currentURL?.host)
+        guard let lastUpgradedURL, let currentURL, currentURL.isHttps else { return false }
+        guard let upgradedDomain = tld.domain(lastUpgradedURL.host) else {
+            return lastUpgradedURL.host == currentURL.host
+        }
+        return upgradedDomain == tld.domain(currentURL.host)
     }
 
     private func onWebpageDidStartLoading(httpsForced: Bool) {

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -2228,13 +2228,21 @@ extension TabViewController: WKNavigationDelegate {
 
         url = webView.url
         let tld = storageCache.tld
-        let httpsForced = tld.domain(lastUpgradedURL?.host) == tld.domain(webView.url?.host)
+        let httpsForced = Self.isHTTPSForced(lastUpgradedURL: lastUpgradedURL, currentURL: webView.url, tld: tld)
         onWebpageDidStartLoading(httpsForced: httpsForced)
         textZoomCoordinator.onNavigationCommitted(applyToWebView: webView)
         
         // Check cache for instant logo display during back navigation
         checkDaxEasterEggCacheIfDuckDuckGoSearch(webView)
 
+    }
+
+    /// Whether the committed page was reached via an HTTPS upgrade.
+    ///
+    /// Guards on `lastUpgradedURL` so an upgrade is only reported when one actually happened.
+    static func isHTTPSForced(lastUpgradedURL: URL?, currentURL: URL?, tld: TLD) -> Bool {
+        guard let lastUpgradedURL else { return false }
+        return tld.domain(lastUpgradedURL.host) == tld.domain(currentURL?.host)
     }
 
     private func onWebpageDidStartLoading(httpsForced: Bool) {

--- a/iOS/DuckDuckGoTests/TabViewControllerHTTPSForcedTests.swift
+++ b/iOS/DuckDuckGoTests/TabViewControllerHTTPSForcedTests.swift
@@ -1,0 +1,57 @@
+//
+//  TabViewControllerHTTPSForcedTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Common
+import XCTest
+@testable import DuckDuckGo
+
+final class TabViewControllerHTTPSForcedTests: XCTestCase {
+
+    private let tld = TLD()
+
+    // Regression: hosts with no Public Suffix List match (IP literals, .local, .lan, single-label)
+    // must not report an upgrade when none happened. Previously tld.domain(...) returned nil on both
+    // sides so nil == nil falsely read as upgraded (~6% of flagged iOS reports, May–Jul 2026).
+    func test_noPriorUpgrade_returnsFalseForHostsWithoutPSLMatch() {
+        for host in ["http://printer.local/", "http://192.168.1.10/", "http://nas.lan/", "http://intranet/"] {
+            let url = URL(string: host)!
+            XCTAssertFalse(
+                TabViewController.isHTTPSForced(lastUpgradedURL: nil, currentURL: url, tld: tld),
+                "\(host) with no prior upgrade should not be reported as HTTPS-forced"
+            )
+        }
+    }
+
+    func test_noPriorUpgrade_returnsFalseForNormalHost() {
+        let url = URL(string: "https://example.com/")!
+        XCTAssertFalse(TabViewController.isHTTPSForced(lastUpgradedURL: nil, currentURL: url, tld: tld))
+    }
+
+    func test_priorUpgradeToSameDomain_returnsTrue() {
+        let upgraded = URL(string: "https://example.com/")!
+        let current = URL(string: "https://www.example.com/page")!
+        XCTAssertTrue(TabViewController.isHTTPSForced(lastUpgradedURL: upgraded, currentURL: current, tld: tld))
+    }
+
+    func test_priorUpgradeToDifferentDomain_returnsFalse() {
+        let upgraded = URL(string: "https://example.com/")!
+        let current = URL(string: "https://other.com/")!
+        XCTAssertFalse(TabViewController.isHTTPSForced(lastUpgradedURL: upgraded, currentURL: current, tld: tld))
+    }
+}

--- a/iOS/DuckDuckGoTests/TabViewControllerHTTPSForcedTests.swift
+++ b/iOS/DuckDuckGoTests/TabViewControllerHTTPSForcedTests.swift
@@ -25,11 +25,9 @@ final class TabViewControllerHTTPSForcedTests: XCTestCase {
 
     private let tld = TLD()
 
-    // Regression: hosts with no Public Suffix List match (IP literals, .local, .lan, single-label)
-    // must not report an upgrade when none happened. Previously tld.domain(...) returned nil on both
-    // sides so nil == nil falsely read as upgraded (~6% of flagged iOS reports, May–Jul 2026).
-    func test_noPriorUpgrade_returnsFalseForHostsWithoutPSLMatch() {
-        for host in ["http://printer.local/", "http://192.168.1.10/", "http://nas.lan/", "http://intranet/"] {
+    // No upgrade recorded → never forced. https:// so we test the nil guard, not the scheme guard.
+    func test_noPriorUpgrade_returnsFalse() {
+        for host in ["https://printer.local/", "https://192.168.1.10/", "https://intranet/", "https://example.com/"] {
             let url = URL(string: host)!
             XCTAssertFalse(
                 TabViewController.isHTTPSForced(lastUpgradedURL: nil, currentURL: url, tld: tld),
@@ -38,9 +36,12 @@ final class TabViewControllerHTTPSForcedTests: XCTestCase {
         }
     }
 
-    func test_noPriorUpgrade_returnsFalseForNormalHost() {
-        let url = URL(string: "https://example.com/")!
-        XCTAssertFalse(TabViewController.isHTTPSForced(lastUpgradedURL: nil, currentURL: url, tld: tld))
+    // The reported bug: printer.local committed over HTTP shouldn't count as forced. Before the fix,
+    // tld.domain was nil on both sides so nil == nil read as upgraded.
+    func test_priorUpgrade_httpCommitOnNoPSLHost_returnsFalse() {
+        let upgraded = URL(string: "https://printer.local/")!
+        let httpCommit = URL(string: "http://printer.local/")!
+        XCTAssertFalse(TabViewController.isHTTPSForced(lastUpgradedURL: upgraded, currentURL: httpCommit, tld: tld))
     }
 
     func test_priorUpgradeToSameDomain_returnsTrue() {
@@ -53,5 +54,21 @@ final class TabViewControllerHTTPSForcedTests: XCTestCase {
         let upgraded = URL(string: "https://example.com/")!
         let current = URL(string: "https://other.com/")!
         XCTAssertFalse(TabViewController.isHTTPSForced(lastUpgradedURL: upgraded, currentURL: current, tld: tld))
+    }
+
+    // A same-domain sibling keeps the stale lastUpgradedURL, but an HTTP commit still isn't forced.
+    func test_staleUpgrade_httpSiblingOnSameDomain_returnsFalse() {
+        let upgraded = URL(string: "https://www.example.com/")!
+        let current = URL(string: "http://legacy.example.com/")!
+        XCTAssertFalse(TabViewController.isHTTPSForced(lastUpgradedURL: upgraded, currentURL: current, tld: tld))
+    }
+
+    // No known TLD, so we fall back to matching the raw host.
+    func test_priorUpgradeToNoPSLHost_matchesByRawHost() {
+        let upgraded = URL(string: "https://printer.local/")!
+        XCTAssertTrue(TabViewController.isHTTPSForced(lastUpgradedURL: upgraded, currentURL: upgraded, tld: tld))
+
+        let otherHost = URL(string: "https://scanner.local/")!
+        XCTAssertFalse(TabViewController.isHTTPSForced(lastUpgradedURL: upgraded, currentURL: otherHost, tld: tld))
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1217273311409053

### Description

iOS breakage reports were setting `upgradedHttps: true` on pages that were never upgraded. In `TabViewController`'s `didCommit`, `httpsForced` was computed as `tld.domain(lastUpgradedURL?.host) == tld.domain(webView.url?.host)`. For hosts with no Public Suffix List match — IP literals, `.local`, `.lan`, single-label hostnames — `TLD.domain(...)` returns `nil` on both sides, so `nil == nil` evaluated to `true` and falsely flagged an upgrade. This affected ~6% of flagged iOS reports (May–Jul 2026); it's a data-quality issue that skews breakage analytics and is not user-facing.

The fix extracts the computation into a testable `isHTTPSForced(...)` helper that guards on `lastUpgradedURL != nil`, so an upgrade is only reported when one actually occurred. This mirrors macOS, which keys the field off `connectionUpgradedTo != nil`.

### Testing Steps

This is a data-quality fix with no visible UI change, so it's primarily verified by the new unit tests.

1. Run the `TabViewControllerHTTPSForcedTests` suite in the `UnitTests` target — all 4 tests should pass.
2. (Optional manual check) On an iOS build, load a page on a host with no Public Suffix List match — e.g. `http://printer.local/`, an IP literal like `http://192.168.1.10/`, or a single-label host — directly, without any HTTP→HTTPS upgrade occurring.
3. Submit a breakage report for that page (Privacy Dashboard → report broken site).
4. Confirm the report's params show `upgradedHttps=false` (previously it was incorrectly `true`).
5. As a regression check, load a site that genuinely upgrades from HTTP to HTTPS and confirm its report still shows `upgradedHttps=true`.

### Impact and Risks

**Low.** Only affects the `upgradedHttps` diagnostic flag in breakage reports — no user-facing behavior.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the breakage-report diagnostic flag; no navigation, upgrade, or UI behavior. Genuine upgrades should still report true via the new helper.
> 
> **Overview**
> Fixes **incorrect `upgradedHttps: true`** on iOS breakage reports when no HTTP→HTTPS upgrade occurred.
> 
> On navigation commit, **`httpsForced`** (which feeds **`upgradedHttps`**) used **`tld.domain(lastUpgradedURL?.host) == tld.domain(webView.url?.host)`**. For hosts without a Public Suffix List match (IPs, `.local`, `.lan`, single-label names), **`TLD.domain`** returns **`nil` on both sides**, so **`nil == nil`** was treated as an upgrade—about **~6%** of flagged reports (May–Jul 2026).
> 
> The logic is moved to **`TabViewController.isHTTPSForced(...)`**, which **returns false when `lastUpgradedURL` is nil** and only then compares registrable domains—aligned with macOS treating upgrades as tied to an actual upgrade URL.
> 
> **`TabViewControllerHTTPSForcedTests`** covers PSL-less hosts, normal hosts without a prior upgrade, same-domain upgrades, and cross-domain navigation after an upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f452e04699a42ce275419611d5aea5ec16a04640. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->