### PR TITLE
[iOS] Fire duck_ai_new_chat on new-chat creation

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatContentHandler.swift
@@ -23,6 +23,8 @@ import Common
 import FoundationExtensions
 import Core
 import os.log
+import PixelKit
+import PixelExperimentKit
 import PrivacyConfig
 import Foundation
 import Subscription
@@ -177,6 +179,7 @@ final class AIChatContentHandler: AIChatContentHandling {
     private let unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding
     private let debugSettings: AIChatDebugSettingsHandling
     private let iPadDuckAIControlsFeature: IPadDuckAIControlsFeatureProviding
+    private let fireNewChatExperimentPixels: () -> Void
 
     private var userScript: AIChatUserScriptProviding?
 
@@ -200,7 +203,8 @@ final class AIChatContentHandler: AIChatContentHandling {
          unifiedToggleInputFeature: UnifiedToggleInputFeatureProviding = UnifiedToggleInputFeature(),
          debugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings(),
          iPadDuckAIControlsFeature: IPadDuckAIControlsFeatureProviding = IPadDuckAIControlsFeature(),
-         getPageContext: PageContextAsyncProvider? = nil) {
+         getPageContext: PageContextAsyncProvider? = nil,
+         fireNewChatExperimentPixels: @escaping () -> Void = { PixelKit.fireNewAIChatExperimentPixels() }) {
         self.aiChatSettings = aiChatSettings
         self.payloadHandler = payloadHandler
         self.pixelMetricHandler = pixelMetricHandler
@@ -212,6 +216,7 @@ final class AIChatContentHandler: AIChatContentHandling {
         self.debugSettings = debugSettings
         self.iPadDuckAIControlsFeature = iPadDuckAIControlsFeature
         self.getPageContext = getPageContext
+        self.fireNewChatExperimentPixels = fireNewChatExperimentPixels
     }
 
     func setup(with userScript: AIChatUserScriptProviding, webView: WKWebView, displayMode: AIChatDisplayMode) {
@@ -387,6 +392,7 @@ extension AIChatContentHandler: AIChatUserScriptDelegate {
         case .sendToSyncSettings, .sendToSetupSync:
             delegate?.aiChatContentHandlerDidReceiveOpenSyncSettingsRequest(self)
         case .newChatStarted:
+            fireNewChatExperimentPixels()
             delegate?.aiChatContentHandlerDidReceiveNewChatCreated(self)
         default:
             break

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContentHandlerTests.swift
@@ -60,6 +60,21 @@ final class AIChatContentHandlerTests: XCTestCase {
         )
     }
 
+    private func makeHandler(fireNewChatExperimentPixels: @escaping () -> Void) -> AIChatContentHandler {
+        AIChatContentHandler(
+            aiChatSettings: mockSettings,
+            payloadHandler: mockPayloadHandler,
+            pixelMetricHandler: mockMetricHandler,
+            featureDiscovery: MockFeatureDiscovery(),
+            productSurfaceTelemetry: mockProductSurfaceTelemetry,
+            freeTrialConversionService: mockFreeTrialConversionService,
+            statisticsLoader: StatisticsLoader(fireSearchExperimentPixels: {}),
+            unifiedToggleInputFeature: mockUnifiedToggleInputFeature,
+            iPadDuckAIControlsFeature: mockIPadDuckAIControlsFeature,
+            fireNewChatExperimentPixels: fireNewChatExperimentPixels
+        )
+    }
+
     // MARK: - setup(with:webView:)
 
     func testSetupSetsUserScriptDelegate() throws {
@@ -694,6 +709,35 @@ final class AIChatContentHandlerTests: XCTestCase {
         // Then
         XCTAssertEqual(mockDelegate.didReceiveNewChatCreatedCallCount, 1)
         XCTAssertEqual(mockDelegate.didReceiveCloseChatRequestCallCount, 0)
+    }
+
+    // MARK: - duck_ai_new_chat metric
+
+    func testNewChatStartedFiresNewChatExperimentPixel() throws {
+        var fireCount = 0
+        let handler = makeHandler { fireCount += 1 }
+
+        handler.aiChatUserScript(makeTestUserScript(), didReceiveMessage: .newChatStarted)
+
+        XCTAssertEqual(fireCount, 1, "Starting a new chat must fire duck_ai_new_chat")
+    }
+
+    func testCloseAIChatDoesNotFireNewChatExperimentPixel() throws {
+        var fireCount = 0
+        let handler = makeHandler { fireCount += 1 }
+
+        handler.aiChatUserScript(makeTestUserScript(), didReceiveMessage: .closeAIChat)
+
+        XCTAssertEqual(fireCount, 0)
+    }
+
+    func testPromptSubmissionDoesNotFireNewChatExperimentPixel() throws {
+        var fireCount = 0
+        let handler = makeHandler { fireCount += 1 }
+
+        handler.aiChatUserScript(makeTestUserScript(), didReceiveMetric: AIChatMetric(metricName: .userDidSubmitPrompt))
+
+        XCTAssertEqual(fireCount, 0, "A prompt submission is not a new chat")
     }
 
     // MARK: - fireAIChatTelemetry


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1216921403712939
Tech Design URL:
CC:

### Description
Wires up the `duck_ai_new_chat` retention experiment metric on iOS (macOS parity — see the macOS PR). The metric and its firing helper already existed in shared `PixelExperimentKit` but iOS never called it; only `duck_ai_prompt_sent` was wired.

iOS fires it from the Duck.ai FE's `.newChatStarted` message (the FE's declared single source of truth for a new chat), handled in `AIChatContentHandler`. This one seam covers, for both the main and contextual handler instances:
- the in-page "New Chat" (side menu), which emits `.newChatStarted` directly, and
- the native chat-header / history "New Chat" buttons, which push `.newChatAction` and the FE echoes `.newChatStarted` back.

Firing is injected as a closure for testability. `UnifiedToggleInputCoordinator.startNewChat()` is deliberately NOT hooked — it's a shared input reset (also runs on contextual session-timer expiry) and would over-count/false-fire.

### Still to verify (before undrafting)
Two entry points need an on-device check to confirm coverage, because whether the FE emits `.newChatStarted` on a cold page load isn't knowable from code:
- Opening a fresh Duck.ai from a query (address bar / NTP / history-from-non-AI-tab). If cold load doesn't emit `.newChatStarted`, add a fire at the `openAIChat(source:)` funnel.
- New Image chat (`.newImageGenerationChatStarted` is routed separately). Add a fire there if it doesn't also emit `.newChatStarted`.

Experiment metrics are unique-per-window, so overlaps are harmless; the check is to close any gap.

### Testing Steps
1. Enroll in an active experiment at a valid `duck_ai_new_chat` window day (0/1/5–7/8–14).
2. Filter debug pixels for the experiment metric.
3. Start a new chat via: in-page New Chat, chat-header New Chat, history New Chat → each fires one `duck_ai_new_chat`.
4. Submit a follow-up prompt in an open chat → does NOT fire `duck_ai_new_chat` (still fires `duck_ai_prompt_sent`).

### Impact
None (adds metric instrumentation only; no user-facing behaviour change).

### Quality Considerations
Unit tests in `AIChatContentHandlerTests`: `.newChatStarted` fires the injected closure; `.closeAIChat` and prompt submission do not.