### PR TITLE
Add awake duration to PIR outcome pixels

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionSharedPixels.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionSharedPixels.swift
@@ -48,6 +48,7 @@ public enum DataBrokerProtectionSharedPixels {
         public static let appVersionParamKey = "app_version"
         public static let attemptIdParamKey = "attempt_id"
         public static let durationParamKey = "duration"
+        public static let awakeDurationParamKey = "awake_duration"
         public static let bundleIDParamKey = "bundle_id"
         public static let vpnConnectionStateParamKey = "vpn_connection_state"
         public static let vpnBypassStatusParamKey = "vpn_bypass"
@@ -119,17 +120,17 @@ public enum DataBrokerProtectionSharedPixels {
     case optOutStart(dataBroker: String, attemptId: UUID, parent: String)
 
     // Process Pixels
-    case optOutSubmitSuccess(dataBroker: String, attemptId: UUID, duration: Double, tries: Int, parent: String, emailPattern: String?, vpnConnectionState: String, vpnBypassStatus: String)
+    case optOutSubmitSuccess(dataBroker: String, attemptId: UUID, duration: Double, awakeDuration: Double, tries: Int, parent: String, emailPattern: String?, vpnConnectionState: String, vpnBypassStatus: String)
     case optOutSuccess(dataBroker: String, attemptId: UUID, duration: Double, parent: String, brokerType: DataBrokerHierarchy, vpnConnectionState: String, vpnBypassStatus: String)
-    case optOutFailure(dataBroker: String, dataBrokerVersion: String, attemptId: UUID, duration: Double, parent: String, errorCategory: String, errorDetails: String, stage: String, tries: Int, emailPattern: String?, actionId: String, actionType: String, vpnConnectionState: String, vpnBypassStatus: String)
+    case optOutFailure(dataBroker: String, dataBrokerVersion: String, attemptId: UUID, duration: Double, awakeDuration: Double, parent: String, errorCategory: String, errorDetails: String, stage: String, tries: Int, emailPattern: String?, actionId: String, actionType: String, vpnConnectionState: String, vpnBypassStatus: String)
 
     // Scan/Search pixels
 #if os(iOS)
     case scanStarted(dataBroker: String)
 #endif
-    case scanSuccess(dataBroker: String, matchesFound: Int, duration: Double, tries: Int, isImmediateOperation: Bool, vpnConnectionState: String, vpnBypassStatus: String, parent: String, isAuthenticated: Bool, isFreeScan: Bool?)
-    case scanNoResults(dataBroker: String, dataBrokerVersion: String, duration: Double, tries: Int, isImmediateOperation: Bool, vpnConnectionState: String, vpnBypassStatus: String, parent: String, actionID: String, actionType: String, isAuthenticated: Bool, isFreeScan: Bool?)
-    case scanError(dataBroker: String, dataBrokerVersion: String, duration: Double, category: String, details: String, isImmediateOperation: Bool, vpnConnectionState: String, vpnBypassStatus: String, parent: String, actionId: String, actionType: String, isAuthenticated: Bool, isFreeScan: Bool?)
+    case scanSuccess(dataBroker: String, matchesFound: Int, duration: Double, awakeDuration: Double, tries: Int, isImmediateOperation: Bool, vpnConnectionState: String, vpnBypassStatus: String, parent: String, isAuthenticated: Bool, isFreeScan: Bool?)
+    case scanNoResults(dataBroker: String, dataBrokerVersion: String, duration: Double, awakeDuration: Double, tries: Int, isImmediateOperation: Bool, vpnConnectionState: String, vpnBypassStatus: String, parent: String, actionID: String, actionType: String, isAuthenticated: Bool, isFreeScan: Bool?)
+    case scanError(dataBroker: String, dataBrokerVersion: String, duration: Double, awakeDuration: Double, category: String, details: String, isImmediateOperation: Bool, vpnConnectionState: String, vpnBypassStatus: String, parent: String, actionId: String, actionType: String, isAuthenticated: Bool, isFreeScan: Bool?)
     case scanStage(dataBroker: String, dataBrokerVersion: String, tries: Int, parent: String, actionId: String, actionType: String, isFreeScan: Bool?)
 
     // Stage Pixels
@@ -406,8 +407,8 @@ extension DataBrokerProtectionSharedPixels: PixelKit.Event {
                     Consts.attemptIdParamKey: attemptId.uuidString,
                     Consts.durationParamKey: String(duration),
                     Consts.parentKey: parent]
-        case .optOutSubmitSuccess(let dataBroker, let attemptId, let duration, let tries, let parent, let pattern, let vpnConnectionState, let vpnBypassStatus):
-            var params = [Consts.dataBrokerParamKey: dataBroker, Consts.attemptIdParamKey: attemptId.uuidString, Consts.durationParamKey: String(duration), Consts.triesKey: String(tries), Consts.parentKey: parent, Consts.vpnConnectionStateParamKey: vpnConnectionState, Consts.vpnBypassStatusParamKey: vpnBypassStatus]
+        case .optOutSubmitSuccess(let dataBroker, let attemptId, let duration, let awakeDuration, let tries, let parent, let pattern, let vpnConnectionState, let vpnBypassStatus):
+            var params = [Consts.dataBrokerParamKey: dataBroker, Consts.attemptIdParamKey: attemptId.uuidString, Consts.durationParamKey: String(duration), Consts.awakeDurationParamKey: String(awakeDuration), Consts.triesKey: String(tries), Consts.parentKey: parent, Consts.vpnConnectionStateParamKey: vpnConnectionState, Consts.vpnBypassStatusParamKey: vpnBypassStatus]
             if let pattern = pattern {
                 params[Consts.pattern] = pattern
             }
@@ -420,11 +421,12 @@ extension DataBrokerProtectionSharedPixels: PixelKit.Event {
                     Consts.isParent: String(type.rawValue),
                     Consts.vpnConnectionStateParamKey: vpnConnectionState,
                     Consts.vpnBypassStatusParamKey: vpnBypassStatus]
-        case .optOutFailure(let dataBroker, let dataBrokerVersion, let attemptId, let duration, let parent, let errorCategory, let errorDetails, let stage, let tries, let pattern, let actionId, let actionType, let vpnConnectionState, let vpnBypassStatus):
+        case .optOutFailure(let dataBroker, let dataBrokerVersion, let attemptId, let duration, let awakeDuration, let parent, let errorCategory, let errorDetails, let stage, let tries, let pattern, let actionId, let actionType, let vpnConnectionState, let vpnBypassStatus):
             var params = [Consts.dataBrokerParamKey: dataBroker,
                           Consts.dataBrokerVersionKey: dataBrokerVersion,
                           Consts.attemptIdParamKey: attemptId.uuidString,
                           Consts.durationParamKey: String(duration),
+                          Consts.awakeDurationParamKey: String(awakeDuration),
                           Consts.parentKey: parent,
                           Consts.errorCategoryKey: errorCategory,
                           Consts.errorDetailsKey: errorDetails,
@@ -442,10 +444,11 @@ extension DataBrokerProtectionSharedPixels: PixelKit.Event {
         case .scanStarted(let dataBroker):
             return [Consts.dataBrokerParamKey: dataBroker]
 #endif
-        case .scanSuccess(let dataBroker, let matchesFound, let duration, let tries, let isImmediateOperation, let vpnConnectionState, let vpnBypassStatus, let parent, let isAuthenticated, let isFreeScan):
+        case .scanSuccess(let dataBroker, let matchesFound, let duration, let awakeDuration, let tries, let isImmediateOperation, let vpnConnectionState, let vpnBypassStatus, let parent, let isAuthenticated, let isFreeScan):
             let params = [Consts.dataBrokerParamKey: dataBroker,
                           Consts.matchesFoundKey: String(matchesFound),
                           Consts.durationParamKey: String(duration),
+                          Consts.awakeDurationParamKey: String(awakeDuration),
                           Consts.triesKey: String(tries),
                           Consts.isImmediateOperation: isImmediateOperation.description,
                           Consts.vpnConnectionStateParamKey: vpnConnectionState,
@@ -453,10 +456,11 @@ extension DataBrokerProtectionSharedPixels: PixelKit.Event {
                           Consts.parentKey: parent,
                           Consts.isAuthenticated: isAuthenticated.description]
             return addingFreeScanParamIfNeeded(to: params, isFreeScan: isFreeScan)
-        case .scanNoResults(let dataBroker, let dataBrokerVersion, let duration, let tries, let isImmediateOperation, let vpnConnectionState, let vpnBypassStatus, let parent, let actionID, let actionType, let isAuthenticated, let isFreeScan):
+        case .scanNoResults(let dataBroker, let dataBrokerVersion, let duration, let awakeDuration, let tries, let isImmediateOperation, let vpnConnectionState, let vpnBypassStatus, let parent, let actionID, let actionType, let isAuthenticated, let isFreeScan):
             let params = [Consts.dataBrokerParamKey: dataBroker,
                           Consts.dataBrokerVersionKey: dataBrokerVersion,
                           Consts.durationParamKey: String(duration),
+                          Consts.awakeDurationParamKey: String(awakeDuration),
                           Consts.triesKey: String(tries),
                           Consts.isImmediateOperation: isImmediateOperation.description,
                           Consts.vpnConnectionStateParamKey: vpnConnectionState,
@@ -466,10 +470,11 @@ extension DataBrokerProtectionSharedPixels: PixelKit.Event {
                           Consts.actionTypeKey: actionType,
                           Consts.isAuthenticated: isAuthenticated.description]
             return addingFreeScanParamIfNeeded(to: params, isFreeScan: isFreeScan)
-        case .scanError(let dataBroker, let dataBrokerVersion, let duration, let category, let details, let isImmediateOperation, let vpnConnectionState, let vpnBypassStatus, let parent, let actionId, let actionType, let isAuthenticated, let isFreeScan):
+        case .scanError(let dataBroker, let dataBrokerVersion, let duration, let awakeDuration, let category, let details, let isImmediateOperation, let vpnConnectionState, let vpnBypassStatus, let parent, let actionId, let actionType, let isAuthenticated, let isFreeScan):
             let params = [Consts.dataBrokerParamKey: dataBroker,
                           Consts.dataBrokerVersionKey: dataBrokerVersion,
                           Consts.durationParamKey: String(duration),
+                          Consts.awakeDurationParamKey: String(awakeDuration),
                           Consts.errorCategoryKey: category,
                           Consts.errorDetailsKey: details,
                           Consts.isImmediateOperation: isImmediateOperation.description,

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionStageDurationCalculator.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionStageDurationCalculator.swift
@@ -49,6 +49,7 @@ public protocol StageDurationCalculator {
 
     func durationSinceLastStage() -> Double
     func durationSinceStartTime() -> Double
+    func awakeDurationSinceStartTime() -> Double
     func fireOptOutStart()
     func fireOptOutEmailGenerate()
     func fireOptOutCaptchaParse()
@@ -90,6 +91,7 @@ final class DataBrokerProtectionStageDurationCalculator: StageDurationCalculator
     let dataBrokerURL: String
     let dataBrokerVersion: String
     let startTime: Date
+    let startUptimeNanos: UInt64
     let parentURL: String?
     let isAuthenticated: Bool
     let isFreeScan: Bool?
@@ -104,6 +106,7 @@ final class DataBrokerProtectionStageDurationCalculator: StageDurationCalculator
 
     init(attemptId: UUID = UUID(),
          startTime: Date = Date(),
+         startUptimeNanos: UInt64 = DispatchTime.now().uptimeNanoseconds,
          dataBrokerURL: String,
          dataBrokerVersion: String,
          handler: EventMapping<DataBrokerProtectionSharedPixels>,
@@ -115,6 +118,7 @@ final class DataBrokerProtectionStageDurationCalculator: StageDurationCalculator
          vpnBypassStatus: String) {
         self.attemptId = attemptId
         self.startTime = startTime
+        self.startUptimeNanos = startUptimeNanos
         self.lastStateTime = startTime
         self.dataBrokerURL = dataBrokerURL
         self.dataBrokerVersion = dataBrokerVersion
@@ -140,6 +144,16 @@ final class DataBrokerProtectionStageDurationCalculator: StageDurationCalculator
     func durationSinceStartTime() -> Double {
         let now = Date()
         return (now.timeIntervalSince(startTime) * 1000).rounded(.towardZero)
+    }
+
+    /// Returned in milliseconds
+    func awakeDurationSinceStartTime() -> Double {
+        let nowUptimeNanos = DispatchTime.now().uptimeNanoseconds
+        guard nowUptimeNanos >= startUptimeNanos else {
+            return 0
+        }
+
+        return (Double(nowUptimeNanos - startUptimeNanos) / 1_000_000).rounded(.towardZero)
     }
 
     func fireOptOutStart() {
@@ -266,6 +280,7 @@ final class DataBrokerProtectionStageDurationCalculator: StageDurationCalculator
         handler.fire(.optOutSubmitSuccess(dataBroker: dataBrokerURL,
                                           attemptId: attemptId,
                                           duration: totalDuration,
+                                          awakeDuration: awakeDurationSinceStartTime(),
                                           tries: tries,
                                           parent: parentURL ?? "",
                                           emailPattern: emailPattern,
@@ -280,6 +295,7 @@ final class DataBrokerProtectionStageDurationCalculator: StageDurationCalculator
                                     dataBrokerVersion: dataBrokerVersion,
                                     attemptId: attemptId,
                                     duration: durationSinceStartTime(),
+                                    awakeDuration: awakeDurationSinceStartTime(),
                                     parent: parentURL ?? "",
                                     errorCategory: errorCategory.toString,
                                     errorDetails: error.localizedDescription,
@@ -324,6 +340,7 @@ final class DataBrokerProtectionStageDurationCalculator: StageDurationCalculator
         handler.fire(.scanSuccess(dataBroker: dataBrokerURL,
                                   matchesFound: matchesFound,
                                   duration: durationSinceStartTime(),
+                                  awakeDuration: awakeDurationSinceStartTime(),
                                   tries: 1,
                                   isImmediateOperation: isImmediateOperation,
                                   vpnConnectionState: vpnConnectionState,
@@ -337,6 +354,7 @@ final class DataBrokerProtectionStageDurationCalculator: StageDurationCalculator
         handler.fire(.scanNoResults(dataBroker: dataBrokerURL,
                                     dataBrokerVersion: dataBrokerVersion,
                                     duration: durationSinceStartTime(),
+                                    awakeDuration: awakeDurationSinceStartTime(),
                                     tries: 1,
                                     isImmediateOperation: isImmediateOperation,
                                     vpnConnectionState: vpnConnectionState,
@@ -360,6 +378,7 @@ final class DataBrokerProtectionStageDurationCalculator: StageDurationCalculator
                 dataBroker: dataBrokerURL,
                 dataBrokerVersion: dataBrokerVersion,
                 duration: durationSinceStartTime(),
+                awakeDuration: awakeDurationSinceStartTime(),
                 category: errorCategory.toString,
                 details: error.localizedDescription,
                 isImmediateOperation: isImmediateOperation,

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -1585,6 +1585,7 @@ public final class MockStageDurationCalculator: StageDurationCalculator {
 
     public var durationSinceLastStageCalled = false
     public var durationSinceStartTimeCalled = false
+    public var awakeDurationSinceStartTimeCalled = false
     public var fireOptOutStartCalled = false
     public var fireOptOutEmailGenerateCalled = false
     public var fireOptOutCaptchaParseCalled = false
@@ -1621,6 +1622,11 @@ public final class MockStageDurationCalculator: StageDurationCalculator {
 
     public func durationSinceStartTime() -> Double {
         durationSinceStartTimeCalled = true
+        return 0.0
+    }
+
+    public func awakeDurationSinceStartTime() -> Double {
+        awakeDurationSinceStartTimeCalled = true
         return 0.0
     }
 
@@ -1729,6 +1735,7 @@ public final class MockStageDurationCalculator: StageDurationCalculator {
         self.stage = nil
         durationSinceLastStageCalled = false
         durationSinceStartTimeCalled = false
+        awakeDurationSinceStartTimeCalled = false
         fireOptOutStartCalled = false
         fireOptOutEmailGenerateCalled = false
         fireOptOutCaptchaParseCalled = false

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileOptOutSubJobTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileOptOutSubJobTests.swift
@@ -330,7 +330,7 @@ final class BrokerProfileOptOutSubJobTests: XCTestCase {
 
         XCTAssertTrue(database.optOutEvents.contains { $0.type == .optOutRequested })
         XCTAssertEqual(database.attemptCount, 1)
-        if case let .optOutSubmitSuccess(_, _, _, tries, _, _, _, _) = mockPixelHandler.lastFiredEvent {
+        if case let .optOutSubmitSuccess(_, _, _, _, tries, _, _, _, _) = mockPixelHandler.lastFiredEvent {
             XCTAssertEqual(tries, 1)
         } else {
             XCTFail("Expected opt-out submit success pixel")
@@ -568,7 +568,7 @@ final class BrokerProfileOptOutSubJobTests: XCTestCase {
 
         if let lastPixelFired = mockPixelHandler.lastFiredEvent {
             switch lastPixelFired {
-            case .optOutSubmitSuccess(_, _, _, let tries, _, _, _, _):
+            case .optOutSubmitSuccess(_, _, _, _, let tries, _, _, _, _):
                 XCTAssertEqual(tries, 3)
             default: XCTFail("We should be firing the opt-out submit-success pixel last")
             }
@@ -586,7 +586,7 @@ final class BrokerProfileOptOutSubJobTests: XCTestCase {
         } catch {
             if let lastPixelFired = mockPixelHandler.lastFiredEvent {
                 switch lastPixelFired {
-                case .optOutFailure(_, _, _, _, _, _, _, _, let tries, _, _, _, _, _):
+                case .optOutFailure(_, _, _, _, _, _, _, _, _, let tries, _, _, _, _, _):
                     XCTAssertEqual(tries, 3)
                 default: XCTFail("We should be firing the opt-out submit-success pixel last")
                 }

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionStageDurationCalculatorTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionStageDurationCalculatorTests.swift
@@ -40,7 +40,7 @@ final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
 
         if let failurePixel = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.last {
             switch failurePixel {
-            case .scanNoResults(let broker, let brokerVersion, _, _, _, _, _, _, _, _, _, _):
+            case .scanNoResults(let broker, let brokerVersion, _, _, _, _, _, _, _, _, _, _, _):
                 XCTAssertEqual(broker, "broker.com")
                 XCTAssertEqual(brokerVersion, "1.1.1")
             default: XCTFail("The scan no results pixel should be fired")
@@ -59,7 +59,7 @@ final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
 
         if let failurePixel = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.last {
             switch failurePixel {
-            case .scanError(_, _, _, let category, _, _, _, _, _, _, _, _, _):
+            case .scanError(_, _, _, _, let category, _, _, _, _, _, _, _, _, _):
                 XCTAssertEqual(category, ErrorCategory.clientError(httpCode: 403).toString)
             default: XCTFail("The scan error pixel should be fired")
             }
@@ -77,7 +77,7 @@ final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
 
         if let failurePixel = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.last {
             switch failurePixel {
-            case .scanError(_, _, _, let category, _, _, _, _, _, _, _, _, _):
+            case .scanError(_, _, _, _, let category, _, _, _, _, _, _, _, _, _):
                 XCTAssertEqual(category, ErrorCategory.serverError(httpCode: 500).toString)
             default: XCTFail("The scan error pixel should be fired")
             }
@@ -98,7 +98,7 @@ final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
         }
 
         switch failurePixel {
-        case .scanError(_, _, _, _, _, _, _, _, _, let actionId, let actionType, _, _):
+        case .scanError(_, _, _, _, _, _, _, _, _, _, let actionId, let actionType, _, _):
             XCTAssertEqual(actionId, "action-123")
             XCTAssertEqual(actionType, "click")
         default:
@@ -117,7 +117,7 @@ final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
         }
 
         switch failurePixel {
-        case .scanError(_, _, _, _, _, _, _, _, _, let actionId, let actionType, _, _):
+        case .scanError(_, _, _, _, _, _, _, _, _, _, let actionId, let actionType, _, _):
             XCTAssertEqual(actionId, "unknown")
             XCTAssertEqual(actionType, "unknown")
         default:
@@ -142,7 +142,7 @@ final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
         }
 
         switch failurePixel {
-        case .scanError(_, _, _, _, _, _, _, _, let parent, _, _, _, _):
+        case .scanError(_, _, _, _, _, _, _, _, _, let parent, _, _, _, _):
             XCTAssertEqual(parent, "parent.com")
         default:
             XCTFail("The scan error pixel should be fired")
@@ -158,7 +158,7 @@ final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
 
         if let failurePixel = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.last {
             switch failurePixel {
-            case .scanError(_, _, _, let category, _, _, _, _, _, _, _, _, _):
+            case .scanError(_, _, _, _, let category, _, _, _, _, _, _, _, _, _):
                 XCTAssertEqual(category, ErrorCategory.validationError.toString)
             default: XCTFail("The scan error pixel should be fired")
             }
@@ -177,7 +177,7 @@ final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
 
         if let failurePixel = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.last {
             switch failurePixel {
-            case .scanError(_, _, _, let category, _, _, _, _, _, _, _, _, _):
+            case .scanError(_, _, _, _, let category, _, _, _, _, _, _, _, _, _):
                 XCTAssertEqual(category, ErrorCategory.networkError.toString)
             default: XCTFail("The scan error pixel should be fired")
             }
@@ -196,7 +196,7 @@ final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
 
         if let failurePixel = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.last {
             switch failurePixel {
-            case .scanError(_, _, _, let category, _, _, _, _, _, _, _, _, _):
+            case .scanError(_, _, _, _, let category, _, _, _, _, _, _, _, _, _):
                 XCTAssertEqual(category, "database-error-SecureVaultError-13")
             default: XCTFail("The scan error pixel should be fired")
             }
@@ -215,7 +215,7 @@ final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
 
         if let failurePixel = MockDataBrokerProtectionPixelsHandler.lastPixelsFired.last {
             switch failurePixel {
-            case .scanError(_, _, _, let category, _, _, _, _, _, _, _, _, _):
+            case .scanError(_, _, _, _, let category, _, _, _, _, _, _, _, _, _):
                 XCTAssertEqual(category, ErrorCategory.unclassified.toString)
             default: XCTFail("The scan error pixel should be fired")
             }
@@ -242,7 +242,7 @@ final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
         }
 
         switch pixel {
-        case .scanSuccess(_, _, _, _, _, _, _, _, _, let isFreeScan):
+        case .scanSuccess(_, _, _, _, _, _, _, _, _, _, let isFreeScan):
             XCTAssertEqual(isFreeScan, true)
         default:
             XCTFail("Expected scanSuccess pixel")
@@ -265,7 +265,7 @@ final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
         }
 
         switch pixel {
-        case .scanSuccess(_, _, _, _, _, _, _, _, _, let isFreeScan):
+        case .scanSuccess(_, _, _, _, _, _, _, _, _, _, let isFreeScan):
             XCTAssertEqual(isFreeScan, false)
         default:
             XCTFail("Expected scanSuccess pixel")
@@ -288,7 +288,7 @@ final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
         }
 
         switch pixel {
-        case .scanError(_, _, _, _, _, _, _, _, _, _, _, _, let isFreeScan):
+        case .scanError(_, _, _, _, _, _, _, _, _, _, _, _, _, let isFreeScan):
             XCTAssertEqual(isFreeScan, true)
         default:
             XCTFail("Expected scanError pixel")
@@ -312,7 +312,7 @@ final class DataBrokerProtectionStageDurationCalculatorTests: XCTestCase {
         }
 
         switch pixel {
-        case .scanNoResults(_, _, _, _, _, _, _, _, _, _, _, let isFreeScan):
+        case .scanNoResults(_, _, _, _, _, _, _, _, _, _, _, _, let isFreeScan):
             XCTAssertEqual(isFreeScan, true)
         default:
             XCTFail("Expected scanNoResults pixel")

--- a/iOS/DuckDuckGo/DBP/RunDBPDebugModeViewController.swift
+++ b/iOS/DuckDuckGo/DBP/RunDBPDebugModeViewController.swift
@@ -907,6 +907,7 @@ final class FakeStageDurationCalculator: StageDurationCalculator {
     
     func durationSinceLastStage() -> Double { 0.0 }
     func durationSinceStartTime() -> Double { 0.0 }
+    func awakeDurationSinceStartTime() -> Double { 0.0 }
     func fireOptOutStart() {}
     func setEmailPattern(_ emailPattern: String?) {}
     func fireScanStarted() {}

--- a/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -239,6 +239,7 @@
             "dbpParentBroker",
             "dbpAttemptId",
             "dbpAttemptDuration",
+            "dbpAwakeDuration",
             {
                 "key": "tries",
                 "description": "The number of tries it took to submit successfully",
@@ -306,6 +307,7 @@
             "dbpBrokerVersion",
             "dbpAttemptId",
             "dbpAttemptDuration",
+            "dbpAwakeDuration",
             {
                 "key": "error_category",
                 "description": "High-level error classification",
@@ -950,6 +952,7 @@
                 "description": "Total duration of the scan in milliseconds",
                 "type": "number"
             },
+            "dbpAwakeDuration",
             "dbpStageTries",
             {
                 "key": "is_manual_scan",
@@ -987,6 +990,7 @@
                 "description": "Total duration of the scan in milliseconds",
                 "type": "number"
             },
+            "dbpAwakeDuration",
             "dbpStageTries",
             {
                 "key": "is_manual_scan",
@@ -1026,6 +1030,7 @@
                 "description": "Total duration of the scan in milliseconds",
                 "type": "number"
             },
+            "dbpAwakeDuration",
             {
                 "key": "error_category",
                 "description": "High-level error classification",

--- a/iOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/iOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -298,6 +298,11 @@
         "type": "number",
         "description": "Total duration of the opt-out attempt in milliseconds"
     },
+    "dbpAwakeDuration": {
+        "key": "awake_duration",
+        "type": "number",
+        "description": "Total duration excluding machine sleep in milliseconds"
+    },
     "dbpConfirmationAttemptNumber": {
         "key": "attempt_number",
         "type": "integer",

--- a/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/Debug/DataBrokerRunCustomJSONViewModel.swift
+++ b/macOS/LocalPackages/DataBrokerProtection-macOS/Sources/DataBrokerProtection-macOS/Debug/DataBrokerRunCustomJSONViewModel.swift
@@ -796,6 +796,10 @@ final class FakeStageDurationCalculator: StageDurationCalculator, DebugEventRepo
         0.0
     }
 
+    func awakeDurationSinceStartTime() -> Double {
+        0.0
+    }
+
     func fireOptOutStart() {
     }
 

--- a/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -251,6 +251,7 @@
             "dbpParentBroker",
             "dbpAttemptId",
             "dbpAttemptDuration",
+            "dbpAwakeDuration",
             {
                 "key": "tries",
                 "description": "The number of tries it took to submit successfully",
@@ -320,6 +321,7 @@
             "dbpBrokerVersion",
             "dbpAttemptId",
             "dbpAttemptDuration",
+            "dbpAwakeDuration",
             {
                 "key": "error_category",
                 "description": "High-level error classification",
@@ -838,6 +840,7 @@
                 "description": "Total duration of the scan in milliseconds",
                 "type": "number"
             },
+            "dbpAwakeDuration",
             "dbpStageTries",
             {
                 "key": "is_manual_scan",
@@ -876,6 +879,7 @@
                 "description": "Total duration of the scan in milliseconds",
                 "type": "number"
             },
+            "dbpAwakeDuration",
             "dbpStageTries",
             {
                 "key": "is_manual_scan",
@@ -916,6 +920,7 @@
                 "description": "Total duration of the scan in milliseconds",
                 "type": "number"
             },
+            "dbpAwakeDuration",
             {
                 "key": "error_category",
                 "description": "High-level error classification",

--- a/macOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/macOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -356,6 +356,11 @@
         "type": "number",
         "description": "Total duration of the opt-out attempt in milliseconds"
     },
+    "dbpAwakeDuration": {
+        "key": "awake_duration",
+        "type": "number",
+        "description": "Total duration excluding machine sleep in milliseconds"
+    },
     "dbpConfirmationAttemptNumber": {
         "key": "attempt_number",
         "type": "integer",


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/task/1217830261292575
Tech Design URL:
CC:

### Description

  - Adds `awake_duration` alongside the existing `duration` to five PIR outcome pixels, allowing machine-sleep time to be identified.

  ### Testing Steps

0. CI passes
  1. Run a PIR scan and opt-out attempt [1]
  2. Inspect the outcome pixels → `duration` and `awake_duration` are both present in milliseconds.

```
👾[Standard-Fired] m_mac_dbp_search_stage_main_status_error ["action_id": "ab2b7b28-4204-48a5-9366-2697382fdcfe", "action_type": "navigate", "appVersion": "1.205.0", "awake_duration": "6759.0", "broker_version": "0.5.0", "channel": "canary", "data_broker": “example.com", "duration": "6759.0", "error_category": "client-error-429", "error_details": "HTTP 429", "free_scan": "false", "isAuthenticated": "true", "is_manual_scan": "true", "parent": "privatereports.com", "pixelSource": "dbpBackgroundAgent", "vpn_bypass": "unsupported", "vpn_connection_state": "disconnected”]
```

[1]:
- Restore DDG subscription
- Go to menu > DDG subscription > PIR
- Set up a profile
- Drop this in the terminal to watch for the pixels:

```
log stream --style compact --debug --info \
  --predicate 'subsystem == "PixelKit" AND eventMessage CONTAINS "awake_duration"'
```

  ### Impact

  Low


<!-- CURSOR_SUMMARY —>
—

> [!NOTE]
> **Low Risk**
> Analytics-only pixel parameter additions with no changes to scan/opt-out business logic; low blast radius beyond pixel schema consumers.
> 
> **Overview**
> Adds **`awake_duration`** (milliseconds) alongside existing **`duration`** on five PIR outcome pixels: opt-out submit success/failure and scan success, no-results, and error.
> 
> **Awake time** is computed from `DispatchTime` uptime at attempt start vs completion, so sleep does not inflate elapsed time; wall-clock **`duration`** still uses `Date` as before. The new field is wired through shared pixel enums, `DataBrokerProtectionStageDurationCalculator`, iOS/macOS pixel definitions (`dbpAwakeDuration` / `awake_duration`), and test/debug mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4735014c69278bae40ddd85df5a2e0f70d135bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY —>