### PR TITLE
fix(dbp): send the profile with a captcha solve

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Model/CCFRequestParameters.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Model/CCFRequestParameters.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 public enum CCFRequestData: Encodable {
-    case solveCaptcha(CaptchaToken)
+    case solveCaptcha(CaptchaToken, ProfileQuery, ExtractedProfile?)
     case userData(ProfileQuery, ExtractedProfile?, FetchedEmail?, ExtractedEmailData)
 }
 
@@ -50,6 +50,7 @@ private enum UserDataCodingKeys: String, CodingKey {
     case extractedProfile
     case fetchedEmail
     case emailData
+    case token
 }
 
 struct ActionRequest: Encodable {
@@ -65,8 +66,13 @@ struct ActionRequest: Encodable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         switch data {
-        case .solveCaptcha(let captchaToken):
-            try container.encode(captchaToken, forKey: .data)
+        case .solveCaptcha(let captchaToken, let profileQuery, let extractedProfile):
+            var captchaContainer = container.nestedContainer(keyedBy: UserDataCodingKeys.self, forKey: .data)
+            try captchaContainer.encode(captchaToken.token, forKey: .token)
+            try captchaContainer.encode(profileQuery, forKey: .userProfile)
+            if let extractedProfile = extractedProfile {
+                try captchaContainer.encode(extractedProfile, forKey: .extractedProfile)
+            }
         case .userData(let profileQuery, let extractedProfile, let fetchedEmail, let emailData):
             var userDataContainer = container.nestedContainer(keyedBy: UserDataCodingKeys.self, forKey: .data)
             try userDataContainer.encode(profileQuery, forKey: .userProfile)

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/SubJobWebRunner/SubJobWebRunner.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/SubJobWebRunner/SubJobWebRunner.swift
@@ -218,7 +218,7 @@ public extension SubJobWebRunning {
                                  actionType: action.actionType,
                                  details: "Captcha resolution received")
                 stageCalculator.fireOptOutCaptchaSolve()
-                let request: CCFRequestData = .solveCaptcha(CaptchaToken(token: captchaData))
+                let request: CCFRequestData = .solveCaptcha(CaptchaToken(token: captchaData), context.profileQuery, extractedProfile)
                 recordDebugEvent(kind: .actionPayload,
                                  actionType: action.actionType,
                                  details: DebugHelper.prettyPrintedActionPayload(action: action, data: request))

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/ActionRequestEncodingTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/ActionRequestEncodingTests.swift
@@ -22,6 +22,38 @@ import DataBrokerProtectionCoreTestsUtils
 
 final class ActionRequestEncodingTests: XCTestCase {
 
+    private let captchaActionID = "solve-captcha-1"
+    private let captchaToken = "captcha-token"
+
+    func testWhenCaptchaIsSolvedWithAMatchedProfile_thenPayloadCarriesTokenAndBothProfiles() throws {
+        let action = SolveCaptchaAction(id: captchaActionID, actionType: .solveCaptcha)
+        let extractedProfile = ExtractedProfile(id: 42, name: "John Doe")
+
+        let payload: EncodedCaptchaRequest = try encodePayload(action: action,
+                                                               data: .solveCaptcha(CaptchaToken(token: captchaToken),
+                                                                                   makeProfileQuery(),
+                                                                                   extractedProfile))
+
+        XCTAssertEqual(payload.state.data.token, captchaToken)
+        XCTAssertEqual(payload.state.data.userProfile?.firstName, "John")
+        XCTAssertEqual(payload.state.data.userProfile?.lastName, "Doe")
+        XCTAssertEqual(payload.state.data.extractedProfile?.name, "John Doe")
+    }
+
+    func testWhenCaptchaIsSolvedOnAScanStep_thenPayloadCarriesTheUserProfileAndNoExtractedProfile() throws {
+        let action = SolveCaptchaAction(id: captchaActionID, actionType: .solveCaptcha)
+
+        let payload: EncodedCaptchaRequest = try encodePayload(action: action,
+                                                               data: .solveCaptcha(CaptchaToken(token: captchaToken),
+                                                                                   makeProfileQuery(),
+                                                                                   nil))
+
+        XCTAssertEqual(payload.state.data.token, captchaToken)
+        XCTAssertEqual(payload.state.data.userProfile?.firstName, "John")
+        XCTAssertEqual(payload.state.data.userProfile?.lastName, "Doe")
+        XCTAssertNil(payload.state.data.extractedProfile)
+    }
+
     func testWhenActionContainsRawJSON_thenEncodingUsesRawActionPayload() throws {
         let stepJSON = """
             {
@@ -328,4 +360,32 @@ final class ActionRequestEncodingTests: XCTestCase {
     private func makeProfileQuery() -> ProfileQuery {
         ProfileQuery(firstName: "John", lastName: "Doe", city: "Miami", state: "FL", birthYear: 1985)
     }
+
+    private func encodePayload<Payload: Decodable>(action: Action, data: CCFRequestData) throws -> Payload {
+        let encoded = try JSONEncoder().encode(Params(state: ActionRequest(action: action, data: data)))
+        return try JSONDecoder().decode(Payload.self, from: encoded)
+    }
+}
+
+private struct EncodedCaptchaRequest: Decodable {
+    struct State: Decodable {
+        let data: CaptchaData
+    }
+
+    struct CaptchaData: Decodable {
+        let token: String
+        let userProfile: UserProfile?
+        let extractedProfile: MatchedProfile?
+    }
+
+    struct UserProfile: Decodable {
+        let firstName: String
+        let lastName: String
+    }
+
+    struct MatchedProfile: Decodable {
+        let name: String?
+    }
+
+    let state: State
 }


### PR DESCRIPTION
### Summary

Asana: https://app.asana.com/1/137249556945/task/1217611870578214

This PR:

* sends the user profile and the extracted profile with the captcha token, because a broker showing one captcha per record needs the profile to pick the right one, and Apple sent the token alone.
* matches what Windows already sends.
