### PR TITLE
Updated Sync device renaming for unified device lists

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -272,6 +272,10 @@ public class DDGSync: DDGSyncing {
                 return try await deviceInfoMigrationCoordinator.renameCurrentDevice(to: name, for: account)
             }
 
+            if dependencies.syncFeatureFlags.canUsePatchEndpointForLegacyDeviceRename() {
+                return try await deviceInfoMigrationCoordinator.renameCurrentDeviceWithoutUnifiedInfo(to: name, for: account)
+            }
+
             let result = try await dependencies.account.refreshToken(account, deviceName: name)
             try dependencies.secureStore.persistAccount(result.account)
             persistRecoveredThirdPartyScopedPasswordIfAvailable(from: result.accessCredentials, account: result.account)

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -268,6 +268,10 @@ public class DDGSync: DDGSyncing {
         }
 
         do {
+            if dependencies.syncFeatureFlags.canWriteUnifiedDeviceList() {
+                return try await deviceInfoMigrationCoordinator.renameCurrentDevice(to: name, for: account)
+            }
+
             let result = try await dependencies.account.refreshToken(account, deviceName: name)
             try dependencies.secureStore.persistAccount(result.account)
             persistRecoveredThirdPartyScopedPasswordIfAvailable(from: result.accessCredentials, account: result.account)

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -259,6 +259,7 @@ public class DDGSync: DDGSyncing {
     }
 
     public func updateDeviceName(_ name: String) async throws -> [RegisteredDevice] {
+        let isUnifiedWriteEnabled = dependencies.syncFeatureFlags.canWriteUnifiedDeviceList()
         isDeviceRenameInProgress = true
         defer { isDeviceRenameInProgress = false }
         await cancelDeviceInfoUpdatesAndWait()
@@ -268,22 +269,22 @@ public class DDGSync: DDGSyncing {
         }
 
         do {
-            if dependencies.syncFeatureFlags.canWriteUnifiedDeviceList() {
-                return try await deviceInfoMigrationCoordinator.renameCurrentDevice(to: name, for: account)
+            if isUnifiedWriteEnabled {
+                return try await deviceInfoMigrationCoordinator.renameCurrentDevice(to: name,
+                                                                                     for: account,
+                                                                                     mode: .unified)
             }
 
             if dependencies.syncFeatureFlags.canUsePatchEndpointForLegacyDeviceRename() {
-                return try await deviceInfoMigrationCoordinator.renameCurrentDeviceWithoutUnifiedInfo(to: name, for: account)
+                return try await deviceInfoMigrationCoordinator.renameCurrentDevice(to: name,
+                                                                                     for: account,
+                                                                                     mode: .legacyOnly)
             }
 
             let result = try await dependencies.account.refreshToken(account, deviceName: name)
             try dependencies.secureStore.persistAccount(result.account)
             persistRecoveredThirdPartyScopedPasswordIfAvailable(from: result.accessCredentials, account: result.account)
             updateProtectedKeysCache(with: result.keys)
-            if dependencies.syncFeatureFlags.canWriteUnifiedDeviceList() {
-                // The legacy rename leaves device_info stale, so allow migration to write the new name.
-                deviceInfoMigrationCoordinator.reset()
-            }
             scheduleDeviceInfoMigration(for: result.account)
             return result.devices
         } catch {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncFeatureFlags.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/SyncFeatureFlags.swift
@@ -110,6 +110,8 @@ public protocol SyncFeatureFlagProviding {
     func isPairingV2CodeEnabled() -> Bool
     /// Allows this client to create and register account_info keys for the unified device list.
     func canWriteUnifiedDeviceList() -> Bool
+    /// Allows legacy-only device renames to use PATCH so stale unified device info is cleared.
+    func canUsePatchEndpointForLegacyDeviceRename() -> Bool
     /// Allows this client to read decrypted metadata from the unified device list.
     func canReadUnifiedDeviceList() -> Bool
 }
@@ -120,17 +122,20 @@ public struct SyncFeatureFlagProvider: SyncFeatureFlagProviding {
     private let isPairingV2ScanningEnabledCallback: () -> Bool
     private let isPairingV2CodeEnabledCallback: () -> Bool
     private let canWriteUnifiedDeviceListCallback: () -> Bool
+    private let canUsePatchEndpointForLegacyDeviceRenameCallback: () -> Bool
     private let canReadUnifiedDeviceListCallback: () -> Bool
 
     public init(isScopedAccessCredentialsEnabled: @escaping () -> Bool,
                 isPairingV2ScanningEnabled: @escaping () -> Bool,
                 isPairingV2CodeEnabled: @escaping () -> Bool,
                 canWriteUnifiedDeviceList: @escaping () -> Bool,
+                canUsePatchEndpointForLegacyDeviceRename: @escaping () -> Bool,
                 canReadUnifiedDeviceList: @escaping () -> Bool) {
         self.isScopedAccessCredentialsEnabledCallback = isScopedAccessCredentialsEnabled
         self.isPairingV2ScanningEnabledCallback = isPairingV2ScanningEnabled
         self.isPairingV2CodeEnabledCallback = isPairingV2CodeEnabled
         self.canWriteUnifiedDeviceListCallback = canWriteUnifiedDeviceList
+        self.canUsePatchEndpointForLegacyDeviceRenameCallback = canUsePatchEndpointForLegacyDeviceRename
         self.canReadUnifiedDeviceListCallback = canReadUnifiedDeviceList
     }
 
@@ -148,6 +153,10 @@ public struct SyncFeatureFlagProvider: SyncFeatureFlagProviding {
 
     public func canWriteUnifiedDeviceList() -> Bool {
         canWriteUnifiedDeviceListCallback()
+    }
+
+    public func canUsePatchEndpointForLegacyDeviceRename() -> Bool {
+        canUsePatchEndpointForLegacyDeviceRenameCallback()
     }
 
     public func canReadUnifiedDeviceList() -> Bool {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -462,6 +462,17 @@ struct UpdateDevices {
 
 extension SyncAccount {
 
+    func updatingDeviceName(_ deviceName: String) -> SyncAccount {
+        SyncAccount(deviceId: self.deviceId,
+                    deviceName: deviceName,
+                    deviceType: self.deviceType,
+                    userId: self.userId,
+                    primaryKey: self.primaryKey,
+                    secretKey: self.secretKey,
+                    token: self.token,
+                    state: self.state)
+    }
+
     func updatingState(_ state: SyncAuthState) -> SyncAccount {
         SyncAccount(deviceId: self.deviceId,
                     deviceName: self.deviceName,

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
@@ -23,6 +23,7 @@ import Persistence
 protocol DeviceInfoMigrationCoordinating {
     func migrateCurrentDeviceIfNeeded(for account: SyncAccount) async
     func repairCurrentDeviceInfo(for account: SyncAccount) async
+    func renameCurrentDevice(to name: String, for account: SyncAccount) async throws -> [RegisteredDevice]
     func hasCompletedMigration(for account: SyncAccount) -> Bool
     func reset()
 }
@@ -94,6 +95,43 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
             return
         }
         await updateCurrentDeviceInfo(for: account, identity: identity)
+    }
+
+    func renameCurrentDevice(to name: String, for account: SyncAccount) async throws -> [RegisteredDevice] {
+        let identity = DeviceInfoMigrationIdentity(account: account)
+        guard let currentAccount = currentAccount(matching: identity),
+              isCurrentAccountSnapshot(account, identity: identity) else {
+            throw SyncError.accountNotFound
+        }
+
+        let protectedKey = try await prepareAccountInfoProtectedKey(for: currentAccount,
+                                                                     identity: identity)
+        guard !Task.isCancelled,
+              isCurrentAccountSnapshot(currentAccount, identity: identity) else {
+            throw CancellationError()
+        }
+
+        let update = try updateBuilder.makeUpdate(deviceID: currentAccount.deviceId,
+                                                   deviceName: name,
+                                                   deviceType: currentAccount.deviceType,
+                                                   primaryKey: currentAccount.primaryKey,
+                                                   protectedKey: protectedKey)
+        guard !Task.isCancelled,
+              isCurrentAccountSnapshot(currentAccount, identity: identity) else {
+            throw CancellationError()
+        }
+
+        let devices = try await accountManager.updateDevice(update, for: currentAccount)
+        guard !Task.isCancelled,
+              isCurrentAccountSnapshot(currentAccount, identity: identity) else {
+            throw CancellationError()
+        }
+
+        let renamedAccount = currentAccount.updatingDeviceName(name)
+        try secureStore.persistAccount(renamedAccount)
+        markMigrationComplete(for: renamedAccount)
+        Logger.sync.debug("Sync-UnifiedDevices: current device rename complete")
+        return devices
     }
 
     private func updateCurrentDeviceInfo(for account: SyncAccount,

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
@@ -24,6 +24,9 @@ protocol DeviceInfoMigrationCoordinating {
     func migrateCurrentDeviceIfNeeded(for account: SyncAccount) async
     func repairCurrentDeviceInfo(for account: SyncAccount) async
     func renameCurrentDevice(to name: String, for account: SyncAccount) async throws -> [RegisteredDevice]
+    /// Renames the current device using legacy fields only.
+    /// Omitting `info` clears stale server-side `device_info`; the migration marker remains unchanged.
+    func renameCurrentDeviceWithoutUnifiedInfo(to name: String, for account: SyncAccount) async throws -> [RegisteredDevice]
     func hasCompletedMigration(for account: SyncAccount) -> Bool
     func reset()
 }
@@ -116,21 +119,31 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
                                                    deviceType: currentAccount.deviceType,
                                                    primaryKey: currentAccount.primaryKey,
                                                    protectedKey: protectedKey)
-        guard !Task.isCancelled,
-              isCurrentAccountSnapshot(currentAccount, identity: identity) else {
-            throw CancellationError()
-        }
-
-        let devices = try await accountManager.updateDevice(update, for: currentAccount)
-        guard !Task.isCancelled,
-              isCurrentAccountSnapshot(currentAccount, identity: identity) else {
-            throw CancellationError()
-        }
-
-        let renamedAccount = currentAccount.updatingDeviceName(name)
-        try secureStore.persistAccount(renamedAccount)
-        markMigrationComplete(for: renamedAccount)
+        let devices = try await applyRename(update,
+                                            newDeviceName: name,
+                                            account: currentAccount,
+                                            identity: identity)
+        markMigrationComplete(for: currentAccount)
         Logger.sync.debug("Sync-UnifiedDevices: current device rename complete")
+        return devices
+    }
+
+    func renameCurrentDeviceWithoutUnifiedInfo(to name: String, for account: SyncAccount) async throws -> [RegisteredDevice] {
+        let identity = DeviceInfoMigrationIdentity(account: account)
+        guard let currentAccount = currentAccount(matching: identity),
+              isCurrentAccountSnapshot(account, identity: identity) else {
+            throw SyncError.accountNotFound
+        }
+
+        let update = try updateBuilder.makeUpdateWithoutUnifiedInfo(deviceID: currentAccount.deviceId,
+                                                                    deviceName: name,
+                                                                    deviceType: currentAccount.deviceType,
+                                                                    primaryKey: currentAccount.primaryKey)
+        let devices = try await applyRename(update,
+                                            newDeviceName: name,
+                                            account: currentAccount,
+                                            identity: identity)
+        Logger.sync.debug("Sync-UnifiedDevices: current device rename PATCH without unified info complete")
         return devices
     }
 
@@ -170,6 +183,25 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
             let errorType = String(describing: Swift.type(of: error))
             Logger.sync.error("Sync-UnifiedDevices: failed to update current device_info: \(errorType)")
         }
+    }
+
+    private func applyRename(_ update: UpdateDevices.Update,
+                             newDeviceName: String,
+                             account: SyncAccount,
+                             identity: DeviceInfoMigrationIdentity) async throws -> [RegisteredDevice] {
+        guard !Task.isCancelled,
+              isCurrentAccountSnapshot(account, identity: identity) else {
+            throw CancellationError()
+        }
+
+        let devices = try await accountManager.updateDevice(update, for: account)
+        guard !Task.isCancelled,
+              isCurrentAccountSnapshot(account, identity: identity) else {
+            throw CancellationError()
+        }
+
+        try secureStore.persistAccount(account.updatingDeviceName(newDeviceName))
+        return devices
     }
 
     func reset() {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
@@ -20,13 +20,16 @@ import Foundation
 import os.log
 import Persistence
 
+enum DeviceInfoRenameMode: Equatable {
+    case unified
+    /// Updates legacy fields and omits `info`, clearing stale server-side `device_info`.
+    case legacyOnly
+}
+
 protocol DeviceInfoMigrationCoordinating {
     func migrateCurrentDeviceIfNeeded(for account: SyncAccount) async
     func repairCurrentDeviceInfo(for account: SyncAccount) async
-    func renameCurrentDevice(to name: String, for account: SyncAccount) async throws -> [RegisteredDevice]
-    /// Renames the current device using legacy fields only.
-    /// Omitting `info` clears stale server-side `device_info`; the migration marker remains unchanged.
-    func renameCurrentDeviceWithoutUnifiedInfo(to name: String, for account: SyncAccount) async throws -> [RegisteredDevice]
+    func renameCurrentDevice(to name: String, for account: SyncAccount, mode: DeviceInfoRenameMode) async throws -> [RegisteredDevice]
     func hasCompletedMigration(for account: SyncAccount) -> Bool
     func reset()
 }
@@ -100,50 +103,45 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
         await updateCurrentDeviceInfo(for: account, identity: identity)
     }
 
-    func renameCurrentDevice(to name: String, for account: SyncAccount) async throws -> [RegisteredDevice] {
+    func renameCurrentDevice(to name: String, for account: SyncAccount, mode: DeviceInfoRenameMode) async throws -> [RegisteredDevice] {
         let identity = DeviceInfoMigrationIdentity(account: account)
         guard let currentAccount = currentAccount(matching: identity),
               isCurrentAccountSnapshot(account, identity: identity) else {
             throw SyncError.accountNotFound
         }
 
-        let protectedKey = try await prepareAccountInfoProtectedKey(for: currentAccount,
-                                                                     identity: identity)
-        guard !Task.isCancelled,
-              isCurrentAccountSnapshot(currentAccount, identity: identity) else {
-            throw CancellationError()
-        }
-
-        let update = try updateBuilder.makeUpdate(deviceID: currentAccount.deviceId,
+        let update: UpdateDevices.Update
+        switch mode {
+        case .unified:
+            let protectedKey = try await prepareAccountInfoProtectedKey(for: currentAccount,
+                                                                         identity: identity)
+            guard !Task.isCancelled,
+                  isCurrentAccountSnapshot(currentAccount, identity: identity) else {
+                throw CancellationError()
+            }
+            update = try updateBuilder.makeUpdate(deviceID: currentAccount.deviceId,
                                                    deviceName: name,
                                                    deviceType: currentAccount.deviceType,
                                                    primaryKey: currentAccount.primaryKey,
                                                    protectedKey: protectedKey)
-        let devices = try await applyRename(update,
-                                            newDeviceName: name,
-                                            account: currentAccount,
-                                            identity: identity)
-        markMigrationComplete(for: currentAccount)
-        Logger.sync.debug("Sync-UnifiedDevices: current device rename complete")
-        return devices
-    }
-
-    func renameCurrentDeviceWithoutUnifiedInfo(to name: String, for account: SyncAccount) async throws -> [RegisteredDevice] {
-        let identity = DeviceInfoMigrationIdentity(account: account)
-        guard let currentAccount = currentAccount(matching: identity),
-              isCurrentAccountSnapshot(account, identity: identity) else {
-            throw SyncError.accountNotFound
+        case .legacyOnly:
+            update = try updateBuilder.makeUpdateWithoutUnifiedInfo(deviceID: currentAccount.deviceId,
+                                                                     deviceName: name,
+                                                                     deviceType: currentAccount.deviceType,
+                                                                     primaryKey: currentAccount.primaryKey)
         }
 
-        let update = try updateBuilder.makeUpdateWithoutUnifiedInfo(deviceID: currentAccount.deviceId,
-                                                                    deviceName: name,
-                                                                    deviceType: currentAccount.deviceType,
-                                                                    primaryKey: currentAccount.primaryKey)
         let devices = try await applyRename(update,
                                             newDeviceName: name,
                                             account: currentAccount,
                                             identity: identity)
-        Logger.sync.debug("Sync-UnifiedDevices: current device rename PATCH without unified info complete")
+        switch mode {
+        case .unified:
+            markMigrationComplete(for: currentAccount)
+            Logger.sync.debug("Sync-UnifiedDevices: current device rename complete")
+        case .legacyOnly:
+            Logger.sync.debug("Sync-UnifiedDevices: current device rename PATCH without unified info complete")
+        }
         return devices
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
@@ -54,8 +54,7 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
 
     private let accountManager: AccountManaging
     private let scopedAccess: ScopedAccessCredentialManaging
-    private let crypter: CryptingInternal
-    private let deviceInfoCodec: DeviceInfoCoding
+    private let updateBuilder: DeviceInfoUpdateBuilder
     private let secureStore: SecureStoring
     private let keyValueStore: ThrowingKeyValueStoring
     private let canWriteUnifiedDeviceList: () -> Bool
@@ -69,8 +68,7 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
          canWriteUnifiedDeviceList: @escaping () -> Bool) {
         self.accountManager = accountManager
         self.scopedAccess = scopedAccess
-        self.crypter = crypter
-        self.deviceInfoCodec = deviceInfoCodec
+        self.updateBuilder = DeviceInfoUpdateBuilder(crypter: crypter, deviceInfoCodec: deviceInfoCodec)
         self.secureStore = secureStore
         self.keyValueStore = keyValueStore
         self.canWriteUnifiedDeviceList = canWriteUnifiedDeviceList
@@ -108,18 +106,11 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
                 return
             }
 
-            let encryptedDeviceInfo = try deviceInfoCodec.encrypt(
-                DeviceInfo(name: currentAccount.deviceName, type: currentAccount.deviceType),
-                using: protectedKey)
-            guard encryptedDeviceInfo.utf8.count <= DeviceInfo.maximumEncryptedLength else {
-                throw DeviceInfoMigrationError.encryptedDeviceInfoTooLarge
-            }
-
-            let update = UpdateDevices.Update(
-                id: currentAccount.deviceId,
-                name: try crypter.encryptAndBase64Encode(currentAccount.deviceName, using: currentAccount.primaryKey),
-                type: try crypter.encryptAndBase64Encode(currentAccount.deviceType, using: currentAccount.primaryKey),
-                info: encryptedDeviceInfo)
+            let update = try updateBuilder.makeUpdate(deviceID: currentAccount.deviceId,
+                                                       deviceName: currentAccount.deviceName,
+                                                       deviceType: currentAccount.deviceType,
+                                                       primaryKey: currentAccount.primaryKey,
+                                                       protectedKey: protectedKey)
             guard !Task.isCancelled,
                   isCurrentAccountSnapshot(currentAccount, identity: identity) else {
                 return

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoUpdateBuilder.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoUpdateBuilder.swift
@@ -1,0 +1,44 @@
+//
+//  DeviceInfoUpdateBuilder.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+struct DeviceInfoUpdateBuilder {
+
+    let crypter: CryptingInternal
+    let deviceInfoCodec: DeviceInfoCoding
+
+    func makeUpdate(deviceID: String,
+                    deviceName: String,
+                    deviceType: String,
+                    primaryKey: Data,
+                    protectedKey: ProtectedKey) throws -> UpdateDevices.Update {
+        let encryptedDeviceInfo = try deviceInfoCodec.encrypt(
+            DeviceInfo(name: deviceName, type: deviceType),
+            using: protectedKey)
+        guard encryptedDeviceInfo.utf8.count <= DeviceInfo.maximumEncryptedLength else {
+            throw DeviceInfoMigrationError.encryptedDeviceInfoTooLarge
+        }
+
+        return UpdateDevices.Update(
+            id: deviceID,
+            name: try crypter.encryptAndBase64Encode(deviceName, using: primaryKey),
+            type: try crypter.encryptAndBase64Encode(deviceType, using: primaryKey),
+            info: encryptedDeviceInfo)
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoUpdateBuilder.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoUpdateBuilder.swift
@@ -35,10 +35,33 @@ struct DeviceInfoUpdateBuilder {
             throw DeviceInfoMigrationError.encryptedDeviceInfoTooLarge
         }
 
-        return UpdateDevices.Update(
-            id: deviceID,
-            name: try crypter.encryptAndBase64Encode(deviceName, using: primaryKey),
-            type: try crypter.encryptAndBase64Encode(deviceType, using: primaryKey),
-            info: encryptedDeviceInfo)
+        return try makeUpdate(deviceID: deviceID,
+                              deviceName: deviceName,
+                              deviceType: deviceType,
+                              primaryKey: primaryKey,
+                              encryptedDeviceInfo: encryptedDeviceInfo)
+    }
+
+    /// Builds an update with `info` omitted, which clears server-side `device_info` under the PATCH contract.
+    func makeUpdateWithoutUnifiedInfo(deviceID: String,
+                                      deviceName: String,
+                                      deviceType: String,
+                                      primaryKey: Data) throws -> UpdateDevices.Update {
+        try makeUpdate(deviceID: deviceID,
+                       deviceName: deviceName,
+                       deviceType: deviceType,
+                       primaryKey: primaryKey,
+                       encryptedDeviceInfo: nil)
+    }
+
+    private func makeUpdate(deviceID: String,
+                            deviceName: String,
+                            deviceType: String,
+                            primaryKey: Data,
+                            encryptedDeviceInfo: String?) throws -> UpdateDevices.Update {
+        UpdateDevices.Update(id: deviceID,
+                             name: try crypter.encryptAndBase64Encode(deviceName, using: primaryKey),
+                             type: try crypter.encryptAndBase64Encode(deviceType, using: primaryKey),
+                             info: encryptedDeviceInfo)
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -614,6 +614,7 @@ public enum SyncSubfeature: String, PrivacySubfeature {
     case canUseV2ConnectFlow
     case canShowV2ConnectCode
     case canWriteUnifiedDeviceList
+    case canUsePatchEndpointForLegacyDeviceRename
     case canReadUnifiedDeviceList
     case simplifiedSyncSetupV2
 }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -631,7 +631,6 @@ final class DDGSyncTests: XCTestCase {
     func testWhenLoginSucceedsThenCurrentDeviceMigrationIsScheduled() async throws {
         (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil
         (dependencies.account as? AccountManagingMock)?.loginStub = LoginResult(account: .mock, devices: [])
-        let scopedAccess = try XCTUnwrap(dependencies.scopedAccess as? ScopedAccessCredentialManagingMock)
         let migrationScheduled = expectation(description: "Device info migration scheduled")
         let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
         migrationCoordinator.migrateCurrentDeviceHandler = {
@@ -965,6 +964,7 @@ final class DDGSyncTests: XCTestCase {
 
     func testWhenRenamingDeviceWithUnifiedWritesDisabledThenMigrationStateIsPreserved() async throws {
         dependencies.canWriteUnifiedDeviceList = { false }
+        dependencies.canUsePatchEndpointForLegacyDeviceRename = { false }
         let migrationScheduled = expectation(description: "Device info migration scheduled")
         let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
         migrationCoordinator.migrateCurrentDeviceHandler = {
@@ -993,9 +993,8 @@ final class DDGSyncTests: XCTestCase {
     func testWhenRenamingDeviceFailsWithUnifiedWritesEnabledThenMigrationStateIsPreserved() async throws {
         dependencies.canWriteUnifiedDeviceList = { true }
         let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.renameCurrentDeviceError = SyncError.noResponseBody
         dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
-        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
-        accountManager.refreshTokenError = SyncError.noResponseBody
         let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
 
         do {
@@ -1008,6 +1007,8 @@ final class DDGSyncTests: XCTestCase {
 
         XCTAssertEqual(migrationCoordinator.resetCallCount, 0)
         XCTAssertTrue(migrationCoordinator.calls.isEmpty)
+        XCTAssertEqual(migrationCoordinator.renameCalls.count, 1)
+        XCTAssertTrue(migrationCoordinator.renameWithoutUnifiedInfoCalls.isEmpty)
     }
 
     func testWhenRepairingFetchCompletesDuringRenameThenRepairWaitsForNextPoll() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -631,6 +631,7 @@ final class DDGSyncTests: XCTestCase {
     func testWhenLoginSucceedsThenCurrentDeviceMigrationIsScheduled() async throws {
         (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil
         (dependencies.account as? AccountManagingMock)?.loginStub = LoginResult(account: .mock, devices: [])
+        let scopedAccess = try XCTUnwrap(dependencies.scopedAccess as? ScopedAccessCredentialManagingMock)
         let migrationScheduled = expectation(description: "Device info migration scheduled")
         let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
         migrationCoordinator.migrateCurrentDeviceHandler = {
@@ -916,7 +917,7 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(scopedAccess.recoverScopedPasswordCalls.count, 1)
     }
 
-    func testWhenRenamingDeviceDuringMigrationThenMigrationIsCancelledBeforeRenameAndRescheduled() async throws {
+    func testWhenWriteIsDisabledAndRenamingDeviceDuringMigrationThenLegacyRefreshRunsAfterCancellationAndMigrationIsRescheduled() async throws {
         dependencies.canWriteUnifiedDeviceList = { true }
         let migrationStarted = expectation(description: "Device info migration started")
         let migrationFinished = expectation(description: "Device info migration finished")
@@ -948,11 +949,13 @@ final class DDGSyncTests: XCTestCase {
         let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
         syncService.initializeIfNeeded()
         await fulfillment(of: [migrationStarted], timeout: 1)
+        dependencies.canWriteUnifiedDeviceList = { false }
 
         _ = try await syncService.updateDeviceName(renamedAccount.deviceName)
         await fulfillment(of: [migrationFinished, migrationRescheduled], timeout: 1)
 
         XCTAssertTrue(accountManager.refreshTokenCalled)
+        XCTAssertTrue(migrationCoordinator.renameCalls.isEmpty)
         XCTAssertEqual((dependencies.secureStore as? SecureStorageStub)?.theAccount?.deviceName, renamedAccount.deviceName)
         XCTAssertEqual(migrationCoordinator.calls.count, 2)
         XCTAssertEqual(migrationCoordinator.calls.last?.account.deviceName, renamedAccount.deviceName)
@@ -1076,6 +1079,109 @@ final class DDGSyncTests: XCTestCase {
         await fulfillment(of: [repairScheduledOnNextPoll], timeout: 1)
 
         XCTAssertEqual(migrationCoordinator.repairCalls.map(\.account.deviceId), [SyncAccount.mock.deviceId])
+    }
+
+    func testWhenWriteIsEnabledThenRenameUsesUnifiedUpdateWithoutRefreshingToken() async throws {
+        dependencies.canWriteUnifiedDeviceList = { true }
+        let expectedDevices = [RegisteredDevice(id: "renamed-device", name: "Renamed Device", type: "iOS")]
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.renameCurrentDeviceStub = expectedDevices
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        let devices = try await syncService.updateDeviceName("Renamed Device")
+
+        XCTAssertEqual(devices.map(\.id), expectedDevices.map(\.id))
+        XCTAssertFalse(accountManager.refreshTokenCalled)
+        XCTAssertEqual(migrationCoordinator.renameCalls.count, 1)
+        XCTAssertEqual(migrationCoordinator.renameCalls.first?.name, "Renamed Device")
+        XCTAssertEqual(migrationCoordinator.renameCalls.first?.account.deviceId, SyncAccount.mock.deviceId)
+    }
+
+    func testWhenWriteIsEnabledAndRenamingDuringMigrationThenMigrationIsCancelledAndAwaitedBeforeUnifiedRename() async throws {
+        dependencies.canWriteUnifiedDeviceList = { true }
+        let migrationStarted = expectation(description: "Device info migration started")
+        let migrationFinished = expectation(description: "Device info migration finished")
+        let unifiedRenameStarted = expectation(description: "Unified rename started")
+        let (migrationGate, migrationGateContinuation) = AsyncStream<Void>.makeStream()
+        defer { migrationGateContinuation.finish() }
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.migrateCurrentDeviceHandler = {
+            migrationStarted.fulfill()
+            for await _ in migrationGate {}
+            migrationFinished.fulfill()
+        }
+        migrationCoordinator.renameCurrentDeviceHandler = {
+            unifiedRenameStarted.fulfill()
+            return [.mock]
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+        syncService.initializeIfNeeded()
+        await fulfillment(of: [migrationStarted], timeout: 1)
+
+        let devices = try await syncService.updateDeviceName("Renamed Device")
+        await fulfillment(of: [migrationFinished, unifiedRenameStarted], timeout: 1, enforceOrder: true)
+
+        XCTAssertEqual(devices.map(\.id), [RegisteredDevice.mock.id])
+        XCTAssertEqual(migrationCoordinator.calls.count, 1)
+        XCTAssertEqual(migrationCoordinator.renameCalls.count, 1)
+    }
+
+    func testWhenWriteIsEnabledAndRenamingDuringRepairThenRepairIsCancelledAndAwaitedBeforeUnifiedRename() async throws {
+        dependencies.canWriteUnifiedDeviceList = { true }
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        accountManager.fetchDevicesForAccountStub = RegisteredDeviceMappingResult(
+            devices: [.mock],
+            needsCurrentDeviceInfoRepair: true)
+        let repairStarted = expectation(description: "Device info repair started")
+        let repairFinished = expectation(description: "Device info repair finished")
+        let unifiedRenameStarted = expectation(description: "Unified rename started")
+        let (repairGate, repairGateContinuation) = AsyncStream<Void>.makeStream()
+        defer { repairGateContinuation.finish() }
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.repairCurrentDeviceInfoHandler = {
+            repairStarted.fulfill()
+            for await _ in repairGate {}
+            repairFinished.fulfill()
+        }
+        migrationCoordinator.renameCurrentDeviceHandler = {
+            unifiedRenameStarted.fulfill()
+            return [.mock]
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+        _ = try await syncService.fetchDevices()
+        await fulfillment(of: [repairStarted], timeout: 1)
+
+        _ = try await syncService.updateDeviceName("Renamed Device")
+        await fulfillment(of: [repairFinished, unifiedRenameStarted], timeout: 1, enforceOrder: true)
+
+        XCTAssertEqual(migrationCoordinator.repairCalls.count, 1)
+        XCTAssertEqual(migrationCoordinator.renameCalls.count, 1)
+    }
+
+    func testWhenUnifiedRenameReturns401ThenExistingUnauthenticatedHandlingLogsOut() async throws {
+        dependencies.canWriteUnifiedDeviceList = { true }
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.renameCurrentDeviceError = SyncError.unexpectedStatusCode(401)
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+        syncService.initializeIfNeeded()
+
+        do {
+            _ = try await syncService.updateDeviceName("Renamed Device")
+            XCTFail("Expected rename to throw")
+        } catch let error as SyncError {
+            XCTAssertEqual(error, .unauthenticatedWhileLoggedIn)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertNil((dependencies.secureStore as? SecureStorageStub)?.theAccount)
+        XCTAssertEqual(syncService.authState, .inactive)
+        XCTAssertEqual(migrationCoordinator.resetCallCount, 1)
     }
 
     func testWhenRefreshResponseContainsRecoverableScopedPasswordThenScopedPasswordIsCached() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -962,8 +962,12 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(migrationCoordinator.resetCallCount, 0)
     }
 
-    func testWhenRenamingDeviceWithUnifiedWritesDisabledThenMigrationStateIsPreserved() async throws {
-        dependencies.canWriteUnifiedDeviceList = { false }
+    func testWhenWriteFlagChangesDuringLegacyRenameThenInitialStateDeterminesRoutingAndMigrationState() async throws {
+        var writeFlagEvaluationCount = 0
+        dependencies.canWriteUnifiedDeviceList = {
+            writeFlagEvaluationCount += 1
+            return writeFlagEvaluationCount > 1
+        }
         dependencies.canUsePatchEndpointForLegacyDeviceRename = { false }
         let migrationScheduled = expectation(description: "Device info migration scheduled")
         let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
@@ -987,6 +991,9 @@ final class DDGSyncTests: XCTestCase {
         _ = try await syncService.updateDeviceName(renamedAccount.deviceName)
         await fulfillment(of: [migrationScheduled], timeout: 1)
 
+        XCTAssertEqual(writeFlagEvaluationCount, 1)
+        XCTAssertTrue(accountManager.refreshTokenCalled)
+        XCTAssertTrue(migrationCoordinator.renameCalls.isEmpty)
         XCTAssertEqual(migrationCoordinator.resetCallCount, 0)
     }
 
@@ -1008,79 +1015,7 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(migrationCoordinator.resetCallCount, 0)
         XCTAssertTrue(migrationCoordinator.calls.isEmpty)
         XCTAssertEqual(migrationCoordinator.renameCalls.count, 1)
-        XCTAssertTrue(migrationCoordinator.renameWithoutUnifiedInfoCalls.isEmpty)
-    }
-
-    func testWhenRepairingFetchCompletesDuringRenameThenRepairWaitsForNextPoll() async throws {
-        dependencies.canWriteUnifiedDeviceList = { true }
-        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
-        let deviceFetchStarted = expectation(description: "Device fetch started")
-        let renameStarted = expectation(description: "Device rename started")
-        let migrationFinished = expectation(description: "Device info migration finished")
-        let unexpectedRepair = expectation(description: "Current device info repair not scheduled during rename")
-        unexpectedRepair.isInverted = true
-        let (deviceFetchGate, deviceFetchGateContinuation) = AsyncStream<Void>.makeStream()
-        let (renameGate, renameGateContinuation) = AsyncStream<Void>.makeStream()
-        defer {
-            deviceFetchGateContinuation.finish()
-            renameGateContinuation.finish()
-        }
-        accountManager.fetchDevicesForAccountHandler = { _ in
-            deviceFetchStarted.fulfill()
-            for await _ in deviceFetchGate {}
-            return RegisteredDeviceMappingResult(devices: [.mock], needsCurrentDeviceInfoRepair: true)
-        }
-        accountManager.refreshTokenHandler = { account, deviceName in
-            renameStarted.fulfill()
-            for await _ in renameGate {}
-            let renamedAccount = SyncAccount(
-                deviceId: account.deviceId,
-                deviceName: deviceName,
-                deviceType: account.deviceType,
-                userId: account.userId,
-                primaryKey: account.primaryKey,
-                secretKey: account.secretKey,
-                token: account.token,
-                state: account.state)
-            return LoginResult(account: renamedAccount, devices: [.mock])
-        }
-        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
-        migrationCoordinator.migrateCurrentDeviceHandler = {
-            migrationFinished.fulfill()
-        }
-        migrationCoordinator.repairCurrentDeviceInfoHandler = {
-            unexpectedRepair.fulfill()
-        }
-        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
-        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
-
-        async let fetchedDevices = syncService.fetchDevices()
-        await fulfillment(of: [deviceFetchStarted], timeout: 1)
-        async let renamedDevices = syncService.updateDeviceName("Renamed Device")
-        await fulfillment(of: [renameStarted], timeout: 1)
-        deviceFetchGateContinuation.finish()
-        _ = try await fetchedDevices
-        await fulfillment(of: [unexpectedRepair], timeout: 0.1)
-        renameGateContinuation.finish()
-        _ = try await renamedDevices
-        await fulfillment(of: [migrationFinished], timeout: 1)
-        await Task.yield()
-
-        XCTAssertTrue(migrationCoordinator.repairCalls.isEmpty)
-
-        let repairScheduledOnNextPoll = expectation(description: "Current device info repair scheduled on next poll")
-        migrationCoordinator.repairCurrentDeviceInfoHandler = {
-            repairScheduledOnNextPoll.fulfill()
-        }
-        accountManager.fetchDevicesForAccountHandler = nil
-        accountManager.fetchDevicesForAccountStub = RegisteredDeviceMappingResult(
-            devices: [.mock],
-            needsCurrentDeviceInfoRepair: true)
-
-        _ = try await syncService.fetchDevices()
-        await fulfillment(of: [repairScheduledOnNextPoll], timeout: 1)
-
-        XCTAssertEqual(migrationCoordinator.repairCalls.map(\.account.deviceId), [SyncAccount.mock.deviceId])
+        XCTAssertEqual(migrationCoordinator.renameCalls.first?.mode, .unified)
     }
 
     func testWhenWriteIsDisabledAndLegacyPatchIsEnabledThenRenameOmitsUnifiedInfoWithoutRefreshingToken() async throws {
@@ -1088,7 +1023,7 @@ final class DDGSyncTests: XCTestCase {
         dependencies.canUsePatchEndpointForLegacyDeviceRename = { true }
         let expectedDevices = [RegisteredDevice(id: "renamed-device", name: "Renamed Device", type: "iOS")]
         let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
-        migrationCoordinator.renameCurrentDeviceWithoutUnifiedInfoStub = expectedDevices
+        migrationCoordinator.renameCurrentDeviceStub = expectedDevices
         dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
         let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
         let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
@@ -1097,10 +1032,10 @@ final class DDGSyncTests: XCTestCase {
 
         XCTAssertEqual(devices.map(\.id), expectedDevices.map(\.id))
         XCTAssertFalse(accountManager.refreshTokenCalled)
-        XCTAssertTrue(migrationCoordinator.renameCalls.isEmpty)
-        XCTAssertEqual(migrationCoordinator.renameWithoutUnifiedInfoCalls.count, 1)
-        XCTAssertEqual(migrationCoordinator.renameWithoutUnifiedInfoCalls.first?.name, "Renamed Device")
-        XCTAssertEqual(migrationCoordinator.renameWithoutUnifiedInfoCalls.first?.account.deviceId, SyncAccount.mock.deviceId)
+        XCTAssertEqual(migrationCoordinator.renameCalls.count, 1)
+        XCTAssertEqual(migrationCoordinator.renameCalls.first?.name, "Renamed Device")
+        XCTAssertEqual(migrationCoordinator.renameCalls.first?.account.deviceId, SyncAccount.mock.deviceId)
+        XCTAssertEqual(migrationCoordinator.renameCalls.first?.mode, .legacyOnly)
     }
 
     func testWhenWriteIsEnabledThenRenameUsesUnifiedUpdateWithoutRefreshingToken() async throws {
@@ -1116,10 +1051,10 @@ final class DDGSyncTests: XCTestCase {
 
         XCTAssertEqual(devices.map(\.id), expectedDevices.map(\.id))
         XCTAssertFalse(accountManager.refreshTokenCalled)
-        XCTAssertTrue(migrationCoordinator.renameWithoutUnifiedInfoCalls.isEmpty)
         XCTAssertEqual(migrationCoordinator.renameCalls.count, 1)
         XCTAssertEqual(migrationCoordinator.renameCalls.first?.name, "Renamed Device")
         XCTAssertEqual(migrationCoordinator.renameCalls.first?.account.deviceId, SyncAccount.mock.deviceId)
+        XCTAssertEqual(migrationCoordinator.renameCalls.first?.mode, .unified)
     }
 
     func testWhenWriteIsEnabledAndRenamingDuringMigrationThenMigrationIsCancelledAndAwaitedBeforeUnifiedRename() async throws {
@@ -1185,6 +1120,63 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(migrationCoordinator.renameCalls.count, 1)
     }
 
+    func testWhenRepairingFetchCompletesDuringRenameThenRepairWaitsForNextPoll() async throws {
+        dependencies.canWriteUnifiedDeviceList = { true }
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        let deviceFetchStarted = expectation(description: "Device fetch started")
+        let unifiedRenameStarted = expectation(description: "Unified rename started")
+        let unexpectedRepair = expectation(description: "Current device info repair not scheduled during rename")
+        unexpectedRepair.isInverted = true
+        let (deviceFetchGate, deviceFetchGateContinuation) = AsyncStream<Void>.makeStream()
+        let (renameGate, renameGateContinuation) = AsyncStream<Void>.makeStream()
+        defer {
+            deviceFetchGateContinuation.finish()
+            renameGateContinuation.finish()
+        }
+        accountManager.fetchDevicesForAccountHandler = { _ in
+            deviceFetchStarted.fulfill()
+            for await _ in deviceFetchGate {}
+            return RegisteredDeviceMappingResult(devices: [.mock], needsCurrentDeviceInfoRepair: true)
+        }
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.renameCurrentDeviceHandler = {
+            unifiedRenameStarted.fulfill()
+            for await _ in renameGate {}
+            return [.mock]
+        }
+        migrationCoordinator.repairCurrentDeviceInfoHandler = {
+            unexpectedRepair.fulfill()
+        }
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        async let fetchedDevices = syncService.fetchDevices()
+        await fulfillment(of: [deviceFetchStarted], timeout: 1)
+        async let renamedDevices = syncService.updateDeviceName("Renamed Device")
+        await fulfillment(of: [unifiedRenameStarted], timeout: 1)
+        deviceFetchGateContinuation.finish()
+        _ = try await fetchedDevices
+        await fulfillment(of: [unexpectedRepair], timeout: 0.1)
+        renameGateContinuation.finish()
+        _ = try await renamedDevices
+
+        XCTAssertTrue(migrationCoordinator.repairCalls.isEmpty)
+
+        let repairScheduledOnNextPoll = expectation(description: "Current device info repair scheduled on next poll")
+        migrationCoordinator.repairCurrentDeviceInfoHandler = {
+            repairScheduledOnNextPoll.fulfill()
+        }
+        accountManager.fetchDevicesForAccountHandler = nil
+        accountManager.fetchDevicesForAccountStub = RegisteredDeviceMappingResult(
+            devices: [.mock],
+            needsCurrentDeviceInfoRepair: true)
+
+        _ = try await syncService.fetchDevices()
+        await fulfillment(of: [repairScheduledOnNextPoll], timeout: 1)
+
+        XCTAssertEqual(migrationCoordinator.repairCalls.map(\.account.deviceId), [SyncAccount.mock.deviceId])
+    }
+
     func testWhenUnifiedRenameReturns401ThenExistingUnauthenticatedHandlingLogsOut() async throws {
         dependencies.canWriteUnifiedDeviceList = { true }
         let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
@@ -1211,7 +1203,7 @@ final class DDGSyncTests: XCTestCase {
         dependencies.canWriteUnifiedDeviceList = { false }
         dependencies.canUsePatchEndpointForLegacyDeviceRename = { true }
         let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
-        migrationCoordinator.renameCurrentDeviceWithoutUnifiedInfoError = SyncError.unexpectedStatusCode(401)
+        migrationCoordinator.renameCurrentDeviceError = SyncError.unexpectedStatusCode(401)
         dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
         let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
         syncService.initializeIfNeeded()

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -919,6 +919,7 @@ final class DDGSyncTests: XCTestCase {
 
     func testWhenWriteIsDisabledAndRenamingDeviceDuringMigrationThenLegacyRefreshRunsAfterCancellationAndMigrationIsRescheduled() async throws {
         dependencies.canWriteUnifiedDeviceList = { true }
+        dependencies.canUsePatchEndpointForLegacyDeviceRename = { false }
         let migrationStarted = expectation(description: "Device info migration started")
         let migrationFinished = expectation(description: "Device info migration finished")
         let migrationRescheduled = expectation(description: "Device info migration rescheduled")
@@ -959,7 +960,7 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual((dependencies.secureStore as? SecureStorageStub)?.theAccount?.deviceName, renamedAccount.deviceName)
         XCTAssertEqual(migrationCoordinator.calls.count, 2)
         XCTAssertEqual(migrationCoordinator.calls.last?.account.deviceName, renamedAccount.deviceName)
-        XCTAssertEqual(migrationCoordinator.resetCallCount, 1)
+        XCTAssertEqual(migrationCoordinator.resetCallCount, 0)
     }
 
     func testWhenRenamingDeviceWithUnifiedWritesDisabledThenMigrationStateIsPreserved() async throws {
@@ -1081,6 +1082,26 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(migrationCoordinator.repairCalls.map(\.account.deviceId), [SyncAccount.mock.deviceId])
     }
 
+    func testWhenWriteIsDisabledAndLegacyPatchIsEnabledThenRenameOmitsUnifiedInfoWithoutRefreshingToken() async throws {
+        dependencies.canWriteUnifiedDeviceList = { false }
+        dependencies.canUsePatchEndpointForLegacyDeviceRename = { true }
+        let expectedDevices = [RegisteredDevice(id: "renamed-device", name: "Renamed Device", type: "iOS")]
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.renameCurrentDeviceWithoutUnifiedInfoStub = expectedDevices
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        let devices = try await syncService.updateDeviceName("Renamed Device")
+
+        XCTAssertEqual(devices.map(\.id), expectedDevices.map(\.id))
+        XCTAssertFalse(accountManager.refreshTokenCalled)
+        XCTAssertTrue(migrationCoordinator.renameCalls.isEmpty)
+        XCTAssertEqual(migrationCoordinator.renameWithoutUnifiedInfoCalls.count, 1)
+        XCTAssertEqual(migrationCoordinator.renameWithoutUnifiedInfoCalls.first?.name, "Renamed Device")
+        XCTAssertEqual(migrationCoordinator.renameWithoutUnifiedInfoCalls.first?.account.deviceId, SyncAccount.mock.deviceId)
+    }
+
     func testWhenWriteIsEnabledThenRenameUsesUnifiedUpdateWithoutRefreshingToken() async throws {
         dependencies.canWriteUnifiedDeviceList = { true }
         let expectedDevices = [RegisteredDevice(id: "renamed-device", name: "Renamed Device", type: "iOS")]
@@ -1094,6 +1115,7 @@ final class DDGSyncTests: XCTestCase {
 
         XCTAssertEqual(devices.map(\.id), expectedDevices.map(\.id))
         XCTAssertFalse(accountManager.refreshTokenCalled)
+        XCTAssertTrue(migrationCoordinator.renameWithoutUnifiedInfoCalls.isEmpty)
         XCTAssertEqual(migrationCoordinator.renameCalls.count, 1)
         XCTAssertEqual(migrationCoordinator.renameCalls.first?.name, "Renamed Device")
         XCTAssertEqual(migrationCoordinator.renameCalls.first?.account.deviceId, SyncAccount.mock.deviceId)
@@ -1184,7 +1206,31 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(migrationCoordinator.resetCallCount, 1)
     }
 
+    func testWhenRenameWithoutUnifiedInfoReturns401ThenExistingUnauthenticatedHandlingLogsOut() async throws {
+        dependencies.canWriteUnifiedDeviceList = { false }
+        dependencies.canUsePatchEndpointForLegacyDeviceRename = { true }
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        migrationCoordinator.renameCurrentDeviceWithoutUnifiedInfoError = SyncError.unexpectedStatusCode(401)
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+        syncService.initializeIfNeeded()
+
+        do {
+            _ = try await syncService.updateDeviceName("Renamed Device")
+            XCTFail("Expected rename to throw")
+        } catch let error as SyncError {
+            XCTAssertEqual(error, .unauthenticatedWhileLoggedIn)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertNil((dependencies.secureStore as? SecureStorageStub)?.theAccount)
+        XCTAssertEqual(syncService.authState, .inactive)
+        XCTAssertEqual(migrationCoordinator.resetCallCount, 1)
+    }
+
     func testWhenRefreshResponseContainsRecoverableScopedPasswordThenScopedPasswordIsCached() async throws {
+        dependencies.canUsePatchEndpointForLegacyDeviceRename = { false }
         let scopedPassword = Data(repeating: 7, count: 32)
         (dependencies.account as? AccountManagingMock)?.refreshTokenStub = LoginResult(
             account: .mock,

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
@@ -25,6 +25,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
 
     private var accountManager: AccountManagingMock!
     private var scopedAccess: ScopedAccessCredentialManagingMock!
+    private var crypter: CryptingMock!
     private var deviceInfoCodec: DeviceInfoMigrationCodingMock!
     private var secureStore: SecureStorageStub!
     private var keyValueStore: MockKeyValueFileStore!
@@ -37,6 +38,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
 
         accountManager = AccountManagingMock()
         scopedAccess = ScopedAccessCredentialManagingMock()
+        crypter = CryptingMock()
         deviceInfoCodec = DeviceInfoMigrationCodingMock()
         secureStore = SecureStorageStub()
         secureStore.theAccount = .mock
@@ -55,6 +57,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
     override func tearDown() {
         accountManager = nil
         scopedAccess = nil
+        crypter = nil
         deviceInfoCodec = nil
         secureStore = nil
         keyValueStore = nil
@@ -89,6 +92,121 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertEqual(call.update.type, "encrypted_\(SyncAccount.mock.deviceType)")
         XCTAssertEqual(call.update.info, deviceInfoCodec.encryptStub)
         XCTAssertTrue(coordinator.hasCompletedMigration(for: .mock))
+    }
+
+    func testWhenRenameSucceedsThenOnlyCurrentDeviceIsPatchedInBothFormatsAndRenamedAccountIsPersisted() async throws {
+        let returnedDevices = [RegisteredDevice(id: "device-1", name: "Device 1", type: "iOS")]
+        accountManager.updateDeviceStub = returnedDevices
+
+        let devices = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock)
+
+        XCTAssertEqual(devices.map(\.id), returnedDevices.map(\.id))
+        XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.map(\.deviceId), [SyncAccount.mock.deviceId])
+        XCTAssertEqual(deviceInfoCodec.encryptCalls.map(\.deviceInfo), [
+            DeviceInfo(name: "Renamed Device", type: SyncAccount.mock.deviceType)
+        ])
+        let call = try XCTUnwrap(accountManager.updateDeviceCalls.first)
+        XCTAssertEqual(accountManager.updateDeviceCalls.count, 1)
+        XCTAssertEqual(call.account.deviceId, SyncAccount.mock.deviceId)
+        XCTAssertEqual(call.update.id, SyncAccount.mock.deviceId)
+        XCTAssertEqual(call.update.name, "encrypted_Renamed Device")
+        XCTAssertEqual(call.update.type, "encrypted_\(SyncAccount.mock.deviceType)")
+        XCTAssertEqual(call.update.info, deviceInfoCodec.encryptStub)
+
+        let persistedAccount = try XCTUnwrap(secureStore.theAccount)
+        XCTAssertEqual(persistedAccount.deviceId, SyncAccount.mock.deviceId)
+        XCTAssertEqual(persistedAccount.deviceName, "Renamed Device")
+        XCTAssertEqual(persistedAccount.deviceType, SyncAccount.mock.deviceType)
+        XCTAssertEqual(persistedAccount.userId, SyncAccount.mock.userId)
+        XCTAssertEqual(persistedAccount.primaryKey, SyncAccount.mock.primaryKey)
+        XCTAssertEqual(persistedAccount.secretKey, SyncAccount.mock.secretKey)
+        XCTAssertEqual(persistedAccount.token, SyncAccount.mock.token)
+        XCTAssertEqual(persistedAccount.state, SyncAccount.mock.state)
+        XCTAssertTrue(coordinator.hasCompletedMigration(for: persistedAccount))
+    }
+
+    func testWhenRenameKeyPreparationFailsThenAccountAndMigrationMarkerAreUnchanged() async {
+        scopedAccess.ensureAccountInfoProtectedKeysError = TestError.expected
+
+        do {
+            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock)
+            XCTFail("Expected rename to throw")
+        } catch TestError.expected {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(secureStore.theAccount?.deviceName, SyncAccount.mock.deviceName)
+        XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+    }
+
+    func testWhenRenameEncryptionFailsThenAccountAndMigrationMarkerAreUnchanged() async {
+        deviceInfoCodec.encryptError = TestError.expected
+
+        do {
+            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock)
+            XCTFail("Expected rename to throw")
+        } catch TestError.expected {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(secureStore.theAccount?.deviceName, SyncAccount.mock.deviceName)
+        XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+    }
+
+    func testWhenRenameLegacyEncryptionFailsThenAccountAndMigrationMarkerAreUnchanged() async {
+        crypter._encryptAndBase64Encode = { _ in throw TestError.expected }
+        coordinator = makeCoordinator()
+
+        do {
+            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock)
+            XCTFail("Expected rename to throw")
+        } catch TestError.expected {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(deviceInfoCodec.encryptCalls.count, 1)
+        XCTAssertEqual(secureStore.theAccount?.deviceName, SyncAccount.mock.deviceName)
+        XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+    }
+
+    func testWhenRenamePatchFailsThenAccountAndMigrationMarkerAreUnchanged() async {
+        accountManager.updateDeviceError = SyncError.unexpectedStatusCode(500)
+
+        do {
+            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock)
+            XCTFail("Expected rename to throw")
+        } catch let error as SyncError {
+            XCTAssertEqual(error, .unexpectedStatusCode(500))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(accountManager.updateDeviceCalls.count, 1)
+        XCTAssertEqual(secureStore.theAccount?.deviceName, SyncAccount.mock.deviceName)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+    }
+
+    func testWhenEncryptedDeviceInfoExceedsServerLimitThenRenameIsNotPatchedPersistedOrMarkedComplete() async {
+        deviceInfoCodec.encryptStub = String(repeating: "a", count: DeviceInfo.maximumEncryptedLength + 1)
+
+        do {
+            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock)
+            XCTFail("Expected rename to throw")
+        } catch let error as DeviceInfoMigrationError {
+            XCTAssertEqual(error, .encryptedDeviceInfoTooLarge)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
+        XCTAssertEqual(secureStore.theAccount?.deviceName, SyncAccount.mock.deviceName)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
     }
 
     func testWhenMigrationRunsTwiceThenCurrentDeviceIsPatchedOnce() async {
@@ -280,7 +398,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         DeviceInfoMigrationCoordinator(
             accountManager: accountManager,
             scopedAccess: scopedAccess,
-            crypter: CryptingMock(),
+            crypter: crypter,
             deviceInfoCodec: deviceInfoCodec,
             secureStore: secureStore,
             keyValueStore: keyValueStore,

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
@@ -125,6 +125,84 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertTrue(coordinator.hasCompletedMigration(for: persistedAccount))
     }
 
+    func testWhenRenameWithoutUnifiedInfoSucceedsThenOnlyCurrentDeviceLegacyFieldsArePatchedAndRenamedAccountIsPersisted() async throws {
+        let returnedDevices = [RegisteredDevice(id: "device-1", name: "Device 1", type: "iOS")]
+        accountManager.updateDeviceStub = returnedDevices
+
+        let devices = try await coordinator.renameCurrentDeviceWithoutUnifiedInfo(to: "Renamed Device", for: .mock)
+
+        XCTAssertEqual(devices.map(\.id), returnedDevices.map(\.id))
+        XCTAssertTrue(scopedAccess.ensureAccountInfoProtectedKeysCalls.isEmpty)
+        XCTAssertTrue(deviceInfoCodec.encryptCalls.isEmpty)
+        let call = try XCTUnwrap(accountManager.updateDeviceCalls.first)
+        XCTAssertEqual(accountManager.updateDeviceCalls.count, 1)
+        XCTAssertEqual(call.account.deviceId, SyncAccount.mock.deviceId)
+        XCTAssertEqual(call.update.id, SyncAccount.mock.deviceId)
+        XCTAssertEqual(call.update.name, "encrypted_Renamed Device")
+        XCTAssertEqual(call.update.type, "encrypted_\(SyncAccount.mock.deviceType)")
+        XCTAssertNil(call.update.info)
+
+        let persistedAccount = try XCTUnwrap(secureStore.theAccount)
+        XCTAssertEqual(persistedAccount.deviceId, SyncAccount.mock.deviceId)
+        XCTAssertEqual(persistedAccount.deviceName, "Renamed Device")
+        XCTAssertEqual(persistedAccount.deviceType, SyncAccount.mock.deviceType)
+        XCTAssertEqual(persistedAccount.userId, SyncAccount.mock.userId)
+        XCTAssertEqual(persistedAccount.primaryKey, SyncAccount.mock.primaryKey)
+        XCTAssertEqual(persistedAccount.secretKey, SyncAccount.mock.secretKey)
+        XCTAssertEqual(persistedAccount.token, SyncAccount.mock.token)
+        XCTAssertEqual(persistedAccount.state, SyncAccount.mock.state)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: persistedAccount))
+    }
+
+    func testWhenRenameWithoutUnifiedInfoSucceedsThenExistingMigrationMarkerIsPreserved() async throws {
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+        XCTAssertTrue(coordinator.hasCompletedMigration(for: .mock))
+
+        _ = try await coordinator.renameCurrentDeviceWithoutUnifiedInfo(to: "Renamed Device", for: .mock)
+
+        let renamedAccount = try XCTUnwrap(secureStore.theAccount)
+        XCTAssertTrue(coordinator.hasCompletedMigration(for: renamedAccount))
+        XCTAssertEqual(accountManager.updateDeviceCalls.count, 2)
+        XCTAssertNil(accountManager.updateDeviceCalls.last?.update.info)
+    }
+
+    func testWhenRenameWithoutUnifiedInfoEncryptionFailsThenAccountAndMigrationMarkerAreUnchanged() async {
+        crypter._encryptAndBase64Encode = { _ in throw TestError.expected }
+        coordinator = makeCoordinator()
+
+        do {
+            _ = try await coordinator.renameCurrentDeviceWithoutUnifiedInfo(to: "Renamed Device", for: .mock)
+            XCTFail("Expected rename to throw")
+        } catch TestError.expected {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertTrue(scopedAccess.ensureAccountInfoProtectedKeysCalls.isEmpty)
+        XCTAssertTrue(deviceInfoCodec.encryptCalls.isEmpty)
+        XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
+        XCTAssertEqual(secureStore.theAccount?.deviceName, SyncAccount.mock.deviceName)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+    }
+
+    func testWhenRenameWithoutUnifiedInfoPatchFailsThenAccountAndMigrationMarkerAreUnchanged() async {
+        accountManager.updateDeviceError = SyncError.unexpectedStatusCode(500)
+
+        do {
+            _ = try await coordinator.renameCurrentDeviceWithoutUnifiedInfo(to: "Renamed Device", for: .mock)
+            XCTFail("Expected rename to throw")
+        } catch let error as SyncError {
+            XCTAssertEqual(error, .unexpectedStatusCode(500))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(accountManager.updateDeviceCalls.count, 1)
+        XCTAssertNil(accountManager.updateDeviceCalls.first?.update.info)
+        XCTAssertEqual(secureStore.theAccount?.deviceName, SyncAccount.mock.deviceName)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+    }
+
     func testWhenRenameKeyPreparationFailsThenAccountAndMigrationMarkerAreUnchanged() async {
         scopedAccess.ensureAccountInfoProtectedKeysError = TestError.expected
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
@@ -98,7 +98,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         let returnedDevices = [RegisteredDevice(id: "device-1", name: "Device 1", type: "iOS")]
         accountManager.updateDeviceStub = returnedDevices
 
-        let devices = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock)
+        let devices = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock, mode: .unified)
 
         XCTAssertEqual(devices.map(\.id), returnedDevices.map(\.id))
         XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.map(\.deviceId), [SyncAccount.mock.deviceId])
@@ -129,7 +129,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         let returnedDevices = [RegisteredDevice(id: "device-1", name: "Device 1", type: "iOS")]
         accountManager.updateDeviceStub = returnedDevices
 
-        let devices = try await coordinator.renameCurrentDeviceWithoutUnifiedInfo(to: "Renamed Device", for: .mock)
+        let devices = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock, mode: .legacyOnly)
 
         XCTAssertEqual(devices.map(\.id), returnedDevices.map(\.id))
         XCTAssertTrue(scopedAccess.ensureAccountInfoProtectedKeysCalls.isEmpty)
@@ -158,7 +158,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
         XCTAssertTrue(coordinator.hasCompletedMigration(for: .mock))
 
-        _ = try await coordinator.renameCurrentDeviceWithoutUnifiedInfo(to: "Renamed Device", for: .mock)
+        _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock, mode: .legacyOnly)
 
         let renamedAccount = try XCTUnwrap(secureStore.theAccount)
         XCTAssertTrue(coordinator.hasCompletedMigration(for: renamedAccount))
@@ -171,7 +171,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         coordinator = makeCoordinator()
 
         do {
-            _ = try await coordinator.renameCurrentDeviceWithoutUnifiedInfo(to: "Renamed Device", for: .mock)
+            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock, mode: .legacyOnly)
             XCTFail("Expected rename to throw")
         } catch TestError.expected {
         } catch {
@@ -189,7 +189,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         accountManager.updateDeviceError = SyncError.unexpectedStatusCode(500)
 
         do {
-            _ = try await coordinator.renameCurrentDeviceWithoutUnifiedInfo(to: "Renamed Device", for: .mock)
+            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock, mode: .legacyOnly)
             XCTFail("Expected rename to throw")
         } catch let error as SyncError {
             XCTAssertEqual(error, .unexpectedStatusCode(500))
@@ -207,7 +207,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         scopedAccess.ensureAccountInfoProtectedKeysError = TestError.expected
 
         do {
-            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock)
+            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock, mode: .unified)
             XCTFail("Expected rename to throw")
         } catch TestError.expected {
         } catch {
@@ -223,7 +223,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         deviceInfoCodec.encryptError = TestError.expected
 
         do {
-            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock)
+            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock, mode: .unified)
             XCTFail("Expected rename to throw")
         } catch TestError.expected {
         } catch {
@@ -240,7 +240,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         coordinator = makeCoordinator()
 
         do {
-            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock)
+            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock, mode: .unified)
             XCTFail("Expected rename to throw")
         } catch TestError.expected {
         } catch {
@@ -257,7 +257,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         accountManager.updateDeviceError = SyncError.unexpectedStatusCode(500)
 
         do {
-            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock)
+            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock, mode: .unified)
             XCTFail("Expected rename to throw")
         } catch let error as SyncError {
             XCTAssertEqual(error, .unexpectedStatusCode(500))
@@ -274,7 +274,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         deviceInfoCodec.encryptStub = String(repeating: "a", count: DeviceInfo.maximumEncryptedLength + 1)
 
         do {
-            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock)
+            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock, mode: .unified)
             XCTFail("Expected rename to throw")
         } catch let error as DeviceInfoMigrationError {
             XCTAssertEqual(error, .encryptedDeviceInfoTooLarge)

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoUpdateBuilderTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoUpdateBuilderTests.swift
@@ -1,0 +1,39 @@
+//
+//  DeviceInfoUpdateBuilderTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import XCTest
+
+@testable import DDGSync
+
+final class DeviceInfoUpdateBuilderTests: XCTestCase {
+
+    func testWhenMakingUpdateWithoutUnifiedInfoThenInfoIsNilAndLegacyFieldsAreEncrypted() throws {
+        let builder = DeviceInfoUpdateBuilder(crypter: CryptingMock(), deviceInfoCodec: DeviceInfoCodec())
+
+        let update = try builder.makeUpdateWithoutUnifiedInfo(deviceID: "device-id",
+                                                               deviceName: "Device Name",
+                                                               deviceType: "desktop",
+                                                               primaryKey: Data())
+
+        XCTAssertEqual(update.id, "device-id")
+        XCTAssertEqual(update.name, "encrypted_Device Name")
+        XCTAssertEqual(update.type, "encrypted_desktop")
+        XCTAssertNil(update.info)
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -602,8 +602,7 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
     private let lock = NSLock()
     private var recordedCalls: [Call] = []
     private var recordedRepairCalls: [Call] = []
-    private var recordedRenameCalls: [(name: String, account: SyncAccount)] = []
-    private var recordedRenameWithoutUnifiedInfoCalls: [(name: String, account: SyncAccount)] = []
+    private var recordedRenameCalls: [(name: String, account: SyncAccount, mode: DeviceInfoRenameMode)] = []
     private var recordedResetCallCount = 0
     var hasCompletedMigrationStub = false
     var calls: [Call] {
@@ -621,24 +620,16 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
         defer { lock.unlock() }
         return recordedResetCallCount
     }
-    var renameCalls: [(name: String, account: SyncAccount)] {
+    var renameCalls: [(name: String, account: SyncAccount, mode: DeviceInfoRenameMode)] {
         lock.lock()
         defer { lock.unlock() }
         return recordedRenameCalls
-    }
-    var renameWithoutUnifiedInfoCalls: [(name: String, account: SyncAccount)] {
-        lock.lock()
-        defer { lock.unlock() }
-        return recordedRenameWithoutUnifiedInfoCalls
     }
     var migrateCurrentDeviceHandler: (() async -> Void)?
     var repairCurrentDeviceInfoHandler: (() async -> Void)?
     var renameCurrentDeviceStub: [RegisteredDevice] = []
     var renameCurrentDeviceError: Error?
     var renameCurrentDeviceHandler: (() async throws -> [RegisteredDevice])?
-    var renameCurrentDeviceWithoutUnifiedInfoStub: [RegisteredDevice] = []
-    var renameCurrentDeviceWithoutUnifiedInfoError: Error?
-    var renameCurrentDeviceWithoutUnifiedInfoHandler: (() async throws -> [RegisteredDevice])?
 
     func migrateCurrentDeviceIfNeeded(for account: SyncAccount) async {
         let handler = record(Call(account: account))
@@ -650,19 +641,10 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
         await handler?()
     }
 
-    func renameCurrentDevice(to name: String, for account: SyncAccount) async throws -> [RegisteredDevice] {
-        let result = recordRename(name: name, account: account)
-        if let handler = result.handler {
-            return try await handler()
-        }
-        if let error = result.error {
-            throw error
-        }
-        return result.stub
-    }
-
-    func renameCurrentDeviceWithoutUnifiedInfo(to name: String, for account: SyncAccount) async throws -> [RegisteredDevice] {
-        let result = recordRenameWithoutUnifiedInfo(name: name, account: account)
+    func renameCurrentDevice(to name: String,
+                             for account: SyncAccount,
+                             mode: DeviceInfoRenameMode) async throws -> [RegisteredDevice] {
+        let result = recordRename(name: name, account: account, mode: mode)
         if let handler = result.handler {
             return try await handler()
         }
@@ -673,23 +655,12 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
     }
 
     private func recordRename(name: String,
-                              account: SyncAccount) -> (handler: (() async throws -> [RegisteredDevice])?, error: Error?, stub: [RegisteredDevice]) {
+                              account: SyncAccount,
+                              mode: DeviceInfoRenameMode) -> (handler: (() async throws -> [RegisteredDevice])?, error: Error?, stub: [RegisteredDevice]) {
         lock.lock()
         defer { lock.unlock() }
-        recordedRenameCalls.append((name: name, account: account))
+        recordedRenameCalls.append((name: name, account: account, mode: mode))
         return (renameCurrentDeviceHandler, renameCurrentDeviceError, renameCurrentDeviceStub)
-    }
-
-    private func recordRenameWithoutUnifiedInfo(name: String,
-                                                account: SyncAccount) -> (handler: (() async throws -> [RegisteredDevice])?,
-                                                                         error: Error?,
-                                                                         stub: [RegisteredDevice]) {
-        lock.lock()
-        defer { lock.unlock() }
-        recordedRenameWithoutUnifiedInfoCalls.append((name: name, account: account))
-        return (renameCurrentDeviceWithoutUnifiedInfoHandler,
-                renameCurrentDeviceWithoutUnifiedInfoError,
-                renameCurrentDeviceWithoutUnifiedInfoStub)
     }
 
     func hasCompletedMigration(for account: SyncAccount) -> Bool {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -284,12 +284,14 @@ final class MockSyncDependencies: SyncDependencies, SyncDependenciesDebuggingSup
     var isPairingV2ScanningEnabled: () -> Bool = { true }
     var isPairingV2CodeEnabled: () -> Bool = { true }
     var canWriteUnifiedDeviceList: () -> Bool = { false }
+    var canUsePatchEndpointForLegacyDeviceRename: () -> Bool = { true }
     var canReadUnifiedDeviceList: () -> Bool = { false }
     lazy var syncFeatureFlags: any SyncFeatureFlagProviding = SyncFeatureFlagProvider(
         isScopedAccessCredentialsEnabled: { [weak self] in self?.isScopedAccessCredentialsEnabled() == true },
         isPairingV2ScanningEnabled: { [weak self] in self?.isPairingV2ScanningEnabled() == true },
         isPairingV2CodeEnabled: { [weak self] in self?.isPairingV2CodeEnabled() == true },
         canWriteUnifiedDeviceList: { [weak self] in self?.canWriteUnifiedDeviceList() == true },
+        canUsePatchEndpointForLegacyDeviceRename: { [weak self] in self?.canUsePatchEndpointForLegacyDeviceRename() == true },
         canReadUnifiedDeviceList: { [weak self] in self?.canReadUnifiedDeviceList() == true }
     )
     var keyValueStore: ThrowingKeyValueStoring = try! MockKeyValueFileStore()

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -603,6 +603,7 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
     private var recordedCalls: [Call] = []
     private var recordedRepairCalls: [Call] = []
     private var recordedRenameCalls: [(name: String, account: SyncAccount)] = []
+    private var recordedRenameWithoutUnifiedInfoCalls: [(name: String, account: SyncAccount)] = []
     private var recordedResetCallCount = 0
     var hasCompletedMigrationStub = false
     var calls: [Call] {
@@ -625,11 +626,19 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
         defer { lock.unlock() }
         return recordedRenameCalls
     }
+    var renameWithoutUnifiedInfoCalls: [(name: String, account: SyncAccount)] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedRenameWithoutUnifiedInfoCalls
+    }
     var migrateCurrentDeviceHandler: (() async -> Void)?
     var repairCurrentDeviceInfoHandler: (() async -> Void)?
     var renameCurrentDeviceStub: [RegisteredDevice] = []
     var renameCurrentDeviceError: Error?
     var renameCurrentDeviceHandler: (() async throws -> [RegisteredDevice])?
+    var renameCurrentDeviceWithoutUnifiedInfoStub: [RegisteredDevice] = []
+    var renameCurrentDeviceWithoutUnifiedInfoError: Error?
+    var renameCurrentDeviceWithoutUnifiedInfoHandler: (() async throws -> [RegisteredDevice])?
 
     func migrateCurrentDeviceIfNeeded(for account: SyncAccount) async {
         let handler = record(Call(account: account))
@@ -652,12 +661,35 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
         return result.stub
     }
 
+    func renameCurrentDeviceWithoutUnifiedInfo(to name: String, for account: SyncAccount) async throws -> [RegisteredDevice] {
+        let result = recordRenameWithoutUnifiedInfo(name: name, account: account)
+        if let handler = result.handler {
+            return try await handler()
+        }
+        if let error = result.error {
+            throw error
+        }
+        return result.stub
+    }
+
     private func recordRename(name: String,
                               account: SyncAccount) -> (handler: (() async throws -> [RegisteredDevice])?, error: Error?, stub: [RegisteredDevice]) {
         lock.lock()
         defer { lock.unlock() }
         recordedRenameCalls.append((name: name, account: account))
         return (renameCurrentDeviceHandler, renameCurrentDeviceError, renameCurrentDeviceStub)
+    }
+
+    private func recordRenameWithoutUnifiedInfo(name: String,
+                                                account: SyncAccount) -> (handler: (() async throws -> [RegisteredDevice])?,
+                                                                         error: Error?,
+                                                                         stub: [RegisteredDevice]) {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedRenameWithoutUnifiedInfoCalls.append((name: name, account: account))
+        return (renameCurrentDeviceWithoutUnifiedInfoHandler,
+                renameCurrentDeviceWithoutUnifiedInfoError,
+                renameCurrentDeviceWithoutUnifiedInfoStub)
     }
 
     func hasCompletedMigration(for account: SyncAccount) -> Bool {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -600,6 +600,7 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
     private let lock = NSLock()
     private var recordedCalls: [Call] = []
     private var recordedRepairCalls: [Call] = []
+    private var recordedRenameCalls: [(name: String, account: SyncAccount)] = []
     private var recordedResetCallCount = 0
     var hasCompletedMigrationStub = false
     var calls: [Call] {
@@ -617,8 +618,16 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
         defer { lock.unlock() }
         return recordedResetCallCount
     }
+    var renameCalls: [(name: String, account: SyncAccount)] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedRenameCalls
+    }
     var migrateCurrentDeviceHandler: (() async -> Void)?
     var repairCurrentDeviceInfoHandler: (() async -> Void)?
+    var renameCurrentDeviceStub: [RegisteredDevice] = []
+    var renameCurrentDeviceError: Error?
+    var renameCurrentDeviceHandler: (() async throws -> [RegisteredDevice])?
 
     func migrateCurrentDeviceIfNeeded(for account: SyncAccount) async {
         let handler = record(Call(account: account))
@@ -628,6 +637,25 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
     func repairCurrentDeviceInfo(for account: SyncAccount) async {
         let handler = recordRepair(Call(account: account))
         await handler?()
+    }
+
+    func renameCurrentDevice(to name: String, for account: SyncAccount) async throws -> [RegisteredDevice] {
+        let result = recordRename(name: name, account: account)
+        if let handler = result.handler {
+            return try await handler()
+        }
+        if let error = result.error {
+            throw error
+        }
+        return result.stub
+    }
+
+    private func recordRename(name: String,
+                              account: SyncAccount) -> (handler: (() async throws -> [RegisteredDevice])?, error: Error?, stub: [RegisteredDevice]) {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedRenameCalls.append((name: name, account: account))
+        return (renameCurrentDeviceHandler, renameCurrentDeviceError, renameCurrentDeviceStub)
     }
 
     func hasCompletedMigration(for account: SyncAccount) -> Bool {

--- a/iOS/DuckDuckGo/AppServices/SyncService.swift
+++ b/iOS/DuckDuckGo/AppServices/SyncService.swift
@@ -100,6 +100,9 @@ final class SyncService {
                 canWriteUnifiedDeviceList: {
                     featureFlagger.isFeatureOn(for: FeatureFlag.syncCanWriteUnifiedDeviceList)
                 },
+                canUsePatchEndpointForLegacyDeviceRename: {
+                    featureFlagger.isFeatureOn(for: FeatureFlag.syncCanUsePatchEndpointForLegacyDeviceRename)
+                },
                 canReadUnifiedDeviceList: {
                     featureFlagger.isFeatureOn(for: FeatureFlag.syncCanReadUnifiedDeviceList)
                 }

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -520,7 +520,7 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217191536064244?focus=true
     case syncCanWriteUnifiedDeviceList
 
-    /// https://app.asana.com/1/137249556945/task/1216792120319849
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217684925915714?focus=true
     case syncCanUsePatchEndpointForLegacyDeviceRename
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217191536064256?focus=true

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -520,6 +520,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217191536064244?focus=true
     case syncCanWriteUnifiedDeviceList
 
+    /// https://app.asana.com/1/137249556945/task/1216792120319849
+    case syncCanUsePatchEndpointForLegacyDeviceRename
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217191536064256?focus=true
     case syncCanReadUnifiedDeviceList
 
@@ -933,6 +936,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(SyncSubfeature.canShowV2ConnectCode))
         case .syncCanWriteUnifiedDeviceList:
             Config(source: .remoteReleasable(SyncSubfeature.canWriteUnifiedDeviceList))
+        case .syncCanUsePatchEndpointForLegacyDeviceRename:
+            Config(defaultValue: .enabled, source: .remoteReleasable(SyncSubfeature.canUsePatchEndpointForLegacyDeviceRename))
         case .syncCanReadUnifiedDeviceList:
             Config(source: .remoteReleasable(SyncSubfeature.canReadUnifiedDeviceList))
         case .iPadTabsBarInWindowControlsRow:

--- a/iOS/LocalPackages/FeatureFlags-iOS/Tests/FeatureFlagsTests/FeatureFlagsTests.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Tests/FeatureFlagsTests/FeatureFlagsTests.swift
@@ -115,4 +115,20 @@ final class FeatureFlagsTests: XCTestCase {
         }
         XCTAssertTrue(flag.supportsLocalOverriding)
     }
+
+    func testLegacyDeviceRenamePatchFlagIsDefaultEnabledAndRemoteReleasable() {
+        let flag = FeatureFlag.syncCanUsePatchEndpointForLegacyDeviceRename
+        guard case let .remoteReleasable(subfeature) = flag.source else {
+            XCTFail("Expected remote-releasable source")
+            return
+        }
+
+        XCTAssertEqual((subfeature as? SyncSubfeature)?.rawValue,
+                       SyncSubfeature.canUsePatchEndpointForLegacyDeviceRename.rawValue)
+        guard case .enabled = flag.defaultValue else {
+            XCTFail("Expected enabled default")
+            return
+        }
+        XCTAssertTrue(flag.supportsLocalOverriding)
+    }
 }

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -2274,6 +2274,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 canWriteUnifiedDeviceList: { [featureFlagger] in
                     featureFlagger.isFeatureOn(.syncCanWriteUnifiedDeviceList)
                 },
+                canUsePatchEndpointForLegacyDeviceRename: { [featureFlagger] in
+                    featureFlagger.isFeatureOn(.syncCanUsePatchEndpointForLegacyDeviceRename)
+                },
                 canReadUnifiedDeviceList: { [featureFlagger] in
                     featureFlagger.isFeatureOn(.syncCanReadUnifiedDeviceList)
                 }

--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -502,6 +502,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217191536064249?focus=true
     case syncCanWriteUnifiedDeviceList
 
+    /// https://app.asana.com/1/137249556945/task/1216792120319849
+    case syncCanUsePatchEndpointForLegacyDeviceRename
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217191536064261?focus=true
     case syncCanReadUnifiedDeviceList
 
@@ -864,6 +867,10 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(SyncSubfeature.canShowV2ConnectCode), category: .sync)
         case .syncCanWriteUnifiedDeviceList:
             Config(source: .remoteReleasable(SyncSubfeature.canWriteUnifiedDeviceList), category: .sync)
+        case .syncCanUsePatchEndpointForLegacyDeviceRename:
+            Config(defaultValue: .enabled,
+                   source: .remoteReleasable(SyncSubfeature.canUsePatchEndpointForLegacyDeviceRename),
+                   category: .sync)
         case .syncCanReadUnifiedDeviceList:
             Config(source: .remoteReleasable(SyncSubfeature.canReadUnifiedDeviceList), category: .sync)
         case .simplifiedSyncSetupV2:

--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -502,7 +502,7 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217191536064249?focus=true
     case syncCanWriteUnifiedDeviceList
 
-    /// https://app.asana.com/1/137249556945/task/1216792120319849
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217684925915706?focus=true
     case syncCanUsePatchEndpointForLegacyDeviceRename
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217191536064261?focus=true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1216959197715042?focus=true
Tech Design URL:
CC:

### Description
Updates how the current device is renamed as Sync moves to the unified device list. When unified-device writes are enabled, renaming updates both the new encrypted device_info and the legacy name/type fields in a single authenticated request. This keeps new and older clients in agreement without refreshing the account token.

When unified-device writes are disabled, a new default-on rollback flag uses the same endpoint to update the legacy fields and clear potentially stale unified metadata. If that rollback flag is also disabled, the existing login-based rename behaviour remains available.

Renames are coordinated with background device-info migration and repair so older work cannot overwrite the new name. The local account is updated only after the server accepts the rename.

### Testing Steps
Prerequisite: Install on an iOS device and a macOS device, then connect both to the same Sync account. On both devices, enable `syncCanReadUnifiedDeviceList` and confirm `syncCanUsePatchEndpointForLegacyDeviceRename` is enabled by default. 

1. On iOS, enable `syncCanWriteUnifiedDeviceList` and confirm `syncCanUsePatchEndpointForLegacyDeviceRename` is already enabled.
2. Open Settings > Sync and rename the iOS device → the new name appears on iOS and updates on macOS; the macOS device’s name remains unchanged.
3. Close and reopen Sync settings on both devices → the renamed iOS device still has the new name and both devices remain connected.
4. On iOS, disable `syncCanWriteUnifiedDeviceList`. Leave `syncCanUsePatchEndpointForLegacyDeviceRename` and `syncCanReadUnifiedDeviceList` enabled on both devices.
5. Rename the iOS device again → both devices display the latest name after refresh, confirming that the legacy-only PATCH does not leave the previous unified name visible.
6. On iOS, disable `syncCanUsePatchEndpointForLegacyDeviceRename`. On both iOS and macOS, disable `syncCanReadUnifiedDeviceList`. At this point the iOS write, read, and legacy-PATCH flags are all disabled.
7. Rename the iOS device again → both devices display the new name from the legacy device list after refresh, and the Sync account remains connected.
8. Take the iOS device offline and attempt another rename → an error is shown; after restoring the connection and refreshing Sync settings, the last successful name remains unchanged.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authenticated device-update and account persistence paths for rename; wrong flag routing or PATCH semantics could leave device lists inconsistent across clients, though behavior is gated and heavily tested.
> 
> **Overview**
> **Sync device rename** no longer always goes through `refreshToken`. `updateDeviceName` picks a path from feature flags at the start of the call: **unified writes** → PATCH with encrypted legacy fields plus unified `device_info`; **new default-on `canUsePatchEndpointForLegacyDeviceRename`** → PATCH legacy name/type only and omit `info` so stale unified metadata is cleared; otherwise the existing login/refresh rename remains.
> 
> Rename work lives in **`DeviceInfoMigrationCoordinator.renameCurrentDevice`** (`.unified` / `.legacyOnly`), with shared **`DeviceInfoUpdateBuilder`** for PATCH payloads. The local account name is updated only after the server accepts the rename; in-flight migration/repair is still cancelled and awaited first. The old “reset migration after legacy rename when unified write was on” path is removed.
> 
> **Rollout:** privacy subfeature + iOS/macOS `FeatureFlag.syncCanUsePatchEndpointForLegacyDeviceRename` (default enabled). Tests cover routing, flag snapshot behavior, migration/repair ordering, and 401 logout for both PATCH rename modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6e030c06a07fc25b18362ae91bc6beca1140ed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->