### PR TITLE
Fix stale selection-journey version expectation

### DIFF
--- a/iOS/DuckDuckGoTests/AIChat/DuckAISelectionJourneyInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAISelectionJourneyInstrumentationTests.swift
@@ -281,7 +281,7 @@ struct DuckAISelectionJourneyInstrumentationTests {
         #expect(DuckAISelectionJourneyWideEventData.metadata.pixelName == "duckai_selection_journey")
         #expect(DuckAISelectionJourneyWideEventData.metadata.featureName == "duckai-selection-journey")
         #expect(DuckAISelectionJourneyWideEventData.metadata.type == "ios-duckai-selection-journey")
-        #expect(DuckAISelectionJourneyWideEventData.metadata.version == "1.1.0")
+        #expect(DuckAISelectionJourneyWideEventData.metadata.version == "1.2.0")
     }
 
     @available(iOS 16, *)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215757651854873?focus=true
CC:

### Description
One test on main expects the selection-journey wide event to be at version 1.1.0, but #6398 moved it to
1.2.0 when it added a new terminal reason, and the registered schema for 1.2.0 exists. The expectation
is stale, so main is red.

Latent since #6398 and invisible until now: every iOS Unit Tests job was cancelled at its 60-minute
ceiling with "No test results found!", so nothing reported the failure.

Not reverting the version instead: the emitter would then announce 1.1.0 while sending a terminal reason
only the 1.2.0 schema permits, and remote validation would drop those payloads. The expectation is what
is wrong, not the version.

### Testing Steps
1. Run `DuckAISelectionJourneyInstrumentationTests` → 15 tests pass, including "Wide event metadata
   matches the registered schema" (that one fails on main without this change).

### Impact
Low — a one-line test expectation. No production code touched.

#### What could go wrong?
Another wide event could carry the same stale-version problem → swept all five (`PostIdleSession`,
`NewTabPageSession`, `ReturnSession`, `DuckAISelectionJourney`, `DuckAIPrompt`); source and test
versions agree in every other case.

### Quality Considerations
Verified locally with `xcodebuild test`, since the iOS Unit Tests CI job is timing out repo-wide and
cannot give a verdict. That timeout hid this failure for days — worth prioritising over this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line unit-test assertion change with no production or telemetry behavior changes.
> 
> **Overview**
> Updates the DuckAI selection-journey wide-event schema test so it expects metadata version `1.2.0` instead of `1.1.0`.
> 
> That matches the version already shipped with the extra terminal reason; production code is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b5f8d5a2b7cb87a7596407e8f00bc7450aa9e39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->