### PR TITLE
Update contextual Duck.ai maestro flows for the address-bar menu

### DIFF
--- a/.maestro/shared/expand_contextual_uti.yaml
+++ b/.maestro/shared/expand_contextual_uti.yaml
@@ -1,0 +1,12 @@
+appId: com.duckduckgo.mobile.ios
+
+---
+
+# Once a chat is under way the UTI sits collapsed to a single line so the conversation gets the room.
+# Tapping it reveals the row holding the attachment menu and the context chip, so anything asserting
+# those has to expand it first — collapsed, they are absent and an assertNotVisible would pass for
+# the wrong reason. There is no model chip in this state; the model is named in the response header.
+- tapOn:
+    id: "searchEntry"
+- waitForAnimationToEnd:
+    timeout: 3000

--- a/.maestro/shared/open_contextual_duckai_from_address_bar.yaml
+++ b/.maestro/shared/open_contextual_duckai_from_address_bar.yaml
@@ -1,0 +1,15 @@
+appId: com.duckduckgo.mobile.ios
+
+---
+
+# On a web page with no contextual chat to return to, the address-bar Duck.ai button opens a menu
+# instead of a surface: New Chat opens full Duck.ai, Ask About Page opens the floating contextual
+# input with the page already attached. Once a chat exists the button reopens the sheet directly,
+# so this is only for the first contextual entry on a tab.
+- tapOn:
+    id: "Browser.OmniBar.Button.AIChat"
+- assertVisible: "New Chat"
+- assertVisible: "Ask About Page"
+- tapOn: "Ask About Page"
+- waitForAnimationToEnd:
+    timeout: 3000

--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_manual_context_clears_after_navigation.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_manual_context_clears_after_navigation.yaml
@@ -7,9 +7,10 @@ name: test_contextual_immediate_uti_manual_context_clears_after_navigation
 
 ---
 
-# With immediate contextual UTI on and automatic attachment off, manual page context
-# survives same-page sheet reopen, but a pre-submit manual attachment is cleared when
-# the sheet is reopened after navigating to another page.
+# With automatic attachment off, page context on the floating input is only ever there because it was
+# asked for: entry through the menu's Ask About Page attaches it, removing the chip clears it, and the
+# attachment menu puts it back. Navigating to another page and reopening shows the new page, never
+# the previous one.
 
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
@@ -33,34 +34,35 @@ name: test_contextual_immediate_uti_manual_context_clears_after_navigation
 - pressKey: Enter
 - assertVisible: ".*Privacy Test Pages.*"
 
-- tapOn:
-    id: "Browser.OmniBar.Button.AIChat"
-- assertVisible:
+- runFlow:
+    file: ../shared/open_contextual_duckai_from_address_bar.yaml
+
+- assertNotVisible:
     id: "AIChat.ContextualSheet"
+- extendedWaitUntil:
+    visible:
+        id: "AIChat.ContextChip.AttachedTitle"
+    timeout: 10000
+
+# Removing the chip clears the context, and the attachment menu re-attaches the same page.
+- tapOn:
+    id: "AIChat.ContextChip.RemoveButton"
 - assertNotVisible:
     id: "AIChat.ContextChip.AttachedTitle"
+- assertNotVisible:
+    id: "AIChat.ContextChip.Placeholder"
 
 - tapOn: "Attach"
+- assertVisible: "Ask About Page"
 - tapOn: "Ask About Page"
 - extendedWaitUntil:
     visible:
         id: "AIChat.ContextChip.AttachedTitle"
     timeout: 10000
 
-- tapOn:
-    id: "AIChat.ContextualSheet.CloseButton"
-- waitForAnimationToEnd:
-    timeout: 3000
-
+# Tapping the Duck.ai button again dismisses the surface; with no prompt submitted no chat remains.
 - tapOn:
     id: "Browser.OmniBar.Button.AIChat"
-- assertVisible:
-    id: "AIChat.ContextualSheet"
-- assertVisible:
-    id: "AIChat.ContextChip.AttachedTitle"
-
-- tapOn:
-    id: "AIChat.ContextualSheet.CloseButton"
 - waitForAnimationToEnd:
     timeout: 3000
 
@@ -70,17 +72,12 @@ name: test_contextual_immediate_uti_manual_context_clears_after_navigation
 - pressKey: Enter
 - assertVisible: ".*Address Bar Spoofing.*"
 
