### PR TITLE
Fix iOS unit test crash loop from a duplicated Persistence module

### DIFF
--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -9,6 +9,10 @@ on:
     branches: [ main ]
     paths:
       - 'SharedPackages/BrowserServicesKit/**'
+      - 'SharedPackages/Common/**'
+      - 'SharedPackages/DDGError/**'
+      - 'SharedPackages/Persistence/**'
+      - 'SharedPackages/PixelKit/**'
   pull_request:
     # opened, synchronize, reopened are the default triggering events for a pull request
     # We're also adding ready_for_review to run checks when a draft PR becomes ready for review.
@@ -17,6 +21,10 @@ on:
       - '.github/**'
       - '.xcode-version'
       - 'SharedPackages/BrowserServicesKit/**'
+      - 'SharedPackages/Common/**'
+      - 'SharedPackages/DDGError/**'
+      - 'SharedPackages/Persistence/**'
+      - 'SharedPackages/PixelKit/**'
   schedule:
     - cron: '10,30,50 4,5,6 * * *'
 
@@ -421,9 +429,133 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  shared-package-unit-tests:
+
+      # Common, DDGError, Persistence and PixelKit were BSK targets until #6405 split them into
+      # their own packages. Their tests ran under this workflow as part of the BSK suite and had no
+      # home afterwards, so they run here, one job per package.
+      name: Run unit tests (${{ matrix.package }}, macOS)
+
+      needs: should-run-checks
+      if: needs.should-run-checks.outputs.should_run == 'true'
+
+      runs-on: [image:osx-tahoe-26, size:large]
+      timeout-minutes: 20
+
+      strategy:
+        fail-fast: false
+        matrix:
+          package: [Common, DDGError, Persistence, PixelKit]
+
+      defaults:
+        run:
+          working-directory: SharedPackages/${{ matrix.package }}
+
+      env:
+        WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+
+      steps:
+
+      - name: Register SSH keys for private repos
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_DUCKSANS_FONT }}
+
+      - name: Check out the code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Print macOS version
+        run: sw_vers
+
+      - name: Select Xcode
+        uses: ./.github/actions/select-xcode-version
+
+      - name: Setup Bitrise Build Cache
+        if: runner.environment == 'self-hosted'
+        uses: ./.github/actions/bitrise-build-cache
+        with:
+          token: ${{ secrets.BITRISE_BUILD_CACHE_AUTH_TOKEN }}
+          workspace-id: ${{ secrets.BITRISE_BUILD_CACHE_WORKSPACE_ID }}
+
+      - name: Run tests
+        id: run-unit-tests
+        run: |
+          set -o pipefail && xcodebuild test \
+            -scheme ${{ matrix.package }} \
+            -destination 'platform=macOS' \
+            -derivedDataPath DerivedData \
+            -skipPackagePluginValidation \
+            -skipMacroValidation \
+            -test-iterations 3 \
+            -retry-tests-on-failure \
+            CODE_SIGNING_ALLOWED=NO \
+            | tee build-log.txt \
+            | sed -e 's/CoreData: error:/CoreData: [notice]:/g' -e 's/Failed to create NSXPCConnection/[notice] NSXPCConnection unavailable/g' \
+            | xcbeautify --report junit --report-path . --junit-report-filename package-tests.xml
+
+      - name: Process test results
+        if: always()
+        uses: ./.github/actions/process-test-results
+        with:
+          working-directory: SharedPackages/${{ matrix.package }}
+          junit-path: package-tests.xml
+          log-path: build-log.txt
+          title: ${{ matrix.package }} (macOS)
+          test-outcome: ${{ steps.run-unit-tests.outcome }}
+
+      - name: Upload JUnit XML as artifact
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: ${{ matrix.package }}-macos-unittests.xml
+          path: |
+            SharedPackages/${{ matrix.package }}/package-tests.xml
+            SharedPackages/${{ matrix.package }}/package-tests-crash-details.json
+          retention-days: 7
+
+      - name: Publish Unit Tests Report
+        uses: mikepenz/action-junit-report@v6
+        if: always()
+        with:
+          check_name: ${{ matrix.package }} Test Report (macOS)
+          report_paths: SharedPackages/${{ matrix.package }}/package-tests.xml
+          require_tests: true
+          check_retries: ${{ needs.should-run-checks.outputs.strict_mode != 'true' }}
+          job_summary: 'false'
+
+      - name: Update Asana with failed unit tests
+        if: always() && steps.run-unit-tests.outcome == 'failure'
+        env:
+          ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
+        run: |
+          # Extract failed tests from the junit report
+          # Only keep failures unique by classname and name (column 1 and 2 of the yq output)
+          yq < package-tests.xml -p xml -o json -r \
+            $'[.testsuites.testsuite[].testcase] | flatten | map(select(.failure) | .+@classname + " " + .+@name + " \'" + .failure.+@message + "\' ${{ env.WORKFLOW_URL }}") | .[]' \
+            | sort -u -k 1,2 \
+            | xargs -L 1 ${{ github.workspace }}/scripts/report-failed-unit-test.sh -s ${{ vars.APPLE_CI_FAILING_TESTS_BSK_FAILED_TESTS_SECTION_ID }}
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: ${{ matrix.package }}-build-log.txt
+          path: SharedPackages/${{ matrix.package }}/build-log.txt
+
+      - name: Upload xcresult bundle
+        uses: actions/upload-artifact@v6
+        if: failure()
+        with:
+          name: ${{ matrix.package }}-macos-xcresult
+          path: SharedPackages/${{ matrix.package }}/DerivedData/Logs/Test/*.xcresult
+          retention-days: 7
+          if-no-files-found: ignore
+
   create-asana-task:
     name: Create Asana Task
-    needs: [unit-tests, unit-tests-ios]
+    needs: [unit-tests, unit-tests-ios, shared-package-unit-tests]
 
     if: failure() && github.ref_name == 'main' && github.run_attempt == 1
 
@@ -444,7 +576,7 @@ jobs:
 
   close-asana-task:
     name: Close Asana Task
-    needs: [unit-tests, unit-tests-ios]
+    needs: [unit-tests, unit-tests-ios, shared-package-unit-tests]
 
     if: success() && github.ref_name == 'main' && github.run_attempt > 1
 

--- a/.github/workflows/bsk_pr_checks.yml
+++ b/.github/workflows/bsk_pr_checks.yml
@@ -433,23 +433,20 @@ jobs:
 
       # Common, DDGError, Persistence and PixelKit were BSK targets until #6405 split them into
       # their own packages. Their tests ran under this workflow as part of the BSK suite and had no
-      # home afterwards, so they run here, one job per package.
-      name: Run unit tests (${{ matrix.package }}, macOS)
+      # home afterwards, so they run here. One job for all four rather than one each: they are small,
+      # and a job apiece meant four checkouts, four Xcode selects and four cache setups to run a few
+      # hundred fast tests.
+      name: Run unit tests (shared packages, macOS)
 
       needs: should-run-checks
       if: needs.should-run-checks.outputs.should_run == 'true'
 
       runs-on: [image:osx-tahoe-26, size:large]
-      timeout-minutes: 20
-
-      strategy:
-        fail-fast: false
-        matrix:
-          package: [Common, DDGError, Persistence, PixelKit]
+      timeout-minutes: 30
 
       defaults:
         run:
-          working-directory: SharedPackages/${{ matrix.package }}
+          working-directory: .
 
       env:
         WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
@@ -482,45 +479,102 @@ jobs:
       - name: Run tests
         id: run-unit-tests
         run: |
-          set -o pipefail && xcodebuild test \
-            -scheme ${{ matrix.package }} \
-            -destination 'platform=macOS' \
-            -derivedDataPath DerivedData \
-            -skipPackagePluginValidation \
-            -skipMacroValidation \
-            -test-iterations 3 \
-            -retry-tests-on-failure \
-            CODE_SIGNING_ALLOWED=NO \
-            | tee build-log.txt \
-            | sed -e 's/CoreData: error:/CoreData: [notice]:/g' -e 's/Failed to create NSXPCConnection/[notice] NSXPCConnection unavailable/g' \
-            | xcbeautify --report junit --report-path . --junit-report-filename package-tests.xml
+          # Every package runs even if an earlier one fails, so one broken package cannot hide
+          # another. Each writes its own report next to its manifest, matching the BSK job layout.
+          failed=()
+          for package in Common DDGError Persistence PixelKit; do
+            echo "::group::${package}"
+            (
+              cd "SharedPackages/${package}" || exit 1
+              set -o pipefail && xcodebuild test \
+                -scheme "${package}" \
+                -destination 'platform=macOS' \
+                -derivedDataPath DerivedData \
+                -skipPackagePluginValidation \
+                -skipMacroValidation \
+                -test-iterations 3 \
+                -retry-tests-on-failure \
+                CODE_SIGNING_ALLOWED=NO \
+                | tee build-log.txt \
+                | sed -e 's/CoreData: error:/CoreData: [notice]:/g' -e 's/Failed to create NSXPCConnection/[notice] NSXPCConnection unavailable/g' \
+                | xcbeautify --report junit --report-path . --junit-report-filename package-tests.xml
+            ) || failed+=("${package}")
+            echo "::endgroup::"
+          done
+          if (( ${#failed[@]} > 0 )); then
+            echo "::error::Unit tests failed for: ${failed[*]}"
+            exit 1
+          fi
 
-      - name: Process test results
+      # One call per package: the action reads a single report, and this keeps a separate
+      # job-summary table per package. test-outcome only gates crash injection, which is a no-op
+      # when a package has no xcresult crashes, so passing the whole step's outcome is safe.
+      - name: Process test results (Common)
         if: always()
         uses: ./.github/actions/process-test-results
         with:
-          working-directory: SharedPackages/${{ matrix.package }}
+          working-directory: SharedPackages/Common
           junit-path: package-tests.xml
           log-path: build-log.txt
-          title: ${{ matrix.package }} (macOS)
+          title: Common (macOS)
+          test-outcome: ${{ steps.run-unit-tests.outcome }}
+
+      - name: Process test results (DDGError)
+        if: always()
+        uses: ./.github/actions/process-test-results
+        with:
+          working-directory: SharedPackages/DDGError
+          junit-path: package-tests.xml
+          log-path: build-log.txt
+          title: DDGError (macOS)
+          test-outcome: ${{ steps.run-unit-tests.outcome }}
+
+      - name: Process test results (Persistence)
+        if: always()
+        uses: ./.github/actions/process-test-results
+        with:
+          working-directory: SharedPackages/Persistence
+          junit-path: package-tests.xml
+          log-path: build-log.txt
+          title: Persistence (macOS)
+          test-outcome: ${{ steps.run-unit-tests.outcome }}
+
+      - name: Process test results (PixelKit)
+        if: always()
+        uses: ./.github/actions/process-test-results
+        with:
+          working-directory: SharedPackages/PixelKit
+          junit-path: package-tests.xml
+          log-path: build-log.txt
+          title: PixelKit (macOS)
           test-outcome: ${{ steps.run-unit-tests.outcome }}
 
       - name: Upload JUnit XML as artifact
         uses: actions/upload-artifact@v6
         if: always()
         with:
-          name: ${{ matrix.package }}-macos-unittests.xml
+          name: shared-packages-macos-unittests.xml
           path: |
-            SharedPackages/${{ matrix.package }}/package-tests.xml
-            SharedPackages/${{ matrix.package }}/package-tests-crash-details.json
+            SharedPackages/Common/package-tests.xml
+            SharedPackages/DDGError/package-tests.xml
+            SharedPackages/Persistence/package-tests.xml
+            SharedPackages/PixelKit/package-tests.xml
+            SharedPackages/Common/package-tests-crash-details.json
+            SharedPackages/DDGError/package-tests-crash-details.json
+            SharedPackages/Persistence/package-tests-crash-details.json
+            SharedPackages/PixelKit/package-tests-crash-details.json
           retention-days: 7
 
       - name: Publish Unit Tests Report
         uses: mikepenz/action-junit-report@v6
         if: always()
         with:
-          check_name: ${{ matrix.package }} Test Report (macOS)
-          report_paths: SharedPackages/${{ matrix.package }}/package-tests.xml
+          check_name: Shared Packages Test Report (macOS)
+          report_paths: |
+            SharedPackages/Common/package-tests.xml
+            SharedPackages/DDGError/package-tests.xml
+            SharedPackages/Persistence/package-tests.xml
+            SharedPackages/PixelKit/package-tests.xml
           require_tests: true
           check_retries: ${{ needs.should-run-checks.outputs.strict_mode != 'true' }}
           job_summary: 'false'
@@ -530,26 +584,40 @@ jobs:
         env:
           ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
         run: |
-          # Extract failed tests from the junit report
+          # Extract failed tests from the junit reports
           # Only keep failures unique by classname and name (column 1 and 2 of the yq output)
-          yq < package-tests.xml -p xml -o json -r \
-            $'[.testsuites.testsuite[].testcase] | flatten | map(select(.failure) | .+@classname + " " + .+@name + " \'" + .failure.+@message + "\' ${{ env.WORKFLOW_URL }}") | .[]' \
-            | sort -u -k 1,2 \
-            | xargs -L 1 ${{ github.workspace }}/scripts/report-failed-unit-test.sh -s ${{ vars.APPLE_CI_FAILING_TESTS_BSK_FAILED_TESTS_SECTION_ID }}
+          for package in Common DDGError Persistence PixelKit; do
+            report="SharedPackages/${package}/package-tests.xml"
+            [[ -f "$report" ]] || continue
+            yq < "$report" -p xml -o json -r \
+              $'[.testsuites.testsuite[].testcase] | flatten | map(select(.failure) | .+@classname + " " + .+@name + " \'" + .failure.+@message + "\' ${{ env.WORKFLOW_URL }}") | .[]' \
+              | sort -u -k 1,2 \
+              | xargs -L 1 ${{ github.workspace }}/scripts/report-failed-unit-test.sh -s ${{ vars.APPLE_CI_FAILING_TESTS_BSK_FAILED_TESTS_SECTION_ID }}
+          done
 
       - name: Upload logs
         uses: actions/upload-artifact@v6
         if: always()
         with:
-          name: ${{ matrix.package }}-build-log.txt
-          path: SharedPackages/${{ matrix.package }}/build-log.txt
+          name: shared-packages-build-logs
+          path: |
+            SharedPackages/Common/build-log.txt
+            SharedPackages/DDGError/build-log.txt
+            SharedPackages/Persistence/build-log.txt
+            SharedPackages/PixelKit/build-log.txt
+          retention-days: 7
+          if-no-files-found: ignore
 
-      - name: Upload xcresult bundle
+      - name: Upload xcresult bundles
         uses: actions/upload-artifact@v6
         if: failure()
         with:
-          name: ${{ matrix.package }}-macos-xcresult
-          path: SharedPackages/${{ matrix.package }}/DerivedData/Logs/Test/*.xcresult
+          name: shared-packages-macos-xcresult
+          path: |
+            SharedPackages/Common/DerivedData/Logs/Test/*.xcresult
+            SharedPackages/DDGError/DerivedData/Logs/Test/*.xcresult
+            SharedPackages/Persistence/DerivedData/Logs/Test/*.xcresult
+            SharedPackages/PixelKit/DerivedData/Logs/Test/*.xcresult
           retention-days: 7
           if-no-files-found: ignore
 

--- a/SharedPackages/AIChat/Package.swift
+++ b/SharedPackages/AIChat/Package.swift
@@ -98,7 +98,7 @@ let package = Package(
                 "AIChatTestingUtilities",
                 .product(name: "BrowserServicesKitTestsUtils", package: "BrowserServicesKit"),
                 .product(name: "NetworkingTestingUtils", package: "BrowserServicesKit"),
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
                 .product(name: "PrivacyConfigTestsUtils", package: "BrowserServicesKit"),
                 .product(name: "Subscription", package: "BrowserServicesKit"),
                 .product(name: "WKAbstractions", package: "BrowserServicesKit")

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatSyncCleanerTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatSyncCleanerTests.swift
@@ -16,7 +16,7 @@
 //  limitations under the License.
 //
 
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 @testable import AIChat
 @testable import DDGSync

--- a/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeDiskStorageHandlerTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeDiskStorageHandlerTests.swift
@@ -18,8 +18,7 @@
 
 import Combine
 import XCTest
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import DuckAiDataStore
 @testable import AIChat
 

--- a/SharedPackages/BrowserServicesKit/Package.swift
+++ b/SharedPackages/BrowserServicesKit/Package.swift
@@ -642,7 +642,7 @@ let package = Package(
                 "BrowserServicesKitTestsUtils",
                 "SecureStorageTestsUtils",
                 "Subscription",
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
                 "PrivacyConfigTestsUtils",
                 "WKAbstractions",
             ],
@@ -659,7 +659,7 @@ let package = Package(
             dependencies: [
                 "SharedObjCTestsUtils",
                 "Crashes",
-                .product(name: "PersistenceTestingUtils", package: "Persistence")
+                .product(name: "Persistence", package: "Persistence")
             ]
         ),
         .testTarget(
@@ -668,7 +668,7 @@ let package = Package(
                 "SharedObjCTestsUtils",
                 "BookmarksTestsUtils",
                 "DDGSync",
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
                 "PrivacyConfigTestsUtils",
                 "NetworkingTestingUtils"
             ],
@@ -738,14 +738,14 @@ let package = Package(
             name: "DuckAiDataStoreTests",
             dependencies: [
                 "DuckAiDataStore",
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
                 "SecureStorage",
             ]
         ),
         .testTarget(
             name: "PrivacyConfigTests",
             dependencies: [
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
                 "PrivacyConfig",
                 "PrivacyConfigTestsUtils"
             ],
@@ -760,7 +760,7 @@ let package = Package(
                 "BrowserServicesKitTestsUtils",
                 "RemoteMessaging",
                 "RemoteMessagingTestsUtils",
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
             ],
             resources: [
                 .copy("Resources/remote-messaging-config-example.json"),
@@ -788,7 +788,7 @@ let package = Package(
                 "SharedObjCTestsUtils",
                 "Configuration",
                 "NetworkingTestingUtils",
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
             ]
         ),
         .testTarget(
@@ -796,7 +796,7 @@ let package = Package(
             dependencies: [
                 "SharedObjCTestsUtils",
                 "BookmarksTestsUtils",
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
                 "SecureStorageTestsUtils",
                 "SyncDataProviders",
             ]
@@ -815,7 +815,7 @@ let package = Package(
             dependencies: [
                 "SharedObjCTestsUtils",
                 "PrivacyDashboard",
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
                 .product(name: "ContentScopeScripts", package: "content-scope-scripts"),
                 "BrowserServicesKitTestsUtils",
             ]
@@ -828,7 +828,7 @@ let package = Package(
                 "Subscription",
                 "SubscriptionTestingUtilities",
                 "NetworkingTestingUtils",
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
             ]
         ),
         .testTarget(
@@ -904,7 +904,7 @@ let package = Package(
             dependencies: [
                 "SharedObjCTestsUtils",
                 "AutoconsentStats",
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
             ]
         ),
     ],

--- a/SharedPackages/BrowserServicesKit/Tests/AutoconsentStatsTests/AutoconsentStatsTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/AutoconsentStatsTests/AutoconsentStatsTests.swift
@@ -17,8 +17,7 @@
 //
 
 import XCTest
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import AutoconsentStats
 import Common
 

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/AdClickAttribution/AdClickAttributionCounterTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/AdClickAttribution/AdClickAttributionCounterTests.swift
@@ -17,8 +17,7 @@
 //
 
 import XCTest
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import BrowserServicesKit
 
 class AdClickAttributionCounterTests: XCTestCase {

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Statistics/DefaultFeatureDiscoveryTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Statistics/DefaultFeatureDiscoveryTests.swift
@@ -17,7 +17,7 @@
 //
 import XCTest
 @testable import BrowserServicesKit
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import BrowserServicesKitTestsUtils
 
 final class DefaultFeatureDiscoveryTests: XCTestCase {

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Statistics/UsageSegmentationStorageTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Statistics/UsageSegmentationStorageTests.swift
@@ -19,9 +19,8 @@
 import Foundation
 import XCTest
 @testable import BrowserServicesKit
-import PersistenceTestingUtils
 
-@testable import Persistence
+@_spi(Testing) @testable import Persistence
 
 final class UsageSegmentationStorageTests: XCTestCase {
 

--- a/SharedPackages/BrowserServicesKit/Tests/ConfigurationTests/ConfigurationManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/ConfigurationTests/ConfigurationManagerTests.swift
@@ -17,8 +17,7 @@
 //
 
 import XCTest
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import Configuration
 @testable import Networking
 import NetworkingTestingUtils

--- a/SharedPackages/BrowserServicesKit/Tests/ConfigurationTests/Mocks/MockStoreWithStorage.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/ConfigurationTests/Mocks/MockStoreWithStorage.swift
@@ -17,8 +17,7 @@
 //
 
 import Foundation
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import Configuration
 
 final class MockStoreWithStorage: ConfigurationStoring {

--- a/SharedPackages/BrowserServicesKit/Tests/CrashesTests/CrashCollectionTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/CrashesTests/CrashCollectionTests.swift
@@ -19,8 +19,7 @@
 @testable import Crashes
 import MetricKit
 import XCTest
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import Common
 
 class CrashCollectionTests: XCTestCase {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncLifecycleTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncLifecycleTests.swift
@@ -19,7 +19,7 @@
 import Combine
 import Common
 import XCTest
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DDGSync
 
 final class DDGSyncLifecycleTests: XCTestCase {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -20,8 +20,7 @@ import Combine
 import Common
 import Foundation
 import Gzip
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 import Networking

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncDailyStatsTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/SyncDailyStatsTests.swift
@@ -17,7 +17,7 @@
 //
 
 import XCTest
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DDGSync
 
 class SyncDailyStatsTests: XCTestCase {

--- a/SharedPackages/BrowserServicesKit/Tests/PrivacyConfigTests/FeatureFlagger/FeatureFlagLocalOverridesTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PrivacyConfigTests/FeatureFlagger/FeatureFlagLocalOverridesTests.swift
@@ -18,7 +18,7 @@
 
 import PrivacyConfig
 import PrivacyConfigTestsUtils
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 
 final class CapturingFeatureFlagLocalOverridesHandler: FeatureFlagLocalOverridesHandling {

--- a/SharedPackages/BrowserServicesKit/Tests/PrivacyConfigTests/FeatureFlagger/FeatureFlaggerUpdatesPublisherTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PrivacyConfigTests/FeatureFlagger/FeatureFlaggerUpdatesPublisherTests.swift
@@ -18,7 +18,7 @@
 
 import XCTest
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfigTestsUtils
 @testable import PrivacyConfig
 

--- a/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/BrokenSiteReporterTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/BrokenSiteReporterTests.swift
@@ -18,7 +18,7 @@
 
 import XCTest
 @testable import PrivacyDashboard
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 final class BrokenSiteReporterTests: XCTestCase {
 

--- a/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/ExpiryStorageTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/PrivacyDashboardTests/ExpiryStorageTests.swift
@@ -17,7 +17,7 @@
 //
 
 import XCTest
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import PrivacyDashboard
 
 final class ExpiryStorageTests: XCTestCase {

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/RemoteMessagingPercentileUserDefaultsStoreTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/RemoteMessagingPercentileUserDefaultsStoreTests.swift
@@ -17,7 +17,7 @@
 //
 
 import XCTest
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import RemoteMessaging
 
 class RemoteMessagingPercentileUserDefaultsStoreTests: XCTestCase {

--- a/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/RemoteMessagingTests/RemoteMessagingStoreTests.swift
@@ -20,8 +20,7 @@ import BrowserServicesKitTestsUtils
 import ConcurrencyExtensions
 import CoreData
 import Foundation
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import RemoteMessagingTestsUtils
 import XCTest
 @testable import RemoteMessaging

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/FreeTrials/FreeTrialBadgePersistorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/FreeTrials/FreeTrialBadgePersistorTests.swift
@@ -17,8 +17,7 @@
 //
 
 import XCTest
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import Subscription
 
 final class FreeTrialBadgePersistorTests: XCTestCase {

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/WinBackOffer/WinbackOfferStoreTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/WinBackOffer/WinbackOfferStoreTests.swift
@@ -17,8 +17,7 @@
 //
 
 import XCTest
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import SecureStorage
 @testable import Subscription
 

--- a/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/CreditCards/CreditCardsRegularSyncResponseHandlerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/CreditCards/CreditCardsRegularSyncResponseHandlerTests.swift
@@ -20,7 +20,7 @@ import XCTest
 import Common
 import DDGSync
 import GRDB
-import Persistence
+@_spi(Testing) import Persistence
 @testable import BrowserServicesKit
 @testable import SyncDataProviders
 

--- a/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/CreditCards/helpers/CreditCardsProviderTestsBase.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SyncDataProvidersTests/CreditCards/helpers/CreditCardsProviderTestsBase.swift
@@ -21,8 +21,7 @@ import Common
 import DDGSync
 import Foundation
 import GRDB
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import SecureStorage
 import SecureStorageTestsUtils
 @testable import BrowserServicesKit

--- a/SharedPackages/DataBrokerProtectionCore/Package.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Package.swift
@@ -92,7 +92,7 @@ let package = Package(
                 "DataBrokerProtectionCoreTestsUtils",
                 "BrowserServicesKit",
                 .product(name: "PixelKit", package: "PixelKit"),
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
                 .product(name: "SubscriptionTestingUtilities", package: "BrowserServicesKit"),
                 .product(name: "BrowserServicesKitTestsUtils", package: "BrowserServicesKit"),
                 .product(name: "SecureStorageTestsUtils", package: "BrowserServicesKit"),

--- a/SharedPackages/Persistence/Package.swift
+++ b/SharedPackages/Persistence/Package.swift
@@ -42,6 +42,9 @@ let package = Package(
                 .product(name: "CombineExtensions", package: "SystemFrameworksExtensions"),
                 .product(name: "ConcurrencyExtensions", package: "SystemFrameworksExtensions"),
             ],
+            exclude: [
+                "TestingSupport/README.md"
+            ],
             swiftSettings: [
                 .define("DEBUG", .when(configuration: .debug))
             ]

--- a/SharedPackages/Persistence/Package.swift
+++ b/SharedPackages/Persistence/Package.swift
@@ -28,7 +28,6 @@ let package = Package(
     ],
     products: [
         .library(name: "Persistence", targets: ["Persistence"]),
-        .library(name: "PersistenceTestingUtils", targets: ["PersistenceTestingUtils"]),
     ],
     dependencies: [
         .package(path: "../Common"),
@@ -47,19 +46,10 @@ let package = Package(
                 .define("DEBUG", .when(configuration: .debug))
             ]
         ),
-        .target(
-            name: "PersistenceTestingUtils",
-            dependencies: [
-                "Persistence"
-            ],
-            swiftSettings: [
-                .define("DEBUG", .when(configuration: .debug))
-            ]
-        ),
         .testTarget(
             name: "PersistenceTests",
             dependencies: [
-                "PersistenceTestingUtils",
+                "Persistence",
             ]
         ),
     ]

--- a/SharedPackages/Persistence/Sources/Persistence/TestingSupport/InMemoryKeyValueStore.swift
+++ b/SharedPackages/Persistence/Sources/Persistence/TestingSupport/InMemoryKeyValueStore.swift
@@ -18,10 +18,10 @@
 
 import Foundation
 import Combine
-import Persistence
 
 /// In-memory implementation of KeyValueStoring with observation support.
 /// Useful for testing and temporary storage scenarios.
+@_spi(Testing)
 open class InMemoryKeyValueStore: ObservableKeyValueStoring {
 
     public var store = [String: Any?]()
@@ -62,6 +62,7 @@ open class InMemoryKeyValueStore: ObservableKeyValueStoring {
     }
 }
 
+@_spi(Testing)
 extension InMemoryKeyValueStore: DictionaryRepresentable {
     public func dictionaryRepresentation() -> [String: Any] {
         return store as [String: Any]
@@ -69,4 +70,5 @@ extension InMemoryKeyValueStore: DictionaryRepresentable {
 }
 
 /// Backward compatibility typealias for existing code
+@_spi(Testing)
 public typealias MockKeyValueStore = InMemoryKeyValueStore

--- a/SharedPackages/Persistence/Sources/Persistence/TestingSupport/InMemoryObservableThrowingKeyValueStore.swift
+++ b/SharedPackages/Persistence/Sources/Persistence/TestingSupport/InMemoryObservableThrowingKeyValueStore.swift
@@ -1,5 +1,5 @@
 //
-//  InMemoryThrowingKeyValueStore.swift
+//  InMemoryObservableThrowingKeyValueStore.swift
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.
 //
@@ -16,11 +16,12 @@
 //  limitations under the License.
 //
 
-import Persistence
+import Combine
 
-/// In-memory implementation of ThrowingKeyValueStoring.
-/// Useful for testing throwing operations without actual persistence.
-open class InMemoryThrowingKeyValueStore: ThrowingKeyValueStoring {
+/// In-memory implementation of ObservableThrowingKeyValueStoring with observation support.
+/// Useful for testing throwing operations with change notifications.
+@_spi(Testing)
+open class InMemoryObservableThrowingKeyValueStore: ObservableThrowingKeyValueStoring {
 
     /// Direct access to underlying storage dictionary for test setup and assertions
     public var underlyingDict: [String: Any]
@@ -52,7 +53,12 @@ open class InMemoryThrowingKeyValueStore: ThrowingKeyValueStoring {
         set { throwOnRemove = newValue ? MockError.removeError : nil }
     }
 
-    public enum MockError: Error {
+    public var objectWillChange = ObservableObjectPublisher()
+
+    // Internal subject for key-specific change notifications
+    private var keyChanges = PassthroughSubject<String?, Never>()
+
+    public enum MockError: Error, Equatable {
         case getError
         case setError
         case removeError
@@ -68,28 +74,39 @@ open class InMemoryThrowingKeyValueStore: ThrowingKeyValueStoring {
         try error.map { throw $0 }
     }
 
-    public func object(forKey defaultName: String) throws -> Any? {
+    public func updatesPublisher(forKey key: String) -> AnyPublisher<Void, Never> {
+        keyChanges.compactMap { change -> Void? in
+            guard change == nil /* all */ || change == key else { return nil }
+            return ()
+        }.eraseToAnyPublisher()
+    }
+
+    public func object(forKey key: String) throws -> Any? {
         if let throwOnRead {
             throw throwOnRead
         }
-        return underlyingDict[defaultName]
+        return underlyingDict[key]
     }
 
