### PR TITLE
[iOS] Re-enable Duck.ai promo cards on the native input

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatNotification.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatNotification.swift
@@ -25,6 +25,8 @@ public extension NSNotification.Name {
     static let aiChatVoiceSessionEnded: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.voiceSessionEnded")
     static let aiChatNewImageGenerationChatStarted: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.newImageGenerationChatStarted")
     static let aiChatShowModelPicker: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.showModelPicker")
+    static let aiChatShowReasoningPicker: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.showReasoningPicker")
+    static let aiChatOpenAttachmentPicker: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.openAttachmentPicker")
     static let aiChatCustomizeResponsesModalClosed: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.customizeResponsesModalClosed")
     static let aiChatCustomizeResponsesDidChange: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.customizeResponsesDidChange")
 }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatNotification.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatNotification.swift
@@ -26,7 +26,7 @@ public extension NSNotification.Name {
     static let aiChatNewImageGenerationChatStarted: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.newImageGenerationChatStarted")
     static let aiChatShowModelPicker: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.showModelPicker")
     static let aiChatShowReasoningPicker: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.showReasoningPicker")
-    static let aiChatOpenAttachmentPicker: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.openAttachmentPicker")
+    static let aiChatOpenFilePicker: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.openFilePicker")
     static let aiChatCustomizeResponsesModalClosed: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.customizeResponsesModalClosed")
     static let aiChatCustomizeResponsesDidChange: NSNotification.Name = Notification.Name(rawValue: "com.duckduckgo.aiChat.customizeResponsesDidChange")
 }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
