### PR TITLE
[iOS] Report app switcher snapshot cleanup failures

### DIFF
--- a/iOS/DuckDuckGo/Fire/AppSwitcherSnapshotCleaner.swift
+++ b/iOS/DuckDuckGo/Fire/AppSwitcherSnapshotCleaner.swift
@@ -19,16 +19,20 @@
 
 import Common
 import Foundation
+import PixelKit
 
 actor AppSwitcherSnapshotCleaner {
 
     private let fileManager: FileManager
     private let libraryDirectoryOverride: URL?
+    private let pixelFiring: PixelFiring?
 
     init(fileManager: FileManager = .default,
-         libraryDirectoryOverride: URL? = nil) {
+         libraryDirectoryOverride: URL? = nil,
+         pixelFiring: PixelFiring? = PixelKit.shared) {
         self.fileManager = fileManager
         self.libraryDirectoryOverride = libraryDirectoryOverride
+        self.pixelFiring = pixelFiring
     }
 
     func clearSnapshots() async {
@@ -40,9 +44,17 @@ actor AppSwitcherSnapshotCleaner {
             .appendingPathComponent("SplashBoard", isDirectory: true)
             .appendingPathComponent("Snapshots", isDirectory: true)
 
-        let snapshotItems = (try? fileManager.contentsOfDirectory(at: snapshotsDirectory,
-                                                                  includingPropertiesForKeys: nil,
-                                                                  options: [])) ?? []
+        let snapshotItems: [URL]
+        do {
+            snapshotItems = try fileManager.contentsOfDirectory(at: snapshotsDirectory,
+                                                                includingPropertiesForKeys: nil,
+                                                                options: [])
+        } catch {
+            let errorDescription = error.localizedDescription
+            Logger.general.error("Failed to enumerate app switcher snapshots: \(errorDescription, privacy: .public)")
+            pixelFiring?.fire(DataClearingPixels.appSwitcherSnapshotEnumerationFailed(error), frequency: .dailyAndCount)
+            return
+        }
 
         for snapshotItem in snapshotItems {
             do {

--- a/iOS/DuckDuckGo/Fire/Statistics/DataClearingPixels.swift
+++ b/iOS/DuckDuckGo/Fire/Statistics/DataClearingPixels.swift
@@ -28,6 +28,9 @@ enum DataClearingPixels {
 
     /// User performed action before data clearing completed
     case userActionBeforeCompletion
+
+    /// App switcher snapshot directory enumeration failed
+    case appSwitcherSnapshotEnumerationFailed(Error)
 }
 
 // MARK: - PixelKit.Event Protocol
@@ -40,6 +43,8 @@ extension DataClearingPixels: PixelKit.Event {
             return "m_fire_retrigger_in_20s"
         case .userActionBeforeCompletion:
             return "m_fire_user_action_before_completion"
+        case .appSwitcherSnapshotEnumerationFailed:
+            return "m_app-switcher_snapshot_enumeration_failed"
         }
     }
 
@@ -48,7 +53,12 @@ extension DataClearingPixels: PixelKit.Event {
     }
 
     var error: NSError? {
-        return nil
+        switch self {
+        case .appSwitcherSnapshotEnumerationFailed(let error):
+            return error as NSError
+        default:
+            return nil
+        }
     }
 
     var standardParameters: [PixelKitStandardParameter]? {

--- a/iOS/DuckDuckGo/Fire/Statistics/DataClearingPixels.swift
+++ b/iOS/DuckDuckGo/Fire/Statistics/DataClearingPixels.swift
@@ -44,7 +44,7 @@ extension DataClearingPixels: PixelKit.Event {
         case .userActionBeforeCompletion:
             return "m_fire_user_action_before_completion"
         case .appSwitcherSnapshotEnumerationFailed:
-            return "m_app-switcher_snapshot_enumeration_failed"
+            return "app-switcher_snapshot_enumeration_failed"
         }
     }
 

--- a/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
@@ -58,7 +58,7 @@ final class AppSwitcherSnapshotCleanerTests: XCTestCase {
 
         let fireCall = try XCTUnwrap(pixelFiring.actualFireCalls.first)
         XCTAssertEqual(pixelFiring.actualFireCalls.count, 1)
-        XCTAssertEqual(fireCall.pixel.name, "m_app-switcher_snapshot_enumeration_failed")
+        XCTAssertEqual(fireCall.pixel.name, "app-switcher_snapshot_enumeration_failed")
         XCTAssertEqual(fireCall.pixel.error?.domain, NSCocoaErrorDomain)
         XCTAssertEqual(fireCall.pixel.error?.code, CocoaError.fileReadNoSuchFile.rawValue)
         XCTAssertEqual(fireCall.frequency, .dailyAndCount)

--- a/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
@@ -18,6 +18,7 @@
 //
 
 import Foundation
+@_spi(Testing) import PixelKit
 import XCTest
 @testable import DuckDuckGo
 
@@ -42,17 +43,25 @@ final class AppSwitcherSnapshotCleanerTests: XCTestCase {
                                                                    includingPropertiesForKeys: nil), [])
     }
 
-    func testClearSnapshotsWhenSnapshotsDirectoryIsMissingDoesNothing() async {
+    func testWhenSnapshotsDirectoryIsMissingThenEnumerationFailurePixelIsFired() async throws {
         let libraryDirectory = makeTemporaryLibraryDirectory()
         defer { try? FileManager.default.removeItem(at: libraryDirectory) }
 
-        let cleaner = AppSwitcherSnapshotCleaner(libraryDirectoryOverride: libraryDirectory)
+        let pixelFiring = PixelKitMock()
+        let cleaner = AppSwitcherSnapshotCleaner(libraryDirectoryOverride: libraryDirectory, pixelFiring: pixelFiring)
         await cleaner.clearSnapshots()
 
         let snapshotsDirectory = libraryDirectory
             .appendingPathComponent("SplashBoard", isDirectory: true)
             .appendingPathComponent("Snapshots", isDirectory: true)
         XCTAssertFalse(FileManager.default.fileExists(atPath: snapshotsDirectory.path))
+
+        let fireCall = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+        XCTAssertEqual(pixelFiring.actualFireCalls.count, 1)
+        XCTAssertEqual(fireCall.pixel.name, "m_app-switcher_snapshot_enumeration_failed")
+        XCTAssertEqual(fireCall.pixel.error?.domain, NSCocoaErrorDomain)
+        XCTAssertEqual(fireCall.pixel.error?.code, CocoaError.fileReadNoSuchFile.rawValue)
+        XCTAssertEqual(fireCall.frequency, .dailyAndCount)
     }
 
     func testClearSnapshotsContinuesAfterAnItemCannotBeRemoved() async throws {

--- a/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
@@ -15,6 +15,14 @@
         "parameters": ["appVersion", "pixelSource"]
     },
 
+    "m_app-switcher_snapshot_enumeration_failed": {
+        "description": "Fired when the app cannot enumerate the iOS app switcher snapshot directory, including when the expected private OS path is missing",
+        "owners": ["bkunat"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion", "pixelSource", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
+    },
+
     "m_fire_clear_website_data_remove_all_containers_after_delay_success": {
         "description": "Fired when website data container cleanup after delay completes successfully",
         "owners": ["hanyutang-sandra"],

--- a/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
@@ -19,7 +19,7 @@
         "description": "Fired when the app cannot enumerate the iOS app switcher snapshot directory, including when the expected private OS path is missing",
         "owners": ["bkunat"],
         "triggers": ["other"],
-        "suffixes": ["daily_count", "platform", "form_factor"],
+        "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
     },
 

--- a/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
@@ -15,7 +15,7 @@
         "parameters": ["appVersion", "pixelSource"]
     },
 
-    "m_app-switcher_snapshot_enumeration_failed": {
+    "app-switcher_snapshot_enumeration_failed": {
         "description": "Fired when the app cannot enumerate the iOS app switcher snapshot directory, including when the expected private OS path is missing",
         "owners": ["bkunat"],
         "triggers": ["other"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217687438407199
Tech Design URL:
CC:

### Description
Reports failures to inspect the app-switcher snapshot directory through a dedicated daily-and-count pixel. This gives us an affected-user trend and an occurrence count if iOS stops exposing the expected directory or directory enumeration begins failing.

### Testing Steps
There's no way to reproduce. A real failure of AppSwitcherSnapshotCleaner.swift. I'd focus on checking the Pixel logic.

### Impact
Low: adds telemetry for snapshot-cleanup failures without changing cleanup behavior.

#### What could go wrong?
Expected missing directories could increase event volume → the event is narrowly scoped and reports only error domain and code, without file paths or error descriptions.

### Quality Considerations
Missing-directory failures are intentionally included because an iOS snapshot-path change would produce the same error. This signal cannot detect a path change if iOS leaves the old directory present but stops using it.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only change to Fire snapshot cleanup; enumeration failures were already non-destructive and now only add logging and a scoped error pixel.
> 
> **Overview**
> Adds **telemetry** when `AppSwitcherSnapshotCleaner` cannot list the iOS app switcher snapshot directory (`SplashBoard/Snapshots`), without changing successful cleanup behavior.
> 
> Enumeration now uses explicit error handling instead of silently treating failures as an empty directory. On failure it logs, fires **`app-switcher_snapshot_enumeration_failed`** at **daily-and-count** via injectable `PixelFiring` (defaults to `PixelKit.shared`), and exits before deletion. The new `DataClearingPixels` case attaches the underlying `NSError` for standard error parameters; pixel definitions document `errorCode` / `errorDomain` fields only (no paths or descriptions).
> 
> Tests replace the “missing directory does nothing” assertion with verification that the enumeration-failure pixel fires with `fileReadNoSuchFile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3ff0bb0f24b886eeb7028961ff7da114dfc8993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->