### PR TITLE
[macOS 1.204.0] Fix bookmarks panel crash when restoring folder expansion state

### DIFF
--- a/macOS/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
+++ b/macOS/DuckDuckGo/Bookmarks/View/BookmarkListViewController.swift
@@ -745,6 +745,8 @@ final class BookmarkListViewController: NSViewController {
 
     private func expandAndRestore(selectedNodes: [BookmarkNode]) {
         treeController.visitNodes { node in
+            guard outlineView.rowIfValid(forItem: node) != nil else { return }
+
             if let objectID = (node.representedObject as? BaseBookmarkEntity)?.id {
                 if dataSource.expandedNodesIDs.contains(objectID) {
                     outlineView.expandItem(node)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1217529314897967
Tech Design URL: N/A
CC: N/A

### Description

Fixes `NSInternalInconsistencyException: Invalid entry for row N` (Sentry [APPLE-MACOS-D54](https://errors.duckduckgo.com/organizations/ddg/issues/APPLE-MACOS-D54/?project=6)): the browser aborts when the bookmarks panel restores folder expansion state after a bookmarks list change. `expandedNodesIDs` retains stale IDs for subfolders nested under a collapsed folder, and the restore walk called `expandItem` on items with no row, desyncing NSOutlineView's row bookkeeping under `usesAutomaticRowHeights`.

The fix guards the walk with the existing `rowIfValid(forItem:)` helper so expand/collapse only applies to nodes currently in the outline view. The walk is pre-order, so parents are expanded before their children are visited — legitimate nested expansion restore is unchanged.

### Testing Steps

1. Open the bookmarks panel with nested folders (folder A containing subfolder B) and enough bookmarks to scroll.
2. Expand A, then expand B, then collapse A.
3. With the panel open, trigger a bookmarks list change (delete/rename a bookmark, or add one from another window).
4. Before the fix this could throw `NSInternalInconsistencyException: Invalid entry for row N`; after the fix the list reloads without crashing.
5. Re-expand A and verify B's expansion state is restored on the next list reload; selection and scroll restore still work.

### Impact

Low

#### What could go wrong?

A folder nested under a collapsed parent may briefly appear collapsed when the parent is manually re-expanded, until the next list reload re-applies the remembered expansion state. Expansion restore for visible nodes is unchanged.

### Quality Considerations

No privacy or security impact. Two-line guard using an existing helper; identical change to #6446 (main).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7677ede87fde46b9bb62542babdbbbeaa59afd41. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->