-    public func set(_ value: Any?, forKey defaultName: String) throws {
+    public func set(_ value: Any?, forKey key: String) throws {
         if let throwOnSet {
             throw throwOnSet
         }
-        underlyingDict[defaultName] = value
+        underlyingDict[key] = value
+        objectWillChange.send()
+        keyChanges.send(key)
     }
 
-    public func removeObject(forKey defaultName: String) throws {
+    public func removeObject(forKey key: String) throws {
         if let throwOnRemove {
             throw throwOnRemove
         }
-        underlyingDict.removeValue(forKey: defaultName)
+        underlyingDict.removeValue(forKey: key)
+        objectWillChange.send()
+        keyChanges.send(key)
     }
 }
 
-/// Backward compatibility typealiases for existing code
-public typealias MockThrowingKeyValueStore = InMemoryThrowingKeyValueStore
-public typealias MockKeyValueFileStore = InMemoryThrowingKeyValueStore
+/// Backward compatibility typealias for existing code
+@_spi(Testing)
+public typealias MockObservableThrowingKeyValueStore = InMemoryObservableThrowingKeyValueStore

--- a/SharedPackages/Persistence/Sources/Persistence/TestingSupport/InMemoryThrowingKeyValueStore.swift
+++ b/SharedPackages/Persistence/Sources/Persistence/TestingSupport/InMemoryThrowingKeyValueStore.swift
@@ -1,5 +1,5 @@
 //
-//  InMemoryObservableThrowingKeyValueStore.swift
+//  InMemoryThrowingKeyValueStore.swift
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.
 //
@@ -16,12 +16,10 @@
 //  limitations under the License.
 //
 
-import Combine
-import Persistence
-
-/// In-memory implementation of ObservableThrowingKeyValueStoring with observation support.
-/// Useful for testing throwing operations with change notifications.
-open class InMemoryObservableThrowingKeyValueStore: ObservableThrowingKeyValueStoring {
+/// In-memory implementation of ThrowingKeyValueStoring.
+/// Useful for testing throwing operations without actual persistence.
+@_spi(Testing)
+open class InMemoryThrowingKeyValueStore: ThrowingKeyValueStoring {
 
     /// Direct access to underlying storage dictionary for test setup and assertions
     public var underlyingDict: [String: Any]
@@ -53,12 +51,7 @@ open class InMemoryObservableThrowingKeyValueStore: ObservableThrowingKeyValueSt
         set { throwOnRemove = newValue ? MockError.removeError : nil }
     }
 
-    public var objectWillChange = ObservableObjectPublisher()
-
-    // Internal subject for key-specific change notifications
-    private var keyChanges = PassthroughSubject<String?, Never>()
-
-    public enum MockError: Error, Equatable {
+    public enum MockError: Error {
         case getError
         case setError
         case removeError
@@ -74,38 +67,30 @@ open class InMemoryObservableThrowingKeyValueStore: ObservableThrowingKeyValueSt
         try error.map { throw $0 }
     }
 
-    public func updatesPublisher(forKey key: String) -> AnyPublisher<Void, Never> {
-        keyChanges.compactMap { change -> Void? in
-            guard change == nil /* all */ || change == key else { return nil }
-            return ()
-        }.eraseToAnyPublisher()
-    }
-
-    public func object(forKey key: String) throws -> Any? {
+    public func object(forKey defaultName: String) throws -> Any? {
         if let throwOnRead {
             throw throwOnRead
         }
-        return underlyingDict[key]
+        return underlyingDict[defaultName]
     }
 
-    public func set(_ value: Any?, forKey key: String) throws {
+    public func set(_ value: Any?, forKey defaultName: String) throws {
         if let throwOnSet {
             throw throwOnSet
         }
-        underlyingDict[key] = value
-        objectWillChange.send()
-        keyChanges.send(key)
+        underlyingDict[defaultName] = value
     }
 
-    public func removeObject(forKey key: String) throws {
+    public func removeObject(forKey defaultName: String) throws {
         if let throwOnRemove {
             throw throwOnRemove
         }
-        underlyingDict.removeValue(forKey: key)
-        objectWillChange.send()
-        keyChanges.send(key)
+        underlyingDict.removeValue(forKey: defaultName)
     }
 }
 
-/// Backward compatibility typealias for existing code
-public typealias MockObservableThrowingKeyValueStore = InMemoryObservableThrowingKeyValueStore
+/// Backward compatibility typealiases for existing code
+@_spi(Testing)
+public typealias MockThrowingKeyValueStore = InMemoryThrowingKeyValueStore
+@_spi(Testing)
+public typealias MockKeyValueFileStore = InMemoryThrowingKeyValueStore

--- a/SharedPackages/Persistence/Sources/Persistence/TestingSupport/README.md
+++ b/SharedPackages/Persistence/Sources/Persistence/TestingSupport/README.md
@@ -1,0 +1,33 @@
+#  Testing support
+
+In-memory `KeyValueStoring` implementations for tests. They live in the `Persistence` target rather
+than in a separate testing-utilities target on purpose, and they are hidden behind `@_spi(Testing)`
+so production code cannot reach them.
+
+## Why they are not a separate target
+
+A `PersistenceTestingUtils` target inside this package could only depend on the `Persistence`
+*target*, and Xcode links target-to-target package dependencies statically into every client. When
+Xcode also builds the `Persistence` *product* as a dynamic framework — which it does as soon as more
+than one image needs it — an app-hosted test bundle ends up with a second static copy of
+Persistence. Two copies in one process break type metadata lookups: boxing the result of
+`keyedStoring()` into an `any KeyedStoring<Keys>` faults on a null metadata pointer, which crashed
+the iOS test host on every test in `OnboardingIntroViewModelTests` and
+`DarkReaderFeatureSettingsTests`. Xcode 26.6 does not dedupe this case; swift-build commit
+`8698d7a7` fixes it upstream.
+
+Keeping these files inside the `Persistence` target removes the extra module entirely, so there is
+only ever one copy of Persistence in the process.
+
+## How to use them
+
+Import with the SPI group:
+
+```swift
+@_spi(Testing) import Persistence
+```
+
+A plain `import Persistence` does not see these declarations, which is what keeps them out of
+production code. When a helper of your own exposes one of these types in its signature, mark that
+helper `@_spi(Testing)` too and let its callers opt in the same way. XCTest-dependent helpers do not
+belong here: this target must not link XCTest.

--- a/SharedPackages/Persistence/Tests/PersistenceTests/InMemoryObservableThrowingKeyValueStoreTests.swift
+++ b/SharedPackages/Persistence/Tests/PersistenceTests/InMemoryObservableThrowingKeyValueStoreTests.swift
@@ -18,8 +18,7 @@
 
 import Combine
 import Foundation
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import Testing
 
 final class InMemoryObservableThrowingKeyValueStoreTests {

--- a/SharedPackages/Persistence/Tests/PersistenceTests/InMemoryThrowingKeyValueStoreTests.swift
+++ b/SharedPackages/Persistence/Tests/PersistenceTests/InMemoryThrowingKeyValueStoreTests.swift
@@ -17,8 +17,7 @@
 //
 
 import Foundation
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import Testing
 
 final class InMemoryThrowingKeyValueStoreTests {

--- a/SharedPackages/Persistence/Tests/PersistenceTests/KeyedStoringTests.swift
+++ b/SharedPackages/Persistence/Tests/PersistenceTests/KeyedStoringTests.swift
@@ -18,8 +18,7 @@
 
 import Combine
 import Foundation
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import Testing
 
 // MARK: - Test Keys
@@ -139,6 +138,7 @@ struct ThrowingInjectionKeys: StoringKeys {
 public final class AppUserDefaults: UserDefaults {}
 
 // Custom file store wrapping InMemoryKeyValueStore  
+@_spi(Testing)
 public final class AppFileStore: InMemoryKeyValueStore {}
 
 // Service classes that depend on storage

--- a/SharedPackages/Persistence/Tests/PersistenceTests/ObservableKeyValueStoringTests.swift
+++ b/SharedPackages/Persistence/Tests/PersistenceTests/ObservableKeyValueStoringTests.swift
@@ -18,8 +18,7 @@
 
 import Combine
 import Foundation
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import Testing
 
 final class ObservableKeyValueStoringTests {

--- a/SharedPackages/PixelKit/Package.swift
+++ b/SharedPackages/PixelKit/Package.swift
@@ -59,7 +59,7 @@ let package = Package(
             name: "PixelKitTests",
             dependencies: [
                 "PixelKit",
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
             ]
         ),
     ]

--- a/SharedPackages/PixelKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
+++ b/SharedPackages/PixelKit/Tests/PixelKitTests/OSDistributionPixelTests.swift
@@ -18,7 +18,7 @@
 
 import XCTest
 import Common
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import PixelKit
 
 final class OSDistributionPixelTests: XCTestCase {

--- a/SharedPackages/PixelKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTests.swift
+++ b/SharedPackages/PixelKit/Tests/PixelKitTests/RetryQueue/PixelRetryQueueTests.swift
@@ -17,7 +17,7 @@
 //
 
 import XCTest
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import PixelKit
 
 final class PixelRetryQueueTests: XCTestCase {

--- a/SharedPackages/SERPSettings/Package.swift
+++ b/SharedPackages/SERPSettings/Package.swift
@@ -43,7 +43,6 @@ let package = Package(
                 "SERPSettings",
                 .product(name: "BrowserServicesKitTestsUtils", package: "BrowserServicesKit"),
                 .product(name: "Persistence", package: "Persistence"),
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
                 .product(name: "UserScript", package: "BrowserServicesKit"),
                 .product(name: "AIChat", package: "AIChat")
             ]

--- a/SharedPackages/SERPSettings/Tests/SERPSettingsTests/Mocks/MockSERPSettingsProvider.swift
+++ b/SharedPackages/SERPSettings/Tests/SERPSettingsTests/Mocks/MockSERPSettingsProvider.swift
@@ -20,8 +20,7 @@ import Foundation
 import UserScript
 import AIChat
 import Common
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import SERPSettings
 
 final class MockSERPSettingsProvider: SERPSettingsProviding {

--- a/SharedPackages/SERPSettings/Tests/SERPSettingsTests/SERPSettingsProvidingTests.swift
+++ b/SharedPackages/SERPSettings/Tests/SERPSettingsTests/SERPSettingsProvidingTests.swift
@@ -18,8 +18,7 @@
 
 import Common
 import Foundation
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 
 @testable import SERPSettings

--- a/SharedPackages/SERPSettings/Tests/SERPSettingsTests/SERPSettingsUserScriptTests.swift
+++ b/SharedPackages/SERPSettings/Tests/SERPSettingsTests/SERPSettingsUserScriptTests.swift
@@ -16,8 +16,7 @@
 //  limitations under the License.
 //
 
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import BrowserServicesKitTestsUtils
 import UserScript
 import WebKit

--- a/SharedPackages/WebExtensions/Package.swift
+++ b/SharedPackages/WebExtensions/Package.swift
@@ -69,7 +69,6 @@ let package = Package(
                 "WebExtensions",
                 "WebExtensionsTestSupport",
                 .product(name: "Persistence", package: "Persistence"),
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
                 .product(name: "PrivacyConfigTestsUtils", package: "BrowserServicesKit")
             ]
         ),

--- a/SharedPackages/WebExtensions/Tests/WebExtensionsTests/InstalledWebExtensionStoreTests.swift
+++ b/SharedPackages/WebExtensions/Tests/WebExtensionsTests/InstalledWebExtensionStoreTests.swift
@@ -17,8 +17,7 @@
 //
 
 import XCTest
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import WebExtensions
 
 @available(macOS 15.4, iOS 18.4, *)

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -410,7 +410,7 @@
 		4BC95EA32D74176D002FAB32 /* PixelExperimentKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4BC95EA22D74176D002FAB32 /* PixelExperimentKit */; };
 		4BC95EA52D741787002FAB32 /* Common in Frameworks */ = {isa = PBXBuildFile; productRef = 4BC95EA42D741787002FAB32 /* Common */; };
 		4BC95EA72D74178C002FAB32 /* ContentBlocking in Frameworks */ = {isa = PBXBuildFile; productRef = 4BC95EA62D74178C002FAB32 /* ContentBlocking */; };
-		4BC95EAB2D74179B002FAB32 /* PersistenceTestingUtils in Frameworks */ = {isa = PBXBuildFile; productRef = 4BC95EAA2D74179B002FAB32 /* PersistenceTestingUtils */; };
+		4BC95EAB2D74179B002FAB32 /* Persistence in Frameworks */ = {isa = PBXBuildFile; productRef = 4BC95EAA2D74179B002FAB32 /* Persistence */; };
 		4BC95EAD2D7417A0002FAB32 /* Subscription in Frameworks */ = {isa = PBXBuildFile; productRef = 4BC95EAC2D7417A0002FAB32 /* Subscription */; };
 		4BC95EAF2D7417A8002FAB32 /* SubscriptionTestingUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = 4BC95EAE2D7417A8002FAB32 /* SubscriptionTestingUtilities */; };
 		4BC95EB12D7417BF002FAB32 /* Subscription in Frameworks */ = {isa = PBXBuildFile; productRef = 4BC95EB02D7417BF002FAB32 /* Subscription */; };
@@ -420,7 +420,7 @@
 		4BC95EB92D7417E0002FAB32 /* ContentBlocking in Frameworks */ = {isa = PBXBuildFile; productRef = 4BC95EB82D7417E0002FAB32 /* ContentBlocking */; };
 		4BC95EBB2D7417E9002FAB32 /* Subscription in Frameworks */ = {isa = PBXBuildFile; productRef = 4BC95EBA2D7417E9002FAB32 /* Subscription */; };
 		4BC95EBD2D7417F0002FAB32 /* SubscriptionTestingUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = 4BC95EBC2D7417F0002FAB32 /* SubscriptionTestingUtilities */; };
-		4BC95EBF2D7417FC002FAB32 /* PersistenceTestingUtils in Frameworks */ = {isa = PBXBuildFile; productRef = 4BC95EBE2D7417FC002FAB32 /* PersistenceTestingUtils */; };
+		4BC95EBF2D7417FC002FAB32 /* Persistence in Frameworks */ = {isa = PBXBuildFile; productRef = 4BC95EBE2D7417FC002FAB32 /* Persistence */; };
 		4BCBE45E2BA7E81F00FC75A1 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 4BCBE45D2BA7E81F00FC75A1 /* PrivacyInfo.xcprivacy */; };
 		4BCBE4602BA7E87100FC75A1 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 4BCBE45F2BA7E87100FC75A1 /* PrivacyInfo.xcprivacy */; };
 		4BCD14672B05B682000B1E4C /* NetworkProtectionTermsAndConditionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BCD14662B05B682000B1E4C /* NetworkProtectionTermsAndConditionsStore.swift */; };
@@ -1153,7 +1153,6 @@
 		986CD53E2DE8FA1400AFA98A /* ConfigurationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986CD53C2DE8FA0500AFA98A /* ConfigurationMocks.swift */; };
 		986CD53F2DE8FA1400AFA98A /* ConfigurationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986CD53C2DE8FA0500AFA98A /* ConfigurationMocks.swift */; };
 		986CD5402DE8FA1400AFA98A /* ConfigurationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986CD53C2DE8FA0500AFA98A /* ConfigurationMocks.swift */; };
-		986CD5422DE8FBCA00AFA98A /* PersistenceTestingUtils in Frameworks */ = {isa = PBXBuildFile; productRef = 986CD5412DE8FBCA00AFA98A /* PersistenceTestingUtils */; };
 		986CD5482DE9134700AFA98A /* ContextualDaxDialogsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986CD5432DE9134700AFA98A /* ContextualDaxDialogsFactoryTests.swift */; };
 		986CD5492DE9134700AFA98A /* NewTabPageControllerDaxDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986CD5452DE9134700AFA98A /* NewTabPageControllerDaxDialogTests.swift */; };
 		986CD54A2DE9134700AFA98A /* ContextualOnboardingNewTabDialogFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986CD5442DE9134700AFA98A /* ContextualOnboardingNewTabDialogFactoryTests.swift */; };