-- tapOn:
-    id: "Browser.OmniBar.Button.AIChat"
-- assertVisible:
-    id: "AIChat.ContextualSheet"
-- assertNotVisible:
-    id: "AIChat.ContextChip.AttachedTitle"
-
-- tapOn: "Attach"
-- assertVisible: "Ask About Page"
-- tapOn: "Ask About Page"
+# Reopening on the new page attaches that page, not the one left behind.
+- runFlow:
+    file: ../shared/open_contextual_duckai_from_address_bar.yaml
 - extendedWaitUntil:
     visible:
         id: "AIChat.ContextChip.AttachedTitle"
     timeout: 10000
+- assertNotVisible:
+    id: "AIChat.ContextChip.Placeholder"

--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_manual_context_clears_after_post_submit_navigation.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_manual_context_clears_after_post_submit_navigation.yaml
@@ -7,9 +7,9 @@ name: test_contextual_immediate_uti_manual_context_clears_after_post_submit_navi
 
 ---
 
-# With immediate contextual UTI on and automatic attachment off, manually attached
-# page context is cleared when the sheet is closed after first submit, the user
-# navigates to another page, and then reopens contextual Duck.ai.
+# With automatic attachment off, the page attached when entering through the menu's Ask About Page is
+# cleared once the sheet is closed after the first submit, the user navigates elsewhere, and the
+# contextual surface is reopened. Ask About Page is still offered to attach the new page.
 
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
@@ -33,15 +33,11 @@ name: test_contextual_immediate_uti_manual_context_clears_after_post_submit_navi
 - pressKey: Enter
 - assertVisible: ".*Privacy Test Pages.*"
 
-- tapOn:
-    id: "Browser.OmniBar.Button.AIChat"
-- assertVisible:
-    id: "AIChat.ContextualSheet"
-- assertNotVisible:
-    id: "AIChat.ContextChip.AttachedTitle"
+- runFlow:
+    file: ../shared/open_contextual_duckai_from_address_bar.yaml
 
-- tapOn: "Attach"
-- tapOn: "Ask About Page"
+- assertNotVisible:
+    id: "AIChat.ContextualSheet"
 - extendedWaitUntil:
     visible:
         id: "AIChat.ContextChip.AttachedTitle"
@@ -55,6 +51,10 @@ name: test_contextual_immediate_uti_manual_context_clears_after_post_submit_navi
 
 - runFlow:
     file: ../shared/dismiss_chat_open_modals.yaml
+- extendedWaitUntil:
+    visible:
+        id: "AIChat.ContextualSheet"
+    timeout: 15000
 
 - tapOn:
     id: "AIChat.ContextualSheet.CloseButton"
@@ -71,6 +71,8 @@ name: test_contextual_immediate_uti_manual_context_clears_after_post_submit_navi
     id: "Browser.OmniBar.Button.AIChat"
 - assertVisible:
     id: "AIChat.ContextualSheet"
+- runFlow:
+    file: ../shared/expand_contextual_uti.yaml
 - assertNotVisible:
     id: "AIChat.ContextChip.AttachedTitle"
 - assertNotVisible:

--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_context.yaml
@@ -7,11 +7,10 @@ name: test_contextual_immediate_uti_pre_submit_context
 
 ---
 
-# With the immediate contextual UTI flag on, the first sheet show uses UTI before
-# submit. Removing pre-submit context clears the current chip, and a real navigation
-# with auto-attach enabled attaches the current page again. After first submit, a
-# same-page reopen does not reattach; dismissed-sheet navigation still auto-attaches
-# the current page when reopened.
+# Pre-submit context lives on the floating input the address-bar menu opens. Removing the chip clears
+# it, a real navigation attaches the new page again, and the first submit promotes the floating input
+# to the sheet. After that the button reopens the sheet directly: a same-page reopen does not
+# reattach, while reopening after navigating away attaches the current page.
 
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
@@ -36,14 +35,13 @@ name: test_contextual_immediate_uti_pre_submit_context
 - pressKey: Enter
 - assertVisible: ".*Privacy Test Pages.*"
 
-- tapOn:
-    id: "Browser.OmniBar.Button.AIChat"
-- assertVisible:
+- runFlow:
+    file: ../shared/open_contextual_duckai_from_address_bar.yaml
+
+- assertNotVisible:
     id: "AIChat.ContextualSheet"
 - assertVisible:
     id: "summarize-page"
-- assertNotVisible:
-    id: "AIChatNativeInputView.submitButton"
 - extendedWaitUntil:
     visible:
         id: "AIChat.ContextChip.AttachedTitle"
