### PR TITLE
Bump fastlane-plugin-ddg_apple_automation to 4.1.6

### DIFF
--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 65cb33fb31923d54146f22fd190148dc976429d8
-  tag: 4.1.5
+  revision: fd870b9cd41c46376e39247e4e2f4c41b73f7dba
+  tag: 4.1.6
   specs:
-    fastlane-plugin-ddg_apple_automation (4.1.5)
+    fastlane-plugin-ddg_apple_automation (4.1.6)
       asana
       climate_control
       httpparty

--- a/iOS/fastlane/Pluginfile
+++ b/iOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '4.1.5'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '4.1.6'

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: 65cb33fb31923d54146f22fd190148dc976429d8
-  tag: 4.1.5
+  revision: fd870b9cd41c46376e39247e4e2f4c41b73f7dba
+  tag: 4.1.6
   specs:
-    fastlane-plugin-ddg_apple_automation (4.1.5)
+    fastlane-plugin-ddg_apple_automation (4.1.6)
       asana
       climate_control
       httpparty

--- a/macOS/fastlane/Pluginfile
+++ b/macOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '4.1.5'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '4.1.6'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217681823896982?focus=true
Tech Design URL:
CC:

### Description
Bump fastlane-plugin-ddg_apple_automation to 4.1.6

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin bump only in Fastlane plugin files; no application or auth/security code changes.
> 
> **Overview**
> Bumps the `fastlane-plugin-ddg_apple_automation` Fastlane plugin from **4.1.5** to **4.1.6** for both iOS and macOS, updating `Pluginfile` and `Gemfile.lock` to the new git tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8d882d2922b63157a8ebd58d63dbc7d0bfab03b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->