### PR TITLE
Don't auto-attach page context when attaching a selection to Duck.ai

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -4314,7 +4314,9 @@
 		D1A7B0010000000000000012 /* AIChatTabPickerSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */; };
 		D1A7B0010000000000000013 /* AIChatTabPickerSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */; };
 		D1A7B0010000000000000022 /* AIChatTabPickerSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */; };
+		D1A7B0010000000000000042 /* AIChatSelectionActionPageContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000041 /* AIChatSelectionActionPageContextTests.swift */; };
 		D1A7B0010000000000000023 /* AIChatTabPickerSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */; };
+		D1A7B0010000000000000043 /* AIChatSelectionActionPageContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000041 /* AIChatSelectionActionPageContextTests.swift */; };
 		D1D1D1D100000000000000E1 /* MouseEventInterceptingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D1D1D100000000000000E0 /* MouseEventInterceptingView.swift */; };
 		D1D1D1D100000000000000E2 /* MouseEventInterceptingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D1D1D100000000000000E0 /* MouseEventInterceptingView.swift */; };
 		D1D1D1D100000000000000F1 /* WindowDimmingBlockingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D1D1D100000000000000F0 /* WindowDimmingBlockingView.swift */; };
@@ -7142,6 +7144,7 @@
 		D1A7B0010000000000000001 /* NewTabPageOmnibarTabsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageOmnibarTabsProvider.swift; sourceTree = "<group>"; };
 		D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabPickerSource.swift; sourceTree = "<group>"; };
 		D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabPickerSourceTests.swift; sourceTree = "<group>"; };
+		D1A7B0010000000000000041 /* AIChatSelectionActionPageContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSelectionActionPageContextTests.swift; sourceTree = "<group>"; };
 		D1D1D1D100000000000000E0 /* MouseEventInterceptingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseEventInterceptingView.swift; sourceTree = "<group>"; };
 		D1D1D1D100000000000000F0 /* WindowDimmingBlockingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDimmingBlockingView.swift; sourceTree = "<group>"; };
 		D1E601A02D510FE0003BB417 /* OSUpgradeCapabilityOverride.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSUpgradeCapabilityOverride.swift; sourceTree = "<group>"; };
@@ -8305,6 +8308,7 @@
 				BBF17D1F2F7B4D33004AFCF4 /* AIChatMenuTests.swift */,
 				37AA017E2E2164A500844427 /* AIChatUserScriptHandlerTests.swift */,
 				D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */,
+				D1A7B0010000000000000041 /* AIChatSelectionActionPageContextTests.swift */,
 				3135647D2D9EBB9900BF4B5D /* AIChatAddressBarPromptExtractorTests.swift */,
 				31FBF2302CDD12FE00626C17 /* AIChatUserScriptTests.swift */,
 				49DF815DCDE34CFBA7F38DFA /* AIChatTabOpenerTests.swift */,
@@ -17144,6 +17148,7 @@
 				BBDF565D2EA8E22100AA2DFF /* WinBackOfferPromptPresenterTests.swift in Sources */,
 				37AA01802E2164A700844427 /* AIChatUserScriptHandlerTests.swift in Sources */,
 				D1A7B0010000000000000022 /* AIChatTabPickerSourceTests.swift in Sources */,
+				D1A7B0010000000000000042 /* AIChatSelectionActionPageContextTests.swift in Sources */,
 				B6619F042B17123200CD9186 /* DataImportViewModelTests.swift in Sources */,
 				1D8C2FE62B70F4C4005E4BBD /* TabSnapshotExtensionTests.swift in Sources */,
 				F49FB7BBACBB4F0195D5E554 /* TabSuspensionExtensionTests.swift in Sources */,
@@ -19509,6 +19514,7 @@
 				56504F102E0D9A8C00333A1E /* MockSubscriptionTabsShowing.swift in Sources */,
 				37AA017F2E2164A700844427 /* AIChatUserScriptHandlerTests.swift in Sources */,
 				D1A7B0010000000000000023 /* AIChatTabPickerSourceTests.swift in Sources */,
