### PR TITLE
[iOS] Delay m_app_return and return-session transmission by 1-30s

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		2CCD716C578642B8BC760D55 /* NTPAfterIdleInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0742FD8DD5F46AB8243103F /* NTPAfterIdleInstrumentation.swift */; };
 		2CCD716C578642B8BCA1A001 /* IdleReturnTabCountInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0742FD8DD5F46AB8243A001 /* IdleReturnTabCountInstrumentation.swift */; };
 		2CCD716C578642B8BCA1A0B1 /* AppReturnInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0742FD8DD5F46AB8243A0B1 /* AppReturnInstrumentation.swift */; };
+		F1A2B3C4D5E60101AABBC0D2 /* PixelTransmissionDelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E60101AABBC0D1 /* PixelTransmissionDelay.swift */; };
 		2CE746E172B444FABF361C7B /* ContextualSheetAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C7E64D7A9241698BA2243F /* ContextualSheetAction.swift */; };
 		2DC3FC65C6D9DA634426672D /* AutofillNoAuthAvailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC3FBD62FBAF21E87610FA8 /* AutofillNoAuthAvailableView.swift */; };
 		3105BCF12DF214A000EB755E /* AIChatPixelMetricHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3105BCF02DF214A000EB755E /* AIChatPixelMetricHandler.swift */; };
@@ -1812,6 +1813,7 @@
 		A1B2C3D4E5F60002A1B2C3D4 /* UnifiedInputContentContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001A1B2C3D4 /* UnifiedInputContentContainerViewController.swift */; };
 		A1B2C3D4E5F60002AABBA001 /* IdleReturnTabCountInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */; };
 		A1B2C3D4E5F60002AABBA0B1 /* AppReturnInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002AABBA0B2 /* AppReturnInstrumentationTests.swift */; };
+		F1A2B3C4D5E60102AABBC0D2 /* PixelTransmissionDelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E60102AABBC0D1 /* PixelTransmissionDelayTests.swift */; };
 		A1B2C3D4E5F60012A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60011A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift */; };
 		A1B2C3D4E5F60014A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60013A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift */; };
 		A1B2C3D72F7F111100ABCDEF /* SyncSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D62F7F111100ABCDEF /* SyncSettingsViewModelTests.swift */; };
@@ -4687,6 +4689,7 @@
 		A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPAfterIdleInstrumentationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnTabCountInstrumentationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60002AABBA0B2 /* AppReturnInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReturnInstrumentationTests.swift; sourceTree = "<group>"; };
+		F1A2B3C4D5E60102AABBC0D1 /* PixelTransmissionDelayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelTransmissionDelayTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60011A1B2C3D4 /* AIChatReasoningMode+UnifiedToggleInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AIChatReasoningMode+UnifiedToggleInput.swift"; sourceTree = "<group>"; };
 		A1B2C3D4E5F60013A1B2C3D4 /* UnifiedToggleInputReasoningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedToggleInputReasoningTests.swift; sourceTree = "<group>"; };
 		A1B2C3D62F7F111100ABCDEF /* SyncSettingsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncSettingsViewModelTests.swift; sourceTree = "<group>"; };
@@ -5469,6 +5472,7 @@
 		E0742FD8DD5F46AB8243103F /* NTPAfterIdleInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPAfterIdleInstrumentation.swift; sourceTree = "<group>"; };
 		E0742FD8DD5F46AB8243A001 /* IdleReturnTabCountInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnTabCountInstrumentation.swift; sourceTree = "<group>"; };
 		E0742FD8DD5F46AB8243A0B1 /* AppReturnInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReturnInstrumentation.swift; sourceTree = "<group>"; };
+		F1A2B3C4D5E60101AABBC0D1 /* PixelTransmissionDelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelTransmissionDelay.swift; sourceTree = "<group>"; };
 		E1A4A4D42F2A111100AA11BB /* TabViewController+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TabViewController+UI.swift"; sourceTree = "<group>"; };
 		E3663DD21563403B96D50EF0 /* AfterInactivityOptionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterInactivityOptionAdapter.swift; sourceTree = "<group>"; };
 		E44F90E856A0488A976B6AFE /* FileCorruptErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCorruptErrorView.swift; sourceTree = "<group>"; };
@@ -10888,6 +10892,7 @@
 				E0742FD8DD5F46AB8243103F /* NTPAfterIdleInstrumentation.swift */,
 				E0742FD8DD5F46AB8243A001 /* IdleReturnTabCountInstrumentation.swift */,
 				E0742FD8DD5F46AB8243A0B1 /* AppReturnInstrumentation.swift */,
+				F1A2B3C4D5E60101AABBC0D1 /* PixelTransmissionDelay.swift */,
 				D1A2B3C4E5F60001AABB0002 /* PostIdleSessionWideEventData.swift */,
 				D1A2B3C4E5F60001AABB0102 /* ReturnSessionWideEventData.swift */,
 				D1A2B3C4E5F60001AABB0006 /* PostIdleSessionInstrumentation.swift */,
@@ -11872,6 +11877,7 @@
 				A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */,
 				A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */,
 				A1B2C3D4E5F60002AABBA0B2 /* AppReturnInstrumentationTests.swift */,
+				F1A2B3C4D5E60102AABBC0D1 /* PixelTransmissionDelayTests.swift */,
 				D1A2B3C4E5F60001AABB0004 /* PostIdleSessionWideEventDataTests.swift */,
 				D1A2B3C4E5F60001AABB0104 /* ReturnSessionWideEventDataTests.swift */,
 				D1A2B3C4E5F60001AABB0008 /* PostIdleSessionInstrumentationTests.swift */,
@@ -13625,6 +13631,7 @@
 				2CCD716C578642B8BC760D55 /* NTPAfterIdleInstrumentation.swift in Sources */,
 				2CCD716C578642B8BCA1A001 /* IdleReturnTabCountInstrumentation.swift in Sources */,
 				2CCD716C578642B8BCA1A0B1 /* AppReturnInstrumentation.swift in Sources */,
+				F1A2B3C4D5E60101AABBC0D2 /* PixelTransmissionDelay.swift in Sources */,
 				D1A2B3C4E5F60001AABB0001 /* PostIdleSessionWideEventData.swift in Sources */,
 				D1A2B3C4E5F60001AABB0101 /* ReturnSessionWideEventData.swift in Sources */,
 				D1A2B3C4E5F60001AABB0005 /* PostIdleSessionInstrumentation.swift in Sources */,
@@ -14851,6 +14858,7 @@
 				9FB484A7301ADA9300125636 /* OnboardingAIModelsResolverTests.swift in Sources */,
 				A1B2C3D4E5F60002AABBA001 /* IdleReturnTabCountInstrumentationTests.swift in Sources */,
 				A1B2C3D4E5F60002AABBA0B1 /* AppReturnInstrumentationTests.swift in Sources */,