@@ -2161,7 +2160,7 @@
 		C1B3BF472D8D99DA00EE1D43 /* AutofillCreditCardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B3BF432D8D99DA00EE1D43 /* AutofillCreditCardListView.swift */; };
 		C1B3BF482D8D99DA00EE1D43 /* AutofillCreditCardListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B3BF442D8D99DA00EE1D43 /* AutofillCreditCardListViewModel.swift */; };
 		C1B3BF4F2D91805F00EE1D43 /* AutofillCreditCardListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B3BF4E2D91805F00EE1D43 /* AutofillCreditCardListViewController.swift */; };
-		C1B441E52E2990F7005E2BA9 /* PersistenceTestingUtils in Frameworks */ = {isa = PBXBuildFile; productRef = C1B441E42E2990F7005E2BA9 /* PersistenceTestingUtils */; };
+		C1B441E52E2990F7005E2BA9 /* Persistence in Frameworks */ = {isa = PBXBuildFile; productRef = C1B441E42E2990F7005E2BA9 /* Persistence */; };
 		C1B7B51C28941E980098FD6A /* HomeMessageViewModelBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B7B51B28941E980098FD6A /* HomeMessageViewModelBuilder.swift */; };
 		C1B7B52528941F2A0098FD6A /* RemoteMessagingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B7B52128941F2A0098FD6A /* RemoteMessagingClient.swift */; };
 		C1B7B52D2894469D0098FD6A /* DefaultVariantManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B7B52C2894469D0098FD6A /* DefaultVariantManager.swift */; };
@@ -5835,7 +5834,7 @@
 				31C71A782E6F4F5B004D503F /* RemoteMessagingTestsUtils in Frameworks */,
 				A7B000012F6A000100000001 /* SnapshotTestingSupport in Frameworks */,
 				9F5412772E3998B000DBF008 /* SetDefaultBrowserTestSupport in Frameworks */,
-				4BC95EAB2D74179B002FAB32 /* PersistenceTestingUtils in Frameworks */,
+				4BC95EAB2D74179B002FAB32 /* Persistence in Frameworks */,
 				5654CF572E22A9820074E806 /* BrowserServicesKitTestsUtils in Frameworks */,
 				4BB88F3F2E5D701200DE539A /* PixelKit in Frameworks */,
 				9FA8A625300EF678000DF5DE /* WebExtensionsTestSupport in Frameworks */,
@@ -5880,7 +5879,7 @@
 				1E1D8B632995143200C96994 /* OHHTTPStubs in Frameworks */,
 				9FA8A627300EF680000DF5DE /* WebExtensionsTestSupport in Frameworks */,
 				1E1D8B652995143200C96994 /* OHHTTPStubsSwift in Frameworks */,
-				C1B441E52E2990F7005E2BA9 /* PersistenceTestingUtils in Frameworks */,
+				C1B441E52E2990F7005E2BA9 /* Persistence in Frameworks */,
 				4BC95EB72D7417DC002FAB32 /* Common in Frameworks */,
 				CC55B2412E82CD860032E8BD /* BrowserServicesKitTestsUtils in Frameworks */,
 				4BC95EBD2D7417F0002FAB32 /* SubscriptionTestingUtilities in Frameworks */,
@@ -5927,7 +5926,7 @@
 				98424A982CED4F430071C7DB /* ContentBlocking in Frameworks */,
 				986CD5392DE8F50400AFA98A /* Configuration in Frameworks */,
 				98424A992CED4F430071C7DB /* SubscriptionTestingUtilities in Frameworks */,
-				4BC95EBF2D7417FC002FAB32 /* PersistenceTestingUtils in Frameworks */,
+				4BC95EBF2D7417FC002FAB32 /* Persistence in Frameworks */,
 				4BC95EB52D7417D2002FAB32 /* BrowserServicesKitTestsUtils in Frameworks */,
 				98424A9A2CED4F430071C7DB /* Subscription in Frameworks */,
 				98424A9D2CED4F430071C7DB /* Common in Frameworks */,
@@ -5947,7 +5946,6 @@
 				C118DACF2F0EF8A6004F403A /* AIChatTestingUtilities in Frameworks */,
 				98E564882DE8DE5A00E6E75F /* Bookmarks in Frameworks */,
 				F11595D92E8570B500CC0481 /* AttributedMetric in Frameworks */,
-				986CD5422DE8FBCA00AFA98A /* PersistenceTestingUtils in Frameworks */,
 				98E564962DE8DE8100E6E75F /* Subscription in Frameworks */,
 				98E564942DE8DE7D00E6E75F /* SubscriptionTestingUtilities in Frameworks */,
 				98E5648C2DE8DE6200E6E75F /* History in Frameworks */,
@@ -12560,7 +12558,7 @@
 				F486D3372506A225002D07D7 /* OHHTTPStubsSwift */,
 				4BC95EA42D741787002FAB32 /* Common */,
 				4BC95EA62D74178C002FAB32 /* ContentBlocking */,
-				4BC95EAA2D74179B002FAB32 /* PersistenceTestingUtils */,
+				4BC95EAA2D74179B002FAB32 /* Persistence */,
 				4BC95EAC2D7417A0002FAB32 /* Subscription */,
 				4BC95EAE2D7417A8002FAB32 /* SubscriptionTestingUtilities */,
 				A7B000032F6A000100000001 /* SnapshotTestingSupport */,
@@ -12646,7 +12644,7 @@
 				4BC95EBA2D7417E9002FAB32 /* Subscription */,
 				4BC95EBC2D7417F0002FAB32 /* SubscriptionTestingUtilities */,
 				986CD5342DE8F4FA00AFA98A /* RemoteMessaging */,
-				C1B441E42E2990F7005E2BA9 /* PersistenceTestingUtils */,
+				C1B441E42E2990F7005E2BA9 /* Persistence */,
 				CC55B2402E82CD860032E8BD /* BrowserServicesKitTestsUtils */,
 				374E760D2EF56D9100F8AADE /* PrivacyConfigTestsUtils */,
 				4B69239E2F28720300A816B9 /* AIChat */,
@@ -12724,7 +12722,7 @@
 				984249C92CED4F430071C7DB /* SubscriptionTestingUtilities */,
 				4BC95EB22D7417CC002FAB32 /* BrowserServicesKit */,
 				4BC95EB42D7417D2002FAB32 /* BrowserServicesKitTestsUtils */,
-				4BC95EBE2D7417FC002FAB32 /* PersistenceTestingUtils */,
+				4BC95EBE2D7417FC002FAB32 /* Persistence */,
 				986CD5362DE8F50100AFA98A /* RemoteMessaging */,
 				986CD5382DE8F50400AFA98A /* Configuration */,
 				7BC26CB52DFC156A00E52480 /* VPNTestUtils */,
@@ -12779,7 +12777,6 @@
 				98E564912DE8DE7500E6E75F /* Configuration */,
 				98E564932DE8DE7D00E6E75F /* SubscriptionTestingUtilities */,
 				98E564952DE8DE8100E6E75F /* Subscription */,
-				986CD5412DE8FBCA00AFA98A /* PersistenceTestingUtils */,
 				7BC26CB32DFC155E00E52480 /* VPNTestUtils */,
 				9FE59CD72E3097B200C4B65D /* SystemSettingsPiPTutorialTestSupport */,
 				F11595D82E8570B500CC0481 /* AttributedMetric */,
@@ -19490,9 +19487,9 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = ContentBlocking;
 		};
-		4BC95EAA2D74179B002FAB32 /* PersistenceTestingUtils */ = {
+		4BC95EAA2D74179B002FAB32 /* Persistence */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = PersistenceTestingUtils;
+			productName = Persistence;
 		};
 		4BC95EAC2D7417A0002FAB32 /* Subscription */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -19530,9 +19527,9 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = SubscriptionTestingUtilities;
 		};
-		4BC95EBE2D7417FC002FAB32 /* PersistenceTestingUtils */ = {
+		4BC95EBE2D7417FC002FAB32 /* Persistence */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = PersistenceTestingUtils;
+			productName = Persistence;
 		};
 		5654CF562E22A9820074E806 /* BrowserServicesKitTestsUtils */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -19640,10 +19637,6 @@
 		986CD5382DE8F50400AFA98A /* Configuration */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Configuration;
-		};
-		986CD5412DE8FBCA00AFA98A /* PersistenceTestingUtils */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = PersistenceTestingUtils;
 		};
 		98E564832DE8DE3F00E6E75F /* Common */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -19833,9 +19826,9 @@
 			package = C14882EB27F211A000D59F0C /* XCRemoteSwiftPackageReference "SwiftSoup" */;
 			productName = SwiftSoup;
 		};
-		C1B441E42E2990F7005E2BA9 /* PersistenceTestingUtils */ = {
+		C1B441E42E2990F7005E2BA9 /* Persistence */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = PersistenceTestingUtils;
+			productName = Persistence;
 		};
 		C1CAAA802CF8C8F400C37EE6 /* DuckUI */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/iOS/DuckDuckGoTests/AIChat/AIChatSettingsMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatSettingsMigrationTests.swift
