### PR TITLE
[iOS] Fix voice search crash when the audio input format is invalid

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1841,6 +1841,7 @@
 		A7B000012F6A000100000001 /* SnapshotTestingSupport in Frameworks */ = {isa = PBXBuildFile; productRef = A7B000032F6A000100000001 /* SnapshotTestingSupport */; };
 		A7B000082F6A000100000001 /* PreviewSnapshots in Frameworks */ = {isa = PBXBuildFile; productRef = A7B000092F6A000100000001 /* PreviewSnapshots */; };
 		A7B001102F6B000100000001 /* VoiceSearchFeedbackViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B001112F6B000100000001 /* VoiceSearchFeedbackViewTests.swift */; };
+		A7B001202F6B000100000002 /* SpeechRecognizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B001212F6B000100000002 /* SpeechRecognizerTests.swift */; };
 		AA10B5022FA0000100AB12CD /* WebExtensionAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10B5012FA0000100AB12CD /* WebExtensionAvailabilityTests.swift */; };
 		AA2000010000000000000002 /* TabSwitcherTrackerInfoHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000010000000000000002 /* TabSwitcherTrackerInfoHeaderView.swift */; };
 		AA2000040000000000000004 /* TabSwitcherTrackerCountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000040000000000000004 /* TabSwitcherTrackerCountViewModel.swift */; };
@@ -4707,6 +4708,7 @@
 		A6C36CDBF1DD7FBC036F9067 /* DarkReaderFeatureSettingsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DarkReaderFeatureSettingsTests.swift; sourceTree = "<group>"; };
 		A6E8A70CF1DFF21DC84B150F /* LaunchTimeMetricsProcessorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LaunchTimeMetricsProcessorTests.swift; sourceTree = "<group>"; };
 		A7B001112F6B000100000001 /* VoiceSearchFeedbackViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSearchFeedbackViewTests.swift; sourceTree = "<group>"; };
+		A7B001212F6B000100000002 /* SpeechRecognizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognizerTests.swift; sourceTree = "<group>"; };
 		A8E195E64C4FA98412110685 /* SearchTokenExperiment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchTokenExperiment.swift; sourceTree = "<group>"; };
 		AA1000010000000000000002 /* TabSwitcherTrackerInfoHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherTrackerInfoHeaderView.swift; sourceTree = "<group>"; };
 		AA1000040000000000000004 /* TabSwitcherTrackerCountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherTrackerCountViewModel.swift; sourceTree = "<group>"; };
@@ -11869,6 +11871,7 @@
 				9770D4B12F7B000300293610 /* VoiceEntryPointPixelTests.swift */,
 				9770D4C12F7C000100293610 /* AIChatEntryPointSourceTests.swift */,
 				A7B001112F6B000100000001 /* VoiceSearchFeedbackViewTests.swift */,
+				A7B001212F6B000100000002 /* SpeechRecognizerTests.swift */,
 				A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */,
 				A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */,
 				A1B2C3D4E5F60002AABBA0B2 /* AppReturnInstrumentationTests.swift */,
@@ -14846,6 +14849,7 @@
 				9770D4B02F7B000300293610 /* VoiceEntryPointPixelTests.swift in Sources */,
 				9770D4C02F7C000100293610 /* AIChatEntryPointSourceTests.swift in Sources */,
 				A7B001102F6B000100000001 /* VoiceSearchFeedbackViewTests.swift in Sources */,
+				A7B001202F6B000100000002 /* SpeechRecognizerTests.swift in Sources */,
 				A1B2C3D4E5F60001AABB0001 /* NTPAfterIdleInstrumentationTests.swift in Sources */,
 				9FB484A6301ADA9300125636 /* OnboardingAIModelsFallbackTests.swift in Sources */,
 				9FB484A7301ADA9300125636 /* OnboardingAIModelsResolverTests.swift in Sources */,

