### PR TITLE
iOS: Scale the new tab page down into the tab cell instead of stretching it

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2283,6 +2283,8 @@
 		CB258D1F29A52B2500DEBA24 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB258D0C29A4CD0500DEBA24 /* Configuration.swift */; };
 		CB27DAE72FFFE65200EEEADB /* WebViewTransitionGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB27DAE62FFFE65200EEEADB /* WebViewTransitionGeometry.swift */; };
 		CB27DAE92FFFE6BC00EEEADB /* WebViewTransitionGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB27DAE82FFFE6BC00EEEADB /* WebViewTransitionGeometryTests.swift */; };
+		A8452A0101C0DE0000000002 /* HomeScreenTransitionGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8452A0101C0DE0000000001 /* HomeScreenTransitionGeometry.swift */; };
+		A8452A0101C0DE0000000004 /* HomeScreenTransitionGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8452A0101C0DE0000000003 /* HomeScreenTransitionGeometryTests.swift */; };
 		CB27DAF330063B4600EEEADB /* ToolbarVisibilityDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB27DAF230063B4600EEEADB /* ToolbarVisibilityDecision.swift */; };
 		CB27DAF530063B4A00EEEADB /* AITabChromeDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB27DAF430063B4A00EEEADB /* AITabChromeDecision.swift */; };
 		CB27DAF730063B9100EEEADB /* ToolbarVisibilityDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB27DAF630063B9100EEEADB /* ToolbarVisibilityDecisionTests.swift */; };
@@ -5173,6 +5175,8 @@
 		CB258D0F29A4D0FD00DEBA24 /* ConfigurationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationManager.swift; sourceTree = "<group>"; };
 		CB27DAE62FFFE65200EEEADB /* WebViewTransitionGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewTransitionGeometry.swift; sourceTree = "<group>"; };
 		CB27DAE82FFFE6BC00EEEADB /* WebViewTransitionGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewTransitionGeometryTests.swift; sourceTree = "<group>"; };
+		A8452A0101C0DE0000000001 /* HomeScreenTransitionGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenTransitionGeometry.swift; sourceTree = "<group>"; };
+		A8452A0101C0DE0000000003 /* HomeScreenTransitionGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenTransitionGeometryTests.swift; sourceTree = "<group>"; };
 		CB27DAF230063B4600EEEADB /* ToolbarVisibilityDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarVisibilityDecision.swift; sourceTree = "<group>"; };
 		CB27DAF430063B4A00EEEADB /* AITabChromeDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AITabChromeDecision.swift; sourceTree = "<group>"; };
 		CB27DAF630063B9100EEEADB /* ToolbarVisibilityDecisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarVisibilityDecisionTests.swift; sourceTree = "<group>"; };
@@ -8149,6 +8153,7 @@
 				BEA13CC2BC37C33434640638 /* WebViewInputAccessoryTests.swift */,
 				CB6EF0502FE020D6000C75BA /* IPadOmnibarFocusModelTests.swift */,
 				CB27DAE82FFFE6BC00EEEADB /* WebViewTransitionGeometryTests.swift */,
+				A8452A0101C0DE0000000003 /* HomeScreenTransitionGeometryTests.swift */,
 			);
 			name = UnitTests;
 			path = DuckDuckGoTests;
@@ -8342,6 +8347,7 @@
 				855D914C2063EF6A00C4B448 /* TabSwitcherTransition.swift */,
 				986DA94924884B18004A7E39 /* WebViewTransition.swift */,
 				CB27DAE62FFFE65200EEEADB /* WebViewTransitionGeometry.swift */,
+				A8452A0101C0DE0000000001 /* HomeScreenTransitionGeometry.swift */,
 			);
 			path = Transitions;
 			sourceTree = "<group>";
@@ -14228,6 +14234,7 @@
 				F2B8A10736AA100000C0DE01 /* UnifiedToggleInputAttachment.swift in Sources */,
 				AABB00010001000100010007 /* UTIAttachmentPolicy.swift in Sources */,
 				CB27DAE72FFFE65200EEEADB /* WebViewTransitionGeometry.swift in Sources */,
+				A8452A0101C0DE0000000002 /* HomeScreenTransitionGeometry.swift in Sources */,
 				AABB0001000100010001000B /* UTIModelStore.swift in Sources */,
 				AABB0001000100010001000F /* UTIToolsController.swift in Sources */,
 				F2B8A10236AA100000C0DE01 /* UnifiedToggleInputModelMenuFactory.swift in Sources */,
@@ -15207,6 +15214,7 @@
 				98E564092DE8B32D00E6E75F /* ContextualOnboardingPresenterMock.swift in Sources */,
 				9F4CC5172C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift in Sources */,
 				CB27DAE92FFFE6BC00EEEADB /* WebViewTransitionGeometryTests.swift in Sources */,
+				A8452A0101C0DE0000000004 /* HomeScreenTransitionGeometryTests.swift in Sources */,
 				F1A83D872E0AB27E00054B03 /* MockFeatureFlagger.swift in Sources */,
 				9FE59CE72E3307AD00C4B65D /* SystemSettingsPiPTutorialPixelHandlerTests.swift in Sources */,
 				F13B4BFB1F18E3D900814661 /* TabsModelPersistenceTests.swift in Sources */,

--- a/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
@@ -29,8 +29,6 @@ class HomeScreenTransition: TabSwitcherTransition {
     fileprivate var homeScreenSnapshot: UIView?
     fileprivate var settingsButtonSnapshot: UIView?
 
-    /// The size the home screen snapshot was captured at, so the morph can keep its aspect ratio.
-    /// See `homeScreenSnapshotFrame(in:)`.
     fileprivate var homeScreenSnapshotSourceSize: CGSize?
 
     fileprivate let tabSwitcherSettings: TabSwitcherSettings = DefaultTabSwitcherSettings()
@@ -54,21 +52,6 @@ class HomeScreenTransition: TabSwitcherTransition {
         }
     }
 
