### PR TITLE
iOS: Contextual Duck.ai follow-ups — chats menu rename, translations, glyph rule, scrim/pill polish

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/iOS/Views/QuickActions/AIChatQuickActionChipView.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/Views/QuickActions/AIChatQuickActionChipView.swift
@@ -42,6 +42,9 @@ public final class AIChatQuickActionChipView: UIView {
         static let glassShadowOpacity: Float = 0.02
         static let glassShadowRadius: CGFloat = 15
         static let glassShadowOffsetY: CGFloat = 8
+        /// Darkens the glass so the pills separate from light page content behind them.
+        static let glassTintAlphaLight: CGFloat = 0.06
+        static let glassTintAlphaDark: CGFloat = 0.14
         /// Outer 8 plus the label group's inner 6, per the design.
         static let glassIconLeadingPadding: CGFloat = 14
         static let glassIconLabelSpacing: CGFloat = 8
@@ -141,13 +144,14 @@ private extension AIChatQuickActionChipView {
                                    iconToLabel: Constants.iconLabelSpacing,
                                    trailing: Constants.trailingPadding)
         case .glass:
-            // The glass is the background: nothing of ours behind it, and no tint holding it lighter than the
-            // page it sits over. It adapts to that page, and its `contentView` keeps the label legible as it does.
+            // The glass is the background: nothing of ours behind it. It adapts to the page it sits over,
+            // darkened by its own tint so the pills read against light page content.
             backgroundColor = .clear
             // No border: it lives on this layer, so it can't scale with the glass's interactive
             // expansion and would sit inside the enlarged pill on touch.
             layer.borderWidth = 0
             installGlassBackgroundIfNeeded()
+            applyGlassEffect()
             hostContent(in: glassBackgroundView?.contentView ?? self)
             applyGlassShadow()
             applyCornerRadius(Constants.height / 2)
@@ -178,14 +182,10 @@ private extension AIChatQuickActionChipView {
     func installGlassBackgroundIfNeeded() {
         guard glassBackgroundView == nil else { return }
 
-        let effectView: UIVisualEffectView
+        let effectView = UIVisualEffectView()
         if #available(iOS 26.0, *) {
-            let effect = UIGlassEffect(style: .regular)
-            effect.isInteractive = true
-            effectView = UIVisualEffectView(effect: effect)
             effectView.cornerConfiguration = .capsule()
         } else {
-            effectView = UIVisualEffectView(effect: UIBlurEffect(style: .systemThinMaterial))
             effectView.clipsToBounds = true
             effectView.layer.cornerCurve = .continuous
         }
@@ -199,6 +199,28 @@ private extension AIChatQuickActionChipView {
             effectView.trailingAnchor.constraint(equalTo: trailingAnchor),
         ])
         glassBackgroundView = effectView
+    }
+
+    /// Re-made rather than mutated: `UIGlassEffect`'s tint is fixed at init, so a light/dark flip
+    /// needs a fresh effect for the new tint to take.
+    func applyGlassEffect() {
+        guard let glassBackgroundView else { return }
+
+        if #available(iOS 26.0, *) {
+            let effect = UIGlassEffect(style: .regular)
+            effect.isInteractive = true
+            effect.tintColor = UIColor.black.withAlphaComponent(glassTintAlpha)
+            glassBackgroundView.effect = effect
+        } else {
+            glassBackgroundView.effect = UIBlurEffect(style: .systemMaterial)
+        }
+    }
+
+    /// Dark glass carries more tint: it sits over darker content, so the same value would barely read.
+    var glassTintAlpha: CGFloat {
+        traitCollection.userInterfaceStyle == .dark
+            ? Constants.glassTintAlphaDark
+            : Constants.glassTintAlphaLight
     }
 
     func applyGlassShadow() {

--- a/SharedPackages/AIChat/Sources/AIChat/iOS/Views/QuickActions/AIChatQuickActionChipView.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/Views/QuickActions/AIChatQuickActionChipView.swift
@@ -209,9 +209,8 @@ private extension AIChatQuickActionChipView {
         return effectView
     }
 
-    /// Re-made rather than mutated: `UIGlassEffect`'s tint is fixed at init, so a light/dark flip
-    /// needs a fresh effect for the new tint to take. Skipped when the tint has not moved, since
-    /// assigning `effect` rebuilds the backdrop chain.
+    /// `UIGlassEffect`'s tint is fixed at init, so a theme flip needs a fresh effect. Skipped when the
+    /// tint hasn't moved — assigning `effect` rebuilds the backdrop chain.
     func applyGlassTint(on glass: UIVisualEffectView) {
         guard #available(iOS 26.0, *) else { return }
 

--- a/SharedPackages/AIChat/Sources/AIChat/iOS/Views/QuickActions/AIChatQuickActionChipView.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/Views/QuickActions/AIChatQuickActionChipView.swift
@@ -42,7 +42,8 @@ public final class AIChatQuickActionChipView: UIView {
         static let glassShadowOpacity: Float = 0.02
         static let glassShadowRadius: CGFloat = 15
         static let glassShadowOffsetY: CGFloat = 8
-        /// Darkens the glass so the pills separate from light page content behind them.
+        /// Darkens the glass so the pills separate from the page behind them. iOS 26 only — the
+        /// earlier blur fallback has no tint to carry it.
         static let glassTintAlphaLight: CGFloat = 0.06
         static let glassTintAlphaDark: CGFloat = 0.14
         /// Outer 8 plus the label group's inner 6, per the design.
@@ -71,6 +72,8 @@ public final class AIChatQuickActionChipView: UIView {
     private var iconLabelSpacingConstraint: NSLayoutConstraint?
     private var labelTrailingConstraint: NSLayoutConstraint?
     private var glassBackgroundView: UIVisualEffectView?
+    /// Tint the live glass effect was built for, so an unchanged appearance skips the rebuild.
+    private var appliedGlassTintAlpha: CGFloat?
 
     // MARK: - UI Components
 
@@ -150,9 +153,9 @@ private extension AIChatQuickActionChipView {
             // No border: it lives on this layer, so it can't scale with the glass's interactive
             // expansion and would sit inside the enlarged pill on touch.
             layer.borderWidth = 0
-            installGlassBackgroundIfNeeded()
-            applyGlassEffect()
-            hostContent(in: glassBackgroundView?.contentView ?? self)
+            let glass = installGlassBackgroundIfNeeded()
+            applyGlassTint(on: glass)
+            hostContent(in: glass.contentView)
             applyGlassShadow()
             applyCornerRadius(Constants.height / 2)
             heightConstraint?.constant = Constants.height
@@ -179,13 +182,15 @@ private extension AIChatQuickActionChipView {
     }
 
     /// Shaped via `cornerConfiguration` — a layer `cornerRadius` leaves the effect rectangular behind it.
-    func installGlassBackgroundIfNeeded() {
-        guard glassBackgroundView == nil else { return }
+    @discardableResult
+    func installGlassBackgroundIfNeeded() -> UIVisualEffectView {
+        if let glassBackgroundView { return glassBackgroundView }
 
         let effectView = UIVisualEffectView()
         if #available(iOS 26.0, *) {
             effectView.cornerConfiguration = .capsule()
         } else {
+            effectView.effect = UIBlurEffect(style: .systemThinMaterial)
             effectView.clipsToBounds = true
             effectView.layer.cornerCurve = .continuous
         }
@@ -199,21 +204,23 @@ private extension AIChatQuickActionChipView {
             effectView.trailingAnchor.constraint(equalTo: trailingAnchor),
         ])
         glassBackgroundView = effectView
+        return effectView
     }
 
     /// Re-made rather than mutated: `UIGlassEffect`'s tint is fixed at init, so a light/dark flip
-    /// needs a fresh effect for the new tint to take.
-    func applyGlassEffect() {
-        guard let glassBackgroundView else { return }
+    /// needs a fresh effect for the new tint to take. Skipped when the tint has not moved, since
+    /// assigning `effect` rebuilds the backdrop chain.
+    func applyGlassTint(on glass: UIVisualEffectView) {
+        guard #available(iOS 26.0, *) else { return }
 
-        if #available(iOS 26.0, *) {
-            let effect = UIGlassEffect(style: .regular)
-            effect.isInteractive = true
-            effect.tintColor = UIColor.black.withAlphaComponent(glassTintAlpha)
-            glassBackgroundView.effect = effect
-        } else {
-            glassBackgroundView.effect = UIBlurEffect(style: .systemMaterial)
-        }
+        let alpha = glassTintAlpha
+        guard appliedGlassTintAlpha != alpha else { return }
+        appliedGlassTintAlpha = alpha
+
+        let effect = UIGlassEffect(style: .regular)
+        effect.isInteractive = true
+        effect.tintColor = UIColor.black.withAlphaComponent(alpha)
+        glass.effect = effect
     }
 
     /// Dark glass carries more tint: it sits over darker content, so the same value would barely read.

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1914,7 +1914,7 @@
 		B6BA95C328891E33004ABA20 /* BrowsingMenuAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6BA95C228891E33004ABA20 /* BrowsingMenuAnimator.swift */; };
 		B772933486CDFE9E9DDBD2BF /* FileCorruptErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B772933186CDFE9E9DDBD2BF /* FileCorruptErrorViewController.swift */; };
 		B77369B84928113F87E18ED6 /* SearchTokenRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD63EDD2D1E5E97F3084B04F /* SearchTokenRequest.swift */; };
-		B7A3E1F20A1B2C3D4E5F6A70 /* AIChatRecentChatsPopupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C4F2A31B2C3D4E5F6A7081 /* AIChatRecentChatsPopupViewModel.swift */; };
+		B7A3E1F20A1B2C3D4E5F6A70 /* AIChatRecentChatsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C4F2A31B2C3D4E5F6A7081 /* AIChatRecentChatsMenuViewModel.swift */; };
 		B7A97190FB026429E034DB99 /* TabViewControllerSiteLoadingPixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3652B1D4CCA25401F948AB69 /* TabViewControllerSiteLoadingPixelTests.swift */; };
 		BA3A30D2938DDAF625858D3A /* SearchTokenExperimentSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF9CB391BF7042CDB857788 /* SearchTokenExperimentSettings.swift */; };
 		BB10B2A22EABF9A30005F174 /* SERPSettingsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB10B2A12EABF99D0005F174 /* SERPSettingsProvider.swift */; };
@@ -2573,7 +2573,7 @@
 		E6D1E41391739570657B247A /* SubscriptionOnboardingDuckAIViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70062CC66468D25459432866 /* SubscriptionOnboardingDuckAIViewModel.swift */; };
 		E7BE23F1F67AF41F9871BC6F /* LaunchTimeMetricsProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E8A70CF1DFF21DC84B150F /* LaunchTimeMetricsProcessorTests.swift */; };
 		E85300B61A233D45A5D82FFC /* SearchTokenExperimentSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F85CFFA884A3D2A0BCD87C /* SearchTokenExperimentSettingsTests.swift */; };
-		E9D5A3B42C3D4E5F6A708192 /* AIChatRecentChatsPopupViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E6B4C53D4E5F6A70819203 /* AIChatRecentChatsPopupViewModelTests.swift */; };
+		E9D5A3B42C3D4E5F6A708192 /* AIChatRecentChatsMenuViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E6B4C53D4E5F6A70819203 /* AIChatRecentChatsMenuViewModelTests.swift */; };
 		EA39B7E2268A1A35000C62CD /* privacy-reference-tests in Resources */ = {isa = PBXBuildFile; fileRef = EA39B7E1268A1A35000C62CD /* privacy-reference-tests */; };
 		EA90A5267F61028E3525A81E /* RebrandedAppIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D67C082BD4927358D771DB /* RebrandedAppIconPicker.swift */; };
 		EAB19EDA268963510015D3EA /* DomainMatchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB19ED9268963510015D3EA /* DomainMatchingTests.swift */; };
@@ -5470,7 +5470,7 @@
 		D6FEB8B22B74990D00C3615F /* HeadlessWebViewNavCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadlessWebViewNavCoordinator.swift; sourceTree = "<group>"; };
 		D6FEB8B42B74994000C3615F /* HeadlessWebViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadlessWebViewCoordinator.swift; sourceTree = "<group>"; };
 		D7916A1677761825AA258550 /* SubscriptionOnboardingHeaderView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingHeaderView.swift; sourceTree = "<group>"; };
-		D8C4F2A31B2C3D4E5F6A7081 /* AIChatRecentChatsPopupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatRecentChatsPopupViewModel.swift; sourceTree = "<group>"; };
+		D8C4F2A31B2C3D4E5F6A7081 /* AIChatRecentChatsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatRecentChatsMenuViewModel.swift; sourceTree = "<group>"; };
 		D9978912B1022C989EF9C224 /* IPadOmnibarAttachmentControllerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IPadOmnibarAttachmentControllerTests.swift; sourceTree = "<group>"; };
 		DA0001042F3D000100000002 /* DarkReaderFeatureSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkReaderFeatureSettings.swift; sourceTree = "<group>"; };
 		DD503EBD506182525F5E8107 /* OnboardingView+Landing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "OnboardingView+Landing.swift"; sourceTree = "<group>"; };
@@ -5585,7 +5585,7 @@
 		F0A1B2C3D4E5F60718293A02 /* FloatingUIChromeStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingUIChromeStyler.swift; sourceTree = "<group>"; };
 		F0A1B2C3D4E5F60718293A03 /* FloatingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingUITests.swift; sourceTree = "<group>"; };
 		F0A200002F31000100BAD001 /* NewBadgeVisibilityManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBadgeVisibilityManagerTests.swift; sourceTree = "<group>"; };
-		F0E6B4C53D4E5F6A70819203 /* AIChatRecentChatsPopupViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatRecentChatsPopupViewModelTests.swift; sourceTree = "<group>"; };
+		F0E6B4C53D4E5F6A70819203 /* AIChatRecentChatsMenuViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatRecentChatsMenuViewModelTests.swift; sourceTree = "<group>"; };
 		F1000FEA2FA3B25D00D96ED0 /* Fire.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Fire.xcassets; sourceTree = "<group>"; };
 		F103073A1E7C91330059FEC7 /* BookmarksDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarksDataSource.swift; sourceTree = "<group>"; };
 		F1075C911E9EF827006BE8A8 /* UserDefaultsExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDefaultsExtension.swift; sourceTree = "<group>"; };
@@ -6429,7 +6429,7 @@
 				C13EBC502EE9CD2F00CE5A4B /* AIChatContextualModeFeatureTests.swift */,
 				C13EBC522EF62A0000CE5A4B /* AIChatContextualSheetCoordinatorTests.swift */,
 				C13EBC542EF62A0100CE5A4B /* AIChatContextualInputViewControllerTests.swift */,
-				F0E6B4C53D4E5F6A70819203 /* AIChatRecentChatsPopupViewModelTests.swift */,
+				F0E6B4C53D4E5F6A70819203 /* AIChatRecentChatsMenuViewModelTests.swift */,
 				E7971E90992B46FABF42A908 /* AIChatContextualWebViewControllerTests.swift */,
 				C1AITEST2F2E000400E35AD5 /* AIChatPageContextHandlerTests.swift */,
 				3124186C2F48C9FE0023B9DE /* IPadModeToggleTextModelTests.swift */,
@@ -9995,7 +9995,7 @@
 				C1F9D9162EEF8BFB00E35AD5 /* AIChatContextualSheetCoordinator.swift */,
 				C13EBC4E2EE9CCE700CE5A4B /* AIChatContextualModeFeature.swift */,
 				C1F9D9112EEAE70400E35AD5 /* AIChatContextualSheetViewController.swift */,