@@ -21,7 +21,7 @@ import XCTest
 @testable import Core
 @testable import DuckDuckGo
 import AIChat
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 final class AIChatSettingsMigrationTests: XCTestCase {
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatSettingsTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatSettingsTests.swift
@@ -23,8 +23,7 @@ import XCTest
 import PrivacyConfig
 import Combine
 import AIChat
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 class AIChatSettingsTests: XCTestCase {
 

--- a/iOS/DuckDuckGoTests/AIChat/DuckAISelectionJourneyInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAISelectionJourneyInstrumentationTests.swift
@@ -281,7 +281,7 @@ struct DuckAISelectionJourneyInstrumentationTests {
         #expect(DuckAISelectionJourneyWideEventData.metadata.pixelName == "duckai_selection_journey")
         #expect(DuckAISelectionJourneyWideEventData.metadata.featureName == "duckai-selection-journey")
         #expect(DuckAISelectionJourneyWideEventData.metadata.type == "ios-duckai-selection-journey")
-        #expect(DuckAISelectionJourneyWideEventData.metadata.version == "1.1.0")
+        #expect(DuckAISelectionJourneyWideEventData.metadata.version == "1.2.0")
     }
 
     @available(iOS 16, *)

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -17,8 +17,7 @@
 //  limitations under the License.
 //
 
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/AIChat/NewAddressBarPickerDisplayValidatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/NewAddressBarPickerDisplayValidatorTests.swift
@@ -20,11 +20,10 @@
 import XCTest
 import Core
 import FoundationExtensions
-import Persistence
+@_spi(Testing) import Persistence
 import BrowserServicesKit
 import RemoteMessaging
 import RemoteMessagingTestsUtils
-import PersistenceTestingUtils
 import AIChat
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/AIChat/OpenAIChatFromAddressBarHandlingTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/OpenAIChatFromAddressBarHandlingTests.swift
@@ -21,7 +21,7 @@ import XCTest
 @testable import Core
 @testable import DuckDuckGo
 import AIChat
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 final class OpenAIChatFromAddressBarHandlingTests: XCTestCase {
 

--- a/iOS/DuckDuckGoTests/AIChat/SwitchBarFunnelTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/SwitchBarFunnelTests.swift
@@ -19,8 +19,7 @@
 
 import XCTest
 @testable import DuckDuckGo
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 final class SwitchBarFunnelTests: XCTestCase {
     

--- a/iOS/DuckDuckGoTests/AdAttribution/AdAttributionFetcherTests.swift
+++ b/iOS/DuckDuckGoTests/AdAttribution/AdAttributionFetcherTests.swift
@@ -21,7 +21,7 @@ import XCTest
 import FoundationExtensions
 
 @testable import DuckDuckGo
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import NetworkingTestingUtils
 
 final class AdAttributionFetcherTests: XCTestCase {

--- a/iOS/DuckDuckGoTests/AfterInactivityEffectiveOptionResolverTests.swift
+++ b/iOS/DuckDuckGoTests/AfterInactivityEffectiveOptionResolverTests.swift
@@ -20,8 +20,7 @@
 import Foundation
 import Testing
 import Core
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import FeatureFlags_iOS
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/AfterInactivityOptionAdapterTests.swift
+++ b/iOS/DuckDuckGoTests/AfterInactivityOptionAdapterTests.swift
@@ -19,8 +19,7 @@
 
 import Foundation
 import Testing
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
 
 @Suite("After Inactivity Option Adapter")

--- a/iOS/DuckDuckGoTests/AppServices/AutofillServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/AutofillServiceTests.swift
@@ -19,9 +19,8 @@
 
 import Foundation
 import Testing
-import Persistence
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
-@testable import PersistenceTestingUtils
 
 final class AutofillServiceTests {
 

--- a/iOS/DuckDuckGoTests/AppServices/InactivityNotificationSchedulerServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/InactivityNotificationSchedulerServiceTests.swift
@@ -19,7 +19,7 @@
 
 import XCTest
 import FoundationExtensions
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
 @testable import Core
 @testable import BrowserServicesKit

--- a/iOS/DuckDuckGoTests/AppServices/InactivityNotificationStateStoreTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/InactivityNotificationStateStoreTests.swift
@@ -18,7 +18,7 @@
 //
 
 import XCTest
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
 
 final class InactivityNotificationStateStoreTests: XCTestCase {

--- a/iOS/DuckDuckGoTests/Autocomplete/AutocompleteSuggestionsDataSourceTests.swift
+++ b/iOS/DuckDuckGoTests/Autocomplete/AutocompleteSuggestionsDataSourceTests.swift
@@ -20,7 +20,7 @@
 import Foundation
 
 import XCTest
-import Persistence
+@_spi(Testing) import Persistence
 import CoreData
 import Bookmarks
 import PrivacyConfig
@@ -29,7 +29,6 @@ import History
 
 @testable import Core
 @testable import DuckDuckGo
-@testable import PersistenceTestingUtils
 
 final class AutocompleteSuggestionsDataSourceTests: XCTestCase {
 

--- a/iOS/DuckDuckGoTests/AutofillExtensionPromotion/AutofillExtensionPromotionManagerTests.swift
+++ b/iOS/DuckDuckGoTests/AutofillExtensionPromotion/AutofillExtensionPromotionManagerTests.swift
@@ -20,8 +20,7 @@
 import XCTest
 import AuthenticationServices
 @testable import DuckDuckGo
-import Persistence
-@testable import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import BrowserServicesKitTestsUtils
 
 @available(iOS 18.0, *)

--- a/iOS/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/AutofillLoginListViewModelTests.swift
@@ -27,8 +27,7 @@ import PrivacyConfigTestsUtils
 @testable import Core
 import BrowserServicesKit
 @testable import Common
-@testable import PersistenceTestingUtils
-import Persistence
+@_spi(Testing) import Persistence
 import PrivacyDashboard
 
 class AutofillLoginListViewModelTests: XCTestCase {

--- a/iOS/DuckDuckGoTests/AutofillSettingsViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/AutofillSettingsViewModelTests.swift
@@ -22,8 +22,7 @@ import XCTest
 import BrowserServicesKit
 import Bookmarks
 import DDGSync
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import Core
 import Common
 import FoundationExtensions

--- a/iOS/DuckDuckGoTests/Autoplay/AutoplaySettingsTests.swift
+++ b/iOS/DuckDuckGoTests/Autoplay/AutoplaySettingsTests.swift
@@ -18,8 +18,7 @@
 //
 
 import Testing
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/BookmarkStateRepairTests.swift
+++ b/iOS/DuckDuckGoTests/BookmarkStateRepairTests.swift
@@ -20,7 +20,7 @@
 import XCTest
 import CoreData
 import Bookmarks
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import Core
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/BookmarksDatabaseSetupTests.swift
+++ b/iOS/DuckDuckGoTests/BookmarksDatabaseSetupTests.swift
@@ -20,12 +20,11 @@
 
 import Foundation
 import XCTest
-import Persistence
+@_spi(Testing) import Persistence
 import CoreData
 import Bookmarks
 @testable import DuckDuckGo
 @testable import Core
-import PersistenceTestingUtils
 
 class DummyCoreDataStoreMock: CoreDataStoring {
 

--- a/iOS/DuckDuckGoTests/BookmarksStateValidationTests.swift
+++ b/iOS/DuckDuckGoTests/BookmarksStateValidationTests.swift
@@ -20,7 +20,7 @@
 import XCTest
 import CoreData
 import Bookmarks
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import Core
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/BrokenSiteReportingTests.swift
+++ b/iOS/DuckDuckGoTests/BrokenSiteReportingTests.swift
@@ -25,7 +25,7 @@ import OHHTTPStubsSwift
 @testable import Core
 import PrivacyDashboard
 @testable import DuckDuckGo
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 final class BrokenSiteReportingTests: XCTestCase {
     private let data = JsonTestDataLoader()

--- a/iOS/DuckDuckGoTests/BrowsingMenu/BrowsingMenuBuilderTests.swift
+++ b/iOS/DuckDuckGoTests/BrowsingMenu/BrowsingMenuBuilderTests.swift
@@ -19,7 +19,7 @@
 
 import Bookmarks
 import Core
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyDashboard
 import UIKit
 import XCTest

--- a/iOS/DuckDuckGoTests/Customization/MobileCustomizationTests.swift
+++ b/iOS/DuckDuckGoTests/Customization/MobileCustomizationTests.swift
@@ -22,7 +22,7 @@ import Testing
 @testable import DuckDuckGo
 @testable import Core
 import DesignResourcesKitIcons
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import VPN
 import VPNTestUtils
 

--- a/iOS/DuckDuckGoTests/DailyPixelTests.swift
+++ b/iOS/DuckDuckGoTests/DailyPixelTests.swift
@@ -19,8 +19,7 @@
 
 import XCTest
 import Networking
-import PersistenceTestingUtils
-import Persistence
+@_spi(Testing) import Persistence
 @testable import Core
 
 final class DailyPixelTests: XCTestCase {

--- a/iOS/DuckDuckGoTests/DarkReader/DarkReaderFeatureSettingsTests.swift
+++ b/iOS/DuckDuckGoTests/DarkReader/DarkReaderFeatureSettingsTests.swift
@@ -20,8 +20,7 @@
 import XCTest
 @testable import DuckDuckGo
 import BrowserServicesKit
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import Combine
 
 class DarkReaderFeatureSettingsTests: XCTestCase {

--- a/iOS/DuckDuckGoTests/DataImport/DataImportUserActivityHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/DataImport/DataImportUserActivityHandlerTests.swift
@@ -19,8 +19,7 @@
 
 import XCTest
 import BrowserServicesKit
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
 
 final class DataImportUserActivityHandlerTests: XCTestCase {

--- a/iOS/DuckDuckGoTests/DefaultBrowserPrompt/DefaultBrowserPromptActivityKeyValueFilesStoreTests.swift
+++ b/iOS/DuckDuckGoTests/DefaultBrowserPrompt/DefaultBrowserPromptActivityKeyValueFilesStoreTests.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 import Testing
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import SetDefaultBrowserCore
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/DefaultBrowserPrompt/DefaultBrowserPromptUserActivityKeyValueFilesStoreTests.swift
+++ b/iOS/DuckDuckGoTests/DefaultBrowserPrompt/DefaultBrowserPromptUserActivityKeyValueFilesStoreTests.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 import Testing
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import SetDefaultBrowserCore
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/DefaultBrowserPrompt/DefaultBrowserPromptUserTypeManagerTests.swift
+++ b/iOS/DuckDuckGoTests/DefaultBrowserPrompt/DefaultBrowserPromptUserTypeManagerTests.swift
@@ -20,7 +20,7 @@
 import Foundation
 import Testing
 import struct Core.VariantIOS
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import SetDefaultBrowserCore
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/DefaultBrowserPrompt/DefaultBrowserPromptUserTypeStoreTests.swift
+++ b/iOS/DuckDuckGoTests/DefaultBrowserPrompt/DefaultBrowserPromptUserTypeStoreTests.swift
@@ -20,7 +20,7 @@
 import Foundation
 import Testing
 import class Common.EventMapping
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import SetDefaultBrowserCore
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/EscapeHatchModelTests.swift
+++ b/iOS/DuckDuckGoTests/EscapeHatchModelTests.swift
@@ -22,7 +22,7 @@ import CoreGraphics
 import Testing
 import Core
 import PrivacyConfig
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
 
 @Suite("Escape Hatch Model")

--- a/iOS/DuckDuckGoTests/EventHub/YouTubeAdBlockingTelemetryConsentRequirementTests.swift
+++ b/iOS/DuckDuckGoTests/EventHub/YouTubeAdBlockingTelemetryConsentRequirementTests.swift
@@ -19,8 +19,7 @@
 
 import Combine
 import EventHub
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 
 @testable import DuckDuckGo

--- a/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/FireExecutorTests.swift
@@ -25,8 +25,7 @@ import AIChatTestingUtilities
 import BrowserServicesKit
 import WebKit
 import Bookmarks
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import DDGSync
 import WKAbstractions
 import BrowserServicesKitTestsUtils

--- a/iOS/DuckDuckGoTests/Fire/GranularFireConfirmationViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/GranularFireConfirmationViewModelTests.swift
@@ -24,8 +24,7 @@ import Common
 import FoundationExtensions
 import History
 import AIChat
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 // swiftlint:disable force_try
 

--- a/iOS/DuckDuckGoTests/FireButtonReferenceTests.swift
+++ b/iOS/DuckDuckGoTests/FireButtonReferenceTests.swift
@@ -23,7 +23,7 @@ import XCTest
 import os.log
 import WebKit
 @testable import Core
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import BrowserServicesKitTestsUtils
 import WKAbstractions
 

--- a/iOS/DuckDuckGoTests/IdleReturnEligibilityManagerTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnEligibilityManagerTests.swift
@@ -20,8 +20,7 @@
 import Foundation
 import Testing
 import Core
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/IdleReturnThresholdResolverTests.swift
+++ b/iOS/DuckDuckGoTests/IdleReturnThresholdResolverTests.swift
@@ -19,8 +19,7 @@
 
 import Foundation
 import Testing
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/LargeOmniBarStateTests.swift
+++ b/iOS/DuckDuckGoTests/LargeOmniBarStateTests.swift
@@ -19,7 +19,7 @@
 
 import FeatureFlags_iOS
 import Foundation
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import UIKit
 import XCTest
 @testable import Core

--- a/iOS/DuckDuckGoTests/LaunchTimeMetricsSubscriberTests.swift
+++ b/iOS/DuckDuckGoTests/LaunchTimeMetricsSubscriberTests.swift
@@ -19,8 +19,7 @@
 
 import XCTest
 import Core
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
 
 final class LaunchTimeMetricsSubscriberTests: XCTestCase {

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicyTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromoQueueCooldownPolicyTests.swift
@@ -18,7 +18,7 @@
 //
 
 import Foundation
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import Testing
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromptCooldownStoreTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/Cooldown/PromptCooldownStoreTests.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 import Testing
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
 
 @Suite("Modal Prompt Coordination - Cooldown Store")

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/Migrator/PromptCooldownMigratorTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/Migrator/PromptCooldownMigratorTests.swift
@@ -19,8 +19,7 @@
 
 import Foundation
 import Testing
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
 
 @Suite("Modal Prompt Coordination - Prompt Cooldown Migrator")

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/PromptCoordinationDebugViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/PromptCoordinationDebugViewModelTests.swift
@@ -18,7 +18,7 @@
 //
 
 import Foundation
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import Testing
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/ModalPromptCoordination/Providers/NewAddressBarPickerModalPromptProviderTests.swift
+++ b/iOS/DuckDuckGoTests/ModalPromptCoordination/Providers/NewAddressBarPickerModalPromptProviderTests.swift
@@ -20,7 +20,7 @@
 import UIKit
 import Testing
 import AIChat
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
 
 @MainActor

--- a/iOS/DuckDuckGoTests/NewBadge/NewBadgeVisibilityManagerTests.swift
+++ b/iOS/DuckDuckGoTests/NewBadge/NewBadgeVisibilityManagerTests.swift
@@ -20,7 +20,7 @@
 import XCTest
 @testable import DuckDuckGo
 import PrivacyConfigTestsUtils
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 final class NewBadgeVisibilityManagerTests: XCTestCase {
 

--- a/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingIntroViewModelTests.swift
@@ -19,8 +19,7 @@
 
 import Core
 import Onboarding
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import SetDefaultBrowserTestSupport
 import SystemSettingsPiPTutorialTestSupport

--- a/iOS/DuckDuckGoTests/OnboardingManagerTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingManagerTests.swift
@@ -18,8 +18,7 @@
 //
 
 import Onboarding
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import Testing
 import class UIKit.UIDevice

--- a/iOS/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingNavigationDelegateTests.swift
@@ -18,7 +18,7 @@
 //
 
 import XCTest
-import Persistence
+@_spi(Testing) import Persistence
 import Bookmarks
 import DDGSync
 import History
@@ -30,7 +30,6 @@ import Combine
 import SubscriptionTestingUtilities
 import Common
 import FoundationExtensions
-import PersistenceTestingUtils
 @testable import DuckDuckGo
 @testable import Core
 

--- a/iOS/DuckDuckGoTests/OnboardingPersonalizationAITests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPersonalizationAITests.swift
@@ -19,8 +19,7 @@
 
 import Testing
 import Foundation
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import AIChat
 import Onboarding

--- a/iOS/DuckDuckGoTests/OnboardingPersonalizationAdBlockingTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPersonalizationAdBlockingTests.swift
@@ -19,8 +19,7 @@
 
 import Testing
 import Foundation
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import WebExtensionsTestSupport
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/OnboardingPersonalizationSERPSettingsTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPersonalizationSERPSettingsTests.swift
@@ -19,8 +19,7 @@
 
 import Testing
 import Foundation
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import SERPSettings
 import AIChat
 @testable import DuckDuckGo

--- a/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/OnboardingPixelReporterTests.swift
@@ -20,8 +20,7 @@
 import XCTest
 import Core
 import Onboarding
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import PixelExperimentKit
 @testable import DuckDuckGo

--- a/iOS/DuckDuckGoTests/PersistentPixelTests.swift
+++ b/iOS/DuckDuckGoTests/PersistentPixelTests.swift
@@ -21,8 +21,7 @@ import Foundation
 import FoundationExtensions
 import XCTest
 import Networking
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import Core
 
 final class PersistentPixelTests: XCTestCase {

--- a/iOS/DuckDuckGoTests/SmallOmniBarStateTests.swift
+++ b/iOS/DuckDuckGoTests/SmallOmniBarStateTests.swift
@@ -19,7 +19,7 @@
 
 import FeatureFlags_iOS
 import Foundation
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 import XCTest
 @testable import DuckDuckGo

--- a/iOS/DuckDuckGoTests/Subscription/FreeTrials/VPNSubscriptionPromotionHelperTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/FreeTrials/VPNSubscriptionPromotionHelperTests.swift
@@ -20,7 +20,7 @@
 import XCTest
 @testable import Subscription
 import Core
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import SubscriptionTestingUtilities
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/SwitchBar/SessionStateMetricsTests.swift
+++ b/iOS/DuckDuckGoTests/SwitchBar/SessionStateMetricsTests.swift
@@ -19,7 +19,7 @@
 
 import XCTest
 @testable import DuckDuckGo
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 final class SessionStateMetricsTests: XCTestCase {
 

--- a/iOS/DuckDuckGoTests/SwitchBar/SwitchBarHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/SwitchBar/SwitchBarHandlerTests.swift
@@ -22,7 +22,7 @@ import PrivacyConfig
 @testable import Core
 @testable import DuckDuckGo
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 final class SwitchBarHandlerTests: XCTestCase {
 

--- a/iOS/DuckDuckGoTests/SwitchBar/SwitchBarRetentionMetricsTests.swift
+++ b/iOS/DuckDuckGoTests/SwitchBar/SwitchBarRetentionMetricsTests.swift
@@ -19,7 +19,7 @@
 
 import XCTest
 @testable import DuckDuckGo
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 final class SwitchBarRetentionMetricsTests: XCTestCase {
 

--- a/iOS/DuckDuckGoTests/SyncCreditCardsAdapterTests.swift
+++ b/iOS/DuckDuckGoTests/SyncCreditCardsAdapterTests.swift
@@ -25,7 +25,7 @@ import SecureStorage
 import Core
 import Common
 import FoundationExtensions
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
 
 final class SyncCreditCardsAdapterTests: XCTestCase {

--- a/iOS/DuckDuckGoTests/SyncRecoveryPromptServiceTests.swift
+++ b/iOS/DuckDuckGoTests/SyncRecoveryPromptServiceTests.swift
@@ -20,10 +20,9 @@
 import XCTest
 import Core
 import BrowserServicesKit
-import Persistence
+@_spi(Testing) import Persistence
 import SecureStorage
 @testable import DuckDuckGo
-@testable import PersistenceTestingUtils
 @testable import DDGSync
 
 @MainActor

--- a/iOS/DuckDuckGoTests/TabManagerExternalLaunchTests.swift
+++ b/iOS/DuckDuckGoTests/TabManagerExternalLaunchTests.swift
@@ -21,7 +21,7 @@ import Testing
 import Combine
 @testable import DuckDuckGo
 @testable import Core
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import BrowserServicesKitTestsUtils
 
 @Suite("TabManager - External Launch Management")

--- a/iOS/DuckDuckGoTests/TabManagerTests.swift
+++ b/iOS/DuckDuckGoTests/TabManagerTests.swift
@@ -18,12 +18,11 @@
 //
 
 import BrowserServicesKit
-import Persistence
+@_spi(Testing) import Persistence
 import BrowserServicesKitTestsUtils
 import Combine
 import ConcurrencyExtensions
 import Core
-import PersistenceTestingUtils
 import PrivacyConfig
 import SubscriptionTestingUtilities
 import XCTest

--- a/iOS/DuckDuckGoTests/TabTerminationTelemetryTests.swift
+++ b/iOS/DuckDuckGoTests/TabTerminationTelemetryTests.swift
@@ -18,8 +18,7 @@
 //
 
 import FeatureFlags_iOS
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PixelKit
 import PrivacyConfigTestsUtils
 import UIKit

--- a/iOS/DuckDuckGoTests/TabsModelPersistenceTests.swift
+++ b/iOS/DuckDuckGoTests/TabsModelPersistenceTests.swift
@@ -18,10 +18,9 @@
 //
 
 import XCTest
-import Persistence
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
 @testable import Core
-@testable import PersistenceTestingUtils
 
 class TabsModelPersistenceTests: XCTestCase {
 

--- a/iOS/DuckDuckGoTests/ToggleMode/DefaultTogglePositionTests.swift
+++ b/iOS/DuckDuckGoTests/ToggleMode/DefaultTogglePositionTests.swift
@@ -19,7 +19,7 @@
 
 import XCTest
 import AIChat
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import Core
 @testable import DuckDuckGo
 

--- a/iOS/DuckDuckGoTests/UserAgentConfigurationTests.swift
+++ b/iOS/DuckDuckGoTests/UserAgentConfigurationTests.swift
@@ -18,8 +18,7 @@
 //
 
 import XCTest
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import Common
 import FoundationExtensions
 import Testing

--- a/iOS/DuckDuckGoTests/WhatsNew/WhatsNewRepositoryTests.swift
+++ b/iOS/DuckDuckGoTests/WhatsNew/WhatsNewRepositoryTests.swift
@@ -21,7 +21,7 @@ import Foundation
 import Testing
 import RemoteMessaging
 import RemoteMessagingTestsUtils
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
 
 @Suite("What's New - Repository")

--- a/iOS/IntegrationTests/InactivityNotificationSchedulerServiceIntegrationTests.swift
+++ b/iOS/IntegrationTests/InactivityNotificationSchedulerServiceIntegrationTests.swift
@@ -18,7 +18,7 @@
 //
 
 import XCTest
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
 @testable import Core
 @testable import BrowserServicesKit

--- a/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
+++ b/iOS/IntegrationTests/ModalPromptCoordination/ModalPromptCoordinationManagerIntegrationTests.swift
@@ -21,8 +21,7 @@ import UIKit
 import Foundation
 import FoundationExtensions
 import Testing
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo
 
 @MainActor

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Package.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Package.swift
@@ -65,7 +65,7 @@ let package = Package(
                 "BrowserServicesKit",
                 .product(name: "Subscription", package: "BrowserServicesKit"),
                 .product(name: "DataBrokerProtectionCoreTestsUtils", package: "DataBrokerProtectionCore"),
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
                 .product(name: "SubscriptionTestingUtilities", package: "BrowserServicesKit"),
             ]
         )

--- a/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
+++ b/iOS/SharedStateTests/OnboardingDaxFavouritesTests.swift
@@ -18,7 +18,7 @@
 //
 
 import XCTest
-import Persistence
+@_spi(Testing) import Persistence
 import Bookmarks
 import DDGSync
 import History
@@ -31,7 +31,6 @@ import Core
 import SubscriptionTestingUtilities
 import Common
 @testable import DuckDuckGo
-@testable import PersistenceTestingUtils
 import SystemSettingsPiPTutorialTestSupport
 import Combine
 import PrivacyConfig

--- a/iOS/SharedStateTests/OnboardingNavigationDelegateTests.swift
+++ b/iOS/SharedStateTests/OnboardingNavigationDelegateTests.swift
@@ -18,7 +18,7 @@
 //
 
 import XCTest
-import Persistence
+@_spi(Testing) import Persistence
 import Bookmarks
 import DDGSync
 import History
@@ -32,7 +32,6 @@ import SubscriptionTestingUtilities
 import Common
 @testable import DuckDuckGo
 @testable import Core
-import PersistenceTestingUtils
 import PrivacyConfig
 
 // swiftlint:disable force_try

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/OmniBar/MockOmnibarDependency.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/OmniBar/MockOmnibarDependency.swift
@@ -20,7 +20,7 @@
 import AIChat
 import Foundation
 import PrivacyConfig
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import UIKit
 @testable import DuckDuckGo
 

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
@@ -25,12 +25,11 @@ import BrowserServicesKit
 import BrowserServicesKitTestsUtils
 import EventHub
 import PrivacyDashboard
-import Persistence
+@_spi(Testing) import Persistence
 import Subscription
 import SubscriptionTestingUtilities
 import SpecialErrorPages
 import MaliciousSiteProtection
-import PersistenceTestingUtils
 @testable import DuckDuckGo
 import Combine
 @testable import Core

--- a/iOS/WebViewUnitTests/CookieStorageTests.swift
+++ b/iOS/WebViewUnitTests/CookieStorageTests.swift
@@ -20,8 +20,7 @@
 import XCTest
 @testable import Core
 import WebKit
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 public class CookieStorageTests: XCTestCase {
 

--- a/iOS/WebViewUnitTests/DataStoreIDManagerTests.swift
+++ b/iOS/WebViewUnitTests/DataStoreIDManagerTests.swift
@@ -22,7 +22,7 @@ import Foundation
 import XCTest
 @testable import Core
 import WebKit
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 
 class DataStoreIDManagerTests: XCTestCase {
 

--- a/iOS/WebViewUnitTests/WebCacheManagerTests.swift
+++ b/iOS/WebViewUnitTests/WebCacheManagerTests.swift
@@ -20,7 +20,7 @@
 import XCTest
 @testable import Core
 import WebKit
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import BrowserServicesKitTestsUtils
 import WKAbstractions
 

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -4567,14 +4567,14 @@
 		F124B9572F2CC15600B29447 /* BuildFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = F124B9502F2CC15600B29447 /* BuildFlags.swift */; };
 		F124B9582F2CC15600B29447 /* BuildFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = F124B9502F2CC15600B29447 /* BuildFlags.swift */; };
 		F124E0DD2D6E12190035C7BA /* NetworkingTestingUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0DC2D6E12190035C7BA /* NetworkingTestingUtils */; };
-		F124E0DF2D6E12190035C7BA /* PersistenceTestingUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0DE2D6E12190035C7BA /* PersistenceTestingUtils */; };
+		F124E0DF2D6E12190035C7BA /* Persistence in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0DE2D6E12190035C7BA /* Persistence */; };
 		F124E0E12D6E12260035C7BA /* NetworkingTestingUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0E02D6E12260035C7BA /* NetworkingTestingUtils */; };
-		F124E0E32D6E12260035C7BA /* PersistenceTestingUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0E22D6E12260035C7BA /* PersistenceTestingUtils */; };
+		F124E0E32D6E12260035C7BA /* Persistence in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0E22D6E12260035C7BA /* Persistence */; };
 		F124E0E52D6E12260035C7BA /* SubscriptionTestingUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0E42D6E12260035C7BA /* SubscriptionTestingUtilities */; };
 		F124E0E72D6E122F0035C7BA /* NetworkingTestingUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0E62D6E122F0035C7BA /* NetworkingTestingUtils */; };
-		F124E0E92D6E122F0035C7BA /* PersistenceTestingUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0E82D6E122F0035C7BA /* PersistenceTestingUtils */; };
+		F124E0E92D6E122F0035C7BA /* Persistence in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0E82D6E122F0035C7BA /* Persistence */; };
 		F124E0EB2D6E123A0035C7BA /* NetworkingTestingUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0EA2D6E123A0035C7BA /* NetworkingTestingUtils */; };
-		F124E0ED2D6E123A0035C7BA /* PersistenceTestingUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0EC2D6E123A0035C7BA /* PersistenceTestingUtils */; };
+		F124E0ED2D6E123A0035C7BA /* Persistence in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0EC2D6E123A0035C7BA /* Persistence */; };
 		F124E0EF2D6E123A0035C7BA /* PixelKit in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0EE2D6E123A0035C7BA /* PixelKit */; };
 		F124E0F12D6E123A0035C7BA /* SubscriptionTestingUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = F124E0F02D6E123A0035C7BA /* SubscriptionTestingUtilities */; };
 		F1396E92FC2749888523B2FD /* AIChatOmnibarSubscriptionUpsellPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D82828FB034DE7BCB7BB91 /* AIChatOmnibarSubscriptionUpsellPresenterTests.swift */; };
@@ -7449,7 +7449,7 @@
 				845F57172E97CE9300C7F78A /* NoARCObjCTestUtilities in Frameworks */,
 				7B4659A42FAC000000CCB375 /* AddressBarPerformance in Frameworks */,
 				D668401C2E82BE31007DAAB2 /* PerformanceTest in Frameworks */,
-				F124E0E92D6E122F0035C7BA /* PersistenceTestingUtils in Frameworks */,
+				F124E0E92D6E122F0035C7BA /* Persistence in Frameworks */,
 				3706FE89293F661700E42796 /* OHHTTPStubsSwift in Frameworks */,
 				9F33033A2E8E605A00D6F0C9 /* RemoteMessagingTestsUtils in Frameworks */,
 				37EACB122EF53F5B002C06F9 /* PrivacyConfigTestsUtils in Frameworks */,
@@ -7466,7 +7466,7 @@
 			files = (
 				844801702E3BA42800E8A2C1 /* Clocks in Frameworks */,
 				845F57152E97CE8E00C7F78A /* NoARCObjCTestUtilities in Frameworks */,
-				F124E0ED2D6E123A0035C7BA /* PersistenceTestingUtils in Frameworks */,
+				F124E0ED2D6E123A0035C7BA /* Persistence in Frameworks */,
 				9F33033C2E8E606400D6F0C9 /* RemoteMessagingTestsUtils in Frameworks */,
 				9DC5FACF2C6BA23C0011F068 /* AppKitExtensions in Frameworks */,
 				F124E0F12D6E123A0035C7BA /* SubscriptionTestingUtilities in Frameworks */,
@@ -7508,7 +7508,7 @@
 				845F57192E97CE9600C7F78A /* NoARCObjCTestUtilities in Frameworks */,
 				F124E0E52D6E12260035C7BA /* SubscriptionTestingUtilities in Frameworks */,
 				9F0F46A22E865BEC00A9FC4D /* RemoteMessagingTestsUtils in Frameworks */,
-				F124E0E32D6E12260035C7BA /* PersistenceTestingUtils in Frameworks */,
+				F124E0E32D6E12260035C7BA /* Persistence in Frameworks */,
 				9DC5FAC92C6B8B910011F068 /* AppKitExtensions in Frameworks */,
 				4B9EE36C2D76CB3800DDC75C /* PixelKit in Frameworks */,
 				4B9EE36E2D76CB4000DDC75C /* Common in Frameworks */,
@@ -7826,7 +7826,7 @@
 				845F571B2E97CE9B00C7F78A /* NoARCObjCTestUtilities in Frameworks */,
 				7B4659A82FAC000000CCB375 /* AddressBarPerformance in Frameworks */,
 				D668401A2E82BE25007DAAB2 /* PerformanceTest in Frameworks */,
-				F124E0DF2D6E12190035C7BA /* PersistenceTestingUtils in Frameworks */,
+				F124E0DF2D6E12190035C7BA /* Persistence in Frameworks */,
 				9F0F46A02E865AFE00A9FC4D /* RemoteMessagingTestsUtils in Frameworks */,
 				B6DA44192616C13800DD1EC2 /* OHHTTPStubsSwift in Frameworks */,
 				37EACB0B2EF53969002C06F9 /* PrivacyConfigTestsUtils in Frameworks */,
@@ -13833,7 +13833,7 @@
 				9DC5FACC2C6B8E620011F068 /* AppKitExtensions */,
 				374EFDF02D01C70A00B30939 /* Utilities */,
 				F124E0E62D6E122F0035C7BA /* NetworkingTestingUtils */,
-				F124E0E82D6E122F0035C7BA /* PersistenceTestingUtils */,
+				F124E0E82D6E122F0035C7BA /* Persistence */,
 				4B9EE36F2D76CB5600DDC75C /* PixelKit */,
 				4B9EE3712D76CB5F00DDC75C /* SubscriptionTestingUtilities */,
 				8448016D2E3BA42400E8A2C1 /* Clocks */,
@@ -13877,7 +13877,7 @@
 				84B49F0C2CB10F0900FF08BB /* OHHTTPStubs */,
 				84B49F0E2CB10F0900FF08BB /* OHHTTPStubsSwift */,
 				F124E0EA2D6E123A0035C7BA /* NetworkingTestingUtils */,
-				F124E0EC2D6E123A0035C7BA /* PersistenceTestingUtils */,
+				F124E0EC2D6E123A0035C7BA /* Persistence */,
 				F124E0EE2D6E123A0035C7BA /* PixelKit */,
 				F124E0F02D6E123A0035C7BA /* SubscriptionTestingUtilities */,
 				4B9EE3732D76CB6D00DDC75C /* Common */,
@@ -13956,7 +13956,7 @@
 				B6AE39F429374AEC00C37AA4 /* OHHTTPStubsSwift */,
 				9DC5FAC82C6B8B910011F068 /* AppKitExtensions */,
 				F124E0E02D6E12260035C7BA /* NetworkingTestingUtils */,
-				F124E0E22D6E12260035C7BA /* PersistenceTestingUtils */,
+				F124E0E22D6E12260035C7BA /* Persistence */,
 				F124E0E42D6E12260035C7BA /* SubscriptionTestingUtilities */,
 				4B9EE36B2D76CB3800DDC75C /* PixelKit */,
 				4B9EE36D2D76CB4000DDC75C /* Common */,
@@ -14428,7 +14428,7 @@
 				9DC5FACA2C6B8E050011F068 /* AppKitExtensions */,
 				374EFDEE2D01C70300B30939 /* Utilities */,
 				F124E0DC2D6E12190035C7BA /* NetworkingTestingUtils */,
-				F124E0DE2D6E12190035C7BA /* PersistenceTestingUtils */,
+				F124E0DE2D6E12190035C7BA /* Persistence */,
 				EC2E83ED38F4FAB06EE3D557 /* EventHub */,
 				4B9EE3672D76CB1600DDC75C /* SubscriptionTestingUtilities */,
 				4B9EE3692D76CB2300DDC75C /* PixelKit */,
@@ -22568,17 +22568,17 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = NetworkingTestingUtils;
 		};
-		F124E0DE2D6E12190035C7BA /* PersistenceTestingUtils */ = {
+		F124E0DE2D6E12190035C7BA /* Persistence */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = PersistenceTestingUtils;
+			productName = Persistence;
 		};
 		F124E0E02D6E12260035C7BA /* NetworkingTestingUtils */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = NetworkingTestingUtils;
 		};
-		F124E0E22D6E12260035C7BA /* PersistenceTestingUtils */ = {
+		F124E0E22D6E12260035C7BA /* Persistence */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = PersistenceTestingUtils;
+			productName = Persistence;
 		};
 		F124E0E42D6E12260035C7BA /* SubscriptionTestingUtilities */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -22588,17 +22588,17 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = NetworkingTestingUtils;
 		};
-		F124E0E82D6E122F0035C7BA /* PersistenceTestingUtils */ = {
+		F124E0E82D6E122F0035C7BA /* Persistence */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = PersistenceTestingUtils;
+			productName = Persistence;
 		};
 		F124E0EA2D6E123A0035C7BA /* NetworkingTestingUtils */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = NetworkingTestingUtils;
 		};
-		F124E0EC2D6E123A0035C7BA /* PersistenceTestingUtils */ = {
+		F124E0EC2D6E123A0035C7BA /* Persistence */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = PersistenceTestingUtils;
+			productName = Persistence;
 		};
 		F124E0EE2D6E123A0035C7BA /* PixelKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/macOS/DuckDuckGo/Preferences/Model/AppearancePreferencesMock.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AppearancePreferencesMock.swift
@@ -18,7 +18,7 @@
 
 #if DEBUG
 
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import BrowserServicesKit
 import PrivacyConfig
 import PrivacyConfigTestsUtils

--- a/macOS/IntegrationTests/Configurations/ConfigurationManagerIntegrationTests.swift
+++ b/macOS/IntegrationTests/Configurations/ConfigurationManagerIntegrationTests.swift
@@ -18,8 +18,7 @@
 
 import XCTest
 import Combine
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 @testable import Configuration

--- a/macOS/IntegrationTests/Fire/FireCoordinatorIntegrationTests.swift
+++ b/macOS/IntegrationTests/Fire/FireCoordinatorIntegrationTests.swift
@@ -20,8 +20,7 @@ import AppKit
 import FeatureFlags_macOS
 import History
 import HistoryView
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import SharedTestUtilities
 @_spi(Testing) import PixelKit

--- a/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
+++ b/macOS/IntegrationTests/Onboarding/BrowserTabViewControllerOnboardingTests.swift
@@ -24,7 +24,7 @@ import FeatureFlags_macOS
 import History
 import HistoryView
 import Onboarding
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 import PrivacyDashboard

--- a/macOS/IntegrationTests/Tab/BrowserTabViewControllerContentOverlayDismissalTests.swift
+++ b/macOS/IntegrationTests/Tab/BrowserTabViewControllerContentOverlayDismissalTests.swift
@@ -19,7 +19,7 @@
 import AppKit
 import BrowserServicesKit
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 import SharedTestUtilities

--- a/macOS/LocalPackages/AppUpdater/Package.swift
+++ b/macOS/LocalPackages/AppUpdater/Package.swift
@@ -98,7 +98,7 @@ let package = Package(
                 .product(name: "FoundationExtensions", package: "SystemFrameworksExtensions"),
                 .product(name: "CombineExtensions", package: "SystemFrameworksExtensions"),
                 .product(name: "ConcurrencyExtensions", package: "SystemFrameworksExtensions"),
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
             ]
         ),
         .testTarget(
@@ -119,7 +119,7 @@ let package = Package(
                 "AppUpdaterTestHelpers",
                 .product(name: "Sparkle", package: "Sparkle"),
                 .product(name: "BrowserServicesKitTestsUtils", package: "BrowserServicesKit"),
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
                 .product(name: "PixelKit", package: "PixelKit"),
                 .product(name: "PrivacyConfig", package: "BrowserServicesKit"),
             ]

--- a/macOS/LocalPackages/AppUpdater/Tests/AppUpdaterSharedTests/ManualUpdateRemovalHandlerTests.swift
+++ b/macOS/LocalPackages/AppUpdater/Tests/AppUpdaterSharedTests/ManualUpdateRemovalHandlerTests.swift
@@ -19,8 +19,7 @@
 import AppUpdaterShared
 import AppUpdaterTestHelpers
 import FeatureFlags_macOS
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import XCTest
 

--- a/macOS/LocalPackages/AppUpdater/Tests/AppUpdaterSharedTests/UpdatesDebugSettingsTests.swift
+++ b/macOS/LocalPackages/AppUpdater/Tests/AppUpdaterSharedTests/UpdatesDebugSettingsTests.swift
@@ -18,8 +18,7 @@
 
 import AppUpdaterShared
 import Common
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 
 final class UpdatesDebugSettingsTests: XCTestCase {

--- a/macOS/LocalPackages/AppUpdater/Tests/SparkleAppUpdaterTests/ApplicationUpdateDetectorTests.swift
+++ b/macOS/LocalPackages/AppUpdater/Tests/SparkleAppUpdaterTests/ApplicationUpdateDetectorTests.swift
@@ -18,8 +18,7 @@
 
 import AppUpdaterShared
 import BrowserServicesKit
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 
 final class ApplicationUpdateDetectorTests: XCTestCase {

--- a/macOS/LocalPackages/AppUpdater/Tests/SparkleAppUpdaterTests/SparkleUpdateCompletionValidatorTests.swift
+++ b/macOS/LocalPackages/AppUpdater/Tests/SparkleAppUpdaterTests/SparkleUpdateCompletionValidatorTests.swift
@@ -18,8 +18,7 @@
 
 import AppUpdaterShared
 import Common
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @_spi(Testing) import PixelKit
 import SparkleAppUpdater
 import XCTest

--- a/macOS/LocalPackages/AppUpdater/Tests/SparkleAppUpdaterTests/SparkleUpdateWideEventTests.swift
+++ b/macOS/LocalPackages/AppUpdater/Tests/SparkleAppUpdaterTests/SparkleUpdateWideEventTests.swift
@@ -18,8 +18,7 @@
 
 import AppUpdaterShared
 import BrowserServicesKitTestsUtils
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @_spi(Testing) import PixelKit
 import SparkleAppUpdater
 import XCTest

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Package.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Package.swift
@@ -77,7 +77,7 @@ let package = Package(
                 "BrowserServicesKit",
                 .product(name: "BrowserServicesKitTestsUtils", package: "BrowserServicesKit"),
                 "Freemium",
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
                 .product(name: "SubscriptionTestingUtilities", package: "BrowserServicesKit"),
                 .product(name: "PrivacyConfigTestsUtils", package: "BrowserServicesKit"),
                 .product(name: "FeatureFlags-macOS", package: "FeatureFlags-macOS"),

--- a/macOS/LocalPackages/NewTabPage/Package.swift
+++ b/macOS/LocalPackages/NewTabPage/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
                 .product(name: "AutoconsentStats", package: "BrowserServicesKit"),
                 .product(name: "Bookmarks", package: "BrowserServicesKit"),
                 .product(name: "BrowserServicesKit", package: "BrowserServicesKit"),
-                .product(name: "PersistenceTestingUtils", package: "Persistence"),
+                .product(name: "Persistence", package: "Persistence"),
                 .product(name: "PrivacyStats", package: "BrowserServicesKit"),
                 .product(name: "RemoteMessaging", package: "BrowserServicesKit"),
                 .product(name: "UserScript", package: "BrowserServicesKit"),

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageFavoritesClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageFavoritesClientTests.swift
@@ -18,7 +18,7 @@
 
 import Combine
 import RemoteMessaging
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 @testable import NewTabPage
 

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageFavoritesModelTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageFavoritesModelTests.swift
@@ -17,7 +17,7 @@
 //
 
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 @testable import NewTabPage
 

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageNextStepsCardsClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageNextStepsCardsClientTests.swift
@@ -17,7 +17,7 @@
 //
 
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 @testable import NewTabPage
 

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPagePrivacyStatsClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPagePrivacyStatsClientTests.swift
@@ -18,7 +18,7 @@
 
 import Combine
 import PrivacyStats
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import TrackerRadarKit
 import XCTest
 @testable import NewTabPage

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPagePrivacyStatsModelTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPagePrivacyStatsModelTests.swift
@@ -19,7 +19,7 @@
 import Combine
 import PrivacyStats
 import AutoconsentStats
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import TrackerRadarKit
 import XCTest
 @testable import NewTabPage

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageProtectionsReportClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageProtectionsReportClientTests.swift
@@ -18,7 +18,7 @@
 
 import Combine
 import PrivacyStats
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import TrackerRadarKit
 import XCTest
 @testable import NewTabPage

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageProtectionsReportModelTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageProtectionsReportModelTests.swift
@@ -18,7 +18,7 @@
 
 import Combine
 import PrivacyStats
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import TrackerRadarKit
 import XCTest
 @testable import NewTabPage

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageRecentActivityClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageRecentActivityClientTests.swift
@@ -17,7 +17,7 @@
 //
 
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyStats
 import TrackerRadarKit
 import XCTest

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageRecentActivityModelTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageRecentActivityModelTests.swift
@@ -17,7 +17,7 @@
 //
 
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyStats
 import TrackerRadarKit
 import XCTest

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/UserDefaultsNewTabPageProtectionsReportSettingsPersistorTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/UserDefaultsNewTabPageProtectionsReportSettingsPersistorTests.swift
@@ -17,7 +17,7 @@
 //
 
 import XCTest
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import NewTabPage
 
 final class UserDefaultsNewTabPageProtectionsReportSettingsPersistorTests: XCTestCase {

--- a/macOS/LocalPackages/TestUtilities/Package.swift
+++ b/macOS/LocalPackages/TestUtilities/Package.swift
@@ -34,6 +34,7 @@ let package = Package(
         .package(path: "../Utilities"),
         .package(path: "../AppKitExtensions"),
         .package(path: "../../../SharedPackages/Common"),
+        .package(path: "../../../SharedPackages/Persistence"),
         .package(path: "../../../SharedPackages/PixelKit"),
         .package(path: "../../../SharedPackages/BrowserServicesKit"),
         .package(path: "../../../SharedPackages/Infrastructure/SystemFrameworksExtensions"),
@@ -64,6 +65,7 @@ let package = Package(
                 .product(name: "Navigation", package: "BrowserServicesKit"),
                 .product(name: "Suggestions", package: "BrowserServicesKit"),
                 .product(name: "SharedObjCTestsUtils", package: "BrowserServicesKit"),
+                .product(name: "Persistence", package: "Persistence"),
                 .product(name: "PixelKit", package: "PixelKit"),
                 .product(name: "Utilities", package: "Utilities"),
             ]

--- a/macOS/UnitTests/AIChat/AIChatRemoteSettingsTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatRemoteSettingsTests.swift
@@ -18,8 +18,7 @@
 
 import BrowserServicesKit
 import Combine
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 import XCTest

--- a/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
@@ -21,8 +21,7 @@ import BrowserServicesKitTestsUtils
 import Combine
 import UserScript
 import WebKit
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 
 @testable import DuckDuckGo_Privacy_Browser

--- a/macOS/UnitTests/Autoconsent/AutoconsentMessageProtocolTests.swift
+++ b/macOS/UnitTests/Autoconsent/AutoconsentMessageProtocolTests.swift
@@ -23,7 +23,7 @@ import FeatureFlags_macOS
 import FoundationExtensions
 import History
 import HistoryView
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PixelKit
 import PrivacyConfig
 import PrivacyConfigTestsUtils

--- a/macOS/UnitTests/Autoconsent/AutoconsentStatsPopoverCoordinatorTests.swift
+++ b/macOS/UnitTests/Autoconsent/AutoconsentStatsPopoverCoordinatorTests.swift
@@ -22,7 +22,7 @@ import Combine
 import Common
 import FoundationExtensions
 import FeatureFlags_macOS
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PixelKit
 import PrivacyConfig
 import PrivacyConfigTestsUtils

--- a/macOS/UnitTests/Common/FileSystem/AppStateRestorationManagerTests.swift
+++ b/macOS/UnitTests/Common/FileSystem/AppStateRestorationManagerTests.swift
@@ -18,7 +18,7 @@
 
 import AppUpdaterShared
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @_spi(Testing) import PixelKit
 import PrivacyConfig
 import PrivacyConfigTestsUtils

--- a/macOS/UnitTests/ContentBlocker/ContentBlockingUpdatingTests.swift
+++ b/macOS/UnitTests/ContentBlocker/ContentBlockingUpdatingTests.swift
@@ -21,7 +21,7 @@ import Common
 import FoundationExtensions
 import History
 import HistoryView
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 import TrackerRadarKit

--- a/macOS/UnitTests/ContentBlocker/ScriptSourceProviderTests.swift
+++ b/macOS/UnitTests/ContentBlocker/ScriptSourceProviderTests.swift
@@ -21,7 +21,7 @@ import Common
 import FoundationExtensions
 import History
 import HistoryView
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 import SharedTestUtilities

--- a/macOS/UnitTests/DarkReader/DarkReaderFeatureSettingsTests.swift
+++ b/macOS/UnitTests/DarkReader/DarkReaderFeatureSettingsTests.swift
@@ -17,7 +17,7 @@
 //
 
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @_spi(Testing) import PixelKit
 import PrivacyConfig
 import PrivacyConfigTestsUtils

--- a/macOS/UnitTests/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromoDelegateTests.swift
+++ b/macOS/UnitTests/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromoDelegateTests.swift
@@ -17,7 +17,7 @@
 //
 
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 import XCTest

--- a/macOS/UnitTests/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptServiceTests.swift
+++ b/macOS/UnitTests/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptServiceTests.swift
@@ -17,7 +17,7 @@
 //
 
 import XCTest
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 @testable import DuckDuckGo_Privacy_Browser

--- a/macOS/UnitTests/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptStorageTests.swift
+++ b/macOS/UnitTests/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptStorageTests.swift
@@ -19,7 +19,7 @@
 import Common
 import FoundationExtensions
 import Foundation
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import Testing
 
 @testable import DuckDuckGo_Privacy_Browser

--- a/macOS/UnitTests/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptUserActivityStoreTests.swift
+++ b/macOS/UnitTests/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptUserActivityStoreTests.swift
@@ -17,7 +17,7 @@
 //
 
 import Foundation
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import Testing
 
 @testable import DuckDuckGo_Privacy_Browser

--- a/macOS/UnitTests/Feedback/QuickFeedback/QuickFeedbackTipControllerTests.swift
+++ b/macOS/UnitTests/Feedback/QuickFeedback/QuickFeedbackTipControllerTests.swift
@@ -16,8 +16,7 @@
 //  limitations under the License.
 //
 
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 

--- a/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
+++ b/macOS/UnitTests/Fire/FireDialogViewModelTests.swift
@@ -21,8 +21,7 @@ import FeatureFlags_macOS
 import FoundationExtensions
 import History
 import HistoryView
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @_spi(Testing) import PixelKit
 import PrivacyConfig
 import SharedTestUtilities

--- a/macOS/UnitTests/MaliciousSiteProtection/MaliciousSiteProtectionTests.swift
+++ b/macOS/UnitTests/MaliciousSiteProtection/MaliciousSiteProtectionTests.swift
@@ -19,7 +19,7 @@
 import Combine
 import Foundation
 import MaliciousSiteProtection
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 import NetworkingTestingUtils

--- a/macOS/UnitTests/NewTabPage/NewTabPageCoordinatorTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageCoordinatorTests.swift
@@ -23,7 +23,7 @@ import FoundationExtensions
 import History
 import HistoryView
 import NewTabPage
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @_spi(Testing) import PixelKit
 import PrivacyConfig
 import PrivacyConfigTestsUtils

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsCardsPersistorTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsCardsPersistorTests.swift
@@ -17,7 +17,7 @@
 //
 
 import NewTabPage
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 

--- a/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageNextStepsSingleCardProviderTests.swift
@@ -21,7 +21,7 @@ import Combine
 import DDGSync
 import FeatureFlags_macOS
 import NewTabPage
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PixelKit
 import PrivacyConfig
 import PrivacyConfigTestsUtils

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
@@ -20,8 +20,7 @@ import AIChat
 import Combine
 import FeatureFlags_macOS
 import XCTest
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PixelKit
 import PrivacyConfig
 import NewTabPage

--- a/macOS/UnitTests/NewTabPage/NewTabPageProtectionsReportSettingsMigratorTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageProtectionsReportSettingsMigratorTests.swift
@@ -17,8 +17,7 @@
 //
 
 import NewTabPage
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 

--- a/macOS/UnitTests/NewTabPage/NewTabPageShownPixelSenderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageShownPixelSenderTests.swift
@@ -18,7 +18,7 @@
 
 import Combine
 import NewTabPage
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PixelKit
 import PrivacyConfig
 import PrivacyConfigTestsUtils

--- a/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
+++ b/macOS/UnitTests/Onboarding/OnboardingManagerTests.swift
@@ -20,8 +20,7 @@ import AIChat
 import Combine
 import FeatureFlags_macOS
 import Onboarding
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PixelExperimentKit
 import PixelKit
 import PrivacyConfig

--- a/macOS/UnitTests/Preferences/AboutPreferencesManualUpdateTests.swift
+++ b/macOS/UnitTests/Preferences/AboutPreferencesManualUpdateTests.swift
@@ -18,7 +18,7 @@
 
 import AppUpdaterShared
 import FeatureFlags_macOS
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser

--- a/macOS/UnitTests/Preferences/AppearancePreferencesTests.swift
+++ b/macOS/UnitTests/Preferences/AppearancePreferencesTests.swift
@@ -18,7 +18,7 @@
 
 import Bookmarks
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @_spi(Testing) import PixelKit
 import PrivacyConfig
 import PrivacyConfigTestsUtils

--- a/macOS/UnitTests/Preferences/PreferencesSidebarModelTests.swift
+++ b/macOS/UnitTests/Preferences/PreferencesSidebarModelTests.swift
@@ -21,7 +21,7 @@ import Common
 import ConcurrencyExtensions
 import FoundationExtensions
 import NetworkingTestingUtils
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @_spi(Testing) import PixelKit
 import PreferencesUI_macOS
 import PrivacyConfig

--- a/macOS/UnitTests/Preferences/RootViewV2Tests.swift
+++ b/macOS/UnitTests/Preferences/RootViewV2Tests.swift
@@ -17,7 +17,7 @@
 //
 
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @_spi(Testing) import PixelKit
 import PrivacyConfig
 import Subscription

--- a/macOS/UnitTests/Preferences/StartupPreferencesTests.swift
+++ b/macOS/UnitTests/Preferences/StartupPreferencesTests.swift
@@ -17,7 +17,7 @@
 //
 
 import XCTest
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 @testable import DuckDuckGo_Privacy_Browser

--- a/macOS/UnitTests/Promotions/PromoHistoryStoreTests.swift
+++ b/macOS/UnitTests/Promotions/PromoHistoryStoreTests.swift
@@ -17,7 +17,7 @@
 //
 
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 

--- a/macOS/UnitTests/Promotions/PromoRegistryTests.swift
+++ b/macOS/UnitTests/Promotions/PromoRegistryTests.swift
@@ -16,7 +16,7 @@
 //  limitations under the License.
 //
 
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import RemoteMessaging
 import RemoteMessagingTestsUtils

--- a/macOS/UnitTests/Promotions/PromoServiceFactoryTests.swift
+++ b/macOS/UnitTests/Promotions/PromoServiceFactoryTests.swift
@@ -16,7 +16,7 @@
 //  limitations under the License.
 //
 
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 import RemoteMessagingTestsUtils

--- a/macOS/UnitTests/PromptBar/PromptBarPreferencesPersistorTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarPreferencesPersistorTests.swift
@@ -17,7 +17,7 @@
 //
 
 import Carbon.HIToolbox
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 

--- a/macOS/UnitTests/PromptBar/PromptBarPreferencesTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarPreferencesTests.swift
@@ -18,7 +18,7 @@
 
 import Carbon.HIToolbox
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 

--- a/macOS/UnitTests/RemoteMessaging/RemoteMessagePromoDelegateTests.swift
+++ b/macOS/UnitTests/RemoteMessaging/RemoteMessagePromoDelegateTests.swift
@@ -18,7 +18,7 @@
 
 import Combine
 import Foundation
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import RemoteMessaging
 import RemoteMessagingTestsUtils
 import XCTest

--- a/macOS/UnitTests/StateRestoration/UncleanExitRestartSourceResolverTests.swift
+++ b/macOS/UnitTests/StateRestoration/UncleanExitRestartSourceResolverTests.swift
@@ -18,8 +18,7 @@
 
 import AppUpdaterShared
 import CrashReportingShared
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 
 @testable import CrashReporting

--- a/macOS/UnitTests/Statistics/ATB/ReinstallUserDetectionTests.swift
+++ b/macOS/UnitTests/Statistics/ATB/ReinstallUserDetectionTests.swift
@@ -17,7 +17,7 @@
 //
 
 import AppUpdaterShared
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import XCTest
 
 @testable import DuckDuckGo_Privacy_Browser

--- a/macOS/UnitTests/Subscription/PreferencesSubscriptionSettingsModelTests.swift
+++ b/macOS/UnitTests/Subscription/PreferencesSubscriptionSettingsModelTests.swift
@@ -21,8 +21,7 @@ import Combine
 import Subscription
 import SubscriptionTestingUtilities
 import BrowserServicesKit
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import SubscriptionUI
 @testable import DuckDuckGo_Privacy_Browser
 

--- a/macOS/UnitTests/Sync/DismissableSyncDeviceButtonModelTests.swift
+++ b/macOS/UnitTests/Sync/DismissableSyncDeviceButtonModelTests.swift
@@ -19,8 +19,7 @@
 import Combine
 import DDGSync
 import FeatureFlags_macOS
-import Persistence
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser

--- a/macOS/UnitTests/Sync/Mocks/MockDDGSyncing.swift
+++ b/macOS/UnitTests/Sync/Mocks/MockDDGSyncing.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 import Combine
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo_Privacy_Browser
 @testable import DDGSync
 

--- a/macOS/UnitTests/Sync/SyncCreditCardsAdapterTests.swift
+++ b/macOS/UnitTests/Sync/SyncCreditCardsAdapterTests.swift
@@ -20,7 +20,7 @@ import XCTest
 import BrowserServicesKit
 import Combine
 import DDGSync
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @testable import DuckDuckGo_Privacy_Browser
 
 final class SyncCreditCardsAdapterTests: XCTestCase {

--- a/macOS/UnitTests/Sync/SyncDialogControllerTests.swift
+++ b/macOS/UnitTests/Sync/SyncDialogControllerTests.swift
@@ -19,11 +19,10 @@
 import Bookmarks
 import Combine
 import Foundation
-import Persistence
+@_spi(Testing) import Persistence
 @_spi(Testing) import PixelKit
 @testable import SyncUI_macOS
 import XCTest
-import PersistenceTestingUtils
 @testable import BrowserServicesKit
 @testable import DDGSync
 @testable import DuckDuckGo_Privacy_Browser

--- a/macOS/UnitTests/Sync/SyncPreferencesTests.swift
+++ b/macOS/UnitTests/Sync/SyncPreferencesTests.swift
@@ -20,9 +20,8 @@ import Bookmarks
 import BrowserServicesKit
 import Combine
 import FeatureFlags_macOS
-import Persistence
+@_spi(Testing) import Persistence
 import XCTest
-import PersistenceTestingUtils
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 @testable import DDGSync

--- a/macOS/UnitTests/Tab/ViewModel/TabViewModelTests.swift
+++ b/macOS/UnitTests/Tab/ViewModel/TabViewModelTests.swift
@@ -22,7 +22,7 @@ import DesignResourcesKitIcons
 import FeatureFlags_macOS
 import MaliciousSiteProtection
 import Navigation
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 import SharedTestUtilities

--- a/macOS/UnitTests/TabBar/ViewModel/TabSuspensionServiceTests.swift
+++ b/macOS/UnitTests/TabBar/ViewModel/TabSuspensionServiceTests.swift
@@ -16,7 +16,7 @@
 //  limitations under the License.
 //
 
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 import PixelKit
 import PrivacyConfig
 import PrivacyConfigTestsUtils

--- a/macOS/UnitTests/UserChurn/UserChurnServiceTests.swift
+++ b/macOS/UnitTests/UserChurn/UserChurnServiceTests.swift
@@ -16,7 +16,7 @@
 //  limitations under the License.
 //
 
-import PersistenceTestingUtils
+@_spi(Testing) import Persistence
 @_spi(Testing) import PixelKit
 import XCTest
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205842942115003/task/1217710722600967

### Description

`Persistence` fixed following the shape already used for PixelKit: the three in-memory stores move into the `Persistence` target under `TestingSupport/` behind `@_spi(Testing)`, and the `PersistenceTestingUtils` product and target are removed, so there is only ever one copy of `Persistence` in the process. Call sites use `@_spi(Testing) import Persistence`; a plain import cannot see the mocks.

Second commit closes a related gap: nothing had been running the `Common`, `DDGError`, `Persistence` and `PixelKit` package tests since #6405 extracted them, so they now run in `bsk_pr_checks.yml`.

### Testing Steps

1. CI is green, in particular `iOS - PR Checks / Unit Tests`, which should finish in its usual ~12 minutes rather than being cancelled at 60.
2. The new `BSK - PR Checks / Run unit tests (<package>, macOS)` legs pass for all four packages.

---

###### Internal references: [DoD](https://app.asana.com/0/1207634633537039) | [Eng Expectations](https://app.asana.com/0/199064865822552) | [Tech Design Template](https://app.asana.com/0/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widespread test-target and SPM product changes around Persistence linking; production APIs are unchanged but a wrong SPI/import could leak test types or miss coverage. CI path filters and a new shared-package test job also affect merge gates.
> 
> **Overview**
> Stops iOS unit tests from crashing by removing the `PersistenceTestingUtils` product. In-memory stores now live in the `Persistence` target under `TestingSupport/` behind `@_spi(Testing)`, so Xcode no longer statically links a second copy of Persistence into app-hosted test bundles.
> 
> Call sites (packages, iOS/macOS test targets, and Xcode projects) switch to `@_spi(Testing) import Persistence`. A plain import cannot see the mocks.
> 
> Also restores CI for `Common`, `DDGError`, `Persistence`, and `PixelKit` in `bsk_pr_checks.yml` with one combined macOS job, since those tests had no home after they were split out of BSK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9556a1dac9b3e4233bad5e292b4513d281889c44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->