### PR TITLE
[macOS] Fire duck_ai_new_chat retention metric on new-chat creation

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -121,7 +121,6 @@ protocol AIChatTabOpening {
 struct AIChatTabOpener: AIChatTabOpening {
     private let promptHandler: AIChatPromptHandler
     private let aiChatTabManaging: AIChatTabManaging
-    /// Fires the `duck_ai_new_chat` retention experiment metric. Injected so it can be observed in tests.
     private let fireNewChatExperimentPixels: () -> Void
 
     let aiChatRemoteSettings = AIChatRemoteSettings()
@@ -140,25 +139,18 @@ struct AIChatTabOpener: AIChatTabOpening {
 
     @MainActor
     func openAIChatTab(with trigger: AIChatOpenTrigger, behavior: LinkOpenBehavior) {
+        var startedNewChat = false
+
         switch trigger {
         case .newChat:
-            if openAIChatTab(query: nil, with: behavior, autoSubmit: true) {
-                fireNewChatExperimentPixels()
-            }
+            startedNewChat = openAIChatTab(query: nil, with: behavior, autoSubmit: true)
 
         case .query(let query, shouldAutoSubmit: let shouldAutoSubmit):
-            if openAIChatTab(query: query, with: behavior, autoSubmit: shouldAutoSubmit) {
-                fireNewChatExperimentPixels()
-            }
+            startedNewChat = openAIChatTab(query: query, with: behavior, autoSubmit: shouldAutoSubmit)
 
         case .url(let url):
             let didOpen = aiChatTabManaging.openAIChat(url, with: behavior, hasPrompt: false)
-            // A mode URL (e.g. `?mode=image`) starts a fresh mode-driven chat, like `.mode`, so it
-            // counts. Other `.url` uses — the customize-responses modal, the sidebar handoff — carry no
-            // `mode` param and are not new chats.
-            if didOpen, url.getParameter(named: AIChatURLParameters.modeName) != nil {
-                fireNewChatExperimentPixels()
-            }
+            startedNewChat = didOpen && url.getParameter(named: AIChatURLParameters.modeName) != nil
 
         case .payload(let payload):
             aiChatTabManaging.insertAIChatTab(with: aiChatRemoteSettings.aiChatURL, payload: payload)
@@ -167,18 +159,18 @@ struct AIChatTabOpener: AIChatTabOpening {
             aiChatTabManaging.insertAIChatTab(with: aiChatRemoteSettings.aiChatURL, restorationData: data)
 
         case .existingChat(let chatId):
-            let chatURL = buildChatURL(for: chatId)
-            aiChatTabManaging.openAIChat(chatURL, with: behavior, hasPrompt: false)
+            aiChatTabManaging.openAIChat(buildChatURL(for: chatId), with: behavior, hasPrompt: false)
 
         case .mode(let mode):
-            let prompt = AIChatNativePrompt.queryPrompt("", autoSubmit: false, mode: mode)
-            promptHandler.setData(prompt)
-            if aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, with: behavior, hasPrompt: true) {
-                fireNewChatExperimentPixels()
-            }
+            promptHandler.setData(AIChatNativePrompt.queryPrompt("", autoSubmit: false, mode: mode))
+            startedNewChat = aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, with: behavior, hasPrompt: true)
 
         case .openSettings:
             aiChatTabManaging.insertAIChatTabRequestingOpenSettings(with: aiChatRemoteSettings.aiChatURL)
+        }
+
+        if startedNewChat {
+            fireNewChatExperimentPixels()
         }
     }
 
@@ -211,9 +203,7 @@ struct AIChatTabOpener: AIChatTabOpening {
 
     // MARK: - Private Helpers
 
-    /// - Returns: `true` if a new Duck.ai chat surface was actually opened (so the caller can fire the
-    ///   `duck_ai_new_chat` metric), `false` when the request resolved to a no-op — e.g. tapping New Chat
-    ///   while already sitting on an empty Duck.ai tab with no prompt.
+    /// Returns `true` if a new chat surface was actually opened (`false` on a no-op).
     @MainActor
     @discardableResult
     private func openAIChatTab(query: String?, with linkOpenBehavior: LinkOpenBehavior, autoSubmit: Bool) -> Bool {
@@ -240,9 +230,7 @@ struct AIChatTabOpener: AIChatTabOpening {
 }
 
 protocol AIChatTabManaging {
-    /// - Returns: `true` if a Duck.ai chat surface was actually opened/shown, `false` for a no-op
-    ///   (e.g. `.currentTab` onto an already-loaded Duck.ai tab with no prompt) or a navigation to an
-    ///   existing chat. Callers use this to avoid counting no-ops toward the `duck_ai_new_chat` metric.
+    /// Returns `true` if a chat surface was actually opened/shown, `false` for a no-op or existing-chat navigation.
     @MainActor
     @discardableResult
     func openAIChat(_ url: URL, with behavior: LinkOpenBehavior, hasPrompt: Bool) -> Bool
@@ -302,7 +290,6 @@ extension WindowControllersManager: AIChatTabManaging {
                     show(url: url, source: .ui, newTab: false)
                     return false
                 }
-                // Already on an empty Duck.ai tab with no prompt: nothing to open.
                 return false
             } else {
                 show(url: url, source: .ui, newTab: false)

--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -18,6 +18,8 @@
 
 import Foundation
 import AIChat
+import PixelKit
+import PixelExperimentKit
 
 /// Represents different triggers for opening an AI chat tab.
 ///
@@ -119,15 +121,19 @@ protocol AIChatTabOpening {
 struct AIChatTabOpener: AIChatTabOpening {
     private let promptHandler: AIChatPromptHandler
     private let aiChatTabManaging: AIChatTabManaging
+    /// Fires the `duck_ai_new_chat` retention experiment metric. Injected so it can be observed in tests.
+    private let fireNewChatExperimentPixels: () -> Void
 
     let aiChatRemoteSettings = AIChatRemoteSettings()
 
     init(
         promptHandler: AIChatPromptHandler,
-        aiChatTabManaging: AIChatTabManaging
+        aiChatTabManaging: AIChatTabManaging,
+        fireNewChatExperimentPixels: @escaping () -> Void = { PixelKit.fireNewAIChatExperimentPixels() }
     ) {
         self.promptHandler = promptHandler
         self.aiChatTabManaging = aiChatTabManaging
+        self.fireNewChatExperimentPixels = fireNewChatExperimentPixels
     }
 
     // MARK: - New Simplified API
@@ -136,10 +142,14 @@ struct AIChatTabOpener: AIChatTabOpening {
     func openAIChatTab(with trigger: AIChatOpenTrigger, behavior: LinkOpenBehavior) {
         switch trigger {
         case .newChat:
-            openAIChatTab(query: nil, with: behavior, autoSubmit: true)
+            if openAIChatTab(query: nil, with: behavior, autoSubmit: true) {
+                fireNewChatExperimentPixels()
+            }
 
         case .query(let query, shouldAutoSubmit: let shouldAutoSubmit):
-            openAIChatTab(query: query, with: behavior, autoSubmit: shouldAutoSubmit)
+            if openAIChatTab(query: query, with: behavior, autoSubmit: shouldAutoSubmit) {
+                fireNewChatExperimentPixels()
+            }
 
         case .url(let url):
             aiChatTabManaging.openAIChat(url, with: behavior, hasPrompt: false)
@@ -157,7 +167,9 @@ struct AIChatTabOpener: AIChatTabOpening {
         case .mode(let mode):
             let prompt = AIChatNativePrompt.queryPrompt("", autoSubmit: false, mode: mode)
             promptHandler.setData(prompt)
-            aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, with: behavior, hasPrompt: true)
+            if aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, with: behavior, hasPrompt: true) {
+                fireNewChatExperimentPixels()
+            }
 
         case .openSettings:
             aiChatTabManaging.insertAIChatTabRequestingOpenSettings(with: aiChatRemoteSettings.aiChatURL)
@@ -181,22 +193,28 @@ struct AIChatTabOpener: AIChatTabOpening {
     func openAIChatTab(withQuery query: String, inNewTabOf windowController: MainWindowController) {
         promptHandler.setData(.queryPrompt(query, autoSubmit: true))
         aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, inNewTabOf: windowController, hasPrompt: true)
+        fireNewChatExperimentPixels()
     }
 
     @MainActor
     func openAIChatTab(withQuery query: String, inNewWindowAt droppingPoint: NSPoint) {
         promptHandler.setData(.queryPrompt(query, autoSubmit: true))
         aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, inNewWindowAt: droppingPoint, hasPrompt: true)
+        fireNewChatExperimentPixels()
     }
 
     // MARK: - Private Helpers
 
+    /// - Returns: `true` if a new Duck.ai chat surface was actually opened (so the caller can fire the
+    ///   `duck_ai_new_chat` metric), `false` when the request resolved to a no-op — e.g. tapping New Chat
+    ///   while already sitting on an empty Duck.ai tab with no prompt.
     @MainActor
-    private func openAIChatTab(query: String?, with linkOpenBehavior: LinkOpenBehavior, autoSubmit: Bool) {
+    @discardableResult
+    private func openAIChatTab(query: String?, with linkOpenBehavior: LinkOpenBehavior, autoSubmit: Bool) -> Bool {
         if let query = query {
             promptHandler.setData(.queryPrompt(query, autoSubmit: autoSubmit))
         }
-        aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, with: linkOpenBehavior, hasPrompt: query != nil)
+        return aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, with: linkOpenBehavior, hasPrompt: query != nil)
     }
 
     /// Builds a URL to open an existing chat by its ID.
@@ -216,8 +234,12 @@ struct AIChatTabOpener: AIChatTabOpening {
 }
 
 protocol AIChatTabManaging {
+    /// - Returns: `true` if a Duck.ai chat surface was actually opened/shown, `false` for a no-op
+    ///   (e.g. `.currentTab` onto an already-loaded Duck.ai tab with no prompt) or a navigation to an
+    ///   existing chat. Callers use this to avoid counting no-ops toward the `duck_ai_new_chat` metric.
     @MainActor
-    func openAIChat(_ url: URL, with behavior: LinkOpenBehavior, hasPrompt: Bool)
+    @discardableResult
+    func openAIChat(_ url: URL, with behavior: LinkOpenBehavior, hasPrompt: Bool) -> Bool
 
     @MainActor
     func openAIChat(_ url: URL, inNewTabOf windowController: MainWindowController, hasPrompt: Bool)
@@ -255,7 +277,8 @@ extension WindowControllersManager: AIChatTabManaging {
     ///   - hasPrompt: With `.currentTab`, if the current tab is already an AI chat and a prompt was supplied,
     ///                opens a fresh chat in a new selected tab so the loaded conversation is left untouched.
     ///                Ignored for `.newTab` / `.newWindow`, which always open a new tab/window.
-    func openAIChat(_ url: URL, with linkOpenBehavior: LinkOpenBehavior = .currentTab, hasPrompt: Bool) {
+    @discardableResult
+    func openAIChat(_ url: URL, with linkOpenBehavior: LinkOpenBehavior = .currentTab, hasPrompt: Bool) -> Bool {
 
         let tabCollectionViewModel = mainWindowController?.mainViewController.tabCollectionViewModel
 
@@ -267,15 +290,21 @@ extension WindowControllersManager: AIChatTabManaging {
                     // selected tab rather than injecting the prompt into the loaded conversation,
                     // which users found confusing.
                     open(url, with: .newTab(selected: true), source: .ui, target: nil)
+                    return true
                 } else if url.getParameter(named: "chatID") != nil {
                     // Navigate to a specific existing chat — must load even if already on duck.ai
                     show(url: url, source: .ui, newTab: false)
+                    return false
                 }
+                // Already on an empty Duck.ai tab with no prompt: nothing to open.
+                return false
             } else {
                 show(url: url, source: .ui, newTab: false)
+                return true
             }
         default:
             open(url, with: linkOpenBehavior, source: .ui, target: nil)
+            return true
         }
     }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -152,7 +152,13 @@ struct AIChatTabOpener: AIChatTabOpening {
             }
 
         case .url(let url):
-            aiChatTabManaging.openAIChat(url, with: behavior, hasPrompt: false)
+            let didOpen = aiChatTabManaging.openAIChat(url, with: behavior, hasPrompt: false)
+            // A mode URL (e.g. `?mode=image`) starts a fresh mode-driven chat, like `.mode`, so it
+            // counts. Other `.url` uses — the customize-responses modal, the sidebar handoff — carry no
+            // `mode` param and are not new chats.
+            if didOpen, url.getParameter(named: AIChatURLParameters.modeName) != nil {
+                fireNewChatExperimentPixels()
+            }
 
         case .payload(let payload):
             aiChatTabManaging.insertAIChatTab(with: aiChatRemoteSettings.aiChatURL, payload: payload)

--- a/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTabOpener.swift
@@ -189,19 +189,32 @@ struct AIChatTabOpener: AIChatTabOpening {
 
     @MainActor
     func openAIChatTab(withQuery query: String, inNewTabOf windowController: MainWindowController) {
-        promptHandler.setData(.queryPrompt(query, autoSubmit: true))
-        aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, inNewTabOf: windowController, hasPrompt: true)
-        fireNewChatExperimentPixels()
+        openNewChatTab(withQuery: query, target: .newTabOf(windowController))
     }
 
     @MainActor
     func openAIChatTab(withQuery query: String, inNewWindowAt droppingPoint: NSPoint) {
-        promptHandler.setData(.queryPrompt(query, autoSubmit: true))
-        aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, inNewWindowAt: droppingPoint, hasPrompt: true)
-        fireNewChatExperimentPixels()
+        openNewChatTab(withQuery: query, target: .newWindowAt(droppingPoint))
     }
 
     // MARK: - Private Helpers
+
+    private enum NewChatPromptTarget {
+        case newTabOf(MainWindowController)
+        case newWindowAt(NSPoint)
+    }
+
+    @MainActor
+    private func openNewChatTab(withQuery query: String, target: NewChatPromptTarget) {
+        promptHandler.setData(.queryPrompt(query, autoSubmit: true))
+        switch target {
+        case .newTabOf(let windowController):
+            aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, inNewTabOf: windowController, hasPrompt: true)
+        case .newWindowAt(let droppingPoint):
+            aiChatTabManaging.openAIChat(aiChatRemoteSettings.aiChatURL, inNewWindowAt: droppingPoint, hasPrompt: true)
+        }
+        fireNewChatExperimentPixels()
+    }
 
     /// Returns `true` if a new chat surface was actually opened (`false` on a no-op).
     @MainActor

--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatCoordinator.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatCoordinator.swift
@@ -307,8 +307,6 @@ final class AIChatCoordinator: AIChatCoordinating {
     private func showSidebar(for tabID: TabIdentifier, animated: Bool) {
         sessionStore.expireSessionIfNeeded(for: tabID)
 
-        // A brand-new session means a new Duck.ai conversation is starting in the sidebar; reusing a
-        // kept session (or a session pre-created by the SERP handoff) is a resume and must not count.
         let isNewConversation = sessionStore.sessions[tabID] == nil
         let session = sessionStore.getOrCreateSession(for: tabID, burnerMode: sidebarHost.burnerMode)
         if isNewConversation {

--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatCoordinator.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatCoordinator.swift
@@ -111,6 +111,7 @@ final class AIChatCoordinator: AIChatCoordinating {
     private let featureFlagger: FeatureFlagger
     private var preferencesStorage: AIChatPreferencesStorage
     private let aiChatConversationSourceHandler: AIChatConversationSourceHandler
+    private let fireNewChatExperimentPixels: () -> Void
     private let sidebarPresenceDidChangeSubject = PassthroughSubject<AIChatPresenceChange, Never>()
     private let chatFloatingStateDidChangeSubject = PassthroughSubject<TabIdentifier, Never>()
 
@@ -147,7 +148,8 @@ final class AIChatCoordinator: AIChatCoordinating {
         pixelFiring: PixelFiring?,
         featureFlagger: FeatureFlagger,
         preferencesStorage: AIChatPreferencesStorage = DefaultAIChatPreferencesStorage(),
-        aiChatConversationSourceHandler: AIChatConversationSourceHandler = Application.appDelegate.aiChatConversationSourceHandler
+        aiChatConversationSourceHandler: AIChatConversationSourceHandler = Application.appDelegate.aiChatConversationSourceHandler,
+        fireNewChatExperimentPixels: @escaping () -> Void = { PixelKit.fireNewAIChatExperimentPixels() }
     ) {
         self.sidebarHost = sidebarHost
         self.sessionStore = sessionStore
@@ -158,6 +160,7 @@ final class AIChatCoordinator: AIChatCoordinating {
         self.featureFlagger = featureFlagger
         self.preferencesStorage = preferencesStorage
         self.aiChatConversationSourceHandler = aiChatConversationSourceHandler
+        self.fireNewChatExperimentPixels = fireNewChatExperimentPixels
 
         if let stored = preferencesStorage.lastUsedSidebarWidth, stored > 0 {
             self.windowDefaultWidth = Swift.min(Constants.maxSidebarWidth, Swift.max(Constants.minSidebarWidth, CGFloat(stored)))
@@ -310,7 +313,7 @@ final class AIChatCoordinator: AIChatCoordinating {
         let isNewConversation = sessionStore.sessions[tabID] == nil
         let session = sessionStore.getOrCreateSession(for: tabID, burnerMode: sidebarHost.burnerMode)
         if isNewConversation {
-            PixelKit.fireNewAIChatExperimentPixels()
+            fireNewChatExperimentPixels()
         }
         let chatViewController = session.chatViewController ?? session.makeChatViewController(tabID: tabID)
 

--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatCoordinator.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatCoordinator.swift
@@ -21,6 +21,7 @@ import AppKit
 import Combine
 import FeatureFlags_macOS
 import PixelKit
+import PixelExperimentKit
 import PrivacyConfig
 
 /// Represents an event of hiding or showing an AI Chat tab sidebar.
@@ -306,7 +307,13 @@ final class AIChatCoordinator: AIChatCoordinating {
     private func showSidebar(for tabID: TabIdentifier, animated: Bool) {
         sessionStore.expireSessionIfNeeded(for: tabID)
 
+        // A brand-new session means a new Duck.ai conversation is starting in the sidebar; reusing a
+        // kept session (or a session pre-created by the SERP handoff) is a resume and must not count.
+        let isNewConversation = sessionStore.sessions[tabID] == nil
         let session = sessionStore.getOrCreateSession(for: tabID, burnerMode: sidebarHost.burnerMode)
+        if isNewConversation {
+            PixelKit.fireNewAIChatExperimentPixels()
+        }
         let chatViewController = session.chatViewController ?? session.makeChatViewController(tabID: tabID)
 
         chatViewController.isChatFloatingEnabled = isChatFloatingEnabled

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -200,6 +200,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     private var conversationSource: AIChatConversationSource?
     private var didConsumeConversationSource = false
     private let conversationSourceHandler: AIChatConversationSourceHandler
+    private let fireNewChatExperimentPixels: () -> Void
 
     /// Whether page context with content is currently attached to this chat — set by the native
     /// auto-attach push and updated by the frontend's add/remove toggle. Read at prompt submit for
@@ -220,7 +221,8 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         freeTrialConversionService: FreeTrialConversionInstrumentationService = Application.appDelegate.freeTrialConversionService,
         notificationCenter: NotificationCenter = .default,
         voiceChatFailureHandler: DuckAiVoiceChatFailureHandling? = nil,
-        conversationSourceHandler: AIChatConversationSourceHandler = Application.appDelegate.aiChatConversationSourceHandler
+        conversationSourceHandler: AIChatConversationSourceHandler = Application.appDelegate.aiChatConversationSourceHandler,
+        fireNewChatExperimentPixels: @escaping () -> Void = { PixelKit.fireNewAIChatExperimentPixels() }
     ) {
         self.storage = storage
         self.messageHandling = messageHandling
@@ -234,6 +236,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         self.featureFlagger = featureFlagger
         self.freeTrialConversionService = freeTrialConversionService
         self.conversationSourceHandler = conversationSourceHandler
+        self.fireNewChatExperimentPixels = fireNewChatExperimentPixels
         self.voiceChatFailureHandler = voiceChatFailureHandler ?? DuckAiVoiceChatFailureHandler(
             permissionCenterPresenter: NotificationCenterPermissionCenterPresenter(
                 notificationCenter: notificationCenter,
@@ -1075,7 +1078,7 @@ extension AIChatUserScriptHandler: AIChatMetricReportingHandling {
             handleTermsAccepted()
             completion?()
         case .userDidCreateNewChat:
-            PixelKit.fireNewAIChatExperimentPixels()
+            fireNewChatExperimentPixels()
             completion?()
         case .userDidSelectSuggestion:
             pixelFiring?.fire(

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -23,6 +23,7 @@ import Common
 import FoundationExtensions
 import Foundation
 import PixelKit
+import PixelExperimentKit
 import Subscription
 import UserScript
 import OSLog
@@ -1072,6 +1073,11 @@ extension AIChatUserScriptHandler: AIChatMetricReportingHandling {
             }
         case .userDidAcceptTermsAndConditions:
             handleTermsAccepted()
+            completion?()
+        case .userDidCreateNewChat:
+            // New chat started from within the Duck.ai page (e.g. its side-menu "New Chat"). Native
+            // new-chat entry points fire duck_ai_new_chat in AIChatTabOpener; this covers the FE ones.
+            PixelKit.fireNewAIChatExperimentPixels()
             completion?()
         case .userDidSelectSuggestion:
             pixelFiring?.fire(

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -1075,8 +1075,6 @@ extension AIChatUserScriptHandler: AIChatMetricReportingHandling {
             handleTermsAccepted()
             completion?()
         case .userDidCreateNewChat:
-            // New chat started from within the Duck.ai page (e.g. its side-menu "New Chat"). Native
-            // new-chat entry points fire duck_ai_new_chat in AIChatTabOpener; this covers the FE ones.
             PixelKit.fireNewAIChatExperimentPixels()
             completion?()
         case .userDidSelectSuggestion:

--- a/macOS/DuckDuckGo/Windows/Model/WindowControllersManagerMock.swift
+++ b/macOS/DuckDuckGo/Windows/Model/WindowControllersManagerMock.swift
@@ -117,8 +117,6 @@ final class WindowControllersManagerMock: WindowControllersManagerProtocol, AICh
         let hasPrompt: Bool
     }
     var openAIChatCalls: [OpenAIChatCall] = []
-    /// Controls the `didOpen` value returned by `openAIChat(_:with:hasPrompt:)`; defaults to `true`
-    /// (a surface was opened). Set to `false` to simulate the no-op path.
     var openAIChatDidOpen = true
 
     @MainActor

--- a/macOS/DuckDuckGo/Windows/Model/WindowControllersManagerMock.swift
+++ b/macOS/DuckDuckGo/Windows/Model/WindowControllersManagerMock.swift
@@ -117,10 +117,15 @@ final class WindowControllersManagerMock: WindowControllersManagerProtocol, AICh
         let hasPrompt: Bool
     }
     var openAIChatCalls: [OpenAIChatCall] = []
+    /// Controls the `didOpen` value returned by `openAIChat(_:with:hasPrompt:)`; defaults to `true`
+    /// (a surface was opened). Set to `false` to simulate the no-op path.
+    var openAIChatDidOpen = true
 
     @MainActor
-    func openAIChat(_ url: URL, with behavior: LinkOpenBehavior, hasPrompt: Bool) {
+    @discardableResult
+    func openAIChat(_ url: URL, with behavior: LinkOpenBehavior, hasPrompt: Bool) -> Bool {
         openAIChatCalls.append(OpenAIChatCall(url: url, behavior: behavior, hasPrompt: hasPrompt))
+        return openAIChatDidOpen
     }
 
     struct OpenAIChatInNewTabOfCall {

--- a/macOS/UnitTests/AIChat/AIChatCoordinatorTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatCoordinatorTests.swift
@@ -148,6 +148,47 @@ final class AIChatCoordinatorTests: XCTestCase {
         XCTAssertEqual(presenceChangeReceived?.isShown, true)
     }
 
+    func testToggleSidebar_newSession_firesNewChatExperimentPixel() {
+        let tabID = "new-chat-tab"
+        mockSidebarHost.currentTabID = tabID
+        var fireCount = 0
+        let coordinator = AIChatCoordinator(
+            sidebarHost: mockSidebarHost,
+            sessionStore: mockSessionStore,
+            aiChatMenuConfig: mockAIChatMenuConfig,
+            aiChatTabOpener: mockAIChatTabOpener,
+            windowControllersManager: mockWindowControllersManager,
+            pixelFiring: mockPixelFiring,
+            featureFlagger: mockFeatureFlagger,
+            fireNewChatExperimentPixels: { fireCount += 1 }
+        )
+
+        coordinator.toggleSidebar()
+
+        XCTAssertEqual(fireCount, 1, "Opening the sidebar with a fresh session must count as a new chat")
+    }
+
+    func testToggleSidebar_existingSession_doesNotFireNewChatExperimentPixel() {
+        let tabID = "existing-session-tab"
+        mockSidebarHost.currentTabID = tabID
+        _ = mockSessionStore.getOrCreateSession(for: tabID, burnerMode: .regular)
+        var fireCount = 0
+        let coordinator = AIChatCoordinator(
+            sidebarHost: mockSidebarHost,
+            sessionStore: mockSessionStore,
+            aiChatMenuConfig: mockAIChatMenuConfig,
+            aiChatTabOpener: mockAIChatTabOpener,
+            windowControllersManager: mockWindowControllersManager,
+            pixelFiring: mockPixelFiring,
+            featureFlagger: mockFeatureFlagger,
+            fireNewChatExperimentPixels: { fireCount += 1 }
+        )
+
+        coordinator.toggleSidebar()
+
+        XCTAssertEqual(fireCount, 0, "Reusing an existing session is a resume, not a new chat")
+    }
+
     func testToggleSidebar_hidesSidebarWhenShowing() {
         // Given
         let tabID = "test-tab"

--- a/macOS/UnitTests/AIChat/AIChatTabOpenerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatTabOpenerTests.swift
@@ -117,7 +117,9 @@ final class AIChatTabOpenerTests: XCTestCase {
     }
 
     @MainActor
-    func testURLTriggerDoesNotFireNewChatExperimentPixel() {
+    func testPlainURLTriggerDoesNotFireNewChatExperimentPixel() {
+        // A .url without a mode param (e.g. the customize-responses modal or a sidebar handoff URL)
+        // is not a new chat.
         let mockManager = WindowControllersManagerMock()
         var fireCount = 0
         let opener = makeOpener(mockManager) { fireCount += 1 }
@@ -125,5 +127,17 @@ final class AIChatTabOpenerTests: XCTestCase {
         opener.openAIChatTab(with: .url(opener.aiChatRemoteSettings.aiChatURL), behavior: .newTab(selected: true))
 
         XCTAssertEqual(fireCount, 0)
+    }
+
+    @MainActor
+    func testImageModeURLTriggerFiresNewChatExperimentPixel() {
+        let mockManager = WindowControllersManagerMock()
+        var fireCount = 0
+        let opener = makeOpener(mockManager) { fireCount += 1 }
+        let imageModeURL = AIChatURLParameters.imageModeURL(from: opener.aiChatRemoteSettings.aiChatURL)
+
+        opener.openAIChatTab(with: .url(imageModeURL), behavior: .newTab(selected: true))
+
+        XCTAssertEqual(fireCount, 1, "A mode-driven fresh chat (e.g. image generation) must count as a new chat")
     }
 }

--- a/macOS/UnitTests/AIChat/AIChatTabOpenerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatTabOpenerTests.swift
@@ -137,4 +137,50 @@ final class AIChatTabOpenerTests: XCTestCase {
 
         XCTAssertEqual(fireCount, 1, "A mode-driven fresh chat (e.g. image generation) must count as a new chat")
     }
+
+    @MainActor
+    func testOpenSettingsTriggerDoesNotFireNewChatExperimentPixel() {
+        let mockManager = WindowControllersManagerMock()
+        var fireCount = 0
+        let opener = makeOpener(mockManager) { fireCount += 1 }
+
+        opener.openAIChatTab(with: .openSettings, behavior: .newTab(selected: true))
+
+        XCTAssertEqual(fireCount, 0)
+    }
+
+    @MainActor
+    func testNewVoiceSessionFiresNewChatExperimentPixel() {
+        let mockManager = WindowControllersManagerMock()
+        mockManager.focusActiveVoiceSessionTabResult = false
+        var fireCount = 0
+        let opener = makeOpener(mockManager) { fireCount += 1 }
+
+        opener.openVoiceSession(inSourceCollection: nil, behavior: .newTab(selected: true))
+
+        XCTAssertEqual(fireCount, 1, "Opening a new voice chat must count as a new chat")
+    }
+
+    @MainActor
+    func testVoiceSessionFocusingExistingTabDoesNotFireNewChatExperimentPixel() {
+        let mockManager = WindowControllersManagerMock()
+        mockManager.focusActiveVoiceSessionTabResult = true
+        var fireCount = 0
+        let opener = makeOpener(mockManager) { fireCount += 1 }
+
+        opener.openVoiceSession(inSourceCollection: nil, behavior: .newTab(selected: true))
+
+        XCTAssertEqual(fireCount, 0, "Focusing an already-active voice tab is a resume, not a new chat")
+    }
+
+    @MainActor
+    func testPromptBarNewWindowFiresNewChatExperimentPixel() {
+        let mockManager = WindowControllersManagerMock()
+        var fireCount = 0
+        let opener = makeOpener(mockManager) { fireCount += 1 }
+
+        opener.openAIChatTab(withQuery: "hello", inNewWindowAt: .zero)
+
+        XCTAssertEqual(fireCount, 1)
+    }
 }

--- a/macOS/UnitTests/AIChat/AIChatTabOpenerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatTabOpenerTests.swift
@@ -94,7 +94,6 @@ final class AIChatTabOpenerTests: XCTestCase {
 
     @MainActor
     func testNewChatNoOpDoesNotFireNewChatExperimentPixel() {
-        // The manager reports it did not open a surface (e.g. already on an empty Duck.ai tab): no metric.
         let mockManager = WindowControllersManagerMock()
         mockManager.openAIChatDidOpen = false
         var fireCount = 0
@@ -118,8 +117,6 @@ final class AIChatTabOpenerTests: XCTestCase {
 
     @MainActor
     func testPlainURLTriggerDoesNotFireNewChatExperimentPixel() {
-        // A .url without a mode param (e.g. the customize-responses modal or a sidebar handoff URL)
-        // is not a new chat.
         let mockManager = WindowControllersManagerMock()
         var fireCount = 0
         let opener = makeOpener(mockManager) { fireCount += 1 }

--- a/macOS/UnitTests/AIChat/AIChatTabOpenerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatTabOpenerTests.swift
@@ -49,4 +49,81 @@ final class AIChatTabOpenerTests: XCTestCase {
 
         XCTAssertEqual(mockManager.insertAIChatTabRequestingOpenSettingsCalls.count, 1)
     }
+
+    // MARK: - duck_ai_new_chat metric
+
+    @MainActor
+    private func makeOpener(_ mockManager: WindowControllersManagerMock, newChatFired: @escaping () -> Void) -> AIChatTabOpener {
+        AIChatTabOpener(promptHandler: AIChatPromptHandler.shared,
+                        aiChatTabManaging: mockManager,
+                        fireNewChatExperimentPixels: newChatFired)
+    }
+
+    @MainActor
+    func testNewChatTriggerFiresNewChatExperimentPixel() {
+        let mockManager = WindowControllersManagerMock()
+        var fireCount = 0
+        let opener = makeOpener(mockManager) { fireCount += 1 }
+
+        opener.openAIChatTab(with: .newChat, behavior: .newTab(selected: true))
+
+        XCTAssertEqual(fireCount, 1, "Starting a new chat must fire duck_ai_new_chat exactly once")
+    }
+
+    @MainActor
+    func testQueryTriggerFiresNewChatExperimentPixel() {
+        let mockManager = WindowControllersManagerMock()
+        var fireCount = 0
+        let opener = makeOpener(mockManager) { fireCount += 1 }
+
+        opener.openAIChatTab(with: .query("hello"), behavior: .newTab(selected: true))
+
+        XCTAssertEqual(fireCount, 1)
+    }
+
+    @MainActor
+    func testModeTriggerFiresNewChatExperimentPixel() {
+        let mockManager = WindowControllersManagerMock()
+        var fireCount = 0
+        let opener = makeOpener(mockManager) { fireCount += 1 }
+
+        opener.openAIChatTab(with: .mode(AIChatNativePrompt.voiceMode), behavior: .newTab(selected: true))
+
+        XCTAssertEqual(fireCount, 1)
+    }
+
+    @MainActor
+    func testNewChatNoOpDoesNotFireNewChatExperimentPixel() {
+        // The manager reports it did not open a surface (e.g. already on an empty Duck.ai tab): no metric.
+        let mockManager = WindowControllersManagerMock()
+        mockManager.openAIChatDidOpen = false
+        var fireCount = 0
+        let opener = makeOpener(mockManager) { fireCount += 1 }
+
+        opener.openAIChatTab(with: .newChat, behavior: .currentTab)
+
+        XCTAssertEqual(fireCount, 0, "A no-op New Chat must not fire duck_ai_new_chat")
+    }
+
+    @MainActor
+    func testExistingChatTriggerDoesNotFireNewChatExperimentPixel() {
+        let mockManager = WindowControllersManagerMock()
+        var fireCount = 0
+        let opener = makeOpener(mockManager) { fireCount += 1 }
+
+        opener.openAIChatTab(with: .existingChat(chatId: "abc"), behavior: .newTab(selected: true))
+
+        XCTAssertEqual(fireCount, 0, "Resuming an existing chat is not a new chat")
+    }
+
+    @MainActor
+    func testURLTriggerDoesNotFireNewChatExperimentPixel() {
+        let mockManager = WindowControllersManagerMock()
+        var fireCount = 0
+        let opener = makeOpener(mockManager) { fireCount += 1 }
+
+        opener.openAIChatTab(with: .url(opener.aiChatRemoteSettings.aiChatURL), behavior: .newTab(selected: true))
+
+        XCTAssertEqual(fireCount, 0)
+    }
 }

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -447,6 +447,33 @@ struct AIChatUserScriptHandlerTests {
     }
 
     @available(iOS 16, macOS 13, *)
+    @Test("didReportMetric fires new-chat experiment pixel for userDidCreateNewChat", .timeLimit(.minutes(1)))
+    @MainActor
+    func testThatUserDidCreateNewChatFiresNewChatExperimentPixel() async {
+        var fireCount = 0
+        let testHandler = AIChatUserScriptHandler(
+            storage: storage,
+            messageHandling: messageHandler,
+            windowControllersManager: windowControllersManager,
+            pixelFiring: pixelFiring,
+            statisticsLoader: statisticsLoader,
+            syncServiceProvider: { nil },
+            syncErrorHandler: syncErrorHandler,
+            featureFlagger: MockFeatureFlagger(),
+            notificationCenter: notificationCenter,
+            fireNewChatExperimentPixels: { fireCount += 1 }
+        )
+
+        await withCheckedContinuation { continuation in
+            testHandler.didReportMetric(.init(metricName: .userDidCreateNewChat)) {
+                continuation.resume()
+            }
+        }
+
+        #expect(fireCount == 1)
+    }
+
+    @available(iOS 16, macOS 13, *)
     @Test("didReportMetric fires start new conversation pixel for first prompt", .timeLimit(.minutes(1)))
     @MainActor
     func testThatUserDidSubmitFirstPromptFiresStartNewConversationPixel() async throws {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1216921686081266
Tech Design URL:
CC:

### Description
Wires up the `duck_ai_new_chat` retention experiment metric on macOS. The metric and its firing helper already existed in shared `PixelExperimentKit` but were never called from app code/

### Testing Steps
1. Force a config with an active experiment and enroll (there should be some ongoing experiment other wise you can put a breakpoint on PixelExperimentKit: fireNewAIChatExperimentPixels
2. Filter debug pixels for the experiment metrics.
3. Start a new chat via each surface (Duck.ai menu → New Chat, title-bar button, omnibar submit, address-bar AI chat, NTP submit, File → New AI Chat, New Voice Chat, New Image Chat, sidebar open) → each fires one `duck_ai_new_chat` (value=1, window per enrollment day).
4. Tap New Chat while already on an empty Duck.ai tab → no additional pixel.
5. Open a recent/existing chat and reopen a kept sidebar → no `duck_ai_new_chat`.

### Impact
None (adds metric instrumentation only; no user-facing behaviour change).

### Quality Considerations
Unit tests in `AIChatTabOpenerTests` cover: fires for new-chat/query/mode and image-mode URL; silent for the no-op path, existing-chat, and plain (non-mode) URL triggers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a78f3a88bdf6f36f676a5fbd07628540813e0586. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->