### PR TITLE
Bug: Keyboard opens down in new Duck.ai web tabs

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1503,7 +1503,7 @@ extension MainViewController: AIChatTabChatHeaderViewDelegate {
     }
 
     func aiChatTabChatHeaderDidTapNewTab() {
-        newTab(reuseExisting: false, allowingKeyboard: false)
+        newTab(reuseExisting: false, allowingKeyboard: true)
     }
 
     /// Force-search NTP. Override mode without committing — preserved toggle preference must survive.


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1210947754188321/task/1217661082724886?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->
After tap on “New Tab” when on Duck.ai chat, new tab opens and keyboard is not in focus. This PR fixes that. Existing automatic selection between Search and Duck.ai remains unchanged.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Open Duck.ai tab and tap `+` in header.
2. Tap **New Tab** → new tab opens with omnibar focused and keyboard visible.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low — limited to keyboard focus when opening new tab from Duck.ai header menu.

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->
No privacy, data, or performance impact. Existing input-mode preference remains unchanged.


### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line UI focus change on a single header action; no auth, data, or navigation logic changes.
> 
> **Overview**
> Fixes missing omnibar/keyboard focus when opening **New Tab** from the Duck.ai chat header `+` menu.
> 
> `aiChatTabChatHeaderDidTapNewTab` now calls `newTab(..., allowingKeyboard: true)`, matching **New Search** and **New Fire Tab**. Search vs Duck.ai toggle preference is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2084cf8d9f0716aeb336670a476e3915781eab4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->