### PR TITLE
[macOS] Strip invisible format characters from address bar and Duck.ai omnibar

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -378,9 +378,10 @@ final class AIChatOmnibarController {
         // Toggling Duck.ai → search runs `cleanup()` (zeroing `currentText`, `activeToolMode`, the attachments view),
         // but the tab's shared state still holds the draft; without re-sync, toggling back would show an empty panel.
         if let draftStore {
-            if draftStore.hasUserInteractedWithText, currentText != draftStore.text {
+            let restoredText = Self.sanitizedPromptText(draftStore.text)
+            if draftStore.hasUserInteractedWithText, currentText != restoredText {
                 isUpdatingFromSharedState = true
-                currentText = draftStore.text
+                currentText = restoredText
                 isUpdatingFromSharedState = false
             }
             if activeToolMode != draftStore.aiChatToolMode {
@@ -830,10 +831,16 @@ final class AIChatOmnibarController {
     /// Updates the current text being typed by the user
     /// - Parameter text: The new text value
     func updateText(_ text: String) {
-        currentText = text
+        let sanitized = Self.sanitizedPromptText(text)
+        currentText = sanitized
         if !isUpdatingFromSharedState {
-            draftStore?.updateText(text, markInteraction: true)
+            draftStore?.updateText(sanitized, markInteraction: true)
         }
+    }
+
+    /// Invisible / format characters must never reach the prompt field (they render as tofu).
+    static func sanitizedPromptText(_ text: String) -> String {
+        text.removingInvisibleFormatCharacters()
     }
 
     /// Persists the prompt text view's cursor position / selection to the current tab's shared state so it
@@ -1143,7 +1150,7 @@ final class AIChatOmnibarController {
                 /// `$activeToolMode` sink writing the restored value straight back to the store.
                 self.isUpdatingFromSharedState = true
                 if let text = store?.text {
-                    self.currentText = text
+                    self.currentText = Self.sanitizedPromptText(text)
                 }
                 self.activeToolMode = store?.aiChatToolMode
                 self.isUpdatingFromSharedState = false
@@ -1172,9 +1179,10 @@ final class AIChatOmnibarController {
         draftStoreCancellable = draftStore.textPublisher
             .sink { [weak self] newText in
                 guard let self = self else { return }
-                if self.currentText != newText && draftStore.hasUserInteractedWithText {
+                let sanitized = Self.sanitizedPromptText(newText)
+                if self.currentText != sanitized && draftStore.hasUserInteractedWithText {
                     self.isUpdatingFromSharedState = true
-                    self.currentText = newText
+                    self.currentText = sanitized
                     self.isUpdatingFromSharedState = false
                 }
             }

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarTextContainerViewController.swift
@@ -619,7 +619,8 @@ final class AIChatOmnibarTextContainerViewController: NSViewController, ThemeUpd
     }
 
     func insertNewlineIfHasContent(addressBarText: String) {
-        guard !addressBarText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        let sanitized = addressBarText.removingInvisibleFormatCharacters()
+        guard !sanitized.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return
         }
         insertNewline()
@@ -799,6 +800,32 @@ private final class FocusableTextView: NSTextView {
 
     override var acceptsFirstResponder: Bool {
         return true
+    }
+
+    /// Drop invisible / format characters before they hit the text storage — they render as tofu.
+    override func insertText(_ string: Any, replacementRange: NSRange) {
+        guard let text = string as? String else {
+            super.insertText(string, replacementRange: replacementRange)
+            return
+        }
+        let filtered = text.removingInvisibleFormatCharacters()
+        if filtered.isEmpty {
+            // Swallow invisible-only input so it never appears as a black box.
+            return
+        }
+        super.insertText(filtered, replacementRange: replacementRange)
+    }
+
+    override func paste(_ sender: Any?) {
+        guard let pasted = NSPasteboard.general.string(forType: .string) else {
+            super.paste(sender)
+            return
+        }
+        let filtered = pasted.removingInvisibleFormatCharacters()
+        let range = selectedRange()
+        guard shouldChangeText(in: range, replacementString: filtered) else { return }
+        replaceCharacters(in: range, with: filtered)
+        didChangeText()
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/macOS/DuckDuckGo/Common/Extensions/StringExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/StringExtension.swift
@@ -76,6 +76,24 @@ extension String {
         self.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    /// Strips characters that render as tofu / are invisible in the Duck.ai prompt field.
+    ///
+    /// Removes Unicode default-ignorable code points (ZWSP, ZWNJ, ZWJ, WJ, BOM, soft hyphen, …)
+    /// and C0/C1 controls other than tab/newline/carriage-return (kept for multiline prompts).
+    func removingInvisibleFormatCharacters() -> String {
+        String(unicodeScalars.filter { scalar in
+            switch scalar {
+            case "\t", "\n", "\r":
+                return true
+            default:
+                if CharacterSet.controlCharacters.contains(scalar) {
+                    return false
+                }
+                return !scalar.properties.isDefaultIgnorableCodePoint
+            }
+        })
+    }
+
     // MARK: - URL
 
     var url: URL? {

--- a/macOS/DuckDuckGo/Common/Extensions/StringExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/StringExtension.swift
@@ -76,22 +76,107 @@ extension String {
         self.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    /// Strips characters that render as tofu / are invisible in the Duck.ai prompt field.
+    /// Strips invisible / tofu-prone format characters while preserving emoji ZWJ
+    /// sequences, emoji variation selectors, and Arabic/Persian ZWNJ/ZWJ shaping.
     ///
-    /// Removes Unicode default-ignorable code points (ZWSP, ZWNJ, ZWJ, WJ, BOM, soft hyphen, …)
-    /// and C0/C1 controls other than tab/newline/carriage-return (kept for multiline prompts).
+    /// Always removes Tags, ZWSP, WJ, soft hyphen, BOM, and C0/C1 controls other than
+    /// tab/newline/carriage-return. Conditionally keeps ZWNJ/ZWJ/VS only when not
+    /// adjacent to Latin (anti-smuggling) and needed for Arabic script or emoji.
     func removingInvisibleFormatCharacters() -> String {
-        String(unicodeScalars.filter { scalar in
+        let scalars = Array(unicodeScalars)
+        var kept: [Unicode.Scalar] = []
+        kept.reserveCapacity(scalars.count)
+
+        for index in scalars.indices {
+            let scalar = scalars[index]
+
             switch scalar {
             case "\t", "\n", "\r":
-                return true
+                kept.append(scalar)
+                continue
             default:
-                if CharacterSet.controlCharacters.contains(scalar) {
-                    return false
-                }
-                return !scalar.properties.isDefaultIgnorableCodePoint
+                break
             }
-        })
+
+            if CharacterSet.controlCharacters.contains(scalar) {
+                continue
+            }
+
+            if !scalar.properties.isDefaultIgnorableCodePoint {
+                kept.append(scalar)
+                continue
+            }
+
+            let value = scalar.value
+            let isJoiner = value == 0x200C || value == 0x200D
+            let isVariationSelector = value >= 0xFE00 && value <= 0xFE0F
+            guard isJoiner || isVariationSelector else { continue }
+
+            if Self.shouldKeepConditionalIgnorable(at: index, in: scalars) {
+                kept.append(scalar)
+            }
+        }
+
+        return String(String.UnicodeScalarView(kept))
+    }
+
+    private static func shouldKeepConditionalIgnorable(at index: Int, in scalars: [Unicode.Scalar]) -> Bool {
+        let scalar = scalars[index]
+        let value = scalar.value
+        let isJoiner = value == 0x200C || value == 0x200D
+        let isVariationSelector = value >= 0xFE00 && value <= 0xFE0F
+
+        let prev = findScriptNeighbor(in: scalars, from: index, direction: -1)
+        let next = findScriptNeighbor(in: scalars, from: index, direction: 1)
+
+        if isLatinScript(prev) || isLatinScript(next) {
+            return false
+        }
+
+        if isJoiner && (isArabicScript(prev) || isArabicScript(next)) {
+            return true
+        }
+
+        if (isJoiner || isVariationSelector) && (isEmojiRelated(prev) || isEmojiRelated(next)) {
+            return true
+        }
+
+        return false
+    }
+
+    private static func findScriptNeighbor(in scalars: [Unicode.Scalar], from index: Int, direction: Int) -> Unicode.Scalar? {
+        var j = index + direction
+        while j >= 0 && j < scalars.count {
+            let value = scalars[j].value
+            let isJoiner = value == 0x200C || value == 0x200D
+            let isVariationSelector = value >= 0xFE00 && value <= 0xFE0F
+            if isJoiner || isVariationSelector {
+                j += direction
+                continue
+            }
+            return scalars[j]
+        }
+        return nil
+    }
+
+    private static func isLatinScript(_ scalar: Unicode.Scalar?) -> Bool {
+        guard let scalar else { return false }
+        return String(scalar).range(of: #"\p{Script=Latin}"#, options: .regularExpression) != nil
+    }
+
+    private static func isArabicScript(_ scalar: Unicode.Scalar?) -> Bool {
+        guard let scalar else { return false }
+        return String(scalar).range(of: #"\p{Script=Arabic}"#, options: .regularExpression) != nil
+    }
+
+    private static func isEmojiRelated(_ scalar: Unicode.Scalar?) -> Bool {
+        guard let scalar else { return false }
+        let value = scalar.value
+        if value == 0x200C || value == 0x200D { return true }
+        if value >= 0xFE00 && value <= 0xFE0F { return true }
+        if value >= 0x1F3FB && value <= 0x1F3FF { return true }
+        if scalar.properties.isEmoji { return true }
+        return String(scalar).range(of: #"\p{Extended_Pictographic}"#, options: .regularExpression) != nil
     }
 
     // MARK: - URL

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextEditor.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextEditor.swift
@@ -166,7 +166,13 @@ final class AddressBarTextEditor: NSTextView {
     override func paste(_ sender: Any?) {
         // Fixes an issue when url-name instead of url is pasted
         if let url = NSPasteboard.general.url {
-            super.pasteAsPlainText(url.absoluteString)
+            let filtered = url.absoluteString.removingInvisibleFormatCharacters()
+            guard !filtered.isEmpty else { return }
+            super.pasteAsPlainText(filtered)
+        } else if let pasted = NSPasteboard.general.string(forType: .string) {
+            let filtered = pasted.removingInvisibleFormatCharacters()
+            guard !filtered.isEmpty else { return }
+            super.pasteAsPlainText(filtered)
         } else {
             super.paste(sender)
         }
@@ -196,10 +202,14 @@ final class AddressBarTextEditor: NSTextView {
             super.insertText(string, replacementRange: replacementRange)
             return
         }
-        breakUndoCoalescingIfNeeded(for: InputType(string))
+        // Drop default-ignorables / controls before they hit the field (render as tofu).
+        let filtered = string.removingInvisibleFormatCharacters()
+        guard !filtered.isEmpty else { return }
 
-        addressBar.textView(self, userTypedString: string, at: replacementRange.location == NSNotFound ? self.selectedRange() : replacementRange) {
-            super.insertText(string, replacementRange: replacementRange)
+        breakUndoCoalescingIfNeeded(for: InputType(filtered))
+
+        addressBar.textView(self, userTypedString: filtered, at: replacementRange.location == NSNotFound ? self.selectedRange() : replacementRange) {
+            super.insertText(filtered, replacementRange: replacementRange)
         }
     }
 

--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarTextField.swift
@@ -987,6 +987,8 @@ extension AddressBarTextField {
         case suggestion(_ suggestionViewModel: SuggestionViewModel)
 
         init(stringValue: String, userTyped: Bool, isSearch: Bool = false) {
+            // Keep the address-bar UI free of tofu / invisible format characters (Tags, ZW*, …).
+            let stringValue = stringValue.removingInvisibleFormatCharacters()
 
             let url: URL? = {
                 let shouldUseUnifiedLogic = Application.appDelegate.featureFlagger.isFeatureOn(.unifiedURLPredictor)

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -234,6 +234,24 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         XCTAssertFalse(mockTabOpener.openAIChatTabCalled)
     }
 
+    func testWhenInvisibleFormatOnlyIsSubmitted_ThenNothingHappens() {
+        // ZWNJ/ZWJ/BOM render as tofu and must not count as prompt content.
+        controller.updateText("\u{200C}\u{200D}\u{FEFF}\u{2060}")
+
+        controller.submit()
+
+        XCTAssertEqual(controller.currentText, "")
+        XCTAssertFalse(mockDelegate.didSubmitCalled)
+        XCTAssertFalse(mockDelegate.didRequestNavigationToURLCalled)
+        XCTAssertFalse(mockTabOpener.openAIChatTabCalled)
+    }
+
+    func testWhenTextContainsInvisibleFormatCharacters_ThenTheyAreStrippedOnUpdate() {
+        controller.updateText("hello\u{200B} world\u{200C}")
+
+        XCTAssertEqual(controller.currentText, "hello world")
+    }
+
     func testWhenTextWithLeadingWhitespaceIsSubmitted_ThenItIsTrimmed() {
         // Given
         controller.updateText("  apple.com  ")

--- a/macOS/UnitTests/Common/Extensions/StringExtensionTests.swift
+++ b/macOS/UnitTests/Common/Extensions/StringExtensionTests.swift
@@ -75,6 +75,18 @@ class StringExtensionTests: XCTestCase {
         XCTAssertFalse("anything".containsAny(of: [""]))
     }
 
+    func testRemovingInvisibleFormatCharacters_stripsZeroWidthAndControls() {
+        XCTAssertEqual("\u{200B}".removingInvisibleFormatCharacters(), "")
+        XCTAssertEqual("\u{200C}".removingInvisibleFormatCharacters(), "")
+        XCTAssertEqual("\u{200D}".removingInvisibleFormatCharacters(), "")
+        XCTAssertEqual("\u{2060}".removingInvisibleFormatCharacters(), "")
+        XCTAssertEqual("\u{FEFF}".removingInvisibleFormatCharacters(), "")
+        XCTAssertEqual("a\u{200C}b\u{200B}c".removingInvisibleFormatCharacters(), "abc")
+        XCTAssertEqual("hello\nworld".removingInvisibleFormatCharacters(), "hello\nworld")
+        XCTAssertEqual("hello\tworld".removingInvisibleFormatCharacters(), "hello\tworld")
+        XCTAssertEqual("a\u{0000}b".removingInvisibleFormatCharacters(), "ab")
+    }
+
     func testDropSubdomainDoesntDropDomainWhenTLDHasTwoComponents() {
         let sample = [
             ("lantean.com.ar", "lantean.com.ar"),

--- a/macOS/UnitTests/Common/Extensions/StringExtensionTests.swift
+++ b/macOS/UnitTests/Common/Extensions/StringExtensionTests.swift
@@ -90,6 +90,24 @@ class StringExtensionTests: XCTestCase {
                        "What color is the sky? ")
     }
 
+    func testRemovingInvisibleFormatCharacters_preservesEmojiSequences() {
+        XCTAssertEqual("👨‍👩‍👧".removingInvisibleFormatCharacters(), "👨‍👩‍👧")
+        XCTAssertEqual("❤️".removingInvisibleFormatCharacters(), "❤️")
+        XCTAssertEqual("👋🏻".removingInvisibleFormatCharacters(), "👋🏻")
+    }
+
+    func testRemovingInvisibleFormatCharacters_preservesPersianAndArabicZWNJ() {
+        XCTAssertEqual("می‌رود".removingInvisibleFormatCharacters(), "می‌رود")
+        XCTAssertEqual("خانه‌ام".removingInvisibleFormatCharacters(), "خانه‌ام")
+    }
+
+    func testRemovingInvisibleFormatCharacters_stripsJoinersNextToLatin() {
+        XCTAssertEqual("a\u{200D}b".removingInvisibleFormatCharacters(), "ab")
+        XCTAssertEqual("a\u{200C}b".removingInvisibleFormatCharacters(), "ab")
+        XCTAssertEqual("hello\u{200B}world".removingInvisibleFormatCharacters(), "helloworld")
+        XCTAssertEqual("test\u{200C}می‌رود".removingInvisibleFormatCharacters(), "testمی‌رود")
+    }
+
     func testDropSubdomainDoesntDropDomainWhenTLDHasTwoComponents() {
         let sample = [
             ("lantean.com.ar", "lantean.com.ar"),

--- a/macOS/UnitTests/Common/Extensions/StringExtensionTests.swift
+++ b/macOS/UnitTests/Common/Extensions/StringExtensionTests.swift
@@ -85,6 +85,9 @@ class StringExtensionTests: XCTestCase {
         XCTAssertEqual("hello\nworld".removingInvisibleFormatCharacters(), "hello\nworld")
         XCTAssertEqual("hello\tworld".removingInvisibleFormatCharacters(), "hello\tworld")
         XCTAssertEqual("a\u{0000}b".removingInvisibleFormatCharacters(), "ab")
+        // Unicode Tags (U+E0000–U+E007F) — ASCII-smuggling / often render as tofu
+        XCTAssertEqual("What color is the sky? \u{E0001}\u{E0054}\u{E0068}\u{E0061}\u{E006E}\u{E006B}\u{E0073}\u{E007F}".removingInvisibleFormatCharacters(),
+                       "What color is the sky? ")
     }
 
     func testDropSubdomainDoesntDropDomainWhenTLDHasTwoComponents() {


### PR DESCRIPTION
## Summary
- Strip Unicode default-ignorable / control characters that render as tofu or enable invisible-text smuggling in the Duck.ai omnibar and the address/search bar.
- Preserve emoji ZWJ sequences and Arabic/Persian ZWNJ/ZWJ shaping; strip joiners when adjacent to Latin to block smuggling.
- Shared helper `removingInvisibleFormatCharacters()` with unit coverage for Tags, emoji, Persian, and Latin-adjacent cases.

## Test plan
- [ ] Paste Tag-smuggling payload into address bar and Duck.ai omnibar — only visible text remains, no tofu
- [ ] Paste ZWSP/ZWNJ/ZWJ-only — field stays empty / submit disabled
- [ ] Paste 👨‍👩‍👧 and ❤️ — sequences preserved
- [ ] Paste Persian `می‌رود` / `خانه‌ام` — ZWNJ preserved
- [ ] Paste `a‍b` / `a‌b` — joiners stripped → `ab`
- [ ] Unit tests: `StringExtensionTests` invisible-format cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all user text entry in the address bar and Duck.ai omnibar; incorrect joiner/emoji rules could break legitimate scripts, though unit tests cover the main cases.
> 
> **Overview**
> Adds **`removingInvisibleFormatCharacters()`** on `String` and routes address bar, Duck.ai omnibar, and draft restore paths through it so invisible Unicode (Tags, ZWSP, BOM, controls, etc.) never shows as tofu or smuggles hidden text into prompts.
> 
> The helper **always drops** default-ignorable junk and most controls (keeping tab/newline/CR). **ZWNJ, ZWJ, and variation selectors** stay only when needed for Arabic/Persian or emoji and **not** next to Latin.
> 
> **Duck.ai:** `AIChatOmnibarController` sanitizes on `updateText`, tab-switch restore, and draft publishers via `sanitizedPromptText`. **`FocusableTextView`** filters typing and paste at the NSTextView layer.
> 
> **Address bar:** `AddressBarTextEditor` filters insert/paste; `AddressBarTextField.Value` sanitizes programmatic string values.
> 
> Unit tests cover Tags, emoji, Persian ZWNJ, and Latin-adjacent joiner stripping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e758277de13bf02987faf93dc94a6629d853ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->