### PR TITLE
iOS: Add opt-in ATB parameter support to PixelKit

### DIFF
--- a/SharedPackages/PixelKit/Sources/PixelKit/PixelKit+Options.swift
+++ b/SharedPackages/PixelKit/Sources/PixelKit/PixelKit+Options.swift
@@ -65,13 +65,28 @@ extension PixelKit {
         /// See `RetryQueue/README.md` for the mechanics.
         public var retryOnFailure: Bool
 
+        /// Whether to append the `atb` parameter, carrying the user's ATB cohort with its variant
+        /// suffix. Off by default.
+        ///
+        /// Deliberately per-pixel rather than PixelKit-wide: ATB is a cohort identifier, so
+        /// attaching it to a pixel adds a correlation vector and is a data-collection decision that
+        /// has to be privacy triaged for that specific pixel. The legacy iOS `Pixel` system gated it
+        /// the same way, through `includedParameters`.
+        ///
+        /// Requires a `PixelKitParameterProviding` to have been injected at `setUp`. Without one the
+        /// parameter is omitted even when a pixel opts in, so a host that has not wired a provider
+        /// keeps its current behaviour rather than sending an empty cohort. With a provider that has
+        /// no ATB yet, the parameter *is* sent with an empty value, matching legacy behaviour.
+        public var includeATB: Bool
+
         public init(headers: [String: String]? = nil,
                     additionalParameters: [String: String]? = nil,
                     namePrefix: String? = nil,
                     allowedQueryReservedCharacters: CharacterSet? = nil,
                     includeAppVersionParameter: Bool = true,
                     enforcePrefix: Bool = true,
-                    retryOnFailure: Bool = false) {
+                    retryOnFailure: Bool = false,
+                    includeATB: Bool = false) {
             self.headers = headers
             self.additionalParameters = additionalParameters
             self.namePrefix = namePrefix
@@ -79,6 +94,7 @@ extension PixelKit {
             self.includeAppVersionParameter = includeAppVersionParameter
             self.enforcePrefix = enforcePrefix
             self.retryOnFailure = retryOnFailure
+            self.includeATB = includeATB
         }
 
         // MARK: - Curated presets
@@ -102,6 +118,10 @@ extension PixelKit {
         /// For pixels whose delivery matters enough to survive a failed send, and that have been
         /// privacy triaged for the retry parameters. See `retryOnFailure`.
         public static let withRetry = Options(retryOnFailure: true)
+
+        /// For pixels that carry the user's ATB cohort, and that have been privacy triaged for it.
+        /// See `includeATB`.
+        public static let withATB = Options(includeATB: true)
 
         /// Attaches extra query parameters.
         public static func parameters(_ parameters: [String: String]) -> Options {

--- a/SharedPackages/PixelKit/Sources/PixelKit/PixelKit+Parameters.swift
+++ b/SharedPackages/PixelKit/Sources/PixelKit/PixelKit+Parameters.swift
@@ -28,6 +28,7 @@ public extension PixelKit {
         public static let appVersion = "appVersion"
         public static let pixelSource = "pixelSource"
         public static let channel = "channel"
+        public static let atb = "atb"
         public static let osMajorVersion = "osMajorVersion"
         public static let osUpgradeCapability = "can_update"
         public static let maxSupportedOSVersion = "maxSupportedOS"

--- a/SharedPackages/PixelKit/Sources/PixelKit/PixelKit.swift
+++ b/SharedPackages/PixelKit/Sources/PixelKit/PixelKit.swift
@@ -188,6 +188,7 @@ public final class PixelKit {
     private let source: String?
     private let channel: String?
     private let pixelCalendar: Calendar
+    private let parameterProvider: PixelKitParameterProviding?
 
     /// Sets up PixelKit for the entire app.
     ///
@@ -196,6 +197,7 @@ public final class PixelKit {
     /// - `source`: if set, adds a `pixelSource` parameter to the pixel call; this can be used to specify which target is sending the pixel
     /// - `session`: a stable, non-telemetry identifier for this PixelKit instance, used to key its retry queue's storage and throttle so distinct instances never share or overwrite one queue
     /// - `channel`: if set, adds a `channel` parameter to pixel calls (e.g. "canary" for internal users, "dev" for alpha/review builds); omit for production builds
+    /// - `parameterProvider`: supplies values PixelKit cannot derive itself, currently the ATB cohort read by pixels that set `Options.includeATB`; omit when the host has no need for them
     /// - `fireRequest`: this is not triggered when `dryRun` is `true`
     public static func setUp(dryRun: Bool,
                              appVersion: String,
@@ -206,6 +208,7 @@ public final class PixelKit {
                              pixelCalendar: Calendar? = nil,
                              dateGenerator: @escaping () -> Date = Date.init,
                              defaults: ThrowingKeyValueStoring,
+                             parameterProvider: PixelKitParameterProviding? = nil,
                              fireRequest: @escaping FireRequest) {
         shared = PixelKit(dryRun: dryRun,
                           appVersion: appVersion,
@@ -216,6 +219,7 @@ public final class PixelKit {
                           pixelCalendar: pixelCalendar,
                           dateGenerator: dateGenerator,
                           defaults: defaults,
+                          parameterProvider: parameterProvider,
                           fireRequest: fireRequest)
     }
 
@@ -234,6 +238,7 @@ public final class PixelKit {
                             pixelCalendar: Calendar? = nil,
                             dateGenerator: @escaping () -> Date = Date.init,
                             defaults: ThrowingKeyValueStoring,
+                            parameterProvider: PixelKitParameterProviding? = nil,
                             fireRequest: @escaping FireRequest) {
         self.init(dryRun: dryRun,
                   appVersion: appVersion,
@@ -244,6 +249,7 @@ public final class PixelKit {
                   pixelCalendar: pixelCalendar,
                   dateGenerator: dateGenerator,
                   defaults: defaults,
+                  parameterProvider: parameterProvider,
                   retryQueueStore: nil,
                   fireRequest: fireRequest)
     }
@@ -259,6 +265,7 @@ public final class PixelKit {
          pixelCalendar: Calendar?,
          dateGenerator: @escaping () -> Date,
          defaults: ThrowingKeyValueStoring,
+         parameterProvider: PixelKitParameterProviding? = nil,
          retryQueueStore: PixelRetryQueueStoring?,
          fireRequest: @escaping FireRequest) {
 
@@ -271,6 +278,7 @@ public final class PixelKit {
         self.dateGenerator = dateGenerator
         self.defaults = defaults
         self.fireRequest = fireRequest
+        self.parameterProvider = parameterProvider
 
         if dryRun {
             self.retryQueue = nil
@@ -351,6 +359,7 @@ public final class PixelKit {
              withError: event.error,
              allowedQueryReservedCharacters: options.allowedQueryReservedCharacters,
              includeAppVersionParameter: options.includeAppVersionParameter,
+             includeATB: options.includeATB,
              standardParameters: event.standardParameters ?? [],
              retryOnFailure: options.retryOnFailure,
              onComplete: onComplete)
@@ -440,6 +449,7 @@ public final class PixelKit {
                       withError error: NSError?,
                       allowedQueryReservedCharacters: CharacterSet?,
                       includeAppVersionParameter: Bool,
+                      includeATB: Bool,
                       standardParameters: [PixelKitStandardParameter],
                       retryOnFailure: Bool,
                       onComplete: @escaping CompletionBlock) {
@@ -448,6 +458,16 @@ public final class PixelKit {
         if includeAppVersionParameter { newParams[Parameters.appVersion] = appVersion }
         if standardParameters.contains(.pixelSource), let source { newParams[Parameters.pixelSource] = source }
         if let channel { newParams[Parameters.channel] = channel }
+        if includeATB {
+            if let parameterProvider {
+                // Empty rather than absent when there is no ATB yet: legacy `Pixel` sent
+                // `statisticsStore.atbWithVariant ?? ""`, so parity means an empty value, not a
+                // missing parameter.
+                newParams[Parameters.atb] = parameterProvider.atb ?? ""
+            } else {
+                logger.fault("👾 \(pixelName, privacy: .public) asked for atb but no PixelKitParameterProviding was injected; omitting it")
+            }
+        }
         if let error { newParams.appendErrorPixelParams(error: error) }
 
         #if DEBUG

--- a/SharedPackages/PixelKit/Sources/PixelKit/PixelKitParameterProviding.swift
+++ b/SharedPackages/PixelKit/Sources/PixelKit/PixelKitParameterProviding.swift
@@ -1,0 +1,40 @@
+//
+//  PixelKitParameterProviding.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Supplies parameter values that PixelKit cannot derive on its own.
+///
+/// PixelKit deliberately sits below the layers that own this state and does not depend on them, so
+/// it cannot reach a statistics store directly. The host app injects a conformer at `setUp`.
+///
+/// Values are read at fire time rather than snapshotted at setup, because they change while the app
+/// runs: there is no ATB until the app has completed its first ATB request, and it is updated
+/// afterwards. Conformers should therefore read through to their underlying store on each access,
+/// and must be safe to read from any thread, since pixels are fired from many.
+///
+/// Injection is optional. With no provider, no pixel carries any of these parameters, which is what
+/// keeps a host that has not opted in byte-identical to its previous behaviour.
+public protocol PixelKitParameterProviding {
+
+    /// The ATB cohort with its variant suffix, for example `v123-4ma`, or `nil` before the app has
+    /// an ATB.
+    ///
+    /// Only read for pixels that opted in through `Options.includeATB`.
+    var atb: String? { get }
+}

--- a/SharedPackages/PixelKit/Tests/PixelKitTests/PixelKitATBTests.swift
+++ b/SharedPackages/PixelKit/Tests/PixelKitTests/PixelKitATBTests.swift
@@ -1,0 +1,199 @@
+//
+//  PixelKitATBTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import PixelKit
+
+/// Covers the `atb` parameter: who opts in, where the value comes from, and when it is read.
+final class PixelKitATBTests: XCTestCase {
+
+    /// A reference type on purpose, so a test can change the value between two fires and prove
+    /// PixelKit re-reads it rather than snapshotting it.
+    private final class MockParameterProvider: PixelKitParameterProviding {
+
+        var atb: String?
+
+        init(atb: String? = nil) {
+            self.atb = atb
+        }
+    }
+
+    private enum TestEvent: String, PixelKit.Event {
+
+        case testEvent
+
+        var name: String {
+            rawValue
+        }
+
+        var parameters: [String: String]? {
+            nil
+        }
+
+        var standardParameters: [PixelKitStandardParameter]? {
+            nil
+        }
+    }
+
+    private func userDefaults() -> UserDefaults {
+        UserDefaults(suiteName: "testing_\(UUID().uuidString)")!
+    }
+
+    private func makePixelKit(parameterProvider: PixelKitParameterProviding?,
+                              onFire: @escaping ([String: String]) -> Void) -> PixelKit {
+        PixelKit(dryRun: false,
+                 appVersion: "1.0.5",
+                 defaultHeaders: [:],
+                 pixelCalendar: nil,
+                 defaults: userDefaults(),
+                 parameterProvider: parameterProvider) { _, _, parameters, _, _, _ in
+            onFire(parameters)
+        }
+    }
+
+    /// The default is off, so migrating a pixel to PixelKit cannot silently start sending a cohort.
+    func testATBIsOmittedWhenThePixelDoesNotOptIn() {
+        let fired = expectation(description: "Expect the pixel firing callback to be called")
+        var firedParameters = [String: String]()
+
+        let pixelKit = makePixelKit(parameterProvider: MockParameterProvider(atb: "v123-4ma")) { parameters in
+            firedParameters = parameters
+            fired.fulfill()
+        }
+
+        pixelKit.fire(TestEvent.testEvent)
+        wait(for: [fired], timeout: 0.5)
+
+        XCTAssertNil(firedParameters[PixelKit.Parameters.atb])
+    }
+
+    func testATBIsSentWhenThePixelOptsIn() {
+        let fired = expectation(description: "Expect the pixel firing callback to be called")
+        var firedParameters = [String: String]()
+
+        let pixelKit = makePixelKit(parameterProvider: MockParameterProvider(atb: "v123-4ma")) { parameters in
+            firedParameters = parameters
+            fired.fulfill()
+        }
+
+        pixelKit.fire(TestEvent.testEvent, options: .withATB)
+        wait(for: [fired], timeout: 0.5)
+
+        XCTAssertEqual(firedParameters[PixelKit.Parameters.atb], "v123-4ma")
+    }
+
+    /// Parity with the legacy `Pixel`, which sent `statisticsStore.atbWithVariant ?? ""`. The
+    /// parameter is present with an empty value rather than missing.
+    func testATBIsSentEmptyWhenTheProviderHasNoValueYet() {
+        let fired = expectation(description: "Expect the pixel firing callback to be called")
+        var firedParameters = [String: String]()
+
+        let pixelKit = makePixelKit(parameterProvider: MockParameterProvider(atb: nil)) { parameters in
+            firedParameters = parameters
+            fired.fulfill()
+        }
+
+        pixelKit.fire(TestEvent.testEvent, options: .withATB)
+        wait(for: [fired], timeout: 0.5)
+
+        XCTAssertEqual(firedParameters[PixelKit.Parameters.atb], "")
+    }
+
+    /// A host that never injects a provider keeps its previous behaviour, even for a shared event
+    /// that opts in. Sending an empty cohort here would be fabricating data from a misconfiguration.
+    func testATBIsOmittedWhenNoProviderIsInjected() {
+        let fired = expectation(description: "Expect the pixel firing callback to be called")
+        var firedParameters = [String: String]()
+
+        let pixelKit = makePixelKit(parameterProvider: nil) { parameters in
+            firedParameters = parameters
+            fired.fulfill()
+        }
+
+        pixelKit.fire(TestEvent.testEvent, options: .withATB)
+        wait(for: [fired], timeout: 0.5)
+
+        XCTAssertNil(firedParameters[PixelKit.Parameters.atb])
+    }
+
+    /// The value is read on every fire, not captured at `setUp`. This matters because there is no
+    /// ATB until the app has completed its first ATB request.
+    func testATBIsResolvedAtFireTimeRatherThanAtSetUpTime() {
+        let provider = MockParameterProvider(atb: nil)
+        let firstFire = expectation(description: "Expect the first pixel firing callback to be called")
+        let secondFire = expectation(description: "Expect the second pixel firing callback to be called")
+        var firedATBs = [String?]()
+
+        let pixelKit = makePixelKit(parameterProvider: provider) { parameters in
+            firedATBs.append(parameters[PixelKit.Parameters.atb])
+            if firedATBs.count == 1 {
+                firstFire.fulfill()
+            } else {
+                secondFire.fulfill()
+            }
+        }
+
+        pixelKit.fire(TestEvent.testEvent, options: .withATB)
+        wait(for: [firstFire], timeout: 0.5)
+
+        provider.atb = "v123-4ma"
+        pixelKit.fire(TestEvent.testEvent, options: .withATB)
+        wait(for: [secondFire], timeout: 0.5)
+
+        XCTAssertEqual(firedATBs, ["", "v123-4ma"])
+    }
+
+    /// Exercises the shape the app actually uses: the static `setUp`, with `parameterProvider:`
+    /// sitting immediately before the trailing `fireRequest` closure.
+    func testSharedSetUpAcceptsAParameterProviderAndAppliesIt() {
+        let fired = expectation(description: "Expect the pixel firing callback to be called")
+        var firedParameters = [String: String]()
+
+        PixelKit.tearDown()
+        PixelKit.setUp(dryRun: false,
+                       appVersion: "1.0.5",
+                       session: "atb-tests",
+                       defaultHeaders: [:],
+                       defaults: userDefaults(),
+                       parameterProvider: MockParameterProvider(atb: "v123-4ma")) { _, _, parameters, _, _, _ in
+            firedParameters = parameters
+            fired.fulfill()
+        }
+        defer { PixelKit.tearDown() }
+
+        PixelKit.fire(TestEvent.testEvent, options: .withATB)
+        wait(for: [fired], timeout: 0.5)
+
+        XCTAssertEqual(firedParameters[PixelKit.Parameters.atb], "v123-4ma")
+    }
+
+    // MARK: - Options
+
+    func testIncludeATBIsOffByDefault() {
+        XCTAssertFalse(PixelKit.Options.default.includeATB)
+        XCTAssertFalse(PixelKit.Options().includeATB)
+    }
+
+    func testWithATBPresetOnlyChangesIncludeATB() {
+        XCTAssertEqual(PixelKit.Options.withATB, PixelKit.Options(includeATB: true))
+        XCTAssertTrue(PixelKit.Options.withATB.includeATB)
+        XCTAssertTrue(PixelKit.Options.withATB.includeAppVersionParameter)
+        XCTAssertTrue(PixelKit.Options.withATB.enforcePrefix)
+        XCTAssertFalse(PixelKit.Options.withATB.retryOnFailure)
+    }
+}

--- a/iOS/Core/PixelKitParameterProvider.swift
+++ b/iOS/Core/PixelKitParameterProvider.swift
@@ -1,0 +1,43 @@
+//
+//  PixelKitParameterProvider.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import BrowserServicesKit
+import PixelKit
+
+/// Supplies PixelKit with the iOS values it cannot derive itself.
+///
+/// Reads through to the statistics store on each access rather than caching, because there is no ATB
+/// until `StatisticsLoader` has completed the app's first ATB request, and it is updated afterwards.
+///
+/// The default store matches the one the legacy `Pixel` path used through
+/// `StatisticsDependentURLFactory`, so a pixel that opts into `atb` gets the same value it would
+/// have got before migrating.
+public final class IOSPixelKitParameterProvider: PixelKitParameterProviding {
+
+    private let statisticsStore: StatisticsStore
+
+    public init(statisticsStore: StatisticsStore = StatisticsUserDefaults()) {
+        self.statisticsStore = statisticsStore
+    }
+
+    public var atb: String? {
+        statisticsStore.atbWithVariant
+    }
+}

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -872,6 +872,7 @@
 		85372447220DD103009D09CD /* UIKeyCommandExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85372446220DD103009D09CD /* UIKeyCommandExtension.swift */; };
 		853807922D6E638000CE1455 /* AlertPlaygroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853807912D6E638000CE1455 /* AlertPlaygroundView.swift */; };
 		853A717620F62FE800FE60BC /* Pixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853A717520F62FE800FE60BC /* Pixel.swift */; };
+		FC0A7B0B2F00000100AAB001 /* PixelKitParameterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC0A7B0A2F00000100AAB001 /* PixelKitParameterProvider.swift */; };
 		853A717820F645FB00FE60BC /* PixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853A717720F645FB00FE60BC /* PixelTests.swift */; };
 		853C5F6121C277C7001F7A05 /* global.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853C5F6021C277C7001F7A05 /* global.swift */; };
 		8540BBA22440857A00017FE4 /* FireproofingWorking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8540BBA12440857A00017FE4 /* FireproofingWorking.swift */; };
@@ -3743,6 +3744,7 @@
 		85372446220DD103009D09CD /* UIKeyCommandExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKeyCommandExtension.swift; sourceTree = "<group>"; };
 		853807912D6E638000CE1455 /* AlertPlaygroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPlaygroundView.swift; sourceTree = "<group>"; };
 		853A717520F62FE800FE60BC /* Pixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pixel.swift; sourceTree = "<group>"; };
+		FC0A7B0A2F00000100AAB001 /* PixelKitParameterProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelKitParameterProvider.swift; sourceTree = "<group>"; };
 		853A717720F645FB00FE60BC /* PixelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelTests.swift; sourceTree = "<group>"; };
 		853C5F6021C277C7001F7A05 /* global.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = global.swift; sourceTree = "<group>"; };
 		8540BBA12440857A00017FE4 /* FireproofingWorking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireproofingWorking.swift; sourceTree = "<group>"; };
@@ -11439,6 +11441,7 @@
 				CB2A7EF028410DF700885F67 /* PixelEvent.swift */,
 				BDC234F62B27F51100D3C798 /* UniquePixel.swift */,
 				853A717520F62FE800FE60BC /* Pixel.swift */,
+				FC0A7B0A2F00000100AAB001 /* PixelKitParameterProvider.swift */,
 				6F03CB062C32F173004179A8 /* PixelFiring.swift */,
 				6F03CB082C32F331004179A8 /* PixelFiringAsync.swift */,
 				6F7FB8E22C660BF300867DA7 /* DailyPixelFiring.swift */,
@@ -15927,6 +15930,7 @@
 				9833913727AC400800DAF119 /* AppTrackerDataSetProvider.swift in Sources */,
 				83004E802193BB8200DA013C /* WKNavigationExtension.swift in Sources */,
 				853A717620F62FE800FE60BC /* Pixel.swift in Sources */,
+				FC0A7B0B2F00000100AAB001 /* PixelKitParameterProvider.swift in Sources */,
 				8596C30D2B7EB1800058EF90 /* DataStoreWarmup.swift in Sources */,
 				F41C2DA526C1975E00F9A760 /* LegacyBookmarksCoreDataStorage.swift in Sources */,
 				1E05D1D829C46EDA00BF9A1F /* TimedPixel.swift in Sources */,

--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencyProvider.swift
@@ -122,7 +122,8 @@ final class AppDependencyProvider: DependencyProvider {
                        source: source.rawValue,
                        session: "ios-browser",
                        defaultHeaders: [:],
-                       defaults: UserDefaults(suiteName: Global.appConfigurationGroupName) ?? UserDefaults()) { (pixelName: String, headers: [String: String], parameters: [String: String], _, _, onComplete: @escaping PixelKit.CompletionBlock) in
+                       defaults: UserDefaults(suiteName: Global.appConfigurationGroupName) ?? UserDefaults(),
+                       parameterProvider: IOSPixelKitParameterProvider()) { (pixelName: String, headers: [String: String], parameters: [String: String], _, _, onComplete: @escaping PixelKit.CompletionBlock) in
 
             let url = URL.pixelUrl(forPixelNamed: pixelName)
             let apiHeaders = APIRequestV2.HeadersV2(userAgent: Pixel.defaultPixelUserAgent, additionalHeaders: headers)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1213789567822288

### Description

Adds an `atb` parameter to PixelKit so pixels migrating off the legacy iOS `Pixel` system can keep sending it.

Off by default and opted into per pixel, matching how legacy gated it behind `includedParameters`. The value comes from a provider injected at setUp and is read on every fire, since there is no ATB until the app's first ATB request completes. Only iOS injects a provider, so macOS and the VPN extensions are unchanged.

### Testing Steps

1. Run the PixelKit unit tests.
2. Launch the iOS app and confirm existing pixels are unchanged and carry no `atb` parameter.

No pixel opts in yet, so there is nothing user-visible to exercise beyond confirming nothing changed.

### Impact and Risks

None

#### What could go wrong?

- This ships inert. Nothing on the wire changes until a migrated pixel opts in.

---

###### Internal references: [DoD](https://app.asana.com/0/1207634633537039) | [Eng Expectations](https://app.asana.com/0/199064865822552) | [Tech Design Template](https://app.asana.com/0/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 42abbd2575a6e274e57cae3e88b5e12b8feddd15. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->