@@ -119,6 +119,9 @@ public struct AIChatNativeConfigValues: Codable {
     public let supportsTabPicker: Bool
     public let supportsNativeStorage: Bool
     public let supportsNativePromptEditing: Bool
+    /// `true` when the native input can handle the Duck.ai promo card CTAs (model/reasoning/attachment
+    /// pickers), so the FE re-enables the promo cards for native-input users.
+    public let supportsPromoCards: Bool
     /// `true` when the native side supplies page-type signals so the duck.ai web app can render
     /// page-tailored suggested prompts ("suggestions").
     public let supportsSuggestions: Bool
@@ -207,6 +210,7 @@ public struct AIChatNativeConfigValues: Codable {
                 supportsTabPicker: Bool = false,
                 supportsNativeStorage: Bool = false,
                 supportsNativePromptEditing: Bool = false,
+                supportsPromoCards: Bool = false,
                 supportsSuggestions: Bool = false,
                 supportsNativeVoicePermissionHandler: Bool = false,
                 supportsNativeDictationPermissionHandler: Bool = false,
@@ -233,6 +237,7 @@ public struct AIChatNativeConfigValues: Codable {
         self.supportsTabPicker = supportsTabPicker
         self.supportsNativeStorage = supportsNativeStorage
         self.supportsNativePromptEditing = supportsNativePromptEditing
+        self.supportsPromoCards = supportsPromoCards
         self.supportsSuggestions = supportsSuggestions
         self.supportsNativeVoicePermissionHandler = supportsNativeVoicePermissionHandler
         self.supportsNativeDictationPermissionHandler = supportsNativeDictationPermissionHandler

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
@@ -80,6 +80,12 @@ public enum AIChatUserScriptMessages: String, CaseIterable {
     /// shown for an unsupported model. Native surfaces its model picker for the active chat
     /// (expands the input, reveals the model chip).
     case showModelPicker
+    
+    case showReasoningPicker
+
+    /// Posted by the FE when the user taps a promo card CTA to add an attachment. Native surfaces
+    /// its attachment picker for the active chat.
+    case openAttachmentPicker
 
     /// Posted by the FE while the subscription recovery card is showing for the active chat.
     case disableChatInput

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
@@ -80,11 +80,9 @@ public enum AIChatUserScriptMessages: String, CaseIterable {
     /// shown for an unsupported model. Native surfaces its model picker for the active chat
     /// (expands the input, reveals the model chip).
     case showModelPicker
-    
+
     case showReasoningPicker
 
-    /// Posted by the FE when the user taps a promo card CTA to add an attachment. Native surfaces
-    /// its attachment picker for the active chat.
     case openAttachmentPicker
 
     /// Posted by the FE while the subscription recovery card is showing for the active chat.

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
@@ -83,7 +83,7 @@ public enum AIChatUserScriptMessages: String, CaseIterable {
 
     case showReasoningPicker
 
-    case openAttachmentPicker
+    case openFilePicker
 
     /// Posted by the FE while the subscription recovery card is showing for the active chat.
     case disableChatInput

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -524,6 +524,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Supports Duck.ai edit prompt from the native input field.
     case nativePromptEditing
 
+    /// Re-enables Duck.ai promo cards on the native input (their CTAs open native pickers).
+    case nativePromoCards
+
     /// Warns users as they approach their daily/weekly Duck.ai limits, using the usage snapshot the
     /// web app writes into the reserved `usageLimits` native-storage entry.
     case usageWarnings

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -256,6 +256,10 @@ final class AIChatUserScript: NSObject, Subfeature {
             return handler.newImageGenerationChatStarted
         case .showModelPicker:
             return handler.showModelPicker
+        case .showReasoningPicker:
+            return handler.showReasoningPicker
+        case .openAttachmentPicker:
+            return handler.openAttachmentPicker
         case .disableChatInput:
             return handler.disableChatInput
         case .enableChatInput:

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -258,8 +258,8 @@ final class AIChatUserScript: NSObject, Subfeature {
             return handler.showModelPicker
         case .showReasoningPicker:
             return handler.showReasoningPicker
-        case .openAttachmentPicker:
-            return handler.openAttachmentPicker
+        case .openFilePicker:
+            return handler.openFilePicker
         case .disableChatInput:
             return handler.disableChatInput
         case .enableChatInput:

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -183,6 +183,8 @@ protocol AIChatUserScriptHandling: AnyObject {
     func voiceSessionEnded(params: Any, message: UserScriptMessage) async -> Encodable?
     func newImageGenerationChatStarted(params: Any, message: UserScriptMessage) async -> Encodable?
     func showModelPicker(params: Any, message: UserScriptMessage) async -> Encodable?
+    func showReasoningPicker(params: Any, message: UserScriptMessage) async -> Encodable?
+    func openAttachmentPicker(params: Any, message: UserScriptMessage) async -> Encodable?
     func disableChatInput(params: Any, message: UserScriptMessage) async -> Encodable?
     func enableChatInput(params: Any, message: UserScriptMessage) async -> Encodable?
     func focusChatInput(params: Any, message: UserScriptMessage) async -> Encodable?
@@ -418,6 +420,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             supportsMultipleContexts: supportsContextualMode && featureFlagger.isFeatureOn(.multiplePageContexts),
             supportsNativeStorage: featureFlagger.isFeatureOn(.aiChatNativeStorage) && isNativeStorageBridgeAvailable,
             supportsNativePromptEditing: featureFlagger.isFeatureOn(.nativeAIPromptEditing) && supportsNativeChatInput,
+            supportsPromoCards: featureFlagger.isFeatureOn(.nativePromoCards) && supportsNativeChatInput,
             supportsSuggestions: supportsSuggestions,
             installType: installTypeProvider(),
             installAge: AIChatNativeConfigValues.installAgeBucket(installDate: installDateProvider())
@@ -622,6 +625,18 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     @MainActor
     func showModelPicker(params: Any, message: UserScriptMessage) async -> Encodable? {
         NotificationCenter.default.post(name: .aiChatShowModelPicker, object: message.messageWebView)
+        return nil
+    }
+    
+    @MainActor
+    func showReasoningPicker(params: Any, message: UserScriptMessage) async -> Encodable? {
+        NotificationCenter.default.post(name: .aiChatShowReasoningPicker, object: message.messageWebView)
+        return nil
+    }
+
+    @MainActor
+    func openAttachmentPicker(params: Any, message: UserScriptMessage) async -> Encodable? {
+        NotificationCenter.default.post(name: .aiChatOpenAttachmentPicker, object: message.messageWebView)
         return nil
     }
 

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -184,7 +184,7 @@ protocol AIChatUserScriptHandling: AnyObject {
     func newImageGenerationChatStarted(params: Any, message: UserScriptMessage) async -> Encodable?
     func showModelPicker(params: Any, message: UserScriptMessage) async -> Encodable?
     func showReasoningPicker(params: Any, message: UserScriptMessage) async -> Encodable?
-    func openAttachmentPicker(params: Any, message: UserScriptMessage) async -> Encodable?
+    func openFilePicker(params: Any, message: UserScriptMessage) async -> Encodable?
     func disableChatInput(params: Any, message: UserScriptMessage) async -> Encodable?
     func enableChatInput(params: Any, message: UserScriptMessage) async -> Encodable?
     func focusChatInput(params: Any, message: UserScriptMessage) async -> Encodable?
@@ -635,8 +635,8 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     }
 
     @MainActor
-    func openAttachmentPicker(params: Any, message: UserScriptMessage) async -> Encodable? {
-        NotificationCenter.default.post(name: .aiChatOpenAttachmentPicker, object: message.messageWebView)
+    func openFilePicker(params: Any, message: UserScriptMessage) async -> Encodable? {
+        NotificationCenter.default.post(name: .aiChatOpenFilePicker, object: message.messageWebView)
         return nil
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIAttachmentController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIAttachmentController.swift
@@ -397,6 +397,14 @@ final class UTIAttachmentController {
         )
     }
 
+    /// Opens the system file picker directly for the promo "add file" CTA. No-ops when files can't be
+    /// attached to the active chat.
+    func presentFilePicker() {
+        guard canPresentFilePicker, !allowedFileUTTypes.isEmpty, !view.isGenerating(),
+              let presenterVC = environment.presenterViewController() else { return }
+        presenter.presentFilePicker(from: presenterVC, allowedFileTypes: allowedFileUTTypes)
+    }
+
     func updateAttachButtonPresentation() {
         let policy = environment.policy()
         let supportsPageContextAttachment = environment.isContextualChatState() && environment.pageContextAttachHandler() != nil && (environment.isPageContextAttachable() ?? true)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -650,7 +650,7 @@ private extension MainViewController {
             .sink { [weak self] in self?.handleShowPicker(.reasoning, for: $0) }
             .store(in: &unifiedToggleInputCancellables)
 
-        NotificationCenter.default.publisher(for: .aiChatOpenAttachmentPicker)
+        NotificationCenter.default.publisher(for: .aiChatOpenFilePicker)
             .compactMap { $0.object as? WKWebView }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.handleShowPicker(.attachment, for: $0) }
@@ -671,7 +671,7 @@ private extension MainViewController {
         switch picker {
         case .model: coordinator.presentModelPickerForActiveChat()
         case .reasoning: coordinator.presentReasoningPickerForActiveChat()
-        case .attachment: coordinator.presentAttachmentPickerForActiveChat()
+        case .attachment: coordinator.presentFilePickerForActiveChat()
         }
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -645,6 +645,22 @@ private extension MainViewController {
                 self?.handleShowModelPicker(for: webView)
             }
             .store(in: &unifiedToggleInputCancellables)
+        
+        NotificationCenter.default.publisher(for: .aiChatShowReasoningPicker)
+            .compactMap { $0.object as? WKWebView }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] webView in
+                self?.handleShowReasoningPicker(for: webView)
+            }
+            .store(in: &unifiedToggleInputCancellables)
+
+        NotificationCenter.default.publisher(for: .aiChatOpenAttachmentPicker)
+            .compactMap { $0.object as? WKWebView }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] webView in
+                self?.handleOpenAttachmentPicker(for: webView)
+            }
+            .store(in: &unifiedToggleInputCancellables)
     }
 
     /// Routes the FE's `showModelPicker` to the foreground Duck.ai tab's UTI so the user can pick a
@@ -657,6 +673,26 @@ private extension MainViewController {
             return
         }
         coordinator.presentModelPickerForActiveChat()
+    }
+    
+    /// Routes the FE's `showReasoningPicker` (reasoning promo CTA) to the foreground Duck.ai tab's UTI.
+    private func handleShowReasoningPicker(for webView: WKWebView) {
+        let isCurrent = tabManager.controller(forWebView: webView) === currentTab
+        let isAITab = currentTab?.isAITab == true
+        guard isCurrent, isAITab, let coordinator = unifiedToggleInputCoordinator else {
+            return
+        }
+        coordinator.presentReasoningPickerForActiveChat()
+    }
+
+    /// Routes the FE's `openAttachmentPicker` (promo CTA) to the foreground Duck.ai tab's UTI.
+    private func handleOpenAttachmentPicker(for webView: WKWebView) {
+        let isCurrent = tabManager.controller(forWebView: webView) === currentTab
+        let isAITab = currentTab?.isAITab == true
+        guard isCurrent, isAITab, let coordinator = unifiedToggleInputCoordinator else {
+            return
+        }
+        coordinator.presentAttachmentPickerForActiveChat()
     }
 
     /// Updates the foreground tab's UTI to reflect an FE-initiated image-generation chat.

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -641,58 +641,38 @@ private extension MainViewController {
         NotificationCenter.default.publisher(for: .aiChatShowModelPicker)
             .compactMap { $0.object as? WKWebView }
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] webView in
-                self?.handleShowModelPicker(for: webView)
-            }
+            .sink { [weak self] in self?.handleShowPicker(.model, for: $0) }
             .store(in: &unifiedToggleInputCancellables)
-        
+
         NotificationCenter.default.publisher(for: .aiChatShowReasoningPicker)
             .compactMap { $0.object as? WKWebView }
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] webView in
-                self?.handleShowReasoningPicker(for: webView)
-            }
+            .sink { [weak self] in self?.handleShowPicker(.reasoning, for: $0) }
             .store(in: &unifiedToggleInputCancellables)
 
         NotificationCenter.default.publisher(for: .aiChatOpenAttachmentPicker)
             .compactMap { $0.object as? WKWebView }
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] webView in
-                self?.handleOpenAttachmentPicker(for: webView)
-            }
+            .sink { [weak self] in self?.handleShowPicker(.attachment, for: $0) }
             .store(in: &unifiedToggleInputCancellables)
     }
 