-				D8C4F2A31B2C3D4E5F6A7081 /* AIChatRecentChatsPopupViewModel.swift */,
+				D8C4F2A31B2C3D4E5F6A7081 /* AIChatRecentChatsMenuViewModel.swift */,
 				C1AIREPO2F2E000000E35AD5 /* AIChatPageContextHandler.swift */,
 				AD5E1ED02B0000000000F001 /* AIChatTextSelectionFeature.swift */,
 				AD5E1ED02B0000000000F005 /* AIChatSelectionContext.swift */,
@@ -14409,7 +14409,7 @@
 				C1F9D9122EEAE70400E35AD5 /* AIChatContextualSheetViewController.swift in Sources */,
 				BBA8EA4E30120A4600FE41CD /* IOSMonthlyFreeTrialDecider.swift in Sources */,
 				CB781CEE301A8221008DCD60 /* DuckAIAddressBarMenuFactory.swift in Sources */,
-				B7A3E1F20A1B2C3D4E5F6A70 /* AIChatRecentChatsPopupViewModel.swift in Sources */,
+				B7A3E1F20A1B2C3D4E5F6A70 /* AIChatRecentChatsMenuViewModel.swift in Sources */,
 				C1F9D91D2EF6400000E35AD5 /* AIChatContextualInputViewController.swift in Sources */,
 				1EC458462948932500CB2B13 /* UIHostingControllerExtension.swift in Sources */,
 				858E45532FEC713D0078B671 /* FloatingDomainCapsuleController.swift in Sources */,
@@ -15246,7 +15246,7 @@
 				F194FAFB1F14E622009B4DF8 /* UIFontExtensionTests.swift in Sources */,
 				C13EBC512EE9CD2F00CE5A4B /* AIChatContextualModeFeatureTests.swift in Sources */,
 				C13EBC532EF62A0000CE5A4B /* AIChatContextualSheetCoordinatorTests.swift in Sources */,
-				E9D5A3B42C3D4E5F6A708192 /* AIChatRecentChatsPopupViewModelTests.swift in Sources */,
+				E9D5A3B42C3D4E5F6A708192 /* AIChatRecentChatsMenuViewModelTests.swift in Sources */,
 				C590E41C21CD46E99C4A5B2E /* AIChatContextualWebViewControllerTests.swift in Sources */,
 				BBFF18B12C76448100C48D7D /* QuerySubmittedTests.swift in Sources */,
 				9FFDA8392DFA8DC2007923F7 /* VideoPlayerCoordinatorTests.swift in Sources */,

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -7,9 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		FCFC00031F00000000030001 /* URLPredictor in Frameworks */ = {isa = PBXBuildFile; productRef = FCFC00021F00000000030001 /* URLPredictor */; };
-		FCFC00031F00000000020001 /* DDGError in Frameworks */ = {isa = PBXBuildFile; productRef = FCFC00021F00000000020001 /* DDGError */; };
-		FCFC00031F00000000010001 /* DDGError in Frameworks */ = {isa = PBXBuildFile; productRef = FCFC00021F00000000010001 /* DDGError */; };
 		02025664298818B200E694E7 /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02025663298818B100E694E7 /* NetworkExtension.framework */; };
 		021440742C7FAB1900426724 /* ConfigurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021440732C7FAB1900426724 /* ConfigurationManager.swift */; };
 		021440762C7FAB4100426724 /* ConfigurationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021440752C7FAB4100426724 /* ConfigurationStore.swift */; };
@@ -25,6 +22,7 @@
 		067CACE8BC2AA354D969019F /* NewAddressBarPickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFAB87418082C5BDE38CE4D /* NewAddressBarPickerViewModelTests.swift */; };
 		06D744C1F541FF4F91F7A664 /* DuckAISubscriptionUpsellPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A43FA34A9C65835FF48566 /* DuckAISubscriptionUpsellPresenter.swift */; };
 		0928A567CE4F37AC8E19B215 /* NavigationPixelNavigationResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2870028D8D7FA19512B7FD0 /* NavigationPixelNavigationResponder.swift */; };
+		0A35258C8C764454B17FCEC4 /* ContextualDictationPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43B9D5DB095468FACD50500 /* ContextualDictationPresenting.swift */; };
 		0A6CC0EF23904D5400E4F627 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 0A6CC0EE23904D5400E4F627 /* Settings.bundle */; };
 		0ADDA22E21E33D1BA5126D53 /* SearchTokenExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E195E64C4FA98412110685 /* SearchTokenExperiment.swift */; };
 		0B5268FDE6E57852467954E2 /* SubscriptionOnboardingDuckAIChatLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9A5579274BE8DDD5A96C214 /* SubscriptionOnboardingDuckAIChatLauncher.swift */; };
@@ -243,7 +241,6 @@
 		31CE145C2D5505520027F11D /* OmnibarDependencyProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CE145B2D5505520027F11D /* OmnibarDependencyProvider.swift */; };
 		31CF26792E6F14AF004D52C2 /* LaunchSourceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CF26782E6F14A9004D52C2 /* LaunchSourceManager.swift */; };
 		31D2D2A22D40F7E900549D12 /* AIChatDeepLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D2D2A12D40F7E900549D12 /* AIChatDeepLinkHandler.swift */; };
-		D3D3D3D3AABB0001CAFE0001 /* AIChatEntryPointSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D3D3D3AABB0001CAFE0002 /* AIChatEntryPointSource.swift */; };
 		31D2D2A42D40F98800549D12 /* WidgetSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D2D2A32D40F98800549D12 /* WidgetSourceType.swift */; };
 		31D2D2A52D40F99100549D12 /* WidgetSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D2D2A32D40F98800549D12 /* WidgetSourceType.swift */; };
 		31D4CD4B2D4D1C2D00BC27C6 /* ToolbarStateHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D4CD4A2D4D1C2600BC27C6 /* ToolbarStateHandling.swift */; };
@@ -354,9 +351,6 @@
 		4B359FD82FB52B9A0020D70F /* InfoPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B359FD72FB52B9A0020D70F /* InfoPanelView.swift */; };
 		4B359FDB2FB5321C0020D70F /* DuckAIPromptWideEventData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B359FDA2FB5321C0020D70F /* DuckAIPromptWideEventData.swift */; };
 		4B359FDD2FB5322C0020D70F /* DuckAIWideEventInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B359FDC2FB5322C0020D70F /* DuckAIWideEventInstrumentation.swift */; };
-		D5A100012FD0000000000001 /* DuckAISelectionJourneyWideEventData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A100022FD0000000000002 /* DuckAISelectionJourneyWideEventData.swift */; };
-		D5A100032FD0000000000003 /* DuckAISelectionJourneyInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A100042FD0000000000004 /* DuckAISelectionJourneyInstrumentation.swift */; };
-		D5A100052FD0000000000005 /* DuckAISelectionJourneyInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A100062FD0000000000006 /* DuckAISelectionJourneyInstrumentationTests.swift */; };
 		4B412ACC2BBB3D0900A39F5E /* LazyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B412ACB2BBB3D0900A39F5E /* LazyView.swift */; };
 		4B470EE4299C6DFB0086EBDC /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F143C2E41E4A4CD400CFDE3A /* Core.framework */; };
 		4B52648B25F9613B00CB4C24 /* trackerData.json in Resources */ = {isa = PBXBuildFile; fileRef = 4B52648A25F9613B00CB4C24 /* trackerData.json */; };
@@ -653,8 +647,6 @@
 		6FF4943F2DDDDC4000BCF5F0 /* NSLayoutConstraintExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF4943E2DDDDC4000BCF5F0 /* NSLayoutConstraintExtension.swift */; };
 		6FF9AD3F2CE63DD800C5A406 /* TabSwitcherOpenDailyPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9AD3E2CE63DC200C5A406 /* TabSwitcherOpenDailyPixel.swift */; };
 		6FF9AD412CE6610F00C5A406 /* TabSwitcherOpenDailyPixelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF9AD402CE6610600C5A406 /* TabSwitcherOpenDailyPixelTests.swift */; };
-		7A0308270000000000000002 /* TabTerminationErrorPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0308270000000000000001 /* TabTerminationErrorPage.swift */; };
-		7A0308270000000000000004 /* TabTerminationErrorPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0308270000000000000003 /* TabTerminationErrorPageTests.swift */; };
 		71DFABCA706A402AB4B27F50 /* UnifiedToggleInputFloatingReturnKeyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5BA3FF1041A3BB9396AE65 /* UnifiedToggleInputFloatingReturnKeyViewController.swift */; };
 		735C2A86135E7F02B89D3D05 /* LaunchTimeMetricsProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B013517D758E8CF18834CC /* LaunchTimeMetricsProcessor.swift */; };
 		7560100309BC4006867327B4 /* ContextualSuggestedPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096F16CFD07B443887F47E3F /* ContextualSuggestedPrompt.swift */; };
@@ -663,6 +655,8 @@
 		78BBBA6B2FE42A6700AE8F41 /* VoiceSearchFeedbackView_PreviewMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BBBA6A2FE42A6700AE8F41 /* VoiceSearchFeedbackView_PreviewMocks.swift */; };
 		7A0308260000000000000002 /* TabTerminationTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0308260000000000000001 /* TabTerminationTelemetry.swift */; };
 		7A0308260000000000000004 /* TabTerminationTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0308260000000000000003 /* TabTerminationTelemetryTests.swift */; };
+		7A0308270000000000000002 /* TabTerminationErrorPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0308270000000000000001 /* TabTerminationErrorPage.swift */; };
+		7A0308270000000000000004 /* TabTerminationErrorPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0308270000000000000003 /* TabTerminationErrorPageTests.swift */; };
 		7A11B0C0D0E0F00102030405 /* IPadOmnibarToolPickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11B0C0D0E0F00102030406 /* IPadOmnibarToolPickerController.swift */; };
 		7A11B0C0D0E0F00102030407 /* IPadOmnibarToolPickerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11B0C0D0E0F00102030408 /* IPadOmnibarToolPickerControllerTests.swift */; };
 		7A1B2C3D2E0000000000F001 /* TabsBarViewControllerSizingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1B2C3D2E0000000000F002 /* TabsBarViewControllerSizingTests.swift */; };
@@ -992,7 +986,6 @@
 		85BA585A1F3506AE00C6E8CA /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BA58591F3506AE00C6E8CA /* AppSettings.swift */; };
 		85BA79911F6FF75000F59015 /* ContentBlockerStoreConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BA79901F6FF75000F59015 /* ContentBlockerStoreConstants.swift */; };
 		85BDC310243359040053DB07 /* FindInPageUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BDC30F243359040053DB07 /* FindInPageUserScript.swift */; };
-		AD5E1ED02B0000000000F10A /* SelectionFrameUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E1ED02B0000000000F109 /* SelectionFrameUserScript.swift */; };
 		85BDC3192436161C0053DB07 /* LoginFormDetectionUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85BDC3182436161C0053DB07 /* LoginFormDetectionUserScript.swift */; };
 		85C11E4120904BBE00BFFEB4 /* VariantManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C11E4020904BBE00BFFEB4 /* VariantManagerTests.swift */; };
 		85C11E4C2090888C00BFFEB4 /* HomeRowReminder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85C11E4B2090888C00BFFEB4 /* HomeRowReminder.swift */; };
@@ -1663,8 +1656,6 @@
 		9FA09DA62EA71F2900E26F3F /* PromptCooldownIntervalProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DA22EA71F2900E26F3F /* PromptCooldownIntervalProvider.swift */; };
 		9FA09DA72EA71F2900E26F3F /* PromptCooldownStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DA32EA71F2900E26F3F /* PromptCooldownStore.swift */; };
 		9FA09DA82EA71F2900E26F3F /* PromptCooldownManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DA42EA71F2900E26F3F /* PromptCooldownManager.swift */; };
-		B6A7C25131A1000100F00D01 /* PromoQueueCooldownPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25031A1000100F00D01 /* PromoQueueCooldownPolicy.swift */; };
-		B6A7C25331A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25231A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift */; };
 		9FA09DAC2EA7400200E26F3F /* PromptCooldownStorePixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DAB2EA7400200E26F3F /* PromptCooldownStorePixelReporter.swift */; };
 		9FA09DAF2EA84F5D00E26F3F /* ModalPromptScheduling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA09DAE2EA84F5200E26F3F /* ModalPromptScheduling.swift */; };
 		9FA0AF192EB4855000713387 /* MockRemoteMessagingPixelReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA0AF182EB4855000713387 /* MockRemoteMessagingPixelReporter.swift */; };
@@ -1875,6 +1866,8 @@
 		AD5E1ED02B0000000000F008 /* AIChatSelectionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E1ED02B0000000000F007 /* AIChatSelectionContextTests.swift */; };
 		AD5E1ED02B0000000000F00A /* AIChatTextSelectionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E1ED02B0000000000F009 /* AIChatTextSelectionAction.swift */; };
 		AD5E1ED02B0000000000F00C /* AIChatTextSelectionActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E1ED02B0000000000F00B /* AIChatTextSelectionActionTests.swift */; };
+		AD5E1ED02B0000000000F10A /* SelectionFrameUserScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E1ED02B0000000000F109 /* SelectionFrameUserScript.swift */; };
+		AD5E1ED02B0000000000F20A /* SelectionFrameUserScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E1ED02B0000000000F209 /* SelectionFrameUserScriptTests.swift */; };
 		AF33940B4B7A2549F1C56A04 /* SearchTokenDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5CCC4AE7E388D27D0689A8 /* SearchTokenDebugView.swift */; };
 		B2258FABEA7BDFCEF297DCFE /* OnboardingView+SearchExperienceContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF81E0C6EDC46254CF28AFCB /* OnboardingView+SearchExperienceContent.swift */; };
 		B39FB0F42E25368100DF2C4E /* AutoconsentPixels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39FB0F32E25368100DF2C4E /* AutoconsentPixels.swift */; };
@@ -1908,6 +1901,8 @@
 		B6A7C21A31A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C21931A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift */; };
 		B6A7C21C31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C21B31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift */; };
 		B6A7C21E31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C21D31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift */; };
+		B6A7C25131A1000100F00D01 /* PromoQueueCooldownPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25031A1000100F00D01 /* PromoQueueCooldownPolicy.swift */; };
+		B6A7C25331A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C25231A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift */; };
 		B6A7C26131A1000100F00D01 /* PromptCoordinationDebugViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A7C26031A1000100F00D01 /* PromptCoordinationDebugViewModelTests.swift */; };
 		B6AD9E3728D4510A0019CDE9 /* ContentBlockingUpdatingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AD9E3528D4510A0019CDE9 /* ContentBlockingUpdatingTests.swift */; };
 		B6AD9E3828D4512E0019CDE9 /* EmbeddedTrackerDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9801F08927E4B21100191874 /* EmbeddedTrackerDataTests.swift */; };
@@ -2358,7 +2353,6 @@
 		CB781CE83019069B008DCD60 /* UTIAttachmentControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB781CE73019069B008DCD60 /* UTIAttachmentControllerTests.swift */; };
 		CB781CEA301A8048008DCD60 /* AIChatContextualFloatingInputFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB781CE9301A8048008DCD60 /* AIChatContextualFloatingInputFeatureTests.swift */; };
 		CB781CEC301A810B008DCD60 /* AIChatContextualFloatingInputFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB781CEB301A810B008DCD60 /* AIChatContextualFloatingInputFeature.swift */; };
