### PR TITLE
Focus Duck.ai sidebar input when it's already open

### DIFF
--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatCoordinator.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatCoordinator.swift
@@ -296,7 +296,10 @@ final class AIChatCoordinator: AIChatCoordinating {
             focusFloatingWindow(for: currentTabID)
             return
         }
-        guard !isSidebarOpen(for: currentTabID) else { return }
+        guard !isSidebarOpen(for: currentTabID) else {
+            sessionStore.sessions[currentTabID]?.chatViewController?.focusChatWebView()
+            return
+        }
         showSidebar(for: currentTabID, animated: true)
     }
 

--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatViewController.swift
@@ -122,6 +122,13 @@ final class AIChatViewController: NSViewController {
         aiTab.aiChat?.submitAIChatSelectionContext(selection)
     }
 
+    /// Hands keyboard focus to the chat web view so the user can type right away.
+    /// ponytail: relies on WebKit restoring DOM focus to the last focused element (the input);
+    /// if that proves flaky, add a native→FE "focus input" message.
+    func focusChatWebView() {
+        view.window?.makeFirstResponder(aiTab.webView)
+    }
+
     public func setAIChatRestorationData(_ restorationData: AIChatRestorationData?) {
         aiTab.aiChat?.setAIChatRestorationData(restorationData)
     }

--- a/macOS/DuckDuckGo/AIChat/Sidebar/AIChatViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/Sidebar/AIChatViewController.swift
@@ -122,9 +122,6 @@ final class AIChatViewController: NSViewController {
         aiTab.aiChat?.submitAIChatSelectionContext(selection)
     }
 
-    /// Hands keyboard focus to the chat web view so the user can type right away.
-    /// ponytail: relies on WebKit restoring DOM focus to the last focused element (the input);
-    /// if that proves flaky, add a native→FE "focus input" message.
     func focusChatWebView() {
         view.window?.makeFirstResponder(aiTab.webView)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1217687138484964?focus=true
Tech Design URL:
CC:

### Description

Fixes keyboard focus when an action reveals a Duck.ai sidebar that's already open: `revealChat()` used to early-return, leaving focus on the page. It now makes the chat web view first responder, so "Ask Duck.ai about selected content" (and every other `revealChat()` caller) lands the caret in the input.

### Testing Steps
1. Open the Duck.ai sidebar on a web page.
2. Select text on the page, right-click → "Ask Duck.ai about selected content".
3. Type without clicking — text goes to the Duck.ai input.

### Impact
Low. Only changes first responder on an already-open sidebar.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small first-responder change for an already-open sidebar; no auth, data, or architecture impact. Focus restoration depends on WebKit DOM behavior and may be flaky.
> 
> **Overview**
> When `revealChat()` runs and the Duck.ai sidebar is already open, it now focuses the chat web view instead of returning immediately and leaving keyboard focus on the page.
> 
> This lets actions like “Ask Duck.ai about selected content” put the caret in the input so the user can type without clicking. Focus relies on WebKit restoring DOM focus to the last focused element.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21f529754954462badfada80be329a0475df71c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->