-    /// Routes the FE's `showModelPicker` to the foreground Duck.ai tab's UTI so the user can pick a
-    /// supported model for the active chat (recovery-card "Switch Model" CTA). No-op when there's no
-    /// foreground Duck.ai UTI.
-    private func handleShowModelPicker(for webView: WKWebView) {
-        let isCurrent = tabManager.controller(forWebView: webView) === currentTab
-        let isAITab = currentTab?.isAITab == true
-        guard isCurrent, isAITab, let coordinator = unifiedToggleInputCoordinator else {
-            return
-        }
-        coordinator.presentModelPickerForActiveChat()
-    }
-    
-    /// Routes the FE's `showReasoningPicker` (reasoning promo CTA) to the foreground Duck.ai tab's UTI.
-    private func handleShowReasoningPicker(for webView: WKWebView) {
-        let isCurrent = tabManager.controller(forWebView: webView) === currentTab
-        let isAITab = currentTab?.isAITab == true
-        guard isCurrent, isAITab, let coordinator = unifiedToggleInputCoordinator else {
-            return
-        }
-        coordinator.presentReasoningPickerForActiveChat()
+    private enum AIChatPickerRequest {
+        case model, reasoning, attachment
     }
 
-    /// Routes the FE's `openAttachmentPicker` (promo CTA) to the foreground Duck.ai tab's UTI.
-    private func handleOpenAttachmentPicker(for webView: WKWebView) {
+    /// Routes an FE picker CTA to the foreground Duck.ai tab's UTI.
+    private func handleShowPicker(_ picker: AIChatPickerRequest, for webView: WKWebView) {
         let isCurrent = tabManager.controller(forWebView: webView) === currentTab
         let isAITab = currentTab?.isAITab == true
         guard isCurrent, isAITab, let coordinator = unifiedToggleInputCoordinator else {
             return
         }
-        coordinator.presentAttachmentPickerForActiveChat()
+        switch picker {
+        case .model: coordinator.presentModelPickerForActiveChat()
+        case .reasoning: coordinator.presentReasoningPickerForActiveChat()
+        case .attachment: coordinator.presentAttachmentPickerForActiveChat()
+        }
     }
 
     /// Updates the foreground tab's UTI to reflect an FE-initiated image-generation chat.

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputAttachmentPresenter.swift
@@ -125,6 +125,11 @@ final class UnifiedToggleInputAttachmentPresenter: NSObject {
 
         return UIMenu(children: actions)
     }
+
+    /// Opens the system file picker directly (bypassing the attachment menu) for the promo "add file" CTA.
+    func presentFilePicker(from presenter: UIViewController, allowedFileTypes: [UTType]) {
+        presentDocumentPicker(from: presenter, allowedFileTypes: allowedFileTypes)
+    }
 }
 
 private extension UnifiedToggleInputAttachmentPresenter {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1375,18 +1375,13 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         pixelReporter.reportSubmitChangeModel(modelId: modelId)
     }
 
-    /// Surfaces the native model picker on the **active** chat in response to the FE's
-    /// `showModelPicker` (e.g. the recovery card's "Switch Model" CTA). Expands the input and
-    /// reveals the model chip **without starting a new chat** — the chat stays `hasSubmittedPrompt`,
-    /// so a subsequent supported-model selection still emits `submitChangeModelAction`.
+    /// Surfaces the native model picker on the active chat (FE `showModelPicker` / recovery card).
     func presentModelPickerForActiveChat() {
         isModelPickerForcedVisible = true
-        // If the bar is already expanded (keyboard kept up), avoid re-running showExpanded (which reloads
-        // the bar); just apply the toolbar so the forced model chip still shows for the recovery flow.
         if !isInputPaneExpanded {
             showExpanded(inputMode: .aiChat)
         } else {
-            applyToolbarPresentation()
+            applyToolbarPresentation() // reveal the forced chip without reloading the expanded bar
         }
         if isSubmitBlockedByRecoveryCard,
            let supportedModel = modelStore.selectedModel,
@@ -1394,8 +1389,6 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             isSubmitBlockedByRecoveryCard = false
             notifyFrontendOfActiveChatModelChange(supportedModel.id)
         }
-        // Defer to the next runloop so the toolbar (and the now-revealed chip) is laid out after the
-        // expand animation before we ask the button to open its menu.
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.pixelReporter.reportShowModelPicker()
@@ -1404,16 +1397,12 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             }
         }
     }
