### PR TITLE
Fix expand test after contextual chat hand-off change

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -297,10 +297,7 @@ final class AIChatContextualSheetViewController: UIViewController {
     /// Mirrors the custom popup's sections, fetched when the menu opens rather than on the tap.
     private func buildNativeChatsMenuElements(_ completion: @escaping ([UIMenuElement]) -> Void) {
         Task { @MainActor in
-            let viewModel = await AIChatRecentChatsPopupViewModel.fetch(
-                using: suggestionsReader,
-                showNewChat: sessionState.hasActiveChat
-            )
+            let viewModel = await AIChatRecentChatsPopupViewModel.fetch(using: suggestionsReader)
             let openDuckAI = UIAction(title: UserText.duckAiContextualOpenDuckAi,
                                       image: DesignSystemImages.Glyphs.Size16.aiChat) { [weak self] _ in
                 self?.recentChatsPopupDidSelectOpenDuckAI()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatRecentChatsPopupViewModel.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatRecentChatsPopupViewModel.swift
@@ -32,9 +32,6 @@ final class AIChatRecentChatsPopupViewModel {
 
     // MARK: - Properties
 
-    /// Whether the "New chat" row should be shown at the top.
-    let showNewChat: Bool
-
     /// The chat suggestions (up to maxVisibleChats).
     let suggestions: [AIChatSuggestion]
 
@@ -43,10 +40,8 @@ final class AIChatRecentChatsPopupViewModel {
     /// Creates a view model from raw fetched data.
     /// - Parameters:
     ///   - suggestions: The chat suggestions to display (will be capped at maxVisibleChats).
-    ///   - showNewChat: Whether the "New chat" row should be shown (true when there's an active chat).
-    init(suggestions: [AIChatSuggestion], showNewChat: Bool = false) {
+    init(suggestions: [AIChatSuggestion]) {
         self.suggestions = Array(suggestions.prefix(Self.maxVisibleChats))
-        self.showNewChat = showNewChat
     }
 
 }
@@ -57,11 +52,11 @@ extension AIChatRecentChatsPopupViewModel {
 
     /// Fetches recent chats from the reader and creates a view model.
     /// Returns nil only if the reader is nil; the popup still opens with no suggestions.
-    static func fetch(using reader: AIChatSuggestionsReading?, showNewChat: Bool = false) async -> AIChatRecentChatsPopupViewModel? {
+    static func fetch(using reader: AIChatSuggestionsReading?) async -> AIChatRecentChatsPopupViewModel? {
         guard let reader else { return nil }
         let result = await reader.fetchSuggestions(query: nil, maxChats: maxVisibleChats + 1)
         let all = result.pinned + result.recent
         let capped = Array(all.prefix(maxVisibleChats))
-        return AIChatRecentChatsPopupViewModel(suggestions: capped, showNewChat: showNewChat)
+        return AIChatRecentChatsPopupViewModel(suggestions: capped)
     }
 }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -549,8 +549,9 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         XCTAssertEqual(mockDelegate.didRequestExpandURLs, [expandURL])
     }
 
+    /// The chat carries on in its own tab, so the tab it left starts over rather than keeping it.
     @MainActor
-    func testExpandRequestRetainsActiveChat() async {
+    func testExpandRequestResetsTheTabsContextualChat() async {
         // Given
         await sut.presentSheet(from: mockPresentingVC)
         XCTAssertNotNil(sut.sheetViewController)
@@ -560,7 +561,9 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         sut.aiChatContextualSheetViewController(sut.sheetViewController!, didRequestExpandWithURL: expandURL)
 
         // Then
-        XCTAssertNotNil(sut.sheetViewController)
+        XCTAssertNil(sut.sheetViewController)
+        XCTAssertFalse(sut.sessionState.hasActiveChat)
+        XCTAssertEqual(mockDelegate.contextualChatURLUpdates.last, .some(nil))
     }
 
     // MARK: - Page Context Handling Tests


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215757651854873?focus=true
CC:

### Description
A test on main asserts the behaviour that #6398 deliberately changed, so it fails there today. Moving a
contextual chat out to its own tab now resets the tab it left, but the test still expects that tab to
keep the chat. Rewritten to state the new behaviour rather than deleted, since the old expectation was
intentional before this change.

Also removes a property left write-only by the chats-popup deletion in the same PR — nothing read it,
because the menu decides whether to offer New Chat at the point it builds the row.

### Testing Steps
1. Run `AIChatContextualSheetCoordinatorTests` → all pass (fails on main without this change).
2. Open a contextual Duck.ai chat on a page and send a prompt.
3. Expand it to its own tab (⤢ or tap the header title).
4. Return to the original tab and tap the Duck.ai icon → fresh input, not the chat you moved.
5. Force-quit, relaunch, tap the Duck.ai icon on that tab → still fresh.

### Impact
Low — a test correction plus dead-code removal. No behaviour change for users.

#### What could go wrong?
The removed property could have had a reader I missed → checked for reads across app and test code
before removing; the suites covering this area pass locally.

### Quality Considerations
The iOS `Unit Tests` CI job is currently timing out repo-wide (cancelled at the 60m ceiling on main's
own commits too), so this could not be verified by CI. Verified locally instead with `xcodebuild test`:
99 tests, 0 failures across `AIChatContextualSheetCoordinatorTests`,
`AIChatContextualFloatingInputViewControllerTests` and `AIChatRecentChatsPopupViewModelTests`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test expectation update and dead-property removal only; no production behavior change.
> 
> **Overview**
> Updates the contextual-sheet expand test so it matches hand-off: moving a chat to its own tab **resets** the original tab instead of keeping the session.
> 
> Also drops unused `showNewChat` from `AIChatRecentChatsPopupViewModel`. The native chats menu already decides whether to show New Chat from `sessionState.hasActiveChat` when it builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f582d3c265295eeb67d917385d3f54da9414e5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->