### PR TITLE
Bump C-S-S to 16.13.0

### DIFF
--- a/SharedPackages/BrowserServicesKit/Package.resolved
+++ b/SharedPackages/BrowserServicesKit/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "8d4ca1c57295af978000d74bf640577e938ff6fd",
-        "version" : "16.12.0"
+        "revision" : "22bfc22f43a4e13cad055bcad96d6f024092db07",
+        "version" : "16.13.0"
       }
     },
     {

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -58,7 +58,7 @@ let package = Package(
         .package(url: "https://github.com/1024jp/GzipSwift.git", exact: "6.0.1"),
         .package(url: "https://github.com/vapor/jwt-kit.git", exact: "4.13.5"),
         .package(url: "https://github.com/pointfreeco/swift-clocks.git", exact: "1.1.0"),
-        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "16.12.0"),
+        .package(url: "https://github.com/duckduckgo/content-scope-scripts.git", exact: "16.13.0"),
         .package(path: "../DDGError"),
         .package(path: "../Common"),
         .package(path: "../Persistence"),

--- a/SharedPackages/DataBrokerProtectionCore/Package.resolved
+++ b/SharedPackages/DataBrokerProtectionCore/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "8d4ca1c57295af978000d74bf640577e938ff6fd",
-        "version" : "16.12.0"
+        "revision" : "22bfc22f43a4e13cad055bcad96d6f024092db07",
+        "version" : "16.13.0"
       }
     },
     {

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "8d4ca1c57295af978000d74bf640577e938ff6fd",
-        "version" : "16.12.0"
+        "revision" : "22bfc22f43a4e13cad055bcad96d6f024092db07",
+        "version" : "16.13.0"
       }
     },
     {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "8d4ca1c57295af978000d74bf640577e938ff6fd",
-        "version" : "16.12.0"
+        "revision" : "22bfc22f43a4e13cad055bcad96d6f024092db07",
+        "version" : "16.13.0"
       }
     },
     {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217611870578207
Tech Design URL:
CC:

### Description

Bumps content-scope-scripts from 16.12.0 to 16.13.0 so Personal Information Removal can handle matched-record CAPTCHA flows.

### Testing Steps

1. Build and run the macOS app from this branch.
2. Open the PIR debug view and paste the PropertyRecord JSON.
3. Run Scan for a test profile and confirm the matched PropertyRecord is returned.
4. Run Opt out for that record and confirm PropertyRecord shows the success page for the same person.

### Impact

Medium: the bundled scripts participate in PIR scan and opt-out flows across data broker sites.

#### What could go wrong?

The updated scripts could regress scan or opt-out behavior on existing brokers → mitigated by the existing BrowserServicesKit, DBP, and PIR end-to-end test suites plus the manual matched-record scan and opt-out checks above.

### Quality Considerations

No native behavior changes. The dependency remains pinned to an exact release, and the downstream iOS, macOS, and DBP lockfiles resolve the same release revision.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bundled content-scope scripts drive PIR scan and opt-out on data-broker sites; a script regression could break those flows even though native code is unchanged.
> 
> **Overview**
> Bumps `content-scope-scripts` from **16.12.0** to **16.13.0** so Personal Information Removal can handle matched-record CAPTCHA flows.
> 
> The pin is updated in `BrowserServicesKit` and lockfiles for BSK, DataBrokerProtectionCore, iOS, and macOS. No native code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d329cd01b49374f49a9e0e4ecf25c2ce0f659914. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->