+				D1A7B0010000000000000043 /* AIChatSelectionActionPageContextTests.swift in Sources */,
 				AAE39D1B24F44885008EF28B /* TabCollectionViewModelDelegateMock.swift in Sources */,
 				9F0A2CF82B96A58600C5B8C0 /* BaseBookmarkEntityTests.swift in Sources */,
 				EE2868502EAFC38200AB597F /* LegacyDataImportViewModelTests.swift in Sources */,

--- a/macOS/DuckDuckGo/AIChat/AIChatSummarizer.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatSummarizer.swift
@@ -54,6 +54,7 @@ final class AIChatSummarizer: AIChatSummarizing {
     private let aiChatCoordinator: AIChatCoordinating
     private let aiChatTabOpener: AIChatTabOpening
     private let pixelFiring: PixelFiring?
+    private let currentPageContextProvider: () -> PageContextProtocol?
     private let aiChatConversationSourceHandler: AIChatConversationSourceHandler
 
     init(
@@ -61,12 +62,14 @@ final class AIChatSummarizer: AIChatSummarizing {
         aiChatCoordinator: AIChatCoordinating,
         aiChatTabOpener: AIChatTabOpening,
         pixelFiring: PixelFiring?,
+        currentPageContextProvider: @escaping () -> PageContextProtocol?,
         aiChatConversationSourceHandler: AIChatConversationSourceHandler = Application.appDelegate.aiChatConversationSourceHandler
     ) {
         self.aiChatMenuConfig = aiChatMenuConfig
         self.aiChatCoordinator = aiChatCoordinator
         self.aiChatTabOpener = aiChatTabOpener
         self.pixelFiring = pixelFiring
+        self.currentPageContextProvider = currentPageContextProvider
         self.aiChatConversationSourceHandler = aiChatConversationSourceHandler
     }
 
@@ -94,6 +97,8 @@ final class AIChatSummarizer: AIChatSummarizing {
             )
             aiChatConversationSourceHandler.setData(.summarization)
         }
+        // The selection is what the user asked about — don't also auto-attach the whole page.
+        currentPageContextProvider()?.suppressAutoPageContextForSelectionAction()
         aiChatCoordinator.revealChat(for: prompt)
     }
 }

