### PR TITLE
iOS: Fix unnecessary scrolling in Fire dialog on iPad

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -740,7 +740,9 @@ private extension AIChatContextualSheetViewController {
             }
         )
 
+        // Inject the presenting context's true size class; the built-in one reports `.compact` inside the sheet/popover.
         let confirmationView = ScopedFireConfirmationView(viewModel: viewModel)
+            .environment(\.presentationHorizontalSizeClass, UserInterfaceSizeClass(traitCollection.horizontalSizeClass))
         let hostingController = UIHostingController(rootView: confirmationView)
         hostingController.view.backgroundColor = UIColor(designSystemColor: .backgroundTertiary)
         hostingController.modalTransitionStyle = .coverVertical
@@ -755,8 +757,8 @@ private extension AIChatContextualSheetViewController {
         present(hostingController, animated: true)
     }
 
-    private func configureIPadPopoverPresentation(for hostingController: UIHostingController<ScopedFireConfirmationView>,
-                                                  confirmationView: ScopedFireConfirmationView) {
+    private func configureIPadPopoverPresentation<Content: View>(for hostingController: UIHostingController<Content>,
+                                                                 confirmationView: Content) {
         if let popover = hostingController.popoverPresentationController {
             popover.sourceView = fireButton
             popover.sourceRect = fireButton.bounds
@@ -772,8 +774,8 @@ private extension AIChatContextualSheetViewController {
         }
     }
 
-    private func configureIPhoneSheetPresentation(for hostingController: UIHostingController<ScopedFireConfirmationView>,
-                                                  confirmationView: ScopedFireConfirmationView) {
+    private func configureIPhoneSheetPresentation<Content: View>(for hostingController: UIHostingController<Content>,
+                                                                 confirmationView: Content) {
         if let sheet = hostingController.sheetPresentationController {
             if #available(iOS 16.0, *) {
                 let sizingController = UIHostingController(rootView: confirmationView)

--- a/iOS/DuckDuckGo/Fire/FireConfirmationPresenter.swift
+++ b/iOS/DuckDuckGo/Fire/FireConfirmationPresenter.swift
@@ -87,7 +87,10 @@ struct FireConfirmationPresenter {
                                                             }
                                                         })
 
+        // Capture the presenting context's true size class; it's reset to `.compact` inside the popover container.
+        let presentationSizeClass = UserInterfaceSizeClass(viewController.traitCollection.horizontalSizeClass)
         let confirmationView = ScopedFireConfirmationView(viewModel: viewModel)
+            .environment(\.presentationHorizontalSizeClass, presentationSizeClass)
         let hostingController = makeHostingController(with: confirmationView)
         // Prevent swipe-to-dismiss for the experiment flow: the user must make an
         // explicit choice (fire or cancel) to keep the locked-controls state consistent.

--- a/iOS/DuckDuckGo/Fire/ScopedFireConfirmationView.swift
+++ b/iOS/DuckDuckGo/Fire/ScopedFireConfirmationView.swift
@@ -29,14 +29,15 @@ struct ScopedFireConfirmationView: View {
     
     @ObservedObject var viewModel: ScopedFireConfirmationViewModel
     @State private var isAnimating = false
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    
+    /// Presenting context's size class; the built-in one reports `.compact` inside a popover even on a wide iPad.
+    @Environment(\.presentationHorizontalSizeClass) private var presentationSizeClass
+
     init(viewModel: ScopedFireConfirmationViewModel) {
         self.viewModel = viewModel
     }
-    
+
     private var contentPadding: EdgeInsets {
-        horizontalSizeClass == .compact ? Constants.sheetViewPadding : Constants.popoverViewPadding
+        presentationSizeClass == .compact ? Constants.sheetViewPadding : Constants.popoverViewPadding
     }
     
     var body: some View {
@@ -131,6 +132,22 @@ private struct DestructiveButtonModifier: ViewModifier {
             content.buttonStyle(SecondaryDestructiveButtonStyle())
         case .secondaryNeutral:
             content.buttonStyle(SecondaryFillButtonStyle())
+        }
+    }
+}
+
+/// Carries the presenting context's size class across the UIKit presentation boundary. Injected by `FireConfirmationPresenter`.
+private struct PresentationHorizontalSizeClassKey: EnvironmentKey {
+    static let defaultValue: UserInterfaceSizeClass? = nil
+}
+
+extension EnvironmentValues {
+    var presentationHorizontalSizeClass: UserInterfaceSizeClass? {
+        get {
+            self[PresentationHorizontalSizeClassKey.self]
+        }
+        set {
+            self[PresentationHorizontalSizeClassKey.self] = newValue
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213200031804032

### Description

On iPad, the Fire confirmation popover would scroll even though all of its content already fit on screen.

The dialog picks its content padding from the horizontal size class, but inside a popover container `\.horizontalSizeClass` is reset to `.compact` even on a wide iPad, so the live view used taller padding than the offscreen pass that sizes the popover measured. The content ended up taller than the popover and overflowed.

The fix captures the *presenting* view controller's true horizontal size class and passes it across the UIKit presentation boundary via a new `presentationHorizontalSizeClass` environment key. Both the live view and the height-measurement pass now read the same value, so measured and actual heights agree and the content no longer scrolls.

### Testing Steps

1. On an iPad (or iPad simulator) in full-screen / regular width.
2. Tap the Fire button to open the Fire confirmation dialog.
3. Verify the popover sizes to its content and does **not** scroll or rubber-band — all options are visible with no scroll.
4. Put the app in a narrow split-view/Slide Over window on iPad, open the Fire dialog (now presented as a sheet), and confirm it looks correct with no clipping.
5. On iPhone, open the Fire dialog and confirm it's unchanged.

### Impact and Risks

**Low.** Scoped to the iOS Fire confirmation dialog's padding/sizing. The change only redirects which size-class value drives content padding (via a new environment key injected at presentation) and doesn't touch the fire/clear logic. Worst case is a cosmetic padding difference; iPhone presentation is unaffected.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic layout/sizing only for the Fire confirmation dialog; no changes to fire or data-clearing behavior.
> 
> **Overview**
> Fixes **unnecessary scrolling** in the Fire confirmation UI on iPad when content already fits.
> 
> `ScopedFireConfirmationView` previously chose padding from `horizontalSizeClass`, which becomes **`.compact` inside a popover** even on a regular-width iPad. Offscreen `sizeThatFits` sizing could use different padding than the live view, so the popover height was too small and the `ScrollView` scrolled.
> 
> The PR introduces **`presentationHorizontalSizeClass`** (environment key) and injects the **presenting** view controller’s horizontal size class from `FireConfirmationPresenter` and `AIChatContextualSheetViewController`. Layout padding now follows that value so measurement and on-screen layout agree.
> 
> iPad popover and iPhone sheet configuration helpers are generalized with **`Content: View`** so the same rooted view (with the injected environment) is used for height calculation and presentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a059474e58d78da10d3c7333e7d446ad8a5bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->