-    /// Aspect-preserving frame for the home screen snapshot inside the morphing container: the
-    /// snapshot scales *down* uniformly and stays centred, rather than being stretched to fill.
-    ///
-    /// A `resizableSnapshotView` stretches its content to whatever frame it's given, so driving the
-    /// snapshot straight off `imageContainer.bounds` distorted it non-uniformly as the container
-    /// morphed between the full screen and a tab cell. In grid view the cell's aspect ratio is close
-    /// enough to the screen's for that to pass unnoticed (and a centred logo is crossfaded over it
-    /// anyway), but a list-view row is far wider than it is tall, so the whole page -- Dax most
-    /// visibly -- squashed flat and "folded" over the transition.
-    ///
-    /// Fitting on the smaller of the two ratios is what makes this a scale rather than a crop. A
-    /// list row is already full-width, so matching the container's *width* would leave the snapshot
-    /// at nearly full size and simply clip it to a thin strip, taking Dax with it; taking the
-    /// minimum instead shrinks the whole page toward the row and keeps it centred and intact while
-    /// it crossfades out.
     fileprivate func homeScreenSnapshotFrame(in containerBounds: CGRect) -> CGRect {
         guard let sourceSize = homeScreenSnapshotSourceSize,
               sourceSize.width > 0,

--- a/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
@@ -28,9 +28,13 @@ class HomeScreenTransition: TabSwitcherTransition {
     
     fileprivate var homeScreenSnapshot: UIView?
     fileprivate var settingsButtonSnapshot: UIView?
-    
+
+    /// The size the home screen snapshot was captured at, so the morph can keep its aspect ratio.
+    /// See `homeScreenSnapshotFrame(in:)`.
+    fileprivate var homeScreenSnapshotSourceSize: CGSize?
+
     fileprivate let tabSwitcherSettings: TabSwitcherSettings = DefaultTabSwitcherSettings()
-    
+
     fileprivate func prepareSnapshots(with transitionSource: HomeScreenTransitionSource,
                                       transitionContext: UIViewControllerContextTransitioning,
                                       addressBarPosition: AddressBarPosition,
@@ -44,9 +48,39 @@ class HomeScreenTransition: TabSwitcherTransition {
                                                                afterScreenUpdates: false,
                                                                withCapInsets: .zero) {
             imageContainer.addSubview(snapshot)
-            snapshot.frame = imageContainer.bounds
+            homeScreenSnapshotSourceSize = frameToSnapshot.size
+            snapshot.frame = homeScreenSnapshotFrame(in: imageContainer.bounds)
             homeScreenSnapshot = snapshot
         }
+    }
+
+    /// Aspect-preserving frame for the home screen snapshot inside the morphing container: the
+    /// snapshot scales *down* uniformly and stays centred, rather than being stretched to fill.
+    ///
+    /// A `resizableSnapshotView` stretches its content to whatever frame it's given, so driving the
+    /// snapshot straight off `imageContainer.bounds` distorted it non-uniformly as the container
+    /// morphed between the full screen and a tab cell. In grid view the cell's aspect ratio is close
+    /// enough to the screen's for that to pass unnoticed (and a centred logo is crossfaded over it
+    /// anyway), but a list-view row is far wider than it is tall, so the whole page -- Dax most
+    /// visibly -- squashed flat and "folded" over the transition.
+    ///
+    /// Fitting on the smaller of the two ratios is what makes this a scale rather than a crop. A
+    /// list row is already full-width, so matching the container's *width* would leave the snapshot
+    /// at nearly full size and simply clip it to a thin strip, taking Dax with it; taking the
+    /// minimum instead shrinks the whole page toward the row and keeps it centred and intact while
+    /// it crossfades out.
+    fileprivate func homeScreenSnapshotFrame(in containerBounds: CGRect) -> CGRect {
+        guard let sourceSize = homeScreenSnapshotSourceSize,
+              sourceSize.width > 0,
+              sourceSize.height > 0 else { return containerBounds }
+
+        let scale = min(containerBounds.width / sourceSize.width,
+                        containerBounds.height / sourceSize.height)
+        let size = CGSize(width: sourceSize.width * scale, height: sourceSize.height * scale)
+        return CGRect(x: containerBounds.midX - size.width / 2,
+                      y: containerBounds.midY - size.height / 2,
+                      width: size.width,
+                      height: size.height)
     }
 
     fileprivate func tabSwitcherCellFrame(for attributes: UICollectionViewLayoutAttributes) -> CGRect {
@@ -124,7 +158,7 @@ class FromHomeScreenTransition: HomeScreenTransition {
                 self.imageContainer.layer.cornerRadius = TabViewCell.Constants.cellCornerRadius
                 self.imageContainer.backgroundColor = UIColor(designSystemColor: .surfaceTertiary)
                 self.imageView.frame = self.previewFrame(for: self.imageContainer.bounds.size)
-                self.homeScreenSnapshot?.frame = self.imageContainer.bounds
+                self.homeScreenSnapshot?.frame = self.homeScreenSnapshotFrame(in: self.imageContainer.bounds)
             }
 
             // Slowly fade out to create a cross fade effect
@@ -216,7 +250,7 @@ class ToHomeScreenTransition: HomeScreenTransition {
                 self.imageContainer.backgroundColor = theme.backgroundColor
                 self.imageView.frame = CGRect(origin: .zero,
                                               size: self.imageContainer.bounds.size)
-                self.homeScreenSnapshot?.frame = self.imageContainer.bounds
+                self.homeScreenSnapshot?.frame = self.homeScreenSnapshotFrame(in: self.imageContainer.bounds)
             }
 
             if tab.viewed {

--- a/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
@@ -48,13 +48,17 @@ class HomeScreenTransition: TabSwitcherTransition {
             imageContainer.addSubview(snapshot)
             homeScreenSnapshotSourceSize = frameToSnapshot.size
             snapshot.frame = HomeScreenTransitionGeometry.snapshotFrame(for: frameToSnapshot.size,
-                                                                        in: imageContainer.bounds)
+                                                                        in: imageContainer.bounds,
+                                                                        isGridViewEnabled: tabSwitcherSettings.isGridViewEnabled)
             homeScreenSnapshot = snapshot
         }
     }
 
     fileprivate func homeScreenSnapshotFrame(in containerBounds: CGRect) -> CGRect {
-        HomeScreenTransitionGeometry.snapshotFrame(for: homeScreenSnapshotSourceSize ?? .zero, in: containerBounds)
+        HomeScreenTransitionGeometry.snapshotFrame(
+            for: homeScreenSnapshotSourceSize ?? .zero,
+            in: containerBounds,
+            isGridViewEnabled: tabSwitcherSettings.isGridViewEnabled)
     }
 
     fileprivate func tabSwitcherCellFrame(for attributes: UICollectionViewLayoutAttributes) -> CGRect {

--- a/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
@@ -77,8 +77,25 @@ class HomeScreenTransition: TabSwitcherTransition {
     }
     
     fileprivate func previewFrame(for cellBounds: CGSize) -> CGRect {
-        return CGRect(origin: .zero, size: cellBounds)
-            .offsetBy(dx: 0, dy: -TabViewCell.Constants.previewPadding)
+        guard tabSwitcherSettings.isGridViewEnabled else {
+            return CGRect(origin: .zero, size: cellBounds)
+                .offsetBy(dx: 0, dy: -TabViewCell.Constants.previewPadding)
+        }
+
+        // Match TabViewGridCell.previewClipView / WebViewTransitionGeometry.previewFrame:
+        // logo sits in the preview area below the cell header, not the full cell.
+        let horizontalInset = TabViewGridCell.Constants.previewHorizontalInset / 2
+        let availableWidth = cellBounds.width - TabViewGridCell.Constants.previewHorizontalInset
+        let availableHeight = cellBounds.height
+            - TabViewGridCell.Constants.headerHeight
+            - TabViewGridCell.Constants.previewBottomPadding
+        guard availableWidth > 0, availableHeight > 0 else {
+            return CGRect(origin: .zero, size: cellBounds)
+        }
+        return CGRect(x: horizontalInset,
+                      y: TabViewGridCell.Constants.headerHeight,
+                      width: availableWidth,
+                      height: availableHeight)
     }
     
 }
@@ -178,7 +195,11 @@ class FromHomeScreenTransition: HomeScreenTransition {
                 }
             } else {
                 UIView.addKeyframe(withRelativeStartTime: 0.7, relativeDuration: 0.3) {
+                    // Fade card chrome with the snapshot so a blank rounded card
+                    // does not linger over the list row.
                     self.imageContainer.alpha = 0
+                    self.cardShadow.alpha = 0
+                    self.cardBorder.alpha = 0
                     self.settingsButtonSnapshot?.alpha = 0
                 }
             }

--- a/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
@@ -133,6 +133,8 @@ class FromHomeScreenTransition: HomeScreenTransition {
             if let cell = tabSwitcherViewController.collectionView.cellForItem(at: IndexPath(row: rowIndex, section: 0)) as? TabViewGridCell {
                 prepareGridChromeSnapshot(for: cell, initiallyVisible: false)
             }
+        } else if let cell = tabSwitcherViewController.collectionView.cellForItem(at: IndexPath(row: rowIndex, section: 0)) as? TabViewListCell {
+            prepareListChrome(for: cell, initiallyVisible: false)
         }
         
         UIView.animateKeyframes(withDuration: TabSwitcherTransition.Constants.duration, delay: 0, options: .calculationModeLinear, animations: {
@@ -147,6 +149,9 @@ class FromHomeScreenTransition: HomeScreenTransition {
                 self.homeScreenSnapshot?.frame = self.homeScreenSnapshotFrame(
                     in: CGRect(origin: .zero, size: containerFrame.size),
                     includesGridChrome: true)
+                if !self.tabSwitcherSettings.isGridViewEnabled {
+                    self.applyListChromePose(isVisible: true)
+                }
             }
 
             if self.tabSwitcherSettings.isGridViewEnabled {
@@ -234,6 +239,8 @@ class ToHomeScreenTransition: HomeScreenTransition {
             if let cell = tabSwitcherViewController.collectionView.cellForItem(at: IndexPath(row: rowIndex, section: 0)) as? TabViewGridCell {
                 prepareGridChromeSnapshot(for: cell, initiallyVisible: true)
             }
+        } else if let cell = tabSwitcherViewController.collectionView.cellForItem(at: IndexPath(row: rowIndex, section: 0)) as? TabViewListCell {
+            prepareListChrome(for: cell, initiallyVisible: true)
         }
         imageView.backgroundColor = .clear
 
@@ -252,6 +259,9 @@ class ToHomeScreenTransition: HomeScreenTransition {
                                               size: self.imageContainer.bounds.size)
                 self.homeScreenSnapshot?.frame = self.homeScreenSnapshotFrame(
                     in: CGRect(origin: .zero, size: destinationFrame.size))
+                if !self.tabSwitcherSettings.isGridViewEnabled {
+                    self.applyListChromePose(isVisible: false)
+                }
             }
 
             if self.tabSwitcherSettings.isGridViewEnabled {

--- a/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
@@ -47,23 +47,14 @@ class HomeScreenTransition: TabSwitcherTransition {
                                                                withCapInsets: .zero) {
             imageContainer.addSubview(snapshot)
             homeScreenSnapshotSourceSize = frameToSnapshot.size
-            snapshot.frame = homeScreenSnapshotFrame(in: imageContainer.bounds)
+            snapshot.frame = HomeScreenTransitionGeometry.snapshotFrame(for: frameToSnapshot.size,
+                                                                        in: imageContainer.bounds)
             homeScreenSnapshot = snapshot
         }
     }
 
     fileprivate func homeScreenSnapshotFrame(in containerBounds: CGRect) -> CGRect {
-        guard let sourceSize = homeScreenSnapshotSourceSize,
-              sourceSize.width > 0,
-              sourceSize.height > 0 else { return containerBounds }
-
-        let scale = min(containerBounds.width / sourceSize.width,
-                        containerBounds.height / sourceSize.height)
-        let size = CGSize(width: sourceSize.width * scale, height: sourceSize.height * scale)
-        return CGRect(x: containerBounds.midX - size.width / 2,
-                      y: containerBounds.midY - size.height / 2,
-                      width: size.width,
-                      height: size.height)
+        HomeScreenTransitionGeometry.snapshotFrame(for: homeScreenSnapshotSourceSize ?? .zero, in: containerBounds)
     }
 
     fileprivate func tabSwitcherCellFrame(for attributes: UICollectionViewLayoutAttributes) -> CGRect {

--- a/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/HomeScreenTransition.swift
@@ -54,24 +54,26 @@ class HomeScreenTransition: TabSwitcherTransition {
         }
     }
 
-    fileprivate func homeScreenSnapshotFrame(in containerBounds: CGRect) -> CGRect {
-        HomeScreenTransitionGeometry.snapshotFrame(
+    fileprivate func homeScreenSnapshotFrame(in containerBounds: CGRect, includesGridChrome: Bool = false) -> CGRect {
+        let snapshotBounds: CGRect
+        if tabSwitcherSettings.isGridViewEnabled, includesGridChrome {
+            snapshotBounds = CGRect(
+                x: TabViewGridCell.Constants.previewHorizontalInset / 2,
+                y: TabViewGridCell.Constants.headerHeight,
+                width: containerBounds.width - TabViewGridCell.Constants.previewHorizontalInset,
+                height: containerBounds.height - TabViewGridCell.Constants.headerHeight - TabViewGridCell.Constants.previewBottomPadding)
+        } else {
+            snapshotBounds = containerBounds
+        }
+        return HomeScreenTransitionGeometry.snapshotFrame(
             for: homeScreenSnapshotSourceSize ?? .zero,
-            in: containerBounds,
+            in: snapshotBounds,
             isGridViewEnabled: tabSwitcherSettings.isGridViewEnabled)
     }
 
     fileprivate func tabSwitcherCellFrame(for attributes: UICollectionViewLayoutAttributes) -> CGRect {
-        var targetFrame = self.tabSwitcherViewController.collectionView.convert(attributes.frame,
-                                                                                to: self.tabSwitcherViewController.view)
-        
-        guard tabSwitcherSettings.isGridViewEnabled else {
-            return targetFrame
-        }
-        
-        targetFrame.origin.y += TabViewCell.Constants.cellHeaderHeight
-        targetFrame.size.height -= TabViewCell.Constants.cellHeaderHeight
-        return targetFrame
+        self.tabSwitcherViewController.collectionView.convert(attributes.frame,
+                                                              to: self.tabSwitcherViewController.view)
     }
     
     fileprivate func previewFrame(for cellBounds: CGSize) -> CGRect {
@@ -96,6 +98,7 @@ class FromHomeScreenTransition: HomeScreenTransition {
         prepareSubviews(using: transitionContext)
         tabSwitcherViewController.view.alpha = 0
         transitionContext.containerView.insertSubview(tabSwitcherViewController.view, belowSubview: imageContainer)
+        transitionContext.containerView.insertSubview(cardShadow, belowSubview: imageContainer)
         tabSwitcherViewController.view.frame = transitionContext.finalFrame(for: tabSwitcherViewController)
         tabSwitcherViewController.prepareForPresentation()
         
@@ -105,6 +108,7 @@ class FromHomeScreenTransition: HomeScreenTransition {
               let layoutAttr = tabSwitcherViewController.collectionView.layoutAttributesForItem(at: IndexPath(row: rowIndex, section: 0))
         else {
             tabSwitcherViewController.view.alpha = 1
+            removeTransitionViews()
             transitionContext.completeTransition(true)
             return
         }
@@ -116,7 +120,7 @@ class FromHomeScreenTransition: HomeScreenTransition {
                                             byHeight: -mainViewController.omniBar.barView.expectedHeight)
         solidBackground.backgroundColor = theme.backgroundColor
 
-        imageContainer.frame = solidBackground.frame
+        setCardFrame(solidBackground.frame, cornerRadius: 0, shadowOpacity: 0)
         imageContainer.backgroundColor = theme.backgroundColor
         
         prepareSnapshots(with: homeScreen, transitionContext: transitionContext, addressBarPosition: mainViewController.appSettings.currentAddressBarPosition, addressBarHeight: mainViewController.omniBar.barView.expectedHeight)
@@ -126,17 +130,31 @@ class FromHomeScreenTransition: HomeScreenTransition {
         imageView.contentMode = .center
         if tabSwitcherSettings.isGridViewEnabled {
             imageView.image = TabViewCell.logoImage(for: tab)
+            if let cell = tabSwitcherViewController.collectionView.cellForItem(at: IndexPath(row: rowIndex, section: 0)) as? TabViewGridCell {
+                prepareGridChromeSnapshot(for: cell, initiallyVisible: false)
+            }
         }
         
         UIView.animateKeyframes(withDuration: TabSwitcherTransition.Constants.duration, delay: 0, options: .calculationModeLinear, animations: {
             
             UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: 1.0) {
                 let containerFrame = self.tabSwitcherCellFrame(for: layoutAttr)
-                self.imageContainer.frame = containerFrame
-                self.imageContainer.layer.cornerRadius = TabViewCell.Constants.cellCornerRadius
+                self.setCardFrame(containerFrame,
+                                  cornerRadius: TabViewCell.Constants.cellCornerRadius,
+                                  shadowOpacity: 1)
                 self.imageContainer.backgroundColor = UIColor(designSystemColor: .surfaceTertiary)
                 self.imageView.frame = self.previewFrame(for: self.imageContainer.bounds.size)
-                self.homeScreenSnapshot?.frame = self.homeScreenSnapshotFrame(in: self.imageContainer.bounds)
+                self.homeScreenSnapshot?.frame = self.homeScreenSnapshotFrame(
+                    in: CGRect(origin: .zero, size: containerFrame.size),
+                    includesGridChrome: true)
+            }
+
+            if self.tabSwitcherSettings.isGridViewEnabled {
+                UIView.addKeyframe(withRelativeStartTime: 0.25, relativeDuration: 0.55) {
+                    self.applyGridChromePose(
+                        isVisible: true,
+                        in: CGRect(origin: .zero, size: self.tabSwitcherCellFrame(for: layoutAttr).size))
+                }
             }
 
             // Slowly fade out to create a cross fade effect
@@ -161,8 +179,7 @@ class FromHomeScreenTransition: HomeScreenTransition {
             }
 
         }, completion: { _ in
-            self.solidBackground.removeFromSuperview()
-            self.imageContainer.removeFromSuperview()
+            self.removeTransitionViews()
             self.settingsButtonSnapshot?.removeFromSuperview()
             transitionContext.completeTransition(true)
         })
@@ -188,8 +205,7 @@ class ToHomeScreenTransition: HomeScreenTransition {
             UIView.animate(withDuration: TabSwitcherTransition.Constants.duration, animations: {
                 self.tabSwitcherViewController.view.alpha = 0
             }, completion: { _ in
-                self.solidBackground.removeFromSuperview()
-                self.imageContainer.removeFromSuperview()
+                self.removeTransitionViews()
                 transitionContext.completeTransition(true)
             })
             return
@@ -198,12 +214,15 @@ class ToHomeScreenTransition: HomeScreenTransition {
         mainViewController.view.alpha = 1
         
         let theme = ThemeManager.shared.currentTheme
-        imageContainer.frame = tabSwitcherCellFrame(for: layoutAttr)
+        let initialContainerFrame = tabSwitcherCellFrame(for: layoutAttr)
+        setCardFrame(initialContainerFrame,
+                     cornerRadius: TabViewCell.Constants.cellCornerRadius,
+                     shadowOpacity: 1)
 
         imageContainer.backgroundColor = theme.tabSwitcherCellBackgroundColor
-        imageContainer.layer.cornerRadius = TabViewCell.Constants.cellCornerRadius
         
         prepareSnapshots(with: homeScreen, transitionContext: transitionContext, addressBarPosition: mainViewController.appSettings.currentAddressBarPosition, addressBarHeight: mainViewController.omniBar.barView.expectedHeight)
+        homeScreenSnapshot?.frame = homeScreenSnapshotFrame(in: imageContainer.bounds, includesGridChrome: true)
         homeScreenSnapshot?.alpha = 0
         settingsButtonSnapshot?.alpha = 0
         
@@ -212,6 +231,9 @@ class ToHomeScreenTransition: HomeScreenTransition {
         if tabSwitcherSettings.isGridViewEnabled {
             imageView.image = TabViewCell.logoImage(for: tab)
             imageView.alpha = tab.viewed ? 1 : 0
+            if let cell = tabSwitcherViewController.collectionView.cellForItem(at: IndexPath(row: rowIndex, section: 0)) as? TabViewGridCell {
+                prepareGridChromeSnapshot(for: cell, initiallyVisible: true)
+            }
         }
         imageView.backgroundColor = .clear
 
@@ -220,15 +242,27 @@ class ToHomeScreenTransition: HomeScreenTransition {
         UIView.animateKeyframes(withDuration: TabSwitcherTransition.Constants.duration, delay: 0, options: .calculationModeLinear, animations: {
             
             UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: 1.0) {
-                self.imageContainer.frame = homeScreen.view.convert(homeScreen.rootContainerView.frame, to: nil)
-                self.imageContainer.frame = self.adjustFrame(self.imageContainer.frame,
-                                                             forAddressBarPosition: mainViewController.appSettings.currentAddressBarPosition,
-                                                             byHeight: -mainViewController.omniBar.barView.expectedHeight)
-                self.imageContainer.layer.cornerRadius = 0
+                var destinationFrame = homeScreen.view.convert(homeScreen.rootContainerView.frame, to: nil)
+                destinationFrame = self.adjustFrame(destinationFrame,
+                                                    forAddressBarPosition: mainViewController.appSettings.currentAddressBarPosition,
+                                                    byHeight: -mainViewController.omniBar.barView.expectedHeight)
+                self.setCardFrame(destinationFrame, cornerRadius: 0, shadowOpacity: 0)
                 self.imageContainer.backgroundColor = theme.backgroundColor
                 self.imageView.frame = CGRect(origin: .zero,
                                               size: self.imageContainer.bounds.size)
-                self.homeScreenSnapshot?.frame = self.homeScreenSnapshotFrame(in: self.imageContainer.bounds)
+                self.homeScreenSnapshot?.frame = self.homeScreenSnapshotFrame(
+                    in: CGRect(origin: .zero, size: destinationFrame.size))
+            }
+
+            if self.tabSwitcherSettings.isGridViewEnabled {
+                UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: 0.55) {
+                    var destinationFrame = homeScreen.view.convert(homeScreen.rootContainerView.frame, to: nil)
+                    destinationFrame = self.adjustFrame(destinationFrame,
+                                                        forAddressBarPosition: mainViewController.appSettings.currentAddressBarPosition,
+                                                        byHeight: -mainViewController.omniBar.barView.expectedHeight)
+                    self.applyGridChromePose(isVisible: false,
+                                             in: CGRect(origin: .zero, size: destinationFrame.size))
+                }
             }
 
             if tab.viewed {
@@ -249,7 +283,7 @@ class ToHomeScreenTransition: HomeScreenTransition {
             }
             
         }, completion: { _ in
-            self.imageContainer.removeFromSuperview()
+            self.removeTransitionViews()
             self.settingsButtonSnapshot?.removeFromSuperview()
             transitionContext.completeTransition(true)
         })

--- a/iOS/DuckDuckGo/Transitions/HomeScreenTransitionGeometry.swift
+++ b/iOS/DuckDuckGo/Transitions/HomeScreenTransitionGeometry.swift
@@ -1,0 +1,41 @@
+//
+//  HomeScreenTransitionGeometry.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+
+enum HomeScreenTransitionGeometry {
+
+    /// Aspect-fit frame for a captured new-tab-page snapshot inside a shrinking/growing
+    /// tab-cell container. Fitting on the smaller ratio scales the page uniformly instead
+    /// of stretching a `resizableSnapshotView` to the container's (often much wider) bounds.
+    static func snapshotFrame(for sourceSize: CGSize, in containerBounds: CGRect) -> CGRect {
+        guard sourceSize.width > 0, sourceSize.height > 0,
+              sourceSize.width.isFinite, sourceSize.height.isFinite else {
+            return containerBounds
+        }
+
+        let scale = min(containerBounds.width / sourceSize.width,
+                        containerBounds.height / sourceSize.height)
+        let size = CGSize(width: sourceSize.width * scale, height: sourceSize.height * scale)
+        return CGRect(x: containerBounds.midX - size.width / 2,
+                      y: containerBounds.midY - size.height / 2,
+                      width: size.width,
+                      height: size.height)
+    }
+}

--- a/iOS/DuckDuckGo/Transitions/HomeScreenTransitionGeometry.swift
+++ b/iOS/DuckDuckGo/Transitions/HomeScreenTransitionGeometry.swift
@@ -24,10 +24,20 @@ enum HomeScreenTransitionGeometry {
     /// Aspect-fit frame for a captured new-tab-page snapshot inside a shrinking/growing
     /// tab-cell container. Fitting on the smaller ratio scales the page uniformly instead
     /// of stretching a `resizableSnapshotView` to the container's (often much wider) bounds.
-    static func snapshotFrame(for sourceSize: CGSize, in containerBounds: CGRect) -> CGRect {
+    static func snapshotFrame(for sourceSize: CGSize,
+                              in containerBounds: CGRect,
+                              isGridViewEnabled: Bool) -> CGRect {
         guard sourceSize.width > 0, sourceSize.height > 0,
               sourceSize.width.isFinite, sourceSize.height.isFinite else {
             return containerBounds
+        }
+
+        if !isGridViewEnabled {
+            let scale = containerBounds.width / sourceSize.width
+            return CGRect(x: containerBounds.minX,
+                          y: containerBounds.minY,
+                          width: containerBounds.width,
+                          height: sourceSize.height * scale)
         }
 
         let scale = min(containerBounds.width / sourceSize.width,

--- a/iOS/DuckDuckGo/Transitions/TabSwitcherTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/TabSwitcherTransition.swift
@@ -18,6 +18,7 @@
 //
 
 import UIKit
+import DesignResourcesKit
 
 class TabSwitcherTransition: NSObject, UIViewControllerAnimatedTransitioning {
     
@@ -27,10 +28,13 @@ class TabSwitcherTransition: NSObject, UIViewControllerAnimatedTransitioning {
     
     // Used to hide contents of the 'from' VC when animating.
     let solidBackground = UIView()
+    // Draws outside the clipped transition card so depth can participate in the morph.
+    let cardShadow = UIView()
     // Container for the image, will clip subviews like tab switcher cell does.
     let imageContainer = UIView()
     // Image to display as a preview.
     let imageView = UIImageView()
+    private(set) var gridChromeSnapshot: UIView?
     
     let tabSwitcherViewController: TabSwitcherViewController
     
@@ -42,9 +46,63 @@ class TabSwitcherTransition: NSObject, UIViewControllerAnimatedTransitioning {
         
         transitionContext.containerView.addSubview(solidBackground)
 
+        cardShadow.backgroundColor = UIColor(designSystemColor: .surfaceTertiary)
+        cardShadow.layer.cornerCurve = .continuous
+        cardShadow.layer.shadowColor = UIColor(designSystemColor: .shadowSecondary).cgColor
+        cardShadow.layer.shadowRadius = TabViewCell.Constants.shadowRadius
+        cardShadow.layer.shadowOffset = TabViewCell.Constants.shadowOffset
+        transitionContext.containerView.addSubview(cardShadow)
+
         imageContainer.clipsToBounds = true
+        imageContainer.layer.cornerCurve = .continuous
         imageContainer.addSubview(imageView)
         transitionContext.containerView.addSubview(imageContainer)
+    }
+
+    func setCardFrame(_ frame: CGRect, cornerRadius: CGFloat, shadowOpacity: Float) {
+        cardShadow.frame = frame
+        cardShadow.layer.cornerRadius = cornerRadius
+        cardShadow.layer.shadowOpacity = shadowOpacity
+        cardShadow.layer.shadowPath = UIBezierPath(
+            roundedRect: cardShadow.bounds,
+            cornerRadius: cornerRadius).cgPath
+
+        imageContainer.frame = frame
+        imageContainer.layer.cornerRadius = cornerRadius
+    }
+
+    func prepareGridChromeSnapshot(for cell: TabViewGridCell, initiallyVisible: Bool) {
+        cell.layoutIfNeeded()
+        let headerFrame = CGRect(x: 0,
+                                 y: 0,
+                                 width: cell.bounds.width,
+                                 height: TabViewGridCell.Constants.headerHeight)
+        guard let snapshot = cell.resizableSnapshotView(from: headerFrame,
+                                                        afterScreenUpdates: true,
+                                                        withCapInsets: .zero) else {
+            return
+        }
+
+        imageContainer.addSubview(snapshot)
+        gridChromeSnapshot = snapshot
+        applyGridChromePose(isVisible: initiallyVisible, in: imageContainer.bounds)
+    }
+
+    func applyGridChromePose(isVisible: Bool, in containerBounds: CGRect) {
+        guard let gridChromeSnapshot else { return }
+        let headerHeight = TabViewGridCell.Constants.headerHeight
+        gridChromeSnapshot.frame = CGRect(x: containerBounds.minX,
+                                          y: isVisible ? containerBounds.minY : containerBounds.minY - headerHeight,
+                                          width: containerBounds.width,
+                                          height: headerHeight)
+        gridChromeSnapshot.alpha = isVisible ? 1 : 0
+    }
+
+    func removeTransitionViews() {
+        solidBackground.removeFromSuperview()
+        cardShadow.removeFromSuperview()
+        imageContainer.removeFromSuperview()
+        gridChromeSnapshot = nil
     }
     
     // MARK: UIViewControllerAnimatedTransitioning

--- a/iOS/DuckDuckGo/Transitions/TabSwitcherTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/TabSwitcherTransition.swift
@@ -30,11 +30,14 @@ class TabSwitcherTransition: NSObject, UIViewControllerAnimatedTransitioning {
     let solidBackground = UIView()
     // Draws outside the clipped transition card so depth can participate in the morph.
     let cardShadow = UIView()
+    let cardBorder = UIView()
     // Container for the image, will clip subviews like tab switcher cell does.
     let imageContainer = UIView()
     // Image to display as a preview.
     let imageView = UIImageView()
     private(set) var gridChromeSnapshot: UIView?
+    private weak var listCellBorder: UIView?
+    private var listCellBorderWasHidden = false
     
     let tabSwitcherViewController: TabSwitcherViewController
     
@@ -69,6 +72,12 @@ class TabSwitcherTransition: NSObject, UIViewControllerAnimatedTransitioning {
 
         imageContainer.frame = frame
         imageContainer.layer.cornerRadius = cornerRadius
+
+        if cardBorder.superview != nil {
+            let borderOutset = TabViewCell.Constants.borderOutset / 2
+            cardBorder.frame = frame.insetBy(dx: -borderOutset, dy: -borderOutset)
+            cardBorder.layer.cornerRadius = cornerRadius == 0 ? 0 : TabViewCell.Constants.borderRadius
+        }
     }
 
     func prepareGridChromeSnapshot(for cell: TabViewGridCell, initiallyVisible: Bool) {
@@ -83,26 +92,55 @@ class TabSwitcherTransition: NSObject, UIViewControllerAnimatedTransitioning {
             return
         }
 
+        snapshot.frame = CGRect(x: imageContainer.bounds.minX,
+                                y: imageContainer.bounds.minY,
+                                width: imageContainer.bounds.width,
+                                height: TabViewGridCell.Constants.headerHeight)
+        snapshot.autoresizingMask = [.flexibleWidth]
         imageContainer.addSubview(snapshot)
         gridChromeSnapshot = snapshot
         applyGridChromePose(isVisible: initiallyVisible, in: imageContainer.bounds)
     }
 
-    func applyGridChromePose(isVisible: Bool, in containerBounds: CGRect) {
+    func applyGridChromePose(isVisible: Bool, in _: CGRect) {
         guard let gridChromeSnapshot else { return }
-        let headerHeight = TabViewGridCell.Constants.headerHeight
-        gridChromeSnapshot.frame = CGRect(x: containerBounds.minX,
-                                          y: isVisible ? containerBounds.minY : containerBounds.minY - headerHeight,
-                                          width: containerBounds.width,
-                                          height: headerHeight)
+        gridChromeSnapshot.transform = isVisible
+            ? .identity
+            : CGAffineTransform(translationX: 0, y: -TabViewGridCell.Constants.headerHeight)
         gridChromeSnapshot.alpha = isVisible ? 1 : 0
+    }
+
+    func prepareListChrome(for cell: TabViewListCell, initiallyVisible: Bool) {
+        cell.layoutIfNeeded()
+        cardBorder.backgroundColor = .clear
+        cardBorder.isUserInteractionEnabled = false
+        cardBorder.layer.cornerCurve = .continuous
+        cardBorder.layer.borderColor = cell.border.layer.borderColor
+        cardBorder.layer.borderWidth = cell.border.layer.borderWidth
+        imageContainer.superview?.addSubview(cardBorder)
+
+        listCellBorder = cell.border
+        listCellBorderWasHidden = cell.border.isHidden
+        cell.border.isHidden = true
+
+        let borderOutset = TabViewCell.Constants.borderOutset / 2
+        cardBorder.frame = imageContainer.frame.insetBy(dx: -borderOutset, dy: -borderOutset)
+        cardBorder.layer.cornerRadius = initiallyVisible ? TabViewCell.Constants.borderRadius : 0
+        applyListChromePose(isVisible: initiallyVisible)
+    }
+
+    func applyListChromePose(isVisible: Bool) {
+        cardBorder.alpha = isVisible ? 1 : 0
     }
 
     func removeTransitionViews() {
         solidBackground.removeFromSuperview()
         cardShadow.removeFromSuperview()
+        cardBorder.removeFromSuperview()
         imageContainer.removeFromSuperview()
         gridChromeSnapshot = nil
+        listCellBorder?.isHidden = listCellBorderWasHidden
+        listCellBorder = nil
     }
     
     // MARK: UIViewControllerAnimatedTransitioning

--- a/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
@@ -53,9 +53,7 @@ class FromWebViewTransition: WebViewTransition {
               let tab = mainViewController.tabManager.currentTabsModel.currentTab,
               let rowIndex = tabSwitcherViewController.tabsModel.indexOf(tab: tab)
         else {
-            tabSwitcherViewController.view.alpha = 1
-            removeTransitionViews()
-            transitionContext.completeTransition(true)
+            completeWithoutAnimation(using: transitionContext)
             return
         }
 
@@ -65,9 +63,7 @@ class FromWebViewTransition: WebViewTransition {
         guard let layoutAttr = tabSwitcherViewController.collectionView.layoutAttributesForItem(at: indexPath),
               let preview = tabSwitcherViewController.previewsSource.preview(for: tab)
         else {
-            tabSwitcherViewController.view.alpha = 1
-            removeTransitionViews()
-            transitionContext.completeTransition(true)
+            completeWithoutAnimation(using: transitionContext)
             return
         }
 
@@ -85,31 +81,53 @@ class FromWebViewTransition: WebViewTransition {
         imageView.frame = imageContainer.bounds
         imageView.image = preview
 
-        // Duck.ai tabs land on a rich card, not a screenshot. Crossfade a snapshot of the
-        // destination cell over the webview preview so the shrink ends on matching content
-        // instead of popping from screenshot to card. Gated on the rich-card flag: with it off
-        // the AI cell is a screenshot, so there's nothing to crossfade to
-        var cellSnapshot: UIView?
-        if tab.isAITab, mainViewController.featureFlagger.isFeatureOn(.aiChatTabSwitcherRichCard) {
-            tabSwitcherViewController.collectionView.layoutIfNeeded()
-            if let cell = tabSwitcherViewController.collectionView.cellForItem(at: indexPath) as? TabViewGridCell {
-                // Force the .image thumbnail in synchronously — its async load won't finish
-                // before snapshotView captures the cell.
-                cell.prepareForSnapshot()
-                let currentBorderHidden = cell.border.isHidden
-                cell.border.isHidden = true
-                if let snapshot = cell.snapshotView(afterScreenUpdates: true) {
-                    snapshot.frame = imageContainer.bounds
-                    snapshot.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-                    snapshot.alpha = 0
-                    imageContainer.addSubview(snapshot)
-                    cellSnapshot = snapshot
-                }
-                cell.border.isHidden = currentBorderHidden
-            }
-               
+        let cellSnapshot = makeAITabCellSnapshotIfNeeded(for: tab, at: indexPath)
+        prepareOutgoingTabChrome(at: indexPath, cellSnapshot: cellSnapshot)
+        animateToTabSwitcher(layoutAttr: layoutAttr,
+                             preview: preview,
+                             cellSnapshot: cellSnapshot,
+                             transitionContext: transitionContext)
+    }
+
+    private func completeWithoutAnimation(using transitionContext: UIViewControllerContextTransitioning) {
+        tabSwitcherViewController.view.alpha = 1
+        removeTransitionViews()
+        transitionContext.completeTransition(true)
+    }
+
+    /// Duck.ai tabs land on a rich card, not a screenshot. Crossfade a snapshot of the
+    /// destination cell over the webview preview so the shrink ends on matching content
+    /// instead of popping from screenshot to card. Gated on the rich-card flag: with it off
+    /// the AI cell is a screenshot, so there's nothing to crossfade to.
+    private func makeAITabCellSnapshotIfNeeded(for tab: Tab, at indexPath: IndexPath) -> UIView? {
+        guard tab.isAITab,
+              mainViewController.featureFlagger.isFeatureOn(.aiChatTabSwitcherRichCard) else {
+            return nil
         }
 
+        tabSwitcherViewController.collectionView.layoutIfNeeded()
+        guard let cell = tabSwitcherViewController.collectionView.cellForItem(at: indexPath) as? TabViewGridCell else {
+            return nil
+        }
+
+        // Force the .image thumbnail in synchronously — its async load won't finish
+        // before snapshotView captures the cell.
+        cell.prepareForSnapshot()
+        let currentBorderHidden = cell.border.isHidden
+        cell.border.isHidden = true
+        defer { cell.border.isHidden = currentBorderHidden }
+
+        guard let snapshot = cell.snapshotView(afterScreenUpdates: true) else {
+            return nil
+        }
+        snapshot.frame = imageContainer.bounds
+        snapshot.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        snapshot.alpha = 0
+        imageContainer.addSubview(snapshot)
+        return snapshot
+    }
+
+    private func prepareOutgoingTabChrome(at indexPath: IndexPath, cellSnapshot: UIView?) {
         if tabSwitcherSettings.isGridViewEnabled,
            cellSnapshot == nil,
            let cell = tabSwitcherViewController.collectionView.cellForItem(at: indexPath) as? TabViewGridCell {
@@ -118,7 +136,12 @@ class FromWebViewTransition: WebViewTransition {
                   let cell = tabSwitcherViewController.collectionView.cellForItem(at: indexPath) as? TabViewListCell {
             prepareListChrome(for: cell, initiallyVisible: false)
         }
+    }
 
+    private func animateToTabSwitcher(layoutAttr: UICollectionViewLayoutAttributes,
+                                      preview: UIImage,
+                                      cellSnapshot: UIView?,
+                                      transitionContext: UIViewControllerContextTransitioning) {
         UIView.animateKeyframes(withDuration: TabSwitcherTransition.Constants.duration, delay: 0, options: .calculationModeLinear, animations: {
 
             UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: 1.0) {
@@ -161,7 +184,6 @@ class FromWebViewTransition: WebViewTransition {
             self.removeTransitionViews()
             transitionContext.completeTransition(true)
         })
-
     }
 }
 

--- a/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
@@ -114,6 +114,9 @@ class FromWebViewTransition: WebViewTransition {
            cellSnapshot == nil,
            let cell = tabSwitcherViewController.collectionView.cellForItem(at: indexPath) as? TabViewGridCell {
             prepareGridChromeSnapshot(for: cell, initiallyVisible: false)
+        } else if !tabSwitcherSettings.isGridViewEnabled,
+                  let cell = tabSwitcherViewController.collectionView.cellForItem(at: indexPath) as? TabViewListCell {
+            prepareListChrome(for: cell, initiallyVisible: false)
         }
 
         UIView.animateKeyframes(withDuration: TabSwitcherTransition.Constants.duration, delay: 0, options: .calculationModeLinear, animations: {
@@ -126,6 +129,9 @@ class FromWebViewTransition: WebViewTransition {
                 self.imageView.frame = WebViewTransitionGeometry.previewFrame(for: containerFrame.size,
                                                                               previewSize: preview.size,
                                                                               isGridViewEnabled: self.tabSwitcherSettings.isGridViewEnabled)
+                if !self.tabSwitcherSettings.isGridViewEnabled {
+                    self.applyListChromePose(isVisible: true)
+                }
             }
 
             if self.tabSwitcherSettings.isGridViewEnabled {
@@ -211,6 +217,9 @@ class ToWebViewTransition: WebViewTransition {
         if tabSwitcherSettings.isGridViewEnabled,
            let cell = tabSwitcherViewController.collectionView.cellForItem(at: IndexPath(row: rowIndex, section: 0)) as? TabViewGridCell {
             prepareGridChromeSnapshot(for: cell, initiallyVisible: true)
+        } else if !tabSwitcherSettings.isGridViewEnabled,
+                  let cell = tabSwitcherViewController.collectionView.cellForItem(at: IndexPath(row: rowIndex, section: 0)) as? TabViewListCell {
+            prepareListChrome(for: cell, initiallyVisible: true)
         }
         
         if !tabSwitcherSettings.isGridViewEnabled {
@@ -228,6 +237,9 @@ class ToWebViewTransition: WebViewTransition {
                 self.imageView.alpha = 1
                 self.solidBackground.alpha = 1
                 self.tabSwitcherViewController.view.alpha = 0
+                if !self.tabSwitcherSettings.isGridViewEnabled {
+                    self.applyListChromePose(isVisible: false)
+                }
             }
 
             if self.tabSwitcherSettings.isGridViewEnabled {

--- a/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
+++ b/iOS/DuckDuckGo/Transitions/WebViewTransition.swift
@@ -54,6 +54,7 @@ class FromWebViewTransition: WebViewTransition {
               let rowIndex = tabSwitcherViewController.tabsModel.indexOf(tab: tab)
         else {
             tabSwitcherViewController.view.alpha = 1
+            removeTransitionViews()
             transitionContext.completeTransition(true)
             return
         }
@@ -65,6 +66,7 @@ class FromWebViewTransition: WebViewTransition {
               let preview = tabSwitcherViewController.previewsSource.preview(for: tab)
         else {
             tabSwitcherViewController.view.alpha = 1
+            removeTransitionViews()
             transitionContext.completeTransition(true)
             return
         }
@@ -75,10 +77,11 @@ class FromWebViewTransition: WebViewTransition {
         solidBackground.backgroundColor = theme.backgroundColor
         solidBackground.frame = webViewFrame
         
-        imageContainer.frame = mainViewController.viewCoordinator.contentContainer.frame
-        imageContainer.frame = adjustFrame(imageContainer.frame,
-                                           forAddressBarPosition: mainViewController.appSettings.currentAddressBarPosition,
-                                           byHeight: -mainViewController.omniBar.barView.expectedHeight)
+        var initialContainerFrame = mainViewController.viewCoordinator.contentContainer.frame
+        initialContainerFrame = adjustFrame(initialContainerFrame,
+                                            forAddressBarPosition: mainViewController.appSettings.currentAddressBarPosition,
+                                            byHeight: -mainViewController.omniBar.barView.expectedHeight)
+        setCardFrame(initialContainerFrame, cornerRadius: 0, shadowOpacity: 0)
         imageView.frame = imageContainer.bounds
         imageView.image = preview
 
@@ -107,15 +110,30 @@ class FromWebViewTransition: WebViewTransition {
                
         }
 
+        if tabSwitcherSettings.isGridViewEnabled,
+           cellSnapshot == nil,
+           let cell = tabSwitcherViewController.collectionView.cellForItem(at: indexPath) as? TabViewGridCell {
+            prepareGridChromeSnapshot(for: cell, initiallyVisible: false)
+        }
+
         UIView.animateKeyframes(withDuration: TabSwitcherTransition.Constants.duration, delay: 0, options: .calculationModeLinear, animations: {
 
             UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: 1.0) {
                 let containerFrame = self.tabSwitcherCellFrame(for: layoutAttr)
-                self.imageContainer.frame = containerFrame
-                self.imageContainer.layer.cornerRadius = TabViewCell.Constants.cellCornerRadius
+                self.setCardFrame(containerFrame,
+                                  cornerRadius: TabViewCell.Constants.cellCornerRadius,
+                                  shadowOpacity: 1)
                 self.imageView.frame = WebViewTransitionGeometry.previewFrame(for: containerFrame.size,
                                                                               previewSize: preview.size,
                                                                               isGridViewEnabled: self.tabSwitcherSettings.isGridViewEnabled)
+            }
+
+            if self.tabSwitcherSettings.isGridViewEnabled {
+                UIView.addKeyframe(withRelativeStartTime: 0.25, relativeDuration: 0.55) {
+                    self.applyGridChromePose(
+                        isVisible: true,
+                        in: CGRect(origin: .zero, size: self.tabSwitcherCellFrame(for: layoutAttr).size))
+                }
             }
             
             UIView.addKeyframe(withRelativeStartTime: 0.3, relativeDuration: 0.7) {
@@ -134,8 +152,7 @@ class FromWebViewTransition: WebViewTransition {
                 }
             }
         }, completion: { _ in
-            self.solidBackground.removeFromSuperview()
-            self.imageContainer.removeFromSuperview()
+            self.removeTransitionViews()
             transitionContext.completeTransition(true)
         })
 
@@ -160,8 +177,7 @@ class ToWebViewTransition: WebViewTransition {
             UIView.animate(withDuration: TabSwitcherTransition.Constants.duration, animations: {
                 self.tabSwitcherViewController.view.alpha = 0
             }, completion: { _ in
-                self.solidBackground.removeFromSuperview()
-                self.imageContainer.removeFromSuperview()
+                self.removeTransitionViews()
                 transitionContext.completeTransition(true)
             })
             return
@@ -177,8 +193,10 @@ class ToWebViewTransition: WebViewTransition {
         solidBackground.removeFromSuperview()
         webView.addSubview(solidBackground)
         
-        imageContainer.frame = tabSwitcherCellFrame(for: layoutAttr)
-        imageContainer.layer.cornerRadius = TabViewCell.Constants.cellCornerRadius
+        let initialContainerFrame = tabSwitcherCellFrame(for: layoutAttr)
+        setCardFrame(initialContainerFrame,
+                     cornerRadius: TabViewCell.Constants.cellCornerRadius,
+                     shadowOpacity: 1)
         
         let preview = tabSwitcherViewController.previewsSource.preview(for: tab)
         if let preview = preview {
@@ -189,6 +207,11 @@ class ToWebViewTransition: WebViewTransition {
             imageView.frame = CGRect(origin: .zero, size: imageContainer.bounds.size)
         }
         imageView.image = preview
+
+        if tabSwitcherSettings.isGridViewEnabled,
+           let cell = tabSwitcherViewController.collectionView.cellForItem(at: IndexPath(row: rowIndex, section: 0)) as? TabViewGridCell {
+            prepareGridChromeSnapshot(for: cell, initiallyVisible: true)
+        }
         
         if !tabSwitcherSettings.isGridViewEnabled {
             self.imageView.alpha = 0
@@ -196,19 +219,26 @@ class ToWebViewTransition: WebViewTransition {
         
         scrollIfOutsideViewport(collectionView: tabSwitcherViewController.collectionView, rowIndex: rowIndex, attributes: layoutAttr)
         
-        UIView.animate(withDuration: TabSwitcherTransition.Constants.duration, animations: {
-            self.imageContainer.frame = mainViewController.viewCoordinator.contentContainer.frame
-            self.imageContainer.layer.cornerRadius = 0
+        UIView.animateKeyframes(withDuration: TabSwitcherTransition.Constants.duration, delay: 0, options: .calculationModeLinear, animations: {
+            UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: 1) {
+                let destinationFrame = mainViewController.viewCoordinator.contentContainer.frame
+                self.setCardFrame(destinationFrame, cornerRadius: 0, shadowOpacity: 0)
+                self.imageView.frame = WebViewTransitionGeometry.destinationImageFrame(for: webViewFrame.size,
+                                                                                       previewSize: preview?.size)
+                self.imageView.alpha = 1
+                self.solidBackground.alpha = 1
+                self.tabSwitcherViewController.view.alpha = 0
+            }
 
-            self.imageView.frame = WebViewTransitionGeometry.destinationImageFrame(for: webViewFrame.size,
-                                                                                   previewSize: preview?.size)
-            self.imageView.alpha = 1
-            
-            self.solidBackground.alpha = 1
-            self.tabSwitcherViewController.view.alpha = 0
+            if self.tabSwitcherSettings.isGridViewEnabled {
+                UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: 0.55) {
+                    self.applyGridChromePose(
+                        isVisible: false,
+                        in: CGRect(origin: .zero, size: mainViewController.viewCoordinator.contentContainer.bounds.size))
+                }
+            }
         }, completion: { _ in
-            self.solidBackground.removeFromSuperview()
-            self.imageContainer.removeFromSuperview()
+            self.removeTransitionViews()
             transitionContext.completeTransition(true)
         })
     }

--- a/iOS/DuckDuckGo/Transitions/WebViewTransitionGeometry.swift
+++ b/iOS/DuckDuckGo/Transitions/WebViewTransitionGeometry.swift
@@ -36,26 +36,28 @@ enum WebViewTransitionGeometry {
             return CGRect(origin: .zero, size: cellBounds)
         }
 
-        let availableHeight = cellBounds.height - TabViewCell.Constants.cellHeaderHeight
-        let containerAspectRatio = availableHeight / cellBounds.width
+        let horizontalInset = TabViewGridCell.Constants.previewHorizontalInset / 2
+        let availableWidth = cellBounds.width - TabViewGridCell.Constants.previewHorizontalInset
+        let availableHeight = cellBounds.height
+            - TabViewGridCell.Constants.headerHeight
+            - TabViewGridCell.Constants.previewBottomPadding
+        guard availableWidth > 0, availableHeight > 0 else {
+            return CGRect(origin: .zero, size: cellBounds)
+        }
+        let containerAspectRatio = availableHeight / availableWidth
 
         if previewAspectRatio <= containerAspectRatio {
-            // Wide (landscape) preview: fill the cell height and centre horizontally so the
-            // overflow is centre-cropped (matching `TabViewCell.updatePreviewToDisplay`), rather
-            // than showing only the left edge or leaving empty space.
             let width = availableHeight / previewAspectRatio
             return CGRect(x: (cellBounds.width - width) / 2,
-                          y: TabViewCell.Constants.cellHeaderHeight,
+                          y: TabViewGridCell.Constants.headerHeight,
                           width: width,
                           height: availableHeight)
         }
 
-        // Tall (portrait) preview: fit the cell width and anchor at the top, cropping excess height.
-        return CGRect(x: 0,
-                      y: TabViewCell.Constants.cellHeaderHeight,
-                      width: cellBounds.width,
-                      height: cellBounds.width * previewAspectRatio - 8)
-            .insetBy(dx: 4, dy: 4)
+        return CGRect(x: horizontalInset,
+                      y: TabViewGridCell.Constants.headerHeight,
+                      width: availableWidth,
+                      height: availableWidth * previewAspectRatio)
     }
 
     static func destinationImageFrame(for containerSize: CGSize, previewSize: CGSize?) -> CGRect {

--- a/iOS/DuckDuckGoTests/HomeScreenTransitionGeometryTests.swift
+++ b/iOS/DuckDuckGoTests/HomeScreenTransitionGeometryTests.swift
@@ -23,16 +23,16 @@ import UIKit
 
 final class HomeScreenTransitionGeometryTests: XCTestCase {
 
-    func testWhenListRowIsWiderThanThePageThenSnapshotScalesUniformlyAndStaysCentred() {
+    func testWhenListViewIsEnabledThenSnapshotFillsTheWidthAndCropsVertically() {
         let sourceSize = CGSize(width: 390, height: 800)
         let container = CGRect(x: 0, y: 0, width: 390, height: 68)
 
-        let frame = HomeScreenTransitionGeometry.snapshotFrame(for: sourceSize, in: container)
+        let frame = HomeScreenTransitionGeometry.snapshotFrame(
+            for: sourceSize,
+            in: container,
+            isGridViewEnabled: false)
 
-        XCTAssertEqual(frame.height, 68)
-        XCTAssertEqual(frame.width, 390 * (68 / 800), accuracy: 0.001)
-        XCTAssertEqual(frame.midX, container.midX, accuracy: 0.001)
-        XCTAssertEqual(frame.midY, container.midY, accuracy: 0.001)
+        XCTAssertEqual(frame, CGRect(x: 0, y: 0, width: 390, height: 800))
         XCTAssertEqual(frame.width / frame.height, sourceSize.width / sourceSize.height, accuracy: 0.001)
     }
 
@@ -40,7 +40,10 @@ final class HomeScreenTransitionGeometryTests: XCTestCase {
         let sourceSize = CGSize(width: 390, height: 800)
         let container = CGRect(x: 10, y: 20, width: 180, height: 240)
 
-        let frame = HomeScreenTransitionGeometry.snapshotFrame(for: sourceSize, in: container)
+        let frame = HomeScreenTransitionGeometry.snapshotFrame(
+            for: sourceSize,
+            in: container,
+            isGridViewEnabled: true)
 
         XCTAssertEqual(frame.width, 180 * (240 / 800), accuracy: 0.001)
         XCTAssertEqual(frame.height, 240)
@@ -51,12 +54,22 @@ final class HomeScreenTransitionGeometryTests: XCTestCase {
 
     func testWhenSourceSizeIsZeroThenFrameFillsTheContainer() {
         let container = CGRect(x: 4, y: 8, width: 180, height: 68)
-        XCTAssertEqual(HomeScreenTransitionGeometry.snapshotFrame(for: .zero, in: container), container)
+        XCTAssertEqual(
+            HomeScreenTransitionGeometry.snapshotFrame(
+                for: .zero,
+                in: container,
+                isGridViewEnabled: false),
+            container)
     }
 
     func testWhenSourceSizeIsNonFiniteThenFrameFillsTheContainer() {
         let container = CGRect(x: 0, y: 0, width: 180, height: 68)
         let infinite = CGSize(width: CGFloat.infinity, height: 800)
-        XCTAssertEqual(HomeScreenTransitionGeometry.snapshotFrame(for: infinite, in: container), container)
+        XCTAssertEqual(
+            HomeScreenTransitionGeometry.snapshotFrame(
+                for: infinite,
+                in: container,
+                isGridViewEnabled: false),
+            container)
     }
 }

--- a/iOS/DuckDuckGoTests/HomeScreenTransitionGeometryTests.swift
+++ b/iOS/DuckDuckGoTests/HomeScreenTransitionGeometryTests.swift
@@ -36,7 +36,7 @@ final class HomeScreenTransitionGeometryTests: XCTestCase {
         XCTAssertEqual(frame.width / frame.height, sourceSize.width / sourceSize.height, accuracy: 0.001)
     }
 
-    func testWhenGridCellIsTallerThanThePageThenSnapshotScalesUniformlyAndStaysCentred() {
+    func testWhenGridCellIsWiderThanThePageThenSnapshotScalesUniformlyAndStaysCentred() {
         let sourceSize = CGSize(width: 390, height: 800)
         let container = CGRect(x: 10, y: 20, width: 180, height: 240)
 
@@ -45,7 +45,7 @@ final class HomeScreenTransitionGeometryTests: XCTestCase {
             in: container,
             isGridViewEnabled: true)
 
-        XCTAssertEqual(frame.width, 180 * (240 / 800), accuracy: 0.001)
+        XCTAssertEqual(frame.width, sourceSize.width * (container.height / sourceSize.height), accuracy: 0.001)
         XCTAssertEqual(frame.height, 240)
         XCTAssertEqual(frame.midX, container.midX, accuracy: 0.001)
         XCTAssertEqual(frame.midY, container.midY, accuracy: 0.001)

--- a/iOS/DuckDuckGoTests/HomeScreenTransitionGeometryTests.swift
+++ b/iOS/DuckDuckGoTests/HomeScreenTransitionGeometryTests.swift
@@ -1,0 +1,62 @@
+//
+//  HomeScreenTransitionGeometryTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import UIKit
+@testable import DuckDuckGo
+
+final class HomeScreenTransitionGeometryTests: XCTestCase {
+
+    func testWhenListRowIsWiderThanThePageThenSnapshotScalesUniformlyAndStaysCentred() {
+        let sourceSize = CGSize(width: 390, height: 800)
+        let container = CGRect(x: 0, y: 0, width: 390, height: 68)
+
+        let frame = HomeScreenTransitionGeometry.snapshotFrame(for: sourceSize, in: container)
+
+        XCTAssertEqual(frame.height, 68)
+        XCTAssertEqual(frame.width, 390 * (68 / 800), accuracy: 0.001)
+        XCTAssertEqual(frame.midX, container.midX, accuracy: 0.001)
+        XCTAssertEqual(frame.midY, container.midY, accuracy: 0.001)
+        XCTAssertEqual(frame.width / frame.height, sourceSize.width / sourceSize.height, accuracy: 0.001)
+    }
+
+    func testWhenGridCellIsTallerThanThePageThenSnapshotScalesUniformlyAndStaysCentred() {
+        let sourceSize = CGSize(width: 390, height: 800)
+        let container = CGRect(x: 10, y: 20, width: 180, height: 240)
+
+        let frame = HomeScreenTransitionGeometry.snapshotFrame(for: sourceSize, in: container)
+
+        XCTAssertEqual(frame.width, 180 * (240 / 800), accuracy: 0.001)
+        XCTAssertEqual(frame.height, 240)
+        XCTAssertEqual(frame.midX, container.midX, accuracy: 0.001)
+        XCTAssertEqual(frame.midY, container.midY, accuracy: 0.001)
+        XCTAssertEqual(frame.width / frame.height, sourceSize.width / sourceSize.height, accuracy: 0.001)
+    }
+
+    func testWhenSourceSizeIsZeroThenFrameFillsTheContainer() {
+        let container = CGRect(x: 4, y: 8, width: 180, height: 68)
+        XCTAssertEqual(HomeScreenTransitionGeometry.snapshotFrame(for: .zero, in: container), container)
+    }
+
+    func testWhenSourceSizeIsNonFiniteThenFrameFillsTheContainer() {
+        let container = CGRect(x: 0, y: 0, width: 180, height: 68)
+        let infinite = CGSize(width: CGFloat.infinity, height: 800)
+        XCTAssertEqual(HomeScreenTransitionGeometry.snapshotFrame(for: infinite, in: container), container)
+    }
+}

--- a/iOS/DuckDuckGoTests/WebViewTransitionGeometryTests.swift
+++ b/iOS/DuckDuckGoTests/WebViewTransitionGeometryTests.swift
@@ -66,6 +66,23 @@ final class WebViewTransitionGeometryTests: XCTestCase {
         XCTAssertEqual(frame, CGRect(x: 4, y: 44, width: 172, height: 344))
     }
 
+    func testWhenGridPreviewIsWideThenItFillsBodyHeightAndStaysCentered() {
+        let frame = WebViewTransitionGeometry.previewFrame(for: CGSize(width: 180, height: 240),
+                                                           previewSize: CGSize(width: 400, height: 200),
+                                                           isGridViewEnabled: true)
+
+        XCTAssertEqual(frame, CGRect(x: -102, y: 44, width: 384, height: 192))
+    }
+
+    func testWhenGridCellCannotFitPreviewThenFrameFallsBackToCellBounds() {
+        let cellBounds = CGSize(width: 4, height: 40)
+        let frame = WebViewTransitionGeometry.previewFrame(for: cellBounds,
+                                                           previewSize: CGSize(width: 300, height: 600),
+                                                           isGridViewEnabled: true)
+
+        XCTAssertEqual(frame, CGRect(origin: .zero, size: cellBounds))
+    }
+
     func testPreviewFrameFillsCellBoundsWhenGridDisabled() {
         let cellBounds = CGSize(width: 180, height: 240)
         let frame = WebViewTransitionGeometry.previewFrame(for: cellBounds,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214749231578703/task/1217674714305361?focus=true
Tech Design URL: N/A
CC: N/A




### Before / After

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/a102d36f-cde0-4bff-a98c-faa043f06d03) | ![After](https://github.com/user-attachments/assets/659b60a4-86e5-4110-a9c8-7d879c3523b3) |

### Description
- Opening the tab switcher from the new tab page in **list** view no longer squashes the page (Dax most obviously) into a wide ellipse
- The NTP snapshot keeps its captured aspect ratio and scales uniformly, centred in the tab cell, instead of stretching to `imageContainer.bounds`
- Fitting on the smaller of the two ratios is what makes this a scale rather than a crop — a list row is already full-width, so matching width would clip Dax to a thin strip
- Aspect-fit math lives in `HomeScreenTransitionGeometry` so it can be unit-tested independently of the transition

### Testing Steps
- Open a new tab with no favorites, switch the tab switcher to **list** view, and open the switcher — Dax stays circular in every frame
- Repeat in **grid** view and confirm the transition is unchanged
- Repeat from a list-view cell back onto the new tab page

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- Grid-view cells whose aspect ratio differs more than today's ~0.75 could show letterboxing around the NTP snapshot. Mitigated by using the same centred aspect-fit in both directions; verified unchanged on current grid layout.

### Quality Considerations
- Edge cases: zero / non-finite source sizes fall back to filling the container (covered by unit tests)
- Performance: no extra snapshots; frame math only
- Privacy/security: none — animation geometry only

### Notes to Reviewer
This is a pre-existing bug, independent of the floating UI work, so it is branched off current `main` rather than stacked. It does touch `HomeScreenTransition.swift`, which #6441 also modifies — expect a small conflict depending on merge order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Animation-only UI changes, but they touch every tab-switcher morph (home and web, grid and list), so timing/layout bugs could cause visual glitches or leftover overlay views.
> 
> **Overview**
> Tab-switcher morphs no longer stretch the new-tab page into the destination cell. NTP snapshots keep their captured aspect ratio via `HomeScreenTransitionGeometry` (uniform scale in grid, width-fit in list) so Dax stays circular.
> 
> Shared `TabSwitcherTransition` now drives a card shadow/border and snapshots of grid headers / list chrome, fading them in as the card shrinks (and out on expand). Web-view preview frames use the same grid insets as `TabViewGridCell` (`headerHeight`, horizontal inset, bottom padding). Cleanup goes through `removeTransitionViews()` so overlays and hidden list borders are restored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f289597457fa834cd646ea71ac4ebb4fc787b9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->