### PR TITLE
Control Bitrise Build Cache with a variable

### DIFF
--- a/.github/actions/bitrise-build-cache/action.yml
+++ b/.github/actions/bitrise-build-cache/action.yml
@@ -2,6 +2,9 @@ name: 'Setup Bitrise Build Cache'
 description: 'Sets up Bitrise build cache'
 
 inputs:
+  enabled:
+    description: 'Whether to enable caching'
+    required: true
   token:
     description: 'Bitrise Build Cache API Token'
     required: true
@@ -12,7 +15,17 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - id: check-conditions
+      shell: bash
+      run: |
+        if [[ "${{ runner.environment }}" != "self-hosted" ]]; then
+          echo "Not a self-hosted runner, Bitrise Build Cache won't be enabled"
+        fi
+        if [[ "${{ inputs.enabled }}" != "1" ]]; then
+          echo "::warning::Bitrise Build Cache is disabled. Pass 'enabled: 1' to enabled it."
+        fi
     - id: bitrise-build-cache
+      if: runner.environment == 'self-hosted' && inputs.enabled == '1'
       shell: bash
       env:
         BITRISE_BUILD_CACHE_AUTH_TOKEN: ${{ inputs.token }}

--- a/.github/actions/bitrise-build-cache/action.yml
+++ b/.github/actions/bitrise-build-cache/action.yml
@@ -20,6 +20,7 @@ runs:
       run: |
         if [[ "${{ runner.environment }}" != "self-hosted" ]]; then
           echo "Not a self-hosted runner, Bitrise Build Cache won't be enabled"
+          exit 0
         fi
         if [[ "${{ inputs.enabled }}" != "1" ]]; then
           echo "::warning::Bitrise Build Cache is disabled. Pass 'enabled: 1' to enabled it."

--- a/.github/actions/bitrise-build-cache/action.yml
+++ b/.github/actions/bitrise-build-cache/action.yml
@@ -20,9 +20,7 @@ runs:
       run: |
         if [[ "${{ runner.environment }}" != "self-hosted" ]]; then
           echo "Not a self-hosted runner, Bitrise Build Cache won't be enabled"
-          exit 0
-        fi
-        if [[ "${{ inputs.enabled }}" != "1" ]]; then
+        elif [[ "${{ inputs.enabled }}" != "1" ]]; then
           echo "::warning::Bitrise Build Cache is disabled. Pass 'enabled: 1' to enabled it."
         fi
     - id: bitrise-build-cache

--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -100,7 +100,7 @@ jobs:
         uses: ./.github/actions/select-xcode-version
 
       - name: Setup Bitrise Build Cache
-        if: runner.environment == 'self-hosted'
+        if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
         uses: ./.github/actions/bitrise-build-cache
         with:
           token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
@@ -309,7 +309,7 @@ jobs:
           exit 1
 
       - name: Setup Bitrise Build Cache
-        if: runner.environment == 'self-hosted'
+        if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
         uses: ./.github/actions/bitrise-build-cache
         with:
           token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}

--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -100,9 +100,9 @@ jobs:
         uses: ./.github/actions/select-xcode-version
 
       - name: Setup Bitrise Build Cache
-        if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
         uses: ./.github/actions/bitrise-build-cache
         with:
+          enabled: ${{ vars.BITRISE_BUILD_CACHE_ENABLED }}
           token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
           workspace-id: ${{ secrets.BITRISE_BUILD_CACHE_WORKSPACE_ID }}
 
@@ -309,9 +309,9 @@ jobs:
           exit 1
 
       - name: Setup Bitrise Build Cache
-        if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
         uses: ./.github/actions/bitrise-build-cache
         with:
+          enabled: ${{ vars.BITRISE_BUILD_CACHE_ENABLED }}
           token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
           workspace-id: ${{ secrets.BITRISE_BUILD_CACHE_WORKSPACE_ID }}
 

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -100,7 +100,7 @@ jobs:
         uses: ./.github/actions/select-xcode-version
 
       - name: Setup Bitrise Build Cache
-        if: runner.environment == 'self-hosted'
+        if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
         uses: ./.github/actions/bitrise-build-cache
         with:
           token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
@@ -291,7 +291,7 @@ jobs:
           exit 1
 
       - name: Setup Bitrise Build Cache
-        if: runner.environment == 'self-hosted'
+        if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
         uses: ./.github/actions/bitrise-build-cache
         with:
           token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}

--- a/.github/workflows/dbp_pr_checks.yml
+++ b/.github/workflows/dbp_pr_checks.yml
@@ -100,9 +100,9 @@ jobs:
         uses: ./.github/actions/select-xcode-version
 
       - name: Setup Bitrise Build Cache
-        if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
         uses: ./.github/actions/bitrise-build-cache
         with:
+          enabled: ${{ vars.BITRISE_BUILD_CACHE_ENABLED }}
           token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
           workspace-id: ${{ secrets.BITRISE_BUILD_CACHE_WORKSPACE_ID }}
 
@@ -291,9 +291,9 @@ jobs:
           exit 1
 
       - name: Setup Bitrise Build Cache
-        if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
         uses: ./.github/actions/bitrise-build-cache
         with:
+          enabled: ${{ vars.BITRISE_BUILD_CACHE_ENABLED }}
           token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
           workspace-id: ${{ secrets.BITRISE_BUILD_CACHE_WORKSPACE_ID }}
 

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -184,9 +184,9 @@ jobs:
           xcode-compilation-cache-ios-unit-tests-
 
     - name: Setup Bitrise Build Cache