-    
-    /// Surfaces the native reasoning picker on the active chat for the FE's `showReasoningPicker`
-    /// (reasoning promo CTA). No-ops when the current model has no reasoning support.
+
+    /// Surfaces the native reasoning picker on the active chat (FE `showReasoningPicker`).
     func presentReasoningPickerForActiveChat() {
-        // If the input bar is already expanded (keyboard kept up), just open the picker — don't re-run
-        // showExpanded, which reloads/re-lays-out the bar. Only expand when it's actually collapsed.
         if !isInputPaneExpanded {
             showExpanded(inputMode: .aiChat)
         }
-        // Defer so the toolbar is laid out after the expand animation before opening the menu.
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             if self.viewController.presentReasoningPickerMenu() {
@@ -1422,16 +1411,11 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         }
     }
 
-    /// Opens the system file picker on the active chat for the FE's `openAttachmentPicker` (pdf promo
-    /// CTA). Goes straight to the document picker, not the attach menu; no-ops when files can't be
-    /// attached to the active chat.
+    /// Opens the system file picker on the active chat (FE `openAttachmentPicker`).
     func presentAttachmentPickerForActiveChat() {
-        // If the input bar is already expanded (keyboard kept up), just open the picker — don't re-run
-        // showExpanded, which reloads/re-lays-out the bar. Only expand when it's actually collapsed.
         if !isInputPaneExpanded {
             showExpanded(inputMode: .aiChat)
         }
-        // Defer so the input is expanded (attachment chip has somewhere to land) before presenting.
         DispatchQueue.main.async { [weak self] in
             self?.attachmentController.presentFilePicker()
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1381,7 +1381,13 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     /// so a subsequent supported-model selection still emits `submitChangeModelAction`.
     func presentModelPickerForActiveChat() {
         isModelPickerForcedVisible = true
-        showExpanded(inputMode: .aiChat)
+        // If the bar is already expanded (keyboard kept up), avoid re-running showExpanded (which reloads
+        // the bar); just apply the toolbar so the forced model chip still shows for the recovery flow.
+        if !isInputPaneExpanded {
+            showExpanded(inputMode: .aiChat)
+        } else {
+            applyToolbarPresentation()
+        }
         if isSubmitBlockedByRecoveryCard,
            let supportedModel = modelStore.selectedModel,
            supportedModel.entityHasAccess {
@@ -1396,6 +1402,38 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             if self.viewController.presentModelPickerMenu() {
                 self.fireModelPickerShown()
             }
+        }
+    }
+    
+    /// Surfaces the native reasoning picker on the active chat for the FE's `showReasoningPicker`
+    /// (reasoning promo CTA). No-ops when the current model has no reasoning support.
+    func presentReasoningPickerForActiveChat() {
+        // If the input bar is already expanded (keyboard kept up), just open the picker — don't re-run
+        // showExpanded, which reloads/re-lays-out the bar. Only expand when it's actually collapsed.
+        if !isInputPaneExpanded {
+            showExpanded(inputMode: .aiChat)
+        }
+        // Defer so the toolbar is laid out after the expand animation before opening the menu.
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if self.viewController.presentReasoningPickerMenu() {
+                self.pixelReporter.reportReasoningPickerShown()
+            }
+        }
+    }
+
+    /// Opens the system file picker on the active chat for the FE's `openAttachmentPicker` (pdf promo
+    /// CTA). Goes straight to the document picker, not the attach menu; no-ops when files can't be
+    /// attached to the active chat.
+    func presentAttachmentPickerForActiveChat() {
+        // If the input bar is already expanded (keyboard kept up), just open the picker — don't re-run
+        // showExpanded, which reloads/re-lays-out the bar. Only expand when it's actually collapsed.
+        if !isInputPaneExpanded {
+            showExpanded(inputMode: .aiChat)
+        }
+        // Defer so the input is expanded (attachment chip has somewhere to land) before presenting.
+        DispatchQueue.main.async { [weak self] in
+            self?.attachmentController.presentFilePicker()
         }
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1375,21 +1375,30 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         pixelReporter.reportSubmitChangeModel(modelId: modelId)
     }
 
+    /// Expands the input if needed, then presents a picker once the toolbar is laid out.
+    private func presentPickerForActiveChat(_ present: @escaping () -> Void) {
+        if isInputPaneExpanded {
+            applyToolbarPresentation()
+            present()
+            return
+        }
+        showExpanded(inputMode: .aiChat)
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.isInputPaneExpanded, self.inputMode == .aiChat else { return }
+            present()
+        }
+    }
+
     /// Surfaces the native model picker on the active chat (FE `showModelPicker` / recovery card).
     func presentModelPickerForActiveChat() {
         isModelPickerForcedVisible = true
-        if !isInputPaneExpanded {
-            showExpanded(inputMode: .aiChat)
-        } else {
-            applyToolbarPresentation() // reveal the forced chip without reloading the expanded bar
-        }
         if isSubmitBlockedByRecoveryCard,
            let supportedModel = modelStore.selectedModel,
            supportedModel.entityHasAccess {
             isSubmitBlockedByRecoveryCard = false
             notifyFrontendOfActiveChatModelChange(supportedModel.id)
         }
-        DispatchQueue.main.async { [weak self] in
+        presentPickerForActiveChat { [weak self] in
             guard let self else { return }
             self.pixelReporter.reportShowModelPicker()
             if self.viewController.presentModelPickerMenu() {
@@ -1400,10 +1409,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
     /// Surfaces the native reasoning picker on the active chat (FE `showReasoningPicker`).
     func presentReasoningPickerForActiveChat() {
-        if !isInputPaneExpanded {
-            showExpanded(inputMode: .aiChat)
-        }
-        DispatchQueue.main.async { [weak self] in
+        presentPickerForActiveChat { [weak self] in
             guard let self else { return }
             if self.viewController.presentReasoningPickerMenu() {
                 self.pixelReporter.reportReasoningPickerShown()
@@ -1411,12 +1417,9 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         }
     }
 
-    /// Opens the system file picker on the active chat (FE `openAttachmentPicker`).
-    func presentAttachmentPickerForActiveChat() {
-        if !isInputPaneExpanded {
-            showExpanded(inputMode: .aiChat)
-        }
-        DispatchQueue.main.async { [weak self] in
+    /// Opens the system file picker on the active chat (FE `openFilePicker`).
+    func presentFilePickerForActiveChat() {
+        presentPickerForActiveChat { [weak self] in
             self?.attachmentController.presentFilePicker()
         }
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -137,6 +137,18 @@ final class UnifiedToggleInputToolbarView: UIView {
         }
         return false
     }
+    
+    @discardableResult
+    func presentReasoningPickerMenu() -> Bool {
+        guard reasoningPickerMenu != nil else { return false }
+
+        if #available(iOS 17.4, *) {
+            reasoningButton.performPrimaryAction()
+            return true
+        }
+        return false
+    }
+
 
     var reasoningPickerMenu: UIMenu? {
         get { reasoningButton.menu }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -255,6 +255,11 @@ final class UnifiedToggleInputView: UIView {
     func presentModelPickerMenu() -> Bool {
         toolsToolbar.presentModelPickerMenu()
     }
+    
+    @discardableResult
+    func presentReasoningPickerMenu() -> Bool {
+        toolsToolbar.presentReasoningPickerMenu()
+    }
 
     var toolsMenu: UIMenu? {
         get { toolsToolbar.toolsMenu }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -195,6 +195,11 @@ final class UnifiedToggleInputViewController: UIViewController {
     func presentModelPickerMenu() -> Bool {
         inputBarView.presentModelPickerMenu()
     }
+    
+    @discardableResult
+    func presentReasoningPickerMenu() -> Bool {
+        inputBarView.presentReasoningPickerMenu()
+    }
 
     var toolsMenu: UIMenu? {
         get { inputBarView.toolsMenu }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
@@ -916,6 +916,8 @@ final class MockAIChatUserScriptHandling: AIChatUserScriptHandling {
     func voiceSessionEnded(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
     func newImageGenerationChatStarted(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
     func showModelPicker(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
+    func showReasoningPicker(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
+    func openAttachmentPicker(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
     func disableChatInput(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
     func enableChatInput(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
     func focusChatInput(params: Any, message: UserScriptMessage) async -> Encodable? { nil }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
@@ -917,7 +917,7 @@ final class MockAIChatUserScriptHandling: AIChatUserScriptHandling {
     func newImageGenerationChatStarted(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
     func showModelPicker(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
     func showReasoningPicker(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
-    func openAttachmentPicker(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
+    func openFilePicker(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
     func disableChatInput(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
     func enableChatInput(params: Any, message: UserScriptMessage) async -> Encodable? { nil }
     func focusChatInput(params: Any, message: UserScriptMessage) async -> Encodable? { nil }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -208,6 +208,38 @@ class AIChatUserScriptHandlerTests: XCTestCase {
         XCTAssertEqual(configValues?.supportsNativePromptEditing, false)
     }
 
+    func testWhenPromoCardsFlagIsOnAndNativeChatInputAvailableThenConfigAdvertisesSupport() {
+        mockFeatureFlagger.enabledFeatureFlags = [.nativePromoCards]
+        mockAIChatFullModeFeature.isAvailable = true
+        mockUnifiedToggleInputFeature.isAvailable = true
+        aiChatUserScriptHandler = makeAIChatUserScriptHandler()
+
+        let configValues = aiChatUserScriptHandler.getAIChatNativeConfigValues(params: [], message: MockUserScriptMessage(name: "test", body: [:])) as? AIChatNativeConfigValues
+
+        XCTAssertEqual(configValues?.supportsPromoCards, true)
+    }
+
+    func testWhenPromoCardsFlagIsOnButNativeChatInputUnavailableThenConfigDoesNotAdvertiseSupport() {
+        mockFeatureFlagger.enabledFeatureFlags = [.nativePromoCards]
+        mockUnifiedToggleInputFeature.isAvailable = false
+        aiChatUserScriptHandler = makeAIChatUserScriptHandler()
+
+        let configValues = aiChatUserScriptHandler.getAIChatNativeConfigValues(params: [], message: MockUserScriptMessage(name: "test", body: [:])) as? AIChatNativeConfigValues
+
+        XCTAssertEqual(configValues?.supportsPromoCards, false)
+    }
+
+    func testWhenPromoCardsFlagIsOffThenConfigDoesNotAdvertiseSupport() {
+        mockFeatureFlagger.enabledFeatureFlags = []
+        mockAIChatFullModeFeature.isAvailable = true
+        mockUnifiedToggleInputFeature.isAvailable = true
+        aiChatUserScriptHandler = makeAIChatUserScriptHandler()
+
+        let configValues = aiChatUserScriptHandler.getAIChatNativeConfigValues(params: [], message: MockUserScriptMessage(name: "test", body: [:])) as? AIChatNativeConfigValues
+
+        XCTAssertEqual(configValues?.supportsPromoCards, false)
+    }
+
     func testWhenNativePromptEditingFlagIsOffThenEditPromptReturnsCancelled() async throws {
         mockFeatureFlagger.enabledFeatureFlags = []
         let params: [String: Any] = ["prompt": "hi", "hasResponsesToLose": false]

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -546,8 +546,7 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1216352541195038?focus=true
     case nativeAIPromptEditing
 
-    /// Re-enables Duck.ai promo cards on the native input (CTAs open native pickers).
-    /// TODO: link Apple Feature Flags Registry task
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217671927314542
     case nativePromoCards
 }
 
@@ -932,7 +931,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .nativeAIPromptEditing:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.nativePromptEditing))
         case .nativePromoCards:
-            Config(defaultValue: .disabled, source: .remoteReleasable(AIChatSubfeature.nativePromoCards))
+            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.nativePromoCards))
         }
     }
 

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -545,6 +545,10 @@ public enum FeatureFlag: String {
     
     /// https://app.asana.com/1/137249556945/project/72649045549333/task/1216352541195038?focus=true
     case nativeAIPromptEditing
+
+    /// Re-enables Duck.ai promo cards on the native input (CTAs open native pickers).
+    /// TODO: link Apple Feature Flags Registry task
+    case nativePromoCards
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -927,6 +931,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.iPadTabsBarInWindowControlsRow))
         case .nativeAIPromptEditing:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.nativePromptEditing))
+        case .nativePromoCards:
+            Config(defaultValue: .disabled, source: .remoteReleasable(AIChatSubfeature.nativePromoCards))
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1217615401000928
Tech Design URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1217615401000919
CC:

### Description

When the unified native input shipped, the Duck.ai empty-state promo cards (advanced models, reasoning, PDF upload, subscription) were disabled for native-input users because their CTAs opened the now-replaced frontend input.
This adds the native side so the promo cards can be re-enabled and their CTAs open the corresponding native surfaces.

### Testing Steps
1. Debug menu → AI Chat → set the custom URL to `https://use-serp-dev-testing13.duck.ai/`.
2. Debug menu → enable the `nativePromoCards` feature flag override.
3. As a Plus/Pro subscriber, open Duck.ai (full tab) and start a new (empty) chat → the **advanced models** promo card appears.
4. Tap the card → the **native model picker** opens. (test tapping both when keyboard on and off)
5. Advance to the **reasoning** card and tap it → the **native reasoning picker** opens.
6. Advance to the **PDF** card and tap it → the **native file picker** (document picker) opens directly.
7. As a free (subscription-eligible) user → the **subscription** card appears and its CTA opens the purchase flow; the **PDF** card opens the file picker.

### Impact

Low — behind a default-off feature flag and additionally gated by the frontend + remote config; only affects the empty-state promo cards in the native input.

#### What could go wrong?
- Promos advertised in contextual mode (where CTAs aren't wired yet) could dead-end → mitigated by the flag being off by default; contextual is confirmed out of scope and will be gated/wired before enabling.

### Quality Considerations
- Feature flag defaults disabled and the remote subfeature isn't added yet, so nothing changes for users until both are turned on.
- Reasoning and file-picker CTAs no-op gracefully when unsupported (model without reasoning support; files not allowed for the chat).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a FE→native bridge that can expand the chat input and open model/reasoning menus or the system file picker. Behavior is flag-gated, but the new messages and picker routing are user-facing and include unrelated files in the same diff.
> 
> **Overview**
> Lets Duck.ai empty-state promo cards work with the native input: the frontend can open the **native model picker**, **reasoning picker**, or **system file picker** instead of the old web input.
> 
> Native advertises `supportsPromoCards` when `nativePromoCards` is on **and** native chat input is available. New user-script messages (`showReasoningPicker`, `openFilePicker`) post notifications that UTI routes to the foreground Duck.ai tab. Shared expand/defer logic presents the picker after the toolbar is laid out; file attach no-ops when the chat cannot take files.
> 
> Also includes unrelated additions: `RollingAverage` math/tests, RMF acceptance tests, and root JSON/markdown files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02b9afd6210a4c2eb6f5bf3404b2703b2c375506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->