### PR TITLE
Add petal=randomize parameter to the app_return pixel

### DIFF
--- a/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppReturnInstrumentation.swift
@@ -26,7 +26,8 @@ enum AppReturnPixel: PixelKit.Event, PixelKitEventWithCustomPrefix {
 
     var name: String { "app_return" }
 
-    var parameters: [String: String]? { nil }
+    // Self-tags the pixel to route through the PETAL (timestamp-randomization) pipeline.
+    var parameters: [String: String]? { ["petal": "randomize"] }
 
     var standardParameters: [PixelKitStandardParameter]? { nil }
 

--- a/iOS/DuckDuckGoTests/AppReturnInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/AppReturnInstrumentationTests.swift
@@ -156,6 +156,14 @@ struct AppReturnInstrumentationTests {
         #expect(collector.fired.first?.params["toggle_enabled"] == "true")
     }
 
+    // MARK: - PETAL tag
+
+    @available(iOS 16, *)
+    @Test("The pixel self-tags petal=randomize for the PETAL pipeline", .timeLimit(.minutes(1)))
+    func pixelSelfTagsPetalRandomize() {
+        #expect(AppReturnPixel.appReturn.parameters?["petal"] == "randomize")
+    }
+
     // MARK: - Launch source
 
     @available(iOS 16, *)

--- a/iOS/PixelDefinitions/pixels/definitions/app_return.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/app_return.json5
@@ -46,6 +46,11 @@
                 "key": "launch_source",
                 "description": "What triggered this foreground: standard, url, shortcut, or user_activity",
                 "type": "string"
+            },
+            {
+                "key": "petal",
+                "description": "Routes the pixel through the PETAL timestamp-randomization pipeline",
+                "enum": ["randomize"]
             }
         ]
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/69071770703008/task/1217644680832271?focus=true
Tech Design URL:
CC:

### Description
Tags the `m_app_return` pixel with `petal=randomize` so it routes through the PETAL timestamp-randomization pipeline, following the self-tagging pattern established by `OSDistributionPixel`. The pixel definition JSON declares the new parameter, and a unit test asserts the tag.

### Testing Steps
1. Foreground the app and observe the fired `m_app_return` pixel in the debug pixel log; confirm it includes `petal=randomize` alongside the existing parameters.

### Impact and Risks
Low — additive parameter on an existing pixel; firing conditions and existing parameters are unchanged.

#### What could go wrong?
If the PETAL pipeline mishandled the tag, `m_app_return` timestamps could be randomized in a way dashboards don't expect, but the pixel would still be received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive telemetry parameter only; no change to when the pixel fires or to app behavior. PETAL may randomize timestamps for this pixel, which could affect dashboards that assume exact event times.
> 
> **Overview**
> Tags the `m_app_return` pixel with `petal=randomize` so it is routed through the PETAL timestamp-randomization pipeline.
> 
> `AppReturnPixel` now self-tags that parameter (same pattern as other PETAL pixels). The pixel definition documents the new enum param, and a unit test asserts the tag. Firing conditions and existing params are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8de2432bc8d3dfe3063b5a87a1a6ffb23ffb6c20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->