-      if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
       uses: ./.github/actions/bitrise-build-cache
       with:
+        enabled: ${{ vars.BITRISE_BUILD_CACHE_ENABLED }}
         token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
         workspace-id: ${{ secrets.BITRISE_BUILD_CACHE_WORKSPACE_ID }}
 
@@ -413,9 +413,9 @@ jobs:
           xcode-compilation-cache-ios-release-
 
     - name: Setup Bitrise Build Cache
-      if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
       uses: ./.github/actions/bitrise-build-cache
       with:
+        enabled: ${{ vars.BITRISE_BUILD_CACHE_ENABLED }}
         token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
         workspace-id: ${{ secrets.BITRISE_BUILD_CACHE_WORKSPACE_ID }}
 

--- a/.github/workflows/ios_pr_checks.yml
+++ b/.github/workflows/ios_pr_checks.yml
@@ -184,7 +184,7 @@ jobs:
           xcode-compilation-cache-ios-unit-tests-
 
     - name: Setup Bitrise Build Cache
-      if: runner.environment == 'self-hosted'
+      if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
       uses: ./.github/actions/bitrise-build-cache
       with:
         token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
@@ -413,7 +413,7 @@ jobs:
           xcode-compilation-cache-ios-release-
 
     - name: Setup Bitrise Build Cache
-      if: runner.environment == 'self-hosted'
+      if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
       uses: ./.github/actions/bitrise-build-cache
       with:
         token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}

--- a/.github/workflows/macos_pir_end_to_end_tests.yml
+++ b/.github/workflows/macos_pir_end_to_end_tests.yml
@@ -166,9 +166,9 @@ jobs:
           xcode-compilation-cache-pir-e2e-
 
     - name: Setup Bitrise Build Cache
-      if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
       uses: ./.github/actions/bitrise-build-cache
       with:
+        enabled: ${{ vars.BITRISE_BUILD_CACHE_ENABLED }}
         token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
         workspace-id: ${{ secrets.BITRISE_BUILD_CACHE_WORKSPACE_ID }}
 

--- a/.github/workflows/macos_pir_end_to_end_tests.yml
+++ b/.github/workflows/macos_pir_end_to_end_tests.yml
@@ -166,7 +166,7 @@ jobs:
           xcode-compilation-cache-pir-e2e-
 
     - name: Setup Bitrise Build Cache
-      if: runner.environment == 'self-hosted'
+      if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
       uses: ./.github/actions/bitrise-build-cache
       with:
         token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -268,7 +268,7 @@ jobs:
           xcode-compilation-cache-${{ matrix.flavor }}-
 
     - name: Setup Bitrise Build Cache
-      if: runner.environment == 'self-hosted'
+      if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
       uses: ./.github/actions/bitrise-build-cache
       with:
         token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
@@ -650,7 +650,7 @@ jobs:
           xcode-compilation-cache-release-
 
     - name: Setup Bitrise Build Cache
-      if: runner.environment == 'self-hosted'
+      if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
       uses: ./.github/actions/bitrise-build-cache
       with:
         token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}

--- a/.github/workflows/macos_pr_checks.yml
+++ b/.github/workflows/macos_pr_checks.yml
@@ -268,9 +268,9 @@ jobs:
           xcode-compilation-cache-${{ matrix.flavor }}-
 
     - name: Setup Bitrise Build Cache
-      if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
       uses: ./.github/actions/bitrise-build-cache
       with:
+        enabled: ${{ vars.BITRISE_BUILD_CACHE_ENABLED }}
         token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
         workspace-id: ${{ secrets.BITRISE_BUILD_CACHE_WORKSPACE_ID }}
 
@@ -650,9 +650,9 @@ jobs:
           xcode-compilation-cache-release-
 
     - name: Setup Bitrise Build Cache
-      if: runner.environment == 'self-hosted' && vars.BITRISE_BUILD_CACHE_ENABLED == '1'
       uses: ./.github/actions/bitrise-build-cache
       with:
+        enabled: ${{ vars.BITRISE_BUILD_CACHE_ENABLED }}
         token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
         workspace-id: ${{ secrets.BITRISE_BUILD_CACHE_WORKSPACE_ID }}
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1217706872174193?focus=true

### Description
This change allows to disable Bitrise Build Cache based on the value of
BITRISE_BUILD_CACHE_ENABLED GitHub Actions variable.

### Testing Steps
Verify that CI is green and that jobs that would normally use build cache have cache disabled (the variable is set to `0` right now). Example: https://github.com/duckduckgo/apple-browsers/actions/runs/32459429382/job/96703356957?pr=6466#step:12:29

### Impact
None

### Notes
We're disabling Bitrise Build Cache temporarily for a few days to observe its impact on build times.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to how Bitrise cache is toggled. No application, auth, or data-handling code is affected. If the variable is unset, cache will stay off on self-hosted runners.
> 
> **Overview**
> Adds an `enabled` input to the `bitrise-build-cache` composite action so cache setup only runs on self-hosted runners when `enabled` is `1`. Call sites now pass `vars.BITRISE_BUILD_CACHE_ENABLED` and drop the job-level `if: runner.environment == 'self-hosted'` guard.
> 
> When cache is skipped, the action logs a message (warning if disabled on a self-hosted runner) instead of running setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5dbbc3f569ea420c07e54314c9ff8b64e1c2158. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->