### PR TITLE
[macOS] Promo Queue: Don't suppress promos in non-conflicting contexts

### DIFF
--- a/macOS/DuckDuckGo/Permissions/Promo/AutoplayDiscoverabilityPromoDelegate.swift
+++ b/macOS/DuckDuckGo/Permissions/Promo/AutoplayDiscoverabilityPromoDelegate.swift
@@ -70,7 +70,7 @@ final class AutoplayDiscoverabilityPromoDelegate: InternalPromoDelegate {
     func show(history: PromoHistoryRecord, force: Bool) async -> PromoResult {
         // Rendered only to pre-existing users, otherwise we'll retire the promo
         if !force, isNewUserProvider() {
-            return .ignored()
+            return .retired
         }
 
         guard let addressBarButtonsViewController else {

--- a/macOS/DuckDuckGo/Promotions/PromoService.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoService.swift
@@ -673,6 +673,9 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
             record.timesDismissed += 1
             record.lastDismissed = currentDate
             record.nextEligibleDate = currentDate.addingTimeInterval(interval)
+        case .retired:
+            record.nextEligibleDate = .distantFuture
+            record.lastShown = nil // Ensure promo is not restored if it was retired before app restart
         case .noChange:
             record.lastShown = nil // Ensure promo is not restored if it was retracted before app restart
         }

--- a/macOS/DuckDuckGo/Promotions/PromoService.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoService.swift
@@ -526,15 +526,18 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
         let coexisting = promo.coexistingPromoIDs
 
         for otherId in visibleIds where otherId != promoId {
-            guard let other = promos.first(where: { $0.id == otherId }) else { continue }
+            // Global rules only apply between medium+ promos. A visible low-severity promo must not
+            // block anything; the early return above covers a low-severity promo being blocked.
+            guard let other = promos.first(where: { $0.id == otherId }),
+                  other.promoType.severity >= .medium else { continue }
+
+            // Coexistence has to be declared by both promos, and is deliberately non-transitive:
+            // it's evaluated per pair, so A<->B plus B<->C still leaves A and C blocking each other.
             let mutuallyCoexisting = coexisting.contains(otherId) && other.coexistingPromoIDs.contains(promoId)
+            guard !mutuallyCoexisting else { continue }
 
-            let contextConflict = !mutuallyCoexisting && (
-                context == .global || other.context == .global || context == other.context
-            )
-            if contextConflict { return false }
-
-            if severity >= .medium && other.promoType.severity >= .medium && !mutuallyCoexisting {
+            // One medium+ promo per context, and `.global` is exclusive with every other context.
+            if context == .global || other.context == .global || context == other.context {
                 return false
             }
         }

--- a/macOS/DuckDuckGo/Promotions/PromoTypes/PromoResult.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoTypes/PromoResult.swift
@@ -29,6 +29,10 @@ enum PromoResult: Equatable {
     /// - `.ignored(cooldown: interval)` -> temporarily dismissed; may re-show after cooldown interval elapses.
     case ignored(cooldown: TimeInterval? = nil)
 
+    /// Promo declined to display for this user and will not be offered again.
+    /// Permanently dismissed without recording a dismissal, so it does not contribute to the global cooldown.
+    case retired
+
     /// Promo retracted itself or encountered an error.
     /// No state change recorded; eligible again on next trigger.
     case noChange

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+AutoplayDiscoverability.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+AutoplayDiscoverability.swift
@@ -29,6 +29,12 @@ extension PromoServiceFactory {
                                                             windowControllersManager: dependencies.windowControllersManager,
                                                             isNewUserProvider: dependencies.isNewUserProvider)
 
-        return InternalPromo(id: identifier, triggers: [.autoplayDiscoverability], initiated: .app, promoType: promoType, context: .webPage, delegate: delegate)
+        return InternalPromo(id: identifier,
+                             triggers: [.autoplayDiscoverability],
+                             initiated: .app,
+                             promoType: promoType,
+                             context: .webPage,
+                             respectsGlobalCooldown: false,
+                             delegate: delegate)
     }
 }

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+AutoplayDiscoverability.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+AutoplayDiscoverability.swift
@@ -21,12 +21,9 @@ import Foundation
 extension PromoServiceFactory {
 
     /// Builds an Autoplay Discoverability Promo.
-    /// - Note:
-    ///     We're picking the `.inlineTip` PromoType for its `.low` severity: `checkRules` returns early for low severity, so no other visible promo can suppress this promo.
-    ///     A Next Steps card on the New Tab Page blocks every `.medium` promo for as long as it exists.
     @MainActor
     static func autoplayDiscoverability(dependencies: PromoDependencies) -> Promo {
-        let promoType = PromoType(.inlineTip, customTimeoutInterval: AutoplayDiscoverabilityPromoDelegate.displayDuration, customTimeoutResult: .ignored())
+        let promoType = PromoType(.featureTip, customTimeoutInterval: AutoplayDiscoverabilityPromoDelegate.displayDuration, customTimeoutResult: .ignored())
         let identifier = "autoplay-discoverability"
         let delegate = AutoplayDiscoverabilityPromoDelegate(featureFlagger: dependencies.featureFlagger,
                                                             windowControllersManager: dependencies.windowControllersManager,

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+Test.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+Test.swift
@@ -27,7 +27,7 @@ extension PromoServiceFactory {
         guard includeTestPromos else { return [] }
 
         var testPromoA = InternalPromo(id: "test-promo-a", triggers: [.testTriggered], initiated: .user, promoType: PromoType(.appModal), context: .newTabPage)
-        var testPromoB = InternalPromo(id: "test-promo-b", triggers: [.testTriggered], initiated: .user, promoType: PromoType(.appModal), context: .webPage)
+        var testPromoB = InternalPromo(id: "test-promo-b", triggers: [.testTriggered], initiated: .user, promoType: PromoType(.appModal), context: .newTabPage)
         var testPromoC = InternalPromo(id: "test-promo-c", triggers: [.testTriggered], initiated: .app, promoType: PromoType(.appModal), context: .global)
         var testPromoD = InternalPromo(id: "test-promo-d", triggers: [.testTriggered], initiated: .app, promoType: PromoType(.appModal, customTimeoutInterval: .seconds(3), customTimeoutResult: .ignored()), context: .global)
 

--- a/macOS/UnitTests/Promotions/AutoplayDiscoverabilityPromoDelegateTests.swift
+++ b/macOS/UnitTests/Promotions/AutoplayDiscoverabilityPromoDelegateTests.swift
@@ -68,14 +68,15 @@ final class AutoplayDiscoverabilityPromoDelegateTests: XCTestCase {
 
     // MARK: - Audience
 
-    /// `.ignored()` retires the promo permanently, which is what stops it from resurfacing once the
-    /// user is no longer new. `.noChange` would leave it eligible.
+    /// `.retired` retires the promo permanently, which is what stops it from resurfacing once the
+    /// user is no longer new. `.noChange` would leave it eligible, and `.ignored()` would record a
+    /// dismissal that contributes to the global cooldown despite nothing having been displayed.
     func testWhenNewUserThenShowRetiresThePromo() async {
         sut = makeSUT(isNewUser: true)
 
         let result = await sut.show(history: PromoHistoryRecord(id: "autoplay-discoverability"), force: false)
 
-        XCTAssertEqual(result, .ignored())
+        XCTAssertEqual(result, .retired)
     }
 
     // MARK: - Eligibility Publisher

--- a/macOS/UnitTests/Promotions/PromoServiceTests.swift
+++ b/macOS/UnitTests/Promotions/PromoServiceTests.swift
@@ -406,6 +406,100 @@ final class PromoServiceTests: XCTestCase {
         await fulfillment(of: [showCExpectation], timeout: 0.5) // Short timeout for inverted expectation
     }
 
+    // MARK: - Global rules: context scoping and low-severity participation
+
+    func testWhenTwoMediumPromosInDifferentContexts_ThenBothCanBeVisible() async {
+        // Given: two medium promos in different, non-global contexts and no declared coexistence.
+        // "One medium+ promo per context" is per context, so these do not compete.
+        let ntpDelegate = MockPromoDelegate(isEligible: true)
+        let webDelegate = MockPromoDelegate(isEligible: true)
+        let ntpPromo = PromoTestHelpers.makePromo(id: "ntp-medium", context: .newTabPage, delegate: ntpDelegate)
+        let webPromo = PromoTestHelpers.makePromo(id: "web-medium", context: .webPage, delegate: webDelegate)
+        let promoService = makeService(promos: [ntpPromo, webPromo])
+
+        let bothShownExpectation = XCTestExpectation(description: "both promos shown")
+        promoService.visiblePromosPublisher
+            .dropFirst()
+            .sink { promos in
+                let ids = Set(promos.map(\.id))
+                if ids.isSuperset(of: ["ntp-medium", "web-medium"]) {
+                    bothShownExpectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        // When
+        promoService.applicationDidBecomeActive()
+        triggerSubject.send(.appLaunched)
+
+        // Then
+        await fulfillment(of: [bothShownExpectation], timeout: timeout)
+    }
+
+    func testWhenTwoMediumPromosInSameNonGlobalContext_ThenSecondIsBlocked() async {
+        // Given: two medium promos sharing a non-global context. Per-context exclusivity must still apply
+        // when neither promo is `.global`.
+        let delegate1 = MockPromoDelegate(isEligible: true)
+        let delegate2 = MockPromoDelegate(isEligible: true)
+        let promo1 = PromoTestHelpers.makePromo(id: "web-first", context: .webPage, delegate: delegate1)
+        let promo2 = PromoTestHelpers.makePromo(id: "web-second", context: .webPage, delegate: delegate2)
+        let promoService = makeService(promos: [promo1, promo2])
+
+        let firstShownExpectation = XCTestExpectation(description: "first promo shown")
+        let secondShownExpectation = XCTestExpectation(description: "second promo shown")
+        secondShownExpectation.isInverted = true // Same context, so the second promo must be skipped
+        promoService.visiblePromosPublisher
+            .dropFirst()
+            .sink { promos in
+                if promos.contains(where: { $0.id == "web-first" }) {
+                    firstShownExpectation.fulfill()
+                }
+                if promos.contains(where: { $0.id == "web-second" }) {
+                    secondShownExpectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        // When
+        promoService.applicationDidBecomeActive()
+        triggerSubject.send(.appLaunched)
+
+        // Then
+        await fulfillment(of: [firstShownExpectation], timeout: timeout)
+        await fulfillment(of: [secondShownExpectation], timeout: 0.5) // Short timeout for inverted expectation
+    }
+
+    func testWhenLowSeverityPromoVisible_ThenDoesNotBlockMediumPromoInSameContext() async {
+        // Given: a visible low-severity promo and a medium promo sharing `.global`. Low-severity promos sit outside
+        // the global rules in both directions, so the medium promo must still show.
+        let lowDelegate = MockPromoDelegate(isEligible: true)
+        let mediumDelegate = MockPromoDelegate(isEligible: true)
+        let lowPromo = PromoTestHelpers.makePromo(id: "low-visible",
+                                                 promoType: PromoType(.inlineMessage),
+                                                 context: .global,
+                                                 delegate: lowDelegate)
+        let mediumPromo = PromoTestHelpers.makePromo(id: "medium-blocked", context: .global, delegate: mediumDelegate)
+        let promoService = makeService(promos: [lowPromo, mediumPromo])
+
+        let bothShownExpectation = XCTestExpectation(description: "low and medium promos both shown")
+        promoService.visiblePromosPublisher
+            .dropFirst()
+            .sink { promos in
+                let ids = Set(promos.map(\.id))
+                if ids.isSuperset(of: ["low-visible", "medium-blocked"]) {
+                    bothShownExpectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        // When
+        promoService.applicationDidBecomeActive()
+        triggerSubject.send(.appLaunched)
+
+        // Then
+        await fulfillment(of: [bothShownExpectation], timeout: timeout)
+    }
+
     func testWhenAppInitiatedPromoDismissedRecently_ThenGlobalCooldownBlocksNextAppPromo() async {
         // Given: promo-1 was dismissed 1 hour ago, cooldown is 24h
         let oneHourAgo = Date().addingTimeInterval(-3600)

--- a/macOS/UnitTests/Promotions/PromoServiceTests.swift
+++ b/macOS/UnitTests/Promotions/PromoServiceTests.swift
@@ -772,6 +772,36 @@ final class PromoServiceTests: XCTestCase {
         XCTAssertFalse(record.actioned)
     }
 
+    func testWhenRetiredResult_ThenPermanentlyDismissedWithoutRecordingDismissal() async {
+        // Given
+        let delegate = MockPromoDelegate(isEligible: true)
+        delegate.setShowResult(.retired)
+        let promo = PromoTestHelpers.makePromo(id: "retired-promo", delegate: delegate)
+        let promoService = makeService(promos: [promo])
+        let expectation = XCTestExpectation(description: "promo is hidden")
+        promoService.visiblePromosPublisher
+            .dropFirst()
+            .sink { promos in
+                if promos.isEmpty {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        // When
+        promoService.applicationDidBecomeActive()
+        triggerSubject.send(.appLaunched)
+        await fulfillment(of: [expectation], timeout: timeout)
+
+        // Then: retired permanently, but no dismissal recorded and nothing left to restore
+        let record = historyStore.record(for: "retired-promo")
+        XCTAssertEqual(record.nextEligibleDate, .distantFuture)
+        XCTAssertEqual(record.timesDismissed, 0)
+        XCTAssertNil(record.lastDismissed)
+        XCTAssertNil(record.lastShown)
+        XCTAssertFalse(record.actioned)
+    }
+
     func testWhenNoneResult_ThenNoStateChange() async {
         // Given
         let delegate = MockPromoDelegate(isEligible: true)
@@ -1257,6 +1287,42 @@ final class PromoServiceTests: XCTestCase {
         XCTAssertEqual(recordA.timesDismissed, 1)
         XCTAssertEqual(recordB.timesDismissed, 1)
         XCTAssertTrue(recordB.actioned)
+    }
+
+    func testWhenRetiredResult_ThenDoesNotContributeToGlobalCooldown() async {
+        // Given: promo A retires without displaying, promo B has default cooldown options
+        let delegateA = MockPromoDelegate(isEligible: true)
+        delegateA.setShowResult(.retired)
+        let delegateB = MockPromoDelegate(isEligible: true)
+        delegateB.setShowResult(.actioned)
+        let promoA = PromoTestHelpers.makePromo(id: "retired-a", delegate: delegateA)
+        let promoB = PromoTestHelpers.makePromo(id: "cooldown-b", delegate: delegateB)
+        let promoService = makeService(promos: [promoA, promoB])
+
+        let hideExpectation = XCTestExpectation(description: "promo a hidden")
+        let showExpectation = XCTestExpectation(description: "promo b shown")
+        promoService.visiblePromosPublisher
+            .dropFirst()
+            .sink { promos in
+                if promos.isEmpty {
+                    hideExpectation.fulfill()
+                } else if promos.contains(where: { $0.id == "cooldown-b" }) {
+                    showExpectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        // When: A retires, then trigger again - B should show (A's retirement didn't set cooldown)
+        promoService.applicationDidBecomeActive()
+        triggerSubject.send(.appLaunched)
+        await fulfillment(of: [hideExpectation], timeout: timeout)
+        triggerSubject.send(.appLaunched)
+        await fulfillment(of: [showExpectation], timeout: timeout)
+
+        // Then
+        let recordA = historyStore.record(for: "retired-a")
+        XCTAssertNil(recordA.lastDismissed)
+        XCTAssertEqual(recordA.timesDismissed, 0)
     }
 
     func testWhenDefaultCooldownOptions_ThenStandardCooldownBehavior() async {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1217692111106645?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1209575551546090?focus=true
CC:

### Description

Fixes two bugs in the Promo Queue framework:

1. Visible low-severity promos do NOT suppress Medium–High promos
2. Medium–High promos in one non-global context do NOT suppress Medium–High promos in another non-global context

This matches the stated global product rules for the Promo Queue:

1. Global rules only apply to promos with Medium or higher severity. Low-severity promos bypass global rules entirely.
2. Only show one Medium–High severity promo per context, unless the promo declares coexistence with any other Medium–High promo in that context. (A `global` context promo is mutually exclusive with all other contexts.)

Along with this bug fix, this also updates the Autoplay Discoverability promo definition:
* The promo now uses the `featureTip` promo — medium severity, which matches the promo purpose and UI. (This also applies other promo queue rules to the promo, rather than bypassing them as a low-severity promo, so it respects the promo queue rules for promos with this interruption level.)
* Adds a new `retired` case to `PromoResult` to support retiring a promo without user interaction (e.g. for this promo's restriction to pre-existing users).
* The bug fix addresses the original concern (the promo couldn't be shown when Next Steps was visible except as a low-severity promo) while this change better aligns it with promo queue rules and guidelines.

### Testing Steps
1. Enable the `Internal User` State
4. Click on `Debug > New Tab Page > Reset Next Steps`
5. Click on `Debug > Promo Queue > Autoplay Discoverability > Undismiss`
6. Open this URL: https://videojs.github.io/autoplay-tests/videojs/play/autoplay.html

- [ ] Verify the Permissions Center gets automatically opened (Next Steps promo in NTP context does not block Autoplay Discoverability promo in webpage context)

<img width="400" height="290" alt="image" src="https://github.com/user-attachments/assets/ffc51ae6-e918-4d91-80bc-ba50f4a0c4b3" />

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
7. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Medium: Bug fix for promo queue; could affect timing for promo presentation

#### What could go wrong?
* Changes to the promo queue rule checks could change existing promo behavior, but only to ensure that the queue shows promos more correctly
* Changing the Autoplay Discoverability promo type can affect how it interacts with other promos (can't be shown mutually with another Medium–High promo, respects and applies the global cooldown). This better enforces the promo queue's rules/guidelines according to the promo's UI and behavior.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes promo scheduling rules and Autoplay Discoverability severity, which can alter which promos appear together and cooldown behavior.
> 
> **Overview**
> Fixes Promo Queue exclusivity so **low-severity promos no longer block medium+ ones**, and **medium+ promos only compete within the same context** (`.global` still exclusive with every context). Coexistence remains pairwise and non-transitive.
> 
> Adds `PromoResult.retired` to permanently skip a promo **without** recording a dismissal or contributing to global cooldown. Autoplay Discoverability now uses `.featureTip` (medium), opts out of global cooldown, and retires for new users instead of `.ignored()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53489553108ef02b1e6e1c2e24892fbf1cfd782c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->