--- a/macOS/DuckDuckGo/AIChat/AIChatTranslator.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatTranslator.swift
@@ -54,6 +54,7 @@ final class AIChatTranslator: AIChatTranslating {
     private let aiChatCoordinator: AIChatCoordinating
     private let aiChatTabOpener: AIChatTabOpening
     private let pixelFiring: PixelFiring?
+    private let currentPageContextProvider: () -> PageContextProtocol?
     private let aiChatConversationSourceHandler: AIChatConversationSourceHandler
 
     init(
@@ -61,12 +62,14 @@ final class AIChatTranslator: AIChatTranslating {
         aiChatCoordinator: AIChatCoordinating,
         aiChatTabOpener: AIChatTabOpening,
         pixelFiring: PixelFiring?,
+        currentPageContextProvider: @escaping () -> PageContextProtocol?,
         aiChatConversationSourceHandler: AIChatConversationSourceHandler = Application.appDelegate.aiChatConversationSourceHandler
     ) {
         self.aiChatMenuConfig = aiChatMenuConfig
         self.aiChatCoordinator = aiChatCoordinator
         self.aiChatTabOpener = aiChatTabOpener
         self.pixelFiring = pixelFiring
+        self.currentPageContextProvider = currentPageContextProvider
         self.aiChatConversationSourceHandler = aiChatConversationSourceHandler
     }
 
@@ -99,6 +102,8 @@ final class AIChatTranslator: AIChatTranslating {
             )
             aiChatConversationSourceHandler.setData(.translation)
         }
+        // The selection is what the user asked about — don't also auto-attach the whole page.
+        currentPageContextProvider()?.suppressAutoPageContextForSelectionAction()
         aiChatCoordinator.revealChat(for: prompt)
     }
 

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -263,14 +263,20 @@ final class MainViewController: NSViewController {
             aiChatMenuConfig: aiChatMenuConfig,
             aiChatCoordinator: aiChatCoordinator,
             aiChatTabOpener: aiChatTabOpener,
-            pixelFiring: pixelFiring
+            pixelFiring: pixelFiring,
+            currentPageContextProvider: { [weak tabCollectionViewModel] in
+                tabCollectionViewModel?.selectedTabViewModel?.tab.pageContext
+            }
         )
 
         aiChatTranslator = AIChatTranslator(
             aiChatMenuConfig: aiChatMenuConfig,
             aiChatCoordinator: aiChatCoordinator,
             aiChatTabOpener: aiChatTabOpener,
-            pixelFiring: pixelFiring
+            pixelFiring: pixelFiring,
+            currentPageContextProvider: { [weak tabCollectionViewModel] in
+                tabCollectionViewModel?.selectedTabViewModel?.tab.pageContext
+            }
         )
 
         aiChatSelectionContextAttacher = AIChatSelectionContextAttacher(

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -157,7 +157,7 @@ final class PageContextTabExtension {
 
                 let previousContent = self.content
                 self.content = tabContent
-                // Reset user-removed suppression when navigating to a new URL so
+                // Reset auto page-context suppression when navigating to a new URL so
                 // auto-collect resumes on the next page, regardless of feature flag state.
                 // Also drop the previous page's cached context so a stale snapshot
                 // can't be re-pushed to the sidebar before the new page is collected.
@@ -506,14 +506,20 @@ final class PageContextTabExtension {
     /// sidebar is shown.
     @MainActor
     func appendSelectionContext(_ selection: AIChatSelectionContextData) {
-        // Opening the sidebar for a selection shouldn't also auto-attach the whole page — the
-        // selection is what the user asked about. Leaves an already-attached page context alone.
-        if Self.shouldSuppressAutoPageContextOnSelectionAttach(isSidebarVisible: isSidebarVisibleForTab) {
-            isAutoPageContextSuppressed = true
-        }
+        suppressAutoPageContextForSelectionAction()
         pendingSelectionContexts.append(selectionWithEncodedFavicon(selection))
         // Defer so a just-revealed sidebar's chat VC exists before we push (matches page-context timing).
         Task { @MainActor [weak self] in self?.flushPendingSelectionContexts() }
+    }
+
+    /// Opening the sidebar for a selection-based action (attach selection, summarize, translate)
+    /// shouldn't also auto-attach the whole page — the selection is what the user asked about.
+    /// Leaves an already-attached page context alone.
+    @MainActor
+    func suppressAutoPageContextForSelectionAction() {
+        if Self.shouldSuppressAutoPageContextOnSelectionAttach(isSidebarVisible: isSidebarVisibleForTab) {
+            isAutoPageContextSuppressed = true
+        }
     }
 
     /// Forces page-context collection into the sidebar regardless of the auto-send preference — the
@@ -633,7 +639,9 @@ final class PageContextTabExtension {
 
     /// Context collection is allowed when it's set to automatic in AI Features Settings
     /// or when we allow one-time collection requested by the user.
-    /// Suppressed when the user explicitly removed context on the current page.
+    /// Suppressed when auto page-context is suppressed for the current page — either the user
+    /// explicitly removed the context, or a selection-based action (attach selection, summarize,
+    /// translate) opened the sidebar.
     private var isContextCollectionEnabled: Bool {
         Self.isContextCollectionEnabled(shouldForceContextCollection: shouldForceContextCollection,
                                         isAutoPageContextSuppressed: isAutoPageContextSuppressed,
@@ -648,8 +656,8 @@ final class PageContextTabExtension {
         return shouldAutomaticallySendPageContext
     }
 
-    /// Attaching a selection suppresses this page's auto page-context only when the selection is
-    /// what opens the sidebar — an already-open sidebar keeps whatever page context it has.
+    /// A selection-based action suppresses this page's auto page-context only when it's what opens
+    /// the sidebar — an already-open sidebar keeps whatever page context it has.
     static func shouldSuppressAutoPageContextOnSelectionAttach(isSidebarVisible: Bool) -> Bool {
         !isSidebarVisible
     }
@@ -760,6 +768,10 @@ protocol PageContextProtocol: AnyObject, NavigationResponder {
     /// Appends a user text selection to the sidebar's selection-context list. See the
     /// implementation in `PageContextTabExtension` for buffering/lifecycle semantics.
     @MainActor func appendSelectionContext(_ selection: AIChatSelectionContextData)
+
+    /// Suppresses this page's auto page-context attachment when a selection-based action
+    /// (attach selection, summarize, translate) is what opens the sidebar.
+    @MainActor func suppressAutoPageContextForSelectionAction()
 
     /// Force-collects and attaches the current page's context to the sidebar, bypassing the
     /// auto-send preference (used by the tab-bar "Ask About Page" action).

--- a/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PageContextTabExtension.swift
@@ -96,9 +96,10 @@ final class PageContextTabExtension {
     /// (content stripped, attached:false). Cleared when that result arrives.
     private var pendingSignalsOnlyCollection: Bool = false
 
-    /// Set when the user explicitly removes page context from the chat.
+    /// Set when the user explicitly removes page context from the chat, or attaches a text
+    /// selection (the selection is the context they asked about).
     /// Suppresses auto-collection on the current page until the next navigation.
-    private var userRemovedContext: Bool = false
+    private var isAutoPageContextSuppressed: Bool = false
 
     private weak var webView: WKWebView?
     private weak var pageContextUserScript: PageContextUserScript? {
@@ -161,7 +162,7 @@ final class PageContextTabExtension {
                 // Also drop the previous page's cached context so a stale snapshot
                 // can't be re-pushed to the sidebar before the new page is collected.
                 if case .url = tabContent {
-                    self.userRemovedContext = false
+                    self.isAutoPageContextSuppressed = false
                     self.cachedPageContext = nil
                     // Selections are tied to the page they were made on — drop any not-yet-flushed ones.
                     self.pendingSelectionContexts = []
@@ -299,7 +300,7 @@ final class PageContextTabExtension {
                 // After submit the context was already consumed; pushing nil back would
                 // make the FE re-show "Add page content" on the same URL.
                 guard !self.hasContextBeenConsumedByChat else { return }
-                self.userRemovedContext = true
+                self.isAutoPageContextSuppressed = true
                 self.cachedPageContext = nil
                 // Clear the stored pageContext too, so a later FE `getAIChatPageContext`
                 // returns nil and triggers a fresh collect instead of the stale snapshot.
@@ -505,6 +506,11 @@ final class PageContextTabExtension {
     /// sidebar is shown.
     @MainActor
     func appendSelectionContext(_ selection: AIChatSelectionContextData) {
+        // Opening the sidebar for a selection shouldn't also auto-attach the whole page — the
+        // selection is what the user asked about. Leaves an already-attached page context alone.
+        if Self.shouldSuppressAutoPageContextOnSelectionAttach(isSidebarVisible: isSidebarVisibleForTab) {
+            isAutoPageContextSuppressed = true
+        }
         pendingSelectionContexts.append(selectionWithEncodedFavicon(selection))
         // Defer so a just-revealed sidebar's chat VC exists before we push (matches page-context timing).
         Task { @MainActor [weak self] in self?.flushPendingSelectionContexts() }
@@ -629,9 +635,23 @@ final class PageContextTabExtension {
     /// or when we allow one-time collection requested by the user.
     /// Suppressed when the user explicitly removed context on the current page.
     private var isContextCollectionEnabled: Bool {
+        Self.isContextCollectionEnabled(shouldForceContextCollection: shouldForceContextCollection,
+                                        isAutoPageContextSuppressed: isAutoPageContextSuppressed,
+                                        shouldAutomaticallySendPageContext: aiChatMenuConfiguration.shouldAutomaticallySendPageContext)
+    }
+
+    static func isContextCollectionEnabled(shouldForceContextCollection: Bool,
+                                           isAutoPageContextSuppressed: Bool,
+                                           shouldAutomaticallySendPageContext: Bool) -> Bool {
         if shouldForceContextCollection { return true }
-        if userRemovedContext { return false }
-        return aiChatMenuConfiguration.shouldAutomaticallySendPageContext
+        if isAutoPageContextSuppressed { return false }
+        return shouldAutomaticallySendPageContext
+    }
+
+    /// Attaching a selection suppresses this page's auto page-context only when the selection is
+    /// what opens the sidebar — an already-open sidebar keeps whatever page context it has.
+    static func shouldSuppressAutoPageContextOnSelectionAttach(isSidebarVisible: Bool) -> Bool {
+        !isSidebarVisible
     }
 
     @MainActor private func replaceFaviconURLWithEncodedData(_ pageContext: AIChatPageContextData?) -> AIChatPageContextData? {

--- a/macOS/UnitTests/AIChat/AIChatSelectionActionPageContextTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatSelectionActionPageContextTests.swift
@@ -1,0 +1,147 @@
+//
+//  AIChatSelectionActionPageContextTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import AppKit
+import Combine
+import Navigation
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+/// Selection-based Duck.ai actions (summarize, translate) must tell the page context extension to
+/// skip auto-attaching the whole page — the selection is the context. The extension's own decision
+/// is covered by `ContextCollectionEnabledTests`.
+@MainActor
+final class AIChatSelectionActionPageContextTests: XCTestCase {
+
+    private var config: DummyAIChatConfig!
+    private var coordinator: SelectionActionAIChatCoordinatorMock!
+    private var pageContext: PageContextMock!
+
+    override func setUp() {
+        super.setUp()
+        config = DummyAIChatConfig()
+        config.shouldDisplaySummarizationMenuItem = true
+        config.shouldDisplayTranslationMenuItem = true
+        coordinator = SelectionActionAIChatCoordinatorMock()
+        pageContext = PageContextMock()
+    }
+
+    func testSummarizeSuppressesAutoPageContext() {
+        makeSummarizer().summarize(.init(text: "selected", websiteURL: URL(string: "https://example.com"), websiteTitle: "Example", source: .contextMenu))
+
+        XCTAssertEqual(pageContext.suppressCallCount, 1)
+        XCTAssertEqual(coordinator.revealChatWithPromptCallCount, 1)
+    }
+
+    func testTranslateSuppressesAutoPageContext() {
+        makeTranslator().translate(.init(text: "selected", websiteURL: URL(string: "https://example.com"), websiteTitle: "Example", websiteTLD: "example.com", sourceLanguage: "en"))
+
+        XCTAssertEqual(pageContext.suppressCallCount, 1)
+        XCTAssertEqual(coordinator.revealChatWithPromptCallCount, 1)
+    }
+
+    /// The gating decision belongs to the extension, so the actions delegate unconditionally —
+    /// including when the sidebar is already up.
+    func testSummarizeStillDelegatesWhenChatAlreadyPresented() {
+        coordinator.isChatPresented = true
+        makeSummarizer().summarize(.init(text: "selected", websiteURL: nil, websiteTitle: nil, source: .keyboardShortcut))
+
+        XCTAssertEqual(pageContext.suppressCallCount, 1)
+    }
+
+    func testSummarizeDoesNothingWhenMenuItemDisabled() {
+        config.shouldDisplaySummarizationMenuItem = false
+        makeSummarizer().summarize(.init(text: "selected", websiteURL: nil, websiteTitle: nil, source: .contextMenu))
+
+        XCTAssertEqual(pageContext.suppressCallCount, 0)
+        XCTAssertEqual(coordinator.revealChatWithPromptCallCount, 0)
+    }
+
+    // MARK: - Factories
+
+    private func makeSummarizer() -> AIChatSummarizer {
+        AIChatSummarizer(aiChatMenuConfig: config,
+                         aiChatCoordinator: coordinator,
+                         aiChatTabOpener: SelectionActionAIChatTabOpenerMock(),
+                         pixelFiring: nil,
+                         currentPageContextProvider: { [pageContext] in pageContext },
+                         aiChatConversationSourceHandler: AIChatConversationSourceHandler())
+    }
+
+    private func makeTranslator() -> AIChatTranslator {
+        AIChatTranslator(aiChatMenuConfig: config,
+                         aiChatCoordinator: coordinator,
+                         aiChatTabOpener: SelectionActionAIChatTabOpenerMock(),
+                         pixelFiring: nil,
+                         currentPageContextProvider: { [pageContext] in pageContext },
+                         aiChatConversationSourceHandler: AIChatConversationSourceHandler())
+    }
+
+}
+
+// MARK: - Mocks
+
+@MainActor
+private final class PageContextMock: PageContextProtocol {
+    var appendSelectionContextCallCount = 0
+    var suppressCallCount = 0
+    var requestPageContextAttachmentCallCount = 0
+
+    func appendSelectionContext(_ selection: AIChatSelectionContextData) {
+        appendSelectionContextCallCount += 1
+    }
+
+    func suppressAutoPageContextForSelectionAction() {
+        suppressCallCount += 1
+    }
+
+    func requestPageContextAttachment() {
+        requestPageContextAttachmentCallCount += 1
+    }
+}
+
+private final class SelectionActionAIChatCoordinatorMock: AIChatCoordinating {
+    var isChatPresented = false
+    var revealChatWithPromptCallCount = 0
+    var revealChatCallCount = 0
+
+    func toggleSidebar() {}
+    func collapseSidebar(withAnimation: Bool) {}
+    func isSidebarOpen(for tabID: TabIdentifier) -> Bool { isChatPresented }
+    func isSidebarOpenForCurrentTab() -> Bool { isChatPresented }
+    func isChatPresentedForCurrentTab() -> Bool { isChatPresented }
+    func sidebarHiddenAt(for tabID: TabIdentifier) -> Date? { nil }
+    func sidebarHiddenAtForCurrentTab() -> Date? { nil }
+    var sidebarPresenceDidChangePublisher: AnyPublisher<AIChatPresenceChange, Never> { Empty().eraseToAnyPublisher() }
+    func isChatFloating(for tabID: TabIdentifier) -> Bool { false }
+    var chatFloatingStateDidChangePublisher: AnyPublisher<TabIdentifier, Never> { Empty().eraseToAnyPublisher() }
+    func focusFloatingWindow(for tabID: TabIdentifier) {}
+    func closeFloatingWindow(for tabID: TabIdentifier) {}
+    func closeChat(for tabID: TabIdentifier, withAnimation: Bool) {}
+    func revealChat(for prompt: AIChatNativePrompt) { revealChatWithPromptCallCount += 1 }
+    func revealChat() { revealChatCallCount += 1 }
+}
+
+private struct SelectionActionAIChatTabOpenerMock: AIChatTabOpening {
+    func openAIChatTab(with trigger: AIChatOpenTrigger, behavior: LinkOpenBehavior) {}
+    func openNewAIChat(in linkOpenBehavior: LinkOpenBehavior) {}
+    func openVoiceSession(inSourceCollection sourceCollection: TabCollectionViewModel?, behavior: LinkOpenBehavior) {}
+    func openAIChatTab(withQuery query: String, inNewTabOf windowController: MainWindowController) {}
+    func openAIChatTab(withQuery query: String, inNewWindowAt droppingPoint: NSPoint) {}
+}

--- a/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
+++ b/macOS/UnitTests/AIChat/PageContextMultipleContextsTests.swift
@@ -46,37 +46,63 @@ struct NavigationContextActionTests {
 
 // MARK: - isContextCollectionEnabled Logic Tests
 
+/// Exercises `PageContextTabExtension`'s real decision functions (not a mirror).
 struct ContextCollectionEnabledTests {
 
-    /// Mirrors the logic in PageContextTabExtension.isContextCollectionEnabled
+    private typealias Extension = PageContextTabExtension
+
     private func isContextCollectionEnabled(
-        shouldForceContextCollection: Bool,
-        userRemovedContext: Bool,
+        shouldForceContextCollection: Bool = false,
+        isAutoPageContextSuppressed: Bool = false,
         shouldAutomaticallySendPageContext: Bool
     ) -> Bool {
-        if shouldForceContextCollection { return true }
-        if userRemovedContext { return false }
-        return shouldAutomaticallySendPageContext
+        Extension.isContextCollectionEnabled(shouldForceContextCollection: shouldForceContextCollection,
+                                             isAutoPageContextSuppressed: isAutoPageContextSuppressed,
+                                             shouldAutomaticallySendPageContext: shouldAutomaticallySendPageContext)
     }
 
     @available(iOS 16, macOS 13, *)
     @Test("Force collection overrides everything", .timeLimit(.minutes(1)))
     func forceCollectionOverrides() {
-        #expect(isContextCollectionEnabled(shouldForceContextCollection: true, userRemovedContext: true, shouldAutomaticallySendPageContext: false) == true)
-        #expect(isContextCollectionEnabled(shouldForceContextCollection: true, userRemovedContext: false, shouldAutomaticallySendPageContext: false) == true)
+        #expect(isContextCollectionEnabled(shouldForceContextCollection: true, isAutoPageContextSuppressed: true, shouldAutomaticallySendPageContext: false) == true)
+        #expect(isContextCollectionEnabled(shouldForceContextCollection: true, shouldAutomaticallySendPageContext: false) == true)
     }
 
     @available(iOS 16, macOS 13, *)
-    @Test("User removed context suppresses auto-collection", .timeLimit(.minutes(1)))
-    func userRemovedSuppresses() {
-        #expect(isContextCollectionEnabled(shouldForceContextCollection: false, userRemovedContext: true, shouldAutomaticallySendPageContext: true) == false)
+    @Test("Suppression beats the auto-send setting", .timeLimit(.minutes(1)))
+    func suppressionBeatsAutoSend() {
+        #expect(isContextCollectionEnabled(isAutoPageContextSuppressed: true, shouldAutomaticallySendPageContext: true) == false)
     }
 
     @available(iOS 16, macOS 13, *)
     @Test("Auto-send setting is respected when no overrides", .timeLimit(.minutes(1)))
     func autoSendRespected() {
-        #expect(isContextCollectionEnabled(shouldForceContextCollection: false, userRemovedContext: false, shouldAutomaticallySendPageContext: true) == true)
-        #expect(isContextCollectionEnabled(shouldForceContextCollection: false, userRemovedContext: false, shouldAutomaticallySendPageContext: false) == false)
+        #expect(isContextCollectionEnabled(shouldAutomaticallySendPageContext: true) == true)
+        #expect(isContextCollectionEnabled(shouldAutomaticallySendPageContext: false) == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Attaching a selection that opens the sidebar suppresses auto page-context", .timeLimit(.minutes(1)))
+    func selectionAttachThatOpensSidebarSuppressesPageContext() {
+        let suppressed = Extension.shouldSuppressAutoPageContextOnSelectionAttach(isSidebarVisible: false)
+        #expect(suppressed == true)
+        // The whole point of the fix: auto-attach ON must not also attach the page.
+        #expect(isContextCollectionEnabled(isAutoPageContextSuppressed: suppressed, shouldAutomaticallySendPageContext: true) == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Attaching a selection with the sidebar already open leaves page context alone", .timeLimit(.minutes(1)))
+    func selectionAttachWithOpenSidebarKeepsPageContext() {
+        let suppressed = Extension.shouldSuppressAutoPageContextOnSelectionAttach(isSidebarVisible: true)
+        #expect(suppressed == false)
+        #expect(isContextCollectionEnabled(isAutoPageContextSuppressed: suppressed, shouldAutomaticallySendPageContext: true) == true)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Ask About Page still forces collection after a selection attach", .timeLimit(.minutes(1)))
+    func askAboutPageOverridesSelectionSuppression() {
+        let suppressed = Extension.shouldSuppressAutoPageContextOnSelectionAttach(isSidebarVisible: false)
+        #expect(isContextCollectionEnabled(shouldForceContextCollection: true, isAutoPageContextSuppressed: suppressed, shouldAutomaticallySendPageContext: false) == true)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1217640626930884?focus=true

### Description

With "Automatically add page content" on, "Ask Duck.ai about selected content" attached both the selection and the whole page. Attaching a selection now suppresses this page's auto page-context, but only when the selection is what opens the sidebar — an already-open sidebar keeps its attached page context, and "Ask About Page" still forces a collect.

### Testing Steps
1. macOS, AI Features settings: turn on "Automatically add page content".
2. On a web page with the Duck.ai sidebar closed, select text → right-click → "Ask Duck.ai about selected content".
3. Sidebar opens with only the selection attached (no page attachment).
4. With the sidebar already open and the page attached, attach a selection → page attachment stays.

### Impact
Low. Narrows one context-menu path; suppression resets on navigation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow AI Chat context-attachment behavior change; suppression is per-page and resets on navigation, with no auth or data-handling impact.
> 
> **Overview**
> Stops auto-attaching the full page when a **selection-based Duck.ai action** (attach selection, summarize, translate) is what opens the sidebar. With “Automatically add page content” on, those actions previously attached both the selection and the page.
> 
> Suppression only applies when the sidebar is closed; an already-open sidebar keeps its page context. **Ask About Page** still force-collects. The flag resets on navigation.
> 
> Summarize/translate now call `suppressAutoPageContextForSelectionAction()` on the current tab’s page context, same as attach-selection. Tests cover the decision logic and those action paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33f1ac0dad37ea2b396b6a53fcd80e1ccfb50a91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->