### PR TITLE
[iOS] Enable PIR unit tests in CI

### DIFF
--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -190,6 +190,7 @@ jobs:
           {"test-tag":"adClick","exclude-tags":"ipad","device-model":"iPhone-16","device-name":"iPhone","device":"iphone"},
           {"test-tag":"duckplayer_native","exclude-tags":"ipad","device-model":"iPhone-16","device":"iphone"},
           {"test-tag":"device_info","exclude-tags":"ipad","device-model":"iPhone-16","device":"iphone"},
+          {"test-tag":"pir","exclude-tags":"ipad","device-model":"iPhone-16","device-name":"iPhone","device":"iphone"},
           {"test-tag":"device_info","exclude-tags":"iphone","device-model":"iPad-10th-generation","device":"ipad"},
           {"test-tag":"duckplayer_classic","exclude-tags":"iphone","device-model":"iPad-10th-generation","device":"ipad"},
           {"test-tag":"duckai_chrome_shortcut","exclude-tags":"iphone","device-model":"iPad-10th-generation","device":"ipad"},

--- a/.github/workflows/ios_end_to_end.yml
+++ b/.github/workflows/ios_end_to_end.yml
@@ -190,7 +190,6 @@ jobs:
           {"test-tag":"adClick","exclude-tags":"ipad","device-model":"iPhone-16","device-name":"iPhone","device":"iphone"},
           {"test-tag":"duckplayer_native","exclude-tags":"ipad","device-model":"iPhone-16","device":"iphone"},
           {"test-tag":"device_info","exclude-tags":"ipad","device-model":"iPhone-16","device":"iphone"},
-          {"test-tag":"pir","exclude-tags":"ipad","device-model":"iPhone-16","device-name":"iPhone","device":"iphone"},
           {"test-tag":"device_info","exclude-tags":"iphone","device-model":"iPad-10th-generation","device":"ipad"},
           {"test-tag":"duckplayer_classic","exclude-tags":"iphone","device-model":"iPad-10th-generation","device":"ipad"},
           {"test-tag":"duckai_chrome_shortcut","exclude-tags":"iphone","device-model":"iPad-10th-generation","device":"ipad"},

--- a/iOS/DuckDuckGo-iOS.xcodeproj/xcshareddata/xcschemes/iOS Browser.xcscheme
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/xcshareddata/xcschemes/iOS Browser.xcscheme
@@ -282,6 +282,16 @@
                ReferencedContainer = "container:LocalPackages/FeatureFlags-iOS">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DataBrokerProtection-iOSTests"
+               BuildableName = "DataBrokerProtection-iOSTests"
+               BlueprintName = "DataBrokerProtection-iOSTests"
+               ReferencedContainer = "container:LocalPackages/DataBrokerProtection-iOS">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <EnvironmentVariables>
          <EnvironmentVariable

--- a/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/Utils.swift
+++ b/iOS/LocalPackages/DataBrokerProtection-iOS/Tests/DataBrokerProtection-iOSTests/Utils.swift
@@ -88,7 +88,10 @@ enum DBPIOSManagerTestUtils {
         optOutJobData: [OptOutJobData] = []
     ) -> BrokerProfileQueryData {
         BrokerProfileQueryData(
-            dataBroker: .mock(withId: brokerId),
+            dataBroker: .mockWithDefaults(
+                id: brokerId,
+                steps: DataBroker.mock.steps
+            ),
             profileQuery: ProfileQuery(id: profileQueryId, firstName: "A", lastName: "B", city: "C", state: "D", birthYear: 1980),
             scanJobData: .init(brokerId: brokerId, profileQueryId: profileQueryId, preferredRunDate: scanPreferredRunDate, historyEvents: []),
             optOutJobData: optOutJobData


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1215419848050295/task/1217699860654503?focus=true
Tech Design URL:
CC:

### Description
Runs the DataBrokerProtection-iOSTests target in the default pull-request suite. Updates shared test data so continued processing receives a broker with valid scan steps.

### Testing Steps
1. Run the DataBrokerProtection-iOSTests target with the iOS Browser scheme on iPhone 17 Pro → 96 tests pass with no skips or failures.

### Impact
None: CI and test-only changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI scheme and test-fixture-only changes; no production or security-sensitive code is modified.
> 
> **Overview**
> Adds `DataBrokerProtection-iOSTests` to the `iOS Browser` scheme so PIR unit tests run with the default PR test suite.
> 
> Also updates `makeBrokerProfileQueryData` to build brokers via `mockWithDefaults` using `DataBroker.mock.steps`, so continued-processing tests get a broker with valid scan steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25f5be7050a89a1adc973ff6841db2e60dee36be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->