### PR TITLE
iOS: Persist Duck.ai entry source per tab for prompt origin

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
@@ -50,7 +50,7 @@ enum AIChatEntryPointPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
     }
 }
 
-enum AIChatEntryPointSource: String {
+public enum AIChatEntryPointSource: String {
     case addressBarPrompt = "address_bar_prompt"
     case addressBarIcon = "address_bar_icon"
     case addressBarShortcutChip = "address_bar_shortcut_chip"

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6610,9 +6610,7 @@ extension MainViewController: TabDelegate {
     func tabDidRequestNewAIChatTab(tab: TabViewController) {
         let source: AIChatEntryPointSource = tab.link == nil ? .browsingMenuNTP : .browsingMenuWebpage
         fireAIChatEntryPointPixel(source: source, opensNewTab: true, hasPrompt: false)
-        tab.openNewChatInNewTab()
-        // `openNewChatInNewTab` selects the new chat tab synchronously via `loadUrlInNewTab`.
-        stampDuckAIEntrySourceOnCurrentTab(source)
+        tab.openNewChatInNewTab(source: source)
     }
 
     func tab(_ tab: TabViewController, didRequestAIChatForSelectedText text: String) {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2465,21 +2465,26 @@ class MainViewController: UIViewController {
     ///     Timing relative to UI refresh differs by exit path: the URL-reuse branch fires this before
     ///     `refreshOmniBar`/tab-bar refresh; all other branches fire it after. Callers should not rely
     ///     on chrome state being settled inside the closure.
-    func loadUrlInNewTab(_ url: URL, reuseExisting: ExistingTabReusePolicy? = .none, inheritedAttribution: AdClickAttributionLogic.State?, fromExternalLink: Bool = false, voiceMode: Bool = false, completion: (() -> Void)? = nil) {
+    /// `completion` receives the tab hosting the load, so per-tab state is stamped on the right tab
+    /// even when a clear defers the whole load and "current" still points at the outgoing tab.
+    func loadUrlInNewTab(_ url: URL, reuseExisting: ExistingTabReusePolicy? = .none, inheritedAttribution: AdClickAttributionLogic.State?, fromExternalLink: Bool = false, voiceMode: Bool = false, completion: ((Tab) -> Void)? = nil) {
 
         func worker() {
             allowContentUnderflow = false
             viewCoordinator.navigationBarContainer.alpha = 1
             loadViewIfNeeded()
 
+            let hostingTab: Tab
+
             // Check if a specific tab ID should be reused.
             if case .tabWithId(let id) = reuseExisting, let existing = tabManager.first(withId: id) {
                 selectTab(existing)
+                hostingTab = existing
             }
             // Check if an existing tab with the same URL should be reused.
             else if reuseExisting != .none, let existing = tabManager.first(withUrl: url) {
                 selectTab(existing)
-                completion?()
+                completion?(existing)
                 return
             }
             // Check if a tab presenting a New Tab page should be reused.
@@ -2489,10 +2494,11 @@ class MainViewController: UIViewController {
                 }
                 tabManager.select(existing, dismissCurrent: false)
                 loadUrl(url, fromExternalLink: fromExternalLink)
+                hostingTab = existing
             }
             // Add a new tab if no existing tab is reused.
             else {
-                addTab(url: url, inheritedAttribution: inheritedAttribution, fromExternalLink: fromExternalLink, voiceMode: voiceMode)
+                hostingTab = addTab(url: url, inheritedAttribution: inheritedAttribution, fromExternalLink: fromExternalLink, voiceMode: voiceMode)
             }
 
             refreshOmniBar()
@@ -2500,7 +2506,7 @@ class MainViewController: UIViewController {
             refreshControls()
             tabsBarController?.refresh(tabsModel: tabManager.currentTabsModel, scrollToSelected: true)
             swipeTabsCoordinator?.refresh(tabsModel: tabManager.currentTabsModel, scrollToSelected: true)
-            completion?()
+            completion?(hostingTab)
         }
 
         if clearInProgress {
@@ -2522,7 +2528,7 @@ class MainViewController: UIViewController {
         }
     }
 
-    func loadQuery(_ query: String, completion: (() -> Void)? = nil) {
+    func loadQuery(_ query: String, completion: ((Tab) -> Void)? = nil) {
         guard let url = URL.makeSearchURL(query: query, useUnifiedLogic: isUnifiedURLPredictionEnabled, queryContext: currentTab?.url) else {
             Logger.general.error("Couldn't form URL for query \"\(query, privacy: .public)\" with context \"\(self.currentTab?.url?.shortDescription ?? "<nil>", privacy: .public)\"")
             return
@@ -2621,7 +2627,8 @@ class MainViewController: UIViewController {
         transitionTo(tab: tab, from: nil)
     }
 
-    private func addTab(url: URL?, inheritedAttribution: AdClickAttributionLogic.State?, fromExternalLink: Bool = false, voiceMode: Bool = false) {
+    @discardableResult
+    private func addTab(url: URL?, inheritedAttribution: AdClickAttributionLogic.State?, fromExternalLink: Bool = false, voiceMode: Bool = false) -> Tab {
         let tab = tabManager.add(url: url, inheritedAttribution: inheritedAttribution)
         tab.inferredOpenerContext = .external
         tab.isVoiceModeRequested = voiceMode
@@ -2638,6 +2645,7 @@ class MainViewController: UIViewController {
         dismissOmniBar()
         resetUnifiedToggleInputForTabTransition(to: tab)
         attachTab(tab: tab)
+        return tab.tabModel
     }
 
     private func resetUnifiedToggleInputForTabTransition(to tab: TabViewController) {
@@ -4186,6 +4194,7 @@ class MainViewController: UIViewController {
 
     /// Stamps the entry on the tab hosting the chat, where it persists as the `origin` of
     /// follow-up prompts — surviving restarts and Duck.ai entries made from other tabs.
+    /// New-tab paths stamp the tab handed to their load completion instead.
     func stampDuckAIEntrySourceOnCurrentTab(_ source: AIChatEntryPointSource) {
         tabManager.currentTabsModel.currentTab?.duckAIEntrySource = source
     }
@@ -4236,9 +4245,7 @@ class MainViewController: UIViewController {
 
         if openInNewTab {
             let voiceURL = currentTab.aiChatContentHandler.buildVoiceModeURL()
-            loadUrlInNewTab(voiceURL, inheritedAttribution: nil, voiceMode: true) { [weak self] in
-                self?.stampDuckAIEntrySourceOnCurrentTab(source)
-            }
+            loadUrlInNewTab(voiceURL, inheritedAttribution: nil, voiceMode: true) { $0.duckAIEntrySource = source }
             if fromDeepLink {
                 // Collapse the input that was auto-expanded for the restored tab.
                 // This cancels any pending async activateInput because showCollapsed
@@ -4321,8 +4328,8 @@ class MainViewController: UIViewController {
                 )
                 AIChatPromptHandler.shared.setData(prompt)
             }
-            loadUrlInNewTab(chatURL, inheritedAttribution: nil) { [weak self] in
-                self?.stampDuckAIEntrySourceOnCurrentTab(source)
+            loadUrlInNewTab(chatURL, inheritedAttribution: nil) { [weak self] tab in
+                tab.duckAIEntrySource = source
                 if let modelId {
                     self?.unifiedToggleInputCoordinator?.updateSelectedModel(modelId)
                 }
@@ -4772,9 +4779,9 @@ extension MainViewController: BrowserChromeDelegate {
         showHomeRowReminder()
     }
 
-    /// `completion` runs once the tab hosting the load is current, so callers can stamp per-tab
-    /// state that the new-tab branch could not set up front (the tab does not exist yet).
-    func loadUrlRespectingAIBoundary(_ url: URL, fromExternalLink: Bool = false, completion: (() -> Void)? = nil) {
+    /// `completion` receives the tab hosting the load, so callers can stamp per-tab state that the
+    /// new-tab branch could not set up front (the tab does not exist yet).
+    func loadUrlRespectingAIBoundary(_ url: URL, fromExternalLink: Bool = false, completion: ((Tab) -> Void)? = nil) {
         let decision = AIBoundaryNavigationDecision.forProgrammaticNavigation(
             currentIsAI: currentTab?.isAITab == true,
             currentHasContent: currentTab?.tabModel.link != nil,
@@ -4791,7 +4798,9 @@ extension MainViewController: BrowserChromeDelegate {
         case .loadInPlace:
             currentTab?.isDuckAIDeepLinkSurfaceRequested = url.isDuckAIChatProtectionOpen
             loadUrl(url, fromExternalLink: fromExternalLink)
-            completion?()
+            if let currentTab = tabManager.currentTabsModel.currentTab {
+                completion?(currentTab)
+            }
         }
     }
 
@@ -4898,9 +4907,7 @@ extension MainViewController: OmniBarDelegate {
         ) == .openInNewTab
         fireAIChatEntryPointPixel(source: .chatHistoryOpenChat, opensNewTab: opensNewTab, hasPrompt: false)
         // Route through boundary helper so NTP transforms in-place; web→chat spawns a new tab; chat→chat stays. Matches `onPromptSubmitted`.
-        loadUrlRespectingAIBoundary(url) { [weak self] in
-            self?.stampDuckAIEntrySourceOnCurrentTab(.chatHistoryOpenChat)
-        }
+        loadUrlRespectingAIBoundary(url) { $0.duckAIEntrySource = .chatHistoryOpenChat }
     }
 
     func onViewAllChatsSelected() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6506,6 +6506,22 @@ extension MainViewController: TabDelegate {
              didRequestNewTabForUrl url: URL,
              openedByPage: Bool,
              inheritingAttribution attribution: AdClickAttributionLogic.State?) {
+        openNewTab(from: tab, url: url, openedByPage: openedByPage, inheritedAttribution: attribution)
+    }
+
+    func tab(_ tab: TabViewController,
+             didRequestNewDuckAITabForUrl url: URL,
+             entrySource: AIChatEntryPointSource) {
+        openNewTab(from: tab, url: url, openedByPage: false, inheritedAttribution: nil) {
+            $0.duckAIEntrySource = entrySource
+        }
+    }
+
+    private func openNewTab(from tab: TabViewController,
+                            url: URL,
+                            openedByPage: Bool,
+                            inheritedAttribution attribution: AdClickAttributionLogic.State?,
+                            completion: ((Tab) -> Void)? = nil) {
         _ = findInPageView?.resignFirstResponder()
         hideNotificationBarIfBrokenSitePromptShown()
         tab.aiChatContextualSheetCoordinator.dismissSheet()
@@ -6521,7 +6537,7 @@ extension MainViewController: TabDelegate {
             capturePreviewForTab(tab)
             showBars()
             newTabAnimation {
-                self.loadUrlInNewTab(url, inheritedAttribution: attribution)
+                self.loadUrlInNewTab(url, inheritedAttribution: attribution, completion: completion)
                 self.currentTab?.openedByPage = true
                 self.currentTab?.openingTab = tab
             }
@@ -6532,7 +6548,7 @@ extension MainViewController: TabDelegate {
                 self.omniBarTabSwitcherButton?.tabCount += 1
             }
         } else {
-            loadUrlInNewTab(url, inheritedAttribution: attribution)
+            loadUrlInNewTab(url, inheritedAttribution: attribution, completion: completion)
             self.currentTab?.adClickExternalOpenDetector.invalidateForUserInitiated()
             self.currentTab?.openingTab = tab
         }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2522,7 +2522,7 @@ class MainViewController: UIViewController {
         }
     }
 
-    func loadQuery(_ query: String) {
+    func loadQuery(_ query: String, completion: (() -> Void)? = nil) {
         guard let url = URL.makeSearchURL(query: query, useUnifiedLogic: isUnifiedURLPredictionEnabled, queryContext: currentTab?.url) else {
             Logger.general.error("Couldn't form URL for query \"\(query, privacy: .public)\" with context \"\(self.currentTab?.url?.shortDescription ?? "<nil>", privacy: .public)\"")
             return
@@ -2530,7 +2530,7 @@ class MainViewController: UIViewController {
         // Make sure that once query is submitted, we don't trigger the non-SERP flow
         skipSERPFlow = false
         endNewTabPageSessionWithLoad(of: url)
-        loadUrlRespectingAIBoundary(url)
+        loadUrlRespectingAIBoundary(url, completion: completion)
     }
 
     func postIdleSubmissionReason(for query: String) -> ReturnSessionWideEventData.StatusReason {
@@ -4772,7 +4772,9 @@ extension MainViewController: BrowserChromeDelegate {
         showHomeRowReminder()
     }
 
-    func loadUrlRespectingAIBoundary(_ url: URL, fromExternalLink: Bool = false) {
+    /// `completion` runs once the tab hosting the load is current, so callers can stamp per-tab
+    /// state that the new-tab branch could not set up front (the tab does not exist yet).
+    func loadUrlRespectingAIBoundary(_ url: URL, fromExternalLink: Bool = false, completion: (() -> Void)? = nil) {
         let decision = AIBoundaryNavigationDecision.forProgrammaticNavigation(
             currentIsAI: currentTab?.isAITab == true,
             currentHasContent: currentTab?.tabModel.link != nil,
@@ -4785,10 +4787,11 @@ extension MainViewController: BrowserChromeDelegate {
             if let tab = currentTab {
                 tab.contextualOnboardingPresenter.dismissContextualOnboardingIfNeeded(from: tab)
             }
-            loadUrlInNewTab(url, inheritedAttribution: nil, fromExternalLink: fromExternalLink)
+            loadUrlInNewTab(url, inheritedAttribution: nil, fromExternalLink: fromExternalLink, completion: completion)
         case .loadInPlace:
             currentTab?.isDuckAIDeepLinkSurfaceRequested = url.isDuckAIChatProtectionOpen
             loadUrl(url, fromExternalLink: fromExternalLink)
+            completion?()
         }
     }
 
@@ -4895,7 +4898,9 @@ extension MainViewController: OmniBarDelegate {
         ) == .openInNewTab
         fireAIChatEntryPointPixel(source: .chatHistoryOpenChat, opensNewTab: opensNewTab, hasPrompt: false)
         // Route through boundary helper so NTP transforms in-place; web→chat spawns a new tab; chat→chat stays. Matches `onPromptSubmitted`.
-        loadUrlRespectingAIBoundary(url)
+        loadUrlRespectingAIBoundary(url) { [weak self] in
+            self?.stampDuckAIEntrySourceOnCurrentTab(.chatHistoryOpenChat)
+        }
     }
 
     func onViewAllChatsSelected() {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -209,8 +209,6 @@ class MainViewController: UIViewController {
     /// VPN connection state as the user left the New Tab Page for the VPN screen, so a toggle made
     /// there can be told apart from a reconnect that happened on its own.
     var vpnConnectedWhenLeavingNewTabPage: Bool?
-    /// The most recent Duck.ai entry, consumed as the `origin` of prompts sent on the opened surface.
-    private(set) var lastDuckAIEntrySource: AIChatEntryPointSource?
     let duckAIWideEventInstrumentation: DuckAIWideEventInstrumentation
     let syncAutoRestoreHandler: SyncAutoRestoreHandling
     private let lastActiveTabStore: LastActiveTabStoring
@@ -4179,12 +4177,17 @@ class MainViewController: UIViewController {
     }
 
     func fireAIChatEntryPointPixel(source: AIChatEntryPointSource, opensNewTab: Bool, hasPrompt: Bool) {
-        lastDuckAIEntrySource = source
         AIChatEntryPointPixel.fire(source: source,
                                    duckAIEnabled: aiChatSettings.isAIChatEnabled,
                                    toggleEnabled: aiChatSettings.isAIChatSearchInputUserSettingsEnabled,
                                    opensNewTab: opensNewTab,
                                    hasPrompt: hasPrompt)
+    }
+
+    /// Stamps the entry on the tab hosting the chat, where it persists as the `origin` of
+    /// follow-up prompts — surviving restarts and Duck.ai entries made from other tabs.
+    func stampDuckAIEntrySourceOnCurrentTab(_ source: AIChatEntryPointSource) {
+        tabManager.currentTabsModel.currentTab?.duckAIEntrySource = source
     }
 
     /// Reads the tab model, not `currentTab`: home tabs have no `TabViewController`, so
@@ -4233,7 +4236,9 @@ class MainViewController: UIViewController {
 
         if openInNewTab {
             let voiceURL = currentTab.aiChatContentHandler.buildVoiceModeURL()
-            loadUrlInNewTab(voiceURL, inheritedAttribution: nil, voiceMode: true)
+            loadUrlInNewTab(voiceURL, inheritedAttribution: nil, voiceMode: true) { [weak self] in
+                self?.stampDuckAIEntrySourceOnCurrentTab(source)
+            }
             if fromDeepLink {
                 // Collapse the input that was auto-expanded for the restored tab.
                 // This cancels any pending async activateInput because showCollapsed
@@ -4244,6 +4249,7 @@ class MainViewController: UIViewController {
             return
         }
 
+        stampDuckAIEntrySourceOnCurrentTab(source)
         prepareTabForRequest {
             currentTab.loadVoiceMode()
         }
@@ -4316,6 +4322,7 @@ class MainViewController: UIViewController {
                 AIChatPromptHandler.shared.setData(prompt)
             }
             loadUrlInNewTab(chatURL, inheritedAttribution: nil) { [weak self] in
+                self?.stampDuckAIEntrySourceOnCurrentTab(source)
                 if let modelId {
                     self?.unifiedToggleInputCoordinator?.updateSelectedModel(modelId)
                 }
@@ -4326,6 +4333,7 @@ class MainViewController: UIViewController {
             return
         }
 
+        stampDuckAIEntrySourceOnCurrentTab(source)
         load(query, autoSend: autoSend, payload: payload, flowType: flowType, tools: tools, modelId: modelId, reasoningEffort: reasoningEffort, images: images, files: files)
         if let modelId {
             unifiedToggleInputCoordinator?.updateSelectedModel(modelId)
@@ -6572,10 +6580,11 @@ extension MainViewController: TabDelegate {
     }
 
     func tabDidRequestNewAIChatTab(tab: TabViewController) {
-        fireAIChatEntryPointPixel(source: tab.link == nil ? .browsingMenuNTP : .browsingMenuWebpage,
-                                  opensNewTab: true,
-                                  hasPrompt: false)
+        let source: AIChatEntryPointSource = tab.link == nil ? .browsingMenuNTP : .browsingMenuWebpage
+        fireAIChatEntryPointPixel(source: source, opensNewTab: true, hasPrompt: false)
         tab.openNewChatInNewTab()
+        // `openNewChatInNewTab` selects the new chat tab synchronously via `loadUrlInNewTab`.
+        stampDuckAIEntrySourceOnCurrentTab(source)
     }
 
     func tab(_ tab: TabViewController, didRequestAIChatForSelectedText text: String) {

--- a/iOS/DuckDuckGo/Tab.swift
+++ b/iOS/DuckDuckGo/Tab.swift
@@ -54,6 +54,7 @@ public class Tab: NSObject, NSCoding {
         static let selectedModelID = "selectedModelID"
         static let selectedReasoningMode = "selectedReasoningMode"
         static let selectedTool = "selectedTool"
+        static let duckAIEntrySource = "duckAIEntrySource"
     }
 
     private var observersHolder = [WeaklyHeldTabObserver]()
@@ -140,6 +141,10 @@ public class Tab: NSObject, NSCoding {
     /// NSCoding so reopening the app restores the tab's selected AI settings.
     var unifiedInputState: UnifiedInputTabState
 
+    /// How the user entered Duck.ai in this tab; reported as the `origin` of prompts
+    /// submitted here. Persisted so follow-ups keep their attribution across restarts.
+    var duckAIEntrySource: AIChatEntryPointSource?
+
     /// Type of tab: web or AI Chat, derived from the current URL
     private var type: TabType {
         if let link, link.url.isDuckAIURL(debugSettings: aichatDebugSettings) {
@@ -206,6 +211,9 @@ public class Tab: NSObject, NSCoding {
         Logger.daxEasterEgg.debug("Tab decode - Restoring logo URL: \(daxEasterEggLogoURL ?? "nil") for tab [\(uid ?? "no-uid")]")
 
         self.init(uid: uid, link: link, viewed: viewed, desktop: desktop, lastViewedDate: lastViewedDate, daxEasterEggLogoURL: daxEasterEggLogoURL, contextualChatURL: contextualChatURL, supportsTabHistory: supportsTabHistory, fireTab: fireTab, isExternalLaunch: isExternalLaunch, shouldSuppressTrackerAnimationOnFirstLoad: shouldSuppressTrackerAnimationOnFirstLoad, unifiedInputState: unifiedInputState)
+
+        let duckAIEntrySourceRaw = decoder.decodeObject(forKey: NSCodingKeys.duckAIEntrySource) as? String
+        self.duckAIEntrySource = duckAIEntrySourceRaw.flatMap(AIChatEntryPointSource.init(rawValue:))
     }
 
     public func encode(with coder: NSCoder) {
@@ -223,22 +231,25 @@ public class Tab: NSObject, NSCoding {
         coder.encode(unifiedInputState.selectedModelID, forKey: NSCodingKeys.selectedModelID)
         coder.encode(unifiedInputState.selectedReasoningMode?.rawValue, forKey: NSCodingKeys.selectedReasoningMode)
         coder.encode(unifiedInputState.selectedTool?.rawValue, forKey: NSCodingKeys.selectedTool)
+        coder.encode(duckAIEntrySource?.rawValue, forKey: NSCodingKeys.duckAIEntrySource)
         // Note: isExternalLaunch and shouldSuppressTrackerAnimationOnFirstLoad are not encoded as they are transient flags
         // Note: type is not encoded as it's now a computed property based on the link URL
     }
 
     /// Returns a frozen deep copy containing only the fields that are persisted via NSCoding.
     func archivalSnapshot() -> Tab {
-        Tab(uid: uid,
-            link: link?.copy() as? Link,
-            viewed: viewed,
-            desktop: isDesktop,
-            lastViewedDate: lastViewedDate,
-            daxEasterEggLogoURL: daxEasterEggLogoURL,
-            contextualChatURL: contextualChatURL,
-            supportsTabHistory: supportsTabHistory,
-            fireTab: fireTab,
-            unifiedInputState: unifiedInputState)
+        let snapshot = Tab(uid: uid,
+                           link: link?.copy() as? Link,
+                           viewed: viewed,
+                           desktop: isDesktop,
+                           lastViewedDate: lastViewedDate,
+                           daxEasterEggLogoURL: daxEasterEggLogoURL,
+                           contextualChatURL: contextualChatURL,
+                           supportsTabHistory: supportsTabHistory,
+                           fireTab: fireTab,
+                           unifiedInputState: unifiedInputState)
+        snapshot.duckAIEntrySource = duckAIEntrySource
+        return snapshot
     }
 
     public override func isEqual(_ other: Any?) -> Bool {

--- a/iOS/DuckDuckGo/Tab.swift
+++ b/iOS/DuckDuckGo/Tab.swift
@@ -167,6 +167,7 @@ public class Tab: NSObject, NSCoding {
                 isExternalLaunch: Bool = false,
                 shouldSuppressTrackerAnimationOnFirstLoad: Bool = false,
                 unifiedInputState: UnifiedInputTabState = UnifiedInputTabState(),
+                duckAIEntrySource: AIChatEntryPointSource? = nil,
                 aichatDebugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings()) {
         self.uid = uid ?? UUID().uuidString
         self.link = link
@@ -180,6 +181,7 @@ public class Tab: NSObject, NSCoding {
         self.isExternalLaunch = isExternalLaunch
         self.shouldSuppressTrackerAnimationOnFirstLoad = shouldSuppressTrackerAnimationOnFirstLoad
         self.unifiedInputState = unifiedInputState
+        self.duckAIEntrySource = duckAIEntrySource
         self.aichatDebugSettings = aichatDebugSettings
     }
 
@@ -207,13 +209,12 @@ public class Tab: NSObject, NSCoding {
             selectedReasoningMode: selectedReasoningMode,
             selectedTool: selectedTool
         )
+        let duckAIEntrySourceRaw = decoder.decodeObject(forKey: NSCodingKeys.duckAIEntrySource) as? String
+        let duckAIEntrySource = duckAIEntrySourceRaw.flatMap(AIChatEntryPointSource.init(rawValue:))
 
         Logger.daxEasterEgg.debug("Tab decode - Restoring logo URL: \(daxEasterEggLogoURL ?? "nil") for tab [\(uid ?? "no-uid")]")
 
-        self.init(uid: uid, link: link, viewed: viewed, desktop: desktop, lastViewedDate: lastViewedDate, daxEasterEggLogoURL: daxEasterEggLogoURL, contextualChatURL: contextualChatURL, supportsTabHistory: supportsTabHistory, fireTab: fireTab, isExternalLaunch: isExternalLaunch, shouldSuppressTrackerAnimationOnFirstLoad: shouldSuppressTrackerAnimationOnFirstLoad, unifiedInputState: unifiedInputState)
-
-        let duckAIEntrySourceRaw = decoder.decodeObject(forKey: NSCodingKeys.duckAIEntrySource) as? String
-        self.duckAIEntrySource = duckAIEntrySourceRaw.flatMap(AIChatEntryPointSource.init(rawValue:))
+        self.init(uid: uid, link: link, viewed: viewed, desktop: desktop, lastViewedDate: lastViewedDate, daxEasterEggLogoURL: daxEasterEggLogoURL, contextualChatURL: contextualChatURL, supportsTabHistory: supportsTabHistory, fireTab: fireTab, isExternalLaunch: isExternalLaunch, shouldSuppressTrackerAnimationOnFirstLoad: shouldSuppressTrackerAnimationOnFirstLoad, unifiedInputState: unifiedInputState, duckAIEntrySource: duckAIEntrySource)
     }
 
     public func encode(with coder: NSCoder) {
@@ -238,18 +239,17 @@ public class Tab: NSObject, NSCoding {
 
     /// Returns a frozen deep copy containing only the fields that are persisted via NSCoding.
     func archivalSnapshot() -> Tab {
-        let snapshot = Tab(uid: uid,
-                           link: link?.copy() as? Link,
-                           viewed: viewed,
-                           desktop: isDesktop,
-                           lastViewedDate: lastViewedDate,
-                           daxEasterEggLogoURL: daxEasterEggLogoURL,
-                           contextualChatURL: contextualChatURL,
-                           supportsTabHistory: supportsTabHistory,
-                           fireTab: fireTab,
-                           unifiedInputState: unifiedInputState)
-        snapshot.duckAIEntrySource = duckAIEntrySource
-        return snapshot
+        Tab(uid: uid,
+            link: link?.copy() as? Link,
+            viewed: viewed,
+            desktop: isDesktop,
+            lastViewedDate: lastViewedDate,
+            daxEasterEggLogoURL: daxEasterEggLogoURL,
+            contextualChatURL: contextualChatURL,
+            supportsTabHistory: supportsTabHistory,
+            fireTab: fireTab,
+            unifiedInputState: unifiedInputState,
+            duckAIEntrySource: duckAIEntrySource)
     }
 
     public override func isEqual(_ other: Any?) -> Bool {

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -59,6 +59,12 @@ protocol TabDelegate: AnyObject {
              openedByPage: Bool,
              inheritingAttribution: AdClickAttributionLogic.State?)
 
+    /// Same as `didRequestNewTabForUrl`, plus it stamps `entrySource` on the opened tab so prompts
+    /// submitted there report the Duck.ai entry that led to it.
+    func tab(_ tab: TabViewController,
+             didRequestNewDuckAITabForUrl url: URL,
+             entrySource: AIChatEntryPointSource)
+
     /// Called on navigate forward on a tab that had just closed a link-opened tab via back.
     /// Re-open that tab at `url` as a child of `tab` again.
     func tab(_ tab: TabViewController, didRequestReopenClosedTabAt url: URL)

--- a/iOS/DuckDuckGo/TabViewControllerAIChatExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerAIChatExtension.swift
@@ -39,8 +39,8 @@ protocol AITabController {
     /// Submits a toggle sidebar action to open/close the sidebar.
     func submitToggleSidebarAction()
 
-    /// Opens a new AI chat in a new tab.
-    func openNewChatInNewTab()
+    /// Opens a new AI chat in a new tab, stamping `source` as its Duck.ai entry.
+    func openNewChatInNewTab(source: AIChatEntryPointSource)
 }
 
 // MARK: - AITabController
@@ -108,14 +108,14 @@ extension TabViewController: AITabController {
     }
     
     /// Opens a new AI chat in a new tab.
-    func openNewChatInNewTab() {
+    func openNewChatInNewTab(source: AIChatEntryPointSource) {
         let newChatURL = aiChatContentHandler.buildQueryURL(
             query: nil,
             autoSend: false,
             flowType: .default,
             tools: nil
         )
-        delegate?.tab(self, didRequestNewTabForUrl: newChatURL, openedByPage: false, inheritingAttribution: nil)
+        delegate?.tab(self, didRequestNewDuckAITabForUrl: newChatURL, entrySource: source)
     }
 
     /// Opens the Duck.ai chats sidebar in a new tab. Mirrors the contextual sheet's "View all chats"

--- a/iOS/DuckDuckGo/TabViewControllerContextualAIChatExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerContextualAIChatExtension.swift
@@ -108,7 +108,7 @@ extension TabViewController: AIChatContextualSheetCoordinatorDelegate {
     }
 
     func aiChatContextualSheetCoordinator(_ coordinator: AIChatContextualSheetCoordinator, didRequestExpandWithURL url: URL) {
-        delegate?.tab(self, didRequestNewTabForUrl: url, openedByPage: false, inheritingAttribution: nil)
+        delegate?.tab(self, didRequestNewDuckAITabForUrl: url, entrySource: .contextualChat)
     }
 
     func aiChatContextualSheetCoordinatorDidRequestViewAllChats(_ coordinator: AIChatContextualSheetCoordinator) {

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -1013,6 +1013,8 @@ extension MainViewController: TabsBarDelegate {
             // Bypasses `openAIChat`, so fire the entry pixel directly.
             fireAIChatEntryPointPixel(source: .tabsBarButton, opensNewTab: true, hasPrompt: false)
             currentTab.openNewChatInNewTab()
+            // `openNewChatInNewTab` selects the new chat tab synchronously via `loadUrlInNewTab`.
+            stampDuckAIEntrySourceOnCurrentTab(.tabsBarButton)
         } else {
             openAIChat(source: .tabsBarButton)
         }

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -1012,9 +1012,7 @@ extension MainViewController: TabsBarDelegate {
         if let currentTab, currentTab.tabModel.link != nil {
             // Bypasses `openAIChat`, so fire the entry pixel directly.
             fireAIChatEntryPointPixel(source: .tabsBarButton, opensNewTab: true, hasPrompt: false)
-            currentTab.openNewChatInNewTab()
-            // `openNewChatInNewTab` selects the new chat tab synchronously via `loadUrlInNewTab`.
-            stampDuckAIEntrySourceOnCurrentTab(.tabsBarButton)
+            currentTab.openNewChatInNewTab(source: .tabsBarButton)
         } else {
             openAIChat(source: .tabsBarButton)
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1198,22 +1198,28 @@ extension MainViewController {
     }
 
     func handleUnifiedToggleInputSearchSubmission(_ query: String) {
-        fireDirectDuckAINavigationPixelIfNeeded(for: query)
+        let duckAIEntrySource = fireDirectDuckAINavigationPixelIfNeeded(for: query)
         if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
             ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: tab.openedAfterIdle)
         }
         postIdleSessionInstrumentation.sessionEnded(reason: postIdleSubmissionReason(for: query))
         recordNewTabPageSessionAction { $0.hitSubmit() }
-        loadQuery(query)
+        // Stamped via the load completion: the new-tab case has no tab to stamp until `loadQuery` creates it.
+        loadQuery(query) { [weak self] in
+            if let duckAIEntrySource {
+                self?.stampDuckAIEntrySourceOnCurrentTab(duckAIEntrySource)
+            }
+        }
     }
 
     /// The only place a typed duck.ai address can be told apart from an in-page or deep link.
     /// Mirrors `loadQuery`'s URL resolution so detection matches what gets navigated.
-    private func fireDirectDuckAINavigationPixelIfNeeded(for query: String) {
+    /// Returns the entry source the caller must stamp on the tab hosting the load.
+    private func fireDirectDuckAINavigationPixelIfNeeded(for query: String) -> AIChatEntryPointSource? {
         guard let url = URL.makeSearchURL(query: query,
                                           useUnifiedLogic: isUnifiedURLPredictionEnabled,
                                           queryContext: currentTab?.url),
-              url.isDuckAIURL else { return }
+              url.isDuckAIURL else { return nil }
 
         DailyPixel.fireDailyAndCount(pixel: .aiChatDuckAIDirectNavigation, withAdditionalParameters: [
             "duckai_enabled": String(aiChatSettings.isAIChatEnabled),
@@ -1235,10 +1241,7 @@ extension MainViewController {
         fireAIChatEntryPointPixel(source: .directURL,
                                   opensNewTab: decision == .openInNewTab,
                                   hasPrompt: false)
-        // The new-tab case can't be stamped here: `loadQuery` creates that tab later.
-        if decision == .loadInPlace {
-            stampDuckAIEntrySourceOnCurrentTab(.directURL)
-        }
+        return .directURL
     }
 
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1205,9 +1205,9 @@ extension MainViewController {
         postIdleSessionInstrumentation.sessionEnded(reason: postIdleSubmissionReason(for: query))
         recordNewTabPageSessionAction { $0.hitSubmit() }
         // Stamped via the load completion: the new-tab case has no tab to stamp until `loadQuery` creates it.
-        loadQuery(query) { [weak self] in
+        loadQuery(query) { tab in
             if let duckAIEntrySource {
-                self?.stampDuckAIEntrySourceOnCurrentTab(duckAIEntrySource)
+                tab.duckAIEntrySource = duckAIEntrySource
             }
         }
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -91,7 +91,7 @@ extension MainViewController {
         )
         coordinator.delegate = self
         coordinator.pageTypeProvider = { [weak self] in self?.currentPromptPageType() }
-        coordinator.duckAIEntrySourceProvider = { [weak self] in self?.lastDuckAIEntrySource }
+        coordinator.duckAIEntrySourceProvider = { [weak self] in self?.tabManager.currentTabsModel.currentTab?.duckAIEntrySource }
         coordinator.updateVoiceSearchAvailability(voiceSearchHelper.isVoiceSearchEnabled)
         coordinator.updateAIVoiceChatAvailability(voiceShortcutFeature.isAvailable)
         coordinator.updateAIChatShortcutAvailability(aiChatAddressBarExperience.shouldShowDuckAIAddressBarButton)
@@ -1235,6 +1235,10 @@ extension MainViewController {
         fireAIChatEntryPointPixel(source: .directURL,
                                   opensNewTab: decision == .openInNewTab,
                                   hasPrompt: false)
+        // The new-tab case can't be stamped here: `loadQuery` creates that tab later.
+        if decision == .loadInPlace {
+            stampDuckAIEntrySourceOnCurrentTab(.directURL)
+        }
     }
 
 }

--- a/iOS/DuckDuckGoTests/TabTests.swift
+++ b/iOS/DuckDuckGoTests/TabTests.swift
@@ -504,6 +504,24 @@ class TabTests: XCTestCase {
         XCTAssertNil(tab?.unifiedInputState.selectedTool)
     }
 
+    func testWhenTabEncodedBeforeDuckAIEntrySourceAddedThenDecodesWithNil() {
+        let tab = Tab(coder: CoderStub(properties: ["link": link(), "viewed": false]))
+
+        XCTAssertNotNil(tab)
+        XCTAssertNil(tab?.duckAIEntrySource)
+    }
+
+    func testWhenTabHasInvalidDuckAIEntrySourceRawValueThenDecodesAsNil() {
+        let tab = Tab(coder: CoderStub(properties: [
+            "link": link(),
+            "viewed": false,
+            "duckAIEntrySource": "not-a-real-source"
+        ]))
+
+        XCTAssertNotNil(tab)
+        XCTAssertNil(tab?.duckAIEntrySource)
+    }
+
     // MARK: - promptPageType
 
     func testWhenTabHasNoLinkThenPromptPageTypeIsNTP() {

--- a/iOS/DuckDuckGoTests/TabsModelTests.swift
+++ b/iOS/DuckDuckGoTests/TabsModelTests.swift
@@ -370,6 +370,43 @@ class TabsModelTests: XCTestCase {
         XCTAssertNil(model.currentIndex)
     }
 
+    // MARK: - Duck.ai Entry Source
+
+    func testWhenTabWithDuckAIEntrySourceIsArchivedThenUnarchivedTabRestoresIt() throws {
+        let tab = Tab(link: exampleLink)
+        tab.duckAIEntrySource = .serp
+
+        let data = try NSKeyedArchiver.archivedData(withRootObject: tab, requiringSecureCoding: false)
+        let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+        unarchiver.requiresSecureCoding = false
+        let decoded = unarchiver.decodeObject(of: Tab.self, forKey: NSKeyedArchiveRootObjectKey)
+
+        XCTAssertEqual(decoded?.duckAIEntrySource, .serp)
+    }
+
+    func testWhenTabWithoutDuckAIEntrySourceIsArchivedThenUnarchivedTabHasNilSource() throws {
+        let tab = Tab(link: exampleLink)
+
+        let data = try NSKeyedArchiver.archivedData(withRootObject: tab, requiringSecureCoding: false)
+        let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+        unarchiver.requiresSecureCoding = false
+        let decoded = unarchiver.decodeObject(of: Tab.self, forKey: NSKeyedArchiveRootObjectKey)
+
+        XCTAssertNil(decoded?.duckAIEntrySource)
+    }
+
+    func testWhenFireTabWithDuckAIEntrySourceIsArchivedThenUnarchivedTabRestoresIt() throws {
+        let tab = Tab(link: exampleLink, fireTab: true)
+        tab.duckAIEntrySource = .addressBarPrompt
+
+        let data = try NSKeyedArchiver.archivedData(withRootObject: tab, requiringSecureCoding: false)
+        let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+        unarchiver.requiresSecureCoding = false
+        let decoded = unarchiver.decodeObject(of: Tab.self, forKey: NSKeyedArchiveRootObjectKey)
+
+        XCTAssertEqual(decoded?.duckAIEntrySource, .addressBarPrompt)
+    }
+
     // MARK: - NSCopying
 
     func testWhenTabSnapshotTakenThenAllPersistedFieldsArePreserved() {
@@ -388,6 +425,7 @@ class TabsModelTests: XCTestCase {
                       supportsTabHistory: true,
                       fireTab: false,
                       unifiedInputState: unifiedState)
+        tab.duckAIEntrySource = .widgetFavorite
 
         let snapshot = tab.archivalSnapshot()
 
@@ -405,6 +443,7 @@ class TabsModelTests: XCTestCase {
         XCTAssertEqual(snapshot.supportsTabHistory, true)
         XCTAssertEqual(snapshot.fireTab, false)
         XCTAssertEqual(snapshot.unifiedInputState, unifiedState)
+        XCTAssertEqual(snapshot.duckAIEntrySource, .widgetFavorite)
     }
 
     func testWhenModelSnapshotTakenThenMutatingSourceDoesNotAffectSnapshot() {

--- a/iOS/DuckDuckGoTests/TabsModelTests.swift
+++ b/iOS/DuckDuckGoTests/TabsModelTests.swift
@@ -424,8 +424,8 @@ class TabsModelTests: XCTestCase {
                       contextualChatURL: "https://chat.example.com",
                       supportsTabHistory: true,
                       fireTab: false,
-                      unifiedInputState: unifiedState)
-        tab.duckAIEntrySource = .widgetFavorite
+                      unifiedInputState: unifiedState,
+                      duckAIEntrySource: .widgetFavorite)
 
         let snapshot = tab.archivalSnapshot()
 

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
@@ -61,6 +61,8 @@ final class MockTabDelegate: TabDelegate {
 
     func tab(_ tab: DuckDuckGo.TabViewController, didRequestNewTabForUrl url: URL, openedByPage: Bool, inheritingAttribution: BrowserServicesKit.AdClickAttributionLogic.State?) {}
 
+    func tab(_ tab: DuckDuckGo.TabViewController, didRequestNewDuckAITabForUrl url: URL, entrySource: DuckDuckGo.AIChatEntryPointSource) {}
+
     func tab(_ tab: DuckDuckGo.TabViewController, didRequestReopenClosedTabAt url: URL) {}
 
     func tab(_ tab: DuckDuckGo.TabViewController, didRequestNewBackgroundTabForUrl url: URL, inheritingAttribution: BrowserServicesKit.AdClickAttributionLogic.State?) {}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217730434026136?focus=true
Tech Design URL:
CC:

### Description
Fix origin param when restarting the app

### Testing Steps
1. Open Duck.ai in a fire-mode tab, select duck.ai, submit a prompt, then relaunch the app.
2. Submit a follow-up prompt in the restored Duck.ai tab and verify `m_aichat_unified_input_prompt_submitted` carries `origin=address_bar_prompt` (pixel debug console) — before this change the param was absent.
3. With a web page loaded, type a duck.ai address in the address bar and submit so the chat opens in a new tab; submit a follow-up prompt there and verify the pixel carries `origin=direct_url`.

### Impact and Risks
Low — measurement-only change to how an existing pixel param is resolved; no pixel definitions or firing conditions changed.

#### What could go wrong?
A tab restored from before this change carries no stamp, so follow-up `origin` there stays absent until the next Duck.ai entry into that tab. No functional impact.

(An earlier revision of this section claimed a rapid-tab-switch race. That isn't reachable: completions run inside `loadUrlInNewTab`'s synchronous `worker()`, and completions now receive the hosting `Tab` rather than re-reading the current one.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Measurement-only: no navigation or pixel firing logic changes. A completion stamping the wrong tab after a rapid tab switch could misattribute `origin` with no user-facing impact.
> 
> **Overview**
> Fixes missing or wrong **`origin`** on **`m_aichat_unified_input_prompt_submitted`** by storing how the user opened Duck.ai on each **tab** instead of a single **`lastDuckAIEntrySource`** on **`MainViewController`**.
> 
> **`Tab`** now has a persisted **`duckAIEntrySource`** (NSCoding), so follow-up prompts after relaunch still report the original entry (e.g. **`address_bar_prompt`**, **`direct_url`**). Unified toggle input reads **`origin`** from **`tabManager.currentTabsModel.currentTab?.duckAIEntrySource`**.
> 
> New-tab flows stamp the hosting tab via updated completions: **`loadUrlInNewTab`**, **`loadQuery`**, and **`loadUrlRespectingAIBoundary`** pass **`((Tab) -> Void)?`** so attribution lands on the tab that actually loads chat—even when a data clear defers the load. **`stampDuckAIEntrySourceOnCurrentTab`** covers in-place opens. **`TabDelegate`** adds **`didRequestNewDuckAITabForUrl`** (with **`entrySource`**) for paths like browsing menu new chat, tabs bar, and contextual sheet expand; **`AIChatEntryPointSource`** is **`public`** for that API.
> 
> Entry pixels are unchanged; only where **`origin`** is resolved and which tab it is tied to.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1813d23ad64e2f3344f90cfd41009769cb20860f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



