### PR TITLE
iOS: Add Slow Animations toggle to the debug menu

### DIFF
--- a/iOS/DuckDuckGo/AppLifecycle/SceneDelegate.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/SceneDelegate.swift
@@ -33,6 +33,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
             self.window = window
+            window.layer.speed = AppUserDefaults().slowAnimationsEnabled ? AppUserDefaults.slowAnimationsLayerSpeed : 1.0
             appStateMachine.handle(.willConnectToWindow(window: window))
         }
 

--- a/iOS/DuckDuckGo/AppUserDefaults.swift
+++ b/iOS/DuckDuckGo/AppUserDefaults.swift
@@ -137,6 +137,7 @@ public class AppUserDefaults: AppSettings {
         static let onboardingForceRestorePromptEligibleKey = "com.duckduckgo.ios.debug.onboardingForceRestorePromptEligible"
         static let onboardingFlowTypeKey = "com.duckduckgo.ios.debug.onboardingFlowType"
         static let shakeToOpenDebugMenuEnabledKey = "com.duckduckgo.ios.debug.shakeToOpenDebugMenuEnabled"
+        static let slowAnimationsEnabledKey = "com.duckduckgo.ios.debug.slowAnimationsEnabled"
     }
 
     private var userDefaults: UserDefaults? {
@@ -529,6 +530,20 @@ public class AppUserDefaults: AppSettings {
             userDefaults?.set(newValue, forKey: DebugKeys.shakeToOpenDebugMenuEnabledKey)
         }
     }
+
+    /// Mirrors Simulator Debug → Slow Animations for in-app / on-device use.
+    var slowAnimationsEnabled: Bool {
+        get {
+            return userDefaults?.object(forKey: DebugKeys.slowAnimationsEnabledKey) as? Bool ?? false
+        }
+
+        set {
+            userDefaults?.set(newValue, forKey: DebugKeys.slowAnimationsEnabledKey)
+        }
+    }
+
+    /// `CALayer.speed` that approximates the Simulator's typical 10× Slow Animations drag.
+    static let slowAnimationsLayerSpeed: Float = 0.1
 
     var autofillDebugScriptEnabled: Bool {
         get {

--- a/iOS/DuckDuckGo/DebugScreensViewController.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewController.swift
@@ -216,6 +216,14 @@ struct DebugTogglesView: View {
                     Image(systemName: "globe")
                 }
             }
+
+            Toggle(isOn: $model.isSlowAnimationsEnabled) {
+                Label {
+                    Text(verbatim: "Slow Animations")
+                } icon: {
+                    Image(systemName: "tortoise")
+                }
+            }
         }
     }
 

--- a/iOS/DuckDuckGo/DebugScreensViewModel.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel.swift
@@ -48,6 +48,14 @@ class DebugScreensViewModel: ObservableObject {
         }
     }
 
+    @Published var isSlowAnimationsEnabled = false {
+        didSet {
+            guard oldValue != isSlowAnimationsEnabled else { return }
+            AppUserDefaults().slowAnimationsEnabled = isSlowAnimationsEnabled
+            Self.applySlowAnimations(enabled: isSlowAnimationsEnabled)
+        }
+    }
+
     @Published var filter = "" {
         didSet {
             refreshFilter()
@@ -103,6 +111,18 @@ class DebugScreensViewModel: ObservableObject {
         self.isInternalUser = dependencies.internalUserDecider.isInternalUser
         self.isInspectibleWebViewsEnabled = AppUserDefaults().inspectableWebViewEnabled
         self.isShakeToOpenDebugMenuEnabled = AppUserDefaults().shakeToOpenDebugMenuEnabled
+        self.isSlowAnimationsEnabled = AppUserDefaults().slowAnimationsEnabled
+    }
+
+    /// Matches Simulator Debug → Slow Animations (~10×) by slowing every window's layer clock.
+    static func applySlowAnimations(enabled: Bool) {
+        let speed = enabled ? AppUserDefaults.slowAnimationsLayerSpeed : 1.0
+        for scene in UIApplication.shared.connectedScenes {
+            guard let windowScene = scene as? UIWindowScene else { continue }
+            for sceneWindow in windowScene.windows {
+                sceneWindow.layer.speed = speed
+            }
+        }
     }
 
     func refreshFilter() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214749231578703/task/1217730165702573?focus=true
Tech Design URL: N/A
CC: N/A

### Description
Adds a **Slow Animations** toggle under Inspectable WebViews in the debug menu. It mirrors Simulator Debug → Slow Animations by setting each window’s `layer.speed` to `0.1` (~10×), so transitions can be inspected on device without Cmd-T. The preference persists across launches.

### Testing Steps
1. Open Debug menu → confirm **Slow Animations** appears under Inspectable WebViews
2. Enable the toggle → UI transitions run ~10× slower
3. Disable the toggle → animations return to normal speed
4. Enable, kill and relaunch the app → Slow Animations remains on


Made with [Cursor](https://cursor.com)