### PR TITLE
iOS: Match floating UI transitions to Safari (scroll collapse, focus, tab switcher)

### DIFF
--- a/iOS/DuckDuckGo/BarsAnimator.swift
+++ b/iOS/DuckDuckGo/BarsAnimator.swift
@@ -21,6 +21,49 @@ import UIKit
 
 class BarsAnimator {
 
+    struct Metrics {
+        /// Scroll distance for a full floating-chrome collapse or reveal. Tuned against iOS 26 Safari,
+        /// which fully collapses in ~75pt. Deliberately absolute rather than a multiple of
+        /// `combinedBarsHeight`, because that value is ~188pt with a bottom address bar but ~122pt with
+        /// a top one, which would gear the two positions differently.
+        static let floatingTransitionTravel: CGFloat = 80
+
+        /// Ceiling on how fast progress may advance while collapsing, in progress-per-second, so a
+        /// full collapse can never take less than ~140ms (Safari's flick collapse measures ~0.15s).
+        /// Without it a 3000pt/s flick crosses `floatingTransitionTravel` in ~25ms and the bars pop.
+        static let maxCollapseProgressPerSecond: CGFloat = 7.0
+
+        /// Longest frame delta the rate limiter will honour, so a stalled frame can't grant a huge step.
+        static let maxRateLimitTimeStep: CFTimeInterval = 1.0 / 30.0
+
+        /// Assumed delta for the first frame of a transition, which has no previous timestamp to measure
+        /// against. Without it the rate limiter would pin the opening frame to zero progress.
+        static let nominalFrameDuration: CFTimeInterval = 1.0 / 60.0
+
+        /// Legacy (non-floating) gearing, preserved exactly.
+        static let legacyTransitionSpeed: CGFloat = 0.5
+
+        /// Below this speed a release is treated as deliberate rather than a flick: the outcome is
+        /// decided by how far the transition actually progressed, not by the sign of a velocity that's
+        /// essentially measurement noise (a real touch release is almost never exactly zero). Units
+        /// match `UIScrollViewDelegate`'s `withVelocity:` (points per millisecond); 0.15 sits well
+        /// below a deliberate flick's typical 0.5+ while safely above the residual velocity left by a
+        /// finger easing to a stop.
+        static let floatingVelocityCommitThreshold: CGFloat = 0.15
+
+        /// Exit velocity (matching `floatingVelocityCommitThreshold`'s pt/ms units) at and above which a
+        /// flick-triggered settle runs at its fastest. Below `floatingVelocityCommitThreshold` a release
+        /// isn't a flick at all (see the deliberate-release branch); between the two thresholds the
+        /// settle duration scales continuously, so a firmer flick visibly finishes quicker — the same
+        /// motion just carrying more of the speed it already had, rather than always restarting the
+        /// animation from a fixed duration regardless of how fast the content was moving.
+        static let flickReferenceVelocity: CGFloat = 1.2
+
+        /// Floor on the settle duration for the hardest flicks, seconds.
+        static let flickFastestCollapseDuration: CFTimeInterval = 0.08
+        static let flickFastestExpandDuration: CFTimeInterval = 0.14
+    }
+
     weak var delegate: BrowserChromeDelegate?
 
     private(set) var barsState: State = .revealed
@@ -30,7 +73,24 @@ class BarsAnimator {
 
     var transitionStartPosY: CGFloat = 0
 
+    /// Progress at the moment the current transition was entered. The floating path measures scroll
+    /// distance from that anchor instead of compounding the previous frame's ratio, so an interrupted
+    /// drag resumes from where it visually is.
+    private var transitionStartProgress: CGFloat = 0
+
+    /// `nil` until the first rate-limited frame of a transition.
+    private var lastProgressTimestamp: CFTimeInterval?
+
+    /// Injected so tests can drive the collapse rate limiter deterministically.
+    private let currentTime: () -> CFTimeInterval
+
     private var bottomRevealGestureState: BottomBounceRevealing = .possible
+
+    #if DEBUG
+    /// Test seam so a test can confirm it has landed on an intended progress before asserting on it.
+    var transitionProgressForTesting: CGFloat { transitionProgress }
+    #endif
+
     private var combinedBarsHeight: CGFloat {
         guard let delegate = delegate else { return 0 }
         return delegate.toolbarHeight + delegate.omniBar.barView.expectedHeight
@@ -48,24 +108,75 @@ class BarsAnimator {
         case cancelled
     }
 
+    init(currentTime: @escaping () -> CFTimeInterval = CACurrentMediaTime) {
+        self.currentTime = currentTime
+    }
+
     func didStartScrolling(in scrollView: UIScrollView) {
         draggingStartPosY = scrollView.contentOffset.y
+
+        if delegate?.isFloatingChromeEnabled == true {
+            // Anchored once, here, for the floating path -- not re-anchored on every state entry the
+            // way the legacy path re-anchors in `revealedAndScrolling`/`hiddenAndScrolling` below. A
+            // fixed anchor makes `calculateTransitionRatio` a pure function of the current offset for
+            // the whole drag, so reversing direction any number of times within one continuous touch
+            // (down, up, down again) just moves the ratio back and forth -- no re-entry guards to fall
+            // through, no stale anchor left over from before a reversal.
+            transitionStartPosY = scrollView.contentOffset.y
+            transitionStartProgress = transitionProgress
+            lastProgressTimestamp = nil
+        }
     }
 
     func didScroll(in scrollView: UIScrollView) {
-
-        switch barsState {
-        case .revealed:
-            revealedAndScrolling(in: scrollView)
-
-        case .transitioning:
-            transitioningAndScrolling(in: scrollView)
-
-        case .hidden:
-            hiddenAndScrolling(in: scrollView)
-
+        guard delegate?.isFloatingChromeEnabled == true else {
+            switch barsState {
+            case .revealed:
+                revealedAndScrolling(in: scrollView)
+            case .transitioning:
+                transitioningAndScrolling(in: scrollView)
+            case .hidden:
+                hiddenAndScrolling(in: scrollView)
+            }
+            return
         }
+        floatingDidScroll(in: scrollView)
     }
+
+    /// Single continuous tracker for the floating path: live 1:1 position tracking in both directions
+    /// for the whole drag, from the fixed anchor `didStartScrolling` set. Replaces the legacy path's
+    /// three-function, re-anchor-on-entry dispatch below, which doesn't handle a drag reversing more
+    /// than once (each function's own entry guard compares against state that's stale after the first
+    /// reversal).
+    private func floatingDidScroll(in scrollView: UIScrollView) {
+        if barsState == .hidden {
+            let startedDraggingAtBottom = draggingStartPosY >= scrollView.contentOffsetYAtBottom
+            if startedDraggingAtBottom, bottomRevealGestureState == .possible {
+                if scrollView.contentOffset.y > scrollView.contentOffsetYAtBottom {
+                    revealBars(animated: true)
+                    bottomRevealGestureState = .triggered
+                    return
+                } else {
+                    // If user starts scrolling up, invalidate the possible reverse (scroll down) gesture.
+                    bottomRevealGestureState = .cancelled
+                }
+            }
+        }
+        guard bottomRevealGestureState != .triggered else { return }
+
+        let ratio = calculateTransitionRatio(for: scrollView.contentOffset.y)
+        if ratio >= 1.0 {
+            barsState = .hidden
+        } else if ratio <= 0.0 {
+            barsState = .revealed
+        } else {
+            barsState = .transitioning
+        }
+        transitionProgress = ratio
+        delegate?.setBarsVisibility(1.0 - ratio, animated: false, animationDuration: nil)
+    }
+
+    // MARK: - Legacy (non-floating) scrolling. Unchanged: re-anchors on every state entry.
 
     private func revealedAndScrolling(in scrollView: UIScrollView) {
         guard scrollView.contentOffset.y > draggingStartPosY else { return }
@@ -79,6 +190,7 @@ class BarsAnimator {
         }
 
         transitionStartPosY = draggingStartPosY < 0 ? 0 : draggingStartPosY
+        transitionStartProgress = transitionProgress
         barsState = .transitioning
 
         let ratio = calculateTransitionRatio(for: scrollView.contentOffset.y)
@@ -124,6 +236,7 @@ class BarsAnimator {
         guard scrollView.contentOffset.y < 0 else { return }
 
         transitionStartPosY = 0
+        transitionStartProgress = transitionProgress
         barsState = .transitioning
 
         let ratio = calculateTransitionRatio(for: scrollView.contentOffset.y)
@@ -137,15 +250,34 @@ class BarsAnimator {
 
         guard barsHeight > 0 else { return 0 }
 
-        let cumulativeDistance = (barsHeight * transitionProgress) + distance
-        let normalizedDistance = max(cumulativeDistance, 0)
+        guard delegate?.isFloatingChromeEnabled == true else {
+            let cumulativeDistance = (barsHeight * transitionProgress) + distance
+            let normalizedDistance = max(cumulativeDistance, 0)
 
-        // We used to fix the scroll position in place as the transition happened
-        //  but now the bars disappear too. This adjusts for that.
-        let transitionSpeed = 0.5
-        
-        let ratio = min(normalizedDistance / barsHeight * transitionSpeed, 1.0)
-        return ratio
+            // We used to fix the scroll position in place as the transition happened
+            //  but now the bars disappear too. This adjusts for that.
+            return min(normalizedDistance / barsHeight * Metrics.legacyTransitionSpeed, 1.0)
+        }
+
+        // Stateless in the frame count: progress is a pure function of how far the current drag has
+        // travelled from the fixed anchor `didStartScrolling` set, so it's correct after any number of
+        // in-drag reversals without needing to re-anchor.
+        let target = transitionStartProgress + distance / Metrics.floatingTransitionTravel
+        return rateLimitedProgress(towards: target)
+    }
+
+    /// Clamps how fast a collapse may advance. Reveals are left uncapped — they are already gated by
+    /// their own thresholds, and slowing them down would fight the finger.
+    private func rateLimitedProgress(towards target: CGFloat) -> CGFloat {
+        let now = currentTime()
+        let elapsed = lastProgressTimestamp.map { now - $0 } ?? Metrics.nominalFrameDuration
+        lastProgressTimestamp = now
+
+        guard target > transitionProgress else { return min(max(target, 0), 1.0) }
+
+        let timeStep = min(max(elapsed, 0), Metrics.maxRateLimitTimeStep)
+        let maxStep = Metrics.maxCollapseProgressPerSecond * CGFloat(timeStep)
+        return min(max(min(target, transitionProgress + maxStep), 0), 1.0)
     }
 
     func didFinishScrolling(in scrollView: UIScrollView, velocity: CGFloat) {
@@ -157,16 +289,58 @@ class BarsAnimator {
             return
         }
 
-        guard velocity >= 0 else {
-            revealBars(animated: true)
+        guard delegate?.isFloatingChromeEnabled == true else {
+            guard velocity >= 0 else {
+                revealBars(animated: true)
+                return
+            }
+
+            let isAboveExtendedBottomBounceArea = scrollView.contentOffset.y < scrollView.contentOffsetYAtBottom - combinedBarsHeight
+            guard barsState == .transitioning || isAboveExtendedBottomBounceArea else { return }
+
+            guard velocity == 0 else {
+                hideBars(animated: true)
+                return
+            }
+
+            switch barsState {
+            case .revealed, .hidden:
+                break
+
+            case .transitioning:
+                if transitionProgress > 0.5 && transitionProgress < 1.0 {
+                    hideBars(animated: true)
+                } else if transitionProgress > 0 && transitionProgress  <= 0.5 {
+                    revealBars(animated: true)
+                }
+            }
             return
         }
 
-        let isAboveExtendedBottomBounceArea = scrollView.contentOffset.y < scrollView.contentOffsetYAtBottom - combinedBarsHeight
-        guard barsState == .transitioning || isAboveExtendedBottomBounceArea else { return }
-
-        guard velocity == 0 else {
-            hideBars(animated: true)
+        // A real touch release is almost never exactly zero velocity, so gating the progress-based
+        // decision on `velocity == 0` (as the legacy branch above does) means noise decides nearly every
+        // slow, deliberate release. Below the commit threshold, settle by how far the transition actually
+        // progressed instead — that's what makes a slow drag feel precise rather than arbitrary.
+        let isFastFlick = abs(velocity) >= Metrics.floatingVelocityCommitThreshold
+        if isFastFlick {
+            if velocity < 0 {
+                let duration = flickAnimationDuration(
+                    base: delegate?.floatingMorphExpandDuration ?? 0.34,
+                    fastest: Metrics.flickFastestExpandDuration,
+                    velocity: velocity
+                )
+                revealBars(animated: true, animationDuration: duration)
+            } else {
+                let isAboveExtendedBottomBounceArea = scrollView.contentOffset.y < scrollView.contentOffsetYAtBottom - combinedBarsHeight
+                if barsState == .transitioning || isAboveExtendedBottomBounceArea {
+                    let duration = flickAnimationDuration(
+                        base: delegate?.floatingMorphCollapseDuration ?? 0.20,
+                        fastest: Metrics.flickFastestCollapseDuration,
+                        velocity: velocity
+                    )
+                    hideBars(animated: true, animationDuration: duration)
+                }
+            }
             return
         }
 
@@ -175,30 +349,43 @@ class BarsAnimator {
             break
 
         case .transitioning:
-            if transitionProgress > 0.5 && transitionProgress < 1.0 {
+            if transitionProgress > 0.5 {
                 hideBars(animated: true)
-            } else if transitionProgress > 0 && transitionProgress  <= 0.5 {
+            } else {
                 revealBars(animated: true)
             }
         }
     }
 
-    func revealBars(animated: Bool) {
+    func revealBars(animated: Bool, animationDuration: CGFloat? = nil) {
         let alreadyRevealed = barsState == .revealed
 
         barsState = .revealed
         transitionProgress = 0
 
-        delegate?.setBarsVisibility(1, animated: animated && !alreadyRevealed, animationDuration: nil)
+        delegate?.setBarsVisibility(1, animated: animated && !alreadyRevealed, animationDuration: animationDuration)
     }
 
-    func hideBars(animated: Bool) {
+    func hideBars(animated: Bool, animationDuration: CGFloat? = nil) {
         guard barsState != .hidden else { return }
 
         barsState = .hidden
         transitionProgress = 1.0
 
-        delegate?.setBarsVisibility(0, animated: animated, animationDuration: nil)
+        delegate?.setBarsVisibility(0, animated: animated, animationDuration: animationDuration)
+    }
+
+    /// Settle duration for a flick-triggered `revealBars`/`hideBars`, scaled by exit velocity so a
+    /// firmer flick visibly finishes quicker. Continuous with `base` at `floatingVelocityCommitThreshold`
+    /// (this is only ever called above that threshold, so there's no seam at the boundary with the
+    /// deliberate-release branch, which always uses the unscaled default).
+    private func flickAnimationDuration(base: CFTimeInterval, fastest: CFTimeInterval, velocity: CGFloat) -> CGFloat {
+        let threshold = Metrics.floatingVelocityCommitThreshold
+        let reference = Metrics.flickReferenceVelocity
+        guard reference > threshold else { return CGFloat(fastest) }
+
+        let speedFactor = ((abs(velocity) - threshold) / (reference - threshold)).clamped(to: 0...1)
+        return CGFloat(base - (base - fastest) * Double(speedFactor))
     }
 }
 

--- a/iOS/DuckDuckGo/BarsAnimator.swift
+++ b/iOS/DuckDuckGo/BarsAnimator.swift
@@ -62,6 +62,13 @@ class BarsAnimator {
         /// Floor on the settle duration for the hardest flicks, seconds.
         static let flickFastestCollapseDuration: CFTimeInterval = 0.08
         static let flickFastestExpandDuration: CFTimeInterval = 0.14
+
+        /// Scroll distance from a drag's anchor beyond which the floating chrome commits fully to the
+        /// next state instead of continuing to track the finger, matching Safari's playful snap. Once
+        /// crossed, the transition completes via the same animated `hideBars`/`revealBars` a release
+        /// would trigger, so a finger that then holds the scroll steady mid-drag lets the animation run
+        /// to completion instead of parking the bar at whatever fraction the hold happened to catch.
+        static let floatingSnapCommitDistance: CGFloat = 16
     }
 
     weak var delegate: BrowserChromeDelegate?
@@ -80,6 +87,17 @@ class BarsAnimator {
 
     /// `nil` until the first rate-limited frame of a transition.
     private var lastProgressTimestamp: CFTimeInterval?
+
+    private enum SnapDirection {
+        case collapsing
+        case revealing
+    }
+
+    /// Set once the current drag has committed past `Metrics.floatingSnapCommitDistance`; `nil` for
+    /// the rest of the drag until a firm reversal (the same distance, measured from the commit point)
+    /// flips it. `nil` at the start of every drag (reset in `didStartScrolling`).
+    private var floatingCommittedDirection: SnapDirection?
+    private var floatingCommitOffsetY: CGFloat?
 
     /// Injected so tests can drive the collapse rate limiter deterministically.
     private let currentTime: () -> CFTimeInterval
@@ -125,6 +143,8 @@ class BarsAnimator {
             transitionStartPosY = scrollView.contentOffset.y
             transitionStartProgress = transitionProgress
             lastProgressTimestamp = nil
+            floatingCommittedDirection = nil
+            floatingCommitOffsetY = nil
         }
     }
 
@@ -164,6 +184,28 @@ class BarsAnimator {
         }
         guard bottomRevealGestureState != .triggered else { return }
 
+        if let committed = floatingCommittedDirection, let commitOffsetY = floatingCommitOffsetY {
+            let reversal = scrollView.contentOffset.y - commitOffsetY
+            switch committed {
+            case .collapsing where reversal <= -Metrics.floatingSnapCommitDistance:
+                commitFloatingTransition(.revealing, at: scrollView.contentOffset.y)
+            case .revealing where reversal >= Metrics.floatingSnapCommitDistance:
+                commitFloatingTransition(.collapsing, at: scrollView.contentOffset.y)
+            default:
+                break
+            }
+            return
+        }
+
+        let distanceFromAnchor = scrollView.contentOffset.y - transitionStartPosY
+        if distanceFromAnchor >= Metrics.floatingSnapCommitDistance {
+            commitFloatingTransition(.collapsing, at: scrollView.contentOffset.y)
+            return
+        } else if distanceFromAnchor <= -Metrics.floatingSnapCommitDistance {
+            commitFloatingTransition(.revealing, at: scrollView.contentOffset.y)
+            return
+        }
+
         let ratio = calculateTransitionRatio(for: scrollView.contentOffset.y)
         if ratio >= 1.0 {
             barsState = .hidden
@@ -174,6 +216,17 @@ class BarsAnimator {
         }
         transitionProgress = ratio
         delegate?.setBarsVisibility(1.0 - ratio, animated: false, animationDuration: nil)
+    }
+
+    private func commitFloatingTransition(_ direction: SnapDirection, at offsetY: CGFloat) {
+        floatingCommittedDirection = direction
+        floatingCommitOffsetY = offsetY
+        switch direction {
+        case .collapsing:
+            hideBars(animated: true)
+        case .revealing:
+            revealBars(animated: true)
+        }
     }
 
     // MARK: - Legacy (non-floating) scrolling. Unchanged: re-anchors on every state entry.

--- a/iOS/DuckDuckGo/BrowserChromeManager.swift
+++ b/iOS/DuckDuckGo/BrowserChromeManager.swift
@@ -39,6 +39,17 @@ protocol BrowserChromeDelegate: AnyObject {
     var barsMaxHeight: CGFloat { get }
     var isInMinimalChromeLayout: Bool { get }
 
+    /// True when the floating-UI chrome owns the bars transition, selecting the retuned
+    /// scroll-distance and progress math in `BarsAnimator`. Legacy chrome keeps its historical feel.
+    var isFloatingChromeEnabled: Bool { get }
+
+    /// Base settle duration (seconds) for a floating-chrome release, before `BarsAnimator` scales it
+    /// down for a fast flick. Mirrors `MainViewController.ChromeAnimationConstants.morphCollapseDuration`
+    /// / `morphExpandDuration` — the single source of truth for the *unscaled* value stays there; this
+    /// just exposes it to `BarsAnimator` without a reverse dependency on `MainViewController`.
+    var floatingMorphCollapseDuration: CFTimeInterval { get }
+    var floatingMorphExpandDuration: CFTimeInterval { get }
+
     /// Height (from the screen bottom) obscured by the visible bottom chrome at the given chrome
     /// visibility fraction, used to resize the floating web view so page-fixed footers pin to the top
     /// of whatever is on screen (toolbar -> capsule -> safe area).
@@ -50,6 +61,15 @@ protocol BrowserChromeDelegate: AnyObject {
 
     var omniBar: any OmniBar { get }
     var tabBarContainer: UIView { get }
+}
+
+extension BrowserChromeDelegate {
+
+    /// Defaults to the legacy math so existing conformances (including test mocks) are unaffected.
+    var isFloatingChromeEnabled: Bool { false }
+
+    var floatingMorphCollapseDuration: CFTimeInterval { 0.20 }
+    var floatingMorphExpandDuration: CFTimeInterval { 0.34 }
 }
 
 class BrowserChromeManager: NSObject, UIScrollViewDelegate {

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -227,6 +227,14 @@ final class BrowserToolbarView: UIView {
         return (verticalContentPadding * 2) + targetHeight + omnibarHeight + omnibarToButtonsSpacing
     }
 
+    /// Height of the bar once the button row has fully collapsed away, leaving only the omnibar row.
+    /// This is what `setButtonRowCollapseProgress` shrinks the panel toward, and what `restingCapsuleFrame`
+    /// reports as the pill's morph target — a value stable across the whole collapse rather than the
+    /// live, mid-animation `buttonsHeightConstraint.constant`.
+    static func singleRowHeight(withOmnibarHeight omnibarHeight: CGFloat) -> CGFloat {
+        (verticalContentPadding * 2) + omnibarHeight
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .clear
@@ -277,6 +285,13 @@ final class BrowserToolbarView: UIView {
     var arrangedToolbarButtonViews: [UIView] {
         buttonStack.arrangedSubviews
     }
+
+    #if DEBUG
+    /// Test seam for `setButtonRowCollapseProgress`'s effect on the button row and panel height.
+    var buttonRowAlphaForTesting: CGFloat { buttonStack.alpha }
+    var buttonRowTransformForTesting: CGAffineTransform { buttonStack.transform }
+    var panelHeightForTesting: CGFloat { buttonsHeightConstraint.constant }
+    #endif
 
     func setFloatingStyleEnabled(_ enabled: Bool, animated: Bool = false) {
         guard isFloatingStyleEnabled != enabled else { return }
@@ -576,10 +591,48 @@ final class BrowserToolbarView: UIView {
         let safeBottom = view.safeAreaInsets.bottom
         let insets = Self.floatingBarOuterInsets
         let width = bounds.width - insets.left - insets.right
-        let height = buttonsHeightConstraint.constant
+        // Once the button row has fully faded, the bar's shape is the single omnibar row -- not the
+        // live `buttonsHeightConstraint.constant`, which is still mid-shrink for part of the collapse
+        // and would make the pill's morph target move under it. Falls back to the live height when
+        // there's no omnibar to hand off to (the standalone, buttons-only toolbar).
+        let height = hasEmbeddedOmnibar
+            ? Self.singleRowHeight(withOmnibarHeight: omnibarHeightConstraint.constant)
+            : buttonsHeightConstraint.constant
         let offset = max(0, safeBottom - floatingBottomMargin)
         let bottom = bounds.maxY - safeBottom + offset
         return CGRect(x: bounds.minX + insets.left, y: bottom - height, width: width, height: height)
+    }
+
+    /// Drives the button-row fade/shrink stage of the scroll-coupled chrome collapse: as `collapseProgress`
+    /// goes from 0 (buttons fully shown) to 1 (buttons fully gone, bar down to just the omnibar row), the
+    /// button row fades and scales down while the panel's height shrinks to match. `collapseProgress` is
+    /// pre-normalized by the caller against `FloatingDomainCapsuleController.handoffStart` -- this view
+    /// only knows about its own two heights, not the bars-visibility fraction those are staged against.
+    /// A no-op (buttons fully shown, panel at full height) outside floating bottom mode, with an expanded
+    /// menu open, or under Reduce Motion. Returns the panel height actually applied, so the caller can
+    /// keep the outer toolbar-height layout constraint in lockstep (this view has no reference to it).
+    @discardableResult
+    func setButtonRowCollapseProgress(_ collapseProgress: CGFloat, reduceMotion: Bool) -> CGFloat {
+        let fullHeight = Self.totalHeight(withOmnibarHeight: omnibarHeightConstraint.constant, isFloating: isFloatingStyleEnabled)
+
+        guard isFloatingStyleEnabled, hasEmbeddedOmnibar, !hasExpandedContent, !reduceMotion else {
+            buttonStack.alpha = 1
+            buttonStack.transform = .identity
+            buttonsHeightConstraint.constant = fullHeight
+            return fullHeight
+        }
+
+        let progress = collapseProgress.clamped(to: 0...1)
+        buttonStack.alpha = 1 - progress
+        let scale = 1 - 0.2 * progress
+        buttonStack.transform = CGAffineTransform(scaleX: scale, y: scale)
+            .concatenating(CGAffineTransform(translationX: 0, y: 8 * progress))
+
+        let singleRowHeight = Self.singleRowHeight(withOmnibarHeight: omnibarHeightConstraint.constant)
+        let height = fullHeight - (fullHeight - singleRowHeight) * progress
+        buttonsHeightConstraint.constant = height
+        updateCornerStyle()
+        return height
     }
     
     /// Shifts the glass capsule down from its safe-area-anchored position toward the device bottom,

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -198,6 +198,9 @@ final class BrowserToolbarView: UIView {
     /// floats near the device bottom (see `floatingBottomMargin`). Kept in sync with the host's
     /// safe-area inset in `layoutSubviews`; also widens the hit-test region.
     private var floatingBottomOffset: CGFloat = 0
+    /// Current scale applied by `setStandaloneCollapseProgress`, combined with `floatingBottomOffset`
+    /// in `applyMaterialBackgroundTransform` since both target the same `transform` property.
+    private var standaloneCollapseScale: CGFloat = 1
     /// The tab switcher reuses this bar purely for button-position parity with the browser, but
     /// paints its own backdrop — so in the non-floating style its own background must stay clear.
     private var isLegacyBackgroundTransparent = false
@@ -634,7 +637,40 @@ final class BrowserToolbarView: UIView {
         updateCornerStyle()
         return height
     }
-    
+
+    #if DEBUG
+    /// Test seam for `setStandaloneCollapseProgress`'s effect on the capsule.
+    var standaloneCapsuleTransformForTesting: CGAffineTransform { materialBackgroundView.transform }
+    #endif
+
+    /// Drives the scroll-coupled collapse for the standalone, buttons-only toolbar -- no embedded
+    /// omnibar to hand off to (e.g. the top address bar position, where the bottom floating UI is just
+    /// the button row). There's nothing to shrink toward the way the embedded case shrinks toward the
+    /// single omnibar row, so the whole capsule scales down toward its own centre as it fades; the
+    /// existing bottom-edge slide (`MainViewController.updateToolbarConstant`, uncompressed for this
+    /// case) carries it the rest of the way off-screen. A no-op when this toolbar hosts an embedded
+    /// omnibar instead (handled by `setButtonRowCollapseProgress`), outside floating style, or under
+    /// Reduce Motion.
+    func setStandaloneCollapseProgress(_ collapseProgress: CGFloat, reduceMotion: Bool) {
+        guard isFloatingStyleEnabled, !hasEmbeddedOmnibar, !reduceMotion else {
+            standaloneCollapseScale = 1
+            applyMaterialBackgroundTransform()
+            return
+        }
+
+        let progress = collapseProgress.clamped(to: 0...1)
+        standaloneCollapseScale = 1 - 0.2 * progress
+        applyMaterialBackgroundTransform()
+    }
+
+    /// Combines `floatingBottomOffset`'s translation with `standaloneCollapseScale` -- both drive
+    /// `materialBackgroundView.transform` independently, so writing either one in isolation would
+    /// clobber the other.
+    private func applyMaterialBackgroundTransform() {
+        materialBackgroundView.transform = CGAffineTransform(translationX: 0, y: floatingBottomOffset)
+            .concatenating(CGAffineTransform(scaleX: standaloneCollapseScale, y: standaloneCollapseScale))
+    }
+
     /// Shifts the glass capsule down from its safe-area-anchored position toward the device bottom,
     /// leaving `floatingBottomMargin`. Done as a transform (not a constraint change) so it doesn't
     /// disturb the toolbar's layout slot or the runtime chrome hide/show constant logic.
@@ -643,7 +679,7 @@ final class BrowserToolbarView: UIView {
         let target = isFloatingStyleEnabled ? max(0, hostBottomInset - floatingBottomMargin) : 0
         guard target != floatingBottomOffset else { return }
         floatingBottomOffset = target
-        materialBackgroundView.transform = CGAffineTransform(translationX: 0, y: target)
+        applyMaterialBackgroundTransform()
     }
 
     private func updateCornerStyle() {

--- a/iOS/DuckDuckGo/ChromeMorphAnimator.swift
+++ b/iOS/DuckDuckGo/ChromeMorphAnimator.swift
@@ -29,6 +29,42 @@ import UIKit
 /// exact transition instead.
 final class ChromeMorphAnimator {
 
+    /// Easing applied to the scrubbed progress. All cases are functions of normalized time, so scaling
+    /// a duration compresses the curve rather than truncating it.
+    enum Curve {
+        /// Ease-in-out. Appropriate when the motion starts from rest.
+        case smoothstep
+
+        /// Starts at full speed and decelerates. The right family for a released fling: the bars are
+        /// already moving when the finger lifts, so an ease-in would visibly stall before continuing.
+        case easeOutCubic
+
+        /// Unit-step response of a damped second-order system. `naturalFrequency` is in radians per unit
+        /// duration (not per second) so the shape holds when the duration is scaled. A `dampingRatio`
+        /// below 1 overshoots by `exp(-pi * ratio / sqrt(1 - ratio * ratio))`; 1 or above never does.
+        case spring(dampingRatio: CGFloat, naturalFrequency: CGFloat)
+
+        func value(at t: CGFloat) -> CGFloat {
+            switch self {
+            case .smoothstep:
+                return t * t * (3 - 2 * t)
+
+            case .easeOutCubic:
+                let remaining = 1 - t
+                return 1 - remaining * remaining * remaining
+
+            case .spring(let dampingRatio, let naturalFrequency):
+                let decay = exp(-dampingRatio * naturalFrequency * t)
+                guard dampingRatio < 1 else {
+                    return 1 - decay * (1 + naturalFrequency * t)
+                }
+                let dampedFrequency = naturalFrequency * sqrt(1 - dampingRatio * dampingRatio)
+                let phase = dampedFrequency * t
+                return 1 - decay * (cos(phase) + (dampingRatio * naturalFrequency / dampedFrequency) * sin(phase))
+            }
+        }
+    }
+
     /// Forwards display-link ticks without the link retaining the animator, so the animator (and its
     /// link) deallocate naturally when their owner goes away even if `cancel()` is never called.
     private final class WeakDisplayLinkProxy {
@@ -51,6 +87,7 @@ final class ChromeMorphAnimator {
     private var toValue: CGFloat = 0
     private var onProgress: ((CGFloat) -> Void)?
     private var onComplete: (() -> Void)?
+    private var curve: Curve = .smoothstep
 
     /// The last value emitted, so an interrupted animation can resume from where it visually is
     /// rather than snapping back to a stale endpoint.
@@ -66,6 +103,7 @@ final class ChromeMorphAnimator {
     func animate(from: CGFloat,
                  to: CGFloat,
                  duration: CFTimeInterval,
+                 curve: Curve = .smoothstep,
                  onProgress: @escaping (CGFloat) -> Void,
                  onComplete: @escaping () -> Void) {
         cancel()
@@ -80,6 +118,7 @@ final class ChromeMorphAnimator {
         self.fromValue = from
         self.toValue = to
         self.duration = duration
+        self.curve = curve
         self.onProgress = onProgress
         self.onComplete = onComplete
         currentValue = from
@@ -121,8 +160,7 @@ final class ChromeMorphAnimator {
             return
         }
 
-        let eased = t * t * (3 - 2 * t)
-        let value = fromValue + (toValue - fromValue) * CGFloat(eased)
+        let value = fromValue + (toValue - fromValue) * curve.value(at: CGFloat(t))
         currentValue = value
         onProgress?(value)
     }

--- a/iOS/DuckDuckGo/FloatingUI/FloatingDomainCapsuleController.swift
+++ b/iOS/DuckDuckGo/FloatingUI/FloatingDomainCapsuleController.swift
@@ -22,11 +22,20 @@ import UIKit
 
 final class FloatingDomainCapsuleController {
 
-    /// Below this `barsVisibilityPercent` the morph pill is fully opaque and physically resizes
-    /// between the capsule and the bar. Above it, the pill fades out over the short remaining band
-    /// while the real chrome fades in, giving a seamless swap without an obvious mid-transition
-    /// cross-fade. Shared with `MainViewController` for the complementary chrome-alpha ramp.
-    static let handoffStart: CGFloat = 0.85
+    /// The `barsVisibilityPercent` at which the real chrome and the morph pill swap which one is
+    /// rendering. Above this point the real bar is opaque (its own button-row fade/shrink, driven by
+    /// `BrowserToolbarView.setButtonRowCollapseProgress`, has already finished by here); below it the pill
+    /// is opaque and continues the same shrink down to the capsule. Both sides read this bar's geometry
+    /// at the same instant (`restingCapsuleFrame(in:)` reports the single-row height, not the live
+    /// two-row one), so the swap is a cut between two identical-looking frames rather than a
+    /// cross-fade — `handoffBandHalfWidth` only exists to blur a seam if that coincidence isn't exact.
+    /// Shared with `MainViewController`'s complementary chrome-alpha step.
+    static let handoffStart: CGFloat = 0.60
+
+    /// Half-width of the linear ramp straddling `handoffStart`, in the same `barsVisibilityPercent`
+    /// units. Kept small — this is a seam-blur, not a cross-fade window: at the shipped
+    /// `floatingTransitionTravel` of 80pt it covers ~3pt (~15ms), well under perceptible.
+    static let handoffBandHalfWidth: CGFloat = 0.02
 
     /// Gap between the pill and the edge of the safe area at its resting position.
     static let restEdgePadding: CGFloat = 8
@@ -62,6 +71,7 @@ final class FloatingDomainCapsuleController {
         return label
     }()
     private var centerYConstraint: NSLayoutConstraint?
+    private var hasAppliedGlassStyleAtValidSize = false
     private var widthConstraint: NSLayoutConstraint?
     private var heightConstraint: NSLayoutConstraint?
 
@@ -136,12 +146,13 @@ final class FloatingDomainCapsuleController {
                 expandedFrame: CGRect,
                 reduceMotion: Bool,
                 in view: UIView) {
-        guard FloatingUILayoutPolicy.shouldShowFloatingDomainCapsule(
+        let shouldShow = FloatingUILayoutPolicy.shouldShowFloatingDomainCapsule(
             isFloatingUIEnabled: isFloatingUIEnabled,
             isUnifiedToggleInputActive: isUnifiedToggleInputActive,
             isAITab: isAITab,
             isMinimalChromeLayout: isMinimalChromeLayout
-        ),
+        )
+        guard shouldShow,
               let domain,
               !domain.isEmpty else {
             button.alpha = 0
@@ -177,20 +188,18 @@ final class FloatingDomainCapsuleController {
         }
     }
 
-    /// Opacity of the morph pill. Fully opaque through the resize band (`p <= handoffStart`), then
-    /// ramps to 0 over `[handoffStart, 1]` so the real chrome takes over. Reduce Motion falls back
-    /// to a plain inverse cross-fade.
+    /// Opacity of the morph pill: opaque below `handoffStart`, transparent above it, with only a
+    /// narrow ramp across `handoffBandHalfWidth` (see its doc comment — this is a seam-blur, not a
+    /// cross-fade). The complement of `MainViewController.chromeAlpha(for:)`, so the two never overlap
+    /// meaningfully. Reduce Motion falls back to a plain inverse cross-fade across the whole range.
     private func pillAlpha(for p: CGFloat, reduceMotion: Bool) -> CGFloat {
         if reduceMotion {
             return max(0, min(1, 1 - p))
         }
-        if p >= 1 {
-            return 0
-        }
-        if p <= Self.handoffStart {
-            return 1
-        }
-        return 1 - (p - Self.handoffStart) / (1 - Self.handoffStart)
+        let bandStart = Self.handoffStart - Self.handoffBandHalfWidth
+        let bandEnd = Self.handoffStart + Self.handoffBandHalfWidth
+        guard bandEnd > bandStart else { return p < Self.handoffStart ? 1 : 0 }
+        return 1 - ((p - bandStart) / (bandEnd - bandStart)).clamped(to: 0...1)
     }
 
     /// Interpolates the pill's real width/height/vertical-centre (and capsule corner radius) between
@@ -208,7 +217,11 @@ final class FloatingDomainCapsuleController {
             ? view.safeAreaInsets.top + Self.restEdgePadding + capsuleHeight / 2
             : view.bounds.maxY - view.safeAreaInsets.bottom - Self.restEdgePadding - capsuleHeight / 2
 
-        let morphP = (reduceMotion || expandedFrame.isEmpty) ? 0 : p
+        // Remapped so the pill reaches `expandedFrame` exactly at `handoffStart` (where the real bar's
+        // button row has already finished fading, per `BrowserToolbarView.setButtonRowCollapseProgress`)
+        // rather than at p = 1. Above `handoffStart` this clamps to 1 -- harmless, since the pill is
+        // invisible there -- but keeps geometry sane if the alpha band ever leaves it briefly visible.
+        let morphP = (reduceMotion || expandedFrame.isEmpty) ? 0 : min(1, p / Self.handoffStart)
         let width = capsuleWidth + (expandedFrame.width - capsuleWidth) * morphP
         let height = capsuleHeight + (expandedFrame.height - capsuleHeight) * morphP
         let centerY = restCenterY + (expandedFrame.midY - restCenterY) * morphP
@@ -219,6 +232,17 @@ final class FloatingDomainCapsuleController {
 
         button.layer.cornerRadius = height / 2
         backgroundView.layer.cornerRadius = height / 2
+
+        // `applyGlassStyle()` runs once from `install(in:)`, while the button is still the zero-sized
+        // placeholder its constraints start at (real geometry only lands here, on the first `update()`).
+        // `UIGlassEffect`/`UIBlurEffect` assigned to a zero-bounds view never composites once the view is
+        // later resized -- unlike ordinary layer properties, the effect needs to be (re-)assigned once a
+        // real size exists. One-shot, not every frame: reassigning a visual effect is not free, and this
+        // runs on every scroll frame.
+        if !hasAppliedGlassStyleAtValidSize, width > 0, height > 0 {
+            hasAppliedGlassStyleAtValidSize = true
+            applyGlassStyle()
+        }
     }
 
     private func applyGlassStyle() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1622,10 +1622,10 @@ class MainViewController: UIViewController {
         return CGRect(x: centerX - width / 2, y: centerY - expectedHeight / 2, width: width, height: expectedHeight)
     }
 
-    /// Alpha for the real chrome (nav bar / tabs / toolbar) during a bars transition. In the floating
-    /// capsule morph the real chrome is opaque above `handoffStart` (where the button row's own
-    /// fade/shrink, driven separately by `setButtonRowCollapseProgress`, is doing the visible work) and
-    /// transparent below it, with only a narrow ramp straddling the boundary — the complement of
+    /// Alpha for the real chrome (nav bar / tabs) during a bars transition. In the floating capsule
+    /// morph the real chrome is opaque above `handoffStart` (where the button row's own fade/shrink,
+    /// driven separately by `setButtonRowCollapseProgress`, is doing the visible work) and transparent
+    /// below it, with only a narrow ramp straddling the boundary — the complement of
     /// `FloatingDomainCapsuleController.pillAlpha`, so the two swap without a wide simultaneous
     /// cross-fade. Everywhere else it tracks `percent` linearly (unchanged behaviour).
     private func chromeAlpha(for percent: CGFloat) -> CGFloat {
@@ -1633,6 +1633,19 @@ class MainViewController: UIViewController {
         let handoffStart = FloatingDomainCapsuleController.handoffStart
         let halfWidth = FloatingDomainCapsuleController.handoffBandHalfWidth
         return rampedProgress(percent, from: handoffStart - halfWidth, to: handoffStart + halfWidth)
+    }
+
+    /// Alpha for `viewCoordinator.toolbar` specifically. Only shares `chromeAlpha`'s narrow handoff
+    /// band when the toolbar is actually hosting the embedded omnibar (bottom address bar) and so has
+    /// a domain-capsule pill taking its place underneath. A standalone, buttons-only toolbar (e.g. top
+    /// address bar position) has no such counterpart — cutting its alpha on that same narrow band, in
+    /// sync with a slide that's also compressed to finish by `handoffStart`, reads as the toolbar
+    /// abruptly vanishing rather than gently collapsing. It fades linearly across the full range
+    /// instead, alongside `setStandaloneCollapseProgress`'s scale-down and the uncompressed slide in
+    /// `updateToolbarConstant`.
+    private func toolbarAlpha(for percent: CGFloat) -> CGFloat {
+        guard viewCoordinator.isOmnibarInToolbar else { return percent }
+        return chromeAlpha(for: percent)
     }
 
     private func rampedProgress(_ percent: CGFloat, from start: CGFloat, to end: CGFloat) -> CGFloat {
@@ -4557,14 +4570,22 @@ extension MainViewController: BrowserChromeDelegate {
         // Ahead of `updateToolbarConstant` so its slide math reads this frame's height, not last
         // frame's. Stage the button row's own fade/shrink from `percent` (1 = expanded) into the
         // [0, 1] "how collapsed are the buttons" progress `setButtonRowCollapseProgress` expects.
-        let buttonCollapseProgress = isFloatingCapsuleActive && !UIAccessibility.isReduceMotionEnabled
+        let reduceMotion = UIAccessibility.isReduceMotionEnabled
+        let buttonCollapseProgress = isFloatingCapsuleActive && !reduceMotion
             ? ((1 - percent) / (1 - FloatingDomainCapsuleController.handoffStart)).clamped(to: 0...1)
             : 0
         let panelHeight = viewCoordinator.toolbar.setButtonRowCollapseProgress(
             buttonCollapseProgress,
-            reduceMotion: UIAccessibility.isReduceMotionEnabled
+            reduceMotion: reduceMotion
         )
         viewCoordinator.constraints.toolbarHeight.constant = panelHeight
+
+        // The standalone (no embedded omnibar) toolbar has no domain-capsule pill to hand off to, so
+        // it collapses over the full range rather than the compressed-to-`handoffStart` progress above.
+        let standaloneCollapseProgress = isFloatingCapsuleActive && !viewCoordinator.isOmnibarInToolbar && !reduceMotion
+            ? 1 - percent
+            : 0
+        viewCoordinator.toolbar.setStandaloneCollapseProgress(standaloneCollapseProgress, reduceMotion: reduceMotion)
 
         updateToolbarConstant(percent)
         updateNavBarConstant(percent)
@@ -4577,7 +4598,7 @@ extension MainViewController: BrowserChromeDelegate {
         if isWindowControlsRowEnabled {
             tabsBarController?.setCurrentTabSelectionAlpha(currentTabSelectionAlpha(for: chromeAlpha))
         }
-        viewCoordinator.toolbar.alpha = chromeAlpha
+        viewCoordinator.toolbar.alpha = toolbarAlpha(for: percent)
         updateFloatingDomainCapsuleVisibility(for: percent)
 
         if postChromeVisibilityNotification {
@@ -4804,8 +4825,10 @@ extension MainViewController: BrowserChromeDelegate {
         // would compound two motions where the user should see one. Remapped so the slide is pinned at
         // "fully shown" until `handoffStart`, then covers the retraction over the remaining range. Below
         // `handoffStart` the panel is already alpha-0 (the capsule pill has taken over), so where
-        // exactly it sits off-screen no longer has a visual effect.
-        let slideRatio = isFloatingCapsuleActive && !UIAccessibility.isReduceMotionEnabled
+        // exactly it sits off-screen no longer has a visual effect. Only applies when the toolbar is
+        // actually hosting the embedded omnibar -- a standalone toolbar has no pill to hand off to, so
+        // it slides over the full range in sync with `setStandaloneCollapseProgress`'s scale-down.
+        let slideRatio = isFloatingCapsuleActive && viewCoordinator.isOmnibarInToolbar && !UIAccessibility.isReduceMotionEnabled
             ? min(1, ratio / FloatingDomainCapsuleController.handoffStart)
             : ratio
         // Minimal chrome owns the toolbar slot as a permanent offscreen spacer for the bottom

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1623,16 +1623,21 @@ class MainViewController: UIViewController {
     }
 
     /// Alpha for the real chrome (nav bar / tabs / toolbar) during a bars transition. In the floating
-    /// capsule morph the chrome stays hidden through the resize band and only fades in over
-    /// `[handoffStart, 1]`, so the morph pill owns the visible transition. Everywhere else it tracks
-    /// `percent` linearly (unchanged behaviour).
+    /// capsule morph the real chrome is opaque above `handoffStart` (where the button row's own
+    /// fade/shrink, driven separately by `setButtonRowCollapseProgress`, is doing the visible work) and
+    /// transparent below it, with only a narrow ramp straddling the boundary — the complement of
+    /// `FloatingDomainCapsuleController.pillAlpha`, so the two swap without a wide simultaneous
+    /// cross-fade. Everywhere else it tracks `percent` linearly (unchanged behaviour).
     private func chromeAlpha(for percent: CGFloat) -> CGFloat {
         guard isFloatingCapsuleActive, !UIAccessibility.isReduceMotionEnabled else { return percent }
-        return rampedProgress(percent, from: FloatingDomainCapsuleController.handoffStart)
+        let handoffStart = FloatingDomainCapsuleController.handoffStart
+        let halfWidth = FloatingDomainCapsuleController.handoffBandHalfWidth
+        return rampedProgress(percent, from: handoffStart - halfWidth, to: handoffStart + halfWidth)
     }
 
-    private func rampedProgress(_ percent: CGFloat, from start: CGFloat) -> CGFloat {
-        ((percent - start) / (1 - start)).clamped(to: 0...1)
+    private func rampedProgress(_ percent: CGFloat, from start: CGFloat, to end: CGFloat) -> CGFloat {
+        guard end > start else { return percent < end ? 0 : 1 }
+        return ((percent - start) / (end - start)).clamped(to: 0...1)
     }
 
     private func currentTabSelectionAlpha(for chromeAlpha: CGFloat) -> CGFloat {
@@ -4414,9 +4419,25 @@ extension MainViewController: BrowserChromeDelegate {
 
     struct ChromeAnimationConstants {
         static let duration = 0.1
+
         /// Longer than `duration` so the floating capsule morph is legible; the pill grows/moves into
-        /// the bars (and back) rather than snapping across the short legacy cross-fade.
-        static let morphDuration = 0.33
+        /// the bars (and back) rather than snapping across the short legacy cross-fade. Asymmetric
+        /// because iOS 26 Safari collapses noticeably faster than it expands.
+        static let morphCollapseDuration = 0.20
+        static let morphExpandDuration = 0.34
+
+        /// The collapse follows a released fling, so it decelerates from full speed rather than easing
+        /// in from rest. No overshoot: the bars clip against the screen edge, where a bounce reads as a
+        /// glitch rather than as weight.
+        static let morphCollapseCurve = ChromeMorphAnimator.Curve.easeOutCubic
+
+        /// ~1% overshoot, settled well inside `morphExpandDuration`. Raise the damping ratio to 1 for a
+        /// critically damped, strictly non-overshooting expand.
+        static let morphExpandCurve = ChromeMorphAnimator.Curve.spring(dampingRatio: 0.82, naturalFrequency: 8.84)
+
+        /// Floor on the duration scaling applied to a partial transition, so an interrupted scrub
+        /// covering a short range finishes quicker without becoming an instant jump.
+        static let minMorphDurationScale: CGFloat = 0.55
     }
 
     var tabBarContainer: UIView {
@@ -4478,10 +4499,21 @@ extension MainViewController: BrowserChromeDelegate {
             && abs(fromPercent - percent) > 0.001
 
         if useMorphScrub {
+            let isExpanding = percent > fromPercent
+            // A partial transition shouldn't take as long as a full one, but shouldn't collapse to an
+            // instant jump either. Scaling normalized time also keeps the spring's shape intact.
+            let durationScale = max(ChromeAnimationConstants.minMorphDurationScale, abs(percent - fromPercent))
+            let baseDuration = isExpanding
+                ? ChromeAnimationConstants.morphExpandDuration
+                : ChromeAnimationConstants.morphCollapseDuration
+
             chromeMorphAnimator.animate(
                 from: fromPercent,
                 to: percent,
-                duration: animationDuration ?? ChromeAnimationConstants.morphDuration,
+                duration: animationDuration ?? baseDuration * Double(durationScale),
+                curve: isExpanding
+                    ? ChromeAnimationConstants.morphExpandCurve
+                    : ChromeAnimationConstants.morphCollapseCurve,
                 onProgress: { [weak self] progress in
                     guard let self else { return }
                     self.applyBarsVisibilityState(progress, postChromeVisibilityNotification: false)
@@ -4522,6 +4554,18 @@ extension MainViewController: BrowserChromeDelegate {
         if isFloatingUIEnabled {
             viewCoordinator.ensureBottomOmnibarAttachedToToolbarIfNeeded()
         }
+        // Ahead of `updateToolbarConstant` so its slide math reads this frame's height, not last
+        // frame's. Stage the button row's own fade/shrink from `percent` (1 = expanded) into the
+        // [0, 1] "how collapsed are the buttons" progress `setButtonRowCollapseProgress` expects.
+        let buttonCollapseProgress = isFloatingCapsuleActive && !UIAccessibility.isReduceMotionEnabled
+            ? ((1 - percent) / (1 - FloatingDomainCapsuleController.handoffStart)).clamped(to: 0...1)
+            : 0
+        let panelHeight = viewCoordinator.toolbar.setButtonRowCollapseProgress(
+            buttonCollapseProgress,
+            reduceMotion: UIAccessibility.isReduceMotionEnabled
+        )
+        viewCoordinator.constraints.toolbarHeight.constant = panelHeight
+
         updateToolbarConstant(percent)
         updateNavBarConstant(percent)
         currentTab?.updateWebViewBottomAnchor(for: percent)
@@ -4625,7 +4669,22 @@ extension MainViewController: BrowserChromeDelegate {
     var toolbarHeight: CGFloat {
         viewCoordinator.constraints.toolbarHeight.constant
     }
-    
+
+    /// Gated on the feature flag rather than `isFloatingCapsuleActive`, so the retuned scroll distance
+    /// also applies on AI tabs and in minimal chrome, where the floating bars still slide even though the
+    /// domain capsule doesn't own the transition.
+    var isFloatingChromeEnabled: Bool {
+        isFloatingUIEnabled
+    }
+
+    var floatingMorphCollapseDuration: CFTimeInterval {
+        ChromeAnimationConstants.morphCollapseDuration
+    }
+
+    var floatingMorphExpandDuration: CFTimeInterval {
+        ChromeAnimationConstants.morphExpandDuration
+    }
+
     var barsMaxHeight: CGFloat {
         let height = max(toolbarHeight, viewCoordinator.omniBar.barView.expectedHeight)
         if isInMinimalChromeLayout && viewCoordinator.addressBarPosition.isBottom {
@@ -4740,11 +4799,20 @@ extension MainViewController: BrowserChromeDelegate {
             bottomHeight += viewCoordinator.navigationBarContainer.frame.height
         }
         bottomHeight += view.safeAreaInsets.bottom
+        // With the floating capsule morph, the panel shouldn't slide at all while its button row is
+        // still fading/shrinking in place (`setButtonRowCollapseProgress`) -- sliding at the same time
+        // would compound two motions where the user should see one. Remapped so the slide is pinned at
+        // "fully shown" until `handoffStart`, then covers the retraction over the remaining range. Below
+        // `handoffStart` the panel is already alpha-0 (the capsule pill has taken over), so where
+        // exactly it sits off-screen no longer has a visual effect.
+        let slideRatio = isFloatingCapsuleActive && !UIAccessibility.isReduceMotionEnabled
+            ? min(1, ratio / FloatingDomainCapsuleController.handoffStart)
+            : ratio
         // Minimal chrome owns the toolbar slot as a permanent offscreen spacer for the bottom
         // address bar, and on iPad the toolbar is permanently hidden (its layout slot would
         // otherwise leave a 49pt gap below the webview). Everywhere else the slot tracks
         // `ratio` (chrome-animator visibility).
-        let multiplier = (viewCoordinator.toolbar.isHidden || isInMinimalChromeLayout) ? 1.0 : 1.0 - ratio
+        let multiplier = (viewCoordinator.toolbar.isHidden || isInMinimalChromeLayout) ? 1.0 : 1.0 - slideRatio
         viewCoordinator.constraints.toolbarBottom.constant = bottomHeight * multiplier
 
         if isInMinimalChromeLayout, viewCoordinator.addressBarPosition.isBottom {

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -362,19 +362,40 @@ class MainViewCoordinator {
 
     func ensureNavContainerOwnershipForUnifiedToggleInputIfNeeded() {
         guard isFloatingUIEnabled, addressBarPosition.isBottom else { return }
-        returnOmnibarToNavigationContainerIfNeeded()
+        // Deferred: applying the toolbar's now-buttons-only height here, before the UTI focus
+        // animation has even started, snapped the floating capsule to its smaller size in one
+        // unanimated frame. The caller applies it inside its own animation block instead, via
+        // `applyDetachedToolbarHeight()`, so the capsule shrinks smoothly alongside everything else.
+        returnOmnibarToNavigationContainerIfNeeded(applyingToolbarHeightImmediately: false)
     }
 
     /// Detaches the bottom omnibar from the toolbar back into the nav container (used by minimal
     /// chrome, where the toolbar is hidden, and the unified toggle input flow).
-    func returnOmnibarToNavigationContainerIfNeeded() {
+    func returnOmnibarToNavigationContainerIfNeeded(applyingToolbarHeightImmediately: Bool = true) {
         guard isOmnibarInToolbar else { return }
         toolbar.setOmnibarView(nil, height: 0)
-        constraints.toolbarHeight.constant = BrowserToolbarView.totalHeight(withOmnibarHeight: 0, isFloating: isFloatingUIEnabled)
+        if applyingToolbarHeightImmediately {
+            applyDetachedToolbarHeight()
+        }
         navigationBarContainer.isHidden = false
         navigationBarContainer.alpha = 1
         navigationBarContainer.isUserInteractionEnabled = true
         isOmnibarInToolbar = false
+    }
+
+    /// The floating toolbar's height once the omnibar has been detached from it (buttons-only).
+    /// Split out from `returnOmnibarToNavigationContainerIfNeeded` so a caller mid-animation-setup
+    /// can fold this into its own animated block instead of snapping it instantly.
+    func applyDetachedToolbarHeight() {
+        constraints.toolbarHeight.constant = BrowserToolbarView.totalHeight(withOmnibarHeight: 0, isFloating: isFloatingUIEnabled)
+    }
+
+    /// The floating toolbar's height once it's grown back to reabsorb the omnibar. Split out from
+    /// `ensureBottomOmnibarAttachedToToolbarIfNeeded` so a UTI dismiss animation can grow the toolbar
+    /// smoothly -- the separated, buttons-only bar expanding upward into the address bar it's about
+    /// to become -- before the omnibar view is actually reparented into it at completion.
+    func applyAttachedToolbarHeight() {
+        constraints.toolbarHeight.constant = BrowserToolbarView.totalHeight(withOmnibarHeight: omniBar.barView.expectedHeight, isFloating: isFloatingUIEnabled)
     }
 
     func updateToolbarWithState(_ state: ToolbarContentState) {
@@ -490,7 +511,10 @@ class MainViewCoordinator {
     func hideUnifiedToggleInputOmnibar(additionalAnimations: (() -> Void)? = nil, completion: (() -> Void)? = nil) {
         omnibarDismissAnimator?.stopAnimation(true)
 
-        let animator = UIViewPropertyAnimator(duration: MainViewController.Constants.omnibarTransitionDuration(isBottom: addressBarPosition.isBottom), curve: .easeOut) { [weak self] in
+        // .easeInOut (vs the plain .easeOut used elsewhere in this transition) eases the toolbar's
+        // reabsorption in gently at the start too, rather than starting at full speed -- reads more
+        // like settling into place than snapping toward it.
+        let animator = UIViewPropertyAnimator(duration: MainViewController.Constants.omnibarTransitionDuration(isBottom: addressBarPosition.isBottom, isFloatingUIEnabled: isFloatingUIEnabled), curve: .easeInOut) { [weak self] in
             self?.animateUnifiedToggleInputOmnibarDismissLayout()
             additionalAnimations?()
         }
@@ -525,6 +549,12 @@ class MainViewCoordinator {
     func animateUnifiedToggleInputOmnibarDismissLayout() {
         if addressBarPosition.isBottom {
             setNavBarContainerBottomToToolbar()
+            // The separated, buttons-only toolbar grows upward to reabsorb the omnibar -- the exact
+            // reverse of `applyDetachedToolbarHeight` on focus-in -- rather than staying small until
+            // an unanimated snap at completion.
+            if isFloatingUIEnabled {
+                applyAttachedToolbarHeight()
+            }
         }
         constraints.navigationBarContainerHeight.constant = standardNavigationBarContainerHeight
         superview.layoutIfNeeded()
@@ -541,6 +571,15 @@ class MainViewCoordinator {
             navigationBarCollectionView.alpha = 0
             unifiedToggleInputContainer.isHidden = false
             unifiedToggleInputContainer.alpha = 1
+        } else if isFloatingUIEnabled, addressBarPosition.isBottom {
+            // Reabsorb the omnibar back into the floating toolbar (already grown to full height by
+            // `animateUnifiedToggleInputOmnibarDismissLayout`) instead of resting it in the nav
+            // container, which is what the plain `else` branch below does for non-floating chrome.
+            unifiedToggleInputContainer.isHidden = true
+            unifiedToggleInputContainer.alpha = 1
+            ensureBottomOmnibarAttachedToToolbarIfNeeded()
+            omniBar?.barView.restoreBarChrome()
+            omniBar?.barView.setIconContainersAlpha(1)
         } else {
             // Snap chrome (pill + text field) back now that UTI is gone; icons faded in alongside the collapse.
             navigationBarCollectionView.alpha = 1

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -579,7 +579,18 @@ class MainViewCoordinator {
             unifiedToggleInputContainer.alpha = 1
             ensureBottomOmnibarAttachedToToolbarIfNeeded()
             omniBar?.barView.restoreBarChrome()
-            omniBar?.barView.setIconContainersAlpha(1)
+            // Crossfade the icons in rather than snapping them to visible the instant the omnibar is
+            // reattached -- otherwise the toolbar arrives at full size with the UTI card already gone
+            // but its own content still invisible, then pops in a single frame. Mirrors the inline
+            // reveal path's `omnibarIconFadeInDurationMultiplier` idiom.
+            omniBar?.barView.setIconContainersAlpha(0)
+            UIView.animate(
+                withDuration: MainViewController.Constants.omnibarTransitionDuration(isBottom: true, isFloatingUIEnabled: true)
+                    * MainViewController.Constants.omnibarIconFadeInDurationMultiplier,
+                delay: 0,
+                options: [.curveEaseIn, .allowUserInteraction],
+                animations: { [weak self] in self?.omniBar?.barView.setIconContainersAlpha(1) }
+            )
         } else {
             // Snap chrome (pill + text field) back now that UTI is gone; icons faded in alongside the collapse.
             navigationBarCollectionView.alpha = 1

--- a/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
@@ -97,9 +97,19 @@ class FromWebViewTransition: WebViewTransition {
         }
 
         imageContainer.frame = mainViewController.viewCoordinator.contentContainer.frame
-        imageContainer.frame = adjustFrame(imageContainer.frame,
-                                           forAddressBarPosition: mainViewController.appSettings.currentAddressBarPosition,
-                                           byHeight: -mainViewController.omniBar.barView.expectedHeight)
+        if !isFloating {
+            // Legacy bottom chrome resizes `contentContainer` to sit above the omnibar, but at the
+            // moment this frame is read it still measures the taller, pre-resize value, so this
+            // compensates. Floating UI's `contentContainer` anchors to the safe area instead (the
+            // toolbar floats on top via obscured content insets, not a frame resize), so it's
+            // already the right height -- applying this compensation there shrank the screenshot
+            // substitute a few points shorter than the live webview it was replacing, reading as a
+            // slight "shrink" the instant the tab button is pressed. `ToWebViewTransition`'s mirror
+            // image (growing back from the tab cell) never applied this adjustment either.
+            imageContainer.frame = adjustFrame(imageContainer.frame,
+                                               forAddressBarPosition: mainViewController.appSettings.currentAddressBarPosition,
+                                               byHeight: -mainViewController.omniBar.barView.expectedHeight)
+        }
         imageView.frame = imageContainer.bounds
         imageView.image = preview
 

--- a/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
@@ -71,10 +71,31 @@ class FromWebViewTransition: WebViewTransition {
 
         let theme = ThemeManager.shared.currentTheme
         let webViewFrame = webView.convert(webView.bounds, to: nil)
-        
+
         solidBackground.backgroundColor = theme.backgroundColor
         solidBackground.frame = webViewFrame
-        
+
+        // Floating UI's toolbar capsule sits outside `contentContainer`/the webview screenshot, so it
+        // was never part of this transition -- it just sat there at full size until the tab switcher's
+        // view opaquely covered it, reading as a sudden pop rather than a smooth exit. Animating the
+        // *live* toolbar's alpha here would race against `tabSwitcherViewController.view`'s own
+        // fade-in keyframe below -- the two compound and the toolbar visually vanishes well before
+        // the fade either animation implies alone, before the screenshot even looks like it's
+        // shrinking. Snapshotting it and animating the snapshot keeps this fully under this
+        // transition's own timing, in step with the screenshot's shrink, matching how Safari shrinks
+        // the whole page as one unit. Shrinks toward its own bottom edge (scaling around the default
+        // centre anchor and translating back down by half the height lost pins the bottom edge in
+        // place) while fading out.
+        let toolbar: BrowserToolbarView = mainViewController.viewCoordinator.toolbar
+        let isFloating = mainViewController.isFloatingUIEnabled
+        var toolbarSnapshot: UIView?
+        if isFloating, let snapshot = toolbar.snapshotView(afterScreenUpdates: false) {
+            snapshot.frame = toolbar.convert(toolbar.bounds, to: transitionContext.containerView)
+            transitionContext.containerView.insertSubview(snapshot, aboveSubview: imageContainer)
+            toolbarSnapshot = snapshot
+            toolbar.alpha = 0
+        }
+
         imageContainer.frame = mainViewController.viewCoordinator.contentContainer.frame
         imageContainer.frame = adjustFrame(imageContainer.frame,
                                            forAddressBarPosition: mainViewController.appSettings.currentAddressBarPosition,
@@ -116,6 +137,13 @@ class FromWebViewTransition: WebViewTransition {
                 self.imageView.frame = WebViewTransitionGeometry.previewFrame(for: containerFrame.size,
                                                                               previewSize: preview.size,
                                                                               isGridViewEnabled: self.tabSwitcherSettings.isGridViewEnabled)
+                if let toolbarSnapshot {
+                    let scale: CGFloat = 0.7
+                    let heightLost = toolbarSnapshot.bounds.height * (1 - scale) / 2
+                    toolbarSnapshot.transform = CGAffineTransform(scaleX: scale, y: scale)
+                        .concatenating(CGAffineTransform(translationX: 0, y: heightLost))
+                    toolbarSnapshot.alpha = 0
+                }
             }
             
             UIView.addKeyframe(withRelativeStartTime: 0.3, relativeDuration: 0.7) {
@@ -136,6 +164,10 @@ class FromWebViewTransition: WebViewTransition {
         }, completion: { _ in
             self.solidBackground.removeFromSuperview()
             self.imageContainer.removeFromSuperview()
+            toolbarSnapshot?.removeFromSuperview()
+            if isFloating {
+                toolbar.alpha = 1
+            }
             transitionContext.completeTransition(true)
         })
 
@@ -156,6 +188,10 @@ class ToWebViewTransition: WebViewTransition {
             // Crossfade fallback when destination is no longer a web view; mirrors ToHomeScreenTransition.
             if let mainViewController = transitionContext.viewController(forKey: .to) as? MainViewController {
                 mainViewController.view.alpha = 1
+                if mainViewController.isFloatingUIEnabled {
+                    mainViewController.viewCoordinator.toolbar.transform = .identity
+                    mainViewController.viewCoordinator.toolbar.alpha = 1
+                }
             }
             UIView.animate(withDuration: TabSwitcherTransition.Constants.duration, animations: {
                 self.tabSwitcherViewController.view.alpha = 0
@@ -170,7 +206,28 @@ class ToWebViewTransition: WebViewTransition {
         let theme = ThemeManager.shared.currentTheme
         let webViewFrame = webView.convert(webView.bounds, to: nil)
         mainViewController.view.alpha = 1
-        
+
+        // Reverse of `FromWebViewTransition`'s shrink, same reasoning: animating the *live* toolbar's
+        // alpha here would compound with `tabSwitcherViewController.view`'s own fade-out in the same
+        // block below, so a snapshot carries the reveal instead, self-contained regardless of
+        // whatever state the toolbar was left in (e.g. a fresh presentation, not just the matching
+        // `FromWebViewTransition`). Starts in that same shrunk/faded state, then animates back to
+        // identity alongside the webview screenshot growing back to full size.
+        let toolbar: BrowserToolbarView = mainViewController.viewCoordinator.toolbar
+        let isFloating = mainViewController.isFloatingUIEnabled
+        var toolbarSnapshot: UIView?
+        if isFloating, let snapshot = toolbar.snapshotView(afterScreenUpdates: false) {
+            let scale: CGFloat = 0.7
+            let heightLost = toolbar.bounds.height * (1 - scale) / 2
+            snapshot.frame = toolbar.convert(toolbar.bounds, to: transitionContext.containerView)
+            snapshot.transform = CGAffineTransform(scaleX: scale, y: scale)
+                .concatenating(CGAffineTransform(translationX: 0, y: heightLost))
+            snapshot.alpha = 0
+            transitionContext.containerView.insertSubview(snapshot, aboveSubview: imageContainer)
+            toolbarSnapshot = snapshot
+            toolbar.alpha = 0
+        }
+
         solidBackground.backgroundColor = theme.backgroundColor
         solidBackground.frame = webView.bounds
         // Put overlay above webview to hide its content till the end of the transition
@@ -203,12 +260,20 @@ class ToWebViewTransition: WebViewTransition {
             self.imageView.frame = WebViewTransitionGeometry.destinationImageFrame(for: webViewFrame.size,
                                                                                    previewSize: preview?.size)
             self.imageView.alpha = 1
-            
+
             self.solidBackground.alpha = 1
             self.tabSwitcherViewController.view.alpha = 0
+            if let toolbarSnapshot {
+                toolbarSnapshot.transform = .identity
+                toolbarSnapshot.alpha = 1
+            }
         }, completion: { _ in
             self.solidBackground.removeFromSuperview()
             self.imageContainer.removeFromSuperview()
+            toolbarSnapshot?.removeFromSuperview()
+            if isFloating {
+                toolbar.alpha = 1
+            }
             transitionContext.completeTransition(true)
         })
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -43,8 +43,14 @@ extension MainViewController {
         static let utiLandscapeKeyboardGap: CGFloat = 8
 
         // Bottom is longer to accommodate concurrent keyboard descent.
-        static func omnibarTransitionDuration(isBottom: Bool) -> TimeInterval {
-            isBottom ? 0.35 : 0.25
+        static func omnibarTransitionDuration(isBottom: Bool, isFloatingUIEnabled: Bool) -> TimeInterval {
+            guard isFloatingUIEnabled else {
+                return isBottom ? 0.35 : 0.25
+            }
+            // Floating UI only: two successive 50%-faster passes from the legacy values above (which
+            // read as sluggish once the floating chrome's own transitions are this snappy), then eased
+            // back up 25% after that landed a little too fast.
+            return isBottom ? 0.109375 : 0.078125
         }
 
         /// Stretch the icon fade-in past UTI's collapse so the build-up reads rather than front-loading.
@@ -1056,7 +1062,7 @@ extension MainViewController {
         let omnibarPlaceholderWindowX = currentOmnibarPlaceholderWindowX() ?? coordinator.cachedOmnibarPlaceholderWindowX
         let omnibarPlaceholderColor = currentOmnibarPlaceholderColor()
         let utiPlaceholderColor = coordinator.viewController.defaultPlaceholderColor
-        let duration = Constants.omnibarTransitionDuration(isBottom: coordinator.cardPosition.isBottom)
+        let duration = Constants.omnibarTransitionDuration(isBottom: coordinator.cardPosition.isBottom, isFloatingUIEnabled: isFloatingUIEnabled)
 
         // Pick the NTP handoff from the host's current content + the NTP's *resting* content (the NTP's
         // `isShowing*` is unreliable here — the focus handoff hid one for the session). logo→logo morphs

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
@@ -240,7 +240,28 @@ private extension MainViewController {
         }
         // Seamless handoffs (logo/favorites) show the content immediately; only other content fades in.
         let isSeamlessHandoff = isLogoToLogo || isFavoritesToFavorites
-        viewCoordinator.unifiedInputContentContainer.alpha = isSeamlessHandoff ? 1 : 0
+        let unifiedInputContentContainer: UIView = viewCoordinator.unifiedInputContentContainer
+        unifiedInputContentContainer.alpha = isSeamlessHandoff ? 1 : 0
+
+        // Floating UI, bottom bar only: grow the content up from its bottom edge as it fades in,
+        // rather than a flat cross-fade, so it reads as rising out of the omnibar it's replacing.
+        // Scaling around the view's default centre anchor would shrink both edges toward the middle;
+        // translating back down by half the height lost pins the bottom edge in place instead, so
+        // only the top edge visibly rises.
+        let growsFromBottom = isBottom && isFloatingUIEnabled && !isSeamlessHandoff
+        if growsFromBottom {
+            let initialScale: CGFloat = 0.85
+            let heightLost = unifiedInputContentContainer.bounds.height * (1 - initialScale) / 2
+            unifiedInputContentContainer.transform = CGAffineTransform(scaleX: initialScale, y: initialScale)
+                .concatenating(CGAffineTransform(translationX: 0, y: heightLost))
+            // The container hosts the suggestions/favorites content, which can be a deep view
+            // hierarchy -- rasterize it for the scale animation's duration so Core Animation composites
+            // a cached bitmap instead of re-rendering that hierarchy every frame. Otherwise this can
+            // compete with the keyboard's own presentation animation for main-thread/compositor time,
+            // right when `becomeFirstResponder` is racing to show it, and read as the focus being slow.
+            unifiedInputContentContainer.layer.shouldRasterize = true
+            unifiedInputContentContainer.layer.rasterizationScale = UIScreen.main.scale
+        }
 
         if let omnibarPlaceholderWindowX {
             coordinator.viewController.alignVisibleTextLeadingEdge(toWindowX: omnibarPlaceholderWindowX)
@@ -253,7 +274,7 @@ private extension MainViewController {
             newTabPageViewController?.setLogoHidden(true)
         }
 
-        let duration = Constants.omnibarTransitionDuration(isBottom: isBottom)
+        let duration = Constants.omnibarTransitionDuration(isBottom: isBottom, isFloatingUIEnabled: isFloatingUIEnabled)
         UIView.animate(
             withDuration: duration,
             delay: 0,
@@ -263,6 +284,9 @@ private extension MainViewController {
                 coordinator.viewController.applyOmnibarEditingShowPose()
                 if coordinator.cardPosition == .bottom {
                     self.applyBottomOmnibarVisibility(.active)
+                    if self.isFloatingUIEnabled {
+                        self.viewCoordinator.applyDetachedToolbarHeight()
+                    }
                 }
                 if let pendingHeight {
                     self.viewCoordinator.constraints.navigationBarContainerHeight.constant = pendingHeight
@@ -270,9 +294,17 @@ private extension MainViewController {
                 self.viewCoordinator.superview.layoutIfNeeded()
                 coordinator.pushContentInsets()
                 if !isSeamlessHandoff {
-                    self.viewCoordinator.unifiedInputContentContainer.alpha = 1
+                    unifiedInputContentContainer.alpha = 1
+                    if growsFromBottom {
+                        unifiedInputContentContainer.transform = .identity
+                    }
                 }
                 coordinator.viewController.setTextHorizontalShift(0)
+            },
+            completion: { _ in
+                if growsFromBottom {
+                    unifiedInputContentContainer.layer.shouldRasterize = false
+                }
             }
         )
 
@@ -287,10 +319,20 @@ private extension MainViewController {
 
     func handleHideOmnibarEditingIntent(animated: Bool) {
         let coordinator = unifiedToggleInputCoordinator
-        let onDismissed: () -> Void = { [weak coordinator] in
+        // Mirrors `growsFromBottom` in `handleShowOmnibarEditingIntent` -- the exact reverse of the
+        // focus-in scale/fade, rather than an instant `isHidden` snap while the rest of the chrome
+        // is still animating.
+        let shrinksToBottom = animated && viewCoordinator.addressBarPosition.isBottom && isFloatingUIEnabled
+        let unifiedInputContentContainer: UIView = viewCoordinator.unifiedInputContentContainer
+        let onDismissed: () -> Void = { [weak self, weak coordinator] in
             coordinator?.viewController.setTextHorizontalShift(0)
             coordinator?.viewController.finalizeOmnibarEditingDismiss()
             coordinator?.clearText()
+            if shrinksToBottom {
+                self?.viewCoordinator.hideUnifiedInputContent()
+                unifiedInputContentContainer.transform = .identity
+                unifiedInputContentContainer.layer.shouldRasterize = false
+            }
         }
         if animated {
             // Bottom floating: the omnibar is detached from the toolbar by now, so fall back to the
@@ -298,12 +340,26 @@ private extension MainViewController {
             let omnibarPlaceholderWindowX = currentOmnibarPlaceholderWindowX() ?? coordinator?.cachedOmnibarPlaceholderWindowX
             let omnibarPlaceholderColor = currentOmnibarPlaceholderColor()
             let utiPlaceholderColor = coordinator?.viewController.defaultPlaceholderColor
-            let duration = Constants.omnibarTransitionDuration(isBottom: viewCoordinator.addressBarPosition.isBottom)
-            let slideUTIText: () -> Void = { [weak coordinator] in
-                guard let coordinator, let omnibarPlaceholderWindowX else { return }
-                coordinator.viewController.alignVisibleTextLeadingEdge(toWindowX: omnibarPlaceholderWindowX)
+            let duration = Constants.omnibarTransitionDuration(isBottom: viewCoordinator.addressBarPosition.isBottom, isFloatingUIEnabled: isFloatingUIEnabled)
+            if shrinksToBottom {
+                // See the matching comment in `handleShowOmnibarEditingIntent`: cache the content
+                // hierarchy as a bitmap for the scale-down instead of re-rendering it every frame.
+                unifiedInputContentContainer.layer.shouldRasterize = true
+                unifiedInputContentContainer.layer.rasterizationScale = UIScreen.main.scale
             }
-            viewCoordinator.hideUnifiedToggleInputOmnibar(additionalAnimations: slideUTIText, completion: onDismissed)
+            let additionalAnimations: () -> Void = {
+                if let coordinator, let omnibarPlaceholderWindowX {
+                    coordinator.viewController.alignVisibleTextLeadingEdge(toWindowX: omnibarPlaceholderWindowX)
+                }
+                if shrinksToBottom {
+                    let initialScale: CGFloat = 0.85
+                    let heightLost = unifiedInputContentContainer.bounds.height * (1 - initialScale) / 2
+                    unifiedInputContentContainer.alpha = 0
+                    unifiedInputContentContainer.transform = CGAffineTransform(scaleX: initialScale, y: initialScale)
+                        .concatenating(CGAffineTransform(translationX: 0, y: heightLost))
+                }
+            }
+            viewCoordinator.hideUnifiedToggleInputOmnibar(additionalAnimations: additionalAnimations, completion: onDismissed)
             if let coordinator, let omnibarPlaceholderColor, let utiPlaceholderColor {
                 coordinator.viewController.animatePlaceholderColorTransition(
                     from: utiPlaceholderColor,
@@ -317,7 +373,7 @@ private extension MainViewController {
             viewCoordinator.finishUnifiedToggleInputOmnibarDismiss()
             onDismissed()
         }
-        resetUnifiedInputContentAfterHide()
+        resetUnifiedInputContentAfterHide(hidingContent: !shrinksToBottom)
         viewCoordinator.suggestionTrayContainer.backgroundColor = .clear
     }
 
@@ -331,9 +387,14 @@ private extension MainViewController {
     }
 
     /// Shared intent teardown; restores the NTP logo/favorites hidden at focus, mirroring the animated back-button dismiss (idempotent).
-    func resetUnifiedInputContentAfterHide() {
+    /// - Parameter hidingContent: pass `false` when the caller is animating the content container's own
+    ///   fade/scale-down (floating UI, bottom bar) and will hide it itself once that finishes -- an
+    ///   instant `isHidden = true` here would otherwise make it invisible before the animation runs.
+    func resetUnifiedInputContentAfterHide(hidingContent: Bool = true) {
         unifiedToggleInputCoordinator?.contentViewController.setActive(false)
-        viewCoordinator.hideUnifiedInputContent()
+        if hidingContent {
+            viewCoordinator.hideUnifiedInputContent()
+        }
         unifiedToggleInputCoordinator?.contentViewController.setContentInset(top: 0, bottom: 0)
         hideSuggestionTray()
         newTabPageViewController?.setLogoHidden(false)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -101,8 +101,10 @@ final class UnifiedToggleInputView: UIView {
         /// Card container's outer horizontal margin in the non-flanked layouts.
         static let cardHorizontalMargin: CGFloat = 8
         static let cardVerticalMargin: CGFloat = 8
-        /// Outer horizontal margin for the expanded card at the bottom-bar position.
-        static let cardHorizontalMarginBottom: CGFloat = 8
+        /// Outer horizontal margin for the expanded card at the bottom-bar position. Matches
+        /// `BrowserToolbarView.floatingBarOuterInsets`'s 16pt so the card's leading/trailing edge
+        /// lines up with the floating toolbar capsule it replaces, instead of jumping inward.
+        static let cardHorizontalMarginBottom: CGFloat = 16
         static let cardVerticalMarginBottom: CGFloat = 8
         /// Omnibar pill's horizontal inset; the card's hand-off start width so it animates to the
         /// narrower editing margins. Mirrors `DefaultOmniBarView`'s portrait value (landscape/iPad differ).

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -101,10 +101,10 @@ final class UnifiedToggleInputView: UIView {
         /// Card container's outer horizontal margin in the non-flanked layouts.
         static let cardHorizontalMargin: CGFloat = 8
         static let cardVerticalMargin: CGFloat = 8
-        /// Outer horizontal margin for the expanded card at the bottom-bar position. Matches
+        /// Outer horizontal margin for the expanded card, at either address-bar position. Matches
         /// `BrowserToolbarView.floatingBarOuterInsets`'s 16pt so the card's leading/trailing edge
         /// lines up with the floating toolbar capsule it replaces, instead of jumping inward.
-        static let cardHorizontalMarginBottom: CGFloat = 16
+        static let cardHorizontalMarginExpanded: CGFloat = 16
         static let cardVerticalMarginBottom: CGFloat = 8
         /// Omnibar pill's horizontal inset; the card's hand-off start width so it animates to the
         /// narrower editing margins. Mirrors `DefaultOmniBarView`'s portrait value (landscape/iPad differ).
@@ -940,9 +940,9 @@ final class UnifiedToggleInputView: UIView {
         let hLeadingMargin: CGFloat
         let hTrailingMargin: CGFloat
 
-        if expanded && cardPosition == .bottom && !usesOmnibarMargins {
-            hLeadingMargin = Constants.cardHorizontalMarginBottom
-            hTrailingMargin = Constants.cardHorizontalMarginBottom
+        if expanded && !usesOmnibarMargins {
+            hLeadingMargin = Constants.cardHorizontalMarginExpanded
+            hTrailingMargin = Constants.cardHorizontalMarginExpanded
         } else if layout == .collapsed {
             hLeadingMargin = Constants.omnibarMatchingHorizontalMargin
             hTrailingMargin = Constants.omnibarMatchingHorizontalMargin
@@ -1191,8 +1191,8 @@ final class UnifiedToggleInputView: UIView {
         let showToolbar = toggleView.selectedMode == .aiChat
         cardView.layer.cornerRadius = Constants.cardCornerRadiusExpanded
         // Width animation: this reveal path bypasses `applyCardLayout`, so set the expanded margins here.
-        cardLeadingConstraint.constant = Constants.cardHorizontalMargin
-        cardTrailingConstraint.constant = -cardTrailingMargin
+        cardLeadingConstraint.constant = expandedCardHorizontalMargin
+        cardTrailingConstraint.constant = -expandedCardHorizontalMargin
         toggleTopConstraint.constant = Constants.toggleTopPadding
         toggleHeightConstraint.constant = Constants.toggleHeight
         toggleView.alpha = 1
@@ -1230,22 +1230,15 @@ final class UnifiedToggleInputView: UIView {
             if inactive {
                 self.cardView.layer.maskedCorners = Constants.allCorners
                 self.cardTopConstraint.constant = Constants.cardVerticalMargin
-                self.cardLeadingConstraint.constant = Constants.cardHorizontalMargin
-                self.cardTrailingConstraint.constant = -self.cardTrailingMargin
+                self.cardLeadingConstraint.constant = self.expandedCardHorizontalMargin
+                self.cardTrailingConstraint.constant = -self.expandedCardHorizontalMargin
                 self.cardBottomConstraint.constant = -Constants.cardVerticalMargin
                 self.toolbarHeightConstraint.constant = 0
                 self.toolsToolbar.alpha = 0
             } else {
                 self.cardView.layer.maskedCorners = Constants.allCorners
-                let leadingMargin: CGFloat
-                let trailingMargin: CGFloat
-                if !self.usesOmnibarMargins && self.cardPosition == .bottom {
-                    leadingMargin = Constants.cardHorizontalMarginBottom
-                    trailingMargin = Constants.cardHorizontalMarginBottom
-                } else {
-                    leadingMargin = Constants.cardHorizontalMargin
-                    trailingMargin = self.cardTrailingMargin
-                }
+                let leadingMargin = self.expandedCardHorizontalMargin
+                let trailingMargin = self.expandedCardHorizontalMargin
                 let verticalMargin: CGFloat = (!self.usesOmnibarMargins && self.cardPosition == .bottom)
                     ? Constants.cardVerticalMarginBottom
                     : Constants.cardVerticalMargin
@@ -1271,6 +1264,15 @@ final class UnifiedToggleInputView: UIView {
     /// the field row alongside the inline buttons when the toggle is hidden at `.top`).
     private var cardTrailingMargin: CGFloat {
         Constants.cardHorizontalMargin
+    }
+
+    /// Outer horizontal margin for the expanded card, at either address-bar position, once it's
+    /// replaced the floating toolbar rather than sitting inline with the plain omnibar. Kept as a
+    /// single source so the toggle-reveal and inactive-appearance paths (which bypass
+    /// `applyCardLayout`) can't drift back out of sync with it, as `.top` did before matching
+    /// `.bottom`'s 16pt margin.
+    private var expandedCardHorizontalMargin: CGFloat {
+        usesOmnibarMargins ? Constants.cardHorizontalMargin : Constants.cardHorizontalMarginExpanded
     }
 
     private func updateToolbarVisibility(for mode: TextEntryMode, animated: Bool) {

--- a/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
+++ b/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
@@ -191,7 +191,431 @@ class BarsAnimatorTests: XCTestCase {
     }
 }
 
+/// The floating chrome uses a different gearing: an absolute 80pt of scroll for a full transition,
+/// measured statelessly from the transition's anchor rather than compounded per frame.
+class BarsAnimatorFloatingTests: XCTestCase {
+
+    private let travel = BarsAnimator.Metrics.floatingTransitionTravel
+
+    func testWhenScrollingTheFullTravelDistanceThenBarsAreFullyHidden() {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+
+        scrollView.contentOffset.y = 0
+        sut.didStartScrolling(in: scrollView)
+
+        // Spread over enough frames that the collapse rate limiter never binds.
+        scroll(sut, scrollView, clock, to: stride(from: 10.0, through: travel, by: 10.0))
+
+        XCTAssertEqual(sut.barsState, .hidden)
+        XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(0.0))
+    }
+
+    func testWhenScrollingHalfTheTravelDistanceThenBarsAreHalfVisible() {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+
+        scrollView.contentOffset.y = 0
+        sut.didStartScrolling(in: scrollView)
+        scroll(sut, scrollView, clock, to: stride(from: 10.0, through: travel / 2, by: 10.0))
+
+        XCTAssertEqual(sut.barsState, .transitioning)
+        XCTAssertEqual(try XCTUnwrap(delegate.receivedMessages.last?.percent), 0.5, accuracy: 0.001)
+    }
+
+    /// `combinedBarsHeight` is ~188pt with a bottom address bar but ~122pt with a top one, so gearing off
+    /// it would collapse the two positions at different speeds. The travel is absolute precisely to avoid
+    /// that, and this is the regression test for it.
+    func testWhenBarHeightDiffersThenTravelDistanceIsUnchanged() throws {
+        var finalPercents: [CGFloat] = []
+
+        for toolbarHeight in [CGFloat(128), CGFloat(62)] {
+            let (sut, delegate, clock) = makeFloatingSUT()
+            delegate.toolbarHeight = toolbarHeight
+            let scrollView = mockTallScrollView()
+
+            scrollView.contentOffset.y = 0
+            sut.didStartScrolling(in: scrollView)
+            scroll(sut, scrollView, clock, to: stride(from: 10.0, through: travel / 2, by: 10.0))
+
+            finalPercents.append(try XCTUnwrap(delegate.receivedMessages.last?.percent))
+        }
+
+        XCTAssertEqual(finalPercents[0], finalPercents[1], accuracy: 0.001)
+    }
+
+    /// Holds only while the per-frame scroll stays inside the collapse rate cap — above it the cap
+    /// deliberately throttles, which `testWhenFlickIsFasterThanTheRateCapThenProgressIsLimited` covers.
+    /// Both step sizes divide the half-travel exactly so the runs end on the same offset.
+    func testWhenFrameStepSizeDiffersThenFinalProgressIsUnchanged() throws {
+        var finalPercents: [CGFloat] = []
+
+        for step in [CGFloat(5), CGFloat(10)] {
+            let (sut, delegate, clock) = makeFloatingSUT()
+            let scrollView = mockTallScrollView()
+
+            scrollView.contentOffset.y = 0
+            sut.didStartScrolling(in: scrollView)
+            scroll(sut, scrollView, clock, to: stride(from: step, through: travel / 2, by: step))
+
+            finalPercents.append(try XCTUnwrap(delegate.receivedMessages.last?.percent))
+        }
+
+        XCTAssertEqual(finalPercents[0], finalPercents[1], accuracy: 0.001)
+    }
+
+    /// The legacy formula re-seeded from `transitionSpeed * transitionProgress`, so a second drag resumed
+    /// at half the progress it had visually reached.
+    func testWhenDragIsInterruptedThenProgressResumesWhereItLeftOff() throws {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+
+        scrollView.contentOffset.y = 0
+        sut.didStartScrolling(in: scrollView)
+        scroll(sut, scrollView, clock, to: stride(from: 10.0, through: travel / 2, by: 10.0))
+        let interruptedPercent = try XCTUnwrap(delegate.receivedMessages.last?.percent)
+
+        // Lift and start a fresh drag from the same offset.
+        sut.didStartScrolling(in: scrollView)
+        clock.advance(by: 1.0 / 60.0)
+        sut.didScroll(in: scrollView)
+
+        XCTAssertEqual(try XCTUnwrap(delegate.receivedMessages.last?.percent), interruptedPercent, accuracy: 0.001)
+    }
+
+    /// Previously the first pixel of top overscroll yielded `0.5 * transitionProgress`, snapping the chrome
+    /// to half visible in a single frame before it began tracking.
+    func testWhenRevealingFromHiddenThenChromeDoesNotJumpToHalfVisible() throws {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+
+        sut.hideBars(animated: false)
+        XCTAssertEqual(sut.barsState, .hidden)
+
+        scrollView.contentOffset.y = 0
+        sut.didStartScrolling(in: scrollView)
+        scrollView.contentOffset.y = -1
+        clock.advance(by: 1.0 / 60.0)
+        sut.didScroll(in: scrollView)
+
+        let percent = try XCTUnwrap(delegate.receivedMessages.last?.percent)
+        XCTAssertEqual(percent, 1.0 / travel, accuracy: 0.001)
+        XCTAssertLessThan(percent, 0.1, "1pt of overscroll must not reveal a large slice of the chrome")
+    }
+
+    func testWhenFlickIsFasterThanTheRateCapThenProgressIsLimited() throws {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+
+        scrollView.contentOffset.y = 0
+        sut.didStartScrolling(in: scrollView)
+
+        // Far past the full travel in a single frame — uncapped this would complete instantly.
+        scrollView.contentOffset.y = 1000
+        clock.advance(by: 1.0 / 60.0)
+        sut.didScroll(in: scrollView)
+
+        let maxStep = BarsAnimator.Metrics.maxCollapseProgressPerSecond * CGFloat(1.0 / 60.0)
+        let percent = try XCTUnwrap(delegate.receivedMessages.last?.percent)
+        XCTAssertEqual(percent, 1.0 - maxStep, accuracy: 0.001)
+        XCTAssertNotEqual(sut.barsState, .hidden, "A single frame must not complete the collapse")
+    }
+
+    // MARK: - Release precision
+
+    /// The bug this guards: gating the progress-based decision on `velocity == 0` means a real touch
+    /// release (which is essentially never exactly zero) is decided by the sign of noise, not by how
+    /// far the user actually dragged.
+    func testWhenReleaseVelocityIsBelowCommitThresholdThenOutcomeIsDecidedByProgress() {
+        let cases: [(progress: CGFloat, velocitySign: CGFloat, expected: BarsAnimator.State)] = [
+            (0.6, 1, .hidden),    // past halfway, released with noise velocity in the "continue" direction
+            (0.6, -1, .hidden),   // ...and in the "reverse" direction: progress wins either way
+            (0.4, 1, .revealed),
+            (0.4, -1, .revealed),
+        ]
+
+        for testCase in cases {
+            let (sut, delegate, clock) = makeFloatingSUT()
+            let scrollView = mockTallScrollView()
+            let travel = BarsAnimator.Metrics.floatingTransitionTravel
+
+            scrollView.contentOffset.y = 0
+            sut.didStartScrolling(in: scrollView)
+            advanceOffset(sut, scrollView, clock, to: travel * testCase.progress)
+            XCTAssertEqual(sut.transitionProgressForTesting, testCase.progress, accuracy: 0.01)
+            XCTAssertEqual(sut.barsState, .transitioning)
+
+            let noiseVelocity = testCase.velocitySign * (BarsAnimator.Metrics.floatingVelocityCommitThreshold - 0.01)
+            sut.didFinishScrolling(in: scrollView, velocity: noiseVelocity)
+
+            XCTAssertEqual(sut.barsState, testCase.expected,
+                          "progress \(testCase.progress), velocity sign \(testCase.velocitySign)")
+            XCTAssertEqual(delegate.receivedMessages.last,
+                          .setBarsVisibility(testCase.expected == .hidden ? 0.0 : 1.0))
+        }
+    }
+
+    func testWhenReleaseVelocityIsAboveCommitThresholdThenDirectionWins() {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+        let travel = BarsAnimator.Metrics.floatingTransitionTravel
+
+        // Only 20% collapsed -- progress alone would reveal -- but a real flick still commits to hiding.
+        scrollView.contentOffset.y = 0
+        sut.didStartScrolling(in: scrollView)
+        sut.didScroll(in: scrollView) // primes lastProgressTimestamp
+        scrollView.contentOffset.y = travel * 0.2
+        clock.advance(by: 1.0)
+        sut.didScroll(in: scrollView)
+        XCTAssertEqual(sut.transitionProgressForTesting, 0.2, accuracy: 0.01)
+
+        sut.didFinishScrolling(in: scrollView, velocity: BarsAnimator.Metrics.floatingVelocityCommitThreshold + 0.1)
+
+        XCTAssertEqual(sut.barsState, .hidden)
+        XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(0.0))
+    }
+
+    // MARK: - Velocity-scaled settle duration
+
+    /// A release right at the commit threshold should feel continuous with a deliberate release: same
+    /// duration as the unscaled default (which the deliberate branch always uses).
+    func testWhenFlickVelocityIsAtTheCommitThresholdThenDurationMatchesTheBase() {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+        let travel = BarsAnimator.Metrics.floatingTransitionTravel
+
+        scrollView.contentOffset.y = 0
+        sut.didStartScrolling(in: scrollView)
+        sut.didScroll(in: scrollView) // primes lastProgressTimestamp
+        scrollView.contentOffset.y = travel * 0.2
+        clock.advance(by: 1.0)
+        sut.didScroll(in: scrollView)
+
+        sut.didFinishScrolling(in: scrollView, velocity: BarsAnimator.Metrics.floatingVelocityCommitThreshold)
+
+        XCTAssertEqual(delegate.lastAnimationDuration ?? -1, CGFloat(delegate.floatingMorphCollapseDuration), accuracy: 0.001)
+    }
+
+    func testWhenFlickVelocityIsAtOrAboveTheReferenceThenDurationIsTheFastestFloor() {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+        let travel = BarsAnimator.Metrics.floatingTransitionTravel
+
+        scrollView.contentOffset.y = 0
+        sut.didStartScrolling(in: scrollView)
+        sut.didScroll(in: scrollView) // primes lastProgressTimestamp
+        scrollView.contentOffset.y = travel * 0.2
+        clock.advance(by: 1.0)
+        sut.didScroll(in: scrollView)
+
+        sut.didFinishScrolling(in: scrollView, velocity: BarsAnimator.Metrics.flickReferenceVelocity + 5)
+
+        XCTAssertEqual(delegate.lastAnimationDuration ?? -1, CGFloat(BarsAnimator.Metrics.flickFastestCollapseDuration), accuracy: 0.001)
+    }
+
+    func testWhenFlickVelocityIsBetweenTheThresholdsThenDurationIsBetweenBaseAndFastest() {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+        let travel = BarsAnimator.Metrics.floatingTransitionTravel
+
+        scrollView.contentOffset.y = 0
+        sut.didStartScrolling(in: scrollView)
+        sut.didScroll(in: scrollView) // primes lastProgressTimestamp
+        scrollView.contentOffset.y = travel * 0.2
+        clock.advance(by: 1.0)
+        sut.didScroll(in: scrollView)
+
+        let midVelocity = (BarsAnimator.Metrics.floatingVelocityCommitThreshold + BarsAnimator.Metrics.flickReferenceVelocity) / 2
+        sut.didFinishScrolling(in: scrollView, velocity: midVelocity)
+
+        let duration = try? XCTUnwrap(delegate.lastAnimationDuration)
+        XCTAssertNotNil(duration)
+        if let duration {
+            XCTAssertLessThan(duration, CGFloat(delegate.floatingMorphCollapseDuration))
+            XCTAssertGreaterThan(duration, CGFloat(BarsAnimator.Metrics.flickFastestCollapseDuration))
+        }
+    }
+
+    func testWhenFasterFlickThenDurationIsShorter() throws {
+        func finishDrag(withVelocity velocity: CGFloat) -> CGFloat? {
+            let (sut, delegate, clock) = makeFloatingSUT()
+            let scrollView = mockTallScrollView()
+            let travel = BarsAnimator.Metrics.floatingTransitionTravel
+
+            scrollView.contentOffset.y = 0
+            sut.didStartScrolling(in: scrollView)
+            sut.didScroll(in: scrollView) // primes lastProgressTimestamp
+            scrollView.contentOffset.y = travel * 0.2
+            clock.advance(by: 1.0)
+            sut.didScroll(in: scrollView)
+
+            sut.didFinishScrolling(in: scrollView, velocity: velocity)
+            return delegate.lastAnimationDuration
+        }
+
+        let slowDuration = try XCTUnwrap(finishDrag(withVelocity: BarsAnimator.Metrics.floatingVelocityCommitThreshold + 0.05))
+        let fastDuration = try XCTUnwrap(finishDrag(withVelocity: BarsAnimator.Metrics.flickReferenceVelocity))
+
+        XCTAssertLessThan(fastDuration, slowDuration, "A firmer flick should settle faster, matching how fast the content was already moving")
+    }
+
+    // MARK: - In-drag reveal (live, unified tracking)
+
+    /// The core fix: reveal tracks live from the very first pixel of upward travel, exactly like
+    /// collapse does -- no hard distance gate before anything visibly happens.
+    func testWhenDraggingUpFromHiddenThenChromeStartsRevealingImmediately() throws {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+        let travel = BarsAnimator.Metrics.floatingTransitionTravel
+
+        sut.hideBars(animated: false)
+        delegate.receivedMessages.removeAll()
+        scrollView.contentOffset.y = 500
+        sut.didStartScrolling(in: scrollView)
+
+        scrollView.contentOffset.y = 500 - (travel * 0.1)
+        clock.advance(by: 1.0 / 60.0)
+        sut.didScroll(in: scrollView)
+
+        let percent = try XCTUnwrap(delegate.receivedMessages.last?.percent)
+        XCTAssertEqual(percent, 0.1, accuracy: 0.01, "10% of the travel back up should show ~10% revealed")
+        XCTAssertEqual(sut.barsState, .transitioning)
+    }
+
+    func testWhenDraggingUpTheFullTravelThenChromeEndsFullyRevealed() {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+        let travel = BarsAnimator.Metrics.floatingTransitionTravel
+
+        sut.hideBars(animated: false)
+        scrollView.contentOffset.y = 500
+        sut.didStartScrolling(in: scrollView)
+
+        scrollView.contentOffset.y = 500 - travel
+        clock.advance(by: 1.0 / 60.0)
+        sut.didScroll(in: scrollView)
+
+        XCTAssertEqual(sut.barsState, .revealed)
+        XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(1.0))
+    }
+
+    /// Regression test for the "continuous gesture, transitions won't happen sometimes" report: with a
+    /// single fixed anchor for the whole drag, reversing direction any number of times within one
+    /// continuous touch must keep tracking live -- not fall through a re-entry guard that compares
+    /// against a start position that's now stale after the first reversal.
+    func testWhenReversingDirectionMultipleTimesWithinOneDragThenTrackingNeverStalls() throws {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+        let travel = BarsAnimator.Metrics.floatingTransitionTravel
+
+        scrollView.contentOffset.y = 0
+        sut.didStartScrolling(in: scrollView)
+
+        // Down (collapsing)... each leg is stepped in small increments (see `advanceOffset`) so the
+        // collapse-direction rate limiter -- tuned for realistic frame deltas, capped per call
+        // regardless of how much wall-clock time a single big jump claims to cover -- never binds.
+        // That cap is separate, already-covered behaviour, not what this test is checking.
+        advanceOffset(sut, scrollView, clock, to: travel * 0.3)
+        XCTAssertEqual(try XCTUnwrap(delegate.receivedMessages.last?.percent), 0.7, accuracy: 0.01)
+
+        // ...up (revealing)...
+        advanceOffset(sut, scrollView, clock, to: travel * 0.1)
+        XCTAssertEqual(try XCTUnwrap(delegate.receivedMessages.last?.percent), 0.9, accuracy: 0.01,
+                      "Must keep tracking after the first reversal, not stall")
+
+        // ...down again (collapsing again)...
+        advanceOffset(sut, scrollView, clock, to: travel * 0.5)
+        XCTAssertEqual(try XCTUnwrap(delegate.receivedMessages.last?.percent), 0.5, accuracy: 0.01,
+                      "Must keep tracking after the second reversal too")
+
+        // ...up again (revealing again), never having lifted the finger.
+        advanceOffset(sut, scrollView, clock, to: 0)
+        XCTAssertEqual(sut.barsState, .revealed)
+        XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(1.0))
+    }
+
+    func testWhenLegacyChromeThenMidPageDragUpFromHiddenDoesNothing() {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        delegate.isFloatingChromeEnabled = false
+        let scrollView = mockTallScrollView()
+
+        sut.hideBars(animated: false)
+        delegate.receivedMessages.removeAll()
+        scrollView.contentOffset.y = 500
+        sut.didStartScrolling(in: scrollView)
+
+        scrollView.contentOffset.y = 0
+        clock.advance(by: 1.0 / 60.0)
+        sut.didScroll(in: scrollView)
+
+        XCTAssertEqual(sut.barsState, .hidden, "Legacy chrome keeps its historical behaviour: only top overscroll reveals")
+        XCTAssertTrue(delegate.receivedMessages.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func scroll<Offsets: Sequence>(_ sut: BarsAnimator,
+                                           _ scrollView: UIScrollView,
+                                           _ clock: TestClock,
+                                           to offsets: Offsets) where Offsets.Element == CGFloat {
+        for offset in offsets {
+            scrollView.contentOffset.y = offset
+            clock.advance(by: BarsAnimator.Metrics.maxRateLimitTimeStep)
+            sut.didScroll(in: scrollView)
+        }
+    }
+
+    /// Steps the offset from its current value to `targetOffset` in small increments, each separated
+    /// by a full `maxRateLimitTimeStep` frame, so the collapse-direction rate limiter (capped at
+    /// `maxCollapseProgressPerSecond * maxRateLimitTimeStep` progress per call, regardless of how much
+    /// wall-clock time a single big jump claims to cover) never binds, and the final progress lands
+    /// exactly on what the offset implies.
+    private func advanceOffset(_ sut: BarsAnimator,
+                               _ scrollView: UIScrollView,
+                               _ clock: TestClock,
+                               to targetOffset: CGFloat,
+                               steps: Int = 20) {
+        let start = scrollView.contentOffset.y
+        for step in 1...steps {
+            scrollView.contentOffset.y = start + (targetOffset - start) * CGFloat(step) / CGFloat(steps)
+            clock.advance(by: BarsAnimator.Metrics.maxRateLimitTimeStep)
+            sut.didScroll(in: scrollView)
+        }
+    }
+}
+
 // MARK: - Helpers
+
+/// Tall enough that `revealedAndScrolling`'s bottom-of-page guard (which reserves
+/// `combinedBarsHeight` for the bottom-bounce gesture) never fires during these tests.
+private func mockTallScrollView() -> UIScrollView {
+    let scrollView = UIScrollView()
+    scrollView.contentSize = .init(width: 300, height: 5000)
+    scrollView.bounds = .init(x: 0, y: 0, width: 300, height: 300)
+
+    return scrollView
+}
+
+private final class TestClock {
+    private(set) var now: CFTimeInterval = 1_000
+
+    func advance(by interval: CFTimeInterval) {
+        now += interval
+    }
+}
+
+private func makeFloatingSUT() -> (sut: BarsAnimator, delegate: BrowserChromeDelegateMock, clock: TestClock) {
+    let clock = TestClock()
+    let sut = BarsAnimator(currentTime: { clock.now })
+    let delegate = BrowserChromeDelegateMock()
+    delegate.isFloatingChromeEnabled = true
+    // Bottom floating address bar metrics: the omnibar is embedded in the toolbar, so its height is
+    // already inside `toolbarHeight`.
+    delegate.toolbarHeight = 128
+    sut.delegate = delegate
+
+    return (sut, delegate, clock)
+}
 
 private func makeSUT() -> (sut: BarsAnimator, delegate: BrowserChromeDelegateMock) {
     let sut = BarsAnimator()
@@ -214,7 +638,10 @@ private class BrowserChromeDelegateMock: BrowserChromeDelegate {
         setBarsHidden(hidden, animated: animated)
     }
 
+    var lastAnimationDuration: CGFloat?
+
     func setBarsVisibility(_ percent: CGFloat, animated: Bool, animationDuration: CGFloat?) {
+        lastAnimationDuration = animationDuration
         setBarsVisibility(percent, animated: animated)
     }
 
@@ -272,6 +699,8 @@ private class BrowserChromeDelegateMock: BrowserChromeDelegate {
     var barsMaxHeight: CGFloat = 0
 
     var isInMinimalChromeLayout: Bool = false
+
+    var isFloatingChromeEnabled: Bool = false
 
     func floatingWebViewBottomObscuredHeight(for barsVisibilityPercent: CGFloat) -> CGFloat { 0 }
 

--- a/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
+++ b/iOS/DuckDuckGoTests/BarsAnimatorTests.swift
@@ -211,23 +211,29 @@ class BarsAnimatorFloatingTests: XCTestCase {
         XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(0.0))
     }
 
-    func testWhenScrollingHalfTheTravelDistanceThenBarsAreHalfVisible() {
+    /// Below `Metrics.floatingSnapCommitDistance` the chrome still tracks the finger live, exactly like
+    /// before -- the commit-and-snap behaviour (covered separately below) only kicks in once a drag
+    /// crosses that distance.
+    func testWhenScrollingBelowTheCommitThresholdThenBarsTrackProportionally() throws {
         let (sut, delegate, clock) = makeFloatingSUT()
         let scrollView = mockTallScrollView()
+        let subThreshold = BarsAnimator.Metrics.floatingSnapCommitDistance / 2
 
         scrollView.contentOffset.y = 0
         sut.didStartScrolling(in: scrollView)
-        scroll(sut, scrollView, clock, to: stride(from: 10.0, through: travel / 2, by: 10.0))
+        scroll(sut, scrollView, clock, to: stride(from: subThreshold / 4, through: subThreshold, by: subThreshold / 4))
 
         XCTAssertEqual(sut.barsState, .transitioning)
-        XCTAssertEqual(try XCTUnwrap(delegate.receivedMessages.last?.percent), 0.5, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(delegate.receivedMessages.last?.percent), 1.0 - (subThreshold / travel), accuracy: 0.001)
     }
 
     /// `combinedBarsHeight` is ~188pt with a bottom address bar but ~122pt with a top one, so gearing off
     /// it would collapse the two positions at different speeds. The travel is absolute precisely to avoid
-    /// that, and this is the regression test for it.
+    /// that, and this is the regression test for it. Kept below the commit threshold so it's still
+    /// exercising live tracking rather than the snap.
     func testWhenBarHeightDiffersThenTravelDistanceIsUnchanged() throws {
         var finalPercents: [CGFloat] = []
+        let subThreshold = BarsAnimator.Metrics.floatingSnapCommitDistance / 2
 
         for toolbarHeight in [CGFloat(128), CGFloat(62)] {
             let (sut, delegate, clock) = makeFloatingSUT()
@@ -236,7 +242,7 @@ class BarsAnimatorFloatingTests: XCTestCase {
 
             scrollView.contentOffset.y = 0
             sut.didStartScrolling(in: scrollView)
-            scroll(sut, scrollView, clock, to: stride(from: 10.0, through: travel / 2, by: 10.0))
+            scroll(sut, scrollView, clock, to: stride(from: subThreshold / 4, through: subThreshold, by: subThreshold / 4))
 
             finalPercents.append(try XCTUnwrap(delegate.receivedMessages.last?.percent))
         }
@@ -245,18 +251,20 @@ class BarsAnimatorFloatingTests: XCTestCase {
     }
 
     /// Holds only while the per-frame scroll stays inside the collapse rate cap — above it the cap
-    /// deliberately throttles, which `testWhenFlickIsFasterThanTheRateCapThenProgressIsLimited` covers.
-    /// Both step sizes divide the half-travel exactly so the runs end on the same offset.
+    /// deliberately throttles, superseded once a drag crosses the commit distance (see
+    /// `testWhenScrollJumpsFarPastTheCommitThresholdInASingleFrameThenChromeSnapsImmediately`). Both step
+    /// sizes divide the sub-threshold distance exactly so the runs end on the same offset.
     func testWhenFrameStepSizeDiffersThenFinalProgressIsUnchanged() throws {
         var finalPercents: [CGFloat] = []
+        let subThreshold = BarsAnimator.Metrics.floatingSnapCommitDistance / 2
 
-        for step in [CGFloat(5), CGFloat(10)] {
+        for step in [CGFloat(2), CGFloat(4)] {
             let (sut, delegate, clock) = makeFloatingSUT()
             let scrollView = mockTallScrollView()
 
             scrollView.contentOffset.y = 0
             sut.didStartScrolling(in: scrollView)
-            scroll(sut, scrollView, clock, to: stride(from: step, through: travel / 2, by: step))
+            scroll(sut, scrollView, clock, to: stride(from: step, through: subThreshold, by: step))
 
             finalPercents.append(try XCTUnwrap(delegate.receivedMessages.last?.percent))
         }
@@ -265,14 +273,16 @@ class BarsAnimatorFloatingTests: XCTestCase {
     }
 
     /// The legacy formula re-seeded from `transitionSpeed * transitionProgress`, so a second drag resumed
-    /// at half the progress it had visually reached.
+    /// at half the progress it had visually reached. Kept below the commit threshold so the drag is still
+    /// live-tracking, not already snapped, when it's interrupted.
     func testWhenDragIsInterruptedThenProgressResumesWhereItLeftOff() throws {
         let (sut, delegate, clock) = makeFloatingSUT()
         let scrollView = mockTallScrollView()
+        let subThreshold = BarsAnimator.Metrics.floatingSnapCommitDistance / 2
 
         scrollView.contentOffset.y = 0
         sut.didStartScrolling(in: scrollView)
-        scroll(sut, scrollView, clock, to: stride(from: 10.0, through: travel / 2, by: 10.0))
+        scroll(sut, scrollView, clock, to: stride(from: subThreshold / 4, through: subThreshold, by: subThreshold / 4))
         let interruptedPercent = try XCTUnwrap(delegate.receivedMessages.last?.percent)
 
         // Lift and start a fresh drag from the same offset.
@@ -303,71 +313,136 @@ class BarsAnimatorFloatingTests: XCTestCase {
         XCTAssertLessThan(percent, 0.1, "1pt of overscroll must not reveal a large slice of the chrome")
     }
 
-    func testWhenFlickIsFasterThanTheRateCapThenProgressIsLimited() throws {
+    /// The core of the "snap once you start scrolling" feature: a drag doesn't need to reach the full
+    /// travel distance, or even a second frame, before the chrome fully commits. This is what stops the
+    /// bar from ever parking at a half-transitioned position if the user holds the scroll steady mid-drag
+    /// without lifting -- by the time they could hold anything, the commit (and its animation) already
+    /// fired.
+    func testWhenScrollJumpsFarPastTheCommitThresholdInASingleFrameThenChromeSnapsImmediately() {
         let (sut, delegate, clock) = makeFloatingSUT()
         let scrollView = mockTallScrollView()
 
         scrollView.contentOffset.y = 0
         sut.didStartScrolling(in: scrollView)
 
-        // Far past the full travel in a single frame — uncapped this would complete instantly.
+        // Far past the commit threshold in a single frame, as a real fast flick would be.
         scrollView.contentOffset.y = 1000
         clock.advance(by: 1.0 / 60.0)
         sut.didScroll(in: scrollView)
 
-        let maxStep = BarsAnimator.Metrics.maxCollapseProgressPerSecond * CGFloat(1.0 / 60.0)
-        let percent = try XCTUnwrap(delegate.receivedMessages.last?.percent)
-        XCTAssertEqual(percent, 1.0 - maxStep, accuracy: 0.001)
-        XCTAssertNotEqual(sut.barsState, .hidden, "A single frame must not complete the collapse")
+        XCTAssertEqual(sut.barsState, .hidden, "Crossing the commit threshold, even within one frame, must snap immediately rather than waiting for release")
+        XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(0.0))
+    }
+
+    /// Symmetric case: revealing from hidden also snaps immediately once the drag crosses the commit
+    /// threshold, without needing `didFinishScrolling` to ever be called.
+    func testWhenScrollJumpsFarPastTheCommitThresholdWhileHiddenThenChromeRevealsImmediately() {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+
+        sut.hideBars(animated: false)
+        delegate.receivedMessages.removeAll()
+        scrollView.contentOffset.y = 500
+        sut.didStartScrolling(in: scrollView)
+
+        scrollView.contentOffset.y = 0
+        clock.advance(by: 1.0 / 60.0)
+        sut.didScroll(in: scrollView)
+
+        XCTAssertEqual(sut.barsState, .revealed)
+        XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(1.0))
+    }
+
+    /// Once committed, holding the scroll steady (no further `didScroll` calls, finger still down) must
+    /// not undo or re-litigate the commit -- this is the exact "held mid-way" scenario the feature exists
+    /// to fix, just expressed as "nothing changes" rather than "something animates," since the commit
+    /// animation itself already ran to completion independent of further scroll events.
+    func testWhenScrollHoldsSteadyAfterCommitThenStateStaysCommitted() {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+        let commit = BarsAnimator.Metrics.floatingSnapCommitDistance
+
+        scrollView.contentOffset.y = 0
+        sut.didStartScrolling(in: scrollView)
+        advanceOffset(sut, scrollView, clock, to: commit + 4)
+        XCTAssertEqual(sut.barsState, .hidden)
+
+        let messageCountAtCommit = delegate.receivedMessages.count
+        clock.advance(by: 1.0 / 60.0)
+        sut.didScroll(in: scrollView) // offset unchanged: finger held steady mid-drag
+
+        XCTAssertEqual(sut.barsState, .hidden)
+        XCTAssertEqual(delegate.receivedMessages.count, messageCountAtCommit, "A held, unmoving scroll must not re-trigger the commit")
+    }
+
+    /// Reversing far enough past the point of commit flips the commitment, and this must keep working
+    /// across any number of reversals within one continuous drag (finger never lifted) -- the scenario
+    /// that used to defeat the legacy re-anchoring formula for live tracking, now replayed against the
+    /// commit/snap model.
+    func testWhenReversingPastTheCommitThresholdMultipleTimesThenFinalStateMatchesLastDirection() {
+        let (sut, delegate, clock) = makeFloatingSUT()
+        let scrollView = mockTallScrollView()
+        let commit = BarsAnimator.Metrics.floatingSnapCommitDistance
+
+        scrollView.contentOffset.y = 0
+        sut.didStartScrolling(in: scrollView)
+
+        // Down past the commit threshold: collapses immediately, without waiting for release.
+        advanceOffset(sut, scrollView, clock, to: commit + 4)
+        XCTAssertEqual(sut.barsState, .hidden)
+        XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(0.0))
+
+        // ...reverse far enough past the commit point to flip to revealing...
+        advanceOffset(sut, scrollView, clock, to: 0)
+        XCTAssertEqual(sut.barsState, .revealed)
+        XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(1.0))
+
+        // ...and back down again, never having lifted the finger.
+        advanceOffset(sut, scrollView, clock, to: commit + 4)
+        XCTAssertEqual(sut.barsState, .hidden)
+        XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(0.0))
     }
 
     // MARK: - Release precision
 
     /// The bug this guards: gating the progress-based decision on `velocity == 0` means a real touch
     /// release (which is essentially never exactly zero) is decided by the sign of noise, not by how
-    /// far the user actually dragged.
-    func testWhenReleaseVelocityIsBelowCommitThresholdThenOutcomeIsDecidedByProgress() {
-        let cases: [(progress: CGFloat, velocitySign: CGFloat, expected: BarsAnimator.State)] = [
-            (0.6, 1, .hidden),    // past halfway, released with noise velocity in the "continue" direction
-            (0.6, -1, .hidden),   // ...and in the "reverse" direction: progress wins either way
-            (0.4, 1, .revealed),
-            (0.4, -1, .revealed),
-        ]
+    /// far the user actually dragged. Now that a real drag commits well before halfway (see the snap
+    /// tests above), a release that's still `.transitioning` can only be at a small progress -- so with
+    /// noise velocity in either direction, it should always reveal.
+    func testWhenReleaseVelocityIsBelowCommitThresholdWhileStillUncommittedThenBarsReveal() {
+        let subThreshold = BarsAnimator.Metrics.floatingSnapCommitDistance / 2
 
-        for testCase in cases {
+        for velocitySign: CGFloat in [1, -1] {
             let (sut, delegate, clock) = makeFloatingSUT()
             let scrollView = mockTallScrollView()
-            let travel = BarsAnimator.Metrics.floatingTransitionTravel
 
             scrollView.contentOffset.y = 0
             sut.didStartScrolling(in: scrollView)
-            advanceOffset(sut, scrollView, clock, to: travel * testCase.progress)
-            XCTAssertEqual(sut.transitionProgressForTesting, testCase.progress, accuracy: 0.01)
+            advanceOffset(sut, scrollView, clock, to: subThreshold)
             XCTAssertEqual(sut.barsState, .transitioning)
 
-            let noiseVelocity = testCase.velocitySign * (BarsAnimator.Metrics.floatingVelocityCommitThreshold - 0.01)
+            let noiseVelocity = velocitySign * (BarsAnimator.Metrics.floatingVelocityCommitThreshold - 0.01)
             sut.didFinishScrolling(in: scrollView, velocity: noiseVelocity)
 
-            XCTAssertEqual(sut.barsState, testCase.expected,
-                          "progress \(testCase.progress), velocity sign \(testCase.velocitySign)")
-            XCTAssertEqual(delegate.receivedMessages.last,
-                          .setBarsVisibility(testCase.expected == .hidden ? 0.0 : 1.0))
+            XCTAssertEqual(sut.barsState, .revealed, "velocity sign \(velocitySign)")
+            XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(1.0))
         }
     }
 
     func testWhenReleaseVelocityIsAboveCommitThresholdThenDirectionWins() {
         let (sut, delegate, clock) = makeFloatingSUT()
         let scrollView = mockTallScrollView()
-        let travel = BarsAnimator.Metrics.floatingTransitionTravel
+        let subThreshold = BarsAnimator.Metrics.floatingSnapCommitDistance / 2
 
-        // Only 20% collapsed -- progress alone would reveal -- but a real flick still commits to hiding.
+        // Only a small fraction collapsed -- progress alone would reveal -- but a real flick still commits to hiding.
         scrollView.contentOffset.y = 0
         sut.didStartScrolling(in: scrollView)
         sut.didScroll(in: scrollView) // primes lastProgressTimestamp
-        scrollView.contentOffset.y = travel * 0.2
+        scrollView.contentOffset.y = subThreshold
         clock.advance(by: 1.0)
         sut.didScroll(in: scrollView)
-        XCTAssertEqual(sut.transitionProgressForTesting, 0.2, accuracy: 0.01)
+        XCTAssertEqual(sut.barsState, .transitioning, "Must still be below the commit threshold for this test to be meaningful")
 
         sut.didFinishScrolling(in: scrollView, velocity: BarsAnimator.Metrics.floatingVelocityCommitThreshold + 0.1)
 
@@ -382,12 +457,12 @@ class BarsAnimatorFloatingTests: XCTestCase {
     func testWhenFlickVelocityIsAtTheCommitThresholdThenDurationMatchesTheBase() {
         let (sut, delegate, clock) = makeFloatingSUT()
         let scrollView = mockTallScrollView()
-        let travel = BarsAnimator.Metrics.floatingTransitionTravel
+        let subThreshold = BarsAnimator.Metrics.floatingSnapCommitDistance / 2
 
         scrollView.contentOffset.y = 0
         sut.didStartScrolling(in: scrollView)
         sut.didScroll(in: scrollView) // primes lastProgressTimestamp
-        scrollView.contentOffset.y = travel * 0.2
+        scrollView.contentOffset.y = subThreshold
         clock.advance(by: 1.0)
         sut.didScroll(in: scrollView)
 
@@ -399,12 +474,12 @@ class BarsAnimatorFloatingTests: XCTestCase {
     func testWhenFlickVelocityIsAtOrAboveTheReferenceThenDurationIsTheFastestFloor() {
         let (sut, delegate, clock) = makeFloatingSUT()
         let scrollView = mockTallScrollView()
-        let travel = BarsAnimator.Metrics.floatingTransitionTravel
+        let subThreshold = BarsAnimator.Metrics.floatingSnapCommitDistance / 2
 
         scrollView.contentOffset.y = 0
         sut.didStartScrolling(in: scrollView)
         sut.didScroll(in: scrollView) // primes lastProgressTimestamp
-        scrollView.contentOffset.y = travel * 0.2
+        scrollView.contentOffset.y = subThreshold
         clock.advance(by: 1.0)
         sut.didScroll(in: scrollView)
 
@@ -416,12 +491,12 @@ class BarsAnimatorFloatingTests: XCTestCase {
     func testWhenFlickVelocityIsBetweenTheThresholdsThenDurationIsBetweenBaseAndFastest() {
         let (sut, delegate, clock) = makeFloatingSUT()
         let scrollView = mockTallScrollView()
-        let travel = BarsAnimator.Metrics.floatingTransitionTravel
+        let subThreshold = BarsAnimator.Metrics.floatingSnapCommitDistance / 2
 
         scrollView.contentOffset.y = 0
         sut.didStartScrolling(in: scrollView)
         sut.didScroll(in: scrollView) // primes lastProgressTimestamp
-        scrollView.contentOffset.y = travel * 0.2
+        scrollView.contentOffset.y = subThreshold
         clock.advance(by: 1.0)
         sut.didScroll(in: scrollView)
 
@@ -440,12 +515,12 @@ class BarsAnimatorFloatingTests: XCTestCase {
         func finishDrag(withVelocity velocity: CGFloat) -> CGFloat? {
             let (sut, delegate, clock) = makeFloatingSUT()
             let scrollView = mockTallScrollView()
-            let travel = BarsAnimator.Metrics.floatingTransitionTravel
+            let subThreshold = BarsAnimator.Metrics.floatingSnapCommitDistance / 2
 
             scrollView.contentOffset.y = 0
             sut.didStartScrolling(in: scrollView)
             sut.didScroll(in: scrollView) // primes lastProgressTimestamp
-            scrollView.contentOffset.y = travel * 0.2
+            scrollView.contentOffset.y = subThreshold
             clock.advance(by: 1.0)
             sut.didScroll(in: scrollView)
 
@@ -500,38 +575,29 @@ class BarsAnimatorFloatingTests: XCTestCase {
     }
 
     /// Regression test for the "continuous gesture, transitions won't happen sometimes" report: with a
-    /// single fixed anchor for the whole drag, reversing direction any number of times within one
-    /// continuous touch must keep tracking live -- not fall through a re-entry guard that compares
-    /// against a start position that's now stale after the first reversal.
-    func testWhenReversingDirectionMultipleTimesWithinOneDragThenTrackingNeverStalls() throws {
+    /// single fixed anchor for the whole drag, reversing direction within one continuous touch must keep
+    /// tracking live below the commit threshold -- not fall through a re-entry guard that compares against
+    /// a start position that's now stale after the first reversal. (Reversal *after* commit is covered by
+    /// `testWhenReversingPastTheCommitThresholdMultipleTimesThenFinalStateMatchesLastDirection` above.)
+    func testWhenReversingDirectionBelowTheCommitThresholdThenTrackingNeverStalls() throws {
         let (sut, delegate, clock) = makeFloatingSUT()
         let scrollView = mockTallScrollView()
-        let travel = BarsAnimator.Metrics.floatingTransitionTravel
+        let subThreshold = BarsAnimator.Metrics.floatingSnapCommitDistance / 2
 
         scrollView.contentOffset.y = 0
         sut.didStartScrolling(in: scrollView)
 
-        // Down (collapsing)... each leg is stepped in small increments (see `advanceOffset`) so the
-        // collapse-direction rate limiter -- tuned for realistic frame deltas, capped per call
-        // regardless of how much wall-clock time a single big jump claims to cover -- never binds.
-        // That cap is separate, already-covered behaviour, not what this test is checking.
-        advanceOffset(sut, scrollView, clock, to: travel * 0.3)
-        XCTAssertEqual(try XCTUnwrap(delegate.receivedMessages.last?.percent), 0.7, accuracy: 0.01)
+        // Down (collapsing)...
+        advanceOffset(sut, scrollView, clock, to: subThreshold)
+        XCTAssertEqual(sut.barsState, .transitioning)
+        let collapsingPercent = try XCTUnwrap(delegate.receivedMessages.last?.percent)
 
-        // ...up (revealing)...
-        advanceOffset(sut, scrollView, clock, to: travel * 0.1)
-        XCTAssertEqual(try XCTUnwrap(delegate.receivedMessages.last?.percent), 0.9, accuracy: 0.01,
-                      "Must keep tracking after the first reversal, not stall")
+        // ...up (revealing), never having lifted the finger.
+        advanceOffset(sut, scrollView, clock, to: subThreshold / 4)
+        let revealingPercent = try XCTUnwrap(delegate.receivedMessages.last?.percent)
 
-        // ...down again (collapsing again)...
-        advanceOffset(sut, scrollView, clock, to: travel * 0.5)
-        XCTAssertEqual(try XCTUnwrap(delegate.receivedMessages.last?.percent), 0.5, accuracy: 0.01,
-                      "Must keep tracking after the second reversal too")
-
-        // ...up again (revealing again), never having lifted the finger.
-        advanceOffset(sut, scrollView, clock, to: 0)
-        XCTAssertEqual(sut.barsState, .revealed)
-        XCTAssertEqual(delegate.receivedMessages.last, .setBarsVisibility(1.0))
+        XCTAssertGreaterThan(revealingPercent, collapsingPercent, "Must keep tracking after the reversal, not stall")
+        XCTAssertEqual(sut.barsState, .transitioning)
     }
 
     func testWhenLegacyChromeThenMidPageDragUpFromHiddenDoesNothing() {

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -1,0 +1,136 @@
+//
+//  BrowserToolbarViewTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import DuckDuckGo
+
+/// Covers `setButtonRowCollapseProgress`, the button-fade/shrink stage of the scroll-coupled chrome
+/// collapse, and the corresponding fix to `restingCapsuleFrame` (which must report a stable single-row
+/// height rather than the live, mid-animation panel height).
+final class BrowserToolbarViewTests: XCTestCase {
+
+    private let omnibarHeight: CGFloat = 60
+
+    private func makeSUT(floating: Bool = true, embeddedOmnibar: Bool = true) -> BrowserToolbarView {
+        let toolbar = BrowserToolbarView(frame: CGRect(x: 0, y: 0, width: 390, height: 200))
+        toolbar.setFloatingStyleEnabled(floating)
+        if embeddedOmnibar {
+            toolbar.setOmnibarView(UIView(), height: omnibarHeight)
+        }
+        toolbar.layoutIfNeeded()
+        return toolbar
+    }
+
+    func testWhenProgressIsZeroThenButtonRowIsFullyShownAtFullHeight() {
+        let sut = makeSUT()
+        let fullHeight = BrowserToolbarView.totalHeight(withOmnibarHeight: omnibarHeight, isFloating: true)
+
+        let height = sut.setButtonRowCollapseProgress(0, reduceMotion: false)
+
+        XCTAssertEqual(height, fullHeight, accuracy: 0.01)
+        XCTAssertEqual(sut.panelHeightForTesting, fullHeight, accuracy: 0.01)
+        XCTAssertEqual(sut.buttonRowAlphaForTesting, 1, accuracy: 0.001)
+        XCTAssertTrue(sut.buttonRowTransformForTesting.isIdentity)
+    }
+
+    func testWhenProgressIsOneThenButtonRowIsGoneAtSingleRowHeight() {
+        let sut = makeSUT()
+        let singleRowHeight = BrowserToolbarView.singleRowHeight(withOmnibarHeight: omnibarHeight)
+
+        let height = sut.setButtonRowCollapseProgress(1, reduceMotion: false)
+
+        XCTAssertEqual(height, singleRowHeight, accuracy: 0.01)
+        XCTAssertEqual(sut.buttonRowAlphaForTesting, 0, accuracy: 0.001)
+        XCTAssertFalse(sut.buttonRowTransformForTesting.isIdentity, "Should have scaled/translated away, not just faded")
+    }
+
+    func testWhenProgressIsHalfThenHeightIsBetweenFullAndSingleRow() {
+        let sut = makeSUT()
+        let fullHeight = BrowserToolbarView.totalHeight(withOmnibarHeight: omnibarHeight, isFloating: true)
+        let singleRowHeight = BrowserToolbarView.singleRowHeight(withOmnibarHeight: omnibarHeight)
+
+        let height = sut.setButtonRowCollapseProgress(0.5, reduceMotion: false)
+
+        XCTAssertEqual(height, (fullHeight + singleRowHeight) / 2, accuracy: 0.01)
+        XCTAssertEqual(sut.buttonRowAlphaForTesting, 0.5, accuracy: 0.001)
+    }
+
+    func testWhenReduceMotionThenProgressIsIgnoredAndButtonRowStaysFullyShown() {
+        let sut = makeSUT()
+        let fullHeight = BrowserToolbarView.totalHeight(withOmnibarHeight: omnibarHeight, isFloating: true)
+
+        let height = sut.setButtonRowCollapseProgress(1, reduceMotion: true)
+
+        XCTAssertEqual(height, fullHeight, accuracy: 0.01)
+        XCTAssertEqual(sut.buttonRowAlphaForTesting, 1, accuracy: 0.001)
+        XCTAssertTrue(sut.buttonRowTransformForTesting.isIdentity)
+    }
+
+    func testWhenNoEmbeddedOmnibarThenProgressIsANoOp() {
+        let sut = makeSUT(embeddedOmnibar: false)
+        let buttonsOnlyHeight = BrowserToolbarView.totalHeight(withOmnibarHeight: 0, isFloating: true)
+
+        let height = sut.setButtonRowCollapseProgress(1, reduceMotion: false)
+
+        XCTAssertEqual(height, buttonsOnlyHeight, accuracy: 0.01)
+        XCTAssertEqual(sut.buttonRowAlphaForTesting, 1, accuracy: 0.001)
+    }
+
+    func testWhenNotFloatingThenProgressIsANoOp() {
+        let sut = makeSUT(floating: false)
+        let legacyFullHeight = BrowserToolbarView.totalHeight(withOmnibarHeight: omnibarHeight, isFloating: false)
+
+        let height = sut.setButtonRowCollapseProgress(1, reduceMotion: false)
+
+        XCTAssertEqual(height, legacyFullHeight, accuracy: 0.01)
+        XCTAssertEqual(sut.buttonRowAlphaForTesting, 1, accuracy: 0.001)
+    }
+
+    // MARK: - restingCapsuleFrame stability
+
+    /// The regression this guards: the pill's morph target used to read the live, animating
+    /// `buttonsHeightConstraint.constant` directly, so as the button row shrank the pill's own target
+    /// moved under it -- a feedback loop. It must report the stable single-row height throughout.
+    func testWhenButtonRowIsMidCollapseThenRestingCapsuleFrameStillReportsSingleRowHeight() {
+        let sut = makeSUT()
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        container.addSubview(sut)
+        let singleRowHeight = BrowserToolbarView.singleRowHeight(withOmnibarHeight: omnibarHeight)
+
+        _ = sut.setButtonRowCollapseProgress(0, reduceMotion: false)
+        let heightAtStart = sut.restingCapsuleFrame(in: container).height
+
+        _ = sut.setButtonRowCollapseProgress(0.3, reduceMotion: false)
+        let heightMidCollapse = sut.restingCapsuleFrame(in: container).height
+
+        XCTAssertEqual(heightAtStart, singleRowHeight, accuracy: 0.01)
+        XCTAssertEqual(heightMidCollapse, singleRowHeight, accuracy: 0.01,
+                       "restingCapsuleFrame must not track the live, mid-animation panel height")
+    }
+
+    func testWhenNoEmbeddedOmnibarThenRestingCapsuleFrameUsesTheLiveButtonsOnlyHeight() {
+        let sut = makeSUT(embeddedOmnibar: false)
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        container.addSubview(sut)
+
+        let height = sut.restingCapsuleFrame(in: container).height
+
+        XCTAssertEqual(height, BrowserToolbarView.floatingButtonsHeight, accuracy: 0.01)
+    }
+}

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -750,3 +750,63 @@ final class FloatingOmnibarSwipeGeometryTests: XCTestCase {
         XCTAssertNil(incomingView.superview)
     }
 }
+
+final class ChromeMorphAnimatorCurveTests: XCTestCase {
+
+    private let expandCurve = MainViewController.ChromeAnimationConstants.morphExpandCurve
+    private let collapseCurve = MainViewController.ChromeAnimationConstants.morphCollapseCurve
+
+    func testWhenCurveIsSmoothstepThenItEasesInAndOutSymmetrically() {
+        let curve = ChromeMorphAnimator.Curve.smoothstep
+
+        XCTAssertEqual(curve.value(at: 0), 0, accuracy: 0.0001)
+        XCTAssertEqual(curve.value(at: 0.5), 0.5, accuracy: 0.0001)
+        XCTAssertEqual(curve.value(at: 1), 1, accuracy: 0.0001)
+    }
+
+    func testWhenCurveIsEaseOutCubicThenItStartsFastAndDecelerates() {
+        let curve = ChromeMorphAnimator.Curve.easeOutCubic
+
+        XCTAssertEqual(curve.value(at: 0), 0, accuracy: 0.0001)
+        XCTAssertEqual(curve.value(at: 0.5), 0.875, accuracy: 0.0001)
+        XCTAssertEqual(curve.value(at: 1), 1, accuracy: 0.0001)
+        // The defining property for a released fling: most of the distance is covered early.
+        XCTAssertGreaterThan(curve.value(at: 0.25), 0.5)
+    }
+
+    func testWhenCollapsingThenTheCurveNeverOvershoots() {
+        for step in 0...100 {
+            let value = collapseCurve.value(at: CGFloat(step) / 100)
+            XCTAssertLessThanOrEqual(value, 1.0, "Collapse must not overshoot at t = \(CGFloat(step) / 100)")
+        }
+    }
+
+    /// The scrubber snaps to the target when normalized time reaches 1, so whatever the spring hasn't
+    /// settled by then becomes a visible jump. At the shipped parameters the residual is ~0.0007.
+    func testWhenExpandingThenTheSpringSettlesByTheEndOfItsDuration() {
+        XCTAssertEqual(expandCurve.value(at: 0), 0, accuracy: 0.0001)
+        XCTAssertEqual(expandCurve.value(at: 1),
+                       1,
+                       accuracy: 0.001,
+                       "Residual at the cutoff becomes a snap. Raise naturalFrequency or the damping ratio.")
+    }
+
+    func testWhenExpandingThenOvershootStaysBelowOnePointFivePercent() {
+        var peak: CGFloat = 0
+        for step in 0...200 {
+            peak = max(peak, expandCurve.value(at: CGFloat(step) / 200))
+        }
+
+        XCTAssertGreaterThan(peak, 1.0, "A lightly damped spring is expected to overshoot slightly")
+        XCTAssertLessThan(peak, 1.015, "Overshoot on a bar that clips the screen edge reads as a glitch")
+    }
+
+    func testWhenSpringIsCriticallyDampedThenItNeverOvershoots() {
+        let curve = ChromeMorphAnimator.Curve.spring(dampingRatio: 1, naturalFrequency: 8.84)
+
+        for step in 0...100 {
+            XCTAssertLessThanOrEqual(curve.value(at: CGFloat(step) / 100), 1.0)
+        }
+        XCTAssertEqual(curve.value(at: 1), 1, accuracy: 0.01)
+    }
+}


### PR DESCRIPTION
## Summary

Retunes the floating UI (`floatingUIAugust2026`) chrome transitions to match iOS 26 Safari's feel, closing out the four transition defects from design review.

Parent: https://app.asana.com/1/137249556945/project/1214749231578703/task/1217585393696103

- **Address bar ↔ capsule on scroll** — https://app.asana.com/1/137249556945/project/1216033800174503/task/1216033900628678
  Retuned the collapse distance/gearing to match Safari (was collapsing over ~3x the scroll distance), fixed a 50% visibility pop when revealing from hidden, switched the release settle to velocity-scaled ease-out/spring curves, and unified the scroll-tracking state machine so continuous-gesture reversals no longer get stuck. Also fixed the standalone (top address bar) button-only toolbar, which previously just snapped away on scroll instead of collapsing gently.

- **Bottom address bar ↔ tab manager** — https://app.asana.com/1/137249556945/project/1216033800174503/task/1216771102562072
  The floating toolbar wasn't part of this transition at all — it just sat at full size until the tab switcher's own view opaquely covered it, reading as a sudden pop. It now shrinks/grows via a snapshot animated in step with the page screenshot (matching how Safari shrinks the whole page as one unit), instead of fading the live toolbar view, which was racing against the tab switcher's own concurrent fade and vanishing early.

- **Single input (UTI) ↔ bottom address bar rest state** — https://app.asana.com/1/137249556945/project/1203862345894171/task/1217377463409084
  Quartered the transition duration so it doesn't feel sluggish next to the now-snappy floating chrome, added a scale/fade-from-bottom-centre for the content on focus (mirrored exactly in reverse on defocus), fixed the expanded card's horizontal inset (was 8pt vs. the toolbar's resting 16pt), and fixed the toolbar growing back to full height/reabsorbing the omnibar as part of the animation instead of an unanimated snap afterward (it was previously being left in the wrong container).

- **UTI ↔ top address bar** — https://app.asana.com/1/137249556945/project/1203862345894171/task/1217412398607929
  Covered by the same duration-quartering fix above (gated on floating UI only — non-floating behaviour is unchanged in all cases).

## Test plan
- [x] Manual pass on simulator for both top and bottom address bar positions: scroll collapse/reveal, tap-to-focus and defocus, and opening/closing the tab switcher — recorded and compared frame-by-frame against Safari
- [x] `BarsAnimatorTests` / `FloatingUITests` pass
- [ ] Design review sign-off on the four linked tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, user-visible animation and scroll-gesture changes across main browser chrome, gated on floating UI but touching core scroll handling and multiple coordinated transitions; regression risk is moderate rather than critical.
> 
> **Overview**
> Retunes **floating UI** scroll, focus, and tab-switcher motion so it feels closer to iOS 26 Safari, while **legacy chrome paths stay unchanged** behind `isFloatingChromeEnabled`.
> 
> **Scroll collapse/reveal** — `BarsAnimator` adds a floating-only path: ~80pt absolute travel, collapse rate limiting, snap-after-16pt drag, velocity-scaled settle (ease-out/spring), and bidirectional tracking from a fixed drag anchor. `BrowserToolbarView` fades/shrinks the button row (or scales the standalone capsule); `MainViewController` stages that against a lower capsule handoff (`handoffStart` 0.60), asymmetric morph durations/curves via `ChromeMorphAnimator.Curve`, and defers toolbar slide until after the button-row stage.
> 
> **Tab switcher** — `WebViewTransition` snapshots the floating toolbar and scales/fades it with the page preview (skips legacy omnibar frame compensation for floating). **UTI ↔ address bar** — shorter floating-only transition durations, scale-from-bottom on UTI content, 16pt expanded card margins aligned with the toolbar, animated toolbar height detach/reattach in `MainViewController` / `MainViewCoordinator`, and icon crossfade on dismiss.
> 
> **Capsule** — `FloatingDomainCapsuleController` reapplies glass once real geometry exists. Tests cover floating `BarsAnimator`, toolbar collapse progress, and morph curves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba3de7ab188083722fe132529494270c26c322a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->