### PR TITLE
iOS: Fix broken PixelKitTestingUtilities import breaking main CI

### DIFF
--- a/iOS/DuckDuckGoTests/AIChat/DuckAISelectionJourneyInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAISelectionJourneyInstrumentationTests.swift
@@ -18,8 +18,7 @@
 //
 
 import Foundation
-import PixelKit
-import PixelKitTestingUtilities
+@_spi(Testing) import PixelKit
 import Testing
 @testable import DuckDuckGo
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205237866452338/task/1217675509771279
Tech Design URL:
CC:

### Description
`DuckAISelectionJourneyInstrumentationTests.swift` (added in #6365) imported a module, `PixelKitTestingUtilities`, that doesn't exist as a package product — this broke the unit test job on `main` after the merge. `WideEventMock` actually lives inside the `PixelKit` target behind `@_spi(Testing)`, so the fix swaps the bogus import for `@_spi(Testing) import PixelKit`, matching the existing pattern in `DuckAIWideEventInstrumentationTests.swift`.

Failing run: https://github.com/duckduckgo/apple-browsers/actions/runs/32360344908

### Testing Steps
1. Run `DuckAISelectionJourneyInstrumentationTests` → module resolves and tests pass.

### Impact
Low: test-only import fix, no production code or behavior change.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)