-		0A35258C8C764454B17FCEC4 /* ContextualDictationPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43B9D5DB095468FACD50500 /* ContextualDictationPresenting.swift */; };
 		CB781CEE301A8221008DCD60 /* DuckAIAddressBarMenuFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB781CED301A8221008DCD60 /* DuckAIAddressBarMenuFactory.swift */; };
 		CB781CF0301A822E008DCD60 /* DuckAIAddressBarEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB781CEF301A822E008DCD60 /* DuckAIAddressBarEntry.swift */; };
 		CB781CF2301A824C008DCD60 /* AIChatContextualFloatingInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB781CF1301A824C008DCD60 /* AIChatContextualFloatingInputViewController.swift */; };
@@ -2461,6 +2455,7 @@
 		CBF5D4232EA92031000530AF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF5D4222EA92031000530AF /* SceneDelegate.swift */; };
 		CBF5D4252EB3B5F5000530AF /* Connected.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF5D4242EB3B5F5000530AF /* Connected.swift */; };
 		CBFCB30E2B2CD47800253E9E /* ConfigurationURLDebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFCB30D2B2CD47800253E9E /* ConfigurationURLDebugViewController.swift */; };
+		CBFE752F30387F36006DD46D /* ContextualSurfaceScrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFE752E30387F36006DD46D /* ContextualSurfaceScrim.swift */; };
 		CBFF381B468220C1A97A5910 /* OnboardingView+AppIconPickerContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB06E4C5FAE7E6BC7CDC6CC /* OnboardingView+AppIconPickerContent.swift */; };
 		CC3445752E6760D100019518 /* UserScriptErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3445742E6760D100019518 /* UserScriptErrorTests.swift */; };
 		CC55B23F2E82CD650032E8BD /* BrowserServicesKitTestsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = CC55B23E2E82CD650032E8BD /* BrowserServicesKitTestsUtils */; };
@@ -2487,12 +2482,16 @@
 		D1A2B3C4E5F60002AABB0001 /* NewTabPageSessionWideEventData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60002AABB0002 /* NewTabPageSessionWideEventData.swift */; };
 		D1A2B3C4E5F60002AABB0003 /* NewTabPageSessionWideEventDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60002AABB0004 /* NewTabPageSessionWideEventDataTests.swift */; };
 		D1A2B3C4E5F60002AABB0005 /* NewTabPageSessionInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60002AABB0006 /* NewTabPageSessionInstrumentation.swift */; };
-		D1A2B3C4E5F60002AABB0009 /* MainViewController+NewTabPageSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60002AABB000A /* MainViewController+NewTabPageSession.swift */; };
 		D1A2B3C4E5F60002AABB0007 /* NewTabPageSessionInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60002AABB0008 /* NewTabPageSessionInstrumentationTests.swift */; };
+		D1A2B3C4E5F60002AABB0009 /* MainViewController+NewTabPageSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60002AABB000A /* MainViewController+NewTabPageSession.swift */; };
 		D1A4C0DE2F210002004E5001 /* NetworkProtectionStatusViewTintSpecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A4C0DE2F210001004E5001 /* NetworkProtectionStatusViewTintSpecTests.swift */; };
 		D1A4C0DE2F210004004E5001 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = D1A4C0DE2F210003004E5001 /* Lottie */; };
 		D2D2D2D200000000000000F1 /* CookiePopupProtectionOptInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D2D2D200000000000000F0 /* CookiePopupProtectionOptInView.swift */; };
+		D3D3D3D3AABB0001CAFE0001 /* AIChatEntryPointSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D3D3D3AABB0001CAFE0002 /* AIChatEntryPointSource.swift */; };
 		D4F72864A16A77A0907EBA57 /* OnboardingView+Landing.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD503EBD506182525F5E8107 /* OnboardingView+Landing.swift */; };
+		D5A100012FD0000000000001 /* DuckAISelectionJourneyWideEventData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A100022FD0000000000002 /* DuckAISelectionJourneyWideEventData.swift */; };
+		D5A100032FD0000000000003 /* DuckAISelectionJourneyInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A100042FD0000000000004 /* DuckAISelectionJourneyInstrumentation.swift */; };
+		D5A100052FD0000000000005 /* DuckAISelectionJourneyInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A100062FD0000000000006 /* DuckAISelectionJourneyInstrumentationTests.swift */; };
 		D60170BD2BA34CE8001911B5 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60170BB2BA32DD6001911B5 /* Subscription.swift */; };
 		D6037E692C32F2E7009AAEC0 /* DuckPlayerSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6037E682C32F2E7009AAEC0 /* DuckPlayerSettings.swift */; };
 		D60B1F272B9DDE5A00AE4760 /* SubscriptionGoogleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60B1F262B9DDE5A00AE4760 /* SubscriptionGoogleView.swift */; };
@@ -2703,7 +2702,6 @@
 		F1849C702D6E3D17000589A4 /* DiagnosticReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1849C6F2D6E3D17000589A4 /* DiagnosticReport.swift */; };
 		F1849C722D6E3D4C000589A4 /* CrashDebugScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1849C712D6E3D4C000589A4 /* CrashDebugScreen.swift */; };
 		F189AED71F18F6DE001EBAE1 /* TabTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F189AED61F18F6DE001EBAE1 /* TabTests.swift */; };
-		AD5E1ED02B0000000000F20A /* SelectionFrameUserScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E1ED02B0000000000F209 /* SelectionFrameUserScriptTests.swift */; };
 		F189AEE41F18FDAF001EBAE1 /* LinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F189AEE31F18FDAF001EBAE1 /* LinkTests.swift */; };
 		F194FAED1F14E2B3009B4DF8 /* UIFontExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F194FAEC1F14E2B3009B4DF8 /* UIFontExtension.swift */; };
 		F194FAFB1F14E622009B4DF8 /* UIFontExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F194FAFA1F14E622009B4DF8 /* UIFontExtensionTests.swift */; };
@@ -2799,6 +2797,9 @@
 		FBA1C0DE0000000000000007 /* IPadDuckAIControlsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE0000000000000008 /* IPadDuckAIControlsFeatureTests.swift */; };
 		FBA1C0DE0000000000000009 /* IPadDuckAIControlValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA1C0DE000000000000000A /* IPadDuckAIControlValues.swift */; };
 		FBAE539C901DDAE3AC71FF58 /* TabsBarLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EE0B87AD01EC45FD8F28E33 /* TabsBarLayout.swift */; };
+		FCFC00031F00000000010001 /* DDGError in Frameworks */ = {isa = PBXBuildFile; productRef = FCFC00021F00000000010001 /* DDGError */; };
+		FCFC00031F00000000020001 /* DDGError in Frameworks */ = {isa = PBXBuildFile; productRef = FCFC00021F00000000020001 /* DDGError */; };
+		FCFC00031F00000000030001 /* URLPredictor in Frameworks */ = {isa = PBXBuildFile; productRef = FCFC00021F00000000030001 /* URLPredictor */; };
 		FD555C0BE82E630360DC2E5A /* ToggleModeStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6090D90640A2B1A529EDBAAB /* ToggleModeStorage.swift */; };
 		FDEC1A2B30260001000000F1 /* IOSMonthlyFreeTrialDeciderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDEC1A2B30260001000000F2 /* IOSMonthlyFreeTrialDeciderTests.swift */; };
 		FE1A2B3C0001000100010001 /* AIChatRAGTool+ToolbarChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1A2B3C0001000100010002 /* AIChatRAGTool+ToolbarChip.swift */; };
@@ -3188,7 +3189,6 @@
 		31CE145B2D5505520027F11D /* OmnibarDependencyProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnibarDependencyProvider.swift; sourceTree = "<group>"; };
 		31CF26782E6F14A9004D52C2 /* LaunchSourceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchSourceManager.swift; sourceTree = "<group>"; };
 		31D2D2A12D40F7E900549D12 /* AIChatDeepLinkHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatDeepLinkHandler.swift; sourceTree = "<group>"; };
-		D3D3D3D3AABB0001CAFE0002 /* AIChatEntryPointSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatEntryPointSource.swift; sourceTree = "<group>"; };
 		31D2D2A32D40F98800549D12 /* WidgetSourceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetSourceType.swift; sourceTree = "<group>"; };
 		31D49A3C2DC294E500262F26 /* UIComponents */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = UIComponents; path = ../SharedPackages/UIComponents; sourceTree = SOURCE_ROOT; };
 		31D4CD4A2D4D1C2600BC27C6 /* ToolbarStateHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarStateHandling.swift; sourceTree = "<group>"; };
@@ -3284,9 +3284,6 @@
 		4B359FD72FB52B9A0020D70F /* InfoPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoPanelView.swift; sourceTree = "<group>"; };
 		4B359FDA2FB5321C0020D70F /* DuckAIPromptWideEventData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIPromptWideEventData.swift; sourceTree = "<group>"; };
 		4B359FDC2FB5322C0020D70F /* DuckAIWideEventInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIWideEventInstrumentation.swift; sourceTree = "<group>"; };
-		D5A100022FD0000000000002 /* DuckAISelectionJourneyWideEventData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAISelectionJourneyWideEventData.swift; sourceTree = "<group>"; };
-		D5A100042FD0000000000004 /* DuckAISelectionJourneyInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAISelectionJourneyInstrumentation.swift; sourceTree = "<group>"; };
-		D5A100062FD0000000000006 /* DuckAISelectionJourneyInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAISelectionJourneyInstrumentationTests.swift; sourceTree = "<group>"; };
 		4B412ACB2BBB3D0900A39F5E /* LazyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyView.swift; sourceTree = "<group>"; };
 		4B4A6D122F0EC5620074444F /* DuckDuckGoExperimental.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DuckDuckGoExperimental.entitlements; sourceTree = "<group>"; };
 		4B52648A25F9613B00CB4C24 /* trackerData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = trackerData.json; sourceTree = "<group>"; };
@@ -3855,7 +3852,6 @@
 		85BA58591F3506AE00C6E8CA /* AppSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
 		85BA79901F6FF75000F59015 /* ContentBlockerStoreConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentBlockerStoreConstants.swift; sourceTree = "<group>"; };
 		85BDC30F243359040053DB07 /* FindInPageUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindInPageUserScript.swift; sourceTree = "<group>"; };
-		AD5E1ED02B0000000000F109 /* SelectionFrameUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionFrameUserScript.swift; sourceTree = "<group>"; };
 		85BDC3182436161C0053DB07 /* LoginFormDetectionUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFormDetectionUserScript.swift; sourceTree = "<group>"; };
 		85C11E4020904BBE00BFFEB4 /* VariantManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VariantManagerTests.swift; sourceTree = "<group>"; };
 		85C11E4B2090888C00BFFEB4 /* HomeRowReminder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRowReminder.swift; sourceTree = "<group>"; };
@@ -4564,8 +4560,6 @@
 		9FA09DA22EA71F2900E26F3F /* PromptCooldownIntervalProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownIntervalProvider.swift; sourceTree = "<group>"; };
 		9FA09DA32EA71F2900E26F3F /* PromptCooldownStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownStore.swift; sourceTree = "<group>"; };
 		9FA09DA42EA71F2900E26F3F /* PromptCooldownManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownManager.swift; sourceTree = "<group>"; };
-		B6A7C25031A1000100F00D01 /* PromoQueueCooldownPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueCooldownPolicy.swift; sourceTree = "<group>"; };
-		B6A7C25231A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueCooldownPolicyTests.swift; sourceTree = "<group>"; };
 		9FA09DAB2EA7400200E26F3F /* PromptCooldownStorePixelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCooldownStorePixelReporter.swift; sourceTree = "<group>"; };
 		9FA09DAE2EA84F5200E26F3F /* ModalPromptScheduling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptScheduling.swift; sourceTree = "<group>"; };
 		9FA0AF182EB4855000713387 /* MockRemoteMessagingPixelReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteMessagingPixelReporter.swift; sourceTree = "<group>"; };
@@ -4745,6 +4739,8 @@
 		AD5E1ED02B0000000000F007 /* AIChatSelectionContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSelectionContextTests.swift; sourceTree = "<group>"; };
 		AD5E1ED02B0000000000F009 /* AIChatTextSelectionAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTextSelectionAction.swift; sourceTree = "<group>"; };
 		AD5E1ED02B0000000000F00B /* AIChatTextSelectionActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTextSelectionActionTests.swift; sourceTree = "<group>"; };
+		AD5E1ED02B0000000000F109 /* SelectionFrameUserScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionFrameUserScript.swift; sourceTree = "<group>"; };
+		AD5E1ED02B0000000000F209 /* SelectionFrameUserScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionFrameUserScriptTests.swift; sourceTree = "<group>"; };
 		AD8CF8E4B152CDB3A4ACB14C /* StartupOnboardingCover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupOnboardingCover.swift; sourceTree = "<group>"; };
 		AEC7FF2261884003814DB9D0 /* OnboardingSearchAIToggle_dark.lottie */ = {isa = PBXFileReference; lastKnownFileType = file; path = OnboardingSearchAIToggle_dark.lottie; sourceTree = "<group>"; };
 		AF81E0C6EDC46254CF28AFCB /* OnboardingView+SearchExperienceContent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "OnboardingView+SearchExperienceContent.swift"; sourceTree = "<group>"; };
@@ -4778,6 +4774,8 @@
 		B6A7C21931A1000100F00D01 /* ModalPromptCoordinationManagerPromoQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationManagerPromoQueueTests.swift; sourceTree = "<group>"; };
 		B6A7C21B31A1000100F00D01 /* ModalPromptRootAttachmentCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptRootAttachmentCheckerTests.swift; sourceTree = "<group>"; };
 		B6A7C21D31A1000100F00D01 /* ModalPromptCoordinationRealUIKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPromptCoordinationRealUIKitTests.swift; sourceTree = "<group>"; };
+		B6A7C25031A1000100F00D01 /* PromoQueueCooldownPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueCooldownPolicy.swift; sourceTree = "<group>"; };
+		B6A7C25231A1000100F00D01 /* PromoQueueCooldownPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoQueueCooldownPolicyTests.swift; sourceTree = "<group>"; };
 		B6A7C26031A1000100F00D01 /* PromptCoordinationDebugViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptCoordinationDebugViewModelTests.swift; sourceTree = "<group>"; };
 		B6AD9E3528D4510A0019CDE9 /* ContentBlockingUpdatingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentBlockingUpdatingTests.swift; sourceTree = "<group>"; };
 		B6BA95C228891E33004ABA20 /* BrowsingMenuAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingMenuAnimator.swift; sourceTree = "<group>"; };
@@ -5244,7 +5242,6 @@
 		CB781CE73019069B008DCD60 /* UTIAttachmentControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIAttachmentControllerTests.swift; sourceTree = "<group>"; };
 		CB781CE9301A8048008DCD60 /* AIChatContextualFloatingInputFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualFloatingInputFeatureTests.swift; sourceTree = "<group>"; };
 		CB781CEB301A810B008DCD60 /* AIChatContextualFloatingInputFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualFloatingInputFeature.swift; sourceTree = "<group>"; };
-		D43B9D5DB095468FACD50500 /* ContextualDictationPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDictationPresenting.swift; sourceTree = "<group>"; };
 		CB781CED301A8221008DCD60 /* DuckAIAddressBarMenuFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIAddressBarMenuFactory.swift; sourceTree = "<group>"; };
 		CB781CEF301A822E008DCD60 /* DuckAIAddressBarEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIAddressBarEntry.swift; sourceTree = "<group>"; };
 		CB781CF1301A824C008DCD60 /* AIChatContextualFloatingInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatContextualFloatingInputViewController.swift; sourceTree = "<group>"; };
@@ -5361,6 +5358,7 @@
 		CBF5D4222EA92031000530AF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		CBF5D4242EB3B5F5000530AF /* Connected.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connected.swift; sourceTree = "<group>"; };
 		CBFCB30D2B2CD47800253E9E /* ConfigurationURLDebugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationURLDebugViewController.swift; sourceTree = "<group>"; };
+		CBFE752E30387F36006DD46D /* ContextualSurfaceScrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualSurfaceScrim.swift; sourceTree = "<group>"; };
 		CC3445742E6760D100019518 /* UserScriptErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserScriptErrorTests.swift; sourceTree = "<group>"; };
 		CC6A60992EA63726003A0398 /* VPNSubscriptionPromotionHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNSubscriptionPromotionHelper.swift; sourceTree = "<group>"; };
 		CCB36B102E5635EB00DBFE3A /* UserScriptError+Pixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserScriptError+Pixel.swift"; sourceTree = "<group>"; };
@@ -5383,11 +5381,16 @@
 		D1A2B3C4E5F60002AABB0002 /* NewTabPageSessionWideEventData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageSessionWideEventData.swift; sourceTree = "<group>"; };
 		D1A2B3C4E5F60002AABB0004 /* NewTabPageSessionWideEventDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageSessionWideEventDataTests.swift; sourceTree = "<group>"; };
 		D1A2B3C4E5F60002AABB0006 /* NewTabPageSessionInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageSessionInstrumentation.swift; sourceTree = "<group>"; };
-		D1A2B3C4E5F60002AABB000A /* MainViewController+NewTabPageSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewController+NewTabPageSession.swift"; sourceTree = "<group>"; };
 		D1A2B3C4E5F60002AABB0008 /* NewTabPageSessionInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageSessionInstrumentationTests.swift; sourceTree = "<group>"; };
+		D1A2B3C4E5F60002AABB000A /* MainViewController+NewTabPageSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewController+NewTabPageSession.swift"; sourceTree = "<group>"; };
 		D1A4C0DE2F210001004E5001 /* NetworkProtectionStatusViewTintSpecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProtectionStatusViewTintSpecTests.swift; sourceTree = "<group>"; };
 		D2870028D8D7FA19512B7FD0 /* NavigationPixelNavigationResponder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NavigationPixelNavigationResponder.swift; sourceTree = "<group>"; };
 		D2D2D2D200000000000000F0 /* CookiePopupProtectionOptInView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CookiePopupProtectionOptInView.swift; sourceTree = "<group>"; };
+		D3D3D3D3AABB0001CAFE0002 /* AIChatEntryPointSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatEntryPointSource.swift; sourceTree = "<group>"; };
+		D43B9D5DB095468FACD50500 /* ContextualDictationPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextualDictationPresenting.swift; sourceTree = "<group>"; };
+		D5A100022FD0000000000002 /* DuckAISelectionJourneyWideEventData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAISelectionJourneyWideEventData.swift; sourceTree = "<group>"; };
+		D5A100042FD0000000000004 /* DuckAISelectionJourneyInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAISelectionJourneyInstrumentation.swift; sourceTree = "<group>"; };
+		D5A100062FD0000000000006 /* DuckAISelectionJourneyInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAISelectionJourneyInstrumentationTests.swift; sourceTree = "<group>"; };
 		D60170BB2BA32DD6001911B5 /* Subscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
 		D6037E682C32F2E7009AAEC0 /* DuckPlayerSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckPlayerSettings.swift; sourceTree = "<group>"; };
 		D60B1F262B9DDE5A00AE4760 /* SubscriptionGoogleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionGoogleView.swift; sourceTree = "<group>"; };
@@ -5648,7 +5651,6 @@
 		F1849C6F2D6E3D17000589A4 /* DiagnosticReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticReport.swift; sourceTree = "<group>"; };
 		F1849C712D6E3D4C000589A4 /* CrashDebugScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashDebugScreen.swift; sourceTree = "<group>"; };
 		F189AED61F18F6DE001EBAE1 /* TabTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabTests.swift; sourceTree = "<group>"; };
-		AD5E1ED02B0000000000F209 /* SelectionFrameUserScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionFrameUserScriptTests.swift; sourceTree = "<group>"; };
 		F189AEE31F18FDAF001EBAE1 /* LinkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkTests.swift; sourceTree = "<group>"; };
 		F194FAEC1F14E2B3009B4DF8 /* UIFontExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIFontExtension.swift; sourceTree = "<group>"; };
 		F194FAFA1F14E622009B4DF8 /* UIFontExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIFontExtensionTests.swift; sourceTree = "<group>"; };
@@ -6251,22 +6253,6 @@
 				314C92B927C3E7CB0042EC96 /* QuickLookContainerViewController.swift */,
 			);
 			name = Modals;