@@ -53,9 +51,12 @@ name: test_contextual_immediate_uti_pre_submit_context
     id: "AIChat.ContextChip.RemoveButton"
 - assertNotVisible:
     id: "AIChat.ContextChip.Placeholder"
+- assertNotVisible:
+    id: "AIChat.ContextChip.AttachedTitle"
 
+# Tapping the Duck.ai button again dismisses whichever contextual surface is showing.
 - tapOn:
-    id: "AIChat.ContextualSheet.CloseButton"
+    id: "Browser.OmniBar.Button.AIChat"
 - waitForAnimationToEnd:
     timeout: 3000
 
@@ -65,15 +66,14 @@ name: test_contextual_immediate_uti_pre_submit_context
 - pressKey: Enter
 - assertVisible: ".*Address Bar Spoofing.*"
 
-- tapOn:
-    id: "Browser.OmniBar.Button.AIChat"
-- assertVisible:
-    id: "AIChat.ContextualSheet"
+- runFlow:
+    file: ../shared/open_contextual_duckai_from_address_bar.yaml
 - extendedWaitUntil:
     visible:
         id: "AIChat.ContextChip.AttachedTitle"
     timeout: 10000
 
+# First submit hands the chat off from the floating input to the sheet.
 - tapOn:
     id: "searchEntry"
 - inputText: "First contextual UTI prompt"
@@ -82,16 +82,23 @@ name: test_contextual_immediate_uti_pre_submit_context
 
 - runFlow:
     file: ../shared/dismiss_chat_open_modals.yaml
+- extendedWaitUntil:
+    visible:
+        id: "AIChat.ContextualSheet"
+    timeout: 15000
 
 - tapOn:
     id: "AIChat.ContextualSheet.CloseButton"
 - waitForAnimationToEnd:
     timeout: 3000
 
+# A chat exists now, so the button reopens the sheet rather than offering the menu.
 - tapOn:
     id: "Browser.OmniBar.Button.AIChat"
 - assertVisible:
     id: "AIChat.ContextualSheet"
+- runFlow:
+    file: ../shared/expand_contextual_uti.yaml
 - assertNotVisible:
     id: "AIChat.ContextChip.AttachedTitle"
 - assertNotVisible:
@@ -112,6 +119,8 @@ name: test_contextual_immediate_uti_pre_submit_context
     id: "Browser.OmniBar.Button.AIChat"
 - assertVisible:
     id: "AIChat.ContextualSheet"
+- runFlow:
+    file: ../shared/expand_contextual_uti.yaml
 - extendedWaitUntil:
     visible:
         id: "AIChat.ContextChip.AttachedTitle"

--- a/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_toolbar.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_immediate_uti_pre_submit_toolbar.yaml
@@ -7,9 +7,10 @@ name: test_contextual_immediate_uti_pre_submit_toolbar
 
 ---
 
-# Immediate contextual UTI starts before the first prompt with its normal toolbar:
-# model picker visible, attachment menu available, no placeholder chip, and page
-# context attach requested through the attachment menu.
+# Immediate contextual UTI before the first prompt shows its normal toolbar: model picker visible,
+# attachment menu available, no placeholder chip. The address-bar button now opens a menu, and its
+# Ask About Page opens the floating input with the page already attached — so the attachment-menu
+# attach is exercised after clearing that chip. The sheet only arrives on first submit.
 
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
@@ -33,15 +34,25 @@ name: test_contextual_immediate_uti_pre_submit_toolbar
 - pressKey: Enter
 - assertVisible: ".*Privacy Test Pages.*"
 
-- tapOn:
-    id: "Browser.OmniBar.Button.AIChat"
-- assertVisible:
+- runFlow:
+    file: ../shared/open_contextual_duckai_from_address_bar.yaml
+
+# The floating input hosts the UTI over the page; no sheet chrome until the first submit.
+- assertNotVisible:
     id: "AIChat.ContextualSheet"
 - assertVisible:
     id: "AIChat.Toolbar.Button.ModelChip"
 - assertVisible: "Attach"
 - assertNotVisible:
     id: "AIChat.ContextChip.Placeholder"
+
+# Entry attached the page; clear it to reach the unattached state the attachment menu acts on.
+- extendedWaitUntil:
+    visible:
+        id: "AIChat.ContextChip.AttachedTitle"
+    timeout: 10000
+- tapOn:
+    id: "AIChat.ContextChip.RemoveButton"
 - assertNotVisible:
     id: "AIChat.ContextChip.AttachedTitle"
 

