### PR TITLE
Add unit coverage for PIR instrumentation

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/QueueManaging/JobQueueManager.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/QueueManaging/JobQueueManager.swift
@@ -123,10 +123,7 @@ public final class JobQueueManager: JobQueueManaging {
     private var mode = BrokerProfileJobQueueMode.idle
     private let operationErrorsLock = NSLock()
     private var operationErrors: [Error] = []
-    private var nextRunID = 0
-    private var activeRunID: Int?
-    // Accessed only from queue barrier blocks.
-    private var isDelegateRunActive = false
+    private var activeRunID: UUID?
 
     public var debugRunningStatusString: String {
         switch mode {
@@ -177,8 +174,9 @@ public final class JobQueueManager: JobQueueManaging {
                                                           completion: (() -> Void)?) {
         cancelCurrentModeAndResetIfNeeded()
         mode = .immediate(errorHandler: nil, completion: nil)
-        let runID = beginRun()
-        addDelegateDidStartOperationsBarrier()
+        let runID = UUID()
+        activeRunID = runID
+        delegate?.queueManagerDidStartOperations(self)
         addEmailConfirmationJobs(showWebView: showWebView, jobDependencies: jobDependencies)
         addJobs(for: .optOut,
                 runID: runID,
@@ -284,8 +282,6 @@ private extension JobQueueManager {
             return
         }
 
-        cancelCurrentModeAndResetIfNeeded()
-
         if delegate != nil {
             jobQueue.addBarrierBlock1 { [weak self] in
                 guard let self, let delegate = self.delegate else { return }
@@ -293,10 +289,12 @@ private extension JobQueueManager {
             }
         }
 
+        cancelCurrentModeAndResetIfNeeded()
         mode = newMode
-        let runID = beginRun()
+        let runID = UUID()
+        activeRunID = runID
 
-        addDelegateDidStartOperationsBarrier()
+        delegate?.queueManagerDidStartOperations(self)
 
         addEmailConfirmationJobs(showWebView: showWebView, jobDependencies: jobDependencies)
         addJobs(for: type,
@@ -309,15 +307,6 @@ private extension JobQueueManager {
                 completion: completion)
     }
 
-    func addDelegateDidStartOperationsBarrier() {
-        guard delegate != nil else { return }
-
-        jobQueue.addBarrierBlock1 { [weak self] in
-            guard let self else { return }
-            self.notifyDelegateDidStartOperations()
-        }
-    }
-
     func cancelCurrentModeAndResetIfNeeded() {
         switch mode {
         case .immediate(let errorHandler, let completion), .scheduled(let errorHandler, let completion):
@@ -325,38 +314,11 @@ private extension JobQueueManager {
             let errorCollection = DataBrokerProtectionJobsErrorCollection(oneTimeError: BrokerProfileJobQueueError.interrupted, operationErrors: operationErrorsForCurrentOperations())
             errorHandler?(errorCollection)
             resetMode()
-            addDelegateDidFinishOperationsBarrier()
+            delegate?.queueManagerDidFinishOperations(self)
             completion?()
         default:
             break
         }
-    }
-
-    func addDelegateDidFinishOperationsBarrier() {
-        guard delegate != nil else { return }
-
-        jobQueue.addBarrierBlock1 { [weak self] in
-            guard let self else { return }
-            self.notifyDelegateDidFinishOperations()
-        }
-    }
-
-    func notifyDelegateDidStartOperations() {
-        guard !isDelegateRunActive else { return }
-        isDelegateRunActive = true
-        delegate?.queueManagerDidStartOperations(self)
-    }
-
-    func notifyDelegateDidFinishOperations() {
-        guard isDelegateRunActive else { return }
-        isDelegateRunActive = false
-        delegate?.queueManagerDidFinishOperations(self)
-    }
-
-    func beginRun() -> Int {
-        nextRunID += 1
-        activeRunID = nextRunID
-        return nextRunID
     }
 
     func resetMode() {
@@ -366,7 +328,7 @@ private extension JobQueueManager {
     }
 
     func addJobs(for jobType: JobType,
-                 runID: Int,
+                 runID: UUID,
                  priorityDate: Date? = nil,
                  showWebView: Bool,
                  isAuthenticatedUser: Bool,
@@ -392,17 +354,19 @@ private extension JobQueueManager {
             Logger.dataBrokerProtection.error("DataBrokerProtectionProcessor error: addOperations, error: \(error.localizedDescription, privacy: .public)")
             errorHandler?(DataBrokerProtectionJobsErrorCollection(oneTimeError: error))
             resetMode()
-            addDelegateDidFinishOperationsBarrier()
+            delegate?.queueManagerDidFinishOperations(self)
             completion?()
             return
         }
 
         jobQueue.addBarrierBlock1 { [weak self] in
-            guard let self, self.activeRunID == runID else { return }
-            let errorCollection = DataBrokerProtectionJobsErrorCollection(oneTimeError: nil, operationErrors: self.operationErrorsForCurrentOperations())
+            if let self, self.activeRunID != runID { return }
+            let errorCollection = DataBrokerProtectionJobsErrorCollection(oneTimeError: nil, operationErrors: self?.operationErrorsForCurrentOperations())
             errorHandler?(errorCollection)
-            self.resetMode()
-            self.notifyDelegateDidFinishOperations()
+            self?.resetMode()
+            if let self {
+                self.delegate?.queueManagerDidFinishOperations(self)
+            }
             completion?()
         }
     }

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/QueueManaging/JobQueueManager.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/QueueManaging/JobQueueManager.swift
@@ -123,6 +123,10 @@ public final class JobQueueManager: JobQueueManaging {
     private var mode = BrokerProfileJobQueueMode.idle
     private let operationErrorsLock = NSLock()
     private var operationErrors: [Error] = []
+    private var nextRunID = 0
+    private var activeRunID: Int?
+    // Accessed only from queue barrier blocks.
+    private var isDelegateRunActive = false
 
     public var debugRunningStatusString: String {
         switch mode {
@@ -173,9 +177,11 @@ public final class JobQueueManager: JobQueueManaging {
                                                           completion: (() -> Void)?) {
         cancelCurrentModeAndResetIfNeeded()
         mode = .immediate(errorHandler: nil, completion: nil)
-        delegate?.queueManagerDidStartOperations(self)
+        let runID = beginRun()
+        addDelegateDidStartOperationsBarrier()
         addEmailConfirmationJobs(showWebView: showWebView, jobDependencies: jobDependencies)
         addJobs(for: .optOut,
+                runID: runID,
                 showWebView: showWebView,
                 isAuthenticatedUser: isAuthenticatedUser,
                 jobDependencies: jobDependencies,
@@ -278,6 +284,8 @@ private extension JobQueueManager {
             return
         }
 
+        cancelCurrentModeAndResetIfNeeded()
+
         if delegate != nil {
             jobQueue.addBarrierBlock1 { [weak self] in
                 guard let self, let delegate = self.delegate else { return }
@@ -285,19 +293,29 @@ private extension JobQueueManager {
             }
         }
 
-        cancelCurrentModeAndResetIfNeeded()
         mode = newMode
+        let runID = beginRun()
 
-        delegate?.queueManagerDidStartOperations(self)
+        addDelegateDidStartOperationsBarrier()
 
         addEmailConfirmationJobs(showWebView: showWebView, jobDependencies: jobDependencies)
         addJobs(for: type,
+                runID: runID,
                 priorityDate: mode.priorityDate,
                 showWebView: showWebView,
                 isAuthenticatedUser: isAuthenticatedUser,
                 jobDependencies: jobDependencies,
                 errorHandler: errorHandler,
                 completion: completion)
+    }
+
+    func addDelegateDidStartOperationsBarrier() {
+        guard delegate != nil else { return }
+
+        jobQueue.addBarrierBlock1 { [weak self] in
+            guard let self else { return }
+            self.notifyDelegateDidStartOperations()
+        }
     }
 
     func cancelCurrentModeAndResetIfNeeded() {
@@ -307,19 +325,48 @@ private extension JobQueueManager {
             let errorCollection = DataBrokerProtectionJobsErrorCollection(oneTimeError: BrokerProfileJobQueueError.interrupted, operationErrors: operationErrorsForCurrentOperations())
             errorHandler?(errorCollection)
             resetMode()
-            delegate?.queueManagerDidFinishOperations(self)
+            addDelegateDidFinishOperationsBarrier()
             completion?()
         default:
             break
         }
     }
 
+    func addDelegateDidFinishOperationsBarrier() {
+        guard delegate != nil else { return }
+
+        jobQueue.addBarrierBlock1 { [weak self] in
+            guard let self else { return }
+            self.notifyDelegateDidFinishOperations()
+        }
+    }
+
+    func notifyDelegateDidStartOperations() {
+        guard !isDelegateRunActive else { return }
+        isDelegateRunActive = true
+        delegate?.queueManagerDidStartOperations(self)
+    }
+
+    func notifyDelegateDidFinishOperations() {
+        guard isDelegateRunActive else { return }
+        isDelegateRunActive = false
+        delegate?.queueManagerDidFinishOperations(self)
+    }
+
+    func beginRun() -> Int {
+        nextRunID += 1
+        activeRunID = nextRunID
+        return nextRunID
+    }
+
     func resetMode() {
         mode = .idle
+        activeRunID = nil
         operationErrorsLock.withLock { operationErrors = [] }
     }
 
     func addJobs(for jobType: JobType,
+                 runID: Int,
                  priorityDate: Date? = nil,
                  showWebView: Bool,
                  isAuthenticatedUser: Bool,
@@ -345,18 +392,17 @@ private extension JobQueueManager {
             Logger.dataBrokerProtection.error("DataBrokerProtectionProcessor error: addOperations, error: \(error.localizedDescription, privacy: .public)")
             errorHandler?(DataBrokerProtectionJobsErrorCollection(oneTimeError: error))
             resetMode()
-            delegate?.queueManagerDidFinishOperations(self)
+            addDelegateDidFinishOperationsBarrier()
             completion?()
             return
         }
 
         jobQueue.addBarrierBlock1 { [weak self] in
-            let errorCollection = DataBrokerProtectionJobsErrorCollection(oneTimeError: nil, operationErrors: self?.operationErrorsForCurrentOperations())
+            guard let self, self.activeRunID == runID else { return }
+            let errorCollection = DataBrokerProtectionJobsErrorCollection(oneTimeError: nil, operationErrors: self.operationErrorsForCurrentOperations())
             errorHandler?(errorCollection)
-            self?.resetMode()
-            if let self {
-                self.delegate?.queueManagerDidFinishOperations(self)
-            }
+            self.resetMode()
+            self.notifyDelegateDidFinishOperations()
             completion?()
         }
     }

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -2035,6 +2035,11 @@ public final class MockEmailConfirmationJobProvider: EmailConfirmationJobProvidi
 }
 
 public final class MockBrokerProfileJobQueue: BrokerProfileJobQueue {
+    private enum QueueEntry {
+        case operation(Operation)
+        case barrier(@Sendable () -> Void)
+    }
+
     public var maxConcurrentOperationCount = 1
 
     public var operations: [Operation] = []
@@ -2046,7 +2051,7 @@ public final class MockBrokerProfileJobQueue: BrokerProfileJobQueue {
     public private(set) var didCallAddCount = 0
     public private(set) var didCallAddBarrierBlockCount = 0
 
-    private var barrierBlock: (@Sendable () -> Void)?
+    private var entries: [QueueEntry] = []
 
     public init() { }
 
@@ -2058,28 +2063,43 @@ public final class MockBrokerProfileJobQueue: BrokerProfileJobQueue {
     public func addOperation(_ op: Operation) {
         didCallAddCount += 1
         self.operations.append(op)
+        entries.append(.operation(op))
     }
 
     public func addBarrierBlock1(_ barrier: @escaping @Sendable () -> Void) {
         didCallAddBarrierBlockCount += 1
-        self.barrierBlock = barrier
+        entries.append(.barrier(barrier))
     }
 
     public func completeAllOperations() {
-        operations.forEach { $0.start() }
-        operations.removeAll()
-        barrierBlock?()
+        while !entries.isEmpty {
+            switch entries.removeFirst() {
+            case .operation(let operation):
+                operation.start()
+                operations.removeAll { $0 === operation }
+            case .barrier(let barrier):
+                barrier()
+            }
+        }
+    }
+
+    public func completeNextBarrierBlock() {
+        guard case .barrier(let barrier)? = entries.first else { return }
+        entries.removeFirst()
+        barrier()
     }
 
     public func completeOperationsUpTo(index: Int) {
         guard index < operationCount else { return }
 
-        (0..<index).forEach {
-            operations[$0].start()
-        }
-
-        (0..<index).forEach {
-            operations.remove(at: $0)
+        let completedOperations = Array(operations.prefix(index))
+        completedOperations.forEach { operation in
+            operation.start()
+            operations.removeAll { $0 === operation }
+            entries.removeAll { entry in
+                guard case .operation(let queuedOperation) = entry else { return false }
+                return queuedOperation === operation
+            }
         }
     }
 }

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/JobQueueManagerTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/JobQueueManagerTests.swift
@@ -141,6 +141,80 @@ final class JobQueueManagerTests: XCTestCase {
         XCTAssertEqual(mockOperationsCreator.isAuthenticatedUser, false)
     }
 
+    func testWhenOperationsComplete_thenDelegateReceivesOneRunLifecycle() {
+        sut = JobQueueManager(jobQueue: mockQueue,
+                              jobProvider: mockOperationsCreator,
+                              emailConfirmationJobProvider: mockEmailConfirmationJobProvider,
+                              mismatchCalculator: mockMismatchCalculator,
+                              pixelHandler: mockPixelHandler)
+        sut.delegate = mockQueueDelegate
+        mockOperationsCreator.operationCollections = [
+            MockBrokerProfileJob(id: 1, jobType: .manualScan, statusReportingDelegate: sut)
+        ]
+
+        sut.startImmediateScanOperationsIfPermitted(showWebView: false,
+                                                    isAuthenticatedUser: true,
+                                                    jobDependencies: mockDependencies,
+                                                    errorHandler: nil,
+                                                    completion: nil)
+
+        XCTAssertEqual(mockQueueDelegate.events, [])
+
+        mockQueue.completeAllOperations()
+
+        XCTAssertEqual(mockQueueDelegate.events, [.willEnqueue, .didStart, .didFinish])
+    }
+
+    func testWhenActiveRunIsReplaced_thenDelegateFinishesOldRunBeforeStartingNewRun() {
+        sut = JobQueueManager(jobQueue: mockQueue,
+                              jobProvider: mockOperationsCreator,
+                              emailConfirmationJobProvider: mockEmailConfirmationJobProvider,
+                              mismatchCalculator: mockMismatchCalculator,
+                              pixelHandler: mockPixelHandler)
+        sut.delegate = mockQueueDelegate
+        mockOperationsCreator.operationCollections = [
+            MockBrokerProfileJob(id: 1, jobType: .manualScan, statusReportingDelegate: sut)
+        ]
+        sut.startImmediateScanOperationsIfPermitted(showWebView: false,
+                                                    isAuthenticatedUser: true,
+                                                    jobDependencies: mockDependencies,
+                                                    errorHandler: nil,
+                                                    completion: nil)
+        mockQueue.completeNextBarrierBlock()
+        mockQueue.completeNextBarrierBlock()
+
+        sut.startImmediateScanOperationsIfPermitted(showWebView: false,
+                                                    isAuthenticatedUser: true,
+                                                    jobDependencies: mockDependencies,
+                                                    errorHandler: nil,
+                                                    completion: nil)
+        mockQueue.completeAllOperations()
+
+        XCTAssertEqual(mockQueueDelegate.events, [
+            .willEnqueue, .didStart, .didFinish,
+            .willEnqueue, .didStart, .didFinish
+        ])
+    }
+
+    func testWhenCreatingJobsFails_thenDelegateLifecycleRemainsBalanced() {
+        sut = JobQueueManager(jobQueue: mockQueue,
+                              jobProvider: mockOperationsCreator,
+                              emailConfirmationJobProvider: mockEmailConfirmationJobProvider,
+                              mismatchCalculator: mockMismatchCalculator,
+                              pixelHandler: mockPixelHandler)
+        sut.delegate = mockQueueDelegate
+        mockOperationsCreator.shouldError = true
+
+        sut.startImmediateScanOperationsIfPermitted(showWebView: false,
+                                                    isAuthenticatedUser: true,
+                                                    jobDependencies: mockDependencies,
+                                                    errorHandler: nil,
+                                                    completion: nil)
+        mockQueue.completeAllOperations()
+
+        XCTAssertEqual(mockQueueDelegate.events, [.willEnqueue, .didStart, .didFinish])
+    }
+
     func testWhenStartImmediateScan_andScanCompletesWithErrors_thenCompletionIsCalledWithErrors() async throws {
         // Given
         sut = JobQueueManager(jobQueue: mockQueue,
@@ -909,11 +983,27 @@ final class JobQueueManagerTests: XCTestCase {
 }
 
 private final class MockJobQueueManagerDelegate: JobQueueManagerDelegate {
+    enum Event: Equatable {
+        case willEnqueue
+        case didStart
+        case didFinish
+    }
+
     var didEnqueueOperations = false
     var completedIdentifiers: [CompletedJobIdentifier?] = []
+    var events: [Event] = []
 
     func queueManagerWillEnqueueOperations(_ queueManager: any JobQueueManaging) {
         didEnqueueOperations = true
+        events.append(.willEnqueue)
+    }
+
+    func queueManagerDidStartOperations(_ queueManager: any JobQueueManaging) {
+        events.append(.didStart)
+    }
+
+    func queueManagerDidFinishOperations(_ queueManager: any JobQueueManaging) {
+        events.append(.didFinish)
     }
 
     func queueManagerDidCompleteIndividualJob(_ queueManager: any JobQueueManaging, identifier: CompletedJobIdentifier?) {

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/JobQueueManagerTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/JobQueueManagerTests.swift
@@ -158,11 +158,11 @@ final class JobQueueManagerTests: XCTestCase {
                                                     errorHandler: nil,
                                                     completion: nil)
 
-        XCTAssertEqual(mockQueueDelegate.events, [])
+        XCTAssertEqual(mockQueueDelegate.events, [.didStart])
 
         mockQueue.completeAllOperations()
 
-        XCTAssertEqual(mockQueueDelegate.events, [.willEnqueue, .didStart, .didFinish])
+        XCTAssertEqual(mockQueueDelegate.events, [.didStart, .willEnqueue, .didFinish])
     }
 
     func testWhenActiveRunIsReplaced_thenDelegateFinishesOldRunBeforeStartingNewRun() {
@@ -181,18 +181,22 @@ final class JobQueueManagerTests: XCTestCase {
                                                     errorHandler: nil,
                                                     completion: nil)
         mockQueue.completeNextBarrierBlock()
-        mockQueue.completeNextBarrierBlock()
 
         sut.startImmediateScanOperationsIfPermitted(showWebView: false,
                                                     isAuthenticatedUser: true,
                                                     jobDependencies: mockDependencies,
                                                     errorHandler: nil,
                                                     completion: nil)
+
+        XCTAssertEqual(mockQueueDelegate.events, [
+            .didStart, .willEnqueue, .didFinish, .didStart
+        ])
+
         mockQueue.completeAllOperations()
 
         XCTAssertEqual(mockQueueDelegate.events, [
-            .willEnqueue, .didStart, .didFinish,
-            .willEnqueue, .didStart, .didFinish
+            .didStart, .willEnqueue, .didFinish, .didStart,
+            .willEnqueue, .didFinish
         ])
     }
 
@@ -210,9 +214,7 @@ final class JobQueueManagerTests: XCTestCase {
                                                     jobDependencies: mockDependencies,
                                                     errorHandler: nil,
                                                     completion: nil)
-        mockQueue.completeAllOperations()
-
-        XCTAssertEqual(mockQueueDelegate.events, [.willEnqueue, .didStart, .didFinish])
+        XCTAssertEqual(mockQueueDelegate.events, [.didStart, .didFinish])
     }
 
     func testWhenStartImmediateScan_andScanCompletesWithErrors_thenCompletionIsCalledWithErrors() async throws {

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/BackgroundAgent/UsageMonitor/CPUUsageMonitor.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/BackgroundAgent/UsageMonitor/CPUUsageMonitor.swift
@@ -38,7 +38,7 @@ import Foundation
 struct CPUUsageMonitor {
 
     private typealias Identity = CPUUsageSample.ProcessIdentity
-    private typealias ProcessCPUTime = CPUUsageSample.ProcessCPUTime
+    typealias ProcessCPUTime = CPUUsageSample.ProcessCPUTime
 
     /// Mach timers count ticks rather than nanoseconds. `numer / denom` converts one tick to nanoseconds.
     private static let timebaseInfo: mach_timebase_info_data_t = {
@@ -70,20 +70,27 @@ struct CPUUsageMonitor {
     // Keep counters for exited processes so their recorded CPU remains in the run total.
     private var webProcesses: [Identity: CPUCounter]
     private let runStartAbsoluteTime: UInt64
+    private let sampleProvider: (Set<pid_t>) -> CPUUsageSample
+    private let secondsFromMachTime: (ProcessCPUTime) -> TimeInterval
     private let startUptime: TimeInterval
     private var latestUptime: TimeInterval
 
-    init(webProcessPIDs: Set<pid_t>, runStartAbsoluteTime: UInt64) {
-        let sample = CPUUsageSampler().takeSample(webProcessPIDs: webProcessPIDs)
+    init(webProcessPIDs: Set<pid_t>,
+         runStartAbsoluteTime: UInt64,
+         sampleProvider: @escaping (Set<pid_t>) -> CPUUsageSample = { CPUUsageSampler().takeSample(webProcessPIDs: $0) },
+         secondsFromMachTime: @escaping (ProcessCPUTime) -> TimeInterval = Self.seconds(fromMachTime:)) {
+        let sample = sampleProvider(webProcessPIDs)
         agent = CPUCounter(baseline: sample.agent)
         webProcesses = sample.webProcesses.mapValues { CPUCounter(baseline: $0) }
         self.runStartAbsoluteTime = runStartAbsoluteTime
+        self.sampleProvider = sampleProvider
+        self.secondsFromMachTime = secondsFromMachTime
         startUptime = sample.uptime
         latestUptime = sample.uptime
     }
 
     mutating func recordSample(webProcessPIDs: Set<pid_t>) {
-        let sample = CPUUsageSampler().takeSample(webProcessPIDs: webProcessPIDs)
+        let sample = sampleProvider(webProcessPIDs)
         updateAgentCPUTime(with: sample.agent)
         updateWebProcessCPUTime(with: sample.webProcesses)
         latestUptime = sample.uptime
@@ -93,9 +100,9 @@ struct CPUUsageMonitor {
 
     func makeReport() -> ResourceSnapshot.CPUUsage {
         let elapsedTime = max(0, latestUptime - startUptime)
-        let agentTime = Self.seconds(fromMachTime: agent.total)
+        let agentTime = secondsFromMachTime(agent.total)
         let webProcessesCPUTime = webProcesses.values.reduce(ProcessCPUTime(0)) { $0 + $1.total }
-        let webProcessesTime = Self.seconds(fromMachTime: webProcessesCPUTime)
+        let webProcessesTime = secondsFromMachTime(webProcessesCPUTime)
         let totalTime = agentTime + webProcessesTime
         // CPU seconds divided by elapsed run time is average usage of one core. Concurrent work can exceed 100%.
         let averagePercent = elapsedTime > 0 ? totalTime / elapsedTime * 100 : 0

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/BackgroundAgent/UsageMonitor/MemoryUsageMonitor.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/BackgroundAgent/UsageMonitor/MemoryUsageMonitor.swift
@@ -38,20 +38,23 @@ struct MemoryUsageMonitor {
     private var current: MemoryUsageSample
     private var peak: PeakUsage
     private var hadCriticalPressure = false
+    private let sampleProvider: (Set<pid_t>?) -> MemoryUsageSample
 
     /// Immediately takes the first memory reading for the run.
-    init(webProcessPIDs: Set<pid_t>?) {
-        let sample = MemoryUsageSampler().takeSample(webProcessPIDs: webProcessPIDs)
+    init(webProcessPIDs: Set<pid_t>?,
+         sampleProvider: @escaping (Set<pid_t>?) -> MemoryUsageSample = { MemoryUsageSampler().takeSample(webProcessPIDs: $0) }) {
+        let sample = sampleProvider(webProcessPIDs)
         current = sample
         peak = PeakUsage(
             agentFootprint: sample.agentFootprint,
             webProcessesFootprint: sample.webProcessesFootprint
         )
+        self.sampleProvider = sampleProvider
     }
 
     /// Replaces the current reading and updates the highest values seen in this run.
     mutating func recordSample(webProcessPIDs: Set<pid_t>?) {
-        let sample = MemoryUsageSampler().takeSample(webProcessPIDs: webProcessPIDs)
+        let sample = sampleProvider(webProcessPIDs)
         current = sample
         peak.record(sample)
     }

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/BackgroundAgent/UsageMonitor/ResourceUsagePixelReporter.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/BackgroundAgent/UsageMonitor/ResourceUsagePixelReporter.swift
@@ -35,20 +35,24 @@ final class ResourceUsagePixelReporter {
         isOnBattery: Bool?,
         thermalState: ProcessInfo.ThermalState
     ) {
-        pixelHandler.fire(
-            .resourceUsageRun(
-                cpuTimeSecondsBucket: Self.durationBucket(snapshot.cpu.totalTime),
-                elapsedSecondsBucket: Self.durationBucket(snapshot.cpu.elapsedTime),
-                coreUtilizationPercentBucket: Self.utilizationBucket(snapshot.cpu.averagePercent),
-                agentPeakFootprintMBBucket: Self.memoryBucket(snapshot.memory.agent.peakFootprintBytes),
-                webPeakFootprintMBBucket: Self.memoryBucket(
-                    snapshot.memory.webProcesses.peakFootprintBytes
-                ),
-                hadCriticalPressure: snapshot.memory.hadCriticalPressure,
-                isOnBattery: isOnBattery,
-                thermalState: Self.thermalStateName(thermalState),
-                architecture: Self.currentArchitecture
-            )
+        pixelHandler.fire(makeRunEvent(snapshot, isOnBattery: isOnBattery, thermalState: thermalState))
+    }
+
+    func makeRunEvent(
+        _ snapshot: ResourceSnapshot,
+        isOnBattery: Bool?,
+        thermalState: ProcessInfo.ThermalState
+    ) -> DataBrokerProtectionMacOSPixels {
+        .resourceUsageRun(
+            cpuTimeSecondsBucket: Self.durationBucket(snapshot.cpu.totalTime),
+            elapsedSecondsBucket: Self.durationBucket(snapshot.cpu.elapsedTime),
+            coreUtilizationPercentBucket: Self.utilizationBucket(snapshot.cpu.averagePercent),
+            agentPeakFootprintMBBucket: Self.memoryBucket(snapshot.memory.agent.peakFootprintBytes),
+            webPeakFootprintMBBucket: Self.memoryBucket(snapshot.memory.webProcesses.peakFootprintBytes),
+            hadCriticalPressure: snapshot.memory.hadCriticalPressure,
+            isOnBattery: isOnBattery,
+            thermalState: Self.thermalStateName(thermalState),
+            architecture: Self.currentArchitecture
         )
     }
 

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/CPUUsageMonitorTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/CPUUsageMonitorTests.swift
@@ -3,6 +3,18 @@
 //
 //  Copyright © 2026 DuckDuckGo. All rights reserved.
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
 
 import XCTest
 @testable import DataBrokerProtection_macOS

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/CPUUsageMonitorTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/CPUUsageMonitorTests.swift
@@ -1,0 +1,46 @@
+//
+//  CPUUsageMonitorTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+
+import XCTest
+@testable import DataBrokerProtection_macOS
+
+final class CPUUsageMonitorTests: XCTestCase {
+
+    func testReportAccountsForProcessLifecyclesWithoutLosingRecordedCPU() {
+        let existing = CPUUsageSample.ProcessIdentity(pid: 1, startAbsoluteTime: 50)
+        let createdDuringRun = CPUUsageSample.ProcessIdentity(pid: 2, startAbsoluteTime: 150)
+        let discoveredLate = CPUUsageSample.ProcessIdentity(pid: 3, startAbsoluteTime: 50)
+        let reusedPID = CPUUsageSample.ProcessIdentity(pid: 1, startAbsoluteTime: 160)
+        var samples = [
+            CPUUsageSample(agent: 100, webProcesses: [existing: 50], uptime: 10),
+            CPUUsageSample(
+                agent: 140,
+                webProcesses: [existing: 70, createdDuringRun: 20, discoveredLate: 40],
+                uptime: 20
+            ),
+            CPUUsageSample(
+                agent: nil,
+                webProcesses: [createdDuringRun: 35, discoveredLate: 55, reusedPID: 10],
+                uptime: 30
+            )
+        ].makeIterator()
+        var monitor = CPUUsageMonitor(
+            webProcessPIDs: [existing.pid],
+            runStartAbsoluteTime: 100,
+            sampleProvider: { _ in samples.next()! },
+            secondsFromMachTime: { TimeInterval($0) }
+        )
+
+        monitor.recordSample(webProcessPIDs: [existing.pid, createdDuringRun.pid, discoveredLate.pid])
+        monitor.recordSample(webProcessPIDs: [createdDuringRun.pid, discoveredLate.pid, reusedPID.pid])
+        let report = monitor.makeReport()
+
+        XCTAssertEqual(report.elapsedTime, 20)
+        XCTAssertEqual(report.agentTime, 40)
+        XCTAssertEqual(report.webProcessesTime, 80)
+        XCTAssertEqual(report.averagePercent, 600)
+    }
+}

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DataBrokerProtectionAgentManagerTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/DataBrokerProtectionAgentManagerTests.swift
@@ -146,6 +146,37 @@ final class DataBrokerProtectionAgentManagerTests: XCTestCase {
         XCTAssertTrue(startScheduledScansCalled)
     }
 
+    func testQueueLifecycleForwardsToResourceMonitor() {
+        let resourceMonitor = MockResourceMonitor()
+        sut = DataBrokerProtectionAgentManager(
+            eventsHandler: mockEventsHandler,
+            activityScheduler: mockActivityScheduler,
+            ipcServer: mockIPCServer,
+            queueManager: mockQueueManager,
+            dataManager: mockDataManager,
+            emailConfirmationDataService: mockEmailConfirmationDataService,
+            jobDependencies: mockDependencies,
+            sharedPixelsHandler: mockSharedPixelsHandler,
+            pixelHandler: mockPixelHandler,
+            engagementPixelRepository: mockEngagementPixelRepository,
+            eventPixelRepository: mockEventPixelRepository,
+            statsPixelRepository: mockStatsPixelRepository,
+            agentStopper: mockAgentStopper,
+            configurationManager: mockConfigurationManager,
+            brokerUpdater: mockBrokerUpdater,
+            privacyConfigurationManager: mockPrivacyConfigurationManager,
+            authenticationManager: mockAuthenticationManager,
+            freemiumDBPUserStateManager: mockFreemiumDBPUserStateManager,
+            resourceMonitor: resourceMonitor
+        )
+
+        sut.queueManagerDidStartOperations(mockQueueManager)
+        sut.queueManagerDidFinishOperations(mockQueueManager)
+
+        XCTAssertEqual(resourceMonitor.startCallCount, 1)
+        XCTAssertEqual(resourceMonitor.stopCallCount, 1)
+    }
+
     func testWhenAgentStart_andProfileExists_andUserIsFreemium_thenActivityIsScheduled_andScheduledScanOperationsRun() async throws {
         // Given
         sut = DataBrokerProtectionAgentManager(
@@ -818,5 +849,18 @@ final class MockEmailConfirmationDataService: EmailConfirmationDataServiceProvid
                       extract: [String],
                       shouldRunNextStep: @escaping () -> Bool) async throws -> ExtractedEmailData {
         [:]
+    }
+}
+
+private final class MockResourceMonitor: ResourceMonitoring {
+    private(set) var startCallCount = 0
+    private(set) var stopCallCount = 0
+
+    func start() {
+        startCallCount += 1
+    }
+
+    func stop() {
+        stopCallCount += 1
     }
 }

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/MemoryUsageMonitorTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/MemoryUsageMonitorTests.swift
@@ -3,6 +3,18 @@
 //
 //  Copyright © 2026 DuckDuckGo. All rights reserved.
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
 
 import XCTest
 @testable import DataBrokerProtection_macOS

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/MemoryUsageMonitorTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/MemoryUsageMonitorTests.swift
@@ -1,0 +1,39 @@
+//
+//  MemoryUsageMonitorTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+
+import XCTest
+@testable import DataBrokerProtection_macOS
+
+final class MemoryUsageMonitorTests: XCTestCase {
+
+    func testReportPreservesPeaksAcrossUnavailableAndLowerSamples() {
+        var samples = [
+            MemoryUsageSample(agentFootprint: 100, webProcessesFootprint: 200, webProcessCount: 2),
+            MemoryUsageSample(agentFootprint: 150, webProcessesFootprint: nil, webProcessCount: 2),
+            MemoryUsageSample(agentFootprint: 120, webProcessesFootprint: 180, webProcessCount: 1)
+        ].makeIterator()
+        var monitor = MemoryUsageMonitor(
+            webProcessPIDs: [1, 2],
+            sampleProvider: { _ in samples.next()! }
+        )
+
+        monitor.recordSample(webProcessPIDs: [1, 2])
+        XCTAssertNil(monitor.makeReport().webProcesses.footprintBytes)
+        XCTAssertEqual(monitor.makeReport().webProcesses.peakFootprintBytes, 200)
+
+        monitor.recordSample(webProcessPIDs: [1])
+        XCTAssertTrue(monitor.recordCriticalPressure())
+        XCTAssertFalse(monitor.recordCriticalPressure())
+        let report = monitor.makeReport()
+
+        XCTAssertEqual(report.agent.footprintBytes, 120)
+        XCTAssertEqual(report.agent.peakFootprintBytes, 150)
+        XCTAssertEqual(report.webProcesses.footprintBytes, 180)
+        XCTAssertEqual(report.webProcesses.peakFootprintBytes, 200)
+        XCTAssertEqual(report.webProcesses.processCount, 1)
+        XCTAssertTrue(report.hadCriticalPressure)
+    }
+}

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/ResourceUsagePixelReporterTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/ResourceUsagePixelReporterTests.swift
@@ -3,6 +3,18 @@
 //
 //  Copyright © 2026 DuckDuckGo. All rights reserved.
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
 
 import XCTest
 @testable import DataBrokerProtection_macOS

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/ResourceUsagePixelReporterTests.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Tests/DataBrokerProtection-macOSTests/ResourceUsagePixelReporterTests.swift
@@ -1,0 +1,104 @@
+//
+//  ResourceUsagePixelReporterTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+
+import XCTest
+@testable import DataBrokerProtection_macOS
+
+final class ResourceUsagePixelReporterTests: XCTestCase {
+
+    private let reporter = ResourceUsagePixelReporter()
+
+    func testRunEventContainsTheCompleteBucketedContract() {
+        let event = reporter.makeRunEvent(
+            makeSnapshot(
+                cpuTime: 11,
+                elapsedTime: 19,
+                averagePercent: 100,
+                agentPeakBytes: 8 * 1_048_576,
+                webPeakBytes: nil,
+                hadCriticalPressure: true
+            ),
+            isOnBattery: nil,
+            thermalState: .serious
+        )
+
+        XCTAssertEqual(event.parameters, [
+            "cpu_time_seconds_bucket": "10",
+            "elapsed_seconds_bucket": "10",
+            "core_utilization_percent_bucket": "100",
+            "agent_peak_footprint_mb_bucket": "8",
+            "web_peak_footprint_mb_bucket": "unknown",
+            "had_critical_pressure": "true",
+            "on_battery": "unknown",
+            "thermal_state": "serious",
+            "architecture": expectedArchitecture
+        ])
+    }
+
+    func testBucketBoundariesMatchThePixelDefinition() {
+        let cases: [(value: Double, duration: String, utilization: String, memory: String)] = [
+            (0, "0", "0", "0"),
+            (5, "5", "3", "0"),
+            (8, "5", "6", "8"),
+            (16, "10", "12", "16"),
+            (25, "20", "25", "16"),
+            (50, "40", "50", "32"),
+            (100, "80", "100", "64"),
+            (200, "160", "200", "128"),
+            (400, "320", "400", "256"),
+            (65_536, "40960", "400", "65536")
+        ]
+
+        for testCase in cases {
+            let parameters = reporter.makeRunEvent(
+                makeSnapshot(
+                    cpuTime: testCase.value,
+                    elapsedTime: testCase.value,
+                    averagePercent: testCase.value,
+                    agentPeakBytes: UInt64(testCase.value * 1_048_576),
+                    webPeakBytes: 0,
+                    hadCriticalPressure: false
+                ),
+                isOnBattery: false,
+                thermalState: .nominal
+            ).parameters
+
+            XCTAssertEqual(parameters?["cpu_time_seconds_bucket"], testCase.duration, "value: \(testCase.value)")
+            XCTAssertEqual(parameters?["elapsed_seconds_bucket"], testCase.duration, "value: \(testCase.value)")
+            XCTAssertEqual(parameters?["core_utilization_percent_bucket"], testCase.utilization, "value: \(testCase.value)")
+            XCTAssertEqual(parameters?["agent_peak_footprint_mb_bucket"], testCase.memory, "value: \(testCase.value)")
+        }
+    }
+
+    private func makeSnapshot(cpuTime: TimeInterval,
+                              elapsedTime: TimeInterval,
+                              averagePercent: Double,
+                              agentPeakBytes: UInt64,
+                              webPeakBytes: UInt64?,
+                              hadCriticalPressure: Bool) -> ResourceSnapshot {
+        ResourceSnapshot(
+            cpu: .init(
+                elapsedTime: elapsedTime,
+                agentTime: cpuTime,
+                webProcessesTime: 0,
+                averagePercent: averagePercent
+            ),
+            memory: .init(
+                agent: .init(footprintBytes: agentPeakBytes, peakFootprintBytes: agentPeakBytes),
+                webProcesses: .init(footprintBytes: webPeakBytes, peakFootprintBytes: webPeakBytes, processCount: nil),
+                hadCriticalPressure: hadCriticalPressure
+            )
+        )
+    }
+
+    private var expectedArchitecture: String {
+        #if arch(arm64)
+        "ARM"
+        #else
+        "Intel"
+        #endif
+    }
+}


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217689816748940
Tech Design URL:
CC:

### Description

Adds unit tests to cover the new PIR performance monitoring code.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. CI passes
2.

### Impact

Low

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches JobQueueManager completion/delegate lifecycle, which drives resource monitoring start/stop. Incorrect run-ID handling could still unbalance start/finish events.
> 
> **Overview**
> Prevents a replaced PIR job-queue run from finishing (or resetting) when a stale barrier from the previous run completes. Each start now gets an `activeRunID`; the completion barrier no-ops if that ID no longer matches.
> 
> CPU/memory monitors and the resource pixel reporter now take injectable sample/time converters so tests can drive them without live process sampling. Coverage includes process create/exit/PID reuse, peak memory across missing samples, bucketed pixel parameters, and balanced queue start/finish events when a run is replaced or job creation fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de0040185c105e281bb37b730b5af61c34c3b98e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->