-			sourceTree = "<group>";
-		};
-		AD5E1ED02B0000000000F409 /* TextSelection */ = {
-			isa = PBXGroup;
-			children = (
-				AD5E1ED02B0000000000F109 /* SelectionFrameUserScript.swift */,
-			);
-			path = TextSelection;
-			sourceTree = "<group>";
-		};
-		AD5E1ED02B0000000000F509 /* TextSelection */ = {
-			isa = PBXGroup;
-			children = (
-				AD5E1ED02B0000000000F209 /* SelectionFrameUserScriptTests.swift */,
-			);
-			path = TextSelection;
 			sourceTree = "<group>";
 		};
 		1E908BED29827C480008C8F3 /* Autoconsent */ = {
@@ -9779,6 +9765,22 @@
 			name = AppIcon;
 			sourceTree = "<group>";
 		};
+		AD5E1ED02B0000000000F409 /* TextSelection */ = {
+			isa = PBXGroup;
+			children = (
+				AD5E1ED02B0000000000F109 /* SelectionFrameUserScript.swift */,
+			);
+			path = TextSelection;
+			sourceTree = "<group>";
+		};
+		AD5E1ED02B0000000000F509 /* TextSelection */ = {
+			isa = PBXGroup;
+			children = (
+				AD5E1ED02B0000000000F209 /* SelectionFrameUserScriptTests.swift */,
+			);
+			path = TextSelection;
+			sourceTree = "<group>";
+		};
 		B56523312FCF40A500B71522 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -10008,6 +10010,7 @@
 				CB781CEF301A822E008DCD60 /* DuckAIAddressBarEntry.swift */,
 				CB781CF1301A824C008DCD60 /* AIChatContextualFloatingInputViewController.swift */,
 				CB781CF3301A82EB008DCD60 /* MainViewController+DuckAIAddressBarMenu.swift */,
+				CBFE752E30387F36006DD46D /* ContextualSurfaceScrim.swift */,
 			);
 			path = ContextualMode;
 			sourceTree = "<group>";
@@ -14490,6 +14493,7 @@
 				1EC8B1832F29139400F18679 /* WebExtensionManager+iOS.swift in Sources */,
 				1EC8B1842F29139400F18679 /* WebExtensionEventsCoordinator+iOS.swift in Sources */,
 				1EC8B1852F29139400F18679 /* TabViewController+WKWebExtensionTab.swift in Sources */,
+				CBFE752F30387F36006DD46D /* ContextualSurfaceScrim.swift in Sources */,
 				1EC8B1862F29139400F18679 /* WebExtensionConfigurationProvider+iOS.swift in Sources */,
 				1EC8B1872F29139400F18679 /* MainViewController+WKWebExtensionWindow.swift in Sources */,
 				1EC8B1882F29139400F18679 /* WebExtensionWindowTabProvider+iOS.swift in Sources */,
@@ -19122,9 +19126,21 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		FCFC00011F00000000050001 /* XCLocalSwiftPackageReference "../SharedPackages/URLPredictor" */ = {
+		315E39632F86ABE100D2289D /* XCLocalSwiftPackageReference "../SharedPackages/DebugServer" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ../SharedPackages/URLPredictor;
+			relativePath = ../SharedPackages/DebugServer;
+		};
+		7B0752DA2F21BFDB00ACA559 /* XCLocalSwiftPackageReference "../SharedPackages/AutomationServer" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../SharedPackages/AutomationServer;
+		};
+		A7B000022F6A000100000001 /* XCLocalSwiftPackageReference "../SharedPackages/SnapshotTestingSupport" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../SharedPackages/SnapshotTestingSupport;
+		};
+		BD0C4D872DC54508001F034F /* XCLocalSwiftPackageReference "LocalPackages/DuckUI" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = LocalPackages/DuckUI;
 		};
 		FCFC00011F00000000010001 /* XCLocalSwiftPackageReference "../SharedPackages/DDGError" */ = {
 			isa = XCLocalSwiftPackageReference;
@@ -19142,21 +19158,9 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../SharedPackages/PixelKit;
 		};
-		315E39632F86ABE100D2289D /* XCLocalSwiftPackageReference "../SharedPackages/DebugServer" */ = {
+		FCFC00011F00000000050001 /* XCLocalSwiftPackageReference "../SharedPackages/URLPredictor" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = ../SharedPackages/DebugServer;
-		};
-		7B0752DA2F21BFDB00ACA559 /* XCLocalSwiftPackageReference "../SharedPackages/AutomationServer" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../SharedPackages/AutomationServer;
-		};
-		A7B000022F6A000100000001 /* XCLocalSwiftPackageReference "../SharedPackages/SnapshotTestingSupport" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../SharedPackages/SnapshotTestingSupport;
-		};
-		BD0C4D872DC54508001F034F /* XCLocalSwiftPackageReference "LocalPackages/DuckUI" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = LocalPackages/DuckUI;
+			relativePath = ../SharedPackages/URLPredictor;
 		};
 /* End XCLocalSwiftPackageReference section */
 
@@ -19286,18 +19290,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		FCFC00021F00000000030001 /* URLPredictor */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = URLPredictor;
-		};
-		FCFC00021F00000000020001 /* DDGError */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = DDGError;
-		};
-		FCFC00021F00000000010001 /* DDGError */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = DDGError;
-		};
 		0238E44E29C0FAA100615E30 /* FindInPageIOSJSSupport */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0238E44D29C0FAA100615E30 /* XCRemoteSwiftPackageReference "ios-js-support" */;
@@ -19944,6 +19936,18 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F4D7F632298C00C3006C3AE9 /* XCRemoteSwiftPackageReference "ios-js-support" */;
 			productName = FindInPageIOSJSSupport;
+		};
+		FCFC00021F00000000010001 /* DDGError */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DDGError;
+		};
+		FCFC00021F00000000020001 /* DDGError */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DDGError;
+		};
+		FCFC00021F00000000030001 /* URLPredictor */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = URLPredictor;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -836,15 +836,14 @@ private extension AIChatContextualChatSessionState {
         }
         // No "Ask about page" for pages that can't be attached — it would no-op on tap.
         guard isCurrentPageAttachable() else { return [] }
-        // Dropped only while the strip is actually offering its own re-attach button, which takes an
-        // explicit removal — feature availability alone would also drop it after a new chat, where the
-        // strip has cleared that offer and neither affordance would be left.
-        let actions = quickActionsIgnoringReattachAffordance()
+        // An explicit removal is the user declining page context: re-attaching is the attachment
+        // menu's job from then on, so offering it here as well would talk them back out of it.
+        let actions = quickActionsForChipState()
         guard floatingInputFeature.isAvailable, userDowngradedToPlaceholder else { return actions }
         return actions.filter { $0 != .askAboutPage }
     }
 