--- a/.maestro/unified_toggle_input/test_contextual_web_uti_auto_attach_regression.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_web_uti_auto_attach_regression.yaml
@@ -73,6 +73,14 @@ name: test_contextual_web_uti_auto_attach_regression
     id: "Browser.OmniBar.Button.AIChat"
 - assertVisible:
     id: "AIChat.ContextualSheet"
+
+# The attached chip is the positive signal that auto-attach picked up the new page. Expanded first:
+# collapsed, neither the chip nor the attach affordance is on screen and both checks below would
+# pass without auto-attach having done anything.
+- runFlow:
+    file: ../shared/expand_contextual_uti.yaml
 - extendedWaitUntil:
-    notVisible: "Attach Page Content"
+    visible:
+        id: "AIChat.ContextChip.AttachedTitle"
     timeout: 10000
+- assertNotVisible: "Attach Page Content"

--- a/.maestro/unified_toggle_input/test_contextual_web_uti_auto_attach_regression.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_web_uti_auto_attach_regression.yaml
@@ -7,9 +7,9 @@ name: test_contextual_web_uti_auto_attach_regression
 
 ---
 
-# Same first-submit web UTI setup as the manual-attach regression, but with automatic
-# context attachment enabled. After navigating and reopening the active contextual
-# chat, the UTI chip should attach the new page automatically.
+# Same first-submit setup as the manual-attach regression, but with automatic context attachment on.
+# The first prompt promotes the floating input to the sheet; after navigating and reopening the active
+# contextual chat, the UTI chip should attach the new page automatically with no prompt to do so.
 
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
@@ -33,21 +33,26 @@ name: test_contextual_web_uti_auto_attach_regression
 - pressKey: Enter
 - assertVisible: ".*Privacy Test Pages.*"
 
-- tapOn:
-    id: "Browser.OmniBar.Button.AIChat"
-- assertVisible:
+- runFlow:
+    file: ../shared/open_contextual_duckai_from_address_bar.yaml
+
+- assertNotVisible:
     id: "AIChat.ContextualSheet"
 - assertVisible:
-    id: "AIChatNativeInputView.submitButton"
+    id: "AIChat.Toolbar.Button.Submit"
 
 - tapOn:
-    id: "AIChatNativeInputView.textView"
+    id: "searchEntry"
 - inputText: "First contextual prompt"
 - tapOn:
-    id: "AIChatNativeInputView.submitButton"
+    id: "AIChat.Toolbar.Button.Submit"
 
 - runFlow:
     file: ../shared/dismiss_chat_open_modals.yaml
+- extendedWaitUntil:
+    visible:
+        id: "AIChat.ContextualSheet"
+    timeout: 15000
 - extendedWaitUntil:
     visible: "We don't track you.*"
     timeout: 30000
@@ -63,6 +68,7 @@ name: test_contextual_web_uti_auto_attach_regression
 - pressKey: Enter
 - assertVisible: ".*Address Bar Spoofing.*"
 
+# A chat exists, so the button reopens the sheet directly rather than offering the menu.
 - tapOn:
     id: "Browser.OmniBar.Button.AIChat"
 - assertVisible:

--- a/.maestro/unified_toggle_input/test_contextual_web_uti_manual_attach_regression.yaml
+++ b/.maestro/unified_toggle_input/test_contextual_web_uti_manual_attach_regression.yaml
@@ -7,11 +7,9 @@ name: test_contextual_web_uti_manual_attach_regression
 
 ---
 
-# With the immediate contextual UTI flag off, contextual chat still starts with the
-# basic native input, then shows the web UTI after the first prompt. In manual mode
-# there is no placeholder chip: page context is attached from the web UTI's attachment
-# menu via "Ask About Page", and a manually attached context is cleared when the sheet
-# is reopened on a different page.
+# With automatic attachment off there is no placeholder chip: page context is attached on purpose,
+# either by entering through the menu's Ask About Page or from the UTI's attachment menu, and a
+# manually attached context is not carried over when the surface is reopened on a different page.
 
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
@@ -35,31 +33,35 @@ name: test_contextual_web_uti_manual_attach_regression
 - pressKey: Enter
 - assertVisible: ".*Privacy Test Pages.*"
 
-- tapOn:
-    id: "Browser.OmniBar.Button.AIChat"
-- assertVisible:
+- runFlow:
+    file: ../shared/open_contextual_duckai_from_address_bar.yaml
+
+- assertNotVisible:
     id: "AIChat.ContextualSheet"
