### PR TITLE
Stop recognizing sync.duckduckgo.com requests on duck.ai as 3rd party

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/TrackerProtectionEventMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/TrackerProtectionEventMapper.swift
@@ -129,12 +129,17 @@ public struct TrackerProtectionEventMapper {
 
     // MARK: - Classification helpers
 
+    /// This set contains eTLD+1 domains owned by DuckDuckGo, to avoid incorrectly
+    /// reporting 3rd party requests between DDG domains.
+    static let duckDuckGoETLDplus1: Set<String> = ["duckduckgo.com", "duck.ai"]
+
     /// Returns true when request and page share the same eTLD+1.
     public func isSameSiteObservation(_ observation: TrackerProtectionSubfeature.ResourceObservation) -> Bool {
         let requestETLDplus1 = tld.eTLDplus1(forStringURL: observation.url)
         let pageETLDplus1 = tld.eTLDplus1(forStringURL: observation.pageUrl)
         guard let requestETLDplus1, let pageETLDplus1 else { return false }
-        return requestETLDplus1 == pageETLDplus1
+        return requestETLDplus1 == pageETLDplus1 ||
+            (Self.duckDuckGoETLDplus1.contains(pageETLDplus1) && Self.duckDuckGoETLDplus1.contains(requestETLDplus1))
     }
 
     /// Build a DetectedRequest for a non-TDS cross-site resource (third-party request).

--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/TrackerProtectionEventMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/TrackerProtectionEventMapper.swift
@@ -131,7 +131,7 @@ public struct TrackerProtectionEventMapper {
 
     /// This set contains eTLD+1 domains owned by DuckDuckGo, to avoid incorrectly
     /// reporting 3rd party requests between DDG domains.
-    static let duckDuckGoETLDplus1: Set<String> = ["duckduckgo.com", "duck.ai"]
+    private static let duckDuckGoETLDplus1: Set<String> = ["duckduckgo.com", "duck.ai"]
 
     /// Returns true when request and page share the same eTLD+1.
     public func isSameSiteObservation(_ observation: TrackerProtectionSubfeature.ResourceObservation) -> Bool {

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentScopeScript/TrackerProtectionEventMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentScopeScript/TrackerProtectionEventMapperTests.swift
@@ -157,6 +157,128 @@ final class TrackerProtectionEventMapperTests: XCTestCase {
         XCTAssertFalse(mapper.isSameSiteObservation(observation))
     }
 
+    // MARK: - DuckDuckGo-Owned Domains Treated As Same Site
+
+    /// TDS that treats duckduckgo.com as a blocked tracker, so a nil result proves the
+    /// same-site guard ran — not merely that the request is unknown to the TDS.
+    private func makeDuckDuckGoAsTrackerTDS() -> TrackerData {
+        let tracker = KnownTracker(
+            domain: "duckduckgo.com",
+            defaultAction: .block,
+            owner: KnownTracker.Owner(name: "DuckDuckGo", displayName: "DuckDuckGo", ownedBy: nil),
+            prevalence: 0.1,
+            subdomains: nil,
+            categories: ["Analytics"],
+            rules: nil)
+
+        let entity = Entity(displayName: "DuckDuckGo", domains: ["duckduckgo.com"], prevalence: 0.1)
+
+        return TrackerData(
+            trackers: ["duckduckgo.com": tracker],
+            entities: ["DuckDuckGo": entity],
+            domains: ["duckduckgo.com": "DuckDuckGo"],
+            cnames: nil)
+    }
+
+    func testWhenRequestToDuckDuckGoComOnDuckAiPageThenIsSameSiteReturnsTrue() {
+        let mapper = makeMapper()
+        let observation = TrackerProtectionSubfeature.ResourceObservation(
+            url: "https://sync.duckduckgo.com/sync/data",
+            resourceType: "xmlhttprequest",
+            potentiallyBlocked: false,
+            pageUrl: "https://duck.ai")
+
+        XCTAssertTrue(mapper.isSameSiteObservation(observation),
+                      "Requests between DuckDuckGo-owned domains must count as same site")
+    }
+
+    func testWhenRequestToDuckAiOnDuckDuckGoComPageThenIsSameSiteReturnsTrue() {
+        let mapper = makeMapper()
+        let observation = TrackerProtectionSubfeature.ResourceObservation(
+            url: "https://duck.ai/script.js",
+            resourceType: "script",
+            potentiallyBlocked: false,
+            pageUrl: "https://duckduckgo.com/?q=test")
+
+        XCTAssertTrue(mapper.isSameSiteObservation(observation),
+                      "The DuckDuckGo domain rule must apply in both directions")
+    }
+
+    func testWhenBothHostsAreSubdomainsOfDuckDuckGoOwnedDomainsThenIsSameSiteReturnsTrue() {
+        let mapper = makeMapper()
+        let observation = TrackerProtectionSubfeature.ResourceObservation(
+            url: "https://improving.duckduckgo.com/t/pixel",
+            resourceType: "image",
+            potentiallyBlocked: false,
+            pageUrl: "https://beta.duck.ai/chat")
+
+        XCTAssertTrue(mapper.isSameSiteObservation(observation),
+                      "Subdomains must resolve to their eTLD+1 before the DuckDuckGo domain check")
+    }
+
+    func testWhenRequestToDuckDuckGoComOnDuckAiPageThenNoThirdPartyRequestIsReported() {
+        let mapper = makeMapper()
+        let observation = TrackerProtectionSubfeature.ResourceObservation(
+            url: "https://sync.duckduckgo.com/sync/data",
+            resourceType: "xmlhttprequest",
+            potentiallyBlocked: false,
+            pageUrl: "https://duck.ai")
+
+        XCTAssertNil(mapper.makeThirdPartyRequest(from: observation),
+                     "sync.duckduckgo.com must not be reported as a 3rd party request on duck.ai")
+    }
+
+    func testWhenDuckDuckGoComIsAKnownTrackerOnDuckAiPageThenClassifyReturnsNil() {
+        let mapper = makeMapper(trackerData: makeDuckDuckGoAsTrackerTDS())
+        let observation = TrackerProtectionSubfeature.ResourceObservation(
+            url: "https://sync.duckduckgo.com/sync/data",
+            resourceType: "xmlhttprequest",
+            potentiallyBlocked: true,
+            pageUrl: "https://duck.ai")
+
+        XCTAssertNil(mapper.classifyResource(observation),
+                     "The same-site guard must suppress DuckDuckGo-to-DuckDuckGo requests before TDS lookup")
+    }
+
+    func testWhenPageIsNotDuckDuckGoOwnedThenRequestToDuckDuckGoComStaysCrossSite() {
+        let mapper = makeMapper()
+        let observation = TrackerProtectionSubfeature.ResourceObservation(
+            url: "https://improving.duckduckgo.com/t/pixel",
+            resourceType: "image",
+            potentiallyBlocked: false,
+            pageUrl: "https://example.com")
+
+        XCTAssertFalse(mapper.isSameSiteObservation(observation),
+                       "A DuckDuckGo request on a non-DuckDuckGo page is still cross site")
+        XCTAssertNotNil(mapper.makeThirdPartyRequest(from: observation))
+    }
+
+    func testWhenRequestIsNotDuckDuckGoOwnedThenDuckAiPageStaysCrossSite() {
+        let mapper = makeMapper()
+        let observation = TrackerProtectionSubfeature.ResourceObservation(
+            url: "https://tracker.com/pixel.js",
+            resourceType: "script",
+            potentiallyBlocked: true,
+            pageUrl: "https://duck.ai")
+
+        XCTAssertFalse(mapper.isSameSiteObservation(observation),
+                       "A non-DuckDuckGo request on duck.ai is still cross site")
+        XCTAssertNotNil(mapper.classifyResource(observation),
+                        "Trackers must still be reported on DuckDuckGo pages")
+    }
+
+    func testWhenDomainOnlyContainsDuckDuckGoAsSubstringThenItStaysCrossSite() {
+        let mapper = makeMapper()
+        let observation = TrackerProtectionSubfeature.ResourceObservation(
+            url: "https://notduckduckgo.com/pixel.js",
+            resourceType: "script",
+            potentiallyBlocked: false,
+            pageUrl: "https://duck.ai")
+
+        XCTAssertFalse(mapper.isSameSiteObservation(observation),
+                       "Only exact eTLD+1 matches count as DuckDuckGo-owned")
+    }
+
     // MARK: - Native Allowlist Override
 
     func testAllowlistedTrackerIsNotBlocked() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1217639705231619?focus=true
CC: @jonathanKingston 

### Description
Add a native-side association between duck.ai and duckduckgo.com so that cross-domain requests
are not treated as 3rd party.

### Testing Steps
1. Enable Sync
2. Open duck.ai
3. Open Privacy Dashboard and verify that it doesn't report 3rd party requests loaded, in particular not from sync.duckduckgo.com.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow classification tweak for Privacy Dashboard reporting on DDG-owned pages; no change to WebKit blocking rules or general third-party detection elsewhere.
> 
> **Overview**
> **Treats cross-requests between DuckDuckGo-owned `duckduckgo.com` and `duck.ai` (including subdomains) as same-site** so they are no longer surfaced as third-party loads in the Privacy Dashboard—e.g. `sync.duckduckgo.com` on `duck.ai`.
> 
> `TrackerProtectionEventMapper.isSameSiteObservation` now also returns true when both the page and request eTLD+1 are in a fixed set (`duckduckgo.com`, `duck.ai`), in addition to matching eTLD+1. That guard already suppresses `classifyResource` and `makeThirdPartyRequest`, so those DDG cross-domain calls are skipped before TDS classification.
> 
> Tests add coverage for bidirectional DDG domains, subdomains, suppression of third-party reporting and TDS classification when DDG domains would otherwise look like trackers, and that unrelated sites and substring domains stay cross-site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 767b9f367373ca97c76d809c8c07a23bb212f443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->