### PR TITLE
macOS: Fix downloads dropped when started from a pinned tab

### DIFF
--- a/macOS/DuckDuckGo/Tab/TabExtensions/PopupHandlingTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/PopupHandlingTabExtension.swift
@@ -428,6 +428,10 @@ extension PopupHandlingTabExtension: NavigationResponder {
         // Must be targeting an existing frame (not a new window/tab)
         guard let targetFrame = navigationAction.targetFrame else { return .next }
 
+        // Downloads must stay in the initiating tab: re-loading the URL in a new tab drops the download
+        // intent (and `blob:` URLs are only resolvable in the page that created them).
+        guard !navigationAction.shouldDownload else { return .next }
+
         // Check if the navigation action is a link activation (clicked link, etc.)
         let isLinkActivated = !navigationAction.isTargetingNewWindow
         && (navigationAction.navigationType.isLinkActivated || (navigationAction.navigationType == .other && navigationAction.isUserInitiated))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1217427154406072?focus=true
Tech Design URL:
CC:

### Description

Fixes downloads started from a pinned tab. The pinned-tab "link leaves this domain" rule cancelled the navigation and re-loaded the URL in a new tab, dropping the download intent. `blob:` URLs got it worst: `host` is nil so every blob looks cross-domain, and a blob is only resolvable in the page that created it, so the new tab rendered the file inline and the download failed with `WebKitBlobResource Code=1`. Download navigations now fall through to `DownloadsTabExtension`.

### Testing Steps
1. Pin a tab, open Duck.ai in it, generate an image.
2. Click "Download image" → save prompt appears, no new tab opens, file lands in Downloads.
3. Unpinned tab: same flow still works.
4. Pinned tab: click a normal cross-domain link → still opens in a new tab.

### Impact

Low. Restores downloads on a path that was fully broken; only download navigations change behaviour.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow navigation-policy exception for download actions only; pinned-tab link behavior is otherwise unchanged.
> 
> **Overview**
> Stops the pinned-tab “open cross-domain links in a new tab” rule from intercepting download navigations.
> 
> `decidePolicy` in `PopupHandlingTabExtension` now returns `.next` when `shouldDownload` is set, so the original tab (and `DownloadsTabExtension`) keep the download. Reloading the URL in a new tab was dropping download intent; `blob:` URLs were especially broken because they have no host (always looked cross-domain) and are only resolvable in the page that created them. Normal pinned-tab cross-domain links still open in a new tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d00ebbde1e8f305aa319d756818edbb18cb51ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->