--- a/iOS/DuckDuckGo/SpeechRecognizer.swift
+++ b/iOS/DuckDuckGo/SpeechRecognizer.swift
@@ -25,6 +25,10 @@ protocol SpeechRecognizerDelegate: AnyObject {
     func speechRecognizer(_ speechRecognizer: SpeechRecognizer, availabilityDidChange available: Bool)
 }
 
+enum SpeechRecognizerError: Error {
+    case audioInputUnavailable
+}
+
 final class SpeechRecognizer: NSObject, SpeechRecognizerProtocol {
     weak var delegate: SpeechRecognizerDelegate?
     private var audioEngine: AVAudioEngine?
@@ -85,6 +89,11 @@ final class SpeechRecognizer: NSObject, SpeechRecognizerProtocol {
         return Array(buffer)
     }
     
+    // AVFAudio raises `IsFormatSampleRateAndChannelCountValid` and aborts when a tap is installed with either value at zero.
+    static func isValidRecordingFormat(_ format: AVAudioFormat) -> Bool {
+        format.sampleRate > 0 && format.channelCount > 0
+    }
+
     func getVolumeLevel(from channelData: UnsafeMutablePointer<Float>) -> Float {
         let channelDataArray = Array(UnsafeBufferPointer(start: channelData, count: 1024))
         guard channelDataArray.count != 0 else { return 0 }
@@ -125,6 +134,10 @@ final class SpeechRecognizer: NSObject, SpeechRecognizerProtocol {
             let inputNode = audioEngine.inputNode
             
             let recordingFormat = inputNode.outputFormat(forBus: 0)
+            guard Self.isValidRecordingFormat(recordingFormat) else {
+                throw SpeechRecognizerError.audioInputUnavailable
+            }
+
             inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { (buffer: AVAudioPCMBuffer, _) in
                 recognitionRequest.append(buffer)
                 

--- a/iOS/DuckDuckGoTests/SpeechRecognizerTests.swift
+++ b/iOS/DuckDuckGoTests/SpeechRecognizerTests.swift
@@ -25,8 +25,10 @@ import Testing
 struct SpeechRecognizerTests {
 
     // AVFAudio raises `IsFormatSampleRateAndChannelCountValid` if a tap is installed with either value at zero.
+    @available(iOS 16, macOS 13, *)
     @Test(
         "Degraded input format is rejected",
+        .timeLimit(.minutes(1)),
         arguments: zip(
             [0, 0, 44100] as [Double],
             [0, 1, 0] as [AVAudioChannelCount]
@@ -39,7 +41,8 @@ struct SpeechRecognizerTests {
         #expect(SpeechRecognizer.isValidRecordingFormat(format) == false)
     }
 
-    @Test("Usable input format is accepted")
+    @available(iOS 16, macOS 13, *)
+    @Test("Usable input format is accepted", .timeLimit(.minutes(1)))
     func testWhenFormatHasSampleRateAndChannelsThenItIsValidForRecording() throws {
         let format = try #require(AVAudioFormat(standardFormatWithSampleRate: 44100, channels: 1))
 

--- a/iOS/DuckDuckGoTests/SpeechRecognizerTests.swift
+++ b/iOS/DuckDuckGoTests/SpeechRecognizerTests.swift
@@ -33,7 +33,7 @@ struct SpeechRecognizerTests {
         )
     )
     func testWhenFormatHasNoSampleRateOrNoChannelsThenItIsNotValidForRecording(sampleRate: Double,
-                                                                              channelCount: AVAudioChannelCount) throws {
+                                                                               channelCount: AVAudioChannelCount) throws {
         let format = try #require(AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: channelCount))
 
         #expect(SpeechRecognizer.isValidRecordingFormat(format) == false)

--- a/iOS/DuckDuckGoTests/SpeechRecognizerTests.swift
+++ b/iOS/DuckDuckGoTests/SpeechRecognizerTests.swift
@@ -1,0 +1,48 @@
+//
+//  SpeechRecognizerTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AVFoundation
+import Testing
+@testable import DuckDuckGo
+
+@Suite("Speech Recognizer Tests")
+struct SpeechRecognizerTests {
+
+    // AVFAudio raises `IsFormatSampleRateAndChannelCountValid` if a tap is installed with either value at zero.
+    @Test(
+        "Degraded input format is rejected",
+        arguments: zip(
+            [0, 0, 44100] as [Double],
+            [0, 1, 0] as [AVAudioChannelCount]
+        )
+    )
+    func testWhenFormatHasNoSampleRateOrNoChannelsThenItIsNotValidForRecording(sampleRate: Double,
+                                                                              channelCount: AVAudioChannelCount) throws {
+        let format = try #require(AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: channelCount))
+
+        #expect(SpeechRecognizer.isValidRecordingFormat(format) == false)
+    }
+
+    @Test("Usable input format is accepted")
+    func testWhenFormatHasSampleRateAndChannelsThenItIsValidForRecording() throws {
+        let format = try #require(AVAudioFormat(standardFormatWithSampleRate: 44100, channels: 1))
+
+        #expect(SpeechRecognizer.isValidRecordingFormat(format))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1217529746763294?focus=true
Tech Design URL:
CC:

### Description
`SpeechRecognizer.startRecording` passed `inputNode.outputFormat(forBus: 0)` straight to `installTap` without validating it, so when the audio input route was unusable (active call, Bluetooth/CarPlay mid-negotiation) the format came back as `0 Hz / 0 ch` and AVFAudio's `IsFormatSampleRateAndChannelCountValid` precondition raised an uncatchable Objective-C exception, crashing the app ([APPLE-IOS-FB15](https://errors.duckduckgo.com/organizations/ddg/issues/APPLE-IOS-FB15/?project=8)). The format is now validated before the tap is installed, throwing into the existing `catch` so the session is torn down and the error surfaces through the already-shipped `voiceSearchError` path instead of aborting. The crash lines are unchanged since 2022 — the spike in 7.232 comes from the new Unified Toggle Input voice entry point increasing exposure, not from a code change to this function.

### Testing Steps
1. Tap the microphone in the address bar and in the Unified Toggle Input bar; confirm voice search still records, transcribes, and submits normally on both entry points.
2. Temporarily make `SpeechRecognizer.isValidRecordingFormat` return `false`, then start voice search: the sheet should dismiss cleanly with no crash, and a `m_voice_search_error` pixel should fire with domain `DuckDuckGo.SpeechRecognizerError`.
3. Run `-only-testing:UnitTests/SpeechRecognizerTests` and confirm the degraded-format cases pass.

### Impact and Risks
Low — the only behaviour change is on a path that previously crashed unconditionally; the valid-format path is untouched.

#### What could go wrong?
If a device legitimately reports a valid-but-unusual format, the guard would reject it and voice search would fail silently rather than record — mitigated by only rejecting zero sample rate or zero channel count, the exact conditions AVFAudio itself refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the previously crashing invalid-format path; normal recording is unchanged. Rejection is limited to zero sample rate or channel count, matching AVFAudio’s own requirements.
> 
> **Overview**
> Fixes a crash when voice search starts while the mic route is unusable (e.g. active call or Bluetooth/CarPlay negotiation), where `inputNode.outputFormat(forBus: 0)` can be **0 Hz / 0 channels** and AVFAudio aborts on `installTap`.
> 
> **SpeechRecognizer** now checks the recording format with `isValidRecordingFormat` (non-zero sample rate and channel count) before installing the tap. Invalid formats throw `SpeechRecognizerError.audioInputUnavailable`, which is handled by the existing `catch` in `startRecording` (reset + error callback) instead of crashing.
> 
> Adds **SpeechRecognizerTests** for rejected degraded formats and accepted normal formats, and wires the test file into the Xcode project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bbd1eac6bd5ab0782cf3c006bb7d7b33adcad0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->