### PR TITLE
Spec: server-rendered first paywall (flag wiring, no implementation)

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -652,6 +652,9 @@ public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {
     case subscriptionPromoForExistingUsers
     case monthlyFreeTrialExperiment2
     case onboardingSubscriptionUpsellExperiment
+
+    /// Gates the server-rendered first paywall. Wired only — nothing reads it yet.
+    case performanceOptimizedPaywalls
 }
 
 public enum DuckPlayerSubfeature: String, PrivacySubfeature {

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
@@ -377,6 +377,75 @@ final class SubscriptionURLTests: XCTestCase {
         XCTAssertEqual(components?.url, expectedURL)
     }
 
+    // MARK: - First paywall, performance-optimized (not implemented)
+
+    // The `performanceOptimizedPaywalls` flag is wired but unread. When it is on, the two first-paywall
+    // entry points this app opens itself have to be opened at a URL that names the page and states
+    // what the page would otherwise resolve after mount, instead of `/subscriptions` plus a
+    // `featurePage` item.
+    //
+    //     entry point                     URL
+    //     ---------------------------------------------------------------------------------
+    //     VPN      (no featurePage)       /subscriptions/new/mobile/vpn
+    //     Duck.ai  (featurePage=duckai)   /subscriptions/new/mobile/duckai
+    //
+    //     query item   values                when
+    //     ---------------------------------------------------------------------------------
+    //     trial        true | false          always, whichever it is
+    //     pir          false                 only when the offering excludes Personal Information
+    //                                        Removal; the page shows PIR unless told otherwise
+    //     origin       unchanged             carried as it is today
+    //
+    // So the full set is eight URLs, e.g.
+    //
+    //     https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false
+    //     https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true&pir=false
+    //
+    // `trial` is whether the offering includes a free trial; `pir` is whether it includes Personal
+    // Information Removal, which is sold in the USA storefront and not in the rest of the world. Both
+    // have to be settled before the URL is opened — that is the whole point, since the page ships
+    // both CTA labels and both feature lists and reveals one from the URL. Where they are read from,
+    // whether the store is allowed to be waited on, and what happens when it never answers are open
+    // questions, deliberately not answered here.
+    //
+    // What must not move: `pir`, `stripe` and `winback` featurePages, intercepted `/pro` links, and
+    // every desktop entry point stay on the URL they use today. The first two create or refresh a
+    // cart account on mount, which would make a load-time comparison measure the network.
+
+    /// Skipped until something produces the URLs above. Delete the `XCTSkipIf` to see it fail, then
+    /// replace the `XCTFail` with assertions against whatever ends up building them.
+    func testFirstPaywallURLsWhenPerformanceOptimizedPaywallsIsOn() throws {
+        try XCTSkipIf(true, "Pending: the server-rendered first paywall is not implemented")
+
+        let required = [
+            "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false",
+            "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=true",
+            "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false&pir=false",
+            "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=true&pir=false",
+            "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=false",
+            "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true",
+            "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=false&pir=false",
+            "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true&pir=false"
+        ]
+
+        XCTFail("Nothing produces the server-rendered first paywall URLs yet: \(required.joined(separator: ", "))")
+    }
+
+    /// Skipped until the state items are ignored when matching screens. `trial` and `pir` choose what
+    /// the page reveals, not which page it is, so every "am I on the purchase screen?" check — and
+    /// the offer-screen impression that the whole comparison is read from — has to see through them.
+    ///
+    /// This one is a real assertion already: delete the `XCTSkipIf` and it fails against today's
+    /// `forComparison()`.
+    func testForComparisonIgnoresFirstPaywallStateParameters() throws {
+        try XCTSkipIf(true, "Pending: forComparison() does not ignore trial and pir yet")
+
+        let page = URL(string: "https://duckduckgo.com/subscriptions/new/mobile/vpn")!
+        let pageWithState = URL(string: "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=true&pir=false")!
+
+        XCTAssertEqual(pageWithState.forComparison(), page.forComparison())
+    }
+
     func testPurchaseURLComponentsWithOnlyOrigin() throws {
         // Given
         let origin = "funnel_appsettings_ios"

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
@@ -379,41 +379,18 @@ final class SubscriptionURLTests: XCTestCase {
 
     // MARK: - First paywall, performance-optimized (not implemented)
 
-    // The `performanceOptimizedPaywalls` flag is wired but unread. When it is on, the two first-paywall
-    // entry points this app opens itself have to be opened at a URL that names the page and states
-    // what the page would otherwise resolve after mount, instead of `/subscriptions` plus a
-    // `featurePage` item.
+    // With `performanceOptimizedPaywalls` on, the two entry points this app opens itself become:
     //
-    //     entry point                     URL
-    //     ---------------------------------------------------------------------------------
-    //     VPN      (no featurePage)       /subscriptions/new/mobile/vpn
-    //     Duck.ai  (featurePage=duckai)   /subscriptions/new/mobile/duckai
+    //     VPN      (no featurePage)      /subscriptions/new/mobile/vpn
+    //     Duck.ai  (featurePage=duckai)  /subscriptions/new/mobile/duckai
     //
-    //     query item   values                when
-    //     ---------------------------------------------------------------------------------
-    //     trial        true | false          always, whichever it is
-    //     pir          false                 only when the offering excludes Personal Information
-    //                                        Removal; the page shows PIR unless told otherwise
-    //     origin       unchanged             carried as it is today
+    //     trial=true|false   always stated
+    //     pir=false          only when the offering excludes Personal Information Removal
+    //     origin             unchanged
     //
-    // So the full set is eight URLs, e.g.
-    //
-    //     https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false
-    //     https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true&pir=false
-    //
-    // `trial` is whether the offering includes a free trial; `pir` is whether it includes Personal
-    // Information Removal, which is sold in the USA storefront and not in the rest of the world. Both
-    // have to be settled before the URL is opened — that is the whole point, since the page ships
-    // both CTA labels and both feature lists and reveals one from the URL. Where they are read from,
-    // whether the store is allowed to be waited on, and what happens when it never answers are open
-    // questions, deliberately not answered here.
-    //
-    // What must not move: `pir`, `stripe` and `winback` featurePages, intercepted `/pro` links, and
-    // every desktop entry point stay on the URL they use today. The first two create or refresh a
-    // cart account on mount, which would make a load-time comparison measure the network.
+    // Everything else keeps today's URL: other featurePages, intercepted `/pro` links, desktop.
 
-    /// Skipped until something produces the URLs above. Delete the `XCTSkipIf` to see it fail, then
-    /// replace the `XCTFail` with assertions against whatever ends up building them.
+    /// Delete the `XCTSkipIf` and replace the `XCTFail` with assertions against whatever builds them.
     func testFirstPaywallURLsWhenPerformanceOptimizedPaywallsIsOn() throws {
         try XCTSkipIf(true, "Pending: the server-rendered first paywall is not implemented")
 
@@ -431,12 +408,8 @@ final class SubscriptionURLTests: XCTestCase {
         XCTFail("Nothing produces the server-rendered first paywall URLs yet: \(required.joined(separator: ", "))")
     }
 
-    /// Skipped until the state items are ignored when matching screens. `trial` and `pir` choose what
-    /// the page reveals, not which page it is, so every "am I on the purchase screen?" check — and
-    /// the offer-screen impression that the whole comparison is read from — has to see through them.
-    ///
-    /// This one is a real assertion already: delete the `XCTSkipIf` and it fails against today's
-    /// `forComparison()`.
+    /// `trial` and `pir` pick what the page reveals, not which page it is, so screen matching has to
+    /// ignore them. Already a real assertion: delete the `XCTSkipIf` and it fails.
     func testForComparisonIgnoresFirstPaywallStateParameters() throws {
         try XCTSkipIf(true, "Pending: forComparison() does not ignore trial and pir yet")
 

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -152,6 +152,13 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866712841283
     case privacyProOnboardingPromotion
 
+    /// Gates the server-rendered first paywall: `/subscriptions/new/mobile/<emphasis>` in place of
+    /// `/subscriptions` with a `featurePage` query item.
+    ///
+    /// Wired only. Nothing reads this yet — see `SubscriptionURLTests` for the URLs it has to
+    /// produce once something does.
+    case performanceOptimizedPaywalls
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213569392605475
     case subscriptionPromoForReinstallers
 
@@ -683,6 +690,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.experimentalAddressBar), supportsLocalOverriding: false)
         case .privacyProOnboardingPromotion:
             Config(source: .remoteReleasable(PrivacyProSubfeature.privacyProOnboardingPromotion))
+        case .performanceOptimizedPaywalls:
+            Config(source: .remoteReleasable(PrivacyProSubfeature.performanceOptimizedPaywalls))
         case .subscriptionPromoForReinstallers:
             Config(defaultValue: .enabled, source: .remoteReleasable(PrivacyProSubfeature.subscriptionPromoForReinstallers))
         case .subscriptionExpirationReminderNotification:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201141132935289/task/1216295712277568

Wires the `performanceOptimizedPaywalls` flag; nothing reads it.
The skipped tests in `SubscriptionURLTests` are the spec — delete the `XCTSkipIf` and implement however you see fit.
