### PR TITLE
Add first_prompt pixel param and return-session prompt origin

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/Statistics/FeatureDiscovery.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/Statistics/FeatureDiscovery.swift
@@ -26,6 +26,8 @@ import Persistence
 public enum WasUsedBeforeFeature: String {
 
     case aiChat
+    /// Set once the user has submitted their first Duck.ai prompt on this install.
+    case duckAIPrompt
     case duckPlayer
     case vpn
     case privacyDashboard

--- a/iOS/Core/Pixel.swift
+++ b/iOS/Core/Pixel.swift
@@ -95,7 +95,7 @@ public struct PixelParameters {
     public static let aiChatHadUnsubmittedSelections = "had_unsubmitted_selections"
     public static let aiChatSuggestionScope = "suggestion_scope"
     public static let aiChatSuggestionsSurface = "surface"
-    public static let aiChatFirstPrompt = "first_prompt"
+    public static let aiChatFirstPromptNewInstall = "first_prompt_new_install"
     public static let cookiePopupPreference = "cookie_popup_preference"
     public static let autoconsentEnabled = "autoconsent_enabled"
     public static let timeSinceShown = "time_since_shown"

--- a/iOS/Core/Pixel.swift
+++ b/iOS/Core/Pixel.swift
@@ -95,6 +95,7 @@ public struct PixelParameters {
     public static let aiChatHadUnsubmittedSelections = "had_unsubmitted_selections"
     public static let aiChatSuggestionScope = "suggestion_scope"
     public static let aiChatSuggestionsSurface = "surface"
+    public static let aiChatFirstPrompt = "first_prompt"
     public static let cookiePopupPreference = "cookie_popup_preference"
     public static let autoconsentEnabled = "autoconsent_enabled"
     public static let timeSinceShown = "time_since_shown"

--- a/iOS/DuckDuckGo/AIChat/AIChatPixelMetricHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatPixelMetricHandler.swift
@@ -19,6 +19,7 @@
 
 import Foundation
 import AIChat
+import BrowserServicesKit
 import Core
 import Subscription
 
@@ -37,7 +38,11 @@ final class AIChatPixelMetricHandler: AIChatPixelMetricHandling {
 
     private let timeElapsedInMinutes: Int?
     private let pixelFiring: PixelFiring.Type
+    private let featureDiscovery: FeatureDiscovery
     private let timestampParameterKey = "delta-timestamp-minutes"
+
+    /// The metrics the frontend reports when a prompt is submitted through its own composer.
+    private static let promptSubmissionMetrics: Set<AIChatMetricName> = [.userDidSubmitPrompt, .userDidSubmitFirstPrompt]
 
     static let metricToEventMap: [AIChatMetricName: Pixel.Event] = [
         .userDidSubmitPrompt: .aiChatMetricSentPromptOngoingChat,
@@ -88,9 +93,12 @@ final class AIChatPixelMetricHandler: AIChatPixelMetricHandling {
 
     // MARK: - Initialization
 
-    init(timeElapsedInMinutes: Int? = nil, pixelFiring: PixelFiring.Type = Pixel.self) {
+    init(timeElapsedInMinutes: Int? = nil,
+         pixelFiring: PixelFiring.Type = Pixel.self,
+         featureDiscovery: FeatureDiscovery = DefaultFeatureDiscovery()) {
         self.timeElapsedInMinutes = timeElapsedInMinutes
         self.pixelFiring = pixelFiring
+        self.featureDiscovery = featureDiscovery
     }
 
     // MARK: - AIChatPixelMetricHandling
@@ -107,7 +115,18 @@ final class AIChatPixelMetricHandler: AIChatPixelMetricHandling {
                 parameters = timestampParameters ?? [:]
             }
 
+            // Native submission paths mark the flag first, so this claims first_prompt only
+            // for submissions made directly in the frontend composer (e.g. iPad AI tabs).
+            let isPromptSubmission = Self.promptSubmissionMetrics.contains(metric.metricName)
+            if isPromptSubmission && featureDiscovery.isFirstDuckAIPrompt {
+                parameters[PixelParameters.aiChatFirstPrompt] = "true"
+            }
+
             pixelFiring.fire(event, withAdditionalParameters: parameters)
+
+            if isPromptSubmission {
+                featureDiscovery.markDuckAIPromptSubmitted()
+            }
             return
         }
 

--- a/iOS/DuckDuckGo/AIChat/AIChatPixelMetricHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatPixelMetricHandler.swift
@@ -115,11 +115,11 @@ final class AIChatPixelMetricHandler: AIChatPixelMetricHandling {
                 parameters = timestampParameters ?? [:]
             }
 
-            // Native submission paths mark the flag first, so this claims first_prompt only
-            // for submissions made directly in the frontend composer (e.g. iPad AI tabs).
+            // Native submission paths mark the flag first, so this claims first_prompt_new_install
+            // only for submissions made directly in the frontend composer (e.g. iPad AI tabs).
             let isPromptSubmission = Self.promptSubmissionMetrics.contains(metric.metricName)
-            if isPromptSubmission && featureDiscovery.isFirstDuckAIPrompt {
-                parameters[PixelParameters.aiChatFirstPrompt] = "true"
+            if isPromptSubmission && featureDiscovery.isFirstDuckAIPromptNewInstall {
+                parameters[PixelParameters.aiChatFirstPromptNewInstall] = "true"
             }
 
             pixelFiring.fire(event, withAdditionalParameters: parameters)

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualModePixelHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualModePixelHandler.swift
@@ -291,8 +291,8 @@ final class AIChatContextualModePixelHandler: AIChatContextualModePixelFiring {
     /// Marking after the fire keeps the first-prompt claim on this submission's pixel; the UTI
     /// prompt pixel for the same submission fires earlier in the flow, so it reads the same state.
     private func firePromptSubmissionPixel(_ event: Pixel.Event) {
-        if featureDiscovery.isFirstDuckAIPrompt {
-            firePixelWithParameters(event, [PixelParameters.aiChatFirstPrompt: "true"])
+        if featureDiscovery.isFirstDuckAIPromptNewInstall {
+            firePixelWithParameters(event, [PixelParameters.aiChatFirstPromptNewInstall: "true"])
             featureDiscovery.markDuckAIPromptSubmitted()
         } else {
             firePixel(event)

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualModePixelHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualModePixelHandler.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+import BrowserServicesKit
 import Core
 import Foundation
 import PixelKit
@@ -116,6 +117,7 @@ final class AIChatContextualModePixelHandler: AIChatContextualModePixelFiring {
     private let firePixel: (Pixel.Event) -> Void
     private let firePixelWithParameters: (Pixel.Event, [String: String]) -> Void
     private let fireSelectionPixel: (PixelKit.Event, PixelKit.Frequency) -> Void
+    private let featureDiscovery: FeatureDiscovery
 
     // MARK: - Public Properties
 
@@ -131,10 +133,12 @@ final class AIChatContextualModePixelHandler: AIChatContextualModePixelFiring {
          },
          fireSelectionPixel: @escaping (PixelKit.Event, PixelKit.Frequency) -> Void = {
              PixelKit.fire($0, frequency: $1)
-         }) {
+         },
+         featureDiscovery: FeatureDiscovery = DefaultFeatureDiscovery()) {
         self.firePixel = firePixel
         self.firePixelWithParameters = firePixelWithParameters
         self.fireSelectionPixel = fireSelectionPixel
+        self.featureDiscovery = featureDiscovery
     }
 
     // MARK: - Sheet Lifecycle
@@ -277,11 +281,22 @@ final class AIChatContextualModePixelHandler: AIChatContextualModePixelFiring {
     // MARK: - Prompt Submission
 
     func firePromptSubmittedWithContext() {
-        firePixel(.aiChatContextualPromptSubmittedWithContextNative)
+        firePromptSubmissionPixel(.aiChatContextualPromptSubmittedWithContextNative)
     }
 
     func firePromptSubmittedWithoutContext() {
-        firePixel(.aiChatContextualPromptSubmittedWithoutContextNative)
+        firePromptSubmissionPixel(.aiChatContextualPromptSubmittedWithoutContextNative)
+    }
+
+    /// Marking after the fire keeps the first-prompt claim on this submission's pixel; the UTI
+    /// prompt pixel for the same submission fires earlier in the flow, so it reads the same state.
+    private func firePromptSubmissionPixel(_ event: Pixel.Event) {
+        if featureDiscovery.isFirstDuckAIPrompt {
+            firePixelWithParameters(event, [PixelParameters.aiChatFirstPrompt: "true"])
+            featureDiscovery.markDuckAIPromptSubmitted()
+        } else {
+            firePixel(event)
+        }
     }
 
     // MARK: - Suggested Prompts

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarSubmissionMetrics.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarSubmissionMetrics.swift
@@ -80,7 +80,10 @@ struct SwitchBarSubmissionMetrics: SwitchBarSubmissionMetricsProviding {
         case .search:
             DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarQuerySubmitted, withAdditionalParameters: additionalParams)
         case .aiChat:
-            let mergedParams = additionalParams.merging(featureDiscovery.addToParams([:], forFeature: .aiChat)) { (_, new) in new }
+            var mergedParams = additionalParams.merging(featureDiscovery.addToParams([:], forFeature: .aiChat)) { (_, new) in new }
+            if featureDiscovery.isFirstDuckAIPrompt {
+                mergedParams[PixelParameters.aiChatFirstPrompt] = "true"
+            }
             DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarPromptSubmitted, withAdditionalParameters: mergedParams)
             featureDiscovery.setWasUsedBefore(.aiChat)
         }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarSubmissionMetrics.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarSubmissionMetrics.swift
@@ -81,8 +81,8 @@ struct SwitchBarSubmissionMetrics: SwitchBarSubmissionMetricsProviding {
             DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarQuerySubmitted, withAdditionalParameters: additionalParams)
         case .aiChat:
             var mergedParams = additionalParams.merging(featureDiscovery.addToParams([:], forFeature: .aiChat)) { (_, new) in new }
-            if featureDiscovery.isFirstDuckAIPrompt {
-                mergedParams[PixelParameters.aiChatFirstPrompt] = "true"
+            if featureDiscovery.isFirstDuckAIPromptNewInstall {
+                mergedParams[PixelParameters.aiChatFirstPromptNewInstall] = "true"
             }
             DailyPixel.fireDailyAndCount(pixel: .aiChatExperimentalOmnibarPromptSubmitted, withAdditionalParameters: mergedParams)
             featureDiscovery.setWasUsedBefore(.aiChat)

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -111,6 +111,9 @@ struct Launching: LaunchingHandling {
             statisticsStore: StatisticsUserDefaults()
         )
 
+        // Pre-mark existing installs (before statistics load) so first_prompt_new_install can only fire on brand-new installs.
+        DuckAIFirstPromptNewInstallCohort.assignIfNeeded(statisticsStore: StatisticsUserDefaults())
+
         // MARK: - Service Initialization (continued)
         // Create and initialize remaining core services
         // These services are instantiated early in the app lifecycle for two main reasons:

--- a/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
@@ -73,10 +73,19 @@ protocol PostIdleSessionInstrumentation: AnyObject {
     func burnTabTapped()
 
     /// Terminal user action ended the session (submission, return-to-page, etc.).
-    func sessionEnded(reason: ReturnSessionWideEventData.StatusReason)
+    /// `promptOrigin` identifies what triggered an `.aiPromptSubmitted` terminal and is
+    /// ignored for every other reason.
+    func sessionEnded(reason: ReturnSessionWideEventData.StatusReason, promptOrigin: AIChatEntryPointSource?)
 
     /// App was backgrounded with a session still active. Completes as CANCELLED.
     func sessionCancelledByBackground()
+}
+
+extension PostIdleSessionInstrumentation {
+
+    func sessionEnded(reason: ReturnSessionWideEventData.StatusReason) {
+        sessionEnded(reason: reason, promptOrigin: nil)
+    }
 }
 
 final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentation {
@@ -158,12 +167,13 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
         recordInteraction { $0.burnTabTapped = true }
     }
 
-    func sessionEnded(reason: ReturnSessionWideEventData.StatusReason) {
+    func sessionEnded(reason: ReturnSessionWideEventData.StatusReason, promptOrigin: AIChatEntryPointSource?) {
         let now = dateProvider()
 
         if let globalID = returnSessionID,
            let data = wideEvent.getFlowData(ReturnSessionWideEventData.self, globalID: globalID) {
             data.statusReason = reason
+            data.promptOrigin = reason == .aiPromptSubmitted ? promptOrigin?.rawValue : nil
             data.sessionInterval.end = now
             markFirstInteractionIfNeeded(on: data, at: now)
             wideEvent.completeFlow(data, status: .success(reason: reason.rawValue), onComplete: { _, _ in })

--- a/iOS/DuckDuckGo/AppLifecycle/ReturnSessionWideEventData.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/ReturnSessionWideEventData.swift
@@ -32,7 +32,7 @@ final class ReturnSessionWideEventData: WideEventData {
         mobileMetaType: "ios-return-session",
         // API requires both; only mobileMetaType is read on iOS.
         desktopMetaType: "macos-return-session",
-        version: "1.0.0"
+        version: "1.1.0"
     )
 
     /// `ntp` is the after-idle NTP; `ntpUserInitiated` is an NTP reached without the treatment.
@@ -65,6 +65,9 @@ final class ReturnSessionWideEventData: WideEventData {
     var timeAwayMs: Int?
     var focused: Bool
     var statusReason: StatusReason?
+    /// What triggered the prompt submission (an `AIChatEntryPointSource` raw value). Set only
+    /// when `statusReason` is `.aiPromptSubmitted`. Optional so old pending flows decode.
+    var promptOrigin: String?
     var sessionInterval: WideEvent.MeasuredInterval
     var firstInteractionInterval: WideEvent.MeasuredInterval
     var pageEngaged: Bool
@@ -136,6 +139,7 @@ extension ReturnSessionWideEventData {
             (WideEventParameter.ReturnSessionFeature.timeAwayMsBucketed, timeAwayMs.map { String(Self.timeAwayBucketMs($0)) }),
             (WideEventParameter.ReturnSessionFeature.focused, focused),
             (WideEventParameter.Feature.statusReason, statusReason?.rawValue),
+            (WideEventParameter.ReturnSessionFeature.promptOrigin, promptOrigin),
             (WideEventParameter.ReturnSessionFeature.sessionDurationMsBucketed, sessionInterval.stringValue(bucket)),
             (WideEventParameter.ReturnSessionFeature.timeToFirstInteractionMsBucketed, firstInteractionInterval.stringValue(bucket)),
             (WideEventParameter.ReturnSessionFeature.pageEngaged, pageEngaged),
@@ -170,6 +174,7 @@ extension WideEventParameter {
         static let afterIdle = "feature.data.ext.after_idle"
         static let timeAwayMsBucketed = "feature.data.ext.time_away_ms_bucketed"
         static let focused = "feature.data.ext.focused"
+        static let promptOrigin = "feature.data.ext.prompt_origin"
         static let sessionDurationMsBucketed = "feature.data.ext.session_duration_ms_bucketed"
         static let timeToFirstInteractionMsBucketed = "feature.data.ext.time_to_first_interaction_ms_bucketed"
         static let pageEngaged = "feature.data.ext.page_engaged"

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -400,10 +400,10 @@ extension DefaultOmniBarViewController {
                 dismissIPadDuckAIMode()
                 omniDelegate?.onOmniQuerySubmitted(query)
             } else {
-                let isFirstEverPrompt = featureDiscovery.isFirstDuckAIPrompt
-                let firstPromptParameters: [String: String] = isFirstEverPrompt ? [PixelParameters.aiChatFirstPrompt: "true"] : [:]
+                let isFirstPromptNewInstall = featureDiscovery.isFirstDuckAIPromptNewInstall
+                let firstPromptParameters: [String: String] = isFirstPromptNewInstall ? [PixelParameters.aiChatFirstPromptNewInstall: "true"] : [:]
                 DailyPixel.fireDailyAndCount(pixel: .aiChatIPadTogglePromptSubmitted, withAdditionalParameters: firstPromptParameters)
-                fireIPadUnifiedPromptSubmittedPixels(hasText: !query.isEmpty, isFirstEverPrompt: isFirstEverPrompt)
+                fireIPadUnifiedPromptSubmittedPixels(hasText: !query.isEmpty, isFirstPromptNewInstall: isFirstPromptNewInstall)
                 featureDiscovery.markDuckAIPromptSubmitted()
                 /// Collapse and resign instantly so a quick re-tap doesn't race the post-submit
                 /// collapse animation.
@@ -641,7 +641,7 @@ extension DefaultOmniBarViewController {
         omniBarView.aiChatAttachmentMenu = attachmentController?.makeMenu()
     }
 
-    private func fireIPadUnifiedPromptSubmittedPixels(hasText: Bool, isFirstEverPrompt: Bool) {
+    private func fireIPadUnifiedPromptSubmittedPixels(hasText: Bool, isFirstPromptNewInstall: Bool) {
         guard modelPickerController != nil else { return }
         let attachments = attachmentController?.pendingAttachments ?? []
         let selectedTool = toolPickerController?.selectedTool
@@ -654,7 +654,7 @@ extension DefaultOmniBarViewController {
             surface: .addressBar,
             pageType: omniDelegate?.currentPromptPageType() ?? .unknown,
             origin: .ipadTogglePrompt,
-            isFirstEverPrompt: isFirstEverPrompt
+            isFirstPromptNewInstall: isFirstPromptNewInstall
         )
         UnifiedToggleInputCoordinatorPixelHelper.fireToolSubmittedPixelIfNeeded(
             selectedTool: selectedTool,

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -18,6 +18,7 @@
 //
 
 import UIKit
+import BrowserServicesKit
 import PrivacyDashboard
 import AIChat
 import Core
@@ -37,6 +38,7 @@ final class DefaultOmniBarViewController: OmniBarViewController {
 
     /// Manages shared text state for the iPad duck.ai ↔ search mode toggle.
     private let modeToggleTextModel: IPadModeToggleTextModeling = IPadModeToggleTextModel()
+    private let featureDiscovery: FeatureDiscovery = DefaultFeatureDiscovery()
     private var modelPickerController: IPadOmnibarModelPickerController?
     private var reasoningPickerController: IPadOmnibarReasoningPickerController?
     private var toolPickerController: IPadOmnibarToolPickerController?
@@ -398,8 +400,11 @@ extension DefaultOmniBarViewController {
                 dismissIPadDuckAIMode()
                 omniDelegate?.onOmniQuerySubmitted(query)
             } else {
-                DailyPixel.fireDailyAndCount(pixel: .aiChatIPadTogglePromptSubmitted)
-                fireIPadUnifiedPromptSubmittedPixels(hasText: !query.isEmpty)
+                let isFirstEverPrompt = featureDiscovery.isFirstDuckAIPrompt
+                let firstPromptParameters: [String: String] = isFirstEverPrompt ? [PixelParameters.aiChatFirstPrompt: "true"] : [:]
+                DailyPixel.fireDailyAndCount(pixel: .aiChatIPadTogglePromptSubmitted, withAdditionalParameters: firstPromptParameters)
+                fireIPadUnifiedPromptSubmittedPixels(hasText: !query.isEmpty, isFirstEverPrompt: isFirstEverPrompt)
+                featureDiscovery.markDuckAIPromptSubmitted()
                 /// Collapse and resign instantly so a quick re-tap doesn't race the post-submit
                 /// collapse animation.
                 /// https://app.asana.com/1/137249556945/project/1201011656765697/task/1215084286493408?focus=true
@@ -636,7 +641,7 @@ extension DefaultOmniBarViewController {
         omniBarView.aiChatAttachmentMenu = attachmentController?.makeMenu()
     }
 
-    private func fireIPadUnifiedPromptSubmittedPixels(hasText: Bool) {
+    private func fireIPadUnifiedPromptSubmittedPixels(hasText: Bool, isFirstEverPrompt: Bool) {
         guard modelPickerController != nil else { return }
         let attachments = attachmentController?.pendingAttachments ?? []
         let selectedTool = toolPickerController?.selectedTool
@@ -648,7 +653,8 @@ extension DefaultOmniBarViewController {
             modelId: modelPickerController?.currentModelId,
             surface: .addressBar,
             pageType: omniDelegate?.currentPromptPageType() ?? .unknown,
-            origin: .ipadTogglePrompt
+            origin: .ipadTogglePrompt,
+            isFirstEverPrompt: isFirstEverPrompt
         )
         UnifiedToggleInputCoordinatorPixelHelper.fireToolSubmittedPixelIfNeeded(
             selectedTool: selectedTool,

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2652,7 +2652,8 @@ class MainViewController: UIViewController {
                       modelId: String? = nil,
                       reasoningEffort: AIChatReasoningEffort? = nil,
                       images: [AIChatNativePrompt.NativePromptImage]? = nil,
-                      files: [AIChatNativePrompt.NativePromptFile]? = nil) {
+                      files: [AIChatNativePrompt.NativePromptFile]? = nil,
+                      source: AIChatEntryPointSource) {
         guard let currentTab else {
             assertionFailure("load called with no current tab")
             return
@@ -2660,7 +2661,7 @@ class MainViewController: UIViewController {
         if currentTab.tabModel.link == nil {
             ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: currentTab.tabModel.openedAfterIdle)
         }
-        postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted)
+        postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted, promptOrigin: source)
         prepareTabForRequest {
             currentTab.load(
                 query,
@@ -4290,7 +4291,7 @@ class MainViewController: UIViewController {
         if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
             ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: tab.openedAfterIdle)
         }
-        postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted)
+        postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted, promptOrigin: .voice)
         openAIChatInVoiceMode()
     }
 
@@ -4391,7 +4392,7 @@ class MainViewController: UIViewController {
             // Mirror the in-place `.aiPromptSubmitted` so the new-tab branch keeps idle-session parity.
             // Gated on `!fromDeepLink` so external entries aren't reclassified as address-bar submissions.
             if !fromDeepLink {
-                postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted)
+                postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted, promptOrigin: source)
             }
             // Stage prompt singleton before `loadUrlInNewTab` — matches legacy `setData → load` order.
             // Per-tab payload runs in completion since it targets the newly-selected chat tab.
@@ -4418,7 +4419,7 @@ class MainViewController: UIViewController {
             return
         }
 
-        load(query, autoSend: autoSend, payload: payload, flowType: flowType, tools: tools, modelId: modelId, reasoningEffort: reasoningEffort, images: images, files: files)
+        load(query, autoSend: autoSend, payload: payload, flowType: flowType, tools: tools, modelId: modelId, reasoningEffort: reasoningEffort, images: images, files: files, source: source)
         if let modelId {
             unifiedToggleInputCoordinator?.updateSelectedModel(modelId)
         }
@@ -4964,7 +4965,11 @@ extension MainViewController: BrowserChromeDelegate {
         if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
             ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: tab.openedAfterIdle)
         }
-        postIdleSessionInstrumentation.sessionEnded(reason: postIdleSubmissionReason(for: suggestion))
+        var promptOrigin: AIChatEntryPointSource?
+        if case .askAIChat = suggestion {
+            promptOrigin = .suggestionAskAI
+        }
+        postIdleSessionInstrumentation.sessionEnded(reason: postIdleSubmissionReason(for: suggestion), promptOrigin: promptOrigin)
         endNewTabPageSessionWithSuggestion(suggestion)
         newTabPageViewController?.chromeDelegate = nil
         dismissOmniBar()
@@ -7932,7 +7937,7 @@ extension MainViewController: VoiceSearchViewControllerDelegate {
                 if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
                     ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: tab.openedAfterIdle)
                 }
-                postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted)
+                postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted, promptOrigin: .voice)
                 coordinator.submitVoicePrompt(query)
             } else {
                 performCancel()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
@@ -219,7 +219,7 @@ final class UTIPixelReporter {
                                reasoningMode: AIChatReasoningMode?,
                                modelId: String?,
                                defaultOmnibarMode: DefaultOmnibarMode,
-                               isFirstEverPrompt: Bool) {
+                               isFirstPromptNewInstall: Bool) {
         withContext {
             UnifiedToggleInputCoordinatorPixelHelper.fireUnifiedPromptSubmittedPixel(
                 hasText: hasText,
@@ -231,7 +231,7 @@ final class UTIPixelReporter {
                 pageType: $0.pageType,
                 origin: Self.promptOrigin(for: $0),
                 defaultMode: defaultOmnibarMode,
-                isFirstEverPrompt: isFirstEverPrompt,
+                isFirstPromptNewInstall: isFirstPromptNewInstall,
                 firing: firing
             )
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
@@ -218,7 +218,8 @@ final class UTIPixelReporter {
                                attachments: [UnifiedToggleInputAttachment],
                                reasoningMode: AIChatReasoningMode?,
                                modelId: String?,
-                               defaultOmnibarMode: DefaultOmnibarMode) {
+                               defaultOmnibarMode: DefaultOmnibarMode,
+                               isFirstEverPrompt: Bool) {
         withContext {
             UnifiedToggleInputCoordinatorPixelHelper.fireUnifiedPromptSubmittedPixel(
                 hasText: hasText,
@@ -230,6 +231,7 @@ final class UTIPixelReporter {
                 pageType: $0.pageType,
                 origin: Self.promptOrigin(for: $0),
                 defaultMode: defaultOmnibarMode,
+                isFirstEverPrompt: isFirstEverPrompt,
                 firing: firing
             )
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1719,7 +1719,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
             reasoningMode: reasoningModeForSubmitPixel,
             modelId: modelStore.persistedModelId,
             defaultOmnibarMode: aiChatSettings.defaultOmnibarMode,
-            isFirstEverPrompt: featureDiscovery.isFirstDuckAIPrompt
+            isFirstPromptNewInstall: featureDiscovery.isFirstDuckAIPromptNewInstall
         )
         pixelReporter.reportToolSubmittedIfNeeded(
             selectedTool: toolsController.selectedTool,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -165,6 +165,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
     private(set) var inputMode: TextEntryMode = .aiChat
     private let stateStore: UnifiedInputStateStoring
     private let switchBarSubmissionMetrics: SwitchBarSubmissionMetricsProviding
+    private let featureDiscovery: FeatureDiscovery
     private let aiChatSettings: AIChatSettingsProvider
     private let sessionMonitor: UTISessionMonitor
     private(set) var currentTabUID: TabUID?
@@ -304,6 +305,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         stateStore: UnifiedInputStateStoring? = nil,
         syncService: DDGSyncing? = nil,
         switchBarSubmissionMetrics: SwitchBarSubmissionMetricsProviding = SwitchBarSubmissionMetrics(),
+        featureDiscovery: FeatureDiscovery = DefaultFeatureDiscovery(),
         aiChatSettings: AIChatSettingsProvider = AIChatSettings(),
         aiChatSyncCleaner: AIChatSyncCleaning? = nil,
         recentModalPromptStatusProvider: RecentModalPromptStatusProviding? = nil,
@@ -324,6 +326,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         self.isToggleEnabled = isToggleEnabled
         self.hidesToggleOnDuckAITab = hidesToggleOnDuckAITab
         self.switchBarSubmissionMetrics = switchBarSubmissionMetrics
+        self.featureDiscovery = featureDiscovery
         self.aiChatSettings = aiChatSettings
         self.sessionMonitor = UTISessionMonitor(
             isEnabled: host == .omnibar,
@@ -1318,6 +1321,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         let didSendBridgeMessage = userScript.canDispatchBridgeMessages
         userScript.submitPrompt(text, images: nil, modelId: configuration.modelId, reasoningEffort: configuration.reasoningEffort)
         recordDuckAIPromptDelivered(wasQueued: false, didSendBridgeMessage: didSendBridgeMessage)
+        featureDiscovery.markDuckAIPromptSubmitted()
     }
 
     func prepareExternalPromptSubmission() -> (modelId: String?, reasoningEffort: AIChatReasoningEffort?) {
@@ -1714,7 +1718,8 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
             attachments: viewController.currentAttachments,
             reasoningMode: reasoningModeForSubmitPixel,
             modelId: modelStore.persistedModelId,
-            defaultOmnibarMode: aiChatSettings.defaultOmnibarMode
+            defaultOmnibarMode: aiChatSettings.defaultOmnibarMode,
+            isFirstEverPrompt: featureDiscovery.isFirstDuckAIPrompt
         )
         pixelReporter.reportToolSubmittedIfNeeded(
             selectedTool: toolsController.selectedTool,
@@ -1741,6 +1746,9 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
         resetToolsSelection()
         clearStoreEntryAfterSubmission()
         deliverAIChatPrompt(text: text, images: images, files: files, configuration: configuration, tools: tools, userScript: userScript)
+        // After delivery, so every pixel this submission fires (including the contextual
+        // ones fired during delivery) still reads the pre-submission first-prompt state.
+        featureDiscovery.markDuckAIPromptSubmitted()
     }
 
     private func deliverAIChatPrompt(text: String,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
@@ -21,19 +21,41 @@ import AIChat
 import BrowserServicesKit
 import Core
 import Foundation
+import Persistence
 import PixelKit
 import Subscription
 
-/// Install-lifetime first-Duck.ai-prompt flag behind the shared `first_prompt` pixel parameter.
-/// Read by every prompt-submission pixel; marked once per submission flow after its pixels fire.
+/// Install-lifetime first-Duck.ai-prompt flag behind the shared `first_prompt_new_install` pixel
+/// parameter. Read by every prompt-submission pixel; marked once per submission flow after its
+/// pixels fire. `DuckAIFirstPromptNewInstallCohort` pre-marks existing installs at launch, so the
+/// parameter can only ever fire on a brand-new install's genuine first prompt.
 extension FeatureDiscovery {
 
-    var isFirstDuckAIPrompt: Bool {
+    var isFirstDuckAIPromptNewInstall: Bool {
         !wasUsedBefore(.duckAIPrompt)
     }
 
     func markDuckAIPromptSubmitted() {
         setWasUsedBefore(.duckAIPrompt)
+    }
+}
+
+/// Launch-time cohort gate for `first_prompt_new_install`: installs that predate this measurement
+/// are pre-marked as having prompted, so only brand-new installs can ever report the parameter.
+enum DuckAIFirstPromptNewInstallCohort {
+
+    static let cohortAssignedKey = "com.duckduckgo.aichat.firstPromptNewInstall.cohortAssigned"
+
+    /// Must run before StatisticsLoader stores install statistics (mirrors `IdleReturnCohort`):
+    /// once they exist every install looks existing, which would disqualify a genuinely new one.
+    static func assignIfNeeded(statisticsStore: StatisticsStore,
+                               featureDiscovery: FeatureDiscovery = DefaultFeatureDiscovery(),
+                               marker: KeyValueStoring = UserDefaults.standard) {
+        guard marker.object(forKey: cohortAssignedKey) == nil else { return }
+        if statisticsStore.hasInstallStatistics {
+            featureDiscovery.markDuckAIPromptSubmitted()
+        }
+        marker.set(true, forKey: cohortAssignedKey)
     }
 }
 
@@ -232,7 +254,7 @@ final class UnifiedToggleInputCoordinatorPixelHelper {
         pageType: UnifiedToggleInputPromptPageType? = nil,
         origin: AIChatEntryPointSource? = nil,
         defaultMode: DefaultOmnibarMode? = nil,
-        isFirstEverPrompt: Bool = false,
+        isFirstPromptNewInstall: Bool = false,
         firing: UTIPixelFiring = .live
     ) {
         let selectedToolValue = UnifiedPromptSubmittedSelectedToolPixelValue(selectedTool: selectedTool).rawValue
@@ -251,7 +273,7 @@ final class UnifiedToggleInputCoordinatorPixelHelper {
         parameters["page_type"] = pageType?.rawValue
         parameters["origin"] = origin?.rawValue
         parameters["default_mode"] = defaultMode?.rawValue
-        parameters[PixelParameters.aiChatFirstPrompt] = isFirstEverPrompt ? "true" : nil
+        parameters[PixelParameters.aiChatFirstPromptNewInstall] = isFirstPromptNewInstall ? "true" : nil
 
         firing.fireDailyAndCount(.unifiedToggleInputPromptSubmitted, parameters)
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinatorPixelHelper.swift
@@ -18,10 +18,24 @@
 //
 
 import AIChat
+import BrowserServicesKit
 import Core
 import Foundation
 import PixelKit
 import Subscription
+
+/// Install-lifetime first-Duck.ai-prompt flag behind the shared `first_prompt` pixel parameter.
+/// Read by every prompt-submission pixel; marked once per submission flow after its pixels fire.
+extension FeatureDiscovery {
+
+    var isFirstDuckAIPrompt: Bool {
+        !wasUsedBefore(.duckAIPrompt)
+    }
+
+    func markDuckAIPromptSubmitted() {
+        setWasUsedBefore(.duckAIPrompt)
+    }
+}
 
 /// The schedule suffix is part of the name, fired with frequencies that append nothing, so PixelKit's
 /// platform suffix lands after it and the wire name stays `..._daily_ios_phone` as the legacy pixel reports it.
@@ -218,6 +232,7 @@ final class UnifiedToggleInputCoordinatorPixelHelper {
         pageType: UnifiedToggleInputPromptPageType? = nil,
         origin: AIChatEntryPointSource? = nil,
         defaultMode: DefaultOmnibarMode? = nil,
+        isFirstEverPrompt: Bool = false,
         firing: UTIPixelFiring = .live
     ) {
         let selectedToolValue = UnifiedPromptSubmittedSelectedToolPixelValue(selectedTool: selectedTool).rawValue
@@ -236,6 +251,7 @@ final class UnifiedToggleInputCoordinatorPixelHelper {
         parameters["page_type"] = pageType?.rawValue
         parameters["origin"] = origin?.rawValue
         parameters["default_mode"] = defaultMode?.rawValue
+        parameters[PixelParameters.aiChatFirstPrompt] = isFirstEverPrompt ? "true" : nil
 
         firing.fireDailyAndCount(.unifiedToggleInputPromptSubmitted, parameters)
     }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualModePixelHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualModePixelHandlerTests.swift
@@ -346,7 +346,7 @@ final class AIChatContextualModePixelHandlerTests {
         #expect(PixelFiringMock.lastPixelName == Pixel.Event.aiChatContextualPromptSubmittedWithoutContextNative.name)
     }
 
-    @Test("First ever prompt submission carries first_prompt and marks the flag")
+    @Test("First prompt on a new install carries first_prompt_new_install and marks the flag")
     func testFirstEverPromptSubmissionCarriesFirstPromptParam() {
         // GIVEN
         var firedEventName: String?
@@ -365,11 +365,11 @@ final class AIChatContextualModePixelHandlerTests {
 
         // THEN
         #expect(firedEventName == Pixel.Event.aiChatContextualPromptSubmittedWithContextNative.name)
-        #expect(firedParameters == ["first_prompt": "true"])
+        #expect(firedParameters == ["first_prompt_new_install": "true"])
         #expect(featureDiscovery.wasSetWasUsedBeforeCalled(for: .duckAIPrompt))
     }
 
-    @Test("Returning-user prompt submission omits first_prompt")
+    @Test("Returning-user prompt submission omits first_prompt_new_install")
     func testReturningUserPromptSubmissionOmitsFirstPromptParam() {
         // GIVEN
         var firedParameters: [String: String]?

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualModePixelHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualModePixelHandlerTests.swift
@@ -18,6 +18,7 @@
 //
 
 import Testing
+import BrowserServicesKitTestsUtils
 import Core
 import PixelKit
 @testable import DuckDuckGo
@@ -311,12 +312,18 @@ final class AIChatContextualModePixelHandlerTests {
 
     // MARK: - Prompt Submission Pixels
 
+    private static func returningUserFeatureDiscovery() -> MockFeatureDiscovery {
+        let featureDiscovery = MockFeatureDiscovery()
+        featureDiscovery.setReturnValue(true, for: .duckAIPrompt)
+        return featureDiscovery
+    }
+
     @Test("Prompt submitted with context pixel fires correctly")
     func testPromptSubmittedWithContextPixel() {
         // GIVEN
         let sut = AIChatContextualModePixelHandler(firePixel: { event in
             PixelFiringMock.fire(event, withAdditionalParameters: [:])
-        })
+        }, featureDiscovery: Self.returningUserFeatureDiscovery())
 
         // WHEN
         sut.firePromptSubmittedWithContext()
@@ -330,13 +337,54 @@ final class AIChatContextualModePixelHandlerTests {
         // GIVEN
         let sut = AIChatContextualModePixelHandler(firePixel: { event in
             PixelFiringMock.fire(event, withAdditionalParameters: [:])
-        })
+        }, featureDiscovery: Self.returningUserFeatureDiscovery())
 
         // WHEN
         sut.firePromptSubmittedWithoutContext()
 
         // THEN
         #expect(PixelFiringMock.lastPixelName == Pixel.Event.aiChatContextualPromptSubmittedWithoutContextNative.name)
+    }
+
+    @Test("First ever prompt submission carries first_prompt and marks the flag")
+    func testFirstEverPromptSubmissionCarriesFirstPromptParam() {
+        // GIVEN
+        var firedEventName: String?
+        var firedParameters: [String: String]?
+        let featureDiscovery = MockFeatureDiscovery()
+        let sut = AIChatContextualModePixelHandler(
+            firePixel: { _ in },
+            firePixelWithParameters: { event, parameters in
+                firedEventName = event.name
+                firedParameters = parameters
+            },
+            featureDiscovery: featureDiscovery)
+
+        // WHEN
+        sut.firePromptSubmittedWithContext()
+
+        // THEN
+        #expect(firedEventName == Pixel.Event.aiChatContextualPromptSubmittedWithContextNative.name)
+        #expect(firedParameters == ["first_prompt": "true"])
+        #expect(featureDiscovery.wasSetWasUsedBeforeCalled(for: .duckAIPrompt))
+    }
+
+    @Test("Returning-user prompt submission omits first_prompt")
+    func testReturningUserPromptSubmissionOmitsFirstPromptParam() {
+        // GIVEN
+        var firedParameters: [String: String]?
+        var firedEventName: String?
+        let sut = AIChatContextualModePixelHandler(
+            firePixel: { event in firedEventName = event.name },
+            firePixelWithParameters: { _, parameters in firedParameters = parameters },
+            featureDiscovery: Self.returningUserFeatureDiscovery())
+
+        // WHEN
+        sut.firePromptSubmittedWithoutContext()
+
+        // THEN
+        #expect(firedEventName == Pixel.Event.aiChatContextualPromptSubmittedWithoutContextNative.name)
+        #expect(firedParameters == nil)
     }
 
     // MARK: - Manual Attach State Management

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualModePixelHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualModePixelHandlerTests.swift
@@ -346,7 +346,8 @@ final class AIChatContextualModePixelHandlerTests {
         #expect(PixelFiringMock.lastPixelName == Pixel.Event.aiChatContextualPromptSubmittedWithoutContextNative.name)
     }
 
-    @Test("First prompt on a new install carries first_prompt_new_install and marks the flag")
+    @available(iOS 16, macOS 13, *)
+    @Test("First prompt on a new install carries first_prompt_new_install and marks the flag", .timeLimit(.minutes(1)))
     func testFirstEverPromptSubmissionCarriesFirstPromptParam() {
         // GIVEN
         var firedEventName: String?
@@ -369,7 +370,8 @@ final class AIChatContextualModePixelHandlerTests {
         #expect(featureDiscovery.wasSetWasUsedBeforeCalled(for: .duckAIPrompt))
     }
 
-    @Test("Returning-user prompt submission omits first_prompt_new_install")
+    @available(iOS 16, macOS 13, *)
+    @Test("Returning-user prompt submission omits first_prompt_new_install", .timeLimit(.minutes(1)))
     func testReturningUserPromptSubmissionOmitsFirstPromptParam() {
         // GIVEN
         var firedParameters: [String: String]?

--- a/iOS/DuckDuckGoTests/AIChat/AIChatPixelMetricHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatPixelMetricHandlerTests.swift
@@ -18,6 +18,7 @@
 //
 
 import XCTest
+import BrowserServicesKitTestsUtils
 @testable import Core
 @testable import DuckDuckGo
 import AIChat
@@ -30,6 +31,13 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
         handler = nil
         PixelFiringMock.tearDown()
         super.tearDown()
+    }
+
+    /// A user who has already submitted a Duck.ai prompt, so no first_prompt param is added.
+    private static func returningUserFeatureDiscovery() -> MockFeatureDiscovery {
+        let featureDiscovery = MockFeatureDiscovery()
+        featureDiscovery.setReturnValue(true, for: .duckAIPrompt)
+        return featureDiscovery
     }
 
     // MARK: - Initialization Tests
@@ -99,7 +107,9 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
 
     func testFirePixelWithMetricForKnownMetric() {
         // Given
-        handler = AIChatPixelMetricHandler(timeElapsedInMinutes: nil, pixelFiring: PixelFiringMock.self)
+        handler = AIChatPixelMetricHandler(timeElapsedInMinutes: nil,
+                                           pixelFiring: PixelFiringMock.self,
+                                           featureDiscovery: Self.returningUserFeatureDiscovery())
         let metric = AIChatMetric(metricName: .userDidSubmitPrompt)
 
         // When
@@ -114,7 +124,9 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
     func testFirePixelWithMetricForKnownMetricWithTimeElapsed() {
         // Given
         let timeElapsed = 15
-        handler = AIChatPixelMetricHandler(timeElapsedInMinutes: timeElapsed, pixelFiring: PixelFiringMock.self)
+        handler = AIChatPixelMetricHandler(timeElapsedInMinutes: timeElapsed,
+                                           pixelFiring: PixelFiringMock.self,
+                                           featureDiscovery: Self.returningUserFeatureDiscovery())
         let metric = AIChatMetric(metricName: .userDidSubmitFirstPrompt)
 
         // When
@@ -128,7 +140,9 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
 
     func testFirePixelWithMetricForAllKnownMetrics() {
         // Given
-        handler = AIChatPixelMetricHandler(timeElapsedInMinutes: nil, pixelFiring: PixelFiringMock.self)
+        handler = AIChatPixelMetricHandler(timeElapsedInMinutes: nil,
+                                           pixelFiring: PixelFiringMock.self,
+                                           featureDiscovery: Self.returningUserFeatureDiscovery())
         let testCases: [(AIChatMetricName, Pixel.Event)] = [
             (.userDidSubmitPrompt, .aiChatMetricSentPromptOngoingChat),
             (.userDidSubmitFirstPrompt, .aiChatMetricStartNewConversation),
@@ -161,6 +175,52 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
         XCTAssertEqual(PixelFiringMock.allPixelsFired.count, 1)
         XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.aiChatMetricDuckAIKeyboardReturnPressed.name)
         XCTAssertTrue(PixelFiringMock.lastParams?.isEmpty ?? false)
+    }
+
+    // MARK: - First prompt
+
+    func testWhenFirstEverPromptReportedByFrontendThenFirstPromptParamIsTrueAndFlagIsMarked() {
+        // Given
+        let featureDiscovery = MockFeatureDiscovery()
+        handler = AIChatPixelMetricHandler(timeElapsedInMinutes: nil,
+                                           pixelFiring: PixelFiringMock.self,
+                                           featureDiscovery: featureDiscovery)
+
+        // When
+        handler.firePixelWithMetric(AIChatMetric(metricName: .userDidSubmitPrompt))
+
+        // Then
+        XCTAssertEqual(PixelFiringMock.lastParams?["first_prompt"], "true")
+        XCTAssertTrue(featureDiscovery.wasSetWasUsedBeforeCalled(for: .duckAIPrompt))
+    }
+
+    func testWhenReturningUserSubmitsPromptThenFirstPromptParamIsOmitted() {
+        // Given
+        let featureDiscovery = Self.returningUserFeatureDiscovery()
+        handler = AIChatPixelMetricHandler(timeElapsedInMinutes: nil,
+                                           pixelFiring: PixelFiringMock.self,
+                                           featureDiscovery: featureDiscovery)
+
+        // When
+        handler.firePixelWithMetric(AIChatMetric(metricName: .userDidSubmitFirstPrompt))
+
+        // Then
+        XCTAssertNil(PixelFiringMock.lastParams?["first_prompt"])
+    }
+
+    func testWhenNonPromptMetricFiresThenFirstPromptFlagIsUntouched() {
+        // Given
+        let featureDiscovery = MockFeatureDiscovery()
+        handler = AIChatPixelMetricHandler(timeElapsedInMinutes: nil,
+                                           pixelFiring: PixelFiringMock.self,
+                                           featureDiscovery: featureDiscovery)
+
+        // When
+        handler.firePixelWithMetric(AIChatMetric(metricName: .userDidOpenHistory))
+
+        // Then
+        XCTAssertNil(PixelFiringMock.lastParams?["first_prompt"])
+        XCTAssertFalse(featureDiscovery.wasSetWasUsedBeforeCalled(for: .duckAIPrompt))
     }
 
     func testFirePixelWithMetricForUnknownMetricDoesNothing() {
@@ -244,7 +304,9 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
     func testMultiplePixelFiresWithConsistentParameters() {
         // Given
         let timeElapsed = 20
-        handler = AIChatPixelMetricHandler(timeElapsedInMinutes: timeElapsed, pixelFiring: PixelFiringMock.self)
+        handler = AIChatPixelMetricHandler(timeElapsedInMinutes: timeElapsed,
+                                           pixelFiring: PixelFiringMock.self,
+                                           featureDiscovery: Self.returningUserFeatureDiscovery())
 
         // When
         handler.fireOpenAIChat()

--- a/iOS/DuckDuckGoTests/AIChat/AIChatPixelMetricHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatPixelMetricHandlerTests.swift
@@ -33,7 +33,7 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
         super.tearDown()
     }
 
-    /// A user who has already submitted a Duck.ai prompt, so no first_prompt param is added.
+    /// A user who has already submitted a Duck.ai prompt, so no first_prompt_new_install param is added.
     private static func returningUserFeatureDiscovery() -> MockFeatureDiscovery {
         let featureDiscovery = MockFeatureDiscovery()
         featureDiscovery.setReturnValue(true, for: .duckAIPrompt)
@@ -190,7 +190,7 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
         handler.firePixelWithMetric(AIChatMetric(metricName: .userDidSubmitPrompt))
 
         // Then
-        XCTAssertEqual(PixelFiringMock.lastParams?["first_prompt"], "true")
+        XCTAssertEqual(PixelFiringMock.lastParams?["first_prompt_new_install"], "true")
         XCTAssertTrue(featureDiscovery.wasSetWasUsedBeforeCalled(for: .duckAIPrompt))
     }
 
@@ -205,7 +205,7 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
         handler.firePixelWithMetric(AIChatMetric(metricName: .userDidSubmitFirstPrompt))
 
         // Then
-        XCTAssertNil(PixelFiringMock.lastParams?["first_prompt"])
+        XCTAssertNil(PixelFiringMock.lastParams?["first_prompt_new_install"])
     }
 
     func testWhenNonPromptMetricFiresThenFirstPromptFlagIsUntouched() {
@@ -219,7 +219,7 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
         handler.firePixelWithMetric(AIChatMetric(metricName: .userDidOpenHistory))
 
         // Then
-        XCTAssertNil(PixelFiringMock.lastParams?["first_prompt"])
+        XCTAssertNil(PixelFiringMock.lastParams?["first_prompt_new_install"])
         XCTAssertFalse(featureDiscovery.wasSetWasUsedBeforeCalled(for: .duckAIPrompt))
     }
 

--- a/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
@@ -337,6 +337,36 @@ struct PostIdleSessionInstrumentationTests {
     }
 
     @available(iOS 16, *)
+    @Test("sessionEnded stores the prompt origin for an AI prompt submission", .timeLimit(.minutes(1)))
+    func sessionEndedStoresPromptOriginForAIPromptSubmission() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(landedOn: .ntp, afterIdleSurface: nil, focused: false)
+        sut.sessionEnded(reason: .aiPromptSubmitted, promptOrigin: .addressBarPrompt)
+
+        #expect(lastReturnCompletion(wideEvent)?.0.promptOrigin == "address_bar_prompt")
+    }
+
+    @available(iOS 16, *)
+    @Test("sessionEnded ignores the prompt origin for non-prompt reasons", .timeLimit(.minutes(1)))
+    func sessionEndedIgnoresPromptOriginForOtherReasons() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(landedOn: .ntp, afterIdleSurface: nil, focused: false)
+        sut.sessionEnded(reason: .searchSubmitted, promptOrigin: .addressBarPrompt)
+
+        #expect(lastReturnCompletion(wideEvent)?.0.promptOrigin == nil)
+    }
+
+    @available(iOS 16, *)
+    @Test("sessionEnded leaves the prompt origin empty when the caller has none", .timeLimit(.minutes(1)))
+    func sessionEndedLeavesPromptOriginEmptyWhenAbsent() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(landedOn: .ntp, afterIdleSurface: nil, focused: false)
+        sut.sessionEnded(reason: .aiPromptSubmitted)
+
+        #expect(lastReturnCompletion(wideEvent)?.0.promptOrigin == nil)
+    }
+
+    @available(iOS 16, *)
     @Test("The post-idle flow collapses the submission split back onto bar_used", .timeLimit(.minutes(1)))
     func postIdleFlowCollapsesSubmissionsOntoBarUsed() {
         for reason in [ReturnSessionWideEventData.StatusReason.searchSubmitted, .aiPromptSubmitted, .urlSubmitted] {

--- a/iOS/DuckDuckGoTests/ReturnSessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/ReturnSessionWideEventDataTests.swift
@@ -33,7 +33,7 @@ struct ReturnSessionWideEventDataTests {
         #expect(ReturnSessionWideEventData.metadata.pixelName == "return_session")
         #expect(ReturnSessionWideEventData.metadata.featureName == "return-session")
         #expect(ReturnSessionWideEventData.metadata.type == "ios-return-session")
-        #expect(ReturnSessionWideEventData.metadata.version == "1.0.0")
+        #expect(ReturnSessionWideEventData.metadata.version == "1.1.0")
     }
 
     // MARK: - jsonParameters
@@ -48,6 +48,7 @@ struct ReturnSessionWideEventDataTests {
         #expect(params["feature.data.ext.focused"] as? Bool == false)
         #expect(params["feature.data.ext.time_away_ms_bucketed"] == nil)
         #expect(params["feature.data.ext.status_reason"] == nil)
+        #expect(params["feature.data.ext.prompt_origin"] == nil)
         #expect(params["feature.data.ext.session_duration_ms_bucketed"] == nil)
         #expect(params["feature.data.ext.time_to_first_interaction_ms_bucketed"] == nil)
         #expect(params["feature.data.ext.page_engaged"] as? Bool == false)
@@ -99,6 +100,27 @@ struct ReturnSessionWideEventDataTests {
             data.statusReason = reason
             #expect(data.jsonParameters()["feature.data.ext.status_reason"] as? String == reason.rawValue)
         }
+    }
+
+    @available(iOS 16, *)
+    @Test("Prompt origin emits its value when set", .timeLimit(.minutes(1)))
+    func promptOriginEmitsWhenSet() {
+        let data = ReturnSessionWideEventData(landedOn: .ntp, afterIdle: true)
+        data.statusReason = .aiPromptSubmitted
+        data.promptOrigin = AIChatEntryPointSource.addressBarPrompt.rawValue
+
+        let params = data.jsonParameters()
+        #expect(params["feature.data.ext.status_reason"] as? String == "ai_prompt_submitted")
+        #expect(params["feature.data.ext.prompt_origin"] as? String == "address_bar_prompt")
+    }
+
+    @available(iOS 16, *)
+    @Test("Prompt origin is absent when nil", .timeLimit(.minutes(1)))
+    func promptOriginAbsentWhenNil() {
+        let data = ReturnSessionWideEventData(landedOn: .ntp, afterIdle: true)
+        data.statusReason = .searchSubmitted
+
+        #expect(data.jsonParameters()["feature.data.ext.prompt_origin"] == nil)
     }
 
     @available(iOS 16, *)
@@ -192,6 +214,7 @@ struct ReturnSessionWideEventDataTests {
                                                   timeAwayMs: 120_000,
                                                   focused: true)
         original.statusReason = .returnToPageTapped
+        original.promptOrigin = AIChatEntryPointSource.voice.rawValue
         original.sessionInterval.end = start.addingTimeInterval(5)
         original.firstInteractionInterval.end = start.addingTimeInterval(1)
         original.pageEngaged = true
@@ -209,6 +232,7 @@ struct ReturnSessionWideEventDataTests {
         #expect(decoded.timeAwayMs == 120_000)
         #expect(decoded.focused == true)
         #expect(decoded.statusReason == .returnToPageTapped)
+        #expect(decoded.promptOrigin == AIChatEntryPointSource.voice.rawValue)
         #expect(decoded.sessionInterval.start == start)
         #expect(decoded.sessionInterval.end == start.addingTimeInterval(5))
         #expect(decoded.firstInteractionInterval.start == start)

--- a/iOS/DuckDuckGoTests/SwitchBar/SwitchBarSubmissionMetricsTests.swift
+++ b/iOS/DuckDuckGoTests/SwitchBar/SwitchBarSubmissionMetricsTests.swift
@@ -142,11 +142,22 @@ final class SwitchBarSubmissionMetricsTests: XCTestCase {
     func testAIChatSubmissionCallsSetWasUsedBefore() {
         let mockFeatureDiscovery = MockFeatureDiscovery()
         let metrics = SwitchBarSubmissionMetrics(featureDiscovery: mockFeatureDiscovery)
-        
+
         metrics.process("test prompt", for: .aiChat)
-        
+
         XCTAssertTrue(mockFeatureDiscovery.wasSetWasUsedBeforeCalled(for: .aiChat))
         XCTAssertEqual(mockFeatureDiscovery.setWasUsedBeforeCallCount, 1)
+    }
+
+    /// The UTI coordinator fires more pixels for the same submission after this one, so the
+    /// first-prompt flag must be marked by the submission flow's owner, never in here.
+    func testAIChatSubmissionDoesNotMarkFirstDuckAIPrompt() {
+        let mockFeatureDiscovery = MockFeatureDiscovery()
+        let metrics = SwitchBarSubmissionMetrics(featureDiscovery: mockFeatureDiscovery)
+
+        metrics.process("test prompt", for: .aiChat)
+
+        XCTAssertFalse(mockFeatureDiscovery.wasSetWasUsedBeforeCalled(for: .duckAIPrompt))
     }
     
     func testSearchSubmissionDoesNotCallSetWasUsedBefore() {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIPixelReporterTests.swift
@@ -122,7 +122,8 @@ final class UTIPixelReporterTests: XCTestCase {
                                        attachments: [],
                                        reasoningMode: nil,
                                        modelId: "gpt-x",
-                                       defaultOmnibarMode: .search)
+                                       defaultOmnibarMode: .search,
+                                       isFirstEverPrompt: false)
 
         XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.pixelName, Pixel.Event.unifiedToggleInputPromptSubmitted.name)
         XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params, [
@@ -139,6 +140,20 @@ final class UTIPixelReporterTests: XCTestCase {
         ])
     }
 
+    func testWhenFirstEverPromptSubmittedThenFirstPromptParamIsTrue() {
+        let reporter = makeReporter { self.context(surface: .addressBar, pageType: .ntp) }
+
+        reporter.reportPromptSubmitted(hasText: true,
+                                       selectedTool: nil,
+                                       attachments: [],
+                                       reasoningMode: nil,
+                                       modelId: nil,
+                                       defaultOmnibarMode: .search,
+                                       isFirstEverPrompt: true)
+
+        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params?["first_prompt"], "true")
+    }
+
     func testWhenPromptSubmittedFromAddressBarThenOriginIsAddressBarPrompt() {
         let reporter = makeReporter { self.context(surface: .addressBar, pageType: .serp) }
 
@@ -147,7 +162,8 @@ final class UTIPixelReporterTests: XCTestCase {
                                        attachments: [],
                                        reasoningMode: nil,
                                        modelId: nil,
-                                       defaultOmnibarMode: .lastUsed)
+                                       defaultOmnibarMode: .lastUsed,
+                                       isFirstEverPrompt: false)
 
         XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params?["origin"], "address_bar_prompt")
         XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params?["page_type"], "serp")
@@ -161,7 +177,8 @@ final class UTIPixelReporterTests: XCTestCase {
                                        attachments: [],
                                        reasoningMode: nil,
                                        modelId: nil,
-                                       defaultOmnibarMode: .lastUsed)
+                                       defaultOmnibarMode: .lastUsed,
+                                       isFirstEverPrompt: false)
 
         XCTAssertNil(PixelFiringMock.lastDailyPixelInfo?.params?["origin"])
     }
@@ -201,7 +218,8 @@ final class UTIPixelReporterTests: XCTestCase {
                                        attachments: [],
                                        reasoningMode: nil,
                                        modelId: nil,
-                                       defaultOmnibarMode: .search)
+                                       defaultOmnibarMode: .search,
+                                       isFirstEverPrompt: false)
         let promptParams = PixelFiringMock.lastDailyPixelInfo?.params ?? [:]
 
         for key in ["surface", "page_type", "default_mode"] {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIPixelReporterTests.swift
@@ -18,7 +18,9 @@
 //
 
 import AIChat
+import BrowserServicesKitTestsUtils
 import Core
+import Persistence
 @_spi(Testing) import PixelKit
 import XCTest
 @testable import DuckDuckGo
@@ -123,7 +125,7 @@ final class UTIPixelReporterTests: XCTestCase {
                                        reasoningMode: nil,
                                        modelId: "gpt-x",
                                        defaultOmnibarMode: .search,
-                                       isFirstEverPrompt: false)
+                                       isFirstPromptNewInstall: false)
 
         XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.pixelName, Pixel.Event.unifiedToggleInputPromptSubmitted.name)
         XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params, [
@@ -140,7 +142,7 @@ final class UTIPixelReporterTests: XCTestCase {
         ])
     }
 
-    func testWhenFirstEverPromptSubmittedThenFirstPromptParamIsTrue() {
+    func testWhenFirstPromptOnNewInstallSubmittedThenParamIsTrue() {
         let reporter = makeReporter { self.context(surface: .addressBar, pageType: .ntp) }
 
         reporter.reportPromptSubmitted(hasText: true,
@@ -149,9 +151,9 @@ final class UTIPixelReporterTests: XCTestCase {
                                        reasoningMode: nil,
                                        modelId: nil,
                                        defaultOmnibarMode: .search,
-                                       isFirstEverPrompt: true)
+                                       isFirstPromptNewInstall: true)
 
-        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params?["first_prompt"], "true")
+        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params?["first_prompt_new_install"], "true")
     }
 
     func testWhenPromptSubmittedFromAddressBarThenOriginIsAddressBarPrompt() {
@@ -163,7 +165,7 @@ final class UTIPixelReporterTests: XCTestCase {
                                        reasoningMode: nil,
                                        modelId: nil,
                                        defaultOmnibarMode: .lastUsed,
-                                       isFirstEverPrompt: false)
+                                       isFirstPromptNewInstall: false)
 
         XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params?["origin"], "address_bar_prompt")
         XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params?["page_type"], "serp")
@@ -178,7 +180,7 @@ final class UTIPixelReporterTests: XCTestCase {
                                        reasoningMode: nil,
                                        modelId: nil,
                                        defaultOmnibarMode: .lastUsed,
-                                       isFirstEverPrompt: false)
+                                       isFirstPromptNewInstall: false)
 
         XCTAssertNil(PixelFiringMock.lastDailyPixelInfo?.params?["origin"])
     }
@@ -219,7 +221,7 @@ final class UTIPixelReporterTests: XCTestCase {
                                        reasoningMode: nil,
                                        modelId: nil,
                                        defaultOmnibarMode: .search,
-                                       isFirstEverPrompt: false)
+                                       isFirstPromptNewInstall: false)
         let promptParams = PixelFiringMock.lastDailyPixelInfo?.params ?? [:]
 
         for key in ["surface", "page_type", "default_mode"] {
@@ -312,4 +314,63 @@ final class UTIPixelReporterTests: XCTestCase {
         XCTAssertNil(PixelFiringMock.lastPixelInfo)
         XCTAssertNil(PixelFiringMock.lastDailyPixelInfo)
     }
+}
+
+final class DuckAIFirstPromptNewInstallCohortTests: XCTestCase {
+
+    private var featureDiscovery: MockFeatureDiscovery!
+    private var statisticsStore: MockStatisticsStore!
+    private var marker: MockKeyValueStore!
+
+    override func setUp() {
+        super.setUp()
+        featureDiscovery = MockFeatureDiscovery()
+        statisticsStore = MockStatisticsStore()
+        marker = MockKeyValueStore()
+    }
+
+    override func tearDown() {
+        featureDiscovery = nil
+        statisticsStore = nil
+        marker = nil
+        super.tearDown()
+    }
+
+    private func assignCohort() {
+        DuckAIFirstPromptNewInstallCohort.assignIfNeeded(statisticsStore: statisticsStore,
+                                                         featureDiscovery: featureDiscovery,
+                                                         marker: marker)
+    }
+
+    func testWhenInstallHasStatisticsThenExistingInstallIsMarkedAsPrompted() {
+        statisticsStore.atb = "v456-7"
+
+        assignCohort()
+
+        XCTAssertTrue(featureDiscovery.wasSetWasUsedBeforeCalled(for: .duckAIPrompt))
+    }
+
+    func testWhenBrandNewInstallThenFlagStaysUnset() {
+        assignCohort()
+
+        XCTAssertFalse(featureDiscovery.wasSetWasUsedBeforeCalled(for: .duckAIPrompt))
+    }
+
+    /// A new install's second launch has install statistics; only the marker keeps it in the cohort.
+    func testWhenCohortAlreadyAssignedThenLaterLaunchesWithStatisticsDoNotMark() {
+        assignCohort()
+        statisticsStore.atb = "v456-7"
+
+        assignCohort()
+
+        XCTAssertFalse(featureDiscovery.wasSetWasUsedBeforeCalled(for: .duckAIPrompt))
+    }
+}
+
+private final class MockKeyValueStore: KeyValueStoring {
+    private var storage: [String: Any] = [:]
+
+    func object(forKey key: String) -> Any? { storage[key] }
+    func set(_ value: Any?, forKey key: String) { storage[key] = value }
+    func removeObject(forKey key: String) { storage.removeValue(forKey: key) }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -18,6 +18,8 @@
 //
 
 import AIChat
+import BrowserServicesKit
+import BrowserServicesKitTestsUtils
 import Combine
 import Core
 import UIKit
@@ -34,6 +36,7 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
     private var mockPreferences: MockAIChatPreferences!
     private var mockToggleModeStorage: MockToggleModeStorage!
     private var mockSubmissionMetrics: MockSwitchBarSubmissionMetrics!
+    private var mockFeatureDiscovery: MockFeatureDiscovery!
     private var retainedBridgeReadyWebView: WKWebView?
     private var retainedBridgeReadyBroker: UserScriptMessageBroker?
     private var cancellables = Set<AnyCancellable>()
@@ -43,12 +46,14 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         mockPreferences = MockAIChatPreferences()
         mockToggleModeStorage = MockToggleModeStorage()
         mockSubmissionMetrics = MockSwitchBarSubmissionMetrics()
+        mockFeatureDiscovery = MockFeatureDiscovery()
         sut = UnifiedToggleInputCoordinator(
             host: .omnibar,
             isToggleEnabled: true,
             preferences: mockPreferences,
             toggleModeStorage: mockToggleModeStorage,
             switchBarSubmissionMetrics: mockSubmissionMetrics,
+            featureDiscovery: mockFeatureDiscovery,
             updatedModelPickerFeature: MockUpdatedModelPickerFeature(isAvailable: false)
         )
         mockDelegate = MockUnifiedToggleInputDelegate()
@@ -62,6 +67,7 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         mockPreferences = nil
         mockToggleModeStorage = nil
         mockSubmissionMetrics = nil
+        mockFeatureDiscovery = nil
         retainedBridgeReadyWebView = nil
         retainedBridgeReadyBroker = nil
         super.tearDown()
@@ -636,6 +642,32 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         sut.unifiedToggleInputVC(sut.viewController, didChangeText: "hello")
         sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "hello", mode: .aiChat)
         XCTAssertEqual(sut.textState, .empty)
+    }
+
+    // MARK: - VC Delegate: Submit — first-prompt flag
+
+    func test_submitAIChat_marksFirstDuckAIPromptSubmitted() {
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "hello", mode: .aiChat)
+        XCTAssertTrue(mockFeatureDiscovery.wasSetWasUsedBeforeCalled(for: .duckAIPrompt))
+    }
+
+    /// Every pixel of the submission must read the pre-submission state, so the mark
+    /// may only land after the prompt has been delivered.
+    func test_submitAIChat_marksFirstPromptOnlyAfterDelivery() {
+        var markedAtDeliveryTime: Bool?
+        mockDelegate.onPromptSubmit = { [mockFeatureDiscovery] in
+            markedAtDeliveryTime = mockFeatureDiscovery?.wasSetWasUsedBeforeCalled(for: .duckAIPrompt)
+        }
+
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "hello", mode: .aiChat)
+
+        XCTAssertEqual(markedAtDeliveryTime, false)
+        XCTAssertTrue(mockFeatureDiscovery.wasSetWasUsedBeforeCalled(for: .duckAIPrompt))
+    }
+
+    func test_submitSearch_doesNotMarkFirstDuckAIPrompt() {
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "ducks", mode: .search)
+        XCTAssertFalse(mockFeatureDiscovery.wasSetWasUsedBeforeCalled(for: .duckAIPrompt))
     }
 
     func test_submitProgrammatic_contextualNoBoundScript_passesAttachmentsBeforeClearing() {

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_contextual_mode.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_contextual_mode.json5
@@ -95,14 +95,14 @@
         "owners": ["aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion", "aichat_first_prompt"]
+        "parameters": ["appVersion", "aichat_first_prompt_new_install"]
     },
     "m_aichat_contextual_prompt_submitted_without_context_native": {
         "description": "Fired when the user submits a prompt without page context via the native input",
         "owners": ["aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion", "aichat_first_prompt"]
+        "parameters": ["appVersion", "aichat_first_prompt_new_install"]
     },
     "m_aichat_contextual_session_restored": {
         "description": "Fired when an AI Chat contextual session is restored after a cold start",

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_contextual_mode.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_contextual_mode.json5
@@ -95,14 +95,14 @@
         "owners": ["aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "aichat_first_prompt"]
     },
     "m_aichat_contextual_prompt_submitted_without_context_native": {
         "description": "Fired when the user submits a prompt without page context via the native input",
         "owners": ["aataraxiaa"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "aichat_first_prompt"]
     },
     "m_aichat_contextual_session_restored": {
         "description": "Fired when an AI Chat contextual session is restored after a cold start",

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_ipad_toggle.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_ipad_toggle.json5
@@ -5,7 +5,7 @@
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "aichat_first_prompt"]
     },
     "m_aichat_ipad_toggle_url_submitted": {
         "description": "Fires when user submits a URL from the iPad Duck.ai toggle",

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_ipad_toggle.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_ipad_toggle.json5
@@ -5,7 +5,7 @@
         "owners": ["Bunn"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion", "aichat_first_prompt"]
+        "parameters": ["appVersion", "aichat_first_prompt_new_install"]
     },
     "m_aichat_ipad_toggle_url_submitted": {
         "description": "Fires when user submits a URL from the iPad Duck.ai toggle",

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -398,7 +398,7 @@
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": [
             "appVersion",
-            "aichat_first_prompt",
+            "aichat_first_prompt_new_install",
             "unified_input_page_type",
             {
                 "key": "default_mode",

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -398,6 +398,7 @@
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": [
             "appVersion",
+            "aichat_first_prompt",
             "unified_input_page_type",
             {
                 "key": "default_mode",

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_frontend_metrics.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_frontend_metrics.json5
@@ -1,0 +1,35 @@
+// Duck.ai frontend-reported prompt submission metrics. The duck.ai page reports these via
+// reportMetric; native maps them to pixels in AIChatPixelMetricHandler. Defined here (the pixels
+// themselves predate pixel definitions) because they now carry the first_prompt parameter.
+{
+    "m_aichat_sent_prompt_ongoing_chat": {
+        "description": "Fires when the duck.ai frontend reports a prompt submission in an ongoing chat (the frontend's userDidSubmitPrompt metric). Covers submissions made directly in the page composer, which fire no native prompt-submission pixel.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "aichat_first_prompt",
+            {
+                "key": "delta-timestamp-minutes",
+                "type": "integer",
+                "description": "Minutes elapsed since the Duck.ai session started. Absent when no session timer is available."
+            }
+        ]
+    },
+    "m_aichat_start_new_conversation": {
+        "description": "Fires when the duck.ai frontend reports the first prompt of a new conversation (the frontend's userDidSubmitFirstPrompt metric). Covers submissions made directly in the page composer, which fire no native prompt-submission pixel.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "aichat_first_prompt",
+            {
+                "key": "delta-timestamp-minutes",
+                "type": "integer",
+                "description": "Minutes elapsed since the Duck.ai session started. Absent when no session timer is available."
+            }
+        ]
+    }
+}

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_frontend_metrics.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_frontend_metrics.json5
@@ -9,7 +9,7 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
-            "aichat_first_prompt",
+            "aichat_first_prompt_new_install",
             {
                 "key": "delta-timestamp-minutes",
                 "type": "integer",
@@ -24,7 +24,7 @@
         "suffixes": ["platform", "form_factor"],
         "parameters": [
             "appVersion",
-            "aichat_first_prompt",
+            "aichat_first_prompt_new_install",
             {
                 "key": "delta-timestamp-minutes",
                 "type": "integer",

--- a/iOS/PixelDefinitions/pixels/definitions/experimental_omnibar_metrics.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/experimental_omnibar_metrics.json5
@@ -27,7 +27,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
-            "aichat_first_prompt",
+            "aichat_first_prompt_new_install",
             {
                 "key": "was_used_before",
                 "description": "Indicates if AI Chat was used before this submission: 1=returning user, 0=first-time user",

--- a/iOS/PixelDefinitions/pixels/definitions/experimental_omnibar_metrics.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/experimental_omnibar_metrics.json5
@@ -27,6 +27,7 @@
         "parameters": [
             "appVersion",
             "pixelSource",
+            "aichat_first_prompt",
             {
                 "key": "was_used_before",
                 "description": "Indicates if AI Chat was used before this submission: 1=returning user, 0=first-time user",

--- a/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
@@ -73,6 +73,38 @@
                 ]
             },
             {
+                "key": "feature.data.ext.prompt_origin",
+                "type": "string",
+                "description": "What triggered the Duck.ai prompt submission that ended the session, as an m_aichat_entry_point source value. Present only when status_reason is ai_prompt_submitted.",
+                "enum": [
+                    "address_bar_prompt",
+                    "address_bar_icon",
+                    "address_bar_shortcut_chip",
+                    "address_bar_editing_state",
+                    "suggestion_ask_ai",
+                    "ipad_toggle_prompt",
+                    "browsing_menu_ntp",
+                    "browsing_menu_webpage",
+                    "tab_switcher",
+                    "tabs_bar_button",
+                    "chat_history_new_chat",
+                    "chat_history_open_chat",
+                    "voice",
+                    "onboarding",
+                    "direct_url",
+                    "serp",
+                    "icon_shortcut",
+                    "contextual_chat",
+                    "widget_quick_actions",
+                    "widget_quick_actions_medium",
+                    "widget_favorite",
+                    "widget_lock_screen",
+                    "widget_control_center",
+                    "siri",
+                    "deep_link_other"
+                ]
+            },
+            {
                 "key": "feature.data.ext.session_duration_ms_bucketed",
                 "type": "string",
                 "description": "Duration from session start to session end, bucketed (lower end of bucket, in ms)",

--- a/iOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/iOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -21,6 +21,11 @@
         "description": "The Unified Toggle Input surface the pixel was fired from, distinguishing the contextual chat sheet from the Duck.ai tab and the address bar.",
         "enum": ["address_bar", "duck_ai", "contextual_chat"]
     },
+    "aichat_first_prompt": {
+        "key": "first_prompt",
+        "type": "boolean",
+        "description": "Present (true) only when this submission is the user's first ever Duck.ai prompt on this install. Omitted on every later submission. For installs that predate the parameter, the first submission after updating also reports true, so filter to new-install cohorts when analysing."
+    },
     "unified_input_page_type": {
         "key": "page_type",
         "type": "string",

--- a/iOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/iOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -21,10 +21,10 @@
         "description": "The Unified Toggle Input surface the pixel was fired from, distinguishing the contextual chat sheet from the Duck.ai tab and the address bar.",
         "enum": ["address_bar", "duck_ai", "contextual_chat"]
     },
-    "aichat_first_prompt": {
-        "key": "first_prompt",
+    "aichat_first_prompt_new_install": {
+        "key": "first_prompt_new_install",
         "type": "boolean",
-        "description": "Present (true) only when this submission is the user's first ever Duck.ai prompt on this install. Omitted on every later submission. For installs that predate the parameter, the first submission after updating also reports true, so filter to new-install cohorts when analysing."
+        "description": "Present (true) only when this submission is the first Duck.ai prompt ever submitted on a brand-new install. Omitted on every later submission. Installs that predate this parameter are excluded at launch (their existing install statistics pre-mark the flag), so updating users never report it."
     },
     "unified_input_page_type": {
         "key": "page_type",

--- a/iOS/PixelDefinitions/wide_events/definitions/return-session.json5
+++ b/iOS/PixelDefinitions/wide_events/definitions/return-session.json5
@@ -4,7 +4,7 @@
         "owners": ["Bunn", "SabrinaTardio"],
         "meta": {
             "type": "ios-return-session",
-            "version": "0.0"
+            "version": "1.0"
         },
         "feature": {
             "name": "return-session",
@@ -42,6 +42,37 @@
                             "favorite_selected",
                             "chat_selected",
                             "app_terminated"
+                        ]
+                    },
+                    "prompt_origin": {
+                        "type": "string",
+                        "description": "What triggered the Duck.ai prompt submission that ended the session, as an m_aichat_entry_point source value. Present only when status_reason is ai_prompt_submitted; absent otherwise.",
+                        "enum": [
+                            "address_bar_prompt",
+                            "address_bar_icon",
+                            "address_bar_shortcut_chip",
+                            "address_bar_editing_state",
+                            "suggestion_ask_ai",
+                            "ipad_toggle_prompt",
+                            "browsing_menu_ntp",
+                            "browsing_menu_webpage",
+                            "tab_switcher",
+                            "tabs_bar_button",
+                            "chat_history_new_chat",
+                            "chat_history_open_chat",
+                            "voice",
+                            "onboarding",
+                            "direct_url",
+                            "serp",
+                            "icon_shortcut",
+                            "contextual_chat",
+                            "widget_quick_actions",
+                            "widget_quick_actions_medium",
+                            "widget_favorite",
+                            "widget_lock_screen",
+                            "widget_control_center",
+                            "siri",
+                            "deep_link_other"
                         ]
                     },
                     "session_duration_ms_bucketed": {

--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-return-session-1.1.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-return-session-1.1.0.json
@@ -1,0 +1,168 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Sent at the end of a return session: every return to the app, whether it got an after-idle treatment (the NTP or LUT shown once the After Inactivity threshold elapses) or was an ordinary return. Captures where the user landed, what they did there, and how the session ended. `ios-post-idle-session` stays scoped to after-idle returns and runs alongside this event.",
+    "$comment": "{\"owners\":[\"Bunn\",\"SabrinaTardio\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "ios-return-session" }, "version": { "const": "1.1.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application",
+                    "enum": ["DuckDuckGo", "DuckDuckGo-Alpha", "DuckDuckGo-Experimental", "PacketTunnelProvider"]
+                },
+                "version": { "type": "string", "description": "The version of the application", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+                "form_factor": { "type": "string", "description": "The form factor of the device", "enum": ["phone", "tablet"] }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["iOS"] },
+                "type": { "type": "string", "description": "The type of application", "enum": ["app"] },
+                "sample_rate": { "type": "number", "description": "Sample rate for this event", "minimum": 0, "maximum": 1 },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first occurrence of this event today. Only included when true."
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["return-session"] },
+                "status": {
+                    "type": "string",
+                    "description": "The overall status of the operation",
+                    "enum": ["SUCCESS", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "after_idle": {
+                                    "type": "boolean",
+                                    "description": "True when the session was started by an after-idle treatment; false for an ordinary return. Filtering after_idle=true gives the population `ios-post-idle-session` reports on."
+                                },
+                                "landed_on": {
+                                    "type": "string",
+                                    "description": "What the user actually landed on: the after-idle NTP, an NTP reached without the treatment, or the resumed tab's content type",
+                                    "enum": ["ntp", "ntp_user_initiated", "web", "serp", "duck_ai"]
+                                },
+                                "focused": {
+                                    "type": "boolean",
+                                    "description": "True when the landing surface appeared with the address bar focused (keyboard up)"
+                                },
+                                "time_away_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time the app spent in the background before this return, bucketed (lower end of bucket, in ms). Absent when there was no prior background date.",
+                                    "enum": ["0", "60000", "300000", "900000", "1800000", "3600000"]
+                                },
+                                "status_reason": {
+                                    "type": "string",
+                                    "description": "Terminal reason describing how the session ended. SUCCESS uses one of the user-action reasons; CANCELLED uses app_backgrounded; UNKNOWN uses app_terminated when an in-flight session is recovered after an app crash or termination. The three submission reasons are what `ios-post-idle-session` reports as a single bar_used.",
+                                    "enum": [
+                                        "search_submitted",
+                                        "ai_prompt_submitted",
+                                        "url_submitted",
+                                        "return_to_page_tapped",
+                                        "tab_switcher_selected",
+                                        "app_backgrounded",
+                                        "favorite_selected",
+                                        "chat_selected",
+                                        "app_terminated"
+                                    ]
+                                },
+                                "prompt_origin": {
+                                    "type": "string",
+                                    "description": "What triggered the Duck.ai prompt submission that ended the session, as an m_aichat_entry_point source value. Present only when status_reason is ai_prompt_submitted; absent otherwise.",
+                                    "enum": [
+                                        "address_bar_prompt",
+                                        "address_bar_icon",
+                                        "address_bar_shortcut_chip",
+                                        "address_bar_editing_state",
+                                        "suggestion_ask_ai",
+                                        "ipad_toggle_prompt",
+                                        "browsing_menu_ntp",
+                                        "browsing_menu_webpage",
+                                        "tab_switcher",
+                                        "tabs_bar_button",
+                                        "chat_history_new_chat",
+                                        "chat_history_open_chat",
+                                        "voice",
+                                        "onboarding",
+                                        "direct_url",
+                                        "serp",
+                                        "icon_shortcut",
+                                        "contextual_chat",
+                                        "widget_quick_actions",
+                                        "widget_quick_actions_medium",
+                                        "widget_favorite",
+                                        "widget_lock_screen",
+                                        "widget_control_center",
+                                        "siri",
+                                        "deep_link_other"
+                                    ]
+                                },
+                                "session_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Total time the landing surface was visible, from session start until the terminal action or background, bucketed (lower end of bucket, in ms). Absent when the session was orphaned (UNKNOWN / app_terminated).",
+                                    "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "time_to_first_interaction_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from session start to the first user interaction with the landing surface (page engagement, toggle, back, or terminal action), bucketed (lower end of bucket, in ms). Absent if the session ended without any interaction.",
+                                    "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "page_engaged": {
+                                    "type": "boolean",
+                                    "description": "True if the user scrolled or activated an in-page link on the landing surface during the session"
+                                },
+                                "toggle_used": {
+                                    "type": "boolean",
+                                    "description": "True if the user toggled between Search and Duck.ai during the session"
+                                },
+                                "back_pressed": {
+                                    "type": "boolean",
+                                    "description": "True if the user pressed back / cancel from the landing surface during the session"
+                                },
+                                "opening_screen_changed": {
+                                    "type": "boolean",
+                                    "description": "True if the user changed the Opening Screen option from the escape hatch's settings menu during the session"
+                                },
+                                "close_tab_tapped": {
+                                    "type": "boolean",
+                                    "description": "True if the user closed the open tab from the escape hatch's menu during the session"
+                                },
+                                "burn_tab_tapped": {
+                                    "type": "boolean",
+                                    "description": "True if the user burned the open tab from the escape hatch's menu during the session"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1217798276718608?focus=true
Tech Design URL:
CC:

### Description
Adds a `first_prompt_new_install=true` parameter to every Duck.ai prompt-submission pixel when the submission is the first Duck.ai prompt ever submitted on a brand-new install

### Testing Steps
1. On a fresh install, submit a prompt from the unified toggle input and verify `m_aichat_unified_input_prompt_submitted` carries `first_prompt_new_install=true`; submit a second prompt and verify the param is absent.
2. On an upgrade (install statistics present before this build first launches), submit a prompt and verify no prompt-submission pixel carries `first_prompt_new_install`.
3. Background the app past the After Inactivity threshold, return, and submit a Duck.ai prompt as the first action; verify the `m_ios_wide_return_session` payload has `status_reason=ai_prompt_submitted` with a matching `feature.data.ext.prompt_origin`, and that non-prompt terminals omit the field.

### Impact and Risks
Low — measurement-only changes: a new optional parameter on existing pixels and a new optional field on the return-session wide event (schema minor-bumped to 1.1.0); no product behavior changes.

#### What could go wrong?
If the launch-time cohort ran after statistics load, a genuinely new install would be misclassified as existing and never report the parameter — it runs alongside `IdleReturnCohort` before `StatisticsLoader`, with a one-shot marker covering later launches, and unit tests cover both cohorts and the mark ordering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Measurement-only changes to pixels and wide events with no user-facing behavior; main risk is mis-timed cohort assignment misclassifying new installs, which the launch ordering and tests aim to prevent.
> 
> **Overview**
> Adds **install-lifetime measurement** for the first Duck.ai prompt on a **brand-new install**: a `first_prompt_new_install=true` parameter on prompt-submission pixels, backed by a new `duckAIPrompt` feature-discovery flag and launch-time `DuckAIFirstPromptNewInstallCohort` that pre-marks upgrades (install statistics already present before statistics load) so updating users never emit the param.
> 
> **Prompt-submission paths** now read the flag before firing and mark it after pixels for that submission: unified toggle input (including experimental omnibar metrics), contextual native submit, iPad Duck.ai toggle, and frontend-reported metrics in `AIChatPixelMetricHandler`. Mark ordering is explicit so multiple pixels from one submit still see pre-submit state.
> 
> **Return-session wide event** bumps to **1.1.0** with optional `feature.data.ext.prompt_origin` when `status_reason` is `ai_prompt_submitted`. `PostIdleSessionInstrumentation.sessionEnded` accepts `promptOrigin`; `MainViewController` passes `AIChatEntryPointSource` from voice, suggestions, UTI new-tab, and in-place AI loads.
> 
> Pixel definitions and JSON schemas document the new parameter and field; unit tests cover cohort assignment, param presence/absence, and prompt origin wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7622c0a3d1397fa155f32c63d34028cd092608d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->