+				F1A2B3C4D5E60102AABBC0D2 /* PixelTransmissionDelayTests.swift in Sources */,
 				D1A2B3C4E5F60001AABB0003 /* PostIdleSessionWideEventDataTests.swift in Sources */,
 				D1A2B3C4E5F60001AABB0103 /* ReturnSessionWideEventDataTests.swift in Sources */,
 				CBB4A8492FD2FB6600A65956 /* DuckAISuggestionsPipelineTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
@@ -179,14 +179,18 @@ final class AppDependencyProvider: DependencyProvider {
         PixelKit.configureExperimentKit(featureFlagger: featureFlagger,
                                         eventTracker: ExperimentEventTracker(store: UserDefaults(suiteName: Global.appConfigurationGroupName) ?? UserDefaults()))
 
-        self.wideEvent = WideEvent(
-            useMockRequests: {
+        let useMockWideEventRequests = {
 #if DEBUG || REVIEW || ALPHA
-                true
+            true
 #else
-                false
+            false
 #endif
-            }(),
+        }()
+        self.wideEvent = WideEvent(
+            storage: WideEventUserDefaultsStorage(),
+            sender: ReturnSessionSendDelayingWideEventSender(
+                wrapping: DefaultWideEventSender(useMockRequests: useMockWideEventRequests)
+            ),
             featureFlagProvider: WideEventFeatureFlagAdapter(featureFlagger: featureFlagger)
         )
         configurationURLProvider = ConfigurationURLProvider(defaultProvider: AppConfigurationURLProvider(featureFlagger: featureFlagger), internalUserDecider: internalUserDecider, store: CustomConfigurationURLStorage(defaults: UserDefaults(suiteName: Global.appConfigurationGroupName) ?? UserDefaults()))

--- a/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
@@ -84,9 +84,10 @@ final class DefaultAppReturnInstrumentation: AppReturnInstrumentation {
         ]
 
         // Defer the whole fire, not just the request: the daily marker is written inside it.
+        // Copied out so the deferred send does not capture `self`.
         let fire = fireDailyAndCount
-        delay.delaySend { requestDidFinish in
-            fire(.appReturn, parameters) { _, _ in requestDidFinish() }
+        delay.delaySend { keepAppAwake in
+            fire(.appReturn, parameters) { _, _ in withExtendedLifetime(keepAppAwake) { } }
         }
     }
 

--- a/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
@@ -43,12 +43,14 @@ final class DefaultAppReturnInstrumentation: AppReturnInstrumentation {
     private let isUnifiedInputAvailable: () -> Bool
     private let isToggleEnabled: () -> Bool
     private let now: () -> Date
+    private let delay: PixelTransmissionDelaying
     private let fireDailyAndCount: (AppReturnPixel, [String: String]) -> Void
 
     init(eligibilityManager: IdleReturnEligibilityManaging,
          isUnifiedInputAvailable: @escaping () -> Bool = { UnifiedToggleInputFeature().isAvailable },
          isToggleEnabled: @escaping () -> Bool,
          now: @escaping () -> Date = Date.init,
+         delay: PixelTransmissionDelaying = PixelTransmissionDelay(),
          fireDailyAndCount: @escaping (AppReturnPixel, [String: String]) -> Void = { event, params in
              PixelKit.fire(event, frequency: .dailyAndCount, withAdditionalParameters: params)
          }) {
@@ -56,6 +58,7 @@ final class DefaultAppReturnInstrumentation: AppReturnInstrumentation {
         self.isUnifiedInputAvailable = isUnifiedInputAvailable
         self.isToggleEnabled = isToggleEnabled
         self.now = now
+        self.delay = delay
         self.fireDailyAndCount = fireDailyAndCount
     }
 
@@ -69,7 +72,7 @@ final class DefaultAppReturnInstrumentation: AppReturnInstrumentation {
         case .lastUsedTab: afterInactivityOption = "last_used_tab"
         }
 
-        fireDailyAndCount(.appReturn, [
+        let parameters = [
             "time_away_bucket": Self.timeAwayBucket(for: timeAway),
             "exceeded_idle_threshold": String(timeAway.map { $0 >= Double(thresholdSeconds) } ?? false),
             "idle_threshold_seconds": String(thresholdSeconds),
@@ -78,7 +81,12 @@ final class DefaultAppReturnInstrumentation: AppReturnInstrumentation {
             "unified_input_available": String(isUnifiedInputAvailable()),
             "toggle_enabled": String(isToggleEnabled()),
             "launch_source": Self.launchSource(for: launchAction)
-        ])
+        ]
+
+        // The whole fire is deferred, not just the request: the daily marker is written inside it,
+        // so delaying only the request would mark the day as sent while the send can still be lost.
+        let fire = fireDailyAndCount
+        delay.delaySend { fire(.appReturn, parameters) }
     }
 
     static func timeAwayBucket(for timeAway: TimeInterval?) -> String {

--- a/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
@@ -44,15 +44,15 @@ final class DefaultAppReturnInstrumentation: AppReturnInstrumentation {
     private let isToggleEnabled: () -> Bool
     private let now: () -> Date
     private let delay: PixelTransmissionDelaying
-    private let fireDailyAndCount: (AppReturnPixel, [String: String]) -> Void
+    private let fireDailyAndCount: (AppReturnPixel, [String: String], @escaping PixelKit.CompletionBlock) -> Void
 
     init(eligibilityManager: IdleReturnEligibilityManaging,
          isUnifiedInputAvailable: @escaping () -> Bool = { UnifiedToggleInputFeature().isAvailable },
          isToggleEnabled: @escaping () -> Bool,
          now: @escaping () -> Date = Date.init,
          delay: PixelTransmissionDelaying = PixelTransmissionDelay(),
-         fireDailyAndCount: @escaping (AppReturnPixel, [String: String]) -> Void = { event, params in
-             PixelKit.fire(event, frequency: .dailyAndCount, withAdditionalParameters: params)
+         fireDailyAndCount: @escaping (AppReturnPixel, [String: String], @escaping PixelKit.CompletionBlock) -> Void = { event, params, onComplete in
+             PixelKit.fire(event, frequency: .dailyAndCount, withAdditionalParameters: params, onComplete: onComplete)
          }) {
         self.eligibilityManager = eligibilityManager
         self.isUnifiedInputAvailable = isUnifiedInputAvailable
@@ -85,7 +85,9 @@ final class DefaultAppReturnInstrumentation: AppReturnInstrumentation {
 
         // Defer the whole fire, not just the request: the daily marker is written inside it.
         let fire = fireDailyAndCount
-        delay.delaySend { fire(.appReturn, parameters) }
+        delay.delaySend { requestDidFinish in
+            fire(.appReturn, parameters) { _, _ in requestDidFinish() }
+        }
     }
 
     static func timeAwayBucket(for timeAway: TimeInterval?) -> String {

--- a/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
@@ -83,8 +83,7 @@ final class DefaultAppReturnInstrumentation: AppReturnInstrumentation {
             "launch_source": Self.launchSource(for: launchAction)
         ]
 
-        // The whole fire is deferred, not just the request: the daily marker is written inside it,
-        // so delaying only the request would mark the day as sent while the send can still be lost.
+        // Defer the whole fire, not just the request: the daily marker is written inside it.
         let fire = fireDailyAndCount
         delay.delaySend { fire(.appReturn, parameters) }
     }

--- a/iOS/DuckDuckGo/AppLifecycle/PixelTransmissionDelay.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PixelTransmissionDelay.swift
@@ -56,12 +56,10 @@ final class PixelTransmissionDelay: PixelTransmissionDelaying {
          makeAssertion: @escaping () -> BackgroundAssertion? = {
              QRunInBackgroundAssertion(name: PixelTransmissionDelay.assertionName, application: .shared)
          },
+         // Always hops, because being on the main thread does not mean being on the main queue and
+         // `QRunInBackgroundAssertion` asserts the latter.
          runOnMain: @escaping (@escaping () -> Void) -> Void = { work in
-             if Thread.isMainThread {
-                 work()
-             } else {
-                 DispatchQueue.main.async(execute: work)
-             }
+             DispatchQueue.main.async(execute: work)
          },
          schedule: @escaping (TimeInterval, @escaping () -> Void) -> Void = { interval, work in
              DispatchQueue.main.asyncAfter(deadline: .now() + interval, execute: work)

--- a/iOS/DuckDuckGo/AppLifecycle/PixelTransmissionDelay.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PixelTransmissionDelay.swift
@@ -1,0 +1,143 @@
+//
+//  PixelTransmissionDelay.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import UIKit
+import PixelKit
+
+/// The part of `QRunInBackgroundAssertion` needed here, so the delay can be exercised without `UIApplication`.
+protocol BackgroundAssertion: AnyObject {
+    var systemDidReleaseAssertion: (() -> Void)? { get set }
+    func release()
+}
+
+extension QRunInBackgroundAssertion: BackgroundAssertion {}
+
+/// Holds a measurement back so it does not land in the burst of pixels the app sends when it
+/// foregrounds. Sends within that burst group into one session, and a time-away parameter sent
+/// alongside them then points back to the previous burst.
+protocol PixelTransmissionDelaying {
+    /// Must be safe to call from any thread; the send itself runs on the main thread.
+    func delaySend(_ send: @escaping () -> Void)
+}
+
+final class PixelTransmissionDelay: PixelTransmissionDelaying {
+
+    /// Agreed with Privacy Triage. The upper bound also matches the background execution window
+    /// iOS grants, so a send drawn at the top of the range still runs if the user leaves at once.
+    static let range: ClosedRange<TimeInterval> = 1...30
+
+    static func randomInterval() -> TimeInterval {
+        .random(in: range)
+    }
+
+    private static let assertionName = "Delayed pixel transmission"
+
+    private let interval: () -> TimeInterval
+    private let makeAssertion: () -> BackgroundAssertion?
+    private let runOnMain: (@escaping () -> Void) -> Void
+    private let schedule: (TimeInterval, @escaping () -> Void) -> Void
+
+    init(interval: @escaping () -> TimeInterval = PixelTransmissionDelay.randomInterval,
+         makeAssertion: @escaping () -> BackgroundAssertion? = {
+             QRunInBackgroundAssertion(name: PixelTransmissionDelay.assertionName, application: .shared)
+         },
+         runOnMain: @escaping (@escaping () -> Void) -> Void = { work in
+             if Thread.isMainThread {
+                 work()
+             } else {
+                 DispatchQueue.main.async(execute: work)
+             }
+         },
+         schedule: @escaping (TimeInterval, @escaping () -> Void) -> Void = { interval, work in
+             DispatchQueue.main.asyncAfter(deadline: .now() + interval, execute: work)
+         }) {
+        self.interval = interval
+        self.makeAssertion = makeAssertion
+        self.runOnMain = runOnMain
+        self.schedule = schedule
+    }
+
+    func delaySend(_ send: @escaping () -> Void) {
+        let interval = self.interval()
+        let makeAssertion = self.makeAssertion
+        let schedule = self.schedule
+
+        // The assertion has to be taken now rather than when the delay elapses, and both it and
+        // its callback are main-thread only.
+        runOnMain {
+            let pending = PendingSend(send: send, assertion: makeAssertion())
+            schedule(interval) { pending.run() }
+        }
+    }
+}
+
+/// Sends once, on whichever comes first: the delay elapsing, or the system reclaiming the
+/// assertion. Both arrive on the main thread, so the one-shot guard needs no locking.
+private final class PendingSend {
+
+    private var send: (() -> Void)?
+    private let assertion: BackgroundAssertion?
+
+    init(send: @escaping () -> Void, assertion: BackgroundAssertion?) {
+        self.send = send
+        self.assertion = assertion
+        assertion?.systemDidReleaseAssertion = { [weak self] in self?.run() }
+    }
+
+    func run() {
+        guard let send else { return }
+        self.send = nil
+        send()
+        assertion?.release()
+    }
+}
+
+/// Applies the transmission delay to the return-session event only. Every other wide event is sent
+/// as it was: none of the others carry a time-away parameter pointing back to a previous session.
+///
+/// This sits at the send seam, which `WideEvent.completeFlow` reaches only after removing the flow
+/// from storage, so a delayed send can never be completed a second time by the orphan sweep.
+final class ReturnSessionSendDelayingWideEventSender: WideEventSending {
+
+    private let wrapped: WideEventSending
+    private let delay: PixelTransmissionDelaying
+
+    init(wrapping wrapped: WideEventSending, delay: PixelTransmissionDelaying = PixelTransmissionDelay()) {
+        self.wrapped = wrapped
+        self.delay = delay
+    }
+
+    func send<T: WideEventData>(_ data: T,
+                                status: WideEventStatus,
+                                featureFlagProvider: WideEventFeatureFlagProviding,
+                                onComplete: @escaping PixelKit.CompletionBlock) {
+        let wrapped = self.wrapped
+        let send = {
+            wrapped.send(data, status: status, featureFlagProvider: featureFlagProvider, onComplete: onComplete)
+        }
+
+        guard data is ReturnSessionWideEventData else {
+            send()
+            return
+        }
+
+        delay.delaySend(send)
+    }
+}

--- a/iOS/DuckDuckGo/AppLifecycle/PixelTransmissionDelay.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PixelTransmissionDelay.swift
@@ -21,7 +21,7 @@ import Foundation
 import UIKit
 import PixelKit
 
-/// The part of `QRunInBackgroundAssertion` needed here, so the delay can be exercised without `UIApplication`.
+/// The part of `QRunInBackgroundAssertion` needed here, so tests can run without `UIApplication`.
 protocol BackgroundAssertion: AnyObject {
     var systemDidReleaseAssertion: (() -> Void)? { get set }
     func release()
@@ -29,18 +29,15 @@ protocol BackgroundAssertion: AnyObject {
 
 extension QRunInBackgroundAssertion: BackgroundAssertion {}
 
-/// Holds a measurement back so it does not land in the burst of pixels the app sends when it
-/// foregrounds. Sends within that burst group into one session, and a time-away parameter sent
-/// alongside them then points back to the previous burst.
+/// Holds a send back so it does not land in the burst of pixels the app sends when it foregrounds.
 protocol PixelTransmissionDelaying {
-    /// Must be safe to call from any thread; the send itself runs on the main thread.
+    /// Safe to call from any thread; the send itself runs on the main thread.
     func delaySend(_ send: @escaping () -> Void)
 }
 
 final class PixelTransmissionDelay: PixelTransmissionDelaying {
 
-    /// Agreed with Privacy Triage. The upper bound also matches the background execution window
-    /// iOS grants, so a send drawn at the top of the range still runs if the user leaves at once.
+    /// Agreed with Privacy Triage; the upper bound also matches the background window iOS grants.
     static let range: ClosedRange<TimeInterval> = 1...30
 
     static func randomInterval() -> TimeInterval {
@@ -79,8 +76,7 @@ final class PixelTransmissionDelay: PixelTransmissionDelaying {
         let makeAssertion = self.makeAssertion
         let schedule = self.schedule
 
-        // The assertion has to be taken now rather than when the delay elapses, and both it and
-        // its callback are main-thread only.
+        // The assertion must be taken now, not when the delay elapses, and is main-thread only.
         runOnMain {
             let pending = PendingSend(send: send, assertion: makeAssertion())
             schedule(interval) { pending.run() }
@@ -88,8 +84,8 @@ final class PixelTransmissionDelay: PixelTransmissionDelaying {
     }
 }
 
-/// Sends once, on whichever comes first: the delay elapsing, or the system reclaiming the
-/// assertion. Both arrive on the main thread, so the one-shot guard needs no locking.
+/// Sends once, on whichever comes first: the delay elapsing or the assertion being reclaimed.
+/// Both arrive on the main thread, so the one-shot guard needs no locking.
 private final class PendingSend {
 
     private var send: (() -> Void)?
@@ -109,11 +105,8 @@ private final class PendingSend {
     }
 }
 
-/// Applies the transmission delay to the return-session event only. Every other wide event is sent
-/// as it was: none of the others carry a time-away parameter pointing back to a previous session.
-///
-/// This sits at the send seam, which `WideEvent.completeFlow` reaches only after removing the flow
-/// from storage, so a delayed send can never be completed a second time by the orphan sweep.
+/// Delays the return-session event only. Sits at the send seam, which `completeFlow` reaches
+/// after removing the flow from storage, so a delayed send is out of reach of the orphan sweep.
 final class ReturnSessionSendDelayingWideEventSender: WideEventSending {
 
     private let wrapped: WideEventSending

--- a/iOS/DuckDuckGo/AppLifecycle/PixelTransmissionDelay.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PixelTransmissionDelay.swift
@@ -29,26 +29,57 @@ protocol BackgroundAssertion: AnyObject {
 
 extension QRunInBackgroundAssertion: BackgroundAssertion {}
 
+/// Keeps the app awake while a delayed send is in flight. The guarantee lasts exactly as long as
+/// the last reference to it, so hold one from every completion the send hands out.
+final class PixelSendToken {
+
+    private let assertion: BackgroundAssertion?
+    private let runOnMain: (@escaping () -> Void) -> Void
+
+    init(assertion: BackgroundAssertion?, runOnMain: @escaping (@escaping () -> Void) -> Void) {
+        self.assertion = assertion
+        self.runOnMain = runOnMain
+    }
+
+    /// Called on the main thread when the system reclaims the assertion before we are done with it.
+    func onSystemRelease(_ handler: @escaping () -> Void) {
+        assertion?.systemDidReleaseAssertion = handler
+    }
+
+    deinit {
+        // Hop because the last reference is usually dropped by a URL session callback, and both
+        // releasing and clearing `systemDidReleaseAssertion` assert they are on the main queue.
+        let assertion = self.assertion
+        runOnMain { assertion?.release() }
+    }
+}
+
 /// Holds a send back so it does not land in the burst of pixels the app sends when it foregrounds.
 protocol PixelTransmissionDelaying {
-    /// Safe to call from any thread; the send itself runs on the main thread. The send must call the
-    /// closure it is handed once its request finished, so the assertion covers the request too.
-    func delaySend(_ send: @escaping (_ requestDidFinish: @escaping () -> Void) -> Void)
+    /// Safe to call from any thread. The send runs on the main thread and must keep the token it is
+    /// handed alive until every request it started has finished.
+    func delaySend(_ send: @escaping (_ keepAppAwake: PixelSendToken) -> Void)
 }
 
 final class PixelTransmissionDelay: PixelTransmissionDelaying {
 
-    /// Agreed with Privacy Triage; the upper bound also matches the background window iOS grants.
+    /// Agreed with Privacy Triage. The wait is trimmed when the remaining background budget is
+    /// smaller, so the upper bound does not have to fit inside the window iOS grants.
     static let range: ClosedRange<TimeInterval> = 1...30
 
     static func randomInterval() -> TimeInterval {
         .random(in: range)
     }
 
+    /// Kept back from the background budget for the request itself, since the assertion starts
+    /// running down the moment it is taken rather than when the wait is over.
+    private static let requestHeadroom: TimeInterval = 10
+
     private static let assertionName = "Delayed pixel transmission"
 
     private let interval: () -> TimeInterval
     private let makeAssertion: () -> BackgroundAssertion?
+    private let backgroundTimeRemaining: () -> TimeInterval
     private let runOnMain: (@escaping () -> Void) -> Void
     private let schedule: (TimeInterval, @escaping () -> Void) -> Void
 
@@ -56,6 +87,9 @@ final class PixelTransmissionDelay: PixelTransmissionDelaying {
          makeAssertion: @escaping () -> BackgroundAssertion? = {
              QRunInBackgroundAssertion(name: PixelTransmissionDelay.assertionName, application: .shared)
          },
+         // `.greatestFiniteMagnitude` while foregrounded, so the wait is only ever trimmed when the
+         // app is on its way out.
+         backgroundTimeRemaining: @escaping () -> TimeInterval = { UIApplication.shared.backgroundTimeRemaining },
          // Always hops, because being on the main thread does not mean being on the main queue and
          // `QRunInBackgroundAssertion` asserts the latter.
          runOnMain: @escaping (@escaping () -> Void) -> Void = { work in
@@ -66,50 +100,54 @@ final class PixelTransmissionDelay: PixelTransmissionDelaying {
          }) {
         self.interval = interval
         self.makeAssertion = makeAssertion
+        self.backgroundTimeRemaining = backgroundTimeRemaining
         self.runOnMain = runOnMain
         self.schedule = schedule
     }
 
-    func delaySend(_ send: @escaping (@escaping () -> Void) -> Void) {
+    func delaySend(_ send: @escaping (PixelSendToken) -> Void) {
         let interval = self.interval()
         let makeAssertion = self.makeAssertion
+        let backgroundTimeRemaining = self.backgroundTimeRemaining
         let runOnMain = self.runOnMain
         let schedule = self.schedule
 
-        // The assertion must be taken now, not when the delay elapses, and is main-thread only.
+        // The assertion must be taken now, not when the wait elapses, and is main-thread only.
         runOnMain {
-            let pending = PendingSend(send: send, assertion: makeAssertion(), runOnMain: runOnMain)
-            schedule(interval) { pending.run() }
+            let token = PixelSendToken(assertion: makeAssertion(), runOnMain: runOnMain)
+            let wait = Self.wait(for: interval, budget: backgroundTimeRemaining())
+            let pending = PendingSend(send: send, token: token)
+            schedule(wait) { pending.run() }
         }
+    }
+
+    /// Read after the assertion is taken, so the budget is the one the system actually granted.
+    private static func wait(for interval: TimeInterval, budget: TimeInterval) -> TimeInterval {
+        min(interval, max(range.lowerBound, budget - requestHeadroom))
     }
 }
 
-/// Sends once, on whichever comes first: the delay elapsing or the assertion being reclaimed.
+/// Sends once, on whichever comes first: the wait elapsing or the assertion being reclaimed.
 /// Both arrive on the main thread, so the one-shot guard needs no locking.
 private final class PendingSend {
 
-    private var send: ((@escaping () -> Void) -> Void)?
-    private let assertion: BackgroundAssertion?
-    private let runOnMain: (@escaping () -> Void) -> Void
+    private var send: ((PixelSendToken) -> Void)?
+    private var token: PixelSendToken?
 
-    init(send: @escaping (@escaping () -> Void) -> Void,
-         assertion: BackgroundAssertion?,
-         runOnMain: @escaping (@escaping () -> Void) -> Void) {
+    init(send: @escaping (PixelSendToken) -> Void, token: PixelSendToken) {
         self.send = send
-        self.assertion = assertion
-        self.runOnMain = runOnMain
-        assertion?.systemDidReleaseAssertion = { [weak self] in self?.run() }
+        self.token = token
+        token.onSystemRelease { [weak self] in self?.run() }
     }
 
     func run() {
-        guard let send else { return }
+        guard let send, let token else { return }
         self.send = nil
 
-        // Handing the assertion to the completion keeps it alive for the request, not just for the
-        // call that starts it. Hop to main because PixelKit calls back off it and releasing cannot.
-        let assertion = self.assertion
-        let runOnMain = self.runOnMain
-        send { runOnMain { assertion?.release() } }
+        // Hand the token over rather than releasing when the send reports back: `.dailyAndCount`
+        // completes once per fired variant, so the first report is not the last request.
+        self.token = nil
+        send(token)
     }
 }
 
@@ -136,10 +174,10 @@ final class ReturnSessionSendDelayingWideEventSender: WideEventSending {
             return
         }
 
-        delay.delaySend { requestDidFinish in
+        delay.delaySend { keepAppAwake in
             wrapped.send(data, status: status, featureFlagProvider: featureFlagProvider) { success, error in
                 onComplete(success, error)
-                requestDidFinish()
+                withExtendedLifetime(keepAppAwake) { }
             }
         }
     }

--- a/iOS/DuckDuckGo/AppLifecycle/PixelTransmissionDelay.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PixelTransmissionDelay.swift
@@ -31,8 +31,9 @@ extension QRunInBackgroundAssertion: BackgroundAssertion {}
 
 /// Holds a send back so it does not land in the burst of pixels the app sends when it foregrounds.
 protocol PixelTransmissionDelaying {
-    /// Safe to call from any thread; the send itself runs on the main thread.
-    func delaySend(_ send: @escaping () -> Void)
+    /// Safe to call from any thread; the send itself runs on the main thread. The send must call the
+    /// closure it is handed once its request finished, so the assertion covers the request too.
+    func delaySend(_ send: @escaping (_ requestDidFinish: @escaping () -> Void) -> Void)
 }
 
 final class PixelTransmissionDelay: PixelTransmissionDelaying {
@@ -71,14 +72,15 @@ final class PixelTransmissionDelay: PixelTransmissionDelaying {
         self.schedule = schedule
     }
 
-    func delaySend(_ send: @escaping () -> Void) {
+    func delaySend(_ send: @escaping (@escaping () -> Void) -> Void) {
         let interval = self.interval()
         let makeAssertion = self.makeAssertion
+        let runOnMain = self.runOnMain
         let schedule = self.schedule
 
         // The assertion must be taken now, not when the delay elapses, and is main-thread only.
         runOnMain {
-            let pending = PendingSend(send: send, assertion: makeAssertion())
+            let pending = PendingSend(send: send, assertion: makeAssertion(), runOnMain: runOnMain)
             schedule(interval) { pending.run() }
         }
     }
@@ -88,20 +90,28 @@ final class PixelTransmissionDelay: PixelTransmissionDelaying {
 /// Both arrive on the main thread, so the one-shot guard needs no locking.
 private final class PendingSend {
 
-    private var send: (() -> Void)?
+    private var send: ((@escaping () -> Void) -> Void)?
     private let assertion: BackgroundAssertion?
+    private let runOnMain: (@escaping () -> Void) -> Void
 
-    init(send: @escaping () -> Void, assertion: BackgroundAssertion?) {
+    init(send: @escaping (@escaping () -> Void) -> Void,
+         assertion: BackgroundAssertion?,
+         runOnMain: @escaping (@escaping () -> Void) -> Void) {
         self.send = send
         self.assertion = assertion
+        self.runOnMain = runOnMain
         assertion?.systemDidReleaseAssertion = { [weak self] in self?.run() }
     }
 
     func run() {
         guard let send else { return }
         self.send = nil
-        send()
-        assertion?.release()
+
+        // Handing the assertion to the completion keeps it alive for the request, not just for the
+        // call that starts it. Hop to main because PixelKit calls back off it and releasing cannot.
+        let assertion = self.assertion
+        let runOnMain = self.runOnMain
+        send { runOnMain { assertion?.release() } }
     }
 }
 
@@ -122,15 +132,17 @@ final class ReturnSessionSendDelayingWideEventSender: WideEventSending {
                                 featureFlagProvider: WideEventFeatureFlagProviding,
                                 onComplete: @escaping PixelKit.CompletionBlock) {
         let wrapped = self.wrapped
-        let send = {
-            wrapped.send(data, status: status, featureFlagProvider: featureFlagProvider, onComplete: onComplete)
-        }
 
         guard data is ReturnSessionWideEventData else {
-            send()
+            wrapped.send(data, status: status, featureFlagProvider: featureFlagProvider, onComplete: onComplete)
             return
         }
 
-        delay.delaySend(send)
+        delay.delaySend { requestDidFinish in
+            wrapped.send(data, status: status, featureFlagProvider: featureFlagProvider) { success, error in
+                onComplete(success, error)
+                requestDidFinish()
+            }
+        }
     }
 }

--- a/iOS/DuckDuckGoTests/AppReturnInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/AppReturnInstrumentationTests.swift
@@ -31,21 +31,22 @@ struct AppReturnInstrumentationTests {
 
     /// Runs the send as soon as it is handed over, so the existing expectations can stay synchronous.
     private final class ImmediateDelay: PixelTransmissionDelaying {
-        func delaySend(_ send: @escaping () -> Void) {
-            send()
+        func delaySend(_ send: @escaping (@escaping () -> Void) -> Void) {
+            send { }
         }
     }
 
     /// Holds the send until the test releases it, standing in for the randomised wait.
     private final class ManualDelay: PixelTransmissionDelaying {
-        private var pending: (() -> Void)?
+        private var pending: ((@escaping () -> Void) -> Void)?
+        private(set) var requestDidFinish = false
 
-        func delaySend(_ send: @escaping () -> Void) {
+        func delaySend(_ send: @escaping (@escaping () -> Void) -> Void) {
             pending = send
         }
 
         func elapse() {
-            pending?()
+            pending?({ self.requestDidFinish = true })
         }
     }
 
@@ -70,8 +71,9 @@ struct AppReturnInstrumentationTests {
             isToggleEnabled: { toggleEnabled },
             now: { Self.now },
             delay: delay,
-            fireDailyAndCount: { event, params in
+            fireDailyAndCount: { event, params, onComplete in
                 collector.fired.append((event.name, params))
+                onComplete(true, nil)
             })
         return (sut, collector)
     }
@@ -209,6 +211,21 @@ struct AppReturnInstrumentationTests {
 
         #expect(collector.fired.first?.params["idle_threshold_seconds"] == "900")
         #expect(collector.fired.first?.params["exceeded_idle_threshold"] == "true")
+    }
+
+    @available(iOS 16, *)
+    @Test("When the fired pixel completes then the delay is told the request finished", .timeLimit(.minutes(1)))
+    func whenFiredPixelCompletesThenDelayIsToldRequestFinished() {
+        let delay = ManualDelay()
+        let (sut, _) = makeSUT(delay: delay)
+
+        sut.recordAppForeground(lastBackgroundDate: backgroundDate(secondsAgo: 120),
+                                launchAction: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: false))
+        #expect(delay.requestDidFinish == false)
+
+        delay.elapse()
+
+        #expect(delay.requestDidFinish)
     }
 
     // MARK: - Launch source

--- a/iOS/DuckDuckGoTests/AppReturnInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/AppReturnInstrumentationTests.swift
@@ -29,6 +29,26 @@ struct AppReturnInstrumentationTests {
         var fired: [(name: String, params: [String: String])] = []
     }
 
+    /// Runs the send as soon as it is handed over, so the existing expectations can stay synchronous.
+    private final class ImmediateDelay: PixelTransmissionDelaying {
+        func delaySend(_ send: @escaping () -> Void) {
+            send()
+        }
+    }
+
+    /// Holds the send until the test releases it, standing in for the randomised wait.
+    private final class ManualDelay: PixelTransmissionDelaying {
+        private var pending: (() -> Void)?
+
+        func delaySend(_ send: @escaping () -> Void) {
+            pending = send
+        }
+
+        func elapse() {
+            pending?()
+        }
+    }
+
     private static let now = Date(timeIntervalSince1970: 1_750_000_000)
 
     private func makeSUT(
@@ -36,7 +56,8 @@ struct AppReturnInstrumentationTests {
         effectiveOption: AfterInactivityOption = .newTab,
         thresholdSeconds: Int = 1800,
         unifiedInputAvailable: Bool = false,
-        toggleEnabled: Bool = false
+        toggleEnabled: Bool = false,
+        delay: PixelTransmissionDelaying = ImmediateDelay()
     ) -> (DefaultAppReturnInstrumentation, PixelCollector) {
         let eligibility = MockIdleReturnEligibilityManager()
         eligibility.isFeatureAvailableResult = featureAvailable
@@ -48,6 +69,7 @@ struct AppReturnInstrumentationTests {
             isUnifiedInputAvailable: { unifiedInputAvailable },
             isToggleEnabled: { toggleEnabled },
             now: { Self.now },
+            delay: delay,
             fireDailyAndCount: { event, params in
                 collector.fired.append((event.name, params))
             })
@@ -154,6 +176,39 @@ struct AppReturnInstrumentationTests {
 
         #expect(collector.fired.first?.params["unified_input_available"] == "true")
         #expect(collector.fired.first?.params["toggle_enabled"] == "true")
+    }
+
+    // MARK: - Transmission delay
+
+    @available(iOS 16, *)
+    @Test("When the app foregrounds then the pixel is held back until the delay elapses", .timeLimit(.minutes(1)))
+    func whenAppForegroundsThenPixelIsHeldBackUntilDelayElapses() {
+        let delay = ManualDelay()
+        let (sut, collector) = makeSUT(delay: delay)
+
+        sut.recordAppForeground(lastBackgroundDate: backgroundDate(secondsAgo: 120),
+                                launchAction: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: false))
+
+        #expect(collector.fired.isEmpty)
+
+        delay.elapse()
+
+        #expect(collector.fired.count == 1)
+        #expect(collector.fired.first?.params["time_away_bucket"] == "1_5m")
+    }
+
+    @available(iOS 16, *)
+    @Test("When the delay elapses then the parameters are the ones captured at foreground time", .timeLimit(.minutes(1)))
+    func whenDelayElapsesThenParametersAreCapturedAtForegroundTime() {
+        let delay = ManualDelay()
+        let (sut, collector) = makeSUT(thresholdSeconds: 900, delay: delay)
+
+        sut.recordAppForeground(lastBackgroundDate: backgroundDate(secondsAgo: 1000),
+                                launchAction: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: false))
+        delay.elapse()
+
+        #expect(collector.fired.first?.params["idle_threshold_seconds"] == "900")
+        #expect(collector.fired.first?.params["exceeded_idle_threshold"] == "true")
     }
 
     // MARK: - Launch source

--- a/iOS/DuckDuckGoTests/AppReturnInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/AppReturnInstrumentationTests.swift
@@ -27,26 +27,39 @@ struct AppReturnInstrumentationTests {
 
     private final class PixelCollector {
         var fired: [(name: String, params: [String: String])] = []
+        private var completions: [(Bool, Error?) -> Void] = []
+
+        func record(_ name: String, _ params: [String: String], _ onComplete: @escaping (Bool, Error?) -> Void) {
+            fired.append((name, params))
+            completions.append(onComplete)
+        }
+
+        /// Reports back and lets go, the way the transport does once a request is done.
+        func completeFires(success: Bool = true) {
+            let reported = completions
+            completions = []
+            reported.forEach { $0(success, nil) }
+        }
     }
 
     /// Runs the send as soon as it is handed over, so the existing expectations can stay synchronous.
     private final class ImmediateDelay: PixelTransmissionDelaying {
-        func delaySend(_ send: @escaping (@escaping () -> Void) -> Void) {
-            send { }
+        func delaySend(_ send: @escaping (PixelSendToken) -> Void) {
+            send(PixelSendToken(assertion: nil, runOnMain: { $0() }))
         }
     }
 
     /// Holds the send until the test releases it, standing in for the randomised wait.
     private final class ManualDelay: PixelTransmissionDelaying {
-        private var pending: ((@escaping () -> Void) -> Void)?
-        private(set) var requestDidFinish = false
+        let assertion = FakeBackgroundAssertion()
+        private var pending: ((PixelSendToken) -> Void)?
 
-        func delaySend(_ send: @escaping (@escaping () -> Void) -> Void) {
+        func delaySend(_ send: @escaping (PixelSendToken) -> Void) {
             pending = send
         }
 
         func elapse() {
-            pending?({ self.requestDidFinish = true })
+            pending?(PixelSendToken(assertion: assertion, runOnMain: { $0() }))
         }
     }
 
@@ -72,8 +85,7 @@ struct AppReturnInstrumentationTests {
             now: { Self.now },
             delay: delay,
             fireDailyAndCount: { event, params, onComplete in
-                collector.fired.append((event.name, params))
-                onComplete(true, nil)
+                collector.record(event.name, params, onComplete)
             })
         return (sut, collector)
     }
@@ -214,18 +226,31 @@ struct AppReturnInstrumentationTests {
     }
 
     @available(iOS 16, *)
-    @Test("When the fired pixel completes then the delay is told the request finished", .timeLimit(.minutes(1)))
-    func whenFiredPixelCompletesThenDelayIsToldRequestFinished() {
+    @Test("When the fired pixel is still in flight then the app is kept awake", .timeLimit(.minutes(1)))
+    func whenFiredPixelIsStillInFlightThenAppIsKeptAwake() {
         let delay = ManualDelay()
-        let (sut, _) = makeSUT(delay: delay)
+        let (sut, collector) = makeSUT(delay: delay)
 
         sut.recordAppForeground(lastBackgroundDate: backgroundDate(secondsAgo: 120),
                                 launchAction: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: false))
-        #expect(delay.requestDidFinish == false)
-
         delay.elapse()
 
-        #expect(delay.requestDidFinish)
+        #expect(collector.fired.count == 1)
+        #expect(delay.assertion.releaseCount == 0)
+    }
+
+    @available(iOS 16, *)
+    @Test("When the fired pixel finishes then the app is let go", .timeLimit(.minutes(1)))
+    func whenFiredPixelFinishesThenAppIsLetGo() {
+        let delay = ManualDelay()
+        let (sut, collector) = makeSUT(delay: delay)
+
+        sut.recordAppForeground(lastBackgroundDate: backgroundDate(secondsAgo: 120),
+                                launchAction: .standardLaunch(lastBackgroundDate: nil, isFirstForeground: false))
+        delay.elapse()
+        collector.completeFires()
+
+        #expect(delay.assertion.releaseCount == 1)
     }
 
     // MARK: - Launch source

--- a/iOS/DuckDuckGoTests/PixelTransmissionDelayTests.swift
+++ b/iOS/DuckDuckGoTests/PixelTransmissionDelayTests.swift
@@ -22,59 +22,72 @@ import Testing
 import PixelKit
 @testable import DuckDuckGo
 
+/// Shared with `AppReturnInstrumentationTests`, which needs to observe the same release.
+final class FakeBackgroundAssertion: BackgroundAssertion {
+    var systemDidReleaseAssertion: (() -> Void)?
+    var releaseCount = 0
+
+    func release() {
+        releaseCount += 1
+    }
+}
+
 @Suite("Pixel Transmission Delay")
 struct PixelTransmissionDelayTests {
 
-    private final class FakeBackgroundAssertion: BackgroundAssertion {
-        var systemDidReleaseAssertion: (() -> Void)?
-        var releaseCount = 0
-
-        func release() {
-            releaseCount += 1
-        }
-    }
-
     private final class Scheduler {
-        var interval: TimeInterval?
-        var work: (() -> Void)?
+        private(set) var intervals: [TimeInterval] = []
+        private var work: [() -> Void] = []
 
-        func elapse() {
-            work?()
+        var interval: TimeInterval? { intervals.first }
+
+        func schedule(_ interval: TimeInterval, _ work: @escaping () -> Void) {
+            intervals.append(interval)
+            self.work.append(work)
+        }
+
+        /// Deliberately keeps the work, so re-firing a scheduled send is possible.
+        func elapse(_ index: Int = 0) {
+            work[index]()
         }
     }
 
     private final class SendSpy {
         var count = 0
-        private var requestDidFinish: (() -> Void)?
+        var requestsPerSend = 1
+        private var tokens: [PixelSendToken] = []
 
-        /// Stands in for a send: records the call and holds its completion until the test finishes it.
-        func send(_ requestDidFinish: @escaping () -> Void) {
+        /// Stands in for a send: records the call and holds the token once per request it starts,
+        /// the way `.dailyAndCount` hands the same completion to both of its requests.
+        func send(_ keepAppAwake: PixelSendToken) {
             count += 1
-            self.requestDidFinish = requestDidFinish
+            tokens.append(contentsOf: Array(repeating: keepAppAwake, count: requestsPerSend))
         }
 
+        /// One of the requests came back.
         func finishRequest() {
-            requestDidFinish?()
+            if !tokens.isEmpty {
+                tokens.removeLast()
+            }
         }
     }
 
     private func makeSUT(interval: TimeInterval = 5,
-                         assertion: BackgroundAssertion? = nil) -> (PixelTransmissionDelay, Scheduler) {
+                         budget: TimeInterval = .greatestFiniteMagnitude,
+                         makeAssertion: @escaping () -> BackgroundAssertion? = { nil }) -> (PixelTransmissionDelay, Scheduler) {
         let scheduler = Scheduler()
         let sut = PixelTransmissionDelay(
             interval: { interval },
-            makeAssertion: { assertion },
+            makeAssertion: makeAssertion,
+            backgroundTimeRemaining: { budget },
             runOnMain: { $0() },
-            schedule: { interval, work in
-                scheduler.interval = interval
-                scheduler.work = work
-            })
+            schedule: scheduler.schedule)
         return (sut, scheduler)
     }
 
     // MARK: - Deferral
 
-    @Test("When a send is delayed then it does not run before the interval elapses")
+    @Test("When a send is delayed then it does not run before the wait elapses")
     func whenSendIsDelayedThenItDoesNotRunImmediately() {
         let (sut, scheduler) = makeSUT(interval: 12)
         let spy = SendSpy()
@@ -85,8 +98,8 @@ struct PixelTransmissionDelayTests {
         #expect(scheduler.interval == 12)
     }
 
-    @Test("When the interval elapses then the send runs")
-    func whenIntervalElapsesThenSendRuns() {
+    @Test("When the wait elapses then the send runs")
+    func whenWaitElapsesThenSendRuns() {
         let (sut, scheduler) = makeSUT()
         let spy = SendSpy()
 
@@ -96,26 +109,120 @@ struct PixelTransmissionDelayTests {
         #expect(spy.count == 1)
     }
 
-    // MARK: - Randomised interval
+    @Test("When the wait elapses twice then the send runs only once")
+    func whenWaitElapsesTwiceThenSendRunsOnce() {
+        let (sut, scheduler) = makeSUT(makeAssertion: { FakeBackgroundAssertion() })
+        let spy = SendSpy()
 
-    @Test("When the interval is randomised then it stays within the range agreed with Privacy Triage")
-    func whenIntervalIsRandomisedThenItStaysWithinRange() {
-        for _ in 0..<500 {
-            #expect(PixelTransmissionDelay.range.contains(PixelTransmissionDelay.randomInterval()))
-        }
+        sut.delaySend(spy.send)
+        scheduler.elapse()
+        scheduler.elapse()
+
+        #expect(spy.count == 1)
     }
 
-    @Test("When the range is read then it matches the 1-30s mitigation")
-    func whenRangeIsReadThenItMatchesTheMitigation() {
-        #expect(PixelTransmissionDelay.range == 1...30)
+    @Test("When two sends are delayed then each gets its own assertion and wait")
+    func whenTwoSendsAreDelayedThenEachGetsItsOwnAssertion() {
+        var assertions: [FakeBackgroundAssertion] = []
+        var intervals: [TimeInterval] = [4, 9]
+        let scheduler = Scheduler()
+        let sut = PixelTransmissionDelay(
+            interval: { intervals.removeFirst() },
+            makeAssertion: {
+                let assertion = FakeBackgroundAssertion()
+                assertions.append(assertion)
+                return assertion
+            },
+            backgroundTimeRemaining: { .greatestFiniteMagnitude },
+            runOnMain: { $0() },
+            schedule: scheduler.schedule)
+        let first = SendSpy()
+        let second = SendSpy()
+
+        sut.delaySend(first.send)
+        sut.delaySend(second.send)
+        scheduler.elapse(1)
+
+        #expect(scheduler.intervals == [4, 9])
+        #expect(assertions.count == 2)
+        #expect(first.count == 0)
+        #expect(second.count == 1)
+        // Finishing the second send leaves the first one's assertion untouched.
+        second.finishRequest()
+        #expect(assertions[0].releaseCount == 0)
+        #expect(assertions[1].releaseCount == 1)
+    }
+
+    // MARK: - Background budget
+
+    @Test("When the app is foregrounded then the full agreed wait is used")
+    func whenAppIsForegroundedThenFullAgreedWaitIsUsed() {
+        // `backgroundTimeRemaining` reports `.greatestFiniteMagnitude` while foregrounded.
+        let (sut, scheduler) = makeSUT(interval: 30, budget: .greatestFiniteMagnitude)
+
+        sut.delaySend(SendSpy().send)
+
+        #expect(scheduler.interval == 30)
+    }
+
+    @Test("When the background budget is shorter than the wait then the wait is trimmed to fit")
+    func whenBudgetIsShorterThanWaitThenWaitIsTrimmed() {
+        // 10s of the budget is kept back for the request itself.
+        let (sut, scheduler) = makeSUT(interval: 30, budget: 25)
+
+        sut.delaySend(SendSpy().send)
+
+        #expect(scheduler.interval == 15)
+    }
+
+    @Test("When the background budget is nearly gone then the shortest agreed wait is used")
+    func whenBudgetIsNearlyGoneThenShortestAgreedWaitIsUsed() {
+        let (sut, scheduler) = makeSUT(interval: 30, budget: 2)
+
+        sut.delaySend(SendSpy().send)
+
+        #expect(scheduler.interval == PixelTransmissionDelay.range.lowerBound)
+    }
+
+    @Test("When the budget is ample then a short wait is left alone")
+    func whenBudgetIsAmpleThenShortWaitIsLeftAlone() {
+        let (sut, scheduler) = makeSUT(interval: 3, budget: 25)
+
+        sut.delaySend(SendSpy().send)
+
+        #expect(scheduler.interval == 3)
     }
 
     // MARK: - Background assertion
 
+    @Test("When a send is delayed then the assertion is taken once, up front")
+    func whenSendIsDelayedThenAssertionIsTakenOnceUpFront() {
+        var made = 0
+        let scheduler = Scheduler()
+        let sut = PixelTransmissionDelay(
+            interval: { 5 },
+            makeAssertion: {
+                made += 1
+                return FakeBackgroundAssertion()
+            },
+            backgroundTimeRemaining: { .greatestFiniteMagnitude },
+            runOnMain: { $0() },
+            schedule: scheduler.schedule)
+
+        sut.delaySend(SendSpy().send)
+
+        // Taken when the send is handed over, not when the wait elapses.
+        #expect(made == 1)
+
+        scheduler.elapse()
+
+        #expect(made == 1)
+    }
+
     @Test("When the system reclaims the background assertion then the send runs without waiting")
     func whenAssertionExpiresThenSendRunsWithoutWaiting() {
         let assertion = FakeBackgroundAssertion()
-        let (sut, _) = makeSUT(assertion: assertion)
+        let (sut, _) = makeSUT(makeAssertion: { assertion })
         let spy = SendSpy()
 
         sut.delaySend(spy.send)
@@ -124,10 +231,10 @@ struct PixelTransmissionDelayTests {
         #expect(spy.count == 1)
     }
 
-    @Test("When the interval elapses after the assertion expired then the send runs only once")
-    func whenIntervalElapsesAfterExpiryThenSendRunsOnce() {
+    @Test("When the wait elapses after the assertion expired then the send runs only once")
+    func whenWaitElapsesAfterExpiryThenSendRunsOnce() {
         let assertion = FakeBackgroundAssertion()
-        let (sut, scheduler) = makeSUT(assertion: assertion)
+        let (sut, scheduler) = makeSUT(makeAssertion: { assertion })
         let spy = SendSpy()
 
         sut.delaySend(spy.send)
@@ -140,7 +247,7 @@ struct PixelTransmissionDelayTests {
     @Test("When the request is still in flight then the background assertion is still held")
     func whenRequestIsInFlightThenAssertionIsStillHeld() {
         let assertion = FakeBackgroundAssertion()
-        let (sut, scheduler) = makeSUT(assertion: assertion)
+        let (sut, scheduler) = makeSUT(makeAssertion: { assertion })
         let spy = SendSpy()
 
         sut.delaySend(spy.send)
@@ -156,7 +263,7 @@ struct PixelTransmissionDelayTests {
     @Test("When the request finishes then the background assertion is released")
     func whenRequestFinishesThenAssertionIsReleased() {
         let assertion = FakeBackgroundAssertion()
-        let (sut, scheduler) = makeSUT(assertion: assertion)
+        let (sut, scheduler) = makeSUT(makeAssertion: { assertion })
         let spy = SendSpy()
 
         sut.delaySend(spy.send)
@@ -166,54 +273,58 @@ struct PixelTransmissionDelayTests {
         #expect(assertion.releaseCount == 1)
     }
 
-    @Test("When the request reports completion twice then the assertion is released twice, harmlessly")
-    func whenRequestReportsCompletionTwiceThenReleaseIsIdempotent() {
+    @Test("When a send starts two requests then the assertion is held until the last one finishes")
+    func whenSendStartsTwoRequestsThenAssertionHeldUntilLastFinishes() {
+        // `.dailyAndCount` fires the daily and the count request off the same completion, so the
+        // first request to come back must not end the assertion.
         let assertion = FakeBackgroundAssertion()
-        let (sut, scheduler) = makeSUT(assertion: assertion)
+        let (sut, scheduler) = makeSUT(makeAssertion: { assertion })
         let spy = SendSpy()
+        spy.requestsPerSend = 2
 
-        // `.dailyAndCount` calls back once per fired variant, and `release()` is documented safe to
-        // call redundantly, so the delay does not need to count completions itself.
         sut.delaySend(spy.send)
         scheduler.elapse()
         spy.finishRequest()
+
+        #expect(assertion.releaseCount == 0)
+
         spy.finishRequest()
 
-        #expect(assertion.releaseCount == 2)
+        #expect(assertion.releaseCount == 1)
     }
 
-    @Test("When the interval elapses twice then the send runs only once")
-    func whenIntervalElapsesTwiceThenSendRunsOnce() {
+    @Test("When a send never reports back then the assertion is released as it is let go")
+    func whenSendNeverReportsBackThenAssertionIsReleasedWhenLetGo() {
+        // Nothing holds the token, e.g. `PixelKit.shared` was nil and the fire never happened.
         let assertion = FakeBackgroundAssertion()
-        let (sut, scheduler) = makeSUT(assertion: assertion)
-        let spy = SendSpy()
+        let (sut, scheduler) = makeSUT(makeAssertion: { assertion })
 
-        sut.delaySend(spy.send)
-        scheduler.elapse()
+        sut.delaySend { _ in }
         scheduler.elapse()
 
-        #expect(spy.count == 1)
+        #expect(assertion.releaseCount == 1)
     }
 
-    @Test("When the release lands off the main thread then it is hopped back onto it")
-    func whenReleaseLandsOffMainThenItIsHoppedOntoMain() {
+    @Test("When the release is triggered then it goes through the main-queue hop")
+    func whenReleaseIsTriggeredThenItGoesThroughTheMainQueueHop() {
         let assertion = FakeBackgroundAssertion()
         let scheduler = Scheduler()
         var hops = 0
         let sut = PixelTransmissionDelay(
             interval: { 5 },
             makeAssertion: { assertion },
+            backgroundTimeRemaining: { .greatestFiniteMagnitude },
             runOnMain: { work in
                 hops += 1
                 work()
             },
-            schedule: { interval, work in
-                scheduler.interval = interval
-                scheduler.work = work
-            })
+            schedule: scheduler.schedule)
         let spy = SendSpy()
 
         sut.delaySend(spy.send)
+        // Taking the assertion is the first hop.
+        #expect(hops == 1)
+
         scheduler.elapse()
         #expect(hops == 1)
 
@@ -223,6 +334,35 @@ struct PixelTransmissionDelayTests {
         #expect(hops == 2)
         #expect(assertion.releaseCount == 1)
     }
+
+    @available(iOS 16, *)
+    @Test("When the delay runs against the real assertion then no main-queue precondition trips", .timeLimit(.minutes(1)))
+    func whenDelayRunsAgainstRealAssertionThenNoMainQueuePreconditionTrips() async {
+        // The assertion, the hop and the scheduler are the production ones here, so a hop the code
+        // forgets to make trips `QRunInBackgroundAssertion`'s preconditions in this test rather
+        // than in the field. Only the wait is shortened.
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            var hops = 0
+            let sut = PixelTransmissionDelay(
+                interval: { 0.01 },
+                runOnMain: { work in
+                    DispatchQueue.main.async {
+                        work()
+                        hops += 1
+                        // The second hop is the release, queued by the token as the send let it go.
+                        if hops == 2 {
+                            continuation.resume()
+                        }
+                    }
+                })
+
+            sut.delaySend { keepAppAwake in
+                DispatchQueue.global().async {
+                    withExtendedLifetime(keepAppAwake) { }
+                }
+            }
+        }
+    }
 }
 
 @Suite("Return Session Send Delaying Wide Event Sender")
@@ -231,6 +371,7 @@ struct ReturnSessionSendDelayingWideEventSenderTests {
     private final class SpyWideEventSender: WideEventSending {
         var sentPixelNames: [String] = []
         var sentStatuses: [WideEventStatus] = []
+        var sentFeatureFlagProviders: [WideEventFeatureFlagProviding] = []
         private var onComplete: PixelKit.CompletionBlock?
 
         func send<T: WideEventData>(_ data: T,
@@ -239,26 +380,36 @@ struct ReturnSessionSendDelayingWideEventSenderTests {
                                     onComplete: @escaping PixelKit.CompletionBlock) {
             sentPixelNames.append(T.metadata.pixelName)
             sentStatuses.append(status)
+            sentFeatureFlagProviders.append(featureFlagProvider)
             self.onComplete = onComplete
         }
 
-        func finishRequest(success: Bool) {
-            onComplete?(success, nil)
+        func finishRequest(success: Bool, error: Error? = nil) {
+            onComplete?(success, error)
+        }
+
+        /// Drops the completion, the way the transport would once it is done with it.
+        func letGoOfCompletion() {
+            onComplete = nil
         }
     }
 
     private final class ImmediateDelay: PixelTransmissionDelaying {
         var delayedSends = 0
-        private(set) var requestDidFinish = false
+        let assertion = FakeBackgroundAssertion()
 
-        func delaySend(_ send: @escaping (@escaping () -> Void) -> Void) {
+        func delaySend(_ send: @escaping (PixelSendToken) -> Void) {
             delayedSends += 1
-            send { self.requestDidFinish = true }
+            send(PixelSendToken(assertion: assertion, runOnMain: { $0() }))
         }
     }
 
     private struct StubFeatureFlagProvider: WideEventFeatureFlagProviding {
         func isEnabled(_ flag: WideEventFeatureFlag) -> Bool { true }
+    }
+
+    private func returnSessionData() -> ReturnSessionWideEventData {
+        ReturnSessionWideEventData(landedOn: .ntp, afterIdle: true)
     }
 
     @Test("When the return session event is sent then it goes through the delay")
@@ -267,7 +418,7 @@ struct ReturnSessionSendDelayingWideEventSenderTests {
         let delay = ImmediateDelay()
         let sut = ReturnSessionSendDelayingWideEventSender(wrapping: wrapped, delay: delay)
 
-        sut.send(ReturnSessionWideEventData(landedOn: .ntp, afterIdle: true),
+        sut.send(returnSessionData(),
                  status: .cancelled,
                  featureFlagProvider: StubFeatureFlagProvider(),
                  onComplete: { _, _ in })
@@ -291,37 +442,77 @@ struct ReturnSessionSendDelayingWideEventSenderTests {
         #expect(wrapped.sentPixelNames == ["post_idle_session"])
     }
 
-    @Test("When the delayed send completes then the caller and the delay are both told")
-    func whenDelayedSendCompletesThenCallerAndDelayAreBothTold() {
+    @Test("When the delayed send completes then the caller is told")
+    func whenDelayedSendCompletesThenCallerIsTold() {
         let wrapped = SpyWideEventSender()
-        let delay = ImmediateDelay()
-        let sut = ReturnSessionSendDelayingWideEventSender(wrapping: wrapped, delay: delay)
+        let sut = ReturnSessionSendDelayingWideEventSender(wrapping: wrapped, delay: ImmediateDelay())
         var reportedSuccess: Bool?
 
-        sut.send(ReturnSessionWideEventData(landedOn: .ntp, afterIdle: true),
+        sut.send(returnSessionData(),
                  status: .cancelled,
                  featureFlagProvider: StubFeatureFlagProvider(),
                  onComplete: { success, _ in reportedSuccess = success })
 
         #expect(reportedSuccess == nil)
-        #expect(delay.requestDidFinish == false)
 
         wrapped.finishRequest(success: true)
 
         #expect(reportedSuccess == true)
-        #expect(delay.requestDidFinish)
     }
 
-    @Test("When an event is wrapped then the status reaches the wrapped sender unchanged")
-    func whenEventIsWrappedThenStatusReachesWrappedSenderUnchanged() {
+    @Test("When the delayed send fails then the failure reaches the caller")
+    func whenDelayedSendFailsThenFailureReachesCaller() {
         let wrapped = SpyWideEventSender()
         let sut = ReturnSessionSendDelayingWideEventSender(wrapping: wrapped, delay: ImmediateDelay())
+        var reportedSuccess: Bool?
+        var reportedError: Error?
 
-        sut.send(ReturnSessionWideEventData(landedOn: .ntp, afterIdle: true),
-                 status: .success(reason: "search_submitted"),
+        sut.send(returnSessionData(),
+                 status: .cancelled,
                  featureFlagProvider: StubFeatureFlagProvider(),
+                 onComplete: { success, error in
+                     reportedSuccess = success
+                     reportedError = error
+                 })
+        wrapped.finishRequest(success: false, error: WideEventError.invalidFlowState)
+
+        #expect(reportedSuccess == false)
+        #expect(reportedError is WideEventError)
+    }
+
+    @Test("When the transport still holds the completion then the app is kept awake")
+    func whenTransportStillHoldsCompletionThenAppIsKeptAwake() {
+        let wrapped = SpyWideEventSender()
+        let delay = ImmediateDelay()
+        let sut = ReturnSessionSendDelayingWideEventSender(wrapping: wrapped, delay: delay)
+
+        sut.send(returnSessionData(),
+                 status: .cancelled,
+                 featureFlagProvider: StubFeatureFlagProvider(),
+                 onComplete: { _, _ in })
+        wrapped.finishRequest(success: true)
+
+        // Reporting back is not letting go: the app stays awake until the transport drops it.
+        #expect(delay.assertion.releaseCount == 0)
+
+        wrapped.letGoOfCompletion()
+
+        #expect(delay.assertion.releaseCount == 1)
+    }
+
+    @Test("When an event is wrapped then the status and flag provider reach the wrapped sender")
+    func whenEventIsWrappedThenStatusAndFlagProviderReachWrappedSender() {
+        let wrapped = SpyWideEventSender()
+        let sut = ReturnSessionSendDelayingWideEventSender(wrapping: wrapped, delay: ImmediateDelay())
+        let featureFlagProvider = StubFeatureFlagProvider()
+
+        sut.send(returnSessionData(),
+                 status: .success(reason: "search_submitted"),
+                 featureFlagProvider: featureFlagProvider,
                  onComplete: { _, _ in })
 
         #expect(wrapped.sentStatuses == [.success(reason: "search_submitted")])
+        #expect(wrapped.sentFeatureFlagProviders.count == 1)
+        #expect(wrapped.sentFeatureFlagProviders.first is StubFeatureFlagProvider)
     }
 }

--- a/iOS/DuckDuckGoTests/PixelTransmissionDelayTests.swift
+++ b/iOS/DuckDuckGoTests/PixelTransmissionDelayTests.swift
@@ -45,6 +45,17 @@ struct PixelTransmissionDelayTests {
 
     private final class SendSpy {
         var count = 0
+        private var requestDidFinish: (() -> Void)?
+
+        /// Stands in for a send: records the call and holds its completion until the test finishes it.
+        func send(_ requestDidFinish: @escaping () -> Void) {
+            count += 1
+            self.requestDidFinish = requestDidFinish
+        }
+
+        func finishRequest() {
+            requestDidFinish?()
+        }
     }
 
     private func makeSUT(interval: TimeInterval = 5,
@@ -68,7 +79,7 @@ struct PixelTransmissionDelayTests {
         let (sut, scheduler) = makeSUT(interval: 12)
         let spy = SendSpy()
 
-        sut.delaySend { spy.count += 1 }
+        sut.delaySend(spy.send)
 
         #expect(spy.count == 0)
         #expect(scheduler.interval == 12)
@@ -79,7 +90,7 @@ struct PixelTransmissionDelayTests {
         let (sut, scheduler) = makeSUT()
         let spy = SendSpy()
 
-        sut.delaySend { spy.count += 1 }
+        sut.delaySend(spy.send)
         scheduler.elapse()
 
         #expect(spy.count == 1)
@@ -107,7 +118,7 @@ struct PixelTransmissionDelayTests {
         let (sut, _) = makeSUT(assertion: assertion)
         let spy = SendSpy()
 
-        sut.delaySend { spy.count += 1 }
+        sut.delaySend(spy.send)
         assertion.systemDidReleaseAssertion?()
 
         #expect(spy.count == 1)
@@ -119,34 +130,97 @@ struct PixelTransmissionDelayTests {
         let (sut, scheduler) = makeSUT(assertion: assertion)
         let spy = SendSpy()
 
-        sut.delaySend { spy.count += 1 }
+        sut.delaySend(spy.send)
         assertion.systemDidReleaseAssertion?()
         scheduler.elapse()
 
         #expect(spy.count == 1)
     }
 
-    @Test("When the send runs then the background assertion is released")
-    func whenSendRunsThenAssertionIsReleased() {
+    @Test("When the request is still in flight then the background assertion is still held")
+    func whenRequestIsInFlightThenAssertionIsStillHeld() {
         let assertion = FakeBackgroundAssertion()
         let (sut, scheduler) = makeSUT(assertion: assertion)
+        let spy = SendSpy()
 
-        sut.delaySend { }
+        sut.delaySend(spy.send)
         #expect(assertion.releaseCount == 0)
 
         scheduler.elapse()
+
+        // The send has been kicked off but its request has not come back yet.
+        #expect(spy.count == 1)
+        #expect(assertion.releaseCount == 0)
+    }
+
+    @Test("When the request finishes then the background assertion is released")
+    func whenRequestFinishesThenAssertionIsReleased() {
+        let assertion = FakeBackgroundAssertion()
+        let (sut, scheduler) = makeSUT(assertion: assertion)
+        let spy = SendSpy()
+
+        sut.delaySend(spy.send)
+        scheduler.elapse()
+        spy.finishRequest()
+
         #expect(assertion.releaseCount == 1)
     }
 
-    @Test("When the interval elapses twice then the assertion is released only once")
-    func whenIntervalElapsesTwiceThenAssertionIsReleasedOnce() {
+    @Test("When the request reports completion twice then the assertion is released twice, harmlessly")
+    func whenRequestReportsCompletionTwiceThenReleaseIsIdempotent() {
         let assertion = FakeBackgroundAssertion()
         let (sut, scheduler) = makeSUT(assertion: assertion)
+        let spy = SendSpy()
 
-        sut.delaySend { }
+        // `.dailyAndCount` calls back once per fired variant, and `release()` is documented safe to
+        // call redundantly, so the delay does not need to count completions itself.
+        sut.delaySend(spy.send)
+        scheduler.elapse()
+        spy.finishRequest()
+        spy.finishRequest()
+
+        #expect(assertion.releaseCount == 2)
+    }
+
+    @Test("When the interval elapses twice then the send runs only once")
+    func whenIntervalElapsesTwiceThenSendRunsOnce() {
+        let assertion = FakeBackgroundAssertion()
+        let (sut, scheduler) = makeSUT(assertion: assertion)
+        let spy = SendSpy()
+
+        sut.delaySend(spy.send)
         scheduler.elapse()
         scheduler.elapse()
 
+        #expect(spy.count == 1)
+    }
+
+    @Test("When the release lands off the main thread then it is hopped back onto it")
+    func whenReleaseLandsOffMainThenItIsHoppedOntoMain() {
+        let assertion = FakeBackgroundAssertion()
+        let scheduler = Scheduler()
+        var hops = 0
+        let sut = PixelTransmissionDelay(
+            interval: { 5 },
+            makeAssertion: { assertion },
+            runOnMain: { work in
+                hops += 1
+                work()
+            },
+            schedule: { interval, work in
+                scheduler.interval = interval
+                scheduler.work = work
+            })
+        let spy = SendSpy()
+
+        sut.delaySend(spy.send)
+        scheduler.elapse()
+        #expect(hops == 1)
+
+        // PixelKit's iOS fire request calls back off the main thread, and releasing asserts on it.
+        spy.finishRequest()
+
+        #expect(hops == 2)
         #expect(assertion.releaseCount == 1)
     }
 }
@@ -156,21 +230,30 @@ struct ReturnSessionSendDelayingWideEventSenderTests {
 
     private final class SpyWideEventSender: WideEventSending {
         var sentPixelNames: [String] = []
+        var sentStatuses: [WideEventStatus] = []
+        private var onComplete: PixelKit.CompletionBlock?
 
         func send<T: WideEventData>(_ data: T,
                                     status: WideEventStatus,
                                     featureFlagProvider: WideEventFeatureFlagProviding,
                                     onComplete: @escaping PixelKit.CompletionBlock) {
             sentPixelNames.append(T.metadata.pixelName)
+            sentStatuses.append(status)
+            self.onComplete = onComplete
+        }
+
+        func finishRequest(success: Bool) {
+            onComplete?(success, nil)
         }
     }
 
     private final class ImmediateDelay: PixelTransmissionDelaying {
         var delayedSends = 0
+        private(set) var requestDidFinish = false
 
-        func delaySend(_ send: @escaping () -> Void) {
+        func delaySend(_ send: @escaping (@escaping () -> Void) -> Void) {
             delayedSends += 1
-            send()
+            send { self.requestDidFinish = true }
         }
     }
 
@@ -206,5 +289,39 @@ struct ReturnSessionSendDelayingWideEventSenderTests {
 
         #expect(delay.delayedSends == 0)
         #expect(wrapped.sentPixelNames == ["post_idle_session"])
+    }
+
+    @Test("When the delayed send completes then the caller and the delay are both told")
+    func whenDelayedSendCompletesThenCallerAndDelayAreBothTold() {
+        let wrapped = SpyWideEventSender()
+        let delay = ImmediateDelay()
+        let sut = ReturnSessionSendDelayingWideEventSender(wrapping: wrapped, delay: delay)
+        var reportedSuccess: Bool?
+
+        sut.send(ReturnSessionWideEventData(landedOn: .ntp, afterIdle: true),
+                 status: .cancelled,
+                 featureFlagProvider: StubFeatureFlagProvider(),
+                 onComplete: { success, _ in reportedSuccess = success })
+
+        #expect(reportedSuccess == nil)
+        #expect(delay.requestDidFinish == false)
+
+        wrapped.finishRequest(success: true)
+
+        #expect(reportedSuccess == true)
+        #expect(delay.requestDidFinish)
+    }
+
+    @Test("When an event is wrapped then the status reaches the wrapped sender unchanged")
+    func whenEventIsWrappedThenStatusReachesWrappedSenderUnchanged() {
+        let wrapped = SpyWideEventSender()
+        let sut = ReturnSessionSendDelayingWideEventSender(wrapping: wrapped, delay: ImmediateDelay())
+
+        sut.send(ReturnSessionWideEventData(landedOn: .ntp, afterIdle: true),
+                 status: .success(reason: "search_submitted"),
+                 featureFlagProvider: StubFeatureFlagProvider(),
+                 onComplete: { _, _ in })
+
+        #expect(wrapped.sentStatuses == [.success(reason: "search_submitted")])
     }
 }

--- a/iOS/DuckDuckGoTests/PixelTransmissionDelayTests.swift
+++ b/iOS/DuckDuckGoTests/PixelTransmissionDelayTests.swift
@@ -1,0 +1,210 @@
+//
+//  PixelTransmissionDelayTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+import PixelKit
+@testable import DuckDuckGo
+
+@Suite("Pixel Transmission Delay")
+struct PixelTransmissionDelayTests {
+
+    private final class FakeBackgroundAssertion: BackgroundAssertion {
+        var systemDidReleaseAssertion: (() -> Void)?
+        var releaseCount = 0
+
+        func release() {
+            releaseCount += 1
+        }
+    }
+
+    private final class Scheduler {
+        var interval: TimeInterval?
+        var work: (() -> Void)?
+
+        func elapse() {
+            work?()
+        }
+    }
+
+    private final class SendSpy {
+        var count = 0
+    }
+
+    private func makeSUT(interval: TimeInterval = 5,
+                         assertion: BackgroundAssertion? = nil) -> (PixelTransmissionDelay, Scheduler) {
+        let scheduler = Scheduler()
+        let sut = PixelTransmissionDelay(
+            interval: { interval },
+            makeAssertion: { assertion },
+            runOnMain: { $0() },
+            schedule: { interval, work in
+                scheduler.interval = interval
+                scheduler.work = work
+            })
+        return (sut, scheduler)
+    }
+
+    // MARK: - Deferral
+
+    @Test("When a send is delayed then it does not run before the interval elapses")
+    func whenSendIsDelayedThenItDoesNotRunImmediately() {
+        let (sut, scheduler) = makeSUT(interval: 12)
+        let spy = SendSpy()
+
+        sut.delaySend { spy.count += 1 }
+
+        #expect(spy.count == 0)
+        #expect(scheduler.interval == 12)
+    }
+
+    @Test("When the interval elapses then the send runs")
+    func whenIntervalElapsesThenSendRuns() {
+        let (sut, scheduler) = makeSUT()
+        let spy = SendSpy()
+
+        sut.delaySend { spy.count += 1 }
+        scheduler.elapse()
+
+        #expect(spy.count == 1)
+    }
+
+    // MARK: - Randomised interval
+
+    @Test("When the interval is randomised then it stays within the range agreed with Privacy Triage")
+    func whenIntervalIsRandomisedThenItStaysWithinRange() {
+        for _ in 0..<500 {
+            #expect(PixelTransmissionDelay.range.contains(PixelTransmissionDelay.randomInterval()))
+        }
+    }
+
+    @Test("When the range is read then it matches the 1-30s mitigation")
+    func whenRangeIsReadThenItMatchesTheMitigation() {
+        #expect(PixelTransmissionDelay.range == 1...30)
+    }
+
+    // MARK: - Background assertion
+
+    @Test("When the system reclaims the background assertion then the send runs without waiting")
+    func whenAssertionExpiresThenSendRunsWithoutWaiting() {
+        let assertion = FakeBackgroundAssertion()
+        let (sut, _) = makeSUT(assertion: assertion)
+        let spy = SendSpy()
+
+        sut.delaySend { spy.count += 1 }
+        assertion.systemDidReleaseAssertion?()
+
+        #expect(spy.count == 1)
+    }
+
+    @Test("When the interval elapses after the assertion expired then the send runs only once")
+    func whenIntervalElapsesAfterExpiryThenSendRunsOnce() {
+        let assertion = FakeBackgroundAssertion()
+        let (sut, scheduler) = makeSUT(assertion: assertion)
+        let spy = SendSpy()
+
+        sut.delaySend { spy.count += 1 }
+        assertion.systemDidReleaseAssertion?()
+        scheduler.elapse()
+
+        #expect(spy.count == 1)
+    }
+
+    @Test("When the send runs then the background assertion is released")
+    func whenSendRunsThenAssertionIsReleased() {
+        let assertion = FakeBackgroundAssertion()
+        let (sut, scheduler) = makeSUT(assertion: assertion)
+
+        sut.delaySend { }
+        #expect(assertion.releaseCount == 0)
+
+        scheduler.elapse()
+        #expect(assertion.releaseCount == 1)
+    }
+
+    @Test("When the interval elapses twice then the assertion is released only once")
+    func whenIntervalElapsesTwiceThenAssertionIsReleasedOnce() {
+        let assertion = FakeBackgroundAssertion()
+        let (sut, scheduler) = makeSUT(assertion: assertion)
+
+        sut.delaySend { }
+        scheduler.elapse()
+        scheduler.elapse()
+
+        #expect(assertion.releaseCount == 1)
+    }
+}
+
+@Suite("Return Session Send Delaying Wide Event Sender")
+struct ReturnSessionSendDelayingWideEventSenderTests {
+
+    private final class SpyWideEventSender: WideEventSending {
+        var sentPixelNames: [String] = []
+
+        func send<T: WideEventData>(_ data: T,
+                                    status: WideEventStatus,
+                                    featureFlagProvider: WideEventFeatureFlagProviding,
+                                    onComplete: @escaping PixelKit.CompletionBlock) {
+            sentPixelNames.append(T.metadata.pixelName)
+        }
+    }
+
+    private final class ImmediateDelay: PixelTransmissionDelaying {
+        var delayedSends = 0
+
+        func delaySend(_ send: @escaping () -> Void) {
+            delayedSends += 1
+            send()
+        }
+    }
+
+    private struct StubFeatureFlagProvider: WideEventFeatureFlagProviding {
+        func isEnabled(_ flag: WideEventFeatureFlag) -> Bool { true }
+    }
+
+    @Test("When the return session event is sent then it goes through the delay")
+    func whenReturnSessionEventIsSentThenItIsDelayed() {
+        let wrapped = SpyWideEventSender()
+        let delay = ImmediateDelay()
+        let sut = ReturnSessionSendDelayingWideEventSender(wrapping: wrapped, delay: delay)
+
+        sut.send(ReturnSessionWideEventData(landedOn: .ntp, afterIdle: true),
+                 status: .cancelled,
+                 featureFlagProvider: StubFeatureFlagProvider(),
+                 onComplete: { _, _ in })
+
+        #expect(delay.delayedSends == 1)
+        #expect(wrapped.sentPixelNames == ["return_session"])
+    }
+
+    @Test("When any other wide event is sent then it is not delayed")
+    func whenOtherWideEventIsSentThenItIsNotDelayed() {
+        let wrapped = SpyWideEventSender()
+        let delay = ImmediateDelay()
+        let sut = ReturnSessionSendDelayingWideEventSender(wrapping: wrapped, delay: delay)
+
+        sut.send(PostIdleSessionWideEventData(surface: .ntp),
+                 status: .cancelled,
+                 featureFlagProvider: StubFeatureFlagProvider(),
+                 onComplete: { _, _ in })
+
+        #expect(delay.delayedSends == 0)
+        #expect(wrapped.sentPixelNames == ["post_idle_session"])
+    }
+}

--- a/iOS/PixelDefinitions/pixels/definitions/app_return.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/app_return.json5
@@ -1,7 +1,7 @@
 // App return: per-foreground snapshot of time away and capability exposure.
 {
     "m_app_return": {
-        "description": "Fires on every foreground transition, ungated and launch-action-independent. Reports how long the user was away, the resolved idle threshold, and which Duck.ai capabilities are available.",
+        "description": "Fires on every foreground transition, ungated and launch-action-independent. Reports how long the user was away, the resolved idle threshold, and which Duck.ai capabilities are available. Transmission is held back by a random 1-30s so it does not land in the burst of pixels sent on launch.",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor", "first_daily_count"],

--- a/iOS/PixelDefinitions/pixels/definitions/app_return.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/app_return.json5
@@ -1,7 +1,7 @@
 // App return: per-foreground snapshot of time away and capability exposure.
 {
     "m_app_return": {
-        "description": "Fires on every foreground transition, ungated and launch-action-independent. Reports how long the user was away, the resolved idle threshold, and which Duck.ai capabilities are available. Transmission is held back by a random 1-30s so it does not land in the burst of pixels sent on launch.",
+        "description": "Fires on every foreground transition, ungated and launch-action-independent. Reports how long the user was away, the resolved idle threshold, and which Duck.ai capabilities are available. Transmission is held back by a random 1-30s so it does not land in the burst of pixels sent on launch, which means two foregrounds inside one window can be transmitted out of order and the first_daily_count variant is not guaranteed to carry the day's first foreground.",
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["platform", "form_factor", "first_daily_count"],

--- a/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
@@ -1,6 +1,6 @@
 {
     "m_ios_wide_return_session": {
-        "description": "Wide pixel sent at the end of a return session on iOS: every return to the app, whether it got an after-idle treatment (NTP or LUT) or was an ordinary return. m_ios_wide_post_idle_session stays scoped to after-idle returns and runs alongside this pixel. Transmission is held back by a random 1-30s so it does not land in the burst of pixels sent on launch.",
+        "description": "Wide pixel sent at the end of a return session on iOS: every return to the app, whether it got an after-idle treatment (NTP or LUT) or was an ordinary return. m_ios_wide_post_idle_session stays scoped to after-idle returns and runs alongside this pixel. Transmission is held back by a random 1-30s so it does not land in the burst of pixels sent on launch, which means a session ending just before midnight UTC can be counted on the following day.",
         "owners": ["Bunn", "SabrinaTardio"],
         "triggers": ["other"],
         "suffixes": ["daily"],

--- a/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
@@ -1,6 +1,6 @@
 {
     "m_ios_wide_return_session": {
-        "description": "Wide pixel sent at the end of a return session on iOS: every return to the app, whether it got an after-idle treatment (NTP or LUT) or was an ordinary return. m_ios_wide_post_idle_session stays scoped to after-idle returns and runs alongside this pixel.",
+        "description": "Wide pixel sent at the end of a return session on iOS: every return to the app, whether it got an after-idle treatment (NTP or LUT) or was an ordinary return. m_ios_wide_post_idle_session stays scoped to after-idle returns and runs alongside this pixel. Transmission is held back by a random 1-30s so it does not land in the burst of pixels sent on launch.",
         "owners": ["Bunn", "SabrinaTardio"],
         "triggers": ["other"],
         "suffixes": ["daily"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/69071770703008/task/1217644680832271?focus=true
Tech Design URL:
CC:

### Description
Add a randomised transmission delay on `m_app_return` and the `ios-return-session` wide event, so they no longer land in the burst of pixels the app fires when it foregrounds

### Testing Steps
1. Run the `PixelTransmissionDelayTests` and `AppReturnInstrumentationTests` suites in `UnitTests`.
2. On a debug build, filter the console for `👾` and background/foreground the app: `m_app_return` should appear 1-30s after the launch pixel burst rather than inside it.
3. Foreground the app and immediately background it — the pixel should still be sent, either when the delay elapses or when iOS reclaims the background assertion.

### Impact and Risks
Medium

#### What could go wrong?
If the app is killed inside the delay window the pixel is lost rather than retried, which would dent `m_app_return` volume and skew it against very short sessions — the background assertion is there to keep that rare.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics timing and can lose pixels if the app is killed during the delay window, which may affect volume and daily/first-count semantics; background assertions mitigate but do not eliminate that risk.
> 
> **Overview**
> Adds a **random 1–30s transmission delay** so `m_app_return` and the **return-session** wide event no longer fire in the launch foreground pixel burst.
> 
> **`PixelTransmissionDelay`** schedules the send on the main queue, takes a background assertion up front, trims the wait when iOS background time is tight (with ~10s headroom for the network), and can fire early if the system reclaims the assertion. **`PixelSendToken`** keeps the assertion alive until every in-flight request completes (including both variants from `.dailyAndCount`).
> 
> **`DefaultAppReturnInstrumentation`** defers the whole `PixelKit.fire` path (not just the HTTP call) so daily markers align with delayed transmission. **`ReturnSessionSendDelayingWideEventSender`** wraps the wide-event sender in **`AppDependencyProvider`** and applies the same delay only for `ReturnSessionWideEventData`; other wide events are unchanged.
> 
> Pixel definition text notes possible **out-of-order** `m_app_return` sends and weaker **`first_daily_count`** semantics, and midnight UTC edge cases for return-session daily counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adcc13a13cff88dfdf8033d52ac0b707421c530b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->