-- assertVisible:
-    id: "AIChatNativeInputView.submitButton"
+- assertNotVisible:
+    id: "AIChat.ContextChip.Placeholder"
 
 - tapOn:
-    id: "AIChatNativeInputView.textView"
+    id: "searchEntry"
 - inputText: "First contextual prompt"
 - tapOn:
-    id: "AIChatNativeInputView.submitButton"
+    id: "AIChat.Toolbar.Button.Submit"
 
 - runFlow:
     file: ../shared/dismiss_chat_open_modals.yaml
+- extendedWaitUntil:
+    visible:
+        id: "AIChat.ContextualSheet"
+    timeout: 15000
 
-# After the first prompt the web UTI replaces the native input. There is no dashed
-# placeholder chip and, in manual mode, no context is attached yet.
+# The promoted sheet's UTI is collapsed; expanded it offers the attachment menu and no placeholder.
+- runFlow:
+    file: ../shared/expand_contextual_uti.yaml
 - extendedWaitUntil:
     visible: "Attach"
     timeout: 30000
 - assertNotVisible:
     id: "AIChat.ContextChip.Placeholder"
-- assertNotVisible:
-    id: "AIChat.ContextChip.AttachedTitle"
 
 - tapOn:
     id: "AIChat.ContextualSheet.CloseButton"
@@ -77,6 +79,8 @@ name: test_contextual_web_uti_manual_attach_regression
     id: "Browser.OmniBar.Button.AIChat"
 - assertVisible:
     id: "AIChat.ContextualSheet"
+- runFlow:
+    file: ../shared/expand_contextual_uti.yaml
 - assertNotVisible:
     id: "AIChat.ContextChip.AttachedTitle"
 - tapOn: "Attach"
@@ -92,9 +96,8 @@ name: test_contextual_web_uti_manual_attach_regression
 - waitForAnimationToEnd:
     timeout: 3000
 
-# Navigating to a different page and reopening clears the manually attached context; it
-# does not silently reattach and no placeholder chip appears. "Ask About Page" is still
-# available to attach the new page.
+# Navigating and reopening clears the manually attached context; it does not silently reattach and no
+# placeholder chip appears. Ask About Page is still available to attach the new page.
 - tapOn:
     id: "searchEntry"
 - inputText: "https://privacy-test-pages.site/privacy-protections/geolocation/"
@@ -105,6 +108,8 @@ name: test_contextual_web_uti_manual_attach_regression
     id: "Browser.OmniBar.Button.AIChat"
 - assertVisible:
     id: "AIChat.ContextualSheet"
+- runFlow:
+    file: ../shared/expand_contextual_uti.yaml
 - extendedWaitUntil:
     notVisible:
         id: "AIChat.ContextChip.AttachedTitle"

--- a/.maestro/unified_toggle_input/test_search_only_website_active_ai_shortcut_prompt.yaml
+++ b/.maestro/unified_toggle_input/test_search_only_website_active_ai_shortcut_prompt.yaml
@@ -60,13 +60,16 @@ name: test_search_only_website_active_ai_shortcut_prompt
 - pressKey: Enter
 - assertVisible: ".*Privacy Test Pages.*"
 
-# A direct web-page shortcut tap should still open the contextual sheet.
+# On a web page the shortcut offers the menu; Ask About Page opens the floating contextual input.
+- runFlow:
+    file: ../shared/open_contextual_duckai_from_address_bar.yaml
+- assertVisible:
+    id: "AIChat.Toolbar.Button.ModelChip"
+- assertNotVisible:
+    id: "AIChat.ContextualSheet"
+# Tapping the Duck.ai button again dismisses whichever contextual surface is showing.
 - tapOn:
     id: "Browser.OmniBar.Button.AIChat"
-- assertVisible:
-    id: "AIChat.ContextualSheet"
-- tapOn:
-    id: "AIChat.ContextualSheet.CloseButton"
 - waitForAnimationToEnd:
     timeout: 3000
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201392122292466/task/1217786689473714?focus=true

### Description

The address-bar Duck.ai button offers a menu on a web page now that the floating contextual input is
on by default, so the 7 flows that expected it to open the contextual sheet failed on main.

They now enter through Ask About Page, expect the floating input, and expect the sheet after the
first submit. The feature stays on — nothing was disabled to make them pass.

### Testing Steps

E2E passed on this branch: https://github.com/duckduckgo/apple-browsers/actions/runs/32843248294

### Impact

None — maestro flows only, no app code.