-    private func quickActionsIgnoringReattachAffordance() -> [AIChatContextualQuickAction] {
+    private func quickActionsForChipState() -> [AIChatContextualQuickAction] {
         if featureFlagger.isFeatureOn(.contextualSuggestedPrompts) {
             switch chipState {
             case .placeholder: return [.askAboutPage]

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualFloatingInputViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualFloatingInputViewController.swift
@@ -419,8 +419,7 @@ private extension AIChatContextualFloatingInputViewController {
     }
 
 
-    /// Resigns with the slide like every other dismissal. Deferring it to the end left the keyboard standing
-    /// through the whole exit — the surface slid down behind it and only then did it drop.
+    /// Resigns with the slide, so the keyboard travels with the surface rather than after it.
     @objc func handlePageTap() {
         requestDismiss()
     }
@@ -466,11 +465,8 @@ private extension AIChatContextualFloatingInputViewController {
     }
 
     /// How far the surface rose from the bottom on the way in, and so how far it settles back down on the way
-    /// out: the keyboard guide's travel, from where its top rests with the keyboard down to where it is now.
-    ///
-    /// Measured to the view's bottom edge, not the safe area's — a dismissing keyboard travels until its top
-    /// reaches the screen bottom, so anchoring to the safe area leaves the surface short by the bottom inset
-    /// and it drifts behind the keyboard it is meant to ride down with.
+    /// out: the keyboard guide's travel. To the view's bottom edge, not the safe area's — a dismissing
+    /// keyboard travels until its top reaches the screen bottom, and falling short lags it the whole way.
     var entranceTravel: CGFloat {
         max(0, view.bounds.maxY - view.keyboardLayoutGuide.layoutFrame.minY)
     }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualFloatingInputViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualFloatingInputViewController.swift
@@ -55,8 +55,8 @@ extension AIChatContextualFloatingInputViewController: ContextualDictationPresen
 final class AIChatContextualFloatingInputViewController: UIViewController {
 
     private enum Constants {
-        /// Matches the design's system overlay scrim, `rgba(0, 0, 0, 0.2)`.
-        static let dimmingAlpha: CGFloat = 0.2
+        /// Deeper than the system overlay scrim, per design review, and matched to the contextual sheet's.
+        static let dimmingAlpha: CGFloat = 0.3
         /// Drag distance that maps to a fully faded dim, and the point past which release dismisses.
         static let dragFadeDistance: CGFloat = 200
         static let dragDismissDistance: CGFloat = 80

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualFloatingInputViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualFloatingInputViewController.swift
@@ -55,8 +55,7 @@ extension AIChatContextualFloatingInputViewController: ContextualDictationPresen
 final class AIChatContextualFloatingInputViewController: UIViewController {
 
     private enum Constants {
-        /// Deeper than the system overlay scrim, per design review, and matched to the contextual sheet's.
-        static let dimmingAlpha: CGFloat = 0.3
+        static let dimmingAlpha = ContextualSurfaceScrim.alpha
         /// Drag distance that maps to a fully faded dim, and the point past which release dismisses.
         static let dragFadeDistance: CGFloat = 200
         static let dragDismissDistance: CGFloat = 80

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualFloatingInputViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualFloatingInputViewController.swift
@@ -99,18 +99,6 @@ final class AIChatContextualFloatingInputViewController: UIViewController {
     private var hasResignedInput = false
     private var hasShownChips = false
 
-    /// Where the keyboard goes while this surface leaves. The slide is the same either way; this only decides
-    /// when the input resigns.
-    private enum KeyboardHandling {
-        /// Nothing else is claiming focus, so resigning now sends the keyboard down alongside the slide.
-        case leavesWithSurface
-        /// The dismissing tap is handing focus to the page, so the page's own focus decides the keyboard — an
-        /// editable element keeps it exactly where it is. Resigning first is what makes it dip and return.
-        case staysWithPage
-    }
-
-    private var keyboardHandling: KeyboardHandling = .leavesWithSurface
-
     /// The view the page-tap recognizer is installed on, so it can be detached even if this controller
     /// has already lost its parent.
     private weak var presenterView: UIView?
@@ -319,12 +307,10 @@ final class AIChatContextualFloatingInputViewController: UIViewController {
         // drag can already have carried the surface past where this lands.
         let target = max(entranceTravel, contentTranslation)
         // Pinned first, so the slide is the only thing that moves the surface and nothing the keyboard does —
-        // leaving, staying, or the page's field raising a taller one — can disturb it.
+        // leaving, or the page's field raising a taller one — can disturb it.
         utiHost.freezeInputPosition()
 
-        if keyboardHandling == .leavesWithSurface {
-            resignInput()
-        }
+        resignInput()
 
         // Resigning above is what reports the dismissal's own duration and curve, so this reads them after it.
         UIView.animate(withDuration: keyboardAnimation.duration,
@@ -334,9 +320,6 @@ final class AIChatContextualFloatingInputViewController: UIViewController {
             self.translateContent(by: target)
             self.view.alpha = 0
         }, completion: { _ in
-            // Already done when the keyboard left with the surface. Otherwise the page was offered the
-            // keyboard and, if it declined, it is still ours to put away now the surface has gone.
-            self.resignInput()
             completion()
         })
     }
@@ -436,8 +419,9 @@ private extension AIChatContextualFloatingInputViewController {
     }
 
 
+    /// Resigns with the slide like every other dismissal. Deferring it to the end left the keyboard standing
+    /// through the whole exit — the surface slid down behind it and only then did it drop.
     @objc func handlePageTap() {
-        keyboardHandling = .staysWithPage
         requestDismiss()
     }
 
@@ -483,8 +467,12 @@ private extension AIChatContextualFloatingInputViewController {
 
     /// How far the surface rose from the bottom on the way in, and so how far it settles back down on the way
     /// out: the keyboard guide's travel, from where its top rests with the keyboard down to where it is now.
+    ///
+    /// Measured to the view's bottom edge, not the safe area's — a dismissing keyboard travels until its top
+    /// reaches the screen bottom, so anchoring to the safe area leaves the surface short by the bottom inset
+    /// and it drifts behind the keyboard it is meant to ride down with.
     var entranceTravel: CGFloat {
-        max(0, view.safeAreaLayoutGuide.layoutFrame.maxY - view.keyboardLayoutGuide.layoutFrame.minY)
+        max(0, view.bounds.maxY - view.keyboardLayoutGuide.layoutFrame.minY)
     }
 
     func observeKeyboardAnimation() {

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualModePixelHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualModePixelHandler.swift
@@ -56,8 +56,8 @@ protocol AIChatContextualModePixelFiring {
                                surface: AIChatContextualSuggestionsSurface)
     func fireSuggestionsContextCollectionTimedOut()
 
-    // MARK: - Recent Chats Popup
-    func fireRecentChatsPopupDisplayed()
+    // MARK: - Recent Chats Menu
+    func fireRecentChatsMenuDisplayed()
     func fireRecentChatSelected()
     func fireViewAllChatsTapped()
 
@@ -313,9 +313,9 @@ final class AIChatContextualModePixelHandler: AIChatContextualModePixelFiring {
         firePixel(.aiChatContextualSuggestionsContextCollectionTimedOut)
     }
 
-    // MARK: - Recent Chats Popup
+    // MARK: - Recent Chats Menu
 
-    func fireRecentChatsPopupDisplayed() {
+    func fireRecentChatsMenuDisplayed() {
         firePixel(.aiChatContextualRecentChatsPopupDisplayed)
     }
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -1035,8 +1035,7 @@ extension AIChatContextualSheetCoordinator: AIChatContextualInputViewControllerD
     func contextualInputViewController(_ viewController: AIChatContextualInputViewController, didSelectQuickAction action: AIChatContextualQuickAction) {
         switch action {
         case .askAboutPage:
-            // Only offered while the strip isn't showing its own re-attach button, so this is the sole
-            // affordance when it appears rather than a duplicate of it.
+            // Only offered before an explicit removal, so it never competes with the attachment menu.
             requestManualPageContextAttach()
         case .summarize, .summarizePage:
             pixelHandler.fireQuickActionSummarizeSelected()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -117,7 +117,7 @@ final class AIChatContextualSheetViewController: UIViewController {
         static let titleSpacing: CGFloat = 4
         static let titleTapHorizontalPadding: CGFloat = 8
         static let contentTopPadding: CGFloat = 8
-        static let dimmingAlpha: CGFloat = 0.3
+        static let dimmingAlpha = ContextualSurfaceScrim.alpha
         static let iPadPopoverWidth: CGFloat = 375
         static let iPadPopoverDefaultHeight: CGFloat = 520
         static let maxHeightRatio: CGFloat = 0.9
@@ -294,13 +294,10 @@ final class AIChatContextualSheetViewController: UIViewController {
         return menu.replacingChildren(menu.children.reversed())
     }
 
-    /// Mirrors the custom popup's sections, fetched when the menu opens rather than on the tap.
+    /// Sections are fetched when the menu opens rather than on the tap.
     private func buildNativeChatsMenuElements(_ completion: @escaping ([UIMenuElement]) -> Void) {
         Task { @MainActor in
-            let viewModel = await AIChatRecentChatsMenuViewModel.fetch(
-                using: suggestionsReader,
-                showNewChat: sessionState.hasActiveChat
-            )
+            let viewModel = await AIChatRecentChatsMenuViewModel.fetch(using: suggestionsReader)
             let openDuckAI = UIAction(title: UserText.duckAiContextualOpenDuckAi,
                                       image: DesignSystemImages.Glyphs.Size16.aiChat) { [weak self] _ in
                 self?.recentChatsMenuDidSelectOpenDuckAI()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetViewController.swift
@@ -269,7 +269,7 @@ final class AIChatContextualSheetViewController: UIViewController {
         button.accessibilityTraits = .button
         button.showsMenuAsPrimaryAction = true
         button.onMenuWillDisplay = { [weak self] animator in
-            self?.pixelHandler.fireRecentChatsPopupDisplayed()
+            self?.pixelHandler.fireRecentChatsMenuDisplayed()
             self?.setHeaderPillShadowsDimmed(true, alongside: animator)
         }
         button.onMenuWillEnd = { [weak self] animator in
@@ -297,20 +297,20 @@ final class AIChatContextualSheetViewController: UIViewController {
     /// Mirrors the custom popup's sections, fetched when the menu opens rather than on the tap.
     private func buildNativeChatsMenuElements(_ completion: @escaping ([UIMenuElement]) -> Void) {
         Task { @MainActor in
-            let viewModel = await AIChatRecentChatsPopupViewModel.fetch(
+            let viewModel = await AIChatRecentChatsMenuViewModel.fetch(
                 using: suggestionsReader,
                 showNewChat: sessionState.hasActiveChat
             )
             let openDuckAI = UIAction(title: UserText.duckAiContextualOpenDuckAi,
                                       image: DesignSystemImages.Glyphs.Size16.aiChat) { [weak self] _ in
-                self?.recentChatsPopupDidSelectOpenDuckAI()
+                self?.recentChatsMenuDidSelectOpenDuckAI()
             }
             var sections: [UIMenuElement] = [UIMenu(options: .displayInline, children: [openDuckAI])]
 
             if sessionState.hasActiveChat {
                 let newChat = UIAction(title: UserText.actionNewAIChat,
                                        image: DesignSystemImages.Glyphs.Size16.compose) { [weak self] _ in
-                    self?.recentChatsPopupDidSelectNewChat()
+                    self?.recentChatsMenuDidSelectNewChat()
                 }
                 sections.append(UIMenu(options: .displayInline, children: [newChat]))
             }
@@ -318,7 +318,7 @@ final class AIChatContextualSheetViewController: UIViewController {
             let chats = (viewModel?.suggestions ?? []).map { suggestion in
                 UIAction(title: suggestion.title,
                          image: suggestion.isPinned ? DesignSystemImages.Glyphs.Size16.pin : DesignSystemImages.Glyphs.Size16.chat) { [weak self] _ in
-                    self?.recentChatsPopupDidSelectChat(suggestion)
+                    self?.recentChatsMenuDidSelectChat(suggestion)
                 }
             }
             if !chats.isEmpty {
@@ -329,7 +329,7 @@ final class AIChatContextualSheetViewController: UIViewController {
 
             let viewAll = UIAction(title: UserText.aiChatViewAllChats,
                                    image: DesignSystemImages.Glyphs.Size16.openIn) { [weak self] _ in
-                self?.recentChatsPopupDidSelectViewAll()
+                self?.recentChatsMenuDidSelectViewAll()
             }
             sections.append(UIMenu(options: .displayInline, children: [viewAll]))
             completion(menuOpensUpward ? sections.reversed().map(Self.reversingChildren) : sections)
@@ -734,12 +734,12 @@ private extension AIChatContextualSheetViewController {
         delegate?.aiChatContextualSheetViewControllerDidRequestRemoveChip(self)
     }
 
-    // MARK: - Recent Chats Popup
+    // MARK: - Recent Chats Menu
 
     func prefetchRecentChatsVisibility() {
         guard suggestionsReader != nil else { return }
         Task { @MainActor in
-            let viewModel = await AIChatRecentChatsPopupViewModel.fetch(using: suggestionsReader)
+            let viewModel = await AIChatRecentChatsMenuViewModel.fetch(using: suggestionsReader)
             guard view.window != nil, !isBeingDismissed else { return }
 
             // If we have an active chat, check if it still exists in the suggestions
@@ -1098,22 +1098,22 @@ extension AIChatContextualSheetViewController: ContextualDictationPresenting {
 
 extension AIChatContextualSheetViewController {
 
-    func recentChatsPopupDidSelectNewChat() {
+    func recentChatsMenuDidSelectNewChat() {
         pixelHandler.fireNewChatButtonTapped()
         delegate?.aiChatContextualSheetViewControllerDidRequestNewChat(self)
     }
 
-    func recentChatsPopupDidSelectOpenDuckAI() {
+    func recentChatsMenuDidSelectOpenDuckAI() {
         delegate?.aiChatContextualSheetViewControllerDidRequestOpenDuckAI(self)
     }
 
-    func recentChatsPopupDidSelectChat(_ chat: AIChatSuggestion) {
+    func recentChatsMenuDidSelectChat(_ chat: AIChatSuggestion) {
         pixelHandler.fireRecentChatSelected()
         let url = aiChatSettings.aiChatURL.withChatID(chat.chatId)
         delegate?.aiChatContextualSheetViewController(self, didRequestExpandWithURL: url)
     }
 
-    func recentChatsPopupDidSelectViewAll() {
+    func recentChatsMenuDidSelectViewAll() {
         pixelHandler.fireViewAllChatsTapped()
         // The native chat history page is an iPhone-only experience; fall back to the duck.ai sidebar
         // when the flag is off or on iPad.

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -99,10 +99,7 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate, AIChatContextua
             originatingURLPublisher: originatingURLPublisher,
             initialAttachedContext: initialAttachedContext,
             initialAttachmentDeliveryState: initialAttachmentDeliveryState,
-            isAutoAttachEnabled: isAutoAttachEnabled,
-            showsAttachAffordance: { [isFloatingInputAvailable] in
-                isFloatingInputAvailable && !hasActiveChat()
-            }
+            isAutoAttachEnabled: isAutoAttachEnabled
         )
         coordinator.delegate = self
         coordinator.updateAIVoiceChatAvailability(voiceShortcutFeature.isAvailable)
@@ -427,7 +424,6 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate, AIChatContextua
         // Back on the start state, so the next prompt is a first prompt again and reports itself.
         hasDeliveredFirstPrompt = false
         clearAttachedContext()
-        chipViewModel.clearReattachOffer()
         if startsPreSubmit, let currentUserScript {
             coordinator.unbind()
             isBoundToUserScript = false
@@ -472,8 +468,6 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate, AIChatContextua
 
     private func reportFirstPromptSubmission() {
         guard claimFirstPromptSubmission() else { return }
-        // The offer was made on the pre-chat surface; the chat it starts is where it stops applying.
-        chipViewModel.clearReattachOffer()
         onPromptSubmitted?()
         commitDeferredBindIfNeeded()
     }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatRecentChatsMenuViewModel.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatRecentChatsMenuViewModel.swift
@@ -20,9 +20,7 @@
 import AIChat
 import Foundation
 
-// MARK: - Delegate
-
-/// Backs the chats menu: the recent chats to offer, capped, plus whether New Chat applies.
+/// Backs the chats menu: the recent chats to offer, capped.
 @MainActor
 final class AIChatRecentChatsMenuViewModel {
 
@@ -32,21 +30,14 @@ final class AIChatRecentChatsMenuViewModel {
 
     // MARK: - Properties
 
-    /// Whether the "New chat" row should be shown at the top.
-    let showNewChat: Bool
-
     /// The chat suggestions (up to maxVisibleChats).
     let suggestions: [AIChatSuggestion]
 
     // MARK: - Initialization
 
-    /// Creates a view model from raw fetched data.
-    /// - Parameters:
-    ///   - suggestions: The chat suggestions to display (will be capped at maxVisibleChats).
-    ///   - showNewChat: Whether the "New chat" row should be shown (true when there's an active chat).
-    init(suggestions: [AIChatSuggestion], showNewChat: Bool = false) {
+    /// - Parameter suggestions: The chat suggestions to display (will be capped at maxVisibleChats).
+    init(suggestions: [AIChatSuggestion]) {
         self.suggestions = Array(suggestions.prefix(Self.maxVisibleChats))
-        self.showNewChat = showNewChat
     }
 
 }
@@ -56,12 +47,11 @@ final class AIChatRecentChatsMenuViewModel {
 extension AIChatRecentChatsMenuViewModel {
 
     /// Fetches recent chats from the reader and creates a view model.
-    /// Returns nil only if the reader is nil; the popup still opens with no suggestions.
-    static func fetch(using reader: AIChatSuggestionsReading?, showNewChat: Bool = false) async -> AIChatRecentChatsMenuViewModel? {
+    /// Returns nil only if the reader is nil; the menu still opens with no suggestions.
+    static func fetch(using reader: AIChatSuggestionsReading?) async -> AIChatRecentChatsMenuViewModel? {
         guard let reader else { return nil }
         let result = await reader.fetchSuggestions(query: nil, maxChats: maxVisibleChats + 1)
         let all = result.pinned + result.recent
-        let capped = Array(all.prefix(maxVisibleChats))
-        return AIChatRecentChatsMenuViewModel(suggestions: capped, showNewChat: showNewChat)
+        return AIChatRecentChatsMenuViewModel(suggestions: Array(all.prefix(maxVisibleChats)))
     }
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatRecentChatsMenuViewModel.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatRecentChatsMenuViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  AIChatRecentChatsPopupViewModel.swift
+//  AIChatRecentChatsMenuViewModel.swift
 //  DuckDuckGo
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.
@@ -24,7 +24,7 @@ import Foundation
 
 /// Backs the chats menu: the recent chats to offer, capped, plus whether New Chat applies.
 @MainActor
-final class AIChatRecentChatsPopupViewModel {
+final class AIChatRecentChatsMenuViewModel {
 
     // MARK: - Constants
 
@@ -53,15 +53,15 @@ final class AIChatRecentChatsPopupViewModel {
 
 // MARK: - Fetching
 
-extension AIChatRecentChatsPopupViewModel {
+extension AIChatRecentChatsMenuViewModel {
 
     /// Fetches recent chats from the reader and creates a view model.
     /// Returns nil only if the reader is nil; the popup still opens with no suggestions.
-    static func fetch(using reader: AIChatSuggestionsReading?, showNewChat: Bool = false) async -> AIChatRecentChatsPopupViewModel? {
+    static func fetch(using reader: AIChatSuggestionsReading?, showNewChat: Bool = false) async -> AIChatRecentChatsMenuViewModel? {
         guard let reader else { return nil }
         let result = await reader.fetchSuggestions(query: nil, maxChats: maxVisibleChats + 1)
         let all = result.pinned + result.recent
         let capped = Array(all.prefix(maxVisibleChats))
-        return AIChatRecentChatsPopupViewModel(suggestions: capped, showNewChat: showNewChat)
+        return AIChatRecentChatsMenuViewModel(suggestions: capped, showNewChat: showNewChat)
     }
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSurfaceScrim.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/ContextualSurfaceScrim.swift
@@ -1,0 +1,26 @@
+//
+//  ContextualSurfaceScrim.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import CoreGraphics
+
+/// How far the page behind a contextual surface is dimmed. Shared by the sheet and the floating
+/// input: they are alternating presentations of the same chat, so a drift between them is visible.
+enum ContextualSurfaceScrim {
+    static let alpha: CGFloat = 0.3
+}

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/DuckAIAddressBarEntry.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/DuckAIAddressBarEntry.swift
@@ -47,10 +47,8 @@ enum DuckAIAddressBarEntry: Equatable {
         return .menu
     }
 
-    /// Whether the button wears its contextual glyph rather than the plain Duck.ai one: a surface is
-    /// open, or this tab has a chat to come back to. Kept beside `resolve` and over the same inputs so
-    /// the glyph can't contradict what a tap does — the enum alone can't answer it, because
-    /// `.contextualSheet` covers both having a chat and the floating input being unavailable.
+    /// A surface is open, or this tab has a chat to come back to. Beside `resolve` and over the same
+    /// inputs so the glyph can't contradict what a tap does.
     static func showsContextualGlyph(isContextualModeAvailable: Bool,
                                      isHomeTab: Bool,
                                      hasChatToReopen: Bool,

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/DuckAIAddressBarEntry.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/DuckAIAddressBarEntry.swift
@@ -46,4 +46,16 @@ enum DuckAIAddressBarEntry: Equatable {
         guard isFloatingInputAvailable, !hasChatToReopen else { return .contextualSheet }
         return .menu
     }
+
+    /// Whether the button wears its contextual glyph rather than the plain Duck.ai one: a surface is
+    /// open, or this tab has a chat to come back to. Kept beside `resolve` and over the same inputs so
+    /// the glyph can't contradict what a tap does — the enum alone can't answer it, because
+    /// `.contextualSheet` covers both having a chat and the floating input being unavailable.
+    static func showsContextualGlyph(isContextualModeAvailable: Bool,
+                                     isHomeTab: Bool,
+                                     hasChatToReopen: Bool,
+                                     isContextualSurfacePresented: Bool) -> Bool {
+        guard isContextualModeAvailable, !isHomeTab else { return false }
+        return hasChatToReopen || isContextualSurfacePresented
+    }
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/MainViewController+DuckAIAddressBarMenu.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/MainViewController+DuckAIAddressBarMenu.swift
@@ -34,6 +34,13 @@ extension MainViewController {
         )
     }
 
+    /// Whether the address-bar Duck.ai button shows its return-to-chat glyph. Keyed to the chat
+    /// existing rather than its surface being on screen, so it survives dismiss and reopen.
+    var hasContextualChatToReturnTo: Bool {
+        guard aiChatContextualModeFeature.isAvailable else { return false }
+        return currentTab?.hasContextualChatToReopen ?? false
+    }
+
     /// Attaches the Duck.ai menu to the address-bar button, or detaches it so a tap acts directly.
     func refreshDuckAIAddressBarMenu() {
         let button = omniBar.barView.aiChatButton

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/MainViewController+DuckAIAddressBarMenu.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/MainViewController+DuckAIAddressBarMenu.swift
@@ -24,21 +24,26 @@ extension MainViewController {
 
     /// What the address-bar Duck.ai button should do for the current tab and session.
     var duckAIAddressBarEntry: DuckAIAddressBarEntry {
-        let coordinator = currentTab?.aiChatContextualSheetCoordinator
-        return DuckAIAddressBarEntry.resolve(
+        DuckAIAddressBarEntry.resolve(
             isContextualModeAvailable: aiChatContextualModeFeature.isAvailable,
             isFloatingInputAvailable: aiChatContextualFloatingInputFeature.isAvailable,
             isHomeTab: currentTab?.tabModel.isHomeTab ?? true,
             hasChatToReopen: currentTab?.hasContextualChatToReopen ?? false,
-            isContextualSurfacePresented: coordinator?.isSheetPresented == true || coordinator?.isFloatingInputPresented == true
+            isContextualSurfacePresented: isContextualSurfacePresented
         )
     }
 
-    /// Whether the address-bar Duck.ai button shows its return-to-chat glyph. Keyed to the chat
-    /// existing rather than its surface being on screen, so it survives dismiss and reopen.
-    var hasContextualChatToReturnTo: Bool {
+    /// A contextual surface — the sheet or the floating input — is on screen for this tab.
+    var isContextualSurfacePresented: Bool {
+        let coordinator = currentTab?.aiChatContextualSheetCoordinator
+        return coordinator?.isSheetPresented == true || coordinator?.isFloatingInputPresented == true
+    }
+
+    /// Whether the address-bar Duck.ai button shows its contextual glyph: a surface is open, or this
+    /// tab has a chat to come back to. A surface dismissed without a prompt leaves neither.
+    var hasContextualSession: Bool {
         guard aiChatContextualModeFeature.isAvailable else { return false }
-        return currentTab?.hasContextualChatToReopen ?? false
+        return currentTab?.hasContextualChatToReopen == true || isContextualSurfacePresented
     }
 
     /// Attaches the Duck.ai menu to the address-bar button, or detaches it so a tap acts directly.

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/MainViewController+DuckAIAddressBarMenu.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/MainViewController+DuckAIAddressBarMenu.swift
@@ -39,11 +39,15 @@ extension MainViewController {
         return coordinator?.isSheetPresented == true || coordinator?.isFloatingInputPresented == true
     }
 
-    /// Whether the address-bar Duck.ai button shows its contextual glyph: a surface is open, or this
-    /// tab has a chat to come back to. A surface dismissed without a prompt leaves neither.
+    /// Whether the address-bar Duck.ai button shows its contextual glyph. A surface dismissed without
+    /// a prompt leaves no chat, so it reverts.
     var hasContextualSession: Bool {
-        guard aiChatContextualModeFeature.isAvailable else { return false }
-        return currentTab?.hasContextualChatToReopen == true || isContextualSurfacePresented
+        DuckAIAddressBarEntry.showsContextualGlyph(
+            isContextualModeAvailable: aiChatContextualModeFeature.isAvailable,
+            isHomeTab: currentTab?.tabModel.isHomeTab ?? true,
+            hasChatToReopen: currentTab?.hasContextualChatToReopen ?? false,
+            isContextualSurfacePresented: isContextualSurfacePresented
+        )
     }
 
     /// Attaches the Duck.ai menu to the address-bar button, or detaches it so a tap acts directly.

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -2294,8 +2294,8 @@ extension DefaultOmniBarView {
         textField.alpha = hasText ? 0 : 1
     }
 
-    func updateAIChatButtonForContextualChat(hasChatToReturnTo: Bool) {
-        searchAreaView.aiChatButton.setImage(hasChatToReturnTo
+    func updateAIChatButtonForContextualChat(hasContextualSession: Bool) {
+        searchAreaView.aiChatButton.setImage(hasContextualSession
             ? DesignSystemImages.Glyphs.Size24.aiChatDown
             : DesignSystemImages.Glyphs.Size24.aiChat)
     }

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -2294,8 +2294,8 @@ extension DefaultOmniBarView {
         textField.alpha = hasText ? 0 : 1
     }
 
-    func updateAIChatButtonForContextualSurface(isPresented: Bool) {
-        searchAreaView.aiChatButton.setImage(isPresented
+    func updateAIChatButtonForContextualChat(hasChatToReturnTo: Bool) {
+        searchAreaView.aiChatButton.setImage(hasChatToReturnTo
             ? DesignSystemImages.Glyphs.Size24.aiChatDown
             : DesignSystemImages.Glyphs.Size24.aiChat)
     }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1145,7 +1145,7 @@ class MainViewController: UIViewController {
             return
         }
 
-        // Every runtime input to `duckAIAddressBarEntry` and `hasContextualChatToReturnTo`, so neither the
+        // Every runtime input to `duckAIAddressBarEntry` and `hasContextualSession`, so neither the
         // tap nor the glyph can go stale. `isHomeTab` only changes with navigation, which refreshes the omnibar.
         let sessionState = coordinator.sessionState
         let hasActiveChat = sessionState.$viewState
@@ -1168,7 +1168,7 @@ class MainViewController: UIViewController {
         let isSheetPresented = currentTab?.aiChatContextualSheetCoordinator.isSheetPresented ?? false
         // iPhone-only: iPad's tabs-bar chip already indicates sheet state, so avoid a duplicate.
         if UIDevice.current.userInterfaceIdiom == .phone {
-            omniBar.barView.updateAIChatButtonForContextualChat(hasChatToReturnTo: hasContextualChatToReturnTo)
+            omniBar.barView.updateAIChatButtonForContextualChat(hasContextualSession: hasContextualSession)
         }
         refreshDuckAIAddressBarMenu()
         guard let tabsBarController else { return }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1145,8 +1145,8 @@ class MainViewController: UIViewController {
             return
         }
 
-        // Every runtime input to `duckAIAddressBarEntry` and `hasContextualSession`, so neither the
-        // tap nor the glyph can go stale. `isHomeTab` only changes with navigation, which refreshes the omnibar.
+        // The inputs that change mid-tab, so neither the tap nor the glyph goes stale. `isHomeTab` and
+        // the tab's persisted chat URL only move with navigation, which refreshes the omnibar anyway.
         let sessionState = coordinator.sessionState
         let hasActiveChat = sessionState.$viewState
             .map { _ in sessionState.hasActiveChat }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1145,8 +1145,8 @@ class MainViewController: UIViewController {
             return
         }
 
-        // Every runtime input to `duckAIAddressBarEntry`, so the button can never disagree with what a tap
-        // does. `isHomeTab`, the remaining input, only changes with navigation, which refreshes the omnibar.
+        // Every runtime input to `duckAIAddressBarEntry` and `hasContextualChatToReturnTo`, so neither the
+        // tap nor the glyph can go stale. `isHomeTab` only changes with navigation, which refreshes the omnibar.
         let sessionState = coordinator.sessionState
         let hasActiveChat = sessionState.$viewState
             .map { _ in sessionState.hasActiveChat }
@@ -1168,7 +1168,7 @@ class MainViewController: UIViewController {
         let isSheetPresented = currentTab?.aiChatContextualSheetCoordinator.isSheetPresented ?? false
         // iPhone-only: iPad's tabs-bar chip already indicates sheet state, so avoid a duplicate.
         if UIDevice.current.userInterfaceIdiom == .phone {
-            omniBar.barView.updateAIChatButtonForContextualSurface(isPresented: duckAIAddressBarEntry == .dismissContextualSurface)
+            omniBar.barView.updateAIChatButtonForContextualChat(hasChatToReturnTo: hasContextualChatToReturnTo)
         }
         refreshDuckAIAddressBarMenu()
         guard let tabsBarController else { return }

--- a/iOS/DuckDuckGo/OmniBarView.swift
+++ b/iOS/DuckDuckGo/OmniBarView.swift
@@ -137,8 +137,9 @@ protocol OmniBarView: UIView, OmniBarStatusUpdateable {
     /// Re-asserts the field's resting background for the current position. No-op unless floating UI.
     func restoreFloatingFieldAppearance()
 
-    /// Swaps the omnibar Duck.ai button glyph to reflect whether a contextual surface is open.
-    func updateAIChatButtonForContextualSurface(isPresented: Bool)
+    /// Swaps the omnibar Duck.ai button glyph to reflect whether this tab has a contextual chat to
+    /// return to, whether or not its surface is currently on screen.
+    func updateAIChatButtonForContextualChat(hasChatToReturnTo: Bool)
 
     /// In floating UI minimal chrome, wraps the button groups in their own glass capsules (the field
     /// keeps its glass). Pass `false` to restore the standard per-position appearance.

--- a/iOS/DuckDuckGo/OmniBarView.swift
+++ b/iOS/DuckDuckGo/OmniBarView.swift
@@ -137,9 +137,9 @@ protocol OmniBarView: UIView, OmniBarStatusUpdateable {
     /// Re-asserts the field's resting background for the current position. No-op unless floating UI.
     func restoreFloatingFieldAppearance()
 
-    /// Swaps the omnibar Duck.ai button glyph to reflect whether this tab has a contextual chat to
-    /// return to, whether or not its surface is currently on screen.
-    func updateAIChatButtonForContextualChat(hasChatToReturnTo: Bool)
+    /// Swaps the omnibar Duck.ai button glyph to reflect a contextual session on this tab: a surface
+    /// on screen, or a chat to return to once it is gone.
+    func updateAIChatButtonForContextualChat(hasContextualSession: Bool)
 
     /// In floating UI minimal chrome, wraps the button groups in their own glass capsules (the field
     /// keeps its glass). Pass `false` to restore the standard per-position appearance.

--- a/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
@@ -53,27 +53,21 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     var onRemoveActionRequested: (() -> Void)?
 
     private let isAutoAttachEnabled: () -> Bool
-    /// Evaluated at removal time: the re-attach offer belongs to the pre-chat surface only.
-    private let showsAttachAffordance: () -> Bool
     private(set) var attachedContext: AIChatPageContext?
     private var attachedURL: URL?
     private var originatingURL: URL?
     /// Presentation-only pending/delivered flag; set solely by `setAttached`, never decided by the chip.
     private var attachmentDeliveryState: PageContextAttachmentDeliveryState = .pendingSubmit
     private var isShowingAttachAffordance = false
-    /// Set only by an explicit removal, so the button appears in place of the pill the user dismissed.
-    private var isOfferingReattach = false
     private var cancellables = Set<AnyCancellable>()
 
     init(
         originatingURLPublisher: AnyPublisher<URL?, Never>,
         initialAttachedContext: AIChatPageContext?,
         initialAttachmentDeliveryState: PageContextAttachmentDeliveryState = .delivered,
-        isAutoAttachEnabled: @escaping () -> Bool,
-        showsAttachAffordance: @escaping () -> Bool = { false }
+        isAutoAttachEnabled: @escaping () -> Bool
     ) {
         self.isAutoAttachEnabled = isAutoAttachEnabled
-        self.showsAttachAffordance = showsAttachAffordance
         self.attachedContext = initialAttachedContext
         self.attachedURL = Self.url(of: initialAttachedContext)
         self.attachmentDeliveryState = initialAttachedContext == nil ? .pendingSubmit : initialAttachmentDeliveryState
@@ -91,25 +85,15 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
 
     func setAttached(_ context: AIChatPageContext, deliveryState: PageContextAttachmentDeliveryState = .pendingSubmit) {
         isShowingAttachAffordance = false
-        isOfferingReattach = false
         updateAttachment(context, deliveryState: deliveryState)
         Logger.contextualUTI.debug("PageContextChip attached")
         recompute()
     }
 
-    /// Deliberately leaves `isOfferingReattach` alone: removal feeds a nil context straight back here,
-    /// so resetting the offer would cancel the button a frame after the removal that asked for it.
     func clearAttached() {
         isShowingAttachAffordance = false
         clearAttachmentState()
         Logger.contextualUTI.debug("PageContextChip detached")
-        recompute()
-    }
-
-    /// Cancels a pending re-attach offer, for session boundaries such as starting a new chat.
-    func clearReattachOffer() {
-        guard isOfferingReattach else { return }
-        isOfferingReattach = false
         recompute()
     }
 
@@ -134,9 +118,6 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
 
     func tapToRemove() {
         Logger.contextualUTI.info("PageContextChip remove tapped — detaching")
-        // Set before clearing so `clearAttached`'s recompute lands the final state in one pass —
-        // publishing twice makes the strip drop the chip and re-add it.
-        isOfferingReattach = showsAttachAffordance()
         clearAttached()
         onRemoveActionRequested?()
     }
@@ -166,12 +147,10 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
         let isMatching = attachedURL != nil && attachedURL == originatingURL
         let branch: String
 
-        if isShowingAttachAffordance || isOfferingReattach {
+        if isShowingAttachAffordance {
             state = .placeholder
-            // Only an explicit removal shows the button: the attach-affordance command is a separate,
-            // pre-existing signal whose contract is a hidden placeholder.
-            isVisible = isOfferingReattach
-            branch = "attachAffordance(reattachOffer=\(isOfferingReattach))"
+            isVisible = false
+            branch = "attachAffordance"
         } else if let ctx = attachedContext {
             state = .attached(title: ctx.title, favicon: ctx.favicon)
             isVisible = attachmentDeliveryState == .pendingSubmit

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2485,7 +2485,7 @@ public struct UserText {
     public static let aiChatQuickActionSummarizePage = NSLocalizedString("duckai.quick.action.summarize.page", value: "Summarize page", comment: "Title for the summarize page quick action chip in the improved Duck.ai contextual sheet")
     public static let aiChatQuickActionAttach = NSLocalizedString("duckai.quick.action.attach", value: "Attach Page Content", comment: "Title for the attach page content quick action chip in Duck.ai contextual sheet")
 
-    // MARK: - AI Chat Recent Chats Popup
+    // MARK: - AI Chat Recent Chats Menu
     public static let aiChatRecentChatsButtonAccessibility = NSLocalizedString("duckai.contextual.recent.chats.button", value: "Recent Chats", comment: "Accessibility label for the recent chats button in the Duck.ai contextual sheet header")
     public static let aiChatRecentChatsSectionTitle = NSLocalizedString("duckai.contextual.recent.chats.section", value: "Recent Chats", comment: "Section header in the recent chats popup")
     public static let duckAiContextualOpenDuckAi = NSLocalizedString("duckai.contextual.open.duckai", value: "Open Duck.ai", comment: "Row in the contextual chat's chats popup that opens Duck.ai in a new tab")

--- a/iOS/DuckDuckGo/bg.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/bg.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Изпратено с твоето съобщение до Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Отваряне на Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Последни чатове";
 

--- a/iOS/DuckDuckGo/cs.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/cs.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Odesláno s tvojí zprávou pro Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Spustit Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Nedávné chaty";
 

--- a/iOS/DuckDuckGo/da.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/da.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Sendt sammen med din besked til Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Åbn Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Seneste chats";
 

--- a/iOS/DuckDuckGo/de.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/de.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Mit deiner Nachricht an Duck.ai gesendet";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Duck.ai öffnen";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Aktuelle Chats";
 

--- a/iOS/DuckDuckGo/el.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/el.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Αποστέλλεται με το μήνυμά σας στο Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Ανοίξτε το Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Πρόσφατες συνομιλίες";
 

--- a/iOS/DuckDuckGo/el.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/el.lproj/Localizable.strings
@@ -1913,7 +1913,7 @@
 "duckai.context.chip.info" = "Αποστέλλεται με το μήνυμά σας στο Duck.ai";
 
 /* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
-"duckai.contextual.open.duckai" = "Ανοίξτε το Duck.ai";
+"duckai.contextual.open.duckai" = "Άνοιξε το Duck.ai";
 
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Πρόσφατες συνομιλίες";

--- a/iOS/DuckDuckGo/es.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/es.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Enviado con tu mensaje a Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Abrir Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Chats recientes";
 

--- a/iOS/DuckDuckGo/et.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/et.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Saadetud koos sinu sõnumiga Duck.ai-le";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Ava Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Hiljutised vestlused";
 

--- a/iOS/DuckDuckGo/fi.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fi.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Lähetetty viestisi mukana Duck.ai:lle";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Avaa Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Viimeaikaiset keskustelut";
 

--- a/iOS/DuckDuckGo/fr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/fr.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Envoyé avec votre message à Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Ouvrir Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Discussions récentes";
 

--- a/iOS/DuckDuckGo/hr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hr.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Poslano s tvojom porukom Duck.ai-u";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Otvori Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Nedavna čavrljanja";
 

--- a/iOS/DuckDuckGo/hu.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/hu.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Üzeneteddel együtt elküldve a Duck.ai-nak";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Duck.ai megnyitása";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Legutóbbi csevegések";
 

--- a/iOS/DuckDuckGo/it.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/it.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Inviato con il tuo messaggio a Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Apri Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Chat recenti";
 

--- a/iOS/DuckDuckGo/ja.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ja.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Duck.aiに送信するメッセージと一緒に送信されます";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Duck.aiを開く";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "最近のチャット";
 

--- a/iOS/DuckDuckGo/lt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lt.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Išsiųstas su jūsų žinute Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Atidaryti „Duck.ai“";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Naujausi pokalbiai";
 

--- a/iOS/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lv.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Nosūtīts kopā ar tavu ziņojumu uz Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Atver Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Pēdējās tērzēšanas sarunas";
 

--- a/iOS/DuckDuckGo/lv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/lv.lproj/Localizable.strings
@@ -1913,7 +1913,7 @@
 "duckai.context.chip.info" = "Nosūtīts kopā ar tavu ziņojumu uz Duck.ai";
 
 /* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
-"duckai.contextual.open.duckai" = "Atver Duck.ai";
+"duckai.contextual.open.duckai" = "Atvērt Duck.ai";
 
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Pēdējās tērzēšanas sarunas";

--- a/iOS/DuckDuckGo/nb.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nb.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Sendt med meldingen din til Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Åpne Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Nylige chatter";
 

--- a/iOS/DuckDuckGo/nl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/nl.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Wordt samen met je bericht naar Duck.ai gestuurd";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Duck.ai openen";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Recente chats";
 

--- a/iOS/DuckDuckGo/pl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pl.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Wysyłane z Twoją wiadomością do Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Otwórz Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Ostatnie czaty";
 

--- a/iOS/DuckDuckGo/pt.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/pt.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Enviado com a tua mensagem para Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Abrir Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Conversas recentes";
 

--- a/iOS/DuckDuckGo/ro.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ro.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Trimis cu mesajul tău către Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Deschide Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Chaturi recente";
 

--- a/iOS/DuckDuckGo/ru.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/ru.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Отправляется вместе с сообщением для Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Открыть Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Последние чаты";
 

--- a/iOS/DuckDuckGo/sk.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sk.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Odoslané s tvojou správou na Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Otvoriť Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Nedávne chaty";
 

--- a/iOS/DuckDuckGo/sl.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sl.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Poslano z vašim sporočilom Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Odprite Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Nedavni klepeti";
 

--- a/iOS/DuckDuckGo/sv.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/sv.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Skickat med ditt meddelande till Duck.ai";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Öppna Duck.ai";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Senaste chattar";
 

--- a/iOS/DuckDuckGo/tr.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/tr.lproj/Localizable.strings
@@ -1912,6 +1912,9 @@
 /* Info text shown below the context chip explaining that content will be sent with the message */
 "duckai.context.chip.info" = "Duck.ai'a mesajınızla gönderildi";
 
+/* Row in the contextual chat's chats popup that opens Duck.ai in a new tab */
+"duckai.contextual.open.duckai" = "Duck.ai'ı aç";
+
 /* Accessibility label for the recent chats button in the Duck.ai contextual sheet header */
 "duckai.contextual.recent.chats.button" = "Son Sohbetler";
 

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -1555,9 +1555,10 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         XCTAssertEqual(sessionState.viewState.quickActions, [.askAboutPage])
     }
 
-    // MARK: - Ask about page vs the attachment strip's re-attach button
+    // MARK: - Ask about page after an explicit removal
 
-    /// The strip's re-attach button takes an explicit removal, so only then is the chip a duplicate.
+    /// Removing the context is the user declining it, so the chip stands down and the attachment menu
+    /// is the way back.
     func testAskAboutPageIsDroppedOnlyOnceTheUserHasRemovedTheContext() {
         // Given a floating-input-capable surface with the page attached
         mockSettings.isAutomaticContextAttachmentEnabled = true
@@ -1570,17 +1571,17 @@ final class AIChatContextualChatSessionStateTests: XCTestCase {
         sessionState.updateContext(makeTestContext())
         XCTAssertEqual(sessionState.viewState.quickActions, [.summarizePage])
 
-        // When the user removes it, the strip offers re-attach, so the chip stands down
+        // When the user removes it, the chip stands down
         sessionState.downgradeToPlaceholder()
         XCTAssertEqual(sessionState.viewState.quickActions, [])
 
-        // Then a new chat clears that offer, so the chip has to come back — otherwise neither is left
+        // Then a new chat resets that decision, so the chip comes back
         sessionState.resetToNoChat()
         XCTAssertEqual(sessionState.viewState.quickActions, [.askAboutPage])
     }
 
     func testAskAboutPageSurvivesRemovalWhenThereIsNoFloatingInput() {
-        // Given no floating input, nothing else offers re-attach, so the chip must stay
+        // Given no floating input, the chip is the only affordance, so it must stay
         mockSettings.isAutomaticContextAttachmentEnabled = true
         sessionState = AIChatContextualChatSessionState(
             aiChatSettings: mockSettings,

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualChatSessionStateTests.swift
@@ -2530,7 +2530,7 @@ private final class MockContextualModePixelHandler: AIChatContextualModePixelFir
                                scope: ResolvePageSuggestionsInput.Scope,
                                surface: AIChatContextualSuggestionsSurface) {}
     func fireSuggestionsContextCollectionTimedOut() {}
-    func fireRecentChatsPopupDisplayed() {}
+    func fireRecentChatsMenuDisplayed() {}
     func fireRecentChatSelected() {}
     func fireViewAllChatsTapped() {}
     func fireFireButtonTapped() { fireButtonTappedFired = true }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualFloatingInputViewControllerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualFloatingInputViewControllerTests.swift
@@ -245,18 +245,18 @@ final class AIChatContextualFloatingInputViewControllerTests: XCTestCase {
         XCTAssertEqual(host.deactivateInputCount, 1, "resigning happens once per dismissal, not on both sides")
     }
 
-    /// Resigning as the tap lands is what made the keyboard dip out and come straight back when the tap
-    /// focused a page field. Waiting leaves the choice to whatever the page does with focus.
-    func testAPageTapDefersResigningTheInputUntilTheSurfaceHasGone() async {
+    /// Deferring the resign left the keyboard up for the whole slide, so the surface sank behind it and the
+    /// keyboard only dropped afterwards. It goes down with the surface instead.
+    func testAPageTapResignsTheInputAsTheSlideStarts() async {
         let (subject, host, _, _) = makeSubjectWithHostSpy()
 
         subject.simulatePageTapForTesting()
         let slideFinished = expectation(description: "slide finished")
         subject.dismiss { slideFinished.fulfill() }
 
-        XCTAssertEqual(host.deactivateInputCount, 0, "the page has to be given the chance to take the keyboard")
+        XCTAssertEqual(host.deactivateInputCount, 1, "the keyboard has to travel with the surface, not after it")
         await fulfillment(of: [slideFinished], timeout: 3)
-        XCTAssertEqual(host.deactivateInputCount, 1, "the page declined it, so it was still ours to put away")
+        XCTAssertEqual(host.deactivateInputCount, 1, "resigning happens once per dismissal, not on both sides")
     }
 
     /// Pinned before it moves, so a keyboard that stays put or changes height cannot drag the surface

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualWebViewControllerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualWebViewControllerTests.swift
@@ -263,7 +263,7 @@ private final class StubContextualModePixelHandler: AIChatContextualModePixelFir
                                scope: ResolvePageSuggestionsInput.Scope,
                                surface: AIChatContextualSuggestionsSurface) {}
     func fireSuggestionsContextCollectionTimedOut() {}
-    func fireRecentChatsPopupDisplayed() {}
+    func fireRecentChatsMenuDisplayed() {}
     func fireRecentChatSelected() {}
     func fireViewAllChatsTapped() {}
     func fireFireButtonTapped() {}

--- a/iOS/DuckDuckGoTests/AIChat/AIChatPageContextHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatPageContextHandlerTests.swift
@@ -707,7 +707,7 @@ private final class MockContextualModePixelHandler: AIChatContextualModePixelFir
                                scope: ResolvePageSuggestionsInput.Scope,
                                surface: AIChatContextualSuggestionsSurface) {}
     func fireSuggestionsContextCollectionTimedOut() {}
-    func fireRecentChatsPopupDisplayed() {}
+    func fireRecentChatsMenuDisplayed() {}
     func fireRecentChatSelected() {}
     func fireViewAllChatsTapped() {}
     func fireFireButtonTapped() {}

--- a/iOS/DuckDuckGoTests/AIChat/AIChatRecentChatsMenuViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatRecentChatsMenuViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-//  AIChatRecentChatsPopupViewModelTests.swift
+//  AIChatRecentChatsMenuViewModelTests.swift
 //  DuckDuckGo
 //
 //  Copyright © 2025 DuckDuckGo. All rights reserved.
@@ -22,7 +22,7 @@ import XCTest
 @testable import DuckDuckGo
 
 @MainActor
-final class AIChatRecentChatsPopupViewModelTests: XCTestCase {
+final class AIChatRecentChatsMenuViewModelTests: XCTestCase {
 
     // MARK: - Mocks
 
@@ -45,23 +45,23 @@ final class AIChatRecentChatsPopupViewModelTests: XCTestCase {
     // MARK: - Initialization Tests
 
     func testInitWithEmptySuggestions() {
-        let vm = AIChatRecentChatsPopupViewModel(suggestions: [])
+        let vm = AIChatRecentChatsMenuViewModel(suggestions: [])
 
         XCTAssertTrue(vm.suggestions.isEmpty)
     }
 
     func testInitWithSuggestions() {
         let suggestions = makeSuggestions(count: 3)
-        let vm = AIChatRecentChatsPopupViewModel(suggestions: suggestions)
+        let vm = AIChatRecentChatsMenuViewModel(suggestions: suggestions)
 
         XCTAssertEqual(vm.suggestions.count, 3)
     }
 
     func testInitCapsAtMaxVisibleChats() {
         let suggestions = makeSuggestions(count: 10)
-        let vm = AIChatRecentChatsPopupViewModel(suggestions: suggestions)
+        let vm = AIChatRecentChatsMenuViewModel(suggestions: suggestions)
 
-        XCTAssertEqual(vm.suggestions.count, AIChatRecentChatsPopupViewModel.maxVisibleChats)
+        XCTAssertEqual(vm.suggestions.count, AIChatRecentChatsMenuViewModel.maxVisibleChats)
     }
 
     // MARK: - Pinned vs Regular Tests
@@ -69,7 +69,7 @@ final class AIChatRecentChatsPopupViewModelTests: XCTestCase {
     func testPinnedSuggestionPreservesFlag() {
         let pinned = AIChatSuggestion(id: "1", title: "Pinned", isPinned: true, chatId: "c1")
         let regular = AIChatSuggestion(id: "2", title: "Regular", isPinned: false, chatId: "c2")
-        let vm = AIChatRecentChatsPopupViewModel(suggestions: [pinned, regular])
+        let vm = AIChatRecentChatsMenuViewModel(suggestions: [pinned, regular])
 
         XCTAssertTrue(vm.suggestions[0].isPinned)
         XCTAssertFalse(vm.suggestions[1].isPinned)
@@ -80,14 +80,14 @@ final class AIChatRecentChatsPopupViewModelTests: XCTestCase {
     // MARK: - fetch() Tests
 
     func testFetchReturnsNilWhenReaderIsNil() async {
-        let result = await AIChatRecentChatsPopupViewModel.fetch(using: nil)
+        let result = await AIChatRecentChatsMenuViewModel.fetch(using: nil)
         XCTAssertNil(result)
     }
 
     func testFetchReturnsViewModelWhenNoSuggestions() async {
         let reader = MockSuggestionsReader()
 
-        let result = await AIChatRecentChatsPopupViewModel.fetch(using: reader)
+        let result = await AIChatRecentChatsMenuViewModel.fetch(using: reader)
 
         XCTAssertNotNil(result)
         XCTAssertTrue(result?.suggestions.isEmpty ?? false)
@@ -98,7 +98,7 @@ final class AIChatRecentChatsPopupViewModelTests: XCTestCase {
         let reader = MockSuggestionsReader()
         reader.recentToReturn = makeSuggestions(count: 3)
 
-        let result = await AIChatRecentChatsPopupViewModel.fetch(using: reader)
+        let result = await AIChatRecentChatsMenuViewModel.fetch(using: reader)
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.suggestions.count, 3)
@@ -108,19 +108,19 @@ final class AIChatRecentChatsPopupViewModelTests: XCTestCase {
         let reader = MockSuggestionsReader()
         reader.recentToReturn = makeSuggestions(count: 3)
 
-        _ = await AIChatRecentChatsPopupViewModel.fetch(using: reader)
+        _ = await AIChatRecentChatsMenuViewModel.fetch(using: reader)
 
-        XCTAssertEqual(reader.lastMaxChats, AIChatRecentChatsPopupViewModel.maxVisibleChats + 1)
+        XCTAssertEqual(reader.lastMaxChats, AIChatRecentChatsMenuViewModel.maxVisibleChats + 1)
     }
 
     func testFetchCapsAtMaxVisibleChats() async {
         let reader = MockSuggestionsReader()
-        reader.recentToReturn = makeSuggestions(count: AIChatRecentChatsPopupViewModel.maxVisibleChats + 1)
+        reader.recentToReturn = makeSuggestions(count: AIChatRecentChatsMenuViewModel.maxVisibleChats + 1)
 
-        let result = await AIChatRecentChatsPopupViewModel.fetch(using: reader)
+        let result = await AIChatRecentChatsMenuViewModel.fetch(using: reader)
 
         XCTAssertNotNil(result)
-        XCTAssertEqual(result?.suggestions.count, AIChatRecentChatsPopupViewModel.maxVisibleChats)
+        XCTAssertEqual(result?.suggestions.count, AIChatRecentChatsMenuViewModel.maxVisibleChats)
     }
 
     func testFetchCombinesPinnedAndRecent() async {
@@ -132,7 +132,7 @@ final class AIChatRecentChatsPopupViewModelTests: XCTestCase {
             AIChatSuggestion(id: "r1", title: "Recent Chat", isPinned: false, chatId: "recent-1")
         ]
 
-        let result = await AIChatRecentChatsPopupViewModel.fetch(using: reader)
+        let result = await AIChatRecentChatsMenuViewModel.fetch(using: reader)
 
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.suggestions.count, 2)

--- a/iOS/DuckDuckGoTests/AIChat/DuckAIAddressBarEntryTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAIAddressBarEntryTests.swift
@@ -81,4 +81,47 @@ final class DuckAIAddressBarEntryTests: XCTestCase {
     func testHomeTabWinsOverAPresentedSurface() {
         XCTAssertEqual(resolve(isHomeTab: true, isContextualSurfacePresented: true), .legacyDuckAI)
     }
+
+    // MARK: - Contextual glyph
+
+    private func showsGlyph(isContextualModeAvailable: Bool = true,
+                            isHomeTab: Bool = false,
+                            hasChatToReopen: Bool = false,
+                            isContextualSurfacePresented: Bool = false) -> Bool {
+        DuckAIAddressBarEntry.showsContextualGlyph(
+            isContextualModeAvailable: isContextualModeAvailable,
+            isHomeTab: isHomeTab,
+            hasChatToReopen: hasChatToReopen,
+            isContextualSurfacePresented: isContextualSurfacePresented
+        )
+    }
+
+    func testNoGlyphOnAWebPageWithNothingGoingOn() {
+        XCTAssertFalse(showsGlyph())
+    }
+
+    func testAChatToReopenShowsTheGlyph() {
+        XCTAssertTrue(showsGlyph(hasChatToReopen: true))
+    }
+
+    /// An open surface counts even before a prompt, so the glyph appears as soon as it does.
+    func testAPresentedSurfaceShowsTheGlyphWithoutAChat() {
+        XCTAssertTrue(showsGlyph(isContextualSurfacePresented: true))
+    }
+
+    /// Dismissing without prompting leaves neither, which is what takes the glyph away again.
+    func testDismissingWithoutAChatDropsTheGlyph() {
+        XCTAssertFalse(showsGlyph(hasChatToReopen: false, isContextualSurfacePresented: false))
+    }
+
+    func testContextualModeOffNeverShowsTheGlyph() {
+        XCTAssertFalse(showsGlyph(isContextualModeAvailable: false, hasChatToReopen: true))
+    }
+
+    /// Matches `resolve`, which sends the home tab to `.legacyDuckAI`: the glyph must not promise a
+    /// contextual session the tap will not open.
+    func testHomeTabNeverShowsTheGlyph() {
+        XCTAssertFalse(showsGlyph(isHomeTab: true, hasChatToReopen: true))
+        XCTAssertFalse(showsGlyph(isHomeTab: true, isContextualSurfacePresented: true))
+    }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
@@ -41,62 +41,32 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
 
     private func makeSUT(
         initialAttachedContext: AIChatPageContext? = nil,
-        initialAttachmentDeliveryState: PageContextAttachmentDeliveryState = .delivered,
-        showsAttachAffordance: @escaping () -> Bool = { false }
+        initialAttachmentDeliveryState: PageContextAttachmentDeliveryState = .delivered
     ) {
         sut = UnifiedToggleInputPageContextChipViewModel(
             originatingURLPublisher: originatingURL.eraseToAnyPublisher(),
             initialAttachedContext: initialAttachedContext,
             initialAttachmentDeliveryState: initialAttachmentDeliveryState,
-            isAutoAttachEnabled: { [weak self] in self?.autoAttachEnabled ?? false },
-            showsAttachAffordance: showsAttachAffordance
+            isAutoAttachEnabled: { [weak self] in self?.autoAttachEnabled ?? false }
         )
         sut.onAttachActionRequested = { [weak self] in self?.attachCalls += 1 }
         sut.onRemoveActionRequested = { [weak self] in self?.removeCalls += 1 }
     }
 
-    // MARK: - Re-attach offer
+    // MARK: - Removal
 
-    /// The offer belongs to the pre-chat surface, where attaching the page is the whole point.
-    func test_removingTheChip_offersReattach_whenTheSurfaceStillWantsIt() {
+    /// The attachment menu is the way back, so a removal leaves nothing behind.
+    func test_removingTheChip_leavesNothingVisible() {
         let url = "https://en.wikipedia.org/wiki/Cat"
         originatingURL.send(URL(string: url))
         makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url),
-                initialAttachmentDeliveryState: .pendingSubmit,
-                showsAttachAffordance: { true })
+                initialAttachmentDeliveryState: .pendingSubmit)
 
         sut.tapToRemove()
 
-        XCTAssertTrue(sut.isVisible, "the placeholder stands in for the chip the user just dismissed")
+        XCTAssertFalse(sut.isVisible)
         XCTAssertEqualState(sut.state, .placeholder)
-    }
-
-    /// Once a chat exists the attachment menu is the way back, so a removal is just a removal.
-    func test_removingTheChip_doesNotOfferReattach_onceTheSurfaceDeclines() {
-        let url = "https://en.wikipedia.org/wiki/Cat"
-        originatingURL.send(URL(string: url))
-        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url),
-                initialAttachmentDeliveryState: .pendingSubmit,
-                showsAttachAffordance: { false })
-
-        sut.tapToRemove()
-
-        XCTAssertFalse(sut.isVisible)
-    }
-
-    /// Evaluated at removal time, not construction — the same view model spans both sides of the boundary.
-    func test_reattachOffer_readsTheSurfaceAtRemovalTime() {
-        let url = "https://en.wikipedia.org/wiki/Cat"
-        originatingURL.send(URL(string: url))
-        var wantsAffordance = true
-        makeSUT(initialAttachedContext: makeContext(title: "Cat", url: url),
-                initialAttachmentDeliveryState: .pendingSubmit,
-                showsAttachAffordance: { wantsAffordance })
-
-        wantsAffordance = false
-        sut.tapToRemove()
-
-        XCTAssertFalse(sut.isVisible)
+        XCTAssertEqual(removeCalls, 1)
     }
 
     // MARK: - State transitions

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/OmniBar/MockOmniBar.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/OmniBar/MockOmniBar.swift
@@ -130,7 +130,7 @@ final class MockOmniBar: OmniBar {
         func makeGlass() { }
         func makeOpaque() { }
         func restoreFloatingFieldAppearance() { }
-        func updateAIChatButtonForContextualChat(hasChatToReturnTo: Bool) { }
+        func updateAIChatButtonForContextualChat(hasContextualSession: Bool) { }
         func setFloatingMinimalChromeBar(_ enabled: Bool) { }
 
         var progressView: DuckDuckGo.ProgressView?

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/OmniBar/MockOmniBar.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/OmniBar/MockOmniBar.swift
@@ -130,7 +130,7 @@ final class MockOmniBar: OmniBar {
         func makeGlass() { }
         func makeOpaque() { }
         func restoreFloatingFieldAppearance() { }
-        func updateAIChatButtonForContextualSurface(isPresented: Bool) { }
+        func updateAIChatButtonForContextualChat(hasChatToReturnTo: Bool) { }
         func setFloatingMinimalChromeBar(_ enabled: Bool) { }
 
         var progressView: DuckDuckGo.ProgressView?


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215757651854873?focus=true

### Description

Follow-ups to the A2 contextual Duck.ai branch (#6398), plus two changes from design/product review.

- Renamed the popup-era chats-menu types — there is no popup any more, only a native `UIMenu`. The pixel name and localisation keys are deliberately unchanged.
- Added the missing `Open Duck.ai` translations for all 25 non-English locales, reusing each locale's existing translation of the same English string.
- Removing the page-context chip no longer leaves a re-attach placeholder behind; re-attaching is the attachment menu's job.
- The address-bar Duck.ai button now shows its contextual glyph whenever the tab has a contextual session — a surface on screen, or a chat to return to — instead of only while a surface is open. Dismissing without prompting leaves neither, so it reverts.
- Darkened the contextual scrim and the suggestion pills' glass, per design review. The pill tint is theme-aware.

### Testing Steps

1. Open a page → tap the Duck.ai icon → the floating input appears and the icon shows the arrow glyph
2. Dismiss without typing → icon returns to the plain Duck.ai glyph
3. Send a prompt, then dismiss the surface → icon keeps the arrow glyph
4. Tap the chats icon in the sheet header → Open Duck.ai / New Chat / Recent Chats / View all chats, header pill shadows fade while open
5. Expand the chat to its own tab (⤢), return to the original tab, tap Duck.ai → fresh floating input, plain glyph
6. Force-quit, relaunch, tap Duck.ai on that tab → still fresh
7. With the page context chip attached, tap its X → chip disappears with nothing in its place; re-attach from the attachment menu
8. Check the scrim and pills in both light and dark appearance

### Impact

Low — the contextual Duck.ai surface is behind `aiChatContextualFloatingInput`. Nothing here changes what a tap does; the glyph, scrim and pill tint are presentational, and the chip change removes an affordance rather than adding one.

#### What could go wrong?

- The glyph could disagree with the tap action → the rule now lives in `DuckAIAddressBarEntry` beside `resolve`, over the same inputs, with tests covering the home-tab and no-chat cases.
- The pill tint could be wrong in one appearance → tint is resolved per `userInterfaceStyle` and the glass effect is rebuilt on a light/dark flip, since `UIGlassEffect`'s tint is fixed at init.

### Quality Considerations

- **The pill tint values have not been reviewed on screen.** They were picked by judgement: the Figma shows the stock `T-Surface-Glass/iOS/Regular-Large` token, so it does not encode the requested darkening. Light 0.06 / dark 0.14, both single constants in `AIChatQuickActionChipView.Constants`, trivial to retune.
- The pill tint is iOS 26 only — the earlier `UIBlurEffect` fallback has no tint to carry it, and was left on `.systemThinMaterial` to match every other pre-26 glass fallback in the app. The darker scrim still applies there.
- `AIChatQuickActionChipViewTests` (SPM target) was not run locally: no `.xctestplan` includes it, and `swift test` on the package fails to build for macOS on a pre-existing `DesignResourcesKitIcons` issue unrelated to this branch.
- `AIChatContextualSheetCoordinatorTests.testExpandRequestRetainsActiveChat` fails on `main` today; the fix is #6467. Rebase once that lands for a clean run.

### Known follow-up (not in this PR)

The address-bar Duck.ai menu fires its shown pixel twice per presentation — `fireAddressBarMenuShown()` sits inside a `UIDeferredMenuElement.uncached` provider, which UIKit resolves more than once per open (observed 136ms apart on one tap). The chats menu in this diff already avoids that by firing from `onMenuWillDisplay`; the address-bar menu should move to the same mechanism.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational and affordance tweaks behind the contextual floating-input flag. No auth, data, or tap-action changes.
> 
> **Overview**
> Follow-up polish for contextual Duck.ai: the address-bar glyph now tracks a **session** (open surface *or* a chat to reopen), not only whether a surface is on screen. Dismissing without a prompt reverts to the plain icon.
> 
> Removing page context no longer leaves a re-attach placeholder; re-attach is only via the attachment menu. “Ask about page” still returns after a new chat.
> 
> The floating input always resigns with the dismiss slide so the keyboard travels with the surface. Sheet and floating input share a darker `ContextualSurfaceScrim` (0.3). Suggestion pills get a theme-aware glass tint on iOS 26.
> 
> Renames chats “popup” types/pixels APIs to “menu” (pixel names and loc keys unchanged) and adds missing **Open Duck.ai** strings for non-English locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e91e10f97bba3451a35a098cf2c1728d19c42415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->