### PR TITLE
Sync: Unified device info pixels

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -113,9 +113,13 @@ public class DDGSync: DDGSyncing {
             throw SyncError.accountAlreadyExists
         }
 
-        let account = try await dependencies.account.createAccount(deviceName: deviceName, deviceType: deviceType)
-        try updateAccount(account)
-        scheduleDeviceInfoMigration(for: account)
+        let result = try await dependencies.account.createAccount(deviceName: deviceName, deviceType: deviceType)
+        try updateAccount(result.account)
+        if result.didPublishDeviceInfo {
+            deviceInfoMigrationCoordinator.recordSuccessfulUnifiedWrite(for: result.account)
+        } else {
+            scheduleDeviceInfoMigration(for: result.account)
+        }
         scheduler.requestSyncImmediately()
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -90,6 +90,7 @@ public class DDGSync: DDGSyncing {
     /// This is the constructor intended for use by app clients.
     public convenience init(dataProvidersSource: DataProvidersSource,
                             errorEvents: EventMapping<SyncError>,
+                            unifiedDeviceListEvents: EventMapping<UnifiedDeviceListEvent>? = nil,
                             privacyConfigurationManager: PrivacyConfigurationManaging,
                             keyValueStore: ThrowingKeyValueStoring,
                             environment: ServerEnvironment = .production,
@@ -100,6 +101,7 @@ public class DDGSync: DDGSyncing {
             privacyConfigurationManager: privacyConfigurationManager,
             keyValueStore: keyValueStore,
             errorEvents: errorEvents,
+            unifiedDeviceListEvents: unifiedDeviceListEvents,
             syncFeatureFlags: syncFeatureFlags,
             shouldPreserveAccountWhenSyncDisabled: shouldPreserveAccountWhenSyncDisabled
         )
@@ -249,6 +251,7 @@ public class DDGSync: DDGSyncing {
         let wasDeviceInfoMigrationRunning = deviceInfoMigrationTask != nil
         do {
             let result = try await dependencies.account.fetchDevicesForAccount(account)
+            fireUnifiedReadObservations(result.unifiedReadObservations, for: account)
             if result.needsCurrentDeviceInfoRepair && !wasDeviceInfoMigrationRunning {
                 scheduleCurrentDeviceInfoRepair(for: account)
             }
@@ -739,6 +742,44 @@ public class DDGSync: DDGSyncing {
             await task.value
             self?.clearCompletedDeviceInfoMigrationTask(withID: taskID)
         }
+    }
+
+    private func fireUnifiedReadObservations(_ observations: [UnifiedDeviceListReadObservation],
+                                             for account: SyncAccount) {
+        let canReportOwnRowFallback = dependencies.syncFeatureFlags.canWriteUnifiedDeviceList()
+        var missingDeviceInfoReason: UnifiedDeviceListEvent.DeviceInfoFallbackReason?
+        for observation in observations {
+            switch observation {
+            case .event(let event):
+                if !canReportOwnRowFallback {
+                    switch event {
+                    case .ownRowResolvedLegacy, .ownRowResolvedPlaceholder:
+                        continue
+                    default:
+                        break
+                    }
+                }
+                dependencies.unifiedDeviceListEvents.fire(event)
+            case .ownRowMissingDeviceInfo(.legacy):
+                guard canReportOwnRowFallback else {
+                    continue
+                }
+                let reason = missingDeviceInfoReason ?? ownRowMissingDeviceInfoReason(for: account)
+                missingDeviceInfoReason = reason
+                dependencies.unifiedDeviceListEvents.fire(.ownRowResolvedLegacy(reason))
+            case .ownRowMissingDeviceInfo(.placeholder):
+                guard canReportOwnRowFallback else {
+                    continue
+                }
+                let reason = missingDeviceInfoReason ?? ownRowMissingDeviceInfoReason(for: account)
+                missingDeviceInfoReason = reason
+                dependencies.unifiedDeviceListEvents.fire(.ownRowResolvedPlaceholder(reason))
+            }
+        }
+    }
+
+    private func ownRowMissingDeviceInfoReason(for account: SyncAccount) -> UnifiedDeviceListEvent.DeviceInfoFallbackReason {
+        deviceInfoMigrationCoordinator.hasCompletedMigration(for: account) ? .blobAbsent : .notPublishedYet
     }
 
     private func scheduleCurrentDeviceInfoRepair(for account: SyncAccount) {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/UnifiedDeviceListEvent.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/UnifiedDeviceListEvent.swift
@@ -1,0 +1,245 @@
+//
+//  UnifiedDeviceListEvent.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Privacy-safe outcomes for the unified Sync device list. Associated values are deliberately
+/// bounded enums so device, account, credential, and key identifiers can never reach pixels.
+public enum UnifiedDeviceListEvent: Equatable {
+
+    public enum Frequency: Equatable {
+        case standard
+        case daily
+    }
+
+    public enum DeviceInfoFallbackReason: String, Equatable {
+        case notPublishedYet = "not_published_yet"
+        case blobAbsent = "blob_absent"
+        case blobDecryptFailed = "blob_decrypt_failed"
+    }
+
+    public enum AccountInfoKeyUnavailableReason: String, Equatable {
+        case noKeyOnServer = "no_key_on_server"
+        case noWrapForOurCredential = "no_wrap_for_our_credential"
+        case unwrapFailed = "unwrap_failed"
+        case invalidKeyMaterial = "invalid_key_material"
+        case keysFetchFailed = "keys_fetch_failed"
+        case rateLimited = "rate_limited"
+    }
+
+    public enum Credential: String, Equatable {
+        case ddg
+        case thirdParty = "3party"
+        case none
+    }
+
+    public enum AccountInfoKeyAdoptFailureReason: String, Equatable {
+        case keysFetchFailed = "keys_fetch_failed"
+        case rateLimited = "rate_limited"
+    }
+
+    public enum AccountInfoKeyCreateFailureReason: String, Equatable {
+        case mintFailed = "mint_failed"
+        case requestFailed = "request_failed"
+        case rateLimited = "rate_limited"
+    }
+
+    public enum AccountInfoKeyWrapFailureReason: String, Equatable {
+        case unwrapFailed = "unwrap_failed"
+        case requestFailed = "request_failed"
+        case rateLimited = "rate_limited"
+    }
+
+    public enum DeviceInfoWriteFailureReason: String, Equatable {
+        case encryptFailed = "encrypt_failed"
+        case requestFailed = "request_failed"
+        case rateLimited = "rate_limited"
+        case persistFailed = "persist_failed"
+    }
+
+    case ownRowResolvedDeviceInfo
+    case ownRowResolvedLegacy(DeviceInfoFallbackReason)
+    case ownRowResolvedPlaceholder(DeviceInfoFallbackReason)
+    case accountInfoKeyUnavailable(AccountInfoKeyUnavailableReason)
+    case otherRowDeviceInfoFailedDecryption(Credential)
+    case otherRowResolvedPlaceholder(Credential)
+
+    case accountInfoKeyAdoptFailed(AccountInfoKeyAdoptFailureReason)
+    case accountInfoKeyCreateSuccess
+    case accountInfoKeyCreateFailed(AccountInfoKeyCreateFailureReason)
+    case accountInfoKeyWrapSuccess
+    case accountInfoKeyWrapFailed(AccountInfoKeyWrapFailureReason)
+    case accountInfoKeyAdoptSuccess
+
+    case ownRowDeviceInfoFirstWriteSuccess
+    case ownRowDeviceInfoFirstWriteFailed(DeviceInfoWriteFailureReason)
+    case ownRowDeviceInfoUpdateSuccess
+    case ownRowDeviceInfoUpdateFailed(DeviceInfoWriteFailureReason)
+    case ownRowDeviceInfoRepairSuccess
+    case ownRowDeviceInfoRepairFailed(DeviceInfoWriteFailureReason)
+
+    public var name: String {
+        let prefix = "sync_unified_devices_"
+        switch self {
+        case .ownRowResolvedDeviceInfo:
+            return prefix + "own_row_resolved_device_info"
+        case .ownRowResolvedLegacy:
+            return prefix + "own_row_resolved_legacy"
+        case .ownRowResolvedPlaceholder:
+            return prefix + "own_row_resolved_placeholder"
+        case .accountInfoKeyUnavailable:
+            return prefix + "account_info_key_unavailable"
+        case .otherRowDeviceInfoFailedDecryption:
+            return prefix + "other_row_device_info_failed_decryption"
+        case .otherRowResolvedPlaceholder:
+            return prefix + "other_row_resolved_placeholder"
+        case .accountInfoKeyAdoptFailed:
+            return prefix + "account_info_key_adopt_failed"
+        case .accountInfoKeyCreateSuccess:
+            return prefix + "account_info_key_create_success"
+        case .accountInfoKeyCreateFailed:
+            return prefix + "account_info_key_create_failed"
+        case .accountInfoKeyWrapSuccess:
+            return prefix + "account_info_key_wrap_success"
+        case .accountInfoKeyWrapFailed:
+            return prefix + "account_info_key_wrap_failed"
+        case .accountInfoKeyAdoptSuccess:
+            return prefix + "account_info_key_adopt_success"
+        case .ownRowDeviceInfoFirstWriteSuccess:
+            return prefix + "own_row_device_info_first_write_success"
+        case .ownRowDeviceInfoFirstWriteFailed:
+            return prefix + "own_row_device_info_first_write_failed"
+        case .ownRowDeviceInfoUpdateSuccess:
+            return prefix + "own_row_device_info_update_success"
+        case .ownRowDeviceInfoUpdateFailed:
+            return prefix + "own_row_device_info_update_failed"
+        case .ownRowDeviceInfoRepairSuccess:
+            return prefix + "own_row_device_info_repair_success"
+        case .ownRowDeviceInfoRepairFailed:
+            return prefix + "own_row_device_info_repair_failed"
+        }
+    }
+
+    public var parameters: [String: String]? {
+        switch self {
+        case .ownRowResolvedLegacy(let reason),
+             .ownRowResolvedPlaceholder(let reason):
+            return ["reason": reason.rawValue]
+        case .accountInfoKeyUnavailable(let reason):
+            return ["reason": reason.rawValue]
+        case .otherRowDeviceInfoFailedDecryption(let credential),
+             .otherRowResolvedPlaceholder(let credential):
+            return ["credential": credential.rawValue]
+        case .accountInfoKeyAdoptFailed(let reason):
+            return ["reason": reason.rawValue]
+        case .accountInfoKeyCreateFailed(let reason):
+            return ["reason": reason.rawValue]
+        case .accountInfoKeyWrapFailed(let reason):
+            return ["reason": reason.rawValue]
+        case .ownRowDeviceInfoFirstWriteFailed(let reason),
+             .ownRowDeviceInfoUpdateFailed(let reason),
+             .ownRowDeviceInfoRepairFailed(let reason):
+            return ["reason": reason.rawValue]
+        default:
+            return nil
+        }
+    }
+
+    public var frequency: Frequency {
+        switch self {
+        case .ownRowResolvedDeviceInfo,
+             .ownRowResolvedLegacy,
+             .ownRowResolvedPlaceholder,
+             .accountInfoKeyUnavailable,
+             .otherRowDeviceInfoFailedDecryption,
+             .otherRowResolvedPlaceholder,
+             .accountInfoKeyAdoptFailed,
+             .accountInfoKeyCreateFailed,
+             .accountInfoKeyWrapFailed,
+             .ownRowDeviceInfoFirstWriteFailed,
+             .ownRowDeviceInfoUpdateFailed,
+             .ownRowDeviceInfoRepairFailed:
+            return .daily
+        case .accountInfoKeyCreateSuccess,
+             .accountInfoKeyWrapSuccess,
+             .accountInfoKeyAdoptSuccess,
+             .ownRowDeviceInfoFirstWriteSuccess,
+             .ownRowDeviceInfoUpdateSuccess,
+             .ownRowDeviceInfoRepairSuccess:
+            return .standard
+        }
+    }
+}
+
+enum UnifiedDeviceListTelemetry {
+
+    static func accountInfoKeyUnavailableReason(for error: Error) -> UnifiedDeviceListEvent.AccountInfoKeyUnavailableReason {
+        if let keyError = error as? AccountInfoKeyManagerError {
+            switch keyError {
+            case .missingProtectedKey:
+                return .noKeyOnServer
+            case .unavailableWrappingKey:
+                return .noWrapForOurCredential
+            case .invalidProtectedKeySet, .publicKeyMismatch:
+                return .invalidKeyMaterial
+            case .unableToUnwrapPrivateKey:
+                return .unwrapFailed
+            }
+        }
+        if let syncError = error as? SyncError {
+            if case .unexpectedStatusCode(let statusCode) = syncError, statusCode == 429 {
+                return .rateLimited
+            }
+            if case .failedToDecryptValue = syncError {
+                return .unwrapFailed
+            }
+            return .keysFetchFailed
+        }
+        if error is URLError {
+            return .keysFetchFailed
+        }
+        if error is RSAKeyImportError {
+            return .invalidKeyMaterial
+        }
+        return .unwrapFailed
+    }
+
+    static func keyAdoptFailureReason(for error: Error) -> UnifiedDeviceListEvent.AccountInfoKeyAdoptFailureReason {
+        isRateLimited(error) ? .rateLimited : .keysFetchFailed
+    }
+
+    static func keyCreateRequestFailureReason(for error: Error) -> UnifiedDeviceListEvent.AccountInfoKeyCreateFailureReason {
+        isRateLimited(error) ? .rateLimited : .requestFailed
+    }
+
+    static func keyWrapRequestFailureReason(for error: Error) -> UnifiedDeviceListEvent.AccountInfoKeyWrapFailureReason {
+        isRateLimited(error) ? .rateLimited : .requestFailed
+    }
+
+    static func deviceInfoRequestFailureReason(for error: Error) -> UnifiedDeviceListEvent.DeviceInfoWriteFailureReason {
+        isRateLimited(error) ? .rateLimited : .requestFailed
+    }
+
+    private static func isRateLimited(_ error: Error) -> Bool {
+        if let syncError = error as? SyncError,
+           case .unexpectedStatusCode(let statusCode) = syncError {
+            return statusCode == 429
+        }
+        return false
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/UnifiedDeviceListEvent.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/UnifiedDeviceListEvent.swift
@@ -16,6 +16,7 @@
 //  limitations under the License.
 //
 
+import Common
 import Foundation
 
 /// Privacy-safe outcomes for the unified Sync device list. Associated values are deliberately
@@ -182,6 +183,15 @@ public enum UnifiedDeviceListEvent: Equatable {
              .ownRowDeviceInfoUpdateSuccess,
              .ownRowDeviceInfoRepairSuccess:
             return .standard
+        }
+    }
+}
+
+extension EventMapping where Event == UnifiedDeviceListEvent {
+
+    static var noOp: EventMapping<UnifiedDeviceListEvent> {
+        EventMapping { _, _, _, onComplete in
+            onComplete(nil)
         }
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import Common
 import DDGSyncCrypto
 import Networking
 import os.log
@@ -32,6 +33,7 @@ struct AccountManager: AccountManaging {
     let accountInfoKeys: (any AccountInfoKeyManaging)?
     let accountInfoKeyFactory: AccountInfoKeyFactory
     let deviceInfoCodec: DeviceInfoCoding
+    let unifiedDeviceListEvents: EventMapping<UnifiedDeviceListEvent>
     let isScopedAccessCredentialsEnabled: () -> Bool
     let canWriteUnifiedDeviceList: () -> Bool
     let canReadUnifiedDeviceList: () -> Bool
@@ -43,6 +45,7 @@ struct AccountManager: AccountManaging {
          accountInfoKeys: (any AccountInfoKeyManaging)? = nil,
          accountInfoKeyFactory: AccountInfoKeyFactory? = nil,
          deviceInfoCodec: DeviceInfoCoding = DeviceInfoCodec(),
+         unifiedDeviceListEvents: EventMapping<UnifiedDeviceListEvent>? = nil,
          isScopedAccessCredentialsEnabled: @escaping () -> Bool,
          canWriteUnifiedDeviceList: @escaping () -> Bool = { false },
          canReadUnifiedDeviceList: @escaping () -> Bool = { false }) {
@@ -56,6 +59,9 @@ struct AccountManager: AccountManaging {
         self.accountInfoKeys = accountInfoKeys
         self.accountInfoKeyFactory = accountInfoKeyFactory ?? DefaultAccountInfoKeyFactory(crypter: crypter)
         self.deviceInfoCodec = deviceInfoCodec
+        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? EventMapping { _, _, _, onComplete in
+            onComplete(nil)
+        }
         self.isScopedAccessCredentialsEnabled = isScopedAccessCredentialsEnabled
         self.canWriteUnifiedDeviceList = canWriteUnifiedDeviceList
         self.canReadUnifiedDeviceList = canReadUnifiedDeviceList
@@ -94,24 +100,39 @@ struct AccountManager: AccountManaging {
 
         let request = api.createUnauthenticatedJSONRequest(url: endpoints.signup, method: .post, json: paramJson)
 
-        let result = try await request.execute()
+        do {
+            let response = try await request.execute()
 
-        guard let body = result.data else {
-            throw SyncError.noResponseBody
+            guard let body = response.data else {
+                throw SyncError.noResponseBody
+            }
+
+            guard let result = try? JSONDecoder.snakeCaseKeys.decode(Signup.Result.self, from: body) else {
+                throw SyncError.unableToDecodeResponse("Failed to decode signup result")
+            }
+
+            if deviceInfoFields != nil {
+                unifiedDeviceListEvents.fire(.accountInfoKeyCreateSuccess)
+                unifiedDeviceListEvents.fire(.ownRowDeviceInfoFirstWriteSuccess)
+            }
+            return SyncAccount(deviceId: deviceId,
+                               deviceName: deviceName,
+                               deviceType: deviceType,
+                               userId: userId,
+                               primaryKey: Data(accountKeys.primaryKey),
+                               secretKey: Data(accountKeys.secretKey),
+                               token: result.token,
+                               state: .active)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            if deviceInfoFields != nil {
+                unifiedDeviceListEvents.fire(
+                    .accountInfoKeyCreateFailed(UnifiedDeviceListTelemetry.keyCreateRequestFailureReason(for: error)),
+                    error: error)
+            }
+            throw error
         }
-
-        guard let result = try? JSONDecoder.snakeCaseKeys.decode(Signup.Result.self, from: body) else {
-            throw SyncError.unableToDecodeResponse("Failed to decode signup result")
-        }
-
-        return SyncAccount(deviceId: deviceId,
-                           deviceName: deviceName,
-                           deviceType: deviceType,
-                           userId: userId,
-                           primaryKey: Data(accountKeys.primaryKey),
-                           secretKey: Data(accountKeys.secretKey),
-                           token: result.token,
-                           state: .active)
     }
 
     func login(_ recoveryKey: SyncCode.RecoveryKey, deviceName: String, deviceType: String) async throws -> LoginResult {
@@ -260,27 +281,40 @@ struct AccountManager: AccountManaging {
             return nil
         }
 
+        let keys: [ProtectedKey]
         do {
-            let keys = try accountInfoKeyFactory.makeProtectedKeys(accountSecretKey: accountSecretKey,
-                                                                  thirdPartyMainKey: nil)
-            guard let protectedKey = keys.first else {
-                Logger.sync.error("Sync-UnifiedDevices: failed to prepare unified device info for signup: missing account_info protected key")
-                return nil
-            }
-            let encryptedDeviceInfo = try deviceInfoCodec.encrypt(DeviceInfo(name: deviceName, type: deviceType),
-                                                                  using: protectedKey)
-            guard encryptedDeviceInfo.utf8.count <= DeviceInfo.maximumEncryptedLength else {
-                Logger.sync.error("Sync-UnifiedDevices: failed to prepare unified device info for signup: encrypted payload exceeds the maximum length")
-                return nil
-            }
-            Logger.sync.debug("Sync-UnifiedDevices: prepared account_info key and device_info for signup")
-            return (keys: keys, deviceInfo: encryptedDeviceInfo)
+            keys = try accountInfoKeyFactory.makeProtectedKeys(accountSecretKey: accountSecretKey,
+                                                               thirdPartyMainKey: nil)
         } catch {
-            // Device info is additive, so local preparation failures must not block legacy signup.
+            unifiedDeviceListEvents.fire(.accountInfoKeyCreateFailed(.mintFailed), error: error)
             let errorType = String(describing: type(of: error))
-            Logger.sync.error("Sync-UnifiedDevices: failed to prepare unified device info for signup: \(errorType)")
+            Logger.sync.error("Sync-UnifiedDevices: failed to prepare account_info key for signup: \(errorType)")
             return nil
         }
+        guard let protectedKey = keys.first else {
+            unifiedDeviceListEvents.fire(.accountInfoKeyCreateFailed(.mintFailed))
+            Logger.sync.error("Sync-UnifiedDevices: failed to prepare unified device info for signup: missing account_info protected key")
+            return nil
+        }
+
+        let encryptedDeviceInfo: String
+        do {
+            encryptedDeviceInfo = try deviceInfoCodec.encrypt(DeviceInfo(name: deviceName, type: deviceType),
+                                                              using: protectedKey)
+        } catch {
+            // Device info is additive, so local preparation failures must not block legacy signup.
+            unifiedDeviceListEvents.fire(.ownRowDeviceInfoFirstWriteFailed(.encryptFailed), error: error)
+            let errorType = String(describing: type(of: error))
+            Logger.sync.error("Sync-UnifiedDevices: failed to encrypt unified device info for signup: \(errorType)")
+            return nil
+        }
+        guard encryptedDeviceInfo.utf8.count <= DeviceInfo.maximumEncryptedLength else {
+            unifiedDeviceListEvents.fire(.ownRowDeviceInfoFirstWriteFailed(.encryptFailed))
+            Logger.sync.error("Sync-UnifiedDevices: failed to prepare unified device info for signup: encrypted payload exceeds the maximum length")
+            return nil
+        }
+        Logger.sync.debug("Sync-UnifiedDevices: prepared account_info key and device_info for signup")
+        return (keys: keys, deviceInfo: encryptedDeviceInfo)
     }
 
     private func login(_ info: ExtractedLoginInfo,

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -67,7 +67,7 @@ struct AccountManager: AccountManaging {
         self.canReadUnifiedDeviceList = canReadUnifiedDeviceList
     }
 
-    func createAccount(deviceName: String, deviceType: String) async throws -> SyncAccount {
+    func createAccount(deviceName: String, deviceType: String) async throws -> AccountCreationResult {
         let deviceId = UUID().uuidString
         let userId = UUID().uuidString
         let password = UUID().uuidString
@@ -115,14 +115,16 @@ struct AccountManager: AccountManaging {
                 unifiedDeviceListEvents.fire(.accountInfoKeyCreateSuccess)
                 unifiedDeviceListEvents.fire(.ownRowDeviceInfoFirstWriteSuccess)
             }
-            return SyncAccount(deviceId: deviceId,
-                               deviceName: deviceName,
-                               deviceType: deviceType,
-                               userId: userId,
-                               primaryKey: Data(accountKeys.primaryKey),
-                               secretKey: Data(accountKeys.secretKey),
-                               token: result.token,
-                               state: .active)
+            let account = SyncAccount(deviceId: deviceId,
+                                      deviceName: deviceName,
+                                      deviceType: deviceType,
+                                      userId: userId,
+                                      primaryKey: Data(accountKeys.primaryKey),
+                                      secretKey: Data(accountKeys.secretKey),
+                                      token: result.token,
+                                      state: .active)
+            return AccountCreationResult(account: account,
+                                         didPublishDeviceInfo: deviceInfoFields != nil)
         } catch is CancellationError {
             throw CancellationError()
         } catch {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/AccountManager.swift
@@ -59,9 +59,7 @@ struct AccountManager: AccountManaging {
         self.accountInfoKeys = accountInfoKeys
         self.accountInfoKeyFactory = accountInfoKeyFactory ?? DefaultAccountInfoKeyFactory(crypter: crypter)
         self.deviceInfoCodec = deviceInfoCodec
-        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? EventMapping { _, _, _, onComplete in
-            onComplete(nil)
-        }
+        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? .noOp
         self.isScopedAccessCredentialsEnabled = isScopedAccessCredentialsEnabled
         self.canWriteUnifiedDeviceList = canWriteUnifiedDeviceList
         self.canReadUnifiedDeviceList = canReadUnifiedDeviceList

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import Common
 import os.log
 import Persistence
 
@@ -55,6 +56,25 @@ enum DeviceInfoMigrationError: Error, Equatable {
 
 struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
 
+    private enum DeviceInfoWrite {
+        case firstWrite
+        case repair
+
+        var successEvent: UnifiedDeviceListEvent {
+            switch self {
+            case .firstWrite: return .ownRowDeviceInfoFirstWriteSuccess
+            case .repair: return .ownRowDeviceInfoRepairSuccess
+            }
+        }
+
+        func failureEvent(_ reason: UnifiedDeviceListEvent.DeviceInfoWriteFailureReason) -> UnifiedDeviceListEvent {
+            switch self {
+            case .firstWrite: return .ownRowDeviceInfoFirstWriteFailed(reason)
+            case .repair: return .ownRowDeviceInfoRepairFailed(reason)
+            }
+        }
+    }
+
     private enum Key: String {
         case completedAccountDevice = "com.duckduckgo.sync.device-info-migration.completed-account-device"
     }
@@ -64,6 +84,7 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
     private let updateBuilder: DeviceInfoUpdateBuilder
     private let secureStore: SecureStoring
     private let keyValueStore: ThrowingKeyValueStoring
+    private let unifiedDeviceListEvents: EventMapping<UnifiedDeviceListEvent>
     private let canWriteUnifiedDeviceList: () -> Bool
 
     init(accountManager: AccountManaging,
@@ -72,12 +93,16 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
          deviceInfoCodec: DeviceInfoCoding = DeviceInfoCodec(),
          secureStore: SecureStoring,
          keyValueStore: ThrowingKeyValueStoring,
+         unifiedDeviceListEvents: EventMapping<UnifiedDeviceListEvent>? = nil,
          canWriteUnifiedDeviceList: @escaping () -> Bool) {
         self.accountManager = accountManager
         self.scopedAccess = scopedAccess
         self.updateBuilder = DeviceInfoUpdateBuilder(crypter: crypter, deviceInfoCodec: deviceInfoCodec)
         self.secureStore = secureStore
         self.keyValueStore = keyValueStore
+        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? EventMapping { _, _, _, onComplete in
+            onComplete(nil)
+        }
         self.canWriteUnifiedDeviceList = canWriteUnifiedDeviceList
     }
 
@@ -90,7 +115,7 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
             return
         }
         Logger.sync.debug("Sync-UnifiedDevices: migrating current device_info")
-        await updateCurrentDeviceInfo(for: account, identity: identity)
+        await updateCurrentDeviceInfo(for: account, identity: identity, write: .firstWrite)
     }
 
     func repairCurrentDeviceInfo(for account: SyncAccount) async {
@@ -100,7 +125,7 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
               !Task.isCancelled else {
             return
         }
-        await updateCurrentDeviceInfo(for: account, identity: identity)
+        await updateCurrentDeviceInfo(for: account, identity: identity, write: .repair)
     }
 
     func renameCurrentDevice(to name: String, for account: SyncAccount, mode: DeviceInfoRenameMode) async throws -> [RegisteredDevice] {
@@ -119,11 +144,18 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
                   isCurrentAccountSnapshot(currentAccount, identity: identity) else {
                 throw CancellationError()
             }
-            update = try updateBuilder.makeUpdate(deviceID: currentAccount.deviceId,
-                                                   deviceName: name,
-                                                   deviceType: currentAccount.deviceType,
-                                                   primaryKey: currentAccount.primaryKey,
-                                                   protectedKey: protectedKey)
+            do {
+                update = try updateBuilder.makeUpdate(deviceID: currentAccount.deviceId,
+                                                       deviceName: name,
+                                                       deviceType: currentAccount.deviceType,
+                                                       primaryKey: currentAccount.primaryKey,
+                                                       protectedKey: protectedKey)
+            } catch {
+                unifiedDeviceListEvents.fire(
+                    .ownRowDeviceInfoUpdateFailed(.encryptFailed),
+                    error: error)
+                throw error
+            }
         case .legacyOnly:
             update = try updateBuilder.makeUpdateWithoutUnifiedInfo(deviceID: currentAccount.deviceId,
                                                                      deviceName: name,
@@ -134,7 +166,8 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
         let devices = try await applyRename(update,
                                             newDeviceName: name,
                                             account: currentAccount,
-                                            identity: identity)
+                                            identity: identity,
+                                            unifiedWrite: mode == .unified)
         switch mode {
         case .unified:
             markMigrationComplete(for: currentAccount)
@@ -146,60 +179,114 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
     }
 
     private func updateCurrentDeviceInfo(for account: SyncAccount,
-                                         identity: DeviceInfoMigrationIdentity) async {
+                                         identity: DeviceInfoMigrationIdentity,
+                                         write: DeviceInfoWrite) async {
+        let protectedKey: ProtectedKey
         do {
-            let protectedKey = try await prepareAccountInfoProtectedKey(for: account,
-                                                                        identity: identity)
-            guard !Task.isCancelled,
-                  let currentAccount = currentAccount(matching: identity) else {
-                return
-            }
-
-            let update = try updateBuilder.makeUpdate(deviceID: currentAccount.deviceId,
-                                                       deviceName: currentAccount.deviceName,
-                                                       deviceType: currentAccount.deviceType,
-                                                       primaryKey: currentAccount.primaryKey,
-                                                       protectedKey: protectedKey)
-            guard !Task.isCancelled,
-                  isCurrentAccountSnapshot(currentAccount, identity: identity) else {
-                return
-            }
-            _ = try await accountManager.updateDevice(update, for: currentAccount)
-
-            guard !Task.isCancelled,
-                  isCurrentAccountSnapshot(currentAccount, identity: identity) else {
-                return
-            }
-            markMigrationComplete(for: currentAccount)
-            Logger.sync.debug("Sync-UnifiedDevices: current device_info update complete")
+            protectedKey = try await prepareAccountInfoProtectedKey(for: account,
+                                                                    identity: identity)
         } catch is CancellationError {
             return
         } catch {
             guard !Task.isCancelled else {
                 return
             }
-            let errorType = String(describing: Swift.type(of: error))
-            Logger.sync.error("Sync-UnifiedDevices: failed to update current device_info: \(errorType)")
+            logDeviceInfoUpdateFailure(error)
+            return
         }
+
+        guard !Task.isCancelled,
+              let currentAccount = currentAccount(matching: identity) else {
+            return
+        }
+        let update: UpdateDevices.Update
+        do {
+            update = try updateBuilder.makeUpdate(deviceID: currentAccount.deviceId,
+                                                   deviceName: currentAccount.deviceName,
+                                                   deviceType: currentAccount.deviceType,
+                                                   primaryKey: currentAccount.primaryKey,
+                                                   protectedKey: protectedKey)
+        } catch {
+            guard !Task.isCancelled else {
+                return
+            }
+            unifiedDeviceListEvents.fire(
+                write.failureEvent(.encryptFailed),
+                error: error)
+            logDeviceInfoUpdateFailure(error)
+            return
+        }
+        guard !Task.isCancelled,
+              isCurrentAccountSnapshot(currentAccount, identity: identity) else {
+            return
+        }
+        do {
+            _ = try await accountManager.updateDevice(update, for: currentAccount)
+        } catch is CancellationError {
+            return
+        } catch {
+            guard !Task.isCancelled else {
+                return
+            }
+            unifiedDeviceListEvents.fire(
+                write.failureEvent(UnifiedDeviceListTelemetry.deviceInfoRequestFailureReason(for: error)),
+                error: error)
+            logDeviceInfoUpdateFailure(error)
+            return
+        }
+
+        guard !Task.isCancelled,
+              isCurrentAccountSnapshot(currentAccount, identity: identity) else {
+            return
+        }
+        markMigrationComplete(for: currentAccount)
+        unifiedDeviceListEvents.fire(write.successEvent)
+        Logger.sync.debug("Sync-UnifiedDevices: current device_info update complete")
     }
 
     private func applyRename(_ update: UpdateDevices.Update,
                              newDeviceName: String,
                              account: SyncAccount,
-                             identity: DeviceInfoMigrationIdentity) async throws -> [RegisteredDevice] {
+                             identity: DeviceInfoMigrationIdentity,
+                             unifiedWrite: Bool) async throws -> [RegisteredDevice] {
         guard !Task.isCancelled,
               isCurrentAccountSnapshot(account, identity: identity) else {
             throw CancellationError()
         }
 
-        let devices = try await accountManager.updateDevice(update, for: account)
+        let devices: [RegisteredDevice]
+        do {
+            devices = try await accountManager.updateDevice(update, for: account)
+        } catch {
+            if unifiedWrite, !(error is CancellationError) {
+                unifiedDeviceListEvents.fire(
+                    .ownRowDeviceInfoUpdateFailed(UnifiedDeviceListTelemetry.deviceInfoRequestFailureReason(for: error)),
+                    error: error)
+            }
+            throw error
+        }
         guard !Task.isCancelled,
               isCurrentAccountSnapshot(account, identity: identity) else {
             throw CancellationError()
         }
 
-        try secureStore.persistAccount(account.updatingDeviceName(newDeviceName))
+        do {
+            try secureStore.persistAccount(account.updatingDeviceName(newDeviceName))
+        } catch {
+            if unifiedWrite {
+                unifiedDeviceListEvents.fire(.ownRowDeviceInfoUpdateFailed(.persistFailed), error: error)
+            }
+            throw error
+        }
+        if unifiedWrite {
+            unifiedDeviceListEvents.fire(.ownRowDeviceInfoUpdateSuccess)
+        }
         return devices
+    }
+
+    private func logDeviceInfoUpdateFailure(_ error: Error) {
+        let errorType = String(describing: Swift.type(of: error))
+        Logger.sync.error("Sync-UnifiedDevices: failed to update current device_info: \(errorType)")
     }
 
     func reset() {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
@@ -31,6 +31,7 @@ protocol DeviceInfoMigrationCoordinating {
     func migrateCurrentDeviceIfNeeded(for account: SyncAccount) async
     func repairCurrentDeviceInfo(for account: SyncAccount) async
     func renameCurrentDevice(to name: String, for account: SyncAccount, mode: DeviceInfoRenameMode) async throws -> [RegisteredDevice]
+    func recordSuccessfulUnifiedWrite(for account: SyncAccount)
     func hasCompletedMigration(for account: SyncAccount) -> Bool
     func reset()
 }
@@ -178,6 +179,7 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
         return devices
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     private func updateCurrentDeviceInfo(for account: SyncAccount,
                                          identity: DeviceInfoMigrationIdentity,
                                          write: DeviceInfoWrite) async {
@@ -298,6 +300,10 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
             return false
         }
         return storedValue as? String == DeviceInfoMigrationIdentity(account: account).persistedValue
+    }
+
+    func recordSuccessfulUnifiedWrite(for account: SyncAccount) {
+        markMigrationComplete(for: account)
     }
 
     private func markMigrationComplete(for account: SyncAccount) {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/DeviceInfoMigrationCoordinator.swift
@@ -101,9 +101,7 @@ struct DeviceInfoMigrationCoordinator: DeviceInfoMigrationCoordinating {
         self.updateBuilder = DeviceInfoUpdateBuilder(crypter: crypter, deviceInfoCodec: deviceInfoCodec)
         self.secureStore = secureStore
         self.keyValueStore = keyValueStore
-        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? EventMapping { _, _, _, onComplete in
-            onComplete(nil)
-        }
+        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? .noOp
         self.canWriteUnifiedDeviceList = canWriteUnifiedDeviceList
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -38,6 +38,7 @@ struct ProductionDependencies: SyncDependencies {
     let scheduler: SchedulingInternal
     let privacyConfigurationManager: PrivacyConfigurationManaging
     let errorEvents: EventMapping<SyncError>
+    let unifiedDeviceListEvents: EventMapping<UnifiedDeviceListEvent>
     let shouldPreserveAccountWhenSyncDisabled: () -> Bool
     let syncFeatureFlags: any SyncFeatureFlagProviding
 
@@ -46,6 +47,7 @@ struct ProductionDependencies: SyncDependencies {
         privacyConfigurationManager: PrivacyConfigurationManaging,
         keyValueStore: ThrowingKeyValueStoring,
         errorEvents: EventMapping<SyncError>,
+        unifiedDeviceListEvents: EventMapping<UnifiedDeviceListEvent>? = nil,
         syncFeatureFlags: any SyncFeatureFlagProviding,
         shouldPreserveAccountWhenSyncDisabled: @escaping () -> Bool = { false }
     ) {
@@ -56,6 +58,7 @@ struct ProductionDependencies: SyncDependencies {
                   secureStore: SecureStorage(),
                   privacyConfigurationManager: privacyConfigurationManager,
                   errorEvents: errorEvents,
+                  unifiedDeviceListEvents: unifiedDeviceListEvents,
                   syncFeatureFlags: syncFeatureFlags,
                   shouldPreserveAccountWhenSyncDisabled: shouldPreserveAccountWhenSyncDisabled)
     }
@@ -68,6 +71,7 @@ struct ProductionDependencies: SyncDependencies {
         secureStore: SecureStoring,
         privacyConfigurationManager: PrivacyConfigurationManaging,
         errorEvents: EventMapping<SyncError>,
+        unifiedDeviceListEvents: EventMapping<UnifiedDeviceListEvent>? = nil,
         syncFeatureFlags: any SyncFeatureFlagProviding,
         shouldPreserveAccountWhenSyncDisabled: @escaping () -> Bool
     ) {
@@ -78,6 +82,9 @@ struct ProductionDependencies: SyncDependencies {
         self.secureStore = secureStore
         self.privacyConfigurationManager = privacyConfigurationManager
         self.errorEvents = errorEvents
+        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? EventMapping { _, _, _, onComplete in
+            onComplete(nil)
+        }
         self.shouldPreserveAccountWhenSyncDisabled = shouldPreserveAccountWhenSyncDisabled
         self.syncFeatureFlags = syncFeatureFlags
 
@@ -90,6 +97,7 @@ struct ProductionDependencies: SyncDependencies {
                                                          api: api,
                                                          crypter: crypter,
                                                          accountInfoKeyFactory: accountInfoKeyFactory,
+                                                         unifiedDeviceListEvents: self.unifiedDeviceListEvents,
                                                          canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() })
         let accountInfoKeyManager = AccountInfoKeyManager(secureStore: secureStore,
                                                           scopedAccess: scopedAccess,
@@ -110,6 +118,7 @@ struct ProductionDependencies: SyncDependencies {
                                  accountInfoKeys: accountInfoKeyManager,
                                  accountInfoKeyFactory: accountInfoKeyFactory,
                                  deviceInfoCodec: deviceInfoCodec,
+                                 unifiedDeviceListEvents: self.unifiedDeviceListEvents,
                                  isScopedAccessCredentialsEnabled: { syncFeatureFlags.isScopedAccessCredentialsEnabled() },
                                  canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() },
                                  canReadUnifiedDeviceList: { syncFeatureFlags.canReadUnifiedDeviceList() })
@@ -159,7 +168,8 @@ struct ProductionDependencies: SyncDependencies {
                                             api: api,
                                             crypter: crypter,
                                             scopedAccess: scopedAccess,
-                                            account: account)
+                                            account: account,
+                                            unifiedDeviceListEvents: unifiedDeviceListEvents)
     }
 
     func createDeviceInfoMigrationCoordinator() -> DeviceInfoMigrationCoordinating {
@@ -168,6 +178,7 @@ struct ProductionDependencies: SyncDependencies {
                                        crypter: crypter,
                                        secureStore: secureStore,
                                        keyValueStore: keyValueStore,
+                                       unifiedDeviceListEvents: unifiedDeviceListEvents,
                                        canWriteUnifiedDeviceList: { syncFeatureFlags.canWriteUnifiedDeviceList() })
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ProductionDependencies.swift
@@ -82,9 +82,7 @@ struct ProductionDependencies: SyncDependencies {
         self.secureStore = secureStore
         self.privacyConfigurationManager = privacyConfigurationManager
         self.errorEvents = errorEvents
-        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? EventMapping { _, _, _, onComplete in
-            onComplete(nil)
-        }
+        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? .noOp
         self.shouldPreserveAccountWhenSyncDisabled = shouldPreserveAccountWhenSyncDisabled
         self.syncFeatureFlags = syncFeatureFlags
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/RegisteredDeviceMapper.swift
@@ -19,17 +19,30 @@
 import Foundation
 import os.log
 
+enum UnifiedDeviceListReadObservation: Equatable {
+    enum MissingDeviceInfoFallback: Equatable {
+        case legacy
+        case placeholder
+    }
+
+    case event(UnifiedDeviceListEvent)
+    case ownRowMissingDeviceInfo(MissingDeviceInfoFallback)
+}
+
 struct RegisteredDeviceMappingResult {
     let devices: [RegisteredDevice]
     let needsCurrentDeviceInfoRepair: Bool
+    let unifiedReadObservations: [UnifiedDeviceListReadObservation]
     // Diagnostics for the Sync debug UI only; not used to drive device-list behaviour.
     let debugDevices: [RegisteredDeviceDebugInfo]
 
     init(devices: [RegisteredDevice],
          needsCurrentDeviceInfoRepair: Bool,
+         unifiedReadObservations: [UnifiedDeviceListReadObservation] = [],
          debugDevices: [RegisteredDeviceDebugInfo] = []) {
         self.devices = devices
         self.needsCurrentDeviceInfoRepair = needsCurrentDeviceInfoRepair
+        self.unifiedReadObservations = unifiedReadObservations
         self.debugDevices = debugDevices
     }
 }
@@ -104,6 +117,20 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
         let unifiedDeviceInfoFailure: UnifiedDeviceInfoFailure?
     }
 
+    private enum AccountInfoKeyResolution {
+        case notNeeded
+        case cancelled
+        case available(AccountInfoKey)
+        case unavailable(UnifiedDeviceListEvent.AccountInfoKeyUnavailableReason)
+
+        var key: AccountInfoKey? {
+            guard case .available(let key) = self else {
+                return nil
+            }
+            return key
+        }
+    }
+
     let crypter: CryptingInternal
     let scopedAccess: ScopedAccessCredentialManaging?
     let accountInfoKeys: AccountInfoKeyManaging?
@@ -145,27 +172,37 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
     func registeredDevicesWithRepairState(from entries: [RegisteredDeviceEntry],
                                           account: SyncAccount,
                                           isUnifiedReadEnabled: Bool) async -> RegisteredDeviceMappingResult {
-        let accountInfoKey = await accountInfoKeyIfNeeded(for: entries,
-                                                          account: account,
-                                                          isUnifiedReadEnabled: isUnifiedReadEnabled)
+        let accountInfoKeyResolution = await accountInfoKeyIfNeeded(for: entries,
+                                                                    account: account,
+                                                                    isUnifiedReadEnabled: isUnifiedReadEnabled)
         let initialMappings = entries.map {
             registeredDevice(from: $0,
                              account: account,
-                             accountInfoKey: accountInfoKey,
+                             accountInfoKey: accountInfoKeyResolution.key,
                              thirdPartyMainKey: nil,
                              isUnifiedReadEnabled: isUnifiedReadEnabled)
         }
         let finalMappings: [MappingAttempt]
+        var wasAccountInfoKeyRefreshCancelled = false
+        var accountInfoKeyRefreshFailureReason: UnifiedDeviceListEvent.AccountInfoKeyUnavailableReason?
         if initialMappings.contains(where: { $0.unifiedDeviceInfoFailure == .staleKey }),
-           let accountInfoKeys,
-           let refreshedAccountInfoKey = try? await accountInfoKeys.refreshKey(for: account) {
-            Logger.sync.debug("Sync-UnifiedDevices: refreshed account_info key after stale device_info")
-            finalMappings = entries.map {
-                registeredDevice(from: $0,
-                                 account: account,
-                                 accountInfoKey: refreshedAccountInfoKey,
-                                 thirdPartyMainKey: nil,
-                                 isUnifiedReadEnabled: isUnifiedReadEnabled)
+           let accountInfoKeys {
+            do {
+                let refreshedAccountInfoKey = try await accountInfoKeys.refreshKey(for: account)
+                Logger.sync.debug("Sync-UnifiedDevices: refreshed account_info key after stale device_info")
+                finalMappings = entries.map {
+                    registeredDevice(from: $0,
+                                     account: account,
+                                     accountInfoKey: refreshedAccountInfoKey,
+                                     thirdPartyMainKey: nil,
+                                     isUnifiedReadEnabled: isUnifiedReadEnabled)
+                }
+            } catch is CancellationError {
+                wasAccountInfoKeyRefreshCancelled = true
+                finalMappings = initialMappings
+            } catch {
+                accountInfoKeyRefreshFailureReason = UnifiedDeviceListTelemetry.accountInfoKeyUnavailableReason(for: error)
+                finalMappings = initialMappings
             }
         } else {
             finalMappings = initialMappings
@@ -178,6 +215,13 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
             needsCurrentDeviceInfoRepair: needsCurrentDeviceInfoRepair(in: resolvedMappings,
                                                                        entries: entries,
                                                                        account: account),
+            unifiedReadObservations: unifiedReadObservations(mappings: resolvedMappings,
+                                                              entries: entries,
+                                                              account: account,
+                                                              accountInfoKeyResolution: accountInfoKeyResolution,
+                                                              wasAccountInfoKeyRefreshCancelled: wasAccountInfoKeyRefreshCancelled,
+                                                              accountInfoKeyRefreshFailureReason: accountInfoKeyRefreshFailureReason,
+                                                              isUnifiedReadEnabled: isUnifiedReadEnabled),
             debugDevices: resolvedMappings.map {
                 RegisteredDeviceDebugInfo(device: $0.device,
                                           source: $0.source.debugSource,
@@ -285,6 +329,109 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
         }
     }
 
+    private func unifiedReadObservations(
+        mappings: [MappingAttempt],
+        entries: [RegisteredDeviceEntry],
+        account: SyncAccount,
+        accountInfoKeyResolution: AccountInfoKeyResolution,
+        wasAccountInfoKeyRefreshCancelled: Bool,
+        accountInfoKeyRefreshFailureReason: UnifiedDeviceListEvent.AccountInfoKeyUnavailableReason?,
+        isUnifiedReadEnabled: Bool
+    ) -> [UnifiedDeviceListReadObservation] {
+        guard isUnifiedReadEnabled else {
+            return []
+        }
+        if case .cancelled = accountInfoKeyResolution {
+            return []
+        }
+        guard !wasAccountInfoKeyRefreshCancelled else {
+            return []
+        }
+
+        var observations: [UnifiedDeviceListReadObservation] = []
+        if case .unavailable(let reason) = accountInfoKeyResolution {
+            observations.append(.event(.accountInfoKeyUnavailable(reason)))
+        }
+        if let accountInfoKeyRefreshFailureReason {
+            append(.event(.accountInfoKeyUnavailable(accountInfoKeyRefreshFailureReason)),
+                   ifMissingFrom: &observations)
+        }
+
+        for (entry, mapping) in zip(entries, mappings) {
+            if entry.id == account.deviceId {
+                appendOwnRowObservation(for: mapping, to: &observations)
+            } else if let credential = credential(for: entry) {
+                appendOtherRowObservations(for: mapping,
+                                           credential: credential,
+                                           to: &observations)
+            }
+        }
+        return observations
+    }
+
+    private func appendOwnRowObservation(for mapping: MappingAttempt,
+                                         to observations: inout [UnifiedDeviceListReadObservation]) {
+        switch mapping.source {
+        case .deviceInfo:
+            append(.event(.ownRowResolvedDeviceInfo), ifMissingFrom: &observations)
+        case .legacy, .placeholder:
+            guard let failure = mapping.unifiedDeviceInfoFailure,
+                  failure != .keyUnavailable else {
+                return
+            }
+            if failure == .missing {
+                let fallback: UnifiedDeviceListReadObservation.MissingDeviceInfoFallback = mapping.source == .legacy
+                    ? .legacy
+                    : .placeholder
+                append(.ownRowMissingDeviceInfo(fallback), ifMissingFrom: &observations)
+                return
+            }
+            let event: UnifiedDeviceListEvent = mapping.source == .legacy
+                ? .ownRowResolvedLegacy(.blobDecryptFailed)
+                : .ownRowResolvedPlaceholder(.blobDecryptFailed)
+            append(.event(event), ifMissingFrom: &observations)
+        }
+    }
+
+    private func appendOtherRowObservations(for mapping: MappingAttempt,
+                                            credential: UnifiedDeviceListEvent.Credential,
+                                            to observations: inout [UnifiedDeviceListReadObservation]) {
+        if mapping.source == .deviceInfo {
+            return
+        }
+
+        guard mapping.unifiedDeviceInfoFailure != .keyUnavailable else {
+            return
+        }
+        if mapping.unifiedDeviceInfoFailure == .staleKey || mapping.unifiedDeviceInfoFailure == .corrupt {
+            append(.event(.otherRowDeviceInfoFailedDecryption(credential)), ifMissingFrom: &observations)
+        }
+        if mapping.source == .placeholder {
+            append(.event(.otherRowResolvedPlaceholder(credential)), ifMissingFrom: &observations)
+        }
+    }
+
+    private func credential(for entry: RegisteredDeviceEntry) -> UnifiedDeviceListEvent.Credential? {
+        switch entry.credentialId {
+        case SyncCredentialID.defaultCredential:
+            return .ddg
+        case SyncCredentialID.thirdParty:
+            return .thirdParty
+        case nil:
+            return UnifiedDeviceListEvent.Credential.none
+        default:
+            return nil
+        }
+    }
+
+    private func append(_ observation: UnifiedDeviceListReadObservation,
+                        ifMissingFrom observations: inout [UnifiedDeviceListReadObservation]) {
+        guard !observations.contains(observation) else {
+            return
+        }
+        observations.append(observation)
+    }
+
     private func readUnifiedDeviceInfo(from entry: RegisteredDeviceEntry,
                                        accountInfoKey: AccountInfoKey?,
                                        isUnifiedReadEnabled: Bool) -> UnifiedDeviceInfoReadResult {
@@ -362,13 +509,21 @@ struct RegisteredDeviceMapper: RegisteredDeviceMapping {
 
     private func accountInfoKeyIfNeeded(for entries: [RegisteredDeviceEntry],
                                         account: SyncAccount,
-                                        isUnifiedReadEnabled: Bool) async -> AccountInfoKey? {
+                                        isUnifiedReadEnabled: Bool) async -> AccountInfoKeyResolution {
         guard isUnifiedReadEnabled,
-              entries.contains(where: { $0.info != nil }),
-              let accountInfoKeys else {
-            return nil
+              entries.contains(where: { $0.info != nil }) else {
+            return .notNeeded
         }
-        return try? await accountInfoKeys.loadKey(for: account)
+        guard let accountInfoKeys else {
+            return .unavailable(.keysFetchFailed)
+        }
+        do {
+            return .available(try await accountInfoKeys.loadKey(for: account))
+        } catch is CancellationError {
+            return .cancelled
+        } catch {
+            return .unavailable(UnifiedDeviceListTelemetry.accountInfoKeyUnavailableReason(for: error))
+        }
     }
 
     private func thirdPartyMainKeyIfNeeded(for entries: [RegisteredDeviceEntry], account: SyncAccount) async -> Data? {

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyFactory.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/AccountInfoKeyFactory.swift
@@ -22,6 +22,10 @@ protocol AccountInfoKeyFactory {
     func makeProtectedKeys(accountSecretKey: Data, thirdPartyMainKey: Data?) throws -> [ProtectedKey]
 }
 
+enum AccountInfoKeyFactoryError: Error {
+    case thirdPartyWrappingFailed(Error)
+}
+
 struct DefaultAccountInfoKeyFactory: AccountInfoKeyFactory {
 
     private static let keySizeInBits = 3072
@@ -45,9 +49,14 @@ struct DefaultAccountInfoKeyFactory: AccountInfoKeyFactory {
             return [defaultCredentialKey]
         }
 
-        let thirdPartyCredentialKey = try makeThirdPartyCredentialKey(keyMaterial: keyMaterial,
+        let thirdPartyCredentialKey: ProtectedKey
+        do {
+            thirdPartyCredentialKey = try makeThirdPartyCredentialKey(keyMaterial: keyMaterial,
                                                                       keyID: keyID,
                                                                       thirdPartyMainKey: thirdPartyMainKey)
+        } catch {
+            throw AccountInfoKeyFactoryError.thirdPartyWrappingFailed(error)
+        }
         return [defaultCredentialKey, thirdPartyCredentialKey]
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -17,6 +17,7 @@
 //
 
 import CryptoKit
+import Common
 import Foundation
 import os.log
 
@@ -33,6 +34,7 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
     let api: RemoteAPIRequestCreating
     let crypter: CryptingInternal
     let accountInfoKeyFactory: AccountInfoKeyFactory
+    let unifiedDeviceListEvents: EventMapping<UnifiedDeviceListEvent>
     private let canWriteUnifiedDeviceList: () -> Bool
     private let jweCompactCodec = JWECompactCodec()
     private let scopedAccessCredentialEnvelope = ScopedAccessCredentialEnvelope()
@@ -41,11 +43,15 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
          api: RemoteAPIRequestCreating,
          crypter: CryptingInternal,
          accountInfoKeyFactory: AccountInfoKeyFactory,
+         unifiedDeviceListEvents: EventMapping<UnifiedDeviceListEvent>? = nil,
          canWriteUnifiedDeviceList: @escaping () -> Bool) {
         self.endpoints = endpoints
         self.api = api
         self.crypter = crypter
         self.accountInfoKeyFactory = accountInfoKeyFactory
+        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? EventMapping { _, _, _, onComplete in
+            onComplete(nil)
+        }
         self.canWriteUnifiedDeviceList = canWriteUnifiedDeviceList
     }
 
@@ -84,7 +90,8 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
                 for: account,
                 scopedPassword: scopedPassword,
                 keys: keyPreparation.protectedKeys,
-                defaultCredentialKeysToUpload: keyPreparation.defaultCredentialKeysToUpload)
+                defaultCredentialKeysToUpload: keyPreparation.defaultCredentialKeysToUpload,
+                addsAccountInfoWrapper: keyPreparation.addsAccountInfoWrapper)
             let protectedKeysToCache: [ProtectedKey]
             if let createdProtectedKeys = ensuredCredential.createdProtectedKeys {
                 // The credential was created with these wrappers
@@ -110,13 +117,28 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
             return []
         }
 
-        let storedKeys = try await fetchProtectedKeys(account)
+        let storedKeys: [ProtectedKey]
+        do {
+            storedKeys = try await fetchProtectedKeys(account)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            unifiedDeviceListEvents.fire(
+                .accountInfoKeyAdoptFailed(UnifiedDeviceListTelemetry.keyAdoptFailureReason(for: error)),
+                error: error)
+            throw error
+        }
         let storedAccountInfoKeys = protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: storedKeys)
         if !storedAccountInfoKeys.isEmpty {
             Logger.sync.debug("Sync-UnifiedDevices: account_info key already exists")
-            let reconciledKeys = try await repairAccountInfoProtectedKeysIfNeeded(storedKeys,
-                                                                                  account: account)
-            return protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: reconciledKeys)
+            let repairResult = try await repairAccountInfoProtectedKeysIfNeeded(storedKeys,
+                                                                                account: account)
+            // The server does not expose key provenance, so "adopt" means this operation resolved an
+            // already-registered key instead of successfully registering its own candidate.
+            if !repairResult.didAddWrapper {
+                unifiedDeviceListEvents.fire(.accountInfoKeyAdoptSuccess)
+            }
+            return protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: repairResult.keys)
         }
 
         let accessCredentials = try await fetchAccessCredentials(account)
@@ -126,23 +148,73 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         let thirdPartyMainKey = scopedPassword.map {
             ScopedAccessKeyDerivation.mainKey(from: $0, userID: account.userId)
         }
-        let keys = try accountInfoKeyFactory.makeProtectedKeys(accountSecretKey: account.secretKey,
-                                                              thirdPartyMainKey: thirdPartyMainKey)
+        let keys: [ProtectedKey]
+        do {
+            keys = try accountInfoKeyFactory.makeProtectedKeys(accountSecretKey: account.secretKey,
+                                                               thirdPartyMainKey: thirdPartyMainKey)
+        } catch let error as AccountInfoKeyFactoryError {
+            switch error {
+            case .thirdPartyWrappingFailed(let underlyingError):
+                // No key request was made, and this failure is neither minting nor a server request outcome.
+                throw underlyingError
+            }
+        } catch {
+            unifiedDeviceListEvents.fire(.accountInfoKeyCreateFailed(.mintFailed), error: error)
+            throw error
+        }
+        guard !keys.isEmpty else {
+            unifiedDeviceListEvents.fire(.accountInfoKeyCreateFailed(.mintFailed))
+            throw SyncError.invalidDataInResponse("account_info key factory returned no protected keys")
+        }
         Logger.sync.debug("Sync-UnifiedDevices: registering account_info key")
-        let registeredKeys = try await setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo, keys: keys, for: account)
-        if keys.first?.kid == registeredKeys.first?.kid {
+        let registeredKeys: [ProtectedKey]
+        do {
+            registeredKeys = try await setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo, keys: keys, for: account)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            unifiedDeviceListEvents.fire(
+                .accountInfoKeyCreateFailed(UnifiedDeviceListTelemetry.keyCreateRequestFailureReason(for: error)),
+                error: error)
+            throw error
+        }
+        let createdKey = keys.first?.kid == registeredKeys.first?.kid
+        if createdKey {
             Logger.sync.debug("Sync-UnifiedDevices: registered new account_info key")
+            unifiedDeviceListEvents.fire(.accountInfoKeyCreateSuccess)
         } else {
             Logger.sync.debug("Sync-UnifiedDevices: adopted existing account_info key")
         }
-        let persistedKeys = try await fetchProtectedKeys(account)
-        let reconciledKeys = try await repairAccountInfoProtectedKeysIfNeeded(
+        let persistedKeys: [ProtectedKey]
+        do {
+            persistedKeys = try await fetchProtectedKeys(account)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            if !createdKey {
+                unifiedDeviceListEvents.fire(
+                    .accountInfoKeyAdoptFailed(UnifiedDeviceListTelemetry.keyAdoptFailureReason(for: error)),
+                    error: error)
+            }
+            throw error
+        }
+        if !createdKey,
+           protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: persistedKeys).isEmpty {
+            let error = SyncError.invalidDataInResponse("account_info protected keys are missing")
+            unifiedDeviceListEvents.fire(.accountInfoKeyAdoptFailed(.keysFetchFailed), error: error)
+            throw error
+        }
+        let repairResult = try await repairAccountInfoProtectedKeysIfNeeded(
             persistedKeys,
             account: account,
             thirdPartyCredential: ThirdPartyCredentialContext(
                 isPresent: accessCredentials.contains { $0.id == SyncCredentialID.thirdParty },
-                scopedPassword: scopedPassword))
-        return protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: reconciledKeys)
+                scopedPassword: scopedPassword),
+            reportsWrapEvents: !createdKey)
+        if !createdKey && !repairResult.didAddWrapper {
+            unifiedDeviceListEvents.fire(.accountInfoKeyAdoptSuccess)
+        }
+        return protectedKeys(for: ProtectedKeyPurpose.accountInfo, in: repairResult.keys)
     }
 
     func makeRecoveryCode(for account: SyncAccount, scopedPassword: Data) -> String? {
@@ -167,7 +239,8 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
     private func ensureThirdPartyAccessCredential(for account: SyncAccount,
                                                   scopedPassword: Data,
                                                   keys protectedKeys: [ProtectedKey],
-                                                  defaultCredentialKeysToUpload: [ProtectedKey]) async throws -> EnsuredThirdPartyAccessCredential {
+                                                  defaultCredentialKeysToUpload: [ProtectedKey],
+                                                  addsAccountInfoWrapper: Bool) async throws -> EnsuredThirdPartyAccessCredential {
         guard let token = account.token else {
             throw SyncError.noToken
         }
@@ -180,11 +253,19 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
                                                                                                           using: defaultCredentialMainKey,
                                                                                                           kid: SyncCredentialID.defaultCredential)
 
-        let createCredentialKeys = try accessCredentialProtectedKeys(from: protectedKeys,
+        let createCredentialKeys: [ProtectedKey]
+        do {
+            createCredentialKeys = try accessCredentialProtectedKeys(from: protectedKeys,
                                                                      scopedPassword: scopedPassword,
                                                                      account: account,
                                                                      defaultCredentialKeysToUpload: defaultCredentialKeysToUpload)
-            .removingDuplicateWrappingIdentities()
+                .removingDuplicateWrappingIdentities()
+        } catch {
+            if addsAccountInfoWrapper {
+                unifiedDeviceListEvents.fire(.accountInfoKeyWrapFailed(.unwrapFailed), error: error)
+            }
+            throw error
+        }
 
         do {
             try await postThirdPartyAccessCredential(token: token,
@@ -199,6 +280,18 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
                                                          createdProtectedKeys: nil)
             }
             throw SyncError.unexpectedStatusCode(statusCode)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            if addsAccountInfoWrapper {
+                unifiedDeviceListEvents.fire(
+                    .accountInfoKeyWrapFailed(UnifiedDeviceListTelemetry.keyWrapRequestFailureReason(for: error)),
+                    error: error)
+            }
+            throw error
+        }
+        if addsAccountInfoWrapper {
+            unifiedDeviceListEvents.fire(.accountInfoKeyWrapSuccess)
         }
         return EnsuredThirdPartyAccessCredential(scopedPassword: scopedPassword,
                                                  createdProtectedKeys: createCredentialKeys)
@@ -289,10 +382,19 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         // The backend rejects credential creation unless every existing ddg key has a matching 3party wrapper
         let fetchedProtectedKeys = try await fetchProtectedKeys(account)
         let fetchedDefaultCredentialKeys = defaultCredentialKeys(in: fetchedProtectedKeys)
+        let addsAccountInfoWrapper = fetchedDefaultCredentialKeys.contains { defaultKey in
+            defaultKey.purpose == ProtectedKeyPurpose.accountInfo
+                && !fetchedProtectedKeys.contains { key in
+                    key.kid == defaultKey.kid
+                        && key.purpose == defaultKey.purpose
+                        && key.encryptedWith == SyncCredentialID.thirdParty
+                }
+        }
         if fetchedDefaultCredentialKeys.contains(where: { $0.purpose == purpose }) {
             return ProtectedKeysForThirdPartyCredential(protectedKeys: fetchedProtectedKeys.removingDuplicateWrappingIdentities(),
                                                         defaultCredentialKeysToUpload: [],
-                                                        protectedKeysToCache: fetchedProtectedKeys)
+                                                        protectedKeysToCache: fetchedProtectedKeys,
+                                                        addsAccountInfoWrapper: addsAccountInfoWrapper)
         }
 
         let protectedKey = try makeDefaultCredentialProtectedKey(purpose: purpose, account: account)
@@ -300,7 +402,8 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
             .removingDuplicateWrappingIdentities()
         return ProtectedKeysForThirdPartyCredential(protectedKeys: protectedKeys,
                                                     defaultCredentialKeysToUpload: [protectedKey],
-                                                    protectedKeysToCache: fetchedProtectedKeys + [protectedKey])
+                                                    protectedKeysToCache: fetchedProtectedKeys + [protectedKey],
+                                                    addsAccountInfoWrapper: addsAccountInfoWrapper)
     }
 
     private func defaultCredentialKeys(in keys: [ProtectedKey]) -> [ProtectedKey] {
@@ -411,24 +514,26 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         guard storedKeys.contains(where: { $0.purpose == ProtectedKeyPurpose.accountInfo }) else {
             return storedKeys
         }
-        return try await repairAccountInfoProtectedKeysIfNeeded(
+        let repairResult = try await repairAccountInfoProtectedKeysIfNeeded(
             storedKeys,
             account: account,
             thirdPartyCredential: ThirdPartyCredentialContext(isPresent: true,
                                                                scopedPassword: scopedPassword))
+        return repairResult.keys
     }
 
     private func repairAccountInfoProtectedKeysIfNeeded(
         _ keys: [ProtectedKey],
         account: SyncAccount,
-        thirdPartyCredential providedThirdPartyCredential: ThirdPartyCredentialContext? = nil
-    ) async throws -> [ProtectedKey] {
+        thirdPartyCredential providedThirdPartyCredential: ThirdPartyCredentialContext? = nil,
+        reportsWrapEvents: Bool = true
+    ) async throws -> AccountInfoKeyRepairResult {
         let accountInfoKeys = try validateAccountInfoProtectedKeyIdentity(keys)
         let hasDefaultWrapper = accountInfoKeys.contains { $0.encryptedWith == SyncCredentialID.defaultCredential }
         let hasThirdPartyWrapper = accountInfoKeys.contains { $0.encryptedWith == SyncCredentialID.thirdParty }
         if hasDefaultWrapper && hasThirdPartyWrapper {
             _ = try validateAccountInfoProtectedKeys(accountInfoKeys, requiresThirdPartyWrapper: true)
-            return keys
+            return AccountInfoKeyRepairResult(keys: keys, didAddWrapper: false)
         }
 
         let thirdPartyCredential: ThirdPartyCredentialContext
@@ -437,51 +542,84 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
             thirdPartyCredential = providedThirdPartyCredential
         } else {
             let accessCredentials = try await fetchAccessCredentials(account)
-            thirdPartyCredential = ThirdPartyCredentialContext(
-                isPresent: accessCredentials.contains { $0.id == SyncCredentialID.thirdParty },
-                scopedPassword: try recoverScopedPassword(from: accessCredentials,
-                                                          primaryKey: account.primaryKey,
-                                                          userID: account.userId))
+            let isThirdPartyCredentialPresent = accessCredentials.contains { $0.id == SyncCredentialID.thirdParty }
+            let scopedPassword: Data?
+            do {
+                scopedPassword = try recoverScopedPassword(from: accessCredentials,
+                                                           primaryKey: account.primaryKey,
+                                                           userID: account.userId)
+            } catch {
+                if reportsWrapEvents {
+                    unifiedDeviceListEvents.fire(.accountInfoKeyWrapFailed(.unwrapFailed), error: error)
+                }
+                throw error
+            }
+            thirdPartyCredential = ThirdPartyCredentialContext(isPresent: isThirdPartyCredentialPresent,
+                                                               scopedPassword: scopedPassword)
         }
         let needsDefaultWrapper = !hasDefaultWrapper
         let needsThirdPartyWrapper = thirdPartyCredential.isPresent && !hasThirdPartyWrapper
         guard needsDefaultWrapper || needsThirdPartyWrapper else {
             _ = try validateAccountInfoProtectedKeys(accountInfoKeys, requiresThirdPartyWrapper: false)
-            return keys
+            return AccountInfoKeyRepairResult(keys: keys, didAddWrapper: false)
         }
 
-        guard let scopedPassword = thirdPartyCredential.scopedPassword else {
-            throw SyncError.invalidDataInResponse("account_info protected keys cannot be repaired without a 3party credential")
-        }
-        guard let sourceKey = accountInfoKeys.first else {
-            throw SyncError.invalidDataInResponse("account_info protected keys are missing")
-        }
-        let privateKeyPKCS8 = try unwrapAccountInfoPrivateKey(from: accountInfoKeys,
-                                                             account: account,
-                                                             scopedPassword: scopedPassword)
-        var repairedKeys = accountInfoKeys
-        if needsDefaultWrapper {
-            Logger.sync.debug("Sync-UnifiedDevices: repairing missing account_info ddg wrapper")
-            repairedKeys.append(try makeDefaultAccountInfoWrapper(sourceKey: sourceKey,
-                                                                  privateKeyPKCS8: privateKeyPKCS8,
-                                                                  accountSecretKey: account.secretKey))
-        }
-        if needsThirdPartyWrapper {
-            Logger.sync.debug("Sync-UnifiedDevices: repairing missing account_info 3party wrapper")
-            repairedKeys.append(try makeThirdPartyAccountInfoWrapper(sourceKey: sourceKey,
-                                                                     privateKeyPKCS8: privateKeyPKCS8,
-                                                                     scopedPassword: scopedPassword,
-                                                                     userID: account.userId))
+        let repairedKeys: [ProtectedKey]
+        do {
+            guard let scopedPassword = thirdPartyCredential.scopedPassword else {
+                throw SyncError.invalidDataInResponse("account_info protected keys cannot be repaired without a 3party credential")
+            }
+            guard let sourceKey = accountInfoKeys.first else {
+                throw SyncError.invalidDataInResponse("account_info protected keys are missing")
+            }
+            let privateKeyPKCS8 = try unwrapAccountInfoPrivateKey(from: accountInfoKeys,
+                                                                 account: account,
+                                                                 scopedPassword: scopedPassword)
+            var keys = accountInfoKeys
+            if needsDefaultWrapper {
+                Logger.sync.debug("Sync-UnifiedDevices: repairing missing account_info ddg wrapper")
+                keys.append(try makeDefaultAccountInfoWrapper(sourceKey: sourceKey,
+                                                              privateKeyPKCS8: privateKeyPKCS8,
+                                                              accountSecretKey: account.secretKey))
+            }
+            if needsThirdPartyWrapper {
+                Logger.sync.debug("Sync-UnifiedDevices: repairing missing account_info 3party wrapper")
+                keys.append(try makeThirdPartyAccountInfoWrapper(sourceKey: sourceKey,
+                                                                 privateKeyPKCS8: privateKeyPKCS8,
+                                                                 scopedPassword: scopedPassword,
+                                                                 userID: account.userId))
+            }
+            repairedKeys = keys
+        } catch {
+            if reportsWrapEvents {
+                unifiedDeviceListEvents.fire(.accountInfoKeyWrapFailed(.unwrapFailed), error: error)
+            }
+            throw error
         }
 
-        _ = try await setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
-                                     keys: repairedKeys,
-                                     for: account)
-        let storedKeys = try await fetchProtectedKeys(account)
-        _ = try validateAccountInfoProtectedKeys(storedKeys,
-                                                 requiresThirdPartyWrapper: thirdPartyCredential.isPresent)
+        let storedKeys: [ProtectedKey]
+        do {
+            _ = try await setKeysIfAbsent(purpose: ProtectedKeyPurpose.accountInfo,
+                                         keys: repairedKeys,
+                                         for: account)
+            storedKeys = try await fetchProtectedKeys(account)
+            _ = try validateAccountInfoProtectedKeys(storedKeys,
+                                                     requiresThirdPartyWrapper: thirdPartyCredential.isPresent)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            if reportsWrapEvents {
+                unifiedDeviceListEvents.fire(
+                    .accountInfoKeyWrapFailed(UnifiedDeviceListTelemetry.keyWrapRequestFailureReason(for: error)),
+                    error: error)
+            }
+            throw error
+        }
+        if reportsWrapEvents {
+            unifiedDeviceListEvents.fire(.accountInfoKeyWrapSuccess)
+        }
         Logger.sync.debug("Sync-UnifiedDevices: account_info wrapper repair complete")
-        return storedKeys
+        return AccountInfoKeyRepairResult(keys: storedKeys, didAddWrapper: true)
     }
 
     private func validateAccountInfoProtectedKeyIdentity(_ keys: [ProtectedKey]) throws -> [ProtectedKey] {
@@ -634,6 +772,7 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         let protectedKeys: [ProtectedKey]
         let defaultCredentialKeysToUpload: [ProtectedKey]
         let protectedKeysToCache: [ProtectedKey]
+        let addsAccountInfoWrapper: Bool
     }
 
     private struct EnsuredThirdPartyAccessCredential {
@@ -644,6 +783,11 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
     private struct ThirdPartyCredentialContext {
         let isPresent: Bool
         let scopedPassword: Data?
+    }
+
+    private struct AccountInfoKeyRepairResult {
+        let keys: [ProtectedKey]
+        let didAddWrapper: Bool
     }
 
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -112,6 +112,7 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         }
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     func ensureAccountInfoProtectedKeys(for account: SyncAccount) async throws -> [ProtectedKey] {
         guard canWriteUnifiedDeviceList() else {
             return []
@@ -522,6 +523,7 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         return repairResult.keys
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     private func repairAccountInfoProtectedKeysIfNeeded(
         _ keys: [ProtectedKey],
         account: SyncAccount,

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ScopedAccessCredentialManager.swift
@@ -49,9 +49,7 @@ struct ScopedAccessCredentialManager: ScopedAccessCredentialManaging {
         self.api = api
         self.crypter = crypter
         self.accountInfoKeyFactory = accountInfoKeyFactory
-        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? EventMapping { _, _, _, onComplete in
-            onComplete(nil)
-        }
+        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? .noOp
         self.canWriteUnifiedDeviceList = canWriteUnifiedDeviceList
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ThirdPartyAccountUpgradeCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ThirdPartyAccountUpgradeCoordinator.swift
@@ -17,6 +17,7 @@
 //
 
 import DDGSyncCrypto
+import Common
 import Foundation
 import os.log
 
@@ -66,6 +67,7 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
     let crypter: CryptingInternal
     let scopedAccess: ScopedAccessCredentialManaging
     let account: AccountManaging
+    let unifiedDeviceListEvents: EventMapping<UnifiedDeviceListEvent>
 
     /// Back-off delays for retrying the final native login on transient failures after the credential
     /// is created. Nanoseconds; default is 0.5s then 1s — two retries.
@@ -81,6 +83,7 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
          crypter: CryptingInternal,
          scopedAccess: ScopedAccessCredentialManaging,
          account: AccountManaging,
+         unifiedDeviceListEvents: EventMapping<UnifiedDeviceListEvent>? = nil,
          finalNativeLoginRetryDelays: [UInt64] = [500_000_000, 1_000_000_000],
          retrySleep: @escaping @Sendable (UInt64) async throws -> Void = { try await Task.sleep(nanoseconds: $0) }) {
         self.endpoints = endpoints
@@ -88,6 +91,9 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
         self.crypter = crypter
         self.scopedAccess = scopedAccess
         self.account = account
+        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? EventMapping { _, _, _, onComplete in
+            onComplete(nil)
+        }
         self.finalNativeLoginRetryDelays = finalNativeLoginRetryDelays
         self.retrySleep = retrySleep
     }
@@ -128,14 +134,26 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
             let thirdPartyProtectedKeys = try await fetchUsableThirdPartyProtectedKeys(for: thirdPartyAccount)
             let accountKeys = try generateDefaultCredentialMaterial(userId: recoveryKey.userId)
             let defaultCredentialMainKey = ScopedAccessKeyDerivation.mainKey(from: accountKeys.primaryKey, userID: recoveryKey.userId)
-            let rewrappedProtectedKeys = try rewrapThirdPartyProtectedKeys(thirdPartyProtectedKeys, fromWrappingKey: thirdPartyLogin.mainKey, toAccountSecretKey: accountKeys.secretKey)
+            let addsAccountInfoWrapper = thirdPartyProtectedKeys.contains { $0.purpose == ProtectedKeyPurpose.accountInfo }
+            let rewrappedProtectedKeys: [ProtectedKey]
+            do {
+                rewrappedProtectedKeys = try rewrapThirdPartyProtectedKeys(thirdPartyProtectedKeys,
+                                                                           fromWrappingKey: thirdPartyLogin.mainKey,
+                                                                           toAccountSecretKey: accountKeys.secretKey)
+            } catch {
+                if addsAccountInfoWrapper {
+                    unifiedDeviceListEvents.fire(.accountInfoKeyWrapFailed(.unwrapFailed), error: error)
+                }
+                throw error
+            }
             let encryptedThirdPartyCredential = try encryptThirdPartyCredential(scopedPassword, defaultCredentialMainKey: defaultCredentialMainKey)
             try await postDefaultAccessCredential(token: thirdPartyLogin.token,
                                                  hashedPassword: thirdPartyLogin.hashedPassword,
                                                  credentialHashedPassword: accountKeys.passwordHash.base64EncodedString(),
                                                  protectedEncryptionKey: accountKeys.protectedSecretKey.base64EncodedString(),
                                                  encryptedThirdPartyCredential: encryptedThirdPartyCredential,
-                                                 keys: rewrappedProtectedKeys)
+                                                 keys: rewrappedProtectedKeys,
+                                                 addsAccountInfoWrapper: addsAccountInfoWrapper)
 
             // Remove the temporary 3party device before logging in as the newly-created native device.
             await logoutTemporaryThirdPartyDevice(thirdPartyLogin)
@@ -305,7 +323,8 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
                                              credentialHashedPassword: String,
                                              protectedEncryptionKey: String,
                                              encryptedThirdPartyCredential: String,
-                                             keys: [ProtectedKey]) async throws {
+                                             keys: [ProtectedKey],
+                                             addsAccountInfoWrapper: Bool) async throws {
         let params = CreateDefaultCredentialParameters(
             hashedPassword: hashedPassword,
             credentialHashedPassword: credentialHashedPassword,
@@ -323,16 +342,30 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
             statusCode = try await request.execute().response.statusCode
         } catch SyncError.unexpectedStatusCode(let code) {
             statusCode = code
+        } catch is CancellationError {
+            throw ThirdPartyAccountUpgradeError.nativeCredentialCreationRequestFailed
         } catch {
+            if addsAccountInfoWrapper {
+                unifiedDeviceListEvents.fire(.accountInfoKeyWrapFailed(.requestFailed), error: error)
+            }
             throw ThirdPartyAccountUpgradeError.nativeCredentialCreationRequestFailed
         }
 
         switch statusCode {
         case 200, 201, 204:
+            if addsAccountInfoWrapper {
+                unifiedDeviceListEvents.fire(.accountInfoKeyWrapSuccess)
+            }
             return
         case 409:
             throw ThirdPartyAccountUpgradeError.nativeCredentialAlreadyPresent
         default:
+            if addsAccountInfoWrapper {
+                let error = SyncError.unexpectedStatusCode(statusCode)
+                unifiedDeviceListEvents.fire(
+                    .accountInfoKeyWrapFailed(UnifiedDeviceListTelemetry.keyWrapRequestFailureReason(for: error)),
+                    error: error)
+            }
             throw ThirdPartyAccountUpgradeError.nativeCredentialCreationFailed(statusCode: statusCode)
         }
     }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ThirdPartyAccountUpgradeCoordinator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/ScopedAccess/ThirdPartyAccountUpgradeCoordinator.swift
@@ -91,9 +91,7 @@ struct ThirdPartyAccountUpgradeCoordinator: ThirdPartyAccountUpgradeCoordinating
         self.crypter = crypter
         self.scopedAccess = scopedAccess
         self.account = account
-        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? EventMapping { _, _, _, onComplete in
-            onComplete(nil)
-        }
+        self.unifiedDeviceListEvents = unifiedDeviceListEvents ?? .noOp
         self.finalNativeLoginRetryDelays = finalNativeLoginRetryDelays
         self.retrySleep = retrySleep
     }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
@@ -61,7 +61,7 @@ protocol SyncDependencies: SyncDependenciesDebuggingSupport {
 
 protocol AccountManaging {
 
-    func createAccount(deviceName: String, deviceType: String) async throws -> SyncAccount
+    func createAccount(deviceName: String, deviceType: String) async throws -> AccountCreationResult
     func deleteAccount(_ account: SyncAccount) async throws
 
     func login(_ recoveryKey: SyncCode.RecoveryKey, deviceName: String, deviceType: String) async throws -> LoginResult
@@ -71,6 +71,11 @@ protocol AccountManaging {
 
     func fetchDevicesForAccount(_ account: SyncAccount) async throws -> RegisteredDeviceMappingResult
     func updateDevice(_ update: UpdateDevices.Update, for account: SyncAccount) async throws -> [RegisteredDevice]
+}
+
+struct AccountCreationResult {
+    let account: SyncAccount
+    let didPublishDeviceInfo: Bool
 }
 
 /// Manages the scoped ("3party") access credential: recovering, creating, and fetching its password and protected keys.

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/internal/SyncDependencies.swift
@@ -42,6 +42,7 @@ protocol SyncDependencies: SyncDependenciesDebuggingSupport {
     var scheduler: SchedulingInternal { get }
     var privacyConfigurationManager: PrivacyConfigurationManaging { get }
     var errorEvents: EventMapping<SyncError> { get }
+    var unifiedDeviceListEvents: EventMapping<UnifiedDeviceListEvent> { get }
     var shouldPreserveAccountWhenSyncDisabled: () -> Bool { get }
     var syncFeatureFlags: any SyncFeatureFlagProviding { get }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -82,11 +82,13 @@ final class AccountManagerTests: XCTestCase {
         let protectedKey = makeAccountInfoProtectedKey()
         accountInfoKeyFactory.makeProtectedKeysStub = [protectedKey]
         let deviceInfoCodec = DeviceInfoCodingMock()
+        let events = UnifiedDeviceListEventMappingMock()
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: CryptingMock(),
                                             accountInfoKeyFactory: accountInfoKeyFactory,
                                             deviceInfoCodec: deviceInfoCodec,
+                                            unifiedDeviceListEvents: events,
                                             isScopedAccessCredentialsEnabled: { true },
                                             canWriteUnifiedDeviceList: { true })
         api.fakeRequests[endpoints.signup] = makeJSONRequest("""
@@ -112,6 +114,10 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(deviceInfoCodec.encryptUsingProtectedKeyCalls.first?.deviceInfo,
                        DeviceInfo(name: "iPhone", type: "iOS"))
         XCTAssertEqual(deviceInfoCodec.encryptUsingProtectedKeyCalls.first?.protectedKey.kid, protectedKey.kid)
+        XCTAssertEqual(events.events, [
+            .accountInfoKeyCreateSuccess,
+            .ownRowDeviceInfoFirstWriteSuccess
+        ])
     }
 
     func testWhenCreatingAccountWithUnifiedWriteDisabledThenSignupOmitsKeysAndDeviceInfo() async throws {
@@ -120,11 +126,13 @@ final class AccountManagerTests: XCTestCase {
         let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
         accountInfoKeyFactory.makeProtectedKeysStub = [makeAccountInfoProtectedKey()]
         let deviceInfoCodec = DeviceInfoCodingMock()
+        let events = UnifiedDeviceListEventMappingMock()
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: CryptingMock(),
                                             accountInfoKeyFactory: accountInfoKeyFactory,
                                             deviceInfoCodec: deviceInfoCodec,
+                                            unifiedDeviceListEvents: events,
                                             isScopedAccessCredentialsEnabled: { true },
                                             canWriteUnifiedDeviceList: { false })
         api.fakeRequests[endpoints.signup] = makeJSONRequest("""
@@ -143,6 +151,7 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(signupBody["device_type"] as? String, "encrypted_iOS")
         XCTAssertTrue(accountInfoKeyFactory.makeProtectedKeysCalls.isEmpty)
         XCTAssertTrue(deviceInfoCodec.encryptUsingProtectedKeyCalls.isEmpty)
+        XCTAssertTrue(events.events.isEmpty)
     }
 
     func testWhenDeviceInfoEncryptionFailsThenSignupFallsBackToLegacyFields() async throws {
@@ -152,11 +161,13 @@ final class AccountManagerTests: XCTestCase {
         accountInfoKeyFactory.makeProtectedKeysStub = [makeAccountInfoProtectedKey()]
         let deviceInfoCodec = DeviceInfoCodingMock()
         deviceInfoCodec.encryptUsingProtectedKeyError = DeviceInfoCodecError.invalidPayload
+        let events = UnifiedDeviceListEventMappingMock()
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: CryptingMock(),
                                             accountInfoKeyFactory: accountInfoKeyFactory,
                                             deviceInfoCodec: deviceInfoCodec,
+                                            unifiedDeviceListEvents: events,
                                             isScopedAccessCredentialsEnabled: { true },
                                             canWriteUnifiedDeviceList: { true })
         api.fakeRequests[endpoints.signup] = makeJSONRequest("""
@@ -174,6 +185,7 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(signupBody["device_name"] as? String, "encrypted_iPhone")
         XCTAssertEqual(signupBody["device_type"] as? String, "encrypted_iOS")
         XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.signup])
+        XCTAssertEqual(events.events, [.ownRowDeviceInfoFirstWriteFailed(.encryptFailed)])
     }
 
     func testWhenAccountInfoKeyGenerationFailsThenSignupFallsBackToSingleLegacyRequest() async throws {
@@ -182,11 +194,13 @@ final class AccountManagerTests: XCTestCase {
         let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
         accountInfoKeyFactory.makeProtectedKeysError = AccountManagerTestError.accountInfoKeyGenerationFailed
         let deviceInfoCodec = DeviceInfoCodingMock()
+        let events = UnifiedDeviceListEventMappingMock()
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: CryptingMock(),
                                             accountInfoKeyFactory: accountInfoKeyFactory,
                                             deviceInfoCodec: deviceInfoCodec,
+                                            unifiedDeviceListEvents: events,
                                             isScopedAccessCredentialsEnabled: { true },
                                             canWriteUnifiedDeviceList: { true })
         api.fakeRequests[endpoints.signup] = makeJSONRequest("""
@@ -206,6 +220,7 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(accountInfoKeyFactory.makeProtectedKeysCalls.count, 1)
         XCTAssertTrue(deviceInfoCodec.encryptUsingProtectedKeyCalls.isEmpty)
         XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.signup])
+        XCTAssertEqual(events.events, [.accountInfoKeyCreateFailed(.mintFailed)])
     }
 
     func testWhenEnrichedSignupRequestFailsThenErrorIsPropagatedWithoutLegacyRetry() async throws {
@@ -214,11 +229,13 @@ final class AccountManagerTests: XCTestCase {
         let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
         accountInfoKeyFactory.makeProtectedKeysStub = [makeAccountInfoProtectedKey()]
         let deviceInfoCodec = DeviceInfoCodingMock()
+        let events = UnifiedDeviceListEventMappingMock()
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: CryptingMock(),
                                             accountInfoKeyFactory: accountInfoKeyFactory,
                                             deviceInfoCodec: deviceInfoCodec,
+                                            unifiedDeviceListEvents: events,
                                             isScopedAccessCredentialsEnabled: { true },
                                             canWriteUnifiedDeviceList: { true })
         let signupRequest = HTTPRequestingMock()
@@ -237,6 +254,7 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(signupBody["device_info"] as? String, deviceInfoCodec.encryptUsingProtectedKeyStub)
         XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.signup])
         XCTAssertEqual(signupRequest.executeCallCount, 1)
+        XCTAssertEqual(events.events, [.accountInfoKeyCreateFailed(.requestFailed)])
     }
 
     func testWhenDeviceInfoExceedsServerLimitThenSignupFallsBackToLegacyFields() async throws {
@@ -247,11 +265,13 @@ final class AccountManagerTests: XCTestCase {
         let deviceInfoCodec = DeviceInfoCodingMock()
         deviceInfoCodec.encryptUsingProtectedKeyStub = String(repeating: "a",
                                                               count: DeviceInfo.maximumEncryptedLength + 1)
+        let events = UnifiedDeviceListEventMappingMock()
         let accountManager = AccountManager(endpoints: endpoints,
                                             api: api,
                                             crypter: CryptingMock(),
                                             accountInfoKeyFactory: accountInfoKeyFactory,
                                             deviceInfoCodec: deviceInfoCodec,
+                                            unifiedDeviceListEvents: events,
                                             isScopedAccessCredentialsEnabled: { true },
                                             canWriteUnifiedDeviceList: { true })
         api.fakeRequests[endpoints.signup] = makeJSONRequest("""
@@ -268,6 +288,7 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertNil(signupBody["device_info"])
         XCTAssertEqual(signupBody["device_name"] as? String, "encrypted_iPhone")
         XCTAssertEqual(signupBody["device_type"] as? String, "encrypted_iOS")
+        XCTAssertEqual(events.events, [.ownRowDeviceInfoFirstWriteFailed(.encryptFailed)])
     }
 
     func testWhenDecodingLoginResultWithoutScopedFieldsThenDecodingSucceeds() throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/AccountManagerTests.swift
@@ -98,7 +98,7 @@ final class AccountManagerTests: XCTestCase {
         }
         """)
 
-        _ = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
+        let result = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
 
         let signupBody = try makeSignupBody(from: api)
         let keys = try XCTUnwrap(signupBody["keys"] as? [[String: Any]])
@@ -114,6 +114,7 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(deviceInfoCodec.encryptUsingProtectedKeyCalls.first?.deviceInfo,
                        DeviceInfo(name: "iPhone", type: "iOS"))
         XCTAssertEqual(deviceInfoCodec.encryptUsingProtectedKeyCalls.first?.protectedKey.kid, protectedKey.kid)
+        XCTAssertTrue(result.didPublishDeviceInfo)
         XCTAssertEqual(events.events, [
             .accountInfoKeyCreateSuccess,
             .ownRowDeviceInfoFirstWriteSuccess
@@ -142,7 +143,7 @@ final class AccountManagerTests: XCTestCase {
         }
         """)
 
-        _ = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
+        let result = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
 
         let signupBody = try makeSignupBody(from: api)
         XCTAssertNil(signupBody["keys"])
@@ -151,6 +152,7 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(signupBody["device_type"] as? String, "encrypted_iOS")
         XCTAssertTrue(accountInfoKeyFactory.makeProtectedKeysCalls.isEmpty)
         XCTAssertTrue(deviceInfoCodec.encryptUsingProtectedKeyCalls.isEmpty)
+        XCTAssertFalse(result.didPublishDeviceInfo)
         XCTAssertTrue(events.events.isEmpty)
     }
 
@@ -177,7 +179,7 @@ final class AccountManagerTests: XCTestCase {
         }
         """)
 
-        _ = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
+        let result = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
 
         let signupBody = try makeSignupBody(from: api)
         XCTAssertNil(signupBody["keys"])
@@ -185,6 +187,7 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(signupBody["device_name"] as? String, "encrypted_iPhone")
         XCTAssertEqual(signupBody["device_type"] as? String, "encrypted_iOS")
         XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.signup])
+        XCTAssertFalse(result.didPublishDeviceInfo)
         XCTAssertEqual(events.events, [.ownRowDeviceInfoFirstWriteFailed(.encryptFailed)])
     }
 
@@ -210,7 +213,7 @@ final class AccountManagerTests: XCTestCase {
         }
         """)
 
-        _ = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
+        let result = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
 
         let signupBody = try makeSignupBody(from: api)
         XCTAssertNil(signupBody["keys"])
@@ -220,6 +223,7 @@ final class AccountManagerTests: XCTestCase {
         XCTAssertEqual(accountInfoKeyFactory.makeProtectedKeysCalls.count, 1)
         XCTAssertTrue(deviceInfoCodec.encryptUsingProtectedKeyCalls.isEmpty)
         XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.signup])
+        XCTAssertFalse(result.didPublishDeviceInfo)
         XCTAssertEqual(events.events, [.accountInfoKeyCreateFailed(.mintFailed)])
     }
 
@@ -281,13 +285,14 @@ final class AccountManagerTests: XCTestCase {
         }
         """)
 
-        _ = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
+        let result = try await accountManager.createAccount(deviceName: "iPhone", deviceType: "iOS")
 
         let signupBody = try makeSignupBody(from: api)
         XCTAssertNil(signupBody["keys"])
         XCTAssertNil(signupBody["device_info"])
         XCTAssertEqual(signupBody["device_name"] as? String, "encrypted_iPhone")
         XCTAssertEqual(signupBody["device_type"] as? String, "encrypted_iOS")
+        XCTAssertFalse(result.didPublishDeviceInfo)
         XCTAssertEqual(events.events, [.ownRowDeviceInfoFirstWriteFailed(.encryptFailed)])
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -626,6 +626,23 @@ final class DDGSyncTests: XCTestCase {
 
         let migrationCall = try XCTUnwrap(migrationCoordinator.calls.first)
         XCTAssertEqual(migrationCall.account.deviceId, SyncAccount.mock.deviceId)
+        XCTAssertTrue(migrationCoordinator.successfulUnifiedWriteCalls.isEmpty)
+    }
+
+    func testWhenAccountCreationPublishesDeviceInfoThenSuccessfulWriteIsRecordedWithoutSchedulingMigration() async throws {
+        (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        accountManager.createAccountStub = AccountCreationResult(account: .mock,
+                                                                  didPublishDeviceInfo: true)
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        try await syncService.createAccount(deviceName: "iPhone", deviceType: "iOS")
+
+        XCTAssertTrue(migrationCoordinator.calls.isEmpty)
+        XCTAssertEqual(migrationCoordinator.successfulUnifiedWriteCalls.map(\.account.deviceId),
+                       [SyncAccount.mock.deviceId])
     }
 
     func testWhenLoginSucceedsThenCurrentDeviceMigrationIsScheduled() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -661,6 +661,80 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(migrationCoordinator.resetCallCount, 1)
     }
 
+    func testWhenUnifiedReadObservationsAreReturnedThenTheyFireWithoutRequiringWriteFlag() async throws {
+        dependencies.canReadUnifiedDeviceList = { true }
+        dependencies.canWriteUnifiedDeviceList = { false }
+        let events = UnifiedDeviceListEventMappingMock()
+        dependencies.unifiedDeviceListEvents = events
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        accountManager.fetchDevicesForAccountStub = RegisteredDeviceMappingResult(
+            devices: [.mock],
+            needsCurrentDeviceInfoRepair: false,
+            unifiedReadObservations: [
+                .event(.ownRowResolvedDeviceInfo),
+                .event(.otherRowResolvedPlaceholder(.ddg))
+            ])
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        _ = try await syncService.fetchDevices()
+
+        XCTAssertEqual(events.events, [
+            .ownRowResolvedDeviceInfo,
+            .otherRowResolvedPlaceholder(.ddg)
+        ])
+    }
+
+    func testWhenUnifiedWriteIsDisabledThenOwnRowFallbackObservationsDoNotFire() async throws {
+        dependencies.canReadUnifiedDeviceList = { true }
+        dependencies.canWriteUnifiedDeviceList = { false }
+        let events = UnifiedDeviceListEventMappingMock()
+        dependencies.unifiedDeviceListEvents = events
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        accountManager.fetchDevicesForAccountStub = RegisteredDeviceMappingResult(
+            devices: [.mock],
+            needsCurrentDeviceInfoRepair: false,
+            unifiedReadObservations: [
+                .event(.ownRowResolvedLegacy(.blobDecryptFailed)),
+                .event(.ownRowResolvedPlaceholder(.blobDecryptFailed)),
+                .ownRowMissingDeviceInfo(.legacy),
+                .ownRowMissingDeviceInfo(.placeholder),
+                .event(.ownRowResolvedDeviceInfo),
+                .event(.otherRowResolvedPlaceholder(.ddg))
+            ])
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        _ = try await syncService.fetchDevices()
+
+        XCTAssertEqual(events.events, [
+            .ownRowResolvedDeviceInfo,
+            .otherRowResolvedPlaceholder(.ddg)
+        ])
+    }
+
+    func testWhenOwnRowDeviceInfoIsMissingThenMigrationMarkerDistinguishesNotPublishedFromAbsent() async throws {
+        dependencies.canReadUnifiedDeviceList = { true }
+        dependencies.canWriteUnifiedDeviceList = { true }
+        let events = UnifiedDeviceListEventMappingMock()
+        dependencies.unifiedDeviceListEvents = events
+        let accountManager = try XCTUnwrap(dependencies.account as? AccountManagingMock)
+        accountManager.fetchDevicesForAccountStub = RegisteredDeviceMappingResult(
+            devices: [.mock],
+            needsCurrentDeviceInfoRepair: false,
+            unifiedReadObservations: [.ownRowMissingDeviceInfo(.legacy)])
+        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
+        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
+        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
+
+        _ = try await syncService.fetchDevices()
+        migrationCoordinator.hasCompletedMigrationStub = true
+        _ = try await syncService.fetchDevices()
+
+        XCTAssertEqual(events.events, [
+            .ownRowResolvedLegacy(.notPublishedYet),
+            .ownRowResolvedLegacy(.blobAbsent)
+        ])
+    }
+
     func testWhenMigrationCompletesDuringDeviceFetchThenStaleResultDoesNotScheduleRepairUntilNextPoll() async throws {
         dependencies.canWriteUnifiedDeviceList = { true }
         (dependencies.secureStore as? SecureStorageStub)?.theAccount = nil

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
@@ -32,6 +32,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
     private var coordinator: DeviceInfoMigrationCoordinator!
     private var canWriteUnifiedDeviceList: Bool!
     private var accountInfoProtectedKey: ProtectedKey!
+    private var unifiedDeviceListEvents: UnifiedDeviceListEventMappingMock!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -44,6 +45,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         secureStore.theAccount = .mock
         keyValueStore = try MockKeyValueFileStore()
         canWriteUnifiedDeviceList = true
+        unifiedDeviceListEvents = UnifiedDeviceListEventMappingMock()
         accountInfoProtectedKey = ProtectedKey(
             kid: "account-info-key",
             encryptedPrivateKey: "encrypted-private-key",
@@ -64,6 +66,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         coordinator = nil
         canWriteUnifiedDeviceList = nil
         accountInfoProtectedKey = nil
+        unifiedDeviceListEvents = nil
 
         super.tearDown()
     }
@@ -76,6 +79,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertTrue(scopedAccess.ensureAccountInfoProtectedKeysCalls.isEmpty)
         XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
         XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+        XCTAssertTrue(unifiedDeviceListEvents.events.isEmpty)
     }
 
     func testWhenMigrationSucceedsThenCurrentDeviceIsPatchedInBothFormatsAndMarkedComplete() async throws {
@@ -92,6 +96,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertEqual(call.update.type, "encrypted_\(SyncAccount.mock.deviceType)")
         XCTAssertEqual(call.update.info, deviceInfoCodec.encryptStub)
         XCTAssertTrue(coordinator.hasCompletedMigration(for: .mock))
+        XCTAssertEqual(unifiedDeviceListEvents.events, [.ownRowDeviceInfoFirstWriteSuccess])
     }
 
     func testWhenRenameSucceedsThenOnlyCurrentDeviceIsPatchedInBothFormatsAndRenamedAccountIsPersisted() async throws {
@@ -123,6 +128,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertEqual(persistedAccount.token, SyncAccount.mock.token)
         XCTAssertEqual(persistedAccount.state, SyncAccount.mock.state)
         XCTAssertTrue(coordinator.hasCompletedMigration(for: persistedAccount))
+        XCTAssertEqual(unifiedDeviceListEvents.events, [.ownRowDeviceInfoUpdateSuccess])
     }
 
     func testWhenRenameWithoutUnifiedInfoSucceedsThenOnlyCurrentDeviceLegacyFieldsArePatchedAndRenamedAccountIsPersisted() async throws {
@@ -152,6 +158,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertEqual(persistedAccount.token, SyncAccount.mock.token)
         XCTAssertEqual(persistedAccount.state, SyncAccount.mock.state)
         XCTAssertFalse(coordinator.hasCompletedMigration(for: persistedAccount))
+        XCTAssertTrue(unifiedDeviceListEvents.events.isEmpty)
     }
 
     func testWhenRenameWithoutUnifiedInfoSucceedsThenExistingMigrationMarkerIsPreserved() async throws {
@@ -217,6 +224,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertEqual(secureStore.theAccount?.deviceName, SyncAccount.mock.deviceName)
         XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
         XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+        XCTAssertTrue(unifiedDeviceListEvents.events.isEmpty)
     }
 
     func testWhenRenameEncryptionFailsThenAccountAndMigrationMarkerAreUnchanged() async {
@@ -233,6 +241,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertEqual(secureStore.theAccount?.deviceName, SyncAccount.mock.deviceName)
         XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
         XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+        XCTAssertEqual(unifiedDeviceListEvents.events, [.ownRowDeviceInfoUpdateFailed(.encryptFailed)])
     }
 
     func testWhenRenameLegacyEncryptionFailsThenAccountAndMigrationMarkerAreUnchanged() async {
@@ -268,6 +277,26 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertEqual(accountManager.updateDeviceCalls.count, 1)
         XCTAssertEqual(secureStore.theAccount?.deviceName, SyncAccount.mock.deviceName)
         XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+        XCTAssertEqual(unifiedDeviceListEvents.events, [.ownRowDeviceInfoUpdateFailed(.requestFailed)])
+    }
+
+    func testWhenRenamePersistenceFailsThenPatchSucceedsButAccountAndMigrationMarkerAreUnchanged() async {
+        let expectedError = SyncError.failedToWriteSecureStore(status: -1)
+        secureStore.mockWriteError = expectedError
+
+        do {
+            _ = try await coordinator.renameCurrentDevice(to: "Renamed Device", for: .mock, mode: .unified)
+            XCTFail("Expected rename to throw")
+        } catch let error as SyncError {
+            XCTAssertEqual(error, expectedError)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(accountManager.updateDeviceCalls.count, 1)
+        XCTAssertEqual(secureStore.theAccount?.deviceName, SyncAccount.mock.deviceName)
+        XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+        XCTAssertEqual(unifiedDeviceListEvents.events, [.ownRowDeviceInfoUpdateFailed(.persistFailed)])
     }
 
     func testWhenEncryptedDeviceInfoExceedsServerLimitThenRenameIsNotPatchedPersistedOrMarkedComplete() async {
@@ -285,6 +314,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
         XCTAssertEqual(secureStore.theAccount?.deviceName, SyncAccount.mock.deviceName)
         XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+        XCTAssertEqual(unifiedDeviceListEvents.events, [.ownRowDeviceInfoUpdateFailed(.encryptFailed)])
     }
 
     func testWhenMigrationRunsTwiceThenCurrentDeviceIsPatchedOnce() async {
@@ -303,6 +333,10 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertEqual(accountManager.updateDeviceCalls.count, 2)
         XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.count, 2)
         XCTAssertTrue(coordinator.hasCompletedMigration(for: .mock))
+        XCTAssertEqual(unifiedDeviceListEvents.events, [
+            .ownRowDeviceInfoFirstWriteSuccess,
+            .ownRowDeviceInfoRepairSuccess
+        ])
     }
 
     func testWhenCompletedMigrationIsResetAfterRenameThenCurrentDeviceIsPatchedAgainWithLatestName() async throws {
@@ -418,6 +452,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.count, 2)
         XCTAssertEqual(accountManager.updateDeviceCalls.count, 1)
         XCTAssertTrue(coordinator.hasCompletedMigration(for: .mock))
+        XCTAssertEqual(unifiedDeviceListEvents.events, [.ownRowDeviceInfoFirstWriteSuccess])
     }
 
     func testWhenPatchFailsThenLaterAttemptRetries() async {
@@ -433,6 +468,10 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(accountManager.updateDeviceCalls.count, 2)
         XCTAssertTrue(coordinator.hasCompletedMigration(for: .mock))
+        XCTAssertEqual(unifiedDeviceListEvents.events, [
+            .ownRowDeviceInfoFirstWriteFailed(.requestFailed),
+            .ownRowDeviceInfoFirstWriteSuccess
+        ])
     }
 
     func testWhenPatchIsUnauthorizedThenAccountIsPreservedAndMigrationIsNotMarkedComplete() async {
@@ -442,6 +481,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
 
         XCTAssertNotNil(secureStore.theAccount)
         XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+        XCTAssertEqual(unifiedDeviceListEvents.events, [.ownRowDeviceInfoFirstWriteFailed(.requestFailed)])
     }
 
     func testWhenEncryptedDeviceInfoExceedsServerLimitThenMigrationIsNotPatchedOrMarkedComplete() async {
@@ -451,6 +491,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
 
         XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
         XCTAssertFalse(coordinator.hasCompletedMigration(for: .mock))
+        XCTAssertEqual(unifiedDeviceListEvents.events, [.ownRowDeviceInfoFirstWriteFailed(.encryptFailed)])
     }
 
     func testWhenAccountChangesThenCompletedMigrationDoesNotSkipNewDevice() async {
@@ -480,6 +521,7 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
             deviceInfoCodec: deviceInfoCodec,
             secureStore: secureStore,
             keyValueStore: keyValueStore,
+            unifiedDeviceListEvents: unifiedDeviceListEvents,
             canWriteUnifiedDeviceList: { [weak self] in self?.canWriteUnifiedDeviceList == true })
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DeviceInfoMigrationCoordinatorTests.swift
@@ -325,6 +325,17 @@ final class DeviceInfoMigrationCoordinatorTests: XCTestCase {
         XCTAssertEqual(scopedAccess.ensureAccountInfoProtectedKeysCalls.count, 1)
     }
 
+    func testWhenSuccessfulUnifiedWriteIsRecordedThenMigrationDoesNotPatchCurrentDevice() async {
+        coordinator.recordSuccessfulUnifiedWrite(for: .mock)
+
+        await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
+
+        XCTAssertTrue(coordinator.hasCompletedMigration(for: .mock))
+        XCTAssertTrue(scopedAccess.ensureAccountInfoProtectedKeysCalls.isEmpty)
+        XCTAssertTrue(accountManager.updateDeviceCalls.isEmpty)
+        XCTAssertTrue(unifiedDeviceListEvents.events.isEmpty)
+    }
+
     func testWhenMigrationAlreadyCompletedThenRepairStillPatchesCurrentDevice() async {
         await coordinator.migrateCurrentDeviceIfNeeded(for: .mock)
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -68,13 +68,14 @@ extension LoginResult {
 
 class AccountManagingMock: AccountManaging {
     var createAccountCalls: [(deviceName: String, deviceType: String)] = []
+    var createAccountStub = AccountCreationResult(account: .mock, didPublishDeviceInfo: false)
     var createAccountError: Error?
-    func createAccount(deviceName: String, deviceType: String) async throws -> SyncAccount {
+    func createAccount(deviceName: String, deviceType: String) async throws -> AccountCreationResult {
         createAccountCalls.append((deviceName: deviceName, deviceType: deviceType))
         if let error = createAccountError {
             throw error
         }
-        return .mock
+        return createAccountStub
     }
 
     func deleteAccount(_ account: SyncAccount) async throws {}
@@ -641,6 +642,7 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
     private var recordedCalls: [Call] = []
     private var recordedRepairCalls: [Call] = []
     private var recordedRenameCalls: [(name: String, account: SyncAccount, mode: DeviceInfoRenameMode)] = []
+    private var recordedSuccessfulUnifiedWriteCalls: [Call] = []
     private var recordedResetCallCount = 0
     var hasCompletedMigrationStub = false
     var calls: [Call] {
@@ -662,6 +664,11 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
         lock.lock()
         defer { lock.unlock() }
         return recordedRenameCalls
+    }
+    var successfulUnifiedWriteCalls: [Call] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedSuccessfulUnifiedWriteCalls
     }
     var migrateCurrentDeviceHandler: (() async -> Void)?
     var repairCurrentDeviceInfoHandler: (() async -> Void)?
@@ -703,6 +710,12 @@ final class DeviceInfoMigrationCoordinatingMock: DeviceInfoMigrationCoordinating
 
     func hasCompletedMigration(for account: SyncAccount) -> Bool {
         hasCompletedMigrationStub
+    }
+
+    func recordSuccessfulUnifiedWrite(for account: SyncAccount) {
+        lock.lock()
+        recordedSuccessfulUnifiedWriteCalls.append(Call(account: account))
+        lock.unlock()
     }
 
     func reset() {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -208,6 +208,41 @@ class MockErrorHandler: EventMapping<SyncError> {
     }
 }
 
+final class UnifiedDeviceListEventMappingMock: EventMapping<UnifiedDeviceListEvent> {
+
+    private final class Storage {
+        private let lock = NSLock()
+        private var recordedEvents: [UnifiedDeviceListEvent] = []
+
+        var events: [UnifiedDeviceListEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return recordedEvents
+        }
+
+        func append(_ event: UnifiedDeviceListEvent) {
+            lock.lock()
+            recordedEvents.append(event)
+            lock.unlock()
+        }
+    }
+
+    private let storage: Storage
+
+    var events: [UnifiedDeviceListEvent] {
+        storage.events
+    }
+
+    init() {
+        let storage = Storage()
+        self.storage = storage
+        super.init { event, _, _, onComplete in
+            storage.append(event)
+            onComplete(nil)
+        }
+    }
+}
+
 extension DefaultInternalUserDecider {
     convenience init(mockedStore: MockInternalUserStoring = MockInternalUserStoring()) {
         self.init(store: mockedStore)
@@ -279,6 +314,9 @@ final class MockSyncDependencies: SyncDependencies, SyncDependenciesDebuggingSup
     var scheduler: SchedulingInternal = SchedulerMock()
     var privacyConfigurationManager: PrivacyConfigurationManaging = MockPrivacyConfigurationManager(privacyConfig: MockPrivacyConfiguration())
     var errorEvents: EventMapping<SyncError> = MockErrorHandler()
+    var unifiedDeviceListEvents: EventMapping<UnifiedDeviceListEvent> = EventMapping { _, _, _, onComplete in
+        onComplete(nil)
+    }
     var shouldPreserveAccountWhenSyncDisabled: () -> Bool = { false }
     var isScopedAccessCredentialsEnabled: () -> Bool = { true }
     var isPairingV2ScanningEnabled: () -> Bool = { true }

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/RegisteredDeviceMapperTests.swift
@@ -167,6 +167,7 @@ final class RegisteredDeviceMapperTests: XCTestCase {
         XCTAssertTrue(accountInfoKeys.loadKeyCalls.isEmpty)
         XCTAssertTrue(deviceInfoCodec.decryptCalls.isEmpty)
         XCTAssertFalse(result.needsCurrentDeviceInfoRepair)
+        XCTAssertTrue(result.unifiedReadObservations.isEmpty)
     }
 
     func testWhenUnifiedReadIsDisabledAndNativeLegacyFieldsCannotBeDecryptedThenReturnsUnknownPlaceholder() async {
@@ -220,20 +221,83 @@ final class RegisteredDeviceMapperTests: XCTestCase {
                                   name: nil,
                                   type: nil,
                                   info: "invalid-info",
-                                  credentialId: SyncCredentialID.thirdParty)
+                                  credentialId: SyncCredentialID.thirdParty),
+            RegisteredDeviceEntry(id: "legacy-native-device",
+                                  name: nil,
+                                  type: nil,
+                                  info: "valid-info",
+                                  credentialId: nil)
         ]
 
         let result = await mapper.registeredDevicesWithRepairState(from: entries, account: account)
         let devices = result.devices
 
-        XCTAssertEqual(devices.map(\.id), ["future-device", "native-device", "third-party-device"])
-        XCTAssertEqual(devices.map(\.name), ["Future Browser", "Legacy Mac", "Browser"])
-        XCTAssertEqual(devices.map(\.type), ["browser", "desktop", "unknown"])
-        XCTAssertEqual(devices.map(\.credentialId), ["future", SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty])
+        XCTAssertEqual(devices.map(\.id), ["future-device", "native-device", "third-party-device", "legacy-native-device"])
+        XCTAssertEqual(devices.map(\.name), ["Future Browser", "Legacy Mac", "Browser", "Future Browser"])
+        XCTAssertEqual(devices.map(\.type), ["browser", "desktop", "unknown", "browser"])
+        XCTAssertEqual(devices.map(\.credentialId), [
+            "future", SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty, SyncCredentialID.defaultCredential
+        ])
         XCTAssertEqual(accountInfoKeys.loadKeyCalls.count, 1)
         XCTAssertTrue(accountInfoKeys.refreshKeyCalls.isEmpty)
-        XCTAssertEqual(deviceInfoCodec.decryptCalls, ["valid-info", "invalid-info", "invalid-info"])
+        XCTAssertEqual(deviceInfoCodec.decryptCalls, ["valid-info", "invalid-info", "invalid-info", "valid-info"])
         XCTAssertFalse(result.needsCurrentDeviceInfoRepair)
+        XCTAssertEqual(result.unifiedReadObservations, [
+            .event(.otherRowDeviceInfoFailedDecryption(.ddg)),
+            .event(.otherRowDeviceInfoFailedDecryption(.thirdParty)),
+            .event(.otherRowResolvedPlaceholder(.thirdParty))
+        ])
+    }
+
+    func testWhenOtherRowUsesUnknownCredentialThenDoesNotEmitCredentialScopedObservations() async throws {
+        let account = makeAccount()
+        let accountInfoKeys = AccountInfoKeyManagingMock()
+        accountInfoKeys.loadKeyStub = try makeAccountInfoKey()
+        let deviceInfoCodec = DeviceInfoReadingMock()
+        deviceInfoCodec.decryptHandler = { _, _ in
+            throw DeviceInfoCodecError.invalidPayload
+        }
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            accountInfoKeys: accountInfoKeys,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true })
+        let entry = RegisteredDeviceEntry(id: "future-device",
+                                          name: nil,
+                                          type: nil,
+                                          info: "invalid-info",
+                                          credentialId: "future")
+
+        let result = await mapper.registeredDevicesWithRepairState(from: [entry], account: account)
+
+        XCTAssertTrue(result.unifiedReadObservations.isEmpty)
+    }
+
+    func testWhenOtherRowOmitsCredentialThenEmitsNoneCredentialObservations() async throws {
+        let account = makeAccount()
+        let accountInfoKeys = AccountInfoKeyManagingMock()
+        accountInfoKeys.loadKeyStub = try makeAccountInfoKey()
+        let deviceInfoCodec = DeviceInfoReadingMock()
+        deviceInfoCodec.decryptHandler = { _, _ in
+            throw DeviceInfoCodecError.invalidPayload
+        }
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            accountInfoKeys: accountInfoKeys,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true })
+        let entry = RegisteredDeviceEntry(id: "legacy-device",
+                                          name: nil,
+                                          type: nil,
+                                          info: "invalid-info",
+                                          credentialId: nil)
+
+        let result = await mapper.registeredDevicesWithRepairState(from: [entry], account: account)
+
+        XCTAssertEqual(result.unifiedReadObservations, [
+            .event(.otherRowDeviceInfoFailedDecryption(.none)),
+            .event(.otherRowResolvedPlaceholder(.none))
+        ])
     }
 
     func testWhenUnifiedInfoUsesUnexpectedKeyIDThenRefreshesOnceAndRetriesAllEntries() async throws {
@@ -274,6 +338,39 @@ final class RegisteredDeviceMapperTests: XCTestCase {
         XCTAssertEqual(accountInfoKeys.refreshKeyCalls.map(\.deviceId), [account.deviceId])
         XCTAssertEqual(deviceInfoCodec.decryptCalls, ["info-one", "info-two", "info-one", "info-two"])
         XCTAssertFalse(result.needsCurrentDeviceInfoRepair)
+        XCTAssertEqual(result.unifiedReadObservations, [
+            .event(.ownRowResolvedDeviceInfo)
+        ])
+    }
+
+    func testWhenStaleKeyRefreshIsRateLimitedThenReportsKeyUnavailableWithoutRefreshExhaustion() async throws {
+        let account = makeAccount()
+        let accountInfoKeys = AccountInfoKeyManagingMock()
+        accountInfoKeys.loadKeyStub = try makeAccountInfoKey(kid: "stale-key")
+        accountInfoKeys.refreshKeyError = SyncError.unexpectedStatusCode(429)
+        let deviceInfoCodec = DeviceInfoReadingMock()
+        deviceInfoCodec.decryptHandler = { _, _ in
+            throw DeviceInfoCodecError.unexpectedKeyID
+        }
+        let mapper = RegisteredDeviceMapper(crypter: CryptingMock(),
+                                            accountInfoKeys: accountInfoKeys,
+                                            deviceInfoCodec: deviceInfoCodec,
+                                            isScopedAccessCredentialsEnabled: { true },
+                                            canReadUnifiedDeviceList: { true })
+        let entry = RegisteredDeviceEntry(id: account.deviceId,
+                                          name: "encrypted_Legacy Mac",
+                                          type: "encrypted_desktop",
+                                          info: "encrypted-info",
+                                          credentialId: SyncCredentialID.defaultCredential)
+
+        let result = await mapper.registeredDevicesWithRepairState(from: [entry], account: account)
+
+        XCTAssertEqual(result.devices.map(\.name), ["Legacy Mac"])
+        XCTAssertEqual(accountInfoKeys.refreshKeyCalls.count, 1)
+        XCTAssertEqual(result.unifiedReadObservations, [
+            .event(.accountInfoKeyUnavailable(.rateLimited)),
+            .event(.ownRowResolvedLegacy(.blobDecryptFailed))
+        ])
     }
 
     func testWhenUnifiedInfoStillUsesUnexpectedKeyIDAfterRefreshThenFallsBackWithoutRefreshingAgain() async throws {
@@ -304,6 +401,7 @@ final class RegisteredDeviceMapperTests: XCTestCase {
         XCTAssertEqual(accountInfoKeys.refreshKeyCalls.count, 1)
         XCTAssertEqual(deviceInfoCodec.decryptCalls, ["encrypted-info", "encrypted-info"])
         XCTAssertTrue(result.needsCurrentDeviceInfoRepair)
+        XCTAssertEqual(result.unifiedReadObservations, [.event(.ownRowResolvedLegacy(.blobDecryptFailed))])
     }
 
     func testWhenCurrentDeviceUnifiedInfoIsCorruptThenRequestsRepair() async throws {
@@ -329,6 +427,7 @@ final class RegisteredDeviceMapperTests: XCTestCase {
 
         XCTAssertEqual(result.devices.map(\.name), ["Legacy Mac"])
         XCTAssertTrue(result.needsCurrentDeviceInfoRepair)
+        XCTAssertEqual(result.unifiedReadObservations, [.event(.ownRowResolvedLegacy(.blobDecryptFailed))])
     }
 
     func testWhenCurrentDeviceAccountInfoKeyIsUnavailableThenDoesNotRequestRepair() async {
@@ -348,6 +447,9 @@ final class RegisteredDeviceMapperTests: XCTestCase {
 
         XCTAssertEqual(result.devices.map(\.name), ["Legacy Mac"])
         XCTAssertFalse(result.needsCurrentDeviceInfoRepair)
+        XCTAssertEqual(result.unifiedReadObservations, [
+            .event(.accountInfoKeyUnavailable(.noKeyOnServer))
+        ])
     }
 
     func testWhenUnifiedReadIsEnabledButNoEntryHasInfoThenDoesNotLoadAccountInfoKey() async {
@@ -369,6 +471,9 @@ final class RegisteredDeviceMapperTests: XCTestCase {
         XCTAssertEqual(devices.map(\.name), ["Mac"])
         XCTAssertTrue(accountInfoKeys.loadKeyCalls.isEmpty)
         XCTAssertTrue(result.needsCurrentDeviceInfoRepair)
+        XCTAssertEqual(result.unifiedReadObservations, [
+            .ownRowMissingDeviceInfo(.legacy)
+        ])
     }
 
     func testWhenMappingThirdPartyEntryWithCachedScopedPasswordThenDecryptsJWEFields() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyFactoryTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/AccountInfoKeyFactoryTests.swift
@@ -61,6 +61,19 @@ final class AccountInfoKeyFactoryTests: XCTestCase {
         XCTAssertEqual(defaultCredentialPrivateKey, thirdPartyCredentialPrivateKey)
     }
 
+    func testWhenThirdPartyWrappingFailsThenReportsThatStage() throws {
+        let factory = DefaultAccountInfoKeyFactory(crypter: CryptingMock())
+
+        XCTAssertThrowsError(try factory.makeProtectedKeys(accountSecretKey: accountSecretKey,
+                                                           thirdPartyMainKey: Data())) { error in
+            guard case AccountInfoKeyFactoryError.thirdPartyWrappingFailed(let underlyingError) = error else {
+                XCTFail("Expected a third-party wrapping failure, got \(error)")
+                return
+            }
+            XCTAssertEqual(underlyingError as? JWECompactCodecError, .invalidContentEncryptionKeyLength(0))
+        }
+    }
+
     private func modulusByteCount(of protectedKey: ProtectedKey) throws -> Int {
         let modulus = try XCTUnwrap(protectedKey.publicKey.n)
         return try XCTUnwrap(Base64URL.decode(modulus)).count

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ScopedAccessCredentialManagerTests.swift
@@ -404,6 +404,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
     func testWhenCreatingThirdPartyCredentialThenRewrapsAllExistingDefaultCredentialKeys() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
+        let events = UnifiedDeviceListEventMappingMock()
         var crypter = CryptingMock()
         crypter._extractLoginInfo = { recoveryKey in
             ExtractedLoginInfo(userId: recoveryKey.userId,
@@ -415,6 +416,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                     api: api,
                                                     crypter: crypter,
                                                     accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    unifiedDeviceListEvents: events,
                                                     canWriteUnifiedDeviceList: { true })
 
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
@@ -461,11 +463,13 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                                      contentEncryptionKey: thirdPartyMainKey,
                                                                      expectedKid: SyncCredentialID.thirdParty)
         XCTAssertEqual(decryptedPrivateKey, accountInfoPrivateKey)
+        XCTAssertEqual(events.events, [.accountInfoKeyWrapSuccess])
     }
 
     func testWhenCreatingThirdPartyCredentialWithUnifiedDeviceListWriteDisabledThenRewrapsExistingAccountInfoKey() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
+        let events = UnifiedDeviceListEventMappingMock()
         var crypter = CryptingMock()
         crypter._extractLoginInfo = { recoveryKey in
             ExtractedLoginInfo(userId: recoveryKey.userId,
@@ -477,6 +481,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                     api: api,
                                                     crypter: crypter,
                                                     accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    unifiedDeviceListEvents: events,
                                                     canWriteUnifiedDeviceList: { false })
 
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
@@ -503,6 +508,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertTrue(keys.allSatisfy { $0["encrypted_with"] as? String == SyncCredentialID.thirdParty })
         XCTAssertEqual(keys.first { $0["purpose"] as? String == ProtectedKeyPurpose.accountInfo }?["kid"] as? String,
                        accountInfoKey.kid)
+        XCTAssertEqual(events.events, [.accountInfoKeyWrapSuccess])
     }
 
     func testWhenCreatingThirdPartyScopedPasswordReturns409ThenRefetchesAndRecoversScopedPassword() async throws {
@@ -551,9 +557,10 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         ])
     }
 
-    func testWhenDefaultCredentialProtectedKeyIsDirectJWEThenThrowsAccountExtendFailed() async throws {
+    func testWhenAccountInfoDefaultCredentialProtectedKeyIsDirectJWEThenFiresWrapFailureAndThrowsAccountExtendFailed() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
+        let events = UnifiedDeviceListEventMappingMock()
         var crypter = CryptingMock()
         crypter._extractLoginInfo = { recoveryKey in
             ExtractedLoginInfo(userId: recoveryKey.userId,
@@ -565,6 +572,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                     api: api,
                                                     crypter: crypter,
                                                     accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    unifiedDeviceListEvents: events,
                                                     canWriteUnifiedDeviceList: { true })
 
         let accountPrimaryKey = Data((0..<32).map(UInt8.init))
@@ -573,7 +581,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let defaultCredentialMainKey = hkdf(input: accountPrimaryKey, salt: account.userId, info: "Main Key")
         let ddgWrappedProtectedKey = try ScopedAccessKeyFactory.makeJWEProtectedKey(wrappingKey: defaultCredentialMainKey,
                                                                                     encryptedWith: "ddg",
-                                                                                    purpose: "ai_chats")
+                                                                                    purpose: ProtectedKeyPurpose.accountInfo)
         api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody([]))
         api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([ddgWrappedProtectedKey]))
 
@@ -586,6 +594,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
+        XCTAssertEqual(events.events, [.accountInfoKeyWrapFailed(.unwrapFailed)])
     }
 
     func testWhenEnsuringAccountInfoProtectedKeysWithUnifiedDeviceListWriteDisabledThenDoesNotMakeNetworkRequests() async throws {
@@ -602,13 +611,103 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertTrue(api.createRequestCallArgs.isEmpty)
     }
 
-    func testWhenEnsuringAccountInfoWrappersWithDifferentKidsThenThrowsInvalidData() async throws {
+    func testWhenResolvingAccountInfoKeysIsRateLimitedThenFiresAdoptFailure() async {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
+        let events = UnifiedDeviceListEventMappingMock()
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
                                                     accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    unifiedDeviceListEvents: events,
+                                                    canWriteUnifiedDeviceList: { true })
+        api.fakeRequests[endpoints.keys] = makeFailingRequest(statusCode: 429)
+
+        do {
+            _ = try await manager.ensureAccountInfoProtectedKeys(
+                for: makeAccount(primaryKey: Data(repeating: 0x1, count: 32)))
+            XCTFail("Expected account_info key resolution to fail")
+        } catch SyncError.unexpectedStatusCode(let statusCode) {
+            XCTAssertEqual(statusCode, 429)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(events.events, [.accountInfoKeyAdoptFailed(.rateLimited)])
+    }
+
+    func testWhenAccessCredentialFetchFailsBeforeMintingAccountInfoKeyThenDoesNotFireCreateFailure() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let events = UnifiedDeviceListEventMappingMock()
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    unifiedDeviceListEvents: events,
+                                                    canWriteUnifiedDeviceList: { true })
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([]))
+        api.fakeRequests[endpoints.accessCredentials] = makeFailingRequest(statusCode: 500)
+
+        do {
+            _ = try await manager.ensureAccountInfoProtectedKeys(
+                for: makeAccount(primaryKey: Data(repeating: 0x1, count: 32)))
+            XCTFail("Expected access credential fetch to fail")
+        } catch SyncError.unexpectedStatusCode(let statusCode) {
+            XCTAssertEqual(statusCode, 500)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.keys, endpoints.accessCredentials])
+        XCTAssertTrue(accountInfoKeyFactory.makeProtectedKeysCalls.isEmpty)
+        XCTAssertTrue(events.events.isEmpty)
+    }
+
+    func testWhenScopedPasswordRecoveryFailsBeforeMintingAccountInfoKeyThenDoesNotFireCreateFailure() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let events = UnifiedDeviceListEventMappingMock()
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    unifiedDeviceListEvents: events,
+                                                    canWriteUnifiedDeviceList: { true })
+        let accessCredentials = [
+            AccessCredential(id: SyncCredentialID.thirdParty,
+                             scope: "sync",
+                             encrypted3PartyCredential: "invalid")
+        ]
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([]))
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
+
+        do {
+            _ = try await manager.ensureAccountInfoProtectedKeys(
+                for: makeAccount(primaryKey: Data(repeating: 0x1, count: 32)))
+            XCTFail("Expected scoped password recovery to fail")
+        } catch ScopedAccessCredentialError.undecryptableThirdPartyCredential {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.keys, endpoints.accessCredentials])
+        XCTAssertTrue(accountInfoKeyFactory.makeProtectedKeysCalls.isEmpty)
+        XCTAssertTrue(events.events.isEmpty)
+    }
+
+    func testWhenEnsuringAccountInfoWrappersWithDifferentKidsThenThrowsInvalidData() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let events = UnifiedDeviceListEventMappingMock()
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    unifiedDeviceListEvents: events,
                                                     canWriteUnifiedDeviceList: { true })
         let storedKeys = [
             makeProtectedKey(kid: "first-key",
@@ -631,16 +730,49 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         }
 
         XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.keys])
+        XCTAssertTrue(events.events.isEmpty)
+    }
+
+    func testWhenAccessCredentialFetchFailsBeforeWrappingStoredKeyThenDoesNotFireAdoptFailure() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let events = UnifiedDeviceListEventMappingMock()
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    unifiedDeviceListEvents: events,
+                                                    canWriteUnifiedDeviceList: { true })
+        let storedKey = makeProtectedKey(kid: "account-info",
+                                         encryptedWith: SyncCredentialID.defaultCredential,
+                                         purpose: ProtectedKeyPurpose.accountInfo)
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([storedKey]))
+        api.fakeRequests[endpoints.accessCredentials] = makeFailingRequest(statusCode: 500)
+
+        do {
+            _ = try await manager.ensureAccountInfoProtectedKeys(
+                for: makeAccount(primaryKey: Data(repeating: 0x1, count: 32)))
+            XCTFail("Expected access credential fetch to fail")
+        } catch SyncError.unexpectedStatusCode(let statusCode) {
+            XCTAssertEqual(statusCode, 500)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.keys, endpoints.accessCredentials])
+        XCTAssertTrue(events.events.isEmpty)
     }
 
     func testWhenEnsuringAccountInfoProtectedKeysAndKeysAreStoredThenReturnsThemWithoutCreatingKeys() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let events = UnifiedDeviceListEventMappingMock()
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
                                                     accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    unifiedDeviceListEvents: events,
                                                     canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data(repeating: 0x1, count: 32))
         let storedKeys = [
@@ -656,6 +788,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         XCTAssertEqual(Set(result.map(\.encryptedWith)), Set([SyncCredentialID.defaultCredential, SyncCredentialID.thirdParty]))
         XCTAssertTrue(accountInfoKeyFactory.makeProtectedKeysCalls.isEmpty)
         XCTAssertEqual(api.createRequestCallArgs.map(\.url), [endpoints.keys])
+        XCTAssertEqual(events.events, [.accountInfoKeyAdoptSuccess])
     }
 
     func testWhenEnsuringStoredDefaultAccountInfoKeyWithThirdPartyCredentialThenAddsThirdPartyWrapper() async throws {
@@ -663,10 +796,12 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
         let crypter = CryptingMock()
+        let events = UnifiedDeviceListEventMappingMock()
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: crypter,
                                                     accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    unifiedDeviceListEvents: events,
                                                     canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         let scopedPassword = Data((32..<64).map(UInt8.init))
@@ -726,6 +861,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                                      contentEncryptionKey: thirdPartyMainKey,
                                                                      expectedKid: SyncCredentialID.thirdParty)
         XCTAssertEqual(decryptedPrivateKey, privateKeyPKCS8)
+        XCTAssertEqual(events.events, [.accountInfoKeyWrapSuccess])
     }
 
     func testWhenEnsuringStoredThirdPartyAccountInfoKeyOnNativeThenAddsDefaultWrapper() async throws {
@@ -803,10 +939,12 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
         let crypter = CryptingMock()
+        let events = UnifiedDeviceListEventMappingMock()
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: crypter,
                                                     accountInfoKeyFactory: AccountInfoKeyFactoryMock(),
+                                                    unifiedDeviceListEvents: events,
                                                     canWriteUnifiedDeviceList: { true })
         let account = makeAccount(primaryKey: Data((0..<32).map(UInt8.init)))
         let scopedPassword = Data((32..<64).map(UInt8.init))
@@ -847,6 +985,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
             endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
             endpoints.keys
         ])
+        XCTAssertEqual(events.events, [.accountInfoKeyWrapFailed(.requestFailed)])
     }
 
     func testWhenEnsuringAccountInfoProtectedKeysWithoutThirdPartyCredentialThenCreatesAndRegistersDefaultWrapper() async throws {
@@ -858,10 +997,12 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                           encryptedWith: SyncCredentialID.defaultCredential,
                                           purpose: ProtectedKeyPurpose.accountInfo)
         accountInfoKeyFactory.makeProtectedKeysStub = [createdKey]
+        let events = UnifiedDeviceListEventMappingMock()
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: CryptingMock(),
                                                     accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    unifiedDeviceListEvents: events,
                                                     canWriteUnifiedDeviceList: { true })
         api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
             .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
@@ -882,6 +1023,128 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
             endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
             endpoints.keys
         ])
+        XCTAssertEqual(events.events, [.accountInfoKeyCreateSuccess])
+    }
+
+    func testWhenCreatedAccountInfoKeyRefetchFailsThenDoesNotFireAdoptFailure() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let createdKey = makeProtectedKey(kid: "created",
+                                          encryptedWith: SyncCredentialID.defaultCredential,
+                                          purpose: ProtectedKeyPurpose.accountInfo)
+        accountInfoKeyFactory.makeProtectedKeysStub = [createdKey]
+        let events = UnifiedDeviceListEventMappingMock()
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    unifiedDeviceListEvents: events,
+                                                    canWriteUnifiedDeviceList: { true })
+        api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
+            .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
+            .init(data: nil, response: makeHTTPURLResponse(statusCode: 200))
+        ])
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody([]))
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(statusCode: 201)
+
+        do {
+            _ = try await manager.ensureAccountInfoProtectedKeys(
+                for: makeAccount(primaryKey: Data(repeating: 0x1, count: 32)))
+            XCTFail("Expected created key refetch to fail")
+        } catch SyncError.noResponseBody {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
+            endpoints.keys,
+            endpoints.accessCredentials,
+            endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
+            endpoints.keys
+        ])
+        XCTAssertEqual(events.events, [.accountInfoKeyCreateSuccess])
+    }
+
+    func testWhenAdoptedAccountInfoKeyRefetchFailsThenFiresAdoptFailure() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let candidateKey = makeProtectedKey(kid: "candidate",
+                                            encryptedWith: SyncCredentialID.defaultCredential,
+                                            purpose: ProtectedKeyPurpose.accountInfo)
+        let adoptedKey = makeProtectedKey(kid: "adopted",
+                                          encryptedWith: SyncCredentialID.defaultCredential,
+                                          purpose: ProtectedKeyPurpose.accountInfo)
+        accountInfoKeyFactory.makeProtectedKeysStub = [candidateKey]
+        let events = UnifiedDeviceListEventMappingMock()
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    unifiedDeviceListEvents: events,
+                                                    canWriteUnifiedDeviceList: { true })
+        api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
+            .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
+            .init(data: nil, response: makeHTTPURLResponse(statusCode: 200))
+        ])
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody([]))
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(
+            statusCode: 200,
+            body: try protectedKeysBody([adoptedKey]))
+
+        do {
+            _ = try await manager.ensureAccountInfoProtectedKeys(
+                for: makeAccount(primaryKey: Data(repeating: 0x1, count: 32)))
+            XCTFail("Expected adopted key refetch to fail")
+        } catch SyncError.noResponseBody {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(events.events, [.accountInfoKeyAdoptFailed(.keysFetchFailed)])
+    }
+
+    func testWhenAdoptedAccountInfoKeyIsMissingFromRefetchThenFiresAdoptFailure() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let candidateKey = makeProtectedKey(kid: "candidate",
+                                            encryptedWith: SyncCredentialID.defaultCredential,
+                                            purpose: ProtectedKeyPurpose.accountInfo)
+        let adoptedKey = makeProtectedKey(kid: "adopted",
+                                          encryptedWith: SyncCredentialID.defaultCredential,
+                                          purpose: ProtectedKeyPurpose.accountInfo)
+        accountInfoKeyFactory.makeProtectedKeysStub = [candidateKey]
+        let events = UnifiedDeviceListEventMappingMock()
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    unifiedDeviceListEvents: events,
+                                                    canWriteUnifiedDeviceList: { true })
+        api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
+            .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
+            .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200))
+        ])
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody([]))
+        api.fakeRequests[endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo)] = makeRequest(
+            statusCode: 200,
+            body: try protectedKeysBody([adoptedKey]))
+
+        do {
+            _ = try await manager.ensureAccountInfoProtectedKeys(
+                for: makeAccount(primaryKey: Data(repeating: 0x1, count: 32)))
+            XCTFail("Expected adopted key refetch to omit the account_info key")
+        } catch SyncError.invalidDataInResponse(let message) {
+            XCTAssertEqual(message, "account_info protected keys are missing")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(events.events, [.accountInfoKeyAdoptFailed(.keysFetchFailed)])
     }
 
     func testWhenEnsuringAccountInfoProtectedKeysWithThirdPartyCredentialThenCreatesAndRegistersBothWrappers() async throws {
@@ -932,6 +1195,50 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
         ])
     }
 
+    func testWhenFreshAccountInfoKeyThirdPartyWrappingFailsThenDoesNotFireOrRegister() async throws {
+        let api = RemoteAPIRequestCreatingMock()
+        let endpoints = Endpoints(baseURL: Self.baseURL)
+        let accountInfoKeyFactory = AccountInfoKeyFactoryMock()
+        let accountPrimaryKey = Data((0..<32).map(UInt8.init))
+        let scopedPassword = Data((32..<64).map(UInt8.init))
+        let account = makeAccount(primaryKey: accountPrimaryKey)
+        let defaultCredentialMainKey = hkdf(input: accountPrimaryKey, salt: account.userId, info: "Main Key")
+        let encryptedCredential = try ScopedAccessCredentialEnvelope().encryptScopedPassword(scopedPassword,
+                                                                                             using: defaultCredentialMainKey,
+                                                                                             kid: SyncCredentialID.defaultCredential)
+        let accessCredentials = [
+            AccessCredential(id: SyncCredentialID.thirdParty,
+                             scope: "sync",
+                             encrypted3PartyCredential: encryptedCredential)
+        ]
+        accountInfoKeyFactory.makeProtectedKeysError = AccountInfoKeyFactoryError.thirdPartyWrappingFailed(
+            JWECompactCodecError.invalidContentEncryptionKeyLength(0))
+        let events = UnifiedDeviceListEventMappingMock()
+        let manager = ScopedAccessCredentialManager(endpoints: endpoints,
+                                                    api: api,
+                                                    crypter: CryptingMock(),
+                                                    accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    unifiedDeviceListEvents: events,
+                                                    canWriteUnifiedDeviceList: { true })
+        api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody([]))
+        api.fakeRequests[endpoints.accessCredentials] = makeRequest(statusCode: 200, body: try accessCredentialsBody(accessCredentials))
+
+        do {
+            _ = try await manager.ensureAccountInfoProtectedKeys(for: account)
+            XCTFail("Expected third-party wrapping to fail")
+        } catch JWECompactCodecError.invalidContentEncryptionKeyLength(let count) {
+            XCTAssertEqual(count, 0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(api.createRequestCallArgs.map(\.url), [
+            endpoints.keys,
+            endpoints.accessCredentials
+        ])
+        XCTAssertTrue(events.events.isEmpty)
+    }
+
     func testWhenAnotherClientRegistersIncompleteAccountInfoKeyThenRepairsAdoptedKey() async throws {
         let api = RemoteAPIRequestCreatingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
@@ -954,6 +1261,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
             makeProtectedKey(kid: "created", encryptedWith: SyncCredentialID.thirdParty, purpose: ProtectedKeyPurpose.accountInfo)
         ]
         accountInfoKeyFactory.makeProtectedKeysStub = createdKeys
+        let events = UnifiedDeviceListEventMappingMock()
         let adoptedPrivateKey = Data([0xFF] + Array("adopted-account-info-private-key".utf8))
         let adoptedDefaultWrapper = try makeNativeEncryptedProtectedKey(privateKey: adoptedPrivateKey,
                                                                          account: account,
@@ -972,6 +1280,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                     api: api,
                                                     crypter: crypter,
                                                     accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    unifiedDeviceListEvents: events,
                                                     canWriteUnifiedDeviceList: { true })
         api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
             .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
@@ -997,6 +1306,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
             endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
             endpoints.keys
         ])
+        XCTAssertEqual(events.events, [.accountInfoKeyWrapSuccess])
     }
 
     func testWhenServerDoesNotPersistAllCreatedAccountInfoWrappersThenThrows() async throws {
@@ -1026,10 +1336,12 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
                                                  purpose: ProtectedKeyPurpose.accountInfo,
                                                  publicKey: defaultWrapper.publicKey)
         accountInfoKeyFactory.makeProtectedKeysStub = [defaultWrapper, thirdPartyWrapper]
+        let events = UnifiedDeviceListEventMappingMock()
         let manager = ScopedAccessCredentialManager(endpoints: endpoints,
                                                     api: api,
                                                     crypter: crypter,
                                                     accountInfoKeyFactory: accountInfoKeyFactory,
+                                                    unifiedDeviceListEvents: events,
                                                     canWriteUnifiedDeviceList: { true })
         api.fakeRequests[endpoints.keys] = SequencedHTTPRequestingMock(results: [
             .init(data: Data(try protectedKeysBody([]).utf8), response: makeHTTPURLResponse(statusCode: 200)),
@@ -1056,6 +1368,7 @@ final class ScopedAccessCredentialManagerTests: XCTestCase {
             endpoints.setKeyIfAbsent(purpose: ProtectedKeyPurpose.accountInfo),
             endpoints.keys
         ])
+        XCTAssertEqual(events.events, [.accountInfoKeyCreateSuccess])
     }
 
     func testWhenRepairingAccountInfoProtectedKeysAndThirdPartyCredentialCannotBeRecoveredThenDoesNotRegisterKeys() async throws {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ThirdPartyAccountUpgradeCoordinatorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/ScopedAccess/ThirdPartyAccountUpgradeCoordinatorTests.swift
@@ -66,6 +66,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
         XCTAssertEqual(keys.count, 1)
         XCTAssertEqual(keys.first?["kid"] as? String, "key-1")
         XCTAssertEqual(keys.first?["encrypted_with"] as? String, SyncCredentialID.defaultCredential)
+        XCTAssertTrue(setup.events.events.isEmpty)
     }
 
     func testWhenUpgradeRunsThenRewrapsAccountInfoKeyForDefaultCredential() async throws {
@@ -93,6 +94,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
         })
         XCTAssertEqual(accountInfoPayload["kid"] as? String, accountInfoKey.kid)
         XCTAssertEqual(accountInfoPayload["encrypted_with"] as? String, SyncCredentialID.defaultCredential)
+        XCTAssertEqual(setup.events.events, [.accountInfoKeyWrapSuccess])
     }
 
     func testWhenUpgradeRunsThenTemporaryLoginUsesAIChatsScopeAndFinalNativeLoginUsesSyncScope() async throws {
@@ -304,7 +306,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
                                                encryptedPrivateKey: "not-jwe",
                                                publicKey: .mock,
                                                encryptedWith: SyncCode.RecoveryKeyV2.thirdPartyCredentialId,
-                                               purpose: "ai_chats")
+                                               purpose: ProtectedKeyPurpose.accountInfo)
         let setup = try makeSUT(protectedKeys: [invalidProtectedKey])
 
         do {
@@ -317,10 +319,13 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
+        XCTAssertEqual(setup.events.events, [.accountInfoKeyWrapFailed(.unwrapFailed)])
     }
 
     func testWhenNativeCredentialCreationReturnsUnexpectedStatusThenUpgradeAbortsWithTypedError() async throws {
-        let setup = try makeSUT()
+        let setup = try makeSUT(protectedKeys: [
+            try thirdPartyProtectedKey(purpose: ProtectedKeyPurpose.accountInfo)
+        ])
         setup.api.fakeRequests[setup.endpoints.accessCredential(SyncCredentialID.defaultCredential)] = makeRequest(statusCode: 500)
 
         do {
@@ -334,6 +339,27 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
+        XCTAssertEqual(setup.events.events, [.accountInfoKeyWrapFailed(.requestFailed)])
+    }
+
+    func testWhenNativeCredentialCreationIsRateLimitedThenFiresAccountInfoWrapRateLimitFailure() async throws {
+        let setup = try makeSUT(protectedKeys: [
+            try thirdPartyProtectedKey(purpose: ProtectedKeyPurpose.accountInfo)
+        ])
+        setup.api.fakeRequests[setup.endpoints.accessCredential(SyncCredentialID.defaultCredential)] = makeRequest(statusCode: 429)
+
+        do {
+            _ = try await setup.coordinator.upgradeThirdPartyAccountToDefaultCredential(
+                recoveryCode(),
+                deviceName: "Mac",
+                deviceType: "desktop")
+            XCTFail("Expected native credential creation to be rate limited")
+        } catch ThirdPartyAccountUpgradeError.nativeCredentialCreationFailed(let statusCode) {
+            XCTAssertEqual(statusCode, 429)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(setup.events.events, [.accountInfoKeyWrapFailed(.rateLimited)])
     }
 
     private func makeSUT(accessCredentials: [AccessCredential] = [],
@@ -341,10 +367,12 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
                          finalNativeLoginRetryDelays: [UInt64] = []) throws -> (coordinator: ThirdPartyAccountUpgradeCoordinator,
                                                                                  api: RemoteAPIRequestCreatingMock,
                                                                                  account: AccountManagingMock,
-                                                                                 endpoints: Endpoints) {
+                                                                                 endpoints: Endpoints,
+                                                                                 events: UnifiedDeviceListEventMappingMock) {
         let api = RemoteAPIRequestCreatingMock()
         let account = AccountManagingMock()
         let endpoints = Endpoints(baseURL: Self.baseURL)
+        let events = UnifiedDeviceListEventMappingMock()
         let userId = self.userId
         let defaultPrimaryKey = self.defaultPrimaryKey
         let defaultSecretKey = self.defaultSecretKey
@@ -377,6 +405,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
                                                               crypter: crypter,
                                                               scopedAccess: manager,
                                                               account: account,
+                                                              unifiedDeviceListEvents: events,
                                                               finalNativeLoginRetryDelays: finalNativeLoginRetryDelays)
         let keys = try protectedKeys ?? [thirdPartyProtectedKey()]
 
@@ -388,7 +417,7 @@ final class ThirdPartyAccountUpgradeCoordinatorTests: XCTestCase {
         api.fakeRequests[endpoints.keys] = makeRequest(statusCode: 200, body: try protectedKeysBody(keys))
         api.fakeRequests[endpoints.accessCredential(SyncCredentialID.defaultCredential)] = makeRequest(statusCode: 201)
 
-        return (coordinator, api, account, endpoints)
+        return (coordinator, api, account, endpoints, events)
     }
 
     private func recoveryCode() throws -> String {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/UnifiedDeviceListEventTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/UnifiedDeviceListEventTests.swift
@@ -1,0 +1,88 @@
+//
+//  UnifiedDeviceListEventTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+@testable import DDGSync
+
+final class UnifiedDeviceListEventTests: XCTestCase {
+
+    func testDimensionsAreEncodedInPixelParameters() {
+        let fallback = UnifiedDeviceListEvent.ownRowResolvedLegacy(.notPublishedYet)
+        XCTAssertEqual(fallback.name, "sync_unified_devices_own_row_resolved_legacy")
+        XCTAssertEqual(fallback.parameters, ["reason": "not_published_yet"])
+
+        let keyUnavailable = UnifiedDeviceListEvent.accountInfoKeyUnavailable(.noWrapForOurCredential)
+        XCTAssertEqual(keyUnavailable.name, "sync_unified_devices_account_info_key_unavailable")
+        XCTAssertEqual(keyUnavailable.parameters, ["reason": "no_wrap_for_our_credential"])
+
+        let invalidKeyMaterial = UnifiedDeviceListEvent.accountInfoKeyUnavailable(.invalidKeyMaterial)
+        XCTAssertEqual(invalidKeyMaterial.parameters, ["reason": "invalid_key_material"])
+
+        let otherRow = UnifiedDeviceListEvent.otherRowDeviceInfoFailedDecryption(.thirdParty)
+        XCTAssertEqual(otherRow.parameters, ["credential": "3party"])
+
+        let writeFailure = UnifiedDeviceListEvent.ownRowDeviceInfoRepairFailed(.encryptFailed)
+        XCTAssertEqual(writeFailure.name, "sync_unified_devices_own_row_device_info_repair_failed")
+        XCTAssertEqual(writeFailure.parameters, ["reason": "encrypt_failed"])
+
+        let persistenceFailure = UnifiedDeviceListEvent.ownRowDeviceInfoUpdateFailed(.persistFailed)
+        XCTAssertEqual(persistenceFailure.parameters, ["reason": "persist_failed"])
+    }
+
+    func testReadEventsAreDaily() {
+        XCTAssertEqual(UnifiedDeviceListEvent.ownRowResolvedDeviceInfo.frequency, .daily)
+        XCTAssertEqual(UnifiedDeviceListEvent.ownRowResolvedPlaceholder(.blobDecryptFailed).frequency, .daily)
+    }
+
+    func testParameterizedEventsAreDailyByName() {
+        let events: [UnifiedDeviceListEvent] = [
+            .ownRowResolvedLegacy(.notPublishedYet),
+            .ownRowResolvedPlaceholder(.blobDecryptFailed),
+            .accountInfoKeyUnavailable(.noKeyOnServer),
+            .otherRowDeviceInfoFailedDecryption(.thirdParty),
+            .otherRowResolvedPlaceholder(.none),
+            .accountInfoKeyAdoptFailed(.keysFetchFailed),
+            .accountInfoKeyCreateFailed(.mintFailed),
+            .accountInfoKeyWrapFailed(.unwrapFailed),
+            .ownRowDeviceInfoFirstWriteFailed(.encryptFailed),
+            .ownRowDeviceInfoUpdateFailed(.requestFailed),
+            .ownRowDeviceInfoRepairFailed(.rateLimited)
+        ]
+
+        for event in events {
+            XCTAssertEqual(event.frequency, .daily, event.name)
+        }
+    }
+
+    func testSuccessEventsAreStandardAndFailureEventsAreDaily() {
+        XCTAssertEqual(UnifiedDeviceListEvent.accountInfoKeyCreateSuccess.frequency, .standard)
+        XCTAssertEqual(UnifiedDeviceListEvent.ownRowDeviceInfoUpdateSuccess.frequency, .standard)
+        XCTAssertEqual(UnifiedDeviceListEvent.accountInfoKeyAdoptFailed(.rateLimited).frequency, .daily)
+        XCTAssertEqual(UnifiedDeviceListEvent.ownRowDeviceInfoFirstWriteFailed(.encryptFailed).frequency, .daily)
+    }
+
+    func testAccountInfoKeyUnavailableClassifiesFetchAndUnwrapFailuresSeparately() {
+        XCTAssertEqual(
+            UnifiedDeviceListTelemetry.accountInfoKeyUnavailableReason(for: URLError(.timedOut)),
+            .keysFetchFailed)
+        XCTAssertEqual(
+            UnifiedDeviceListTelemetry.accountInfoKeyUnavailableReason(for: SyncError.failedToDecryptValue("test")),
+            .unwrapFailed)
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/UnifiedDeviceListEventTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/UnifiedDeviceListEventTests.swift
@@ -22,59 +22,36 @@ import XCTest
 
 final class UnifiedDeviceListEventTests: XCTestCase {
 
-    func testDimensionsAreEncodedInPixelParameters() {
-        let fallback = UnifiedDeviceListEvent.ownRowResolvedLegacy(.notPublishedYet)
-        XCTAssertEqual(fallback.name, "sync_unified_devices_own_row_resolved_legacy")
-        XCTAssertEqual(fallback.parameters, ["reason": "not_published_yet"])
-
-        let keyUnavailable = UnifiedDeviceListEvent.accountInfoKeyUnavailable(.noWrapForOurCredential)
-        XCTAssertEqual(keyUnavailable.name, "sync_unified_devices_account_info_key_unavailable")
-        XCTAssertEqual(keyUnavailable.parameters, ["reason": "no_wrap_for_our_credential"])
-
-        let invalidKeyMaterial = UnifiedDeviceListEvent.accountInfoKeyUnavailable(.invalidKeyMaterial)
-        XCTAssertEqual(invalidKeyMaterial.parameters, ["reason": "invalid_key_material"])
-
-        let otherRow = UnifiedDeviceListEvent.otherRowDeviceInfoFailedDecryption(.thirdParty)
-        XCTAssertEqual(otherRow.parameters, ["credential": "3party"])
-
-        let writeFailure = UnifiedDeviceListEvent.ownRowDeviceInfoRepairFailed(.encryptFailed)
-        XCTAssertEqual(writeFailure.name, "sync_unified_devices_own_row_device_info_repair_failed")
-        XCTAssertEqual(writeFailure.parameters, ["reason": "encrypt_failed"])
-
-        let persistenceFailure = UnifiedDeviceListEvent.ownRowDeviceInfoUpdateFailed(.persistFailed)
-        XCTAssertEqual(persistenceFailure.parameters, ["reason": "persist_failed"])
-    }
-
-    func testReadEventsAreDaily() {
-        XCTAssertEqual(UnifiedDeviceListEvent.ownRowResolvedDeviceInfo.frequency, .daily)
-        XCTAssertEqual(UnifiedDeviceListEvent.ownRowResolvedPlaceholder(.blobDecryptFailed).frequency, .daily)
-    }
-
-    func testParameterizedEventsAreDailyByName() {
-        let events: [UnifiedDeviceListEvent] = [
-            .ownRowResolvedLegacy(.notPublishedYet),
-            .ownRowResolvedPlaceholder(.blobDecryptFailed),
-            .accountInfoKeyUnavailable(.noKeyOnServer),
-            .otherRowDeviceInfoFailedDecryption(.thirdParty),
-            .otherRowResolvedPlaceholder(.none),
-            .accountInfoKeyAdoptFailed(.keysFetchFailed),
-            .accountInfoKeyCreateFailed(.mintFailed),
-            .accountInfoKeyWrapFailed(.unwrapFailed),
-            .ownRowDeviceInfoFirstWriteFailed(.encryptFailed),
-            .ownRowDeviceInfoUpdateFailed(.requestFailed),
-            .ownRowDeviceInfoRepairFailed(.rateLimited)
+    func testEventsExposeExpectedPixelContract() {
+        let expectations: [(event: UnifiedDeviceListEvent,
+                            suffix: String,
+                            parameters: [String: String]?,
+                            frequency: UnifiedDeviceListEvent.Frequency)] = [
+            (.ownRowResolvedDeviceInfo, "own_row_resolved_device_info", nil, .daily),
+            (.ownRowResolvedLegacy(.notPublishedYet), "own_row_resolved_legacy", ["reason": "not_published_yet"], .daily),
+            (.ownRowResolvedPlaceholder(.blobDecryptFailed), "own_row_resolved_placeholder", ["reason": "blob_decrypt_failed"], .daily),
+            (.accountInfoKeyUnavailable(.invalidKeyMaterial), "account_info_key_unavailable", ["reason": "invalid_key_material"], .daily),
+            (.otherRowDeviceInfoFailedDecryption(.thirdParty), "other_row_device_info_failed_decryption", ["credential": "3party"], .daily),
+            (.otherRowResolvedPlaceholder(.none), "other_row_resolved_placeholder", ["credential": "none"], .daily),
+            (.accountInfoKeyAdoptFailed(.keysFetchFailed), "account_info_key_adopt_failed", ["reason": "keys_fetch_failed"], .daily),
+            (.accountInfoKeyCreateSuccess, "account_info_key_create_success", nil, .standard),
+            (.accountInfoKeyCreateFailed(.mintFailed), "account_info_key_create_failed", ["reason": "mint_failed"], .daily),
+            (.accountInfoKeyWrapSuccess, "account_info_key_wrap_success", nil, .standard),
+            (.accountInfoKeyWrapFailed(.unwrapFailed), "account_info_key_wrap_failed", ["reason": "unwrap_failed"], .daily),
+            (.accountInfoKeyAdoptSuccess, "account_info_key_adopt_success", nil, .standard),
+            (.ownRowDeviceInfoFirstWriteSuccess, "own_row_device_info_first_write_success", nil, .standard),
+            (.ownRowDeviceInfoFirstWriteFailed(.encryptFailed), "own_row_device_info_first_write_failed", ["reason": "encrypt_failed"], .daily),
+            (.ownRowDeviceInfoUpdateSuccess, "own_row_device_info_update_success", nil, .standard),
+            (.ownRowDeviceInfoUpdateFailed(.persistFailed), "own_row_device_info_update_failed", ["reason": "persist_failed"], .daily),
+            (.ownRowDeviceInfoRepairSuccess, "own_row_device_info_repair_success", nil, .standard),
+            (.ownRowDeviceInfoRepairFailed(.rateLimited), "own_row_device_info_repair_failed", ["reason": "rate_limited"], .daily)
         ]
 
-        for event in events {
-            XCTAssertEqual(event.frequency, .daily, event.name)
+        for expectation in expectations {
+            XCTAssertEqual(expectation.event.name, "sync_unified_devices_" + expectation.suffix)
+            XCTAssertEqual(expectation.event.parameters, expectation.parameters, expectation.suffix)
+            XCTAssertEqual(expectation.event.frequency, expectation.frequency, expectation.suffix)
         }
-    }
-
-    func testSuccessEventsAreStandardAndFailureEventsAreDaily() {
-        XCTAssertEqual(UnifiedDeviceListEvent.accountInfoKeyCreateSuccess.frequency, .standard)
-        XCTAssertEqual(UnifiedDeviceListEvent.ownRowDeviceInfoUpdateSuccess.frequency, .standard)
-        XCTAssertEqual(UnifiedDeviceListEvent.accountInfoKeyAdoptFailed(.rateLimited).frequency, .daily)
-        XCTAssertEqual(UnifiedDeviceListEvent.ownRowDeviceInfoFirstWriteFailed(.encryptFailed).frequency, .daily)
     }
 
     func testAccountInfoKeyUnavailableClassifiesFetchAndUnwrapFailuresSeparately() {

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -311,6 +311,7 @@
 		4B104AEC2F6F655800843054 /* SyncCredentialsAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E615742A5F533E00ACD63D /* SyncCredentialsAdapter.swift */; };
 		4B104AED2F6F658800843054 /* SyncDataProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37445F962A155F7C0029F789 /* SyncDataProviders.swift */; };
 		4B104AEE2F6F658800843054 /* SyncErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD780E2A29E28B00B36DB1 /* SyncErrorHandler.swift */; };
+		A71D000130EEA00100A11A01 /* UnifiedDeviceListPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71D000230EEA00100A11A01 /* UnifiedDeviceListPixelHandler.swift */; };
 		4B104AEF2F6F65B900843054 /* SyncMetadataDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DF000929F9C416002B7D3E /* SyncMetadataDatabase.swift */; };
 		4B104AF02F6F65B900843054 /* SyncSettingsAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37CBCA9D2A8A659C0050218F /* SyncSettingsAdapter.swift */; };
 		4B104AF12F6F65B900843054 /* SyncMetricsEventsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372A0FEF2B2389590033BF7F /* SyncMetricsEventsHandler.swift */; };
@@ -429,6 +430,7 @@
 		569437242BDD405400C0881B /* SyncBookmarksAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569437232BDD405400C0881B /* SyncBookmarksAdapterTests.swift */; };
 		569437292BDD487600C0881B /* SyncCredentialsAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569437282BDD487600C0881B /* SyncCredentialsAdapterTests.swift */; };
 		5694372B2BE3F2D900C0881B /* SyncErrorHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5694372A2BE3F2D900C0881B /* SyncErrorHandlerTests.swift */; };
+		A71D000630EEA00100A11A01 /* UnifiedDeviceListPixelHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71D000730EEA00100A11A01 /* UnifiedDeviceListPixelHandlerTests.swift */; };
 		569437312BE3F64400C0881B /* SyncErrorHandlerSyncPausedAlertsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5694372F2BE3F63B00C0881B /* SyncErrorHandlerSyncPausedAlertsTests.swift */; };
 		569437342BE4E41500C0881B /* SyncErrorHandlerSyncErrorsAlertsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569437322BE4E3DD00C0881B /* SyncErrorHandlerSyncErrorsAlertsTests.swift */; };
 		569437362BE5160600C0881B /* SyncSettingsViewControllerErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569437352BE5160600C0881B /* SyncSettingsViewControllerErrorTests.swift */; };
@@ -2877,6 +2879,7 @@
 		37FCAABB2992F592000E420A /* MultilineScrollableTextFix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineScrollableTextFix.swift; sourceTree = "<group>"; };
 		37FCAABF29930E26000E420A /* FailedAssertionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailedAssertionView.swift; sourceTree = "<group>"; };
 		37FD780E2A29E28B00B36DB1 /* SyncErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncErrorHandler.swift; sourceTree = "<group>"; };
+		A71D000230EEA00100A11A01 /* UnifiedDeviceListPixelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedDeviceListPixelHandler.swift; sourceTree = "<group>"; };
 		3901A00979D78E26EF811EEA /* SubscriptionOnboardingSectionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingSectionTests.swift; sourceTree = "<group>"; };
 		392856D96DBE03E4E18EFCF8 /* RebrandedOnboardingAddressBarPositionPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RebrandedOnboardingAddressBarPositionPicker.swift; sourceTree = "<group>"; };
 		3E2C051DF91949BEA602FF89 /* SubscriptionOnboardingPIRLaunchState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionOnboardingPIRLaunchState.swift; sourceTree = "<group>"; };
@@ -2962,6 +2965,7 @@
 		569437232BDD405400C0881B /* SyncBookmarksAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncBookmarksAdapterTests.swift; sourceTree = "<group>"; };
 		569437282BDD487600C0881B /* SyncCredentialsAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncCredentialsAdapterTests.swift; sourceTree = "<group>"; };
 		5694372A2BE3F2D900C0881B /* SyncErrorHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncErrorHandlerTests.swift; sourceTree = "<group>"; };
+		A71D000730EEA00100A11A01 /* UnifiedDeviceListPixelHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedDeviceListPixelHandlerTests.swift; sourceTree = "<group>"; };
 		5694372F2BE3F63B00C0881B /* SyncErrorHandlerSyncPausedAlertsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncErrorHandlerSyncPausedAlertsTests.swift; sourceTree = "<group>"; };
 		569437322BE4E3DD00C0881B /* SyncErrorHandlerSyncErrorsAlertsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncErrorHandlerSyncErrorsAlertsTests.swift; sourceTree = "<group>"; };
 		569437352BE5160600C0881B /* SyncSettingsViewControllerErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncSettingsViewControllerErrorTests.swift; sourceTree = "<group>"; };
@@ -6628,6 +6632,7 @@
 				569437282BDD487600C0881B /* SyncCredentialsAdapterTests.swift */,
 				C1D3C56C2E895B820086A2BD /* SyncCreditCardsAdapterTests.swift */,
 				5694372A2BE3F2D900C0881B /* SyncErrorHandlerTests.swift */,
+				A71D000730EEA00100A11A01 /* UnifiedDeviceListPixelHandlerTests.swift */,
 				5694372F2BE3F63B00C0881B /* SyncErrorHandlerSyncPausedAlertsTests.swift */,
 				569437322BE4E3DD00C0881B /* SyncErrorHandlerSyncErrorsAlertsTests.swift */,
 				569437352BE5160600C0881B /* SyncSettingsViewControllerErrorTests.swift */,
@@ -7626,6 +7631,7 @@
 				372A0FEF2B2389590033BF7F /* SyncMetricsEventsHandler.swift */,
 				37445F962A155F7C0029F789 /* SyncDataProviders.swift */,
 				37FD780E2A29E28B00B36DB1 /* SyncErrorHandler.swift */,
+				A71D000230EEA00100A11A01 /* UnifiedDeviceListPixelHandler.swift */,
 				37CEFCAB2A673B90001EF741 /* CredentialsCleanupErrorHandling.swift */,
 				C13C54A22E7472A5003451F5 /* CreditCardsCleanupErrorHandling.swift */,
 				4B104AE92F6F653900843054 /* Adapters */,
@@ -12386,6 +12392,7 @@
 				C1935A122C88D1D8001AD72D /* AutofillHeaderViewFactory.swift in Sources */,
 				4B104AED2F6F658800843054 /* SyncDataProviders.swift in Sources */,
 				4B104AEE2F6F658800843054 /* SyncErrorHandler.swift in Sources */,
+				A71D000130EEA00100A11A01 /* UnifiedDeviceListPixelHandler.swift in Sources */,
 				C1DA98E92E7C464000F8BED9 /* SyncRecoveryPromptService.swift in Sources */,
 				C1F4A0D62F7B9C1400C0A1B2 /* SyncAutoRestoreDecisionStore.swift in Sources */,
 				CB7E0A212D5E1D96002A7C0C /* UIInteractionManager.swift in Sources */,
@@ -13117,6 +13124,7 @@
 				D625AAEC2BBEF27600BC189A /* TabURLInterceptorTests.swift in Sources */,
 				97FCCDD72F60ACA200EDB025 /* MockAIChatContentHandlingDelegate.swift in Sources */,
 				5694372B2BE3F2D900C0881B /* SyncErrorHandlerTests.swift in Sources */,
+				A71D000630EEA00100A11A01 /* UnifiedDeviceListPixelHandlerTests.swift in Sources */,
 				987130C7294AAB9F00AB05E0 /* MenuBookmarksViewModelTests.swift in Sources */,
 				9FFDA83D2DFA8F6F007923F7 /* MockAudioSessionManager.swift in Sources */,
 				C1A74BB02EC2618D00870321 /* AutofillServiceTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AppServices/SyncService.swift
+++ b/iOS/DuckDuckGo/AppServices/SyncService.swift
@@ -84,6 +84,7 @@ final class SyncService {
         sync = DDGSync(
             dataProvidersSource: syncDataProviders,
             errorEvents: SyncErrorHandler(),
+            unifiedDeviceListEvents: UnifiedDeviceListPixelHandler(),
             privacyConfigurationManager: privacyConfigurationManager,
             keyValueStore: keyValueStore,
             environment: environment,

--- a/iOS/DuckDuckGo/SyncErrorHandler.swift
+++ b/iOS/DuckDuckGo/SyncErrorHandler.swift
@@ -26,7 +26,10 @@ import Foundation
 import SyncDataProviders
 import os.log
 import Core
-import PixelKit
+import class PixelKit.PixelKit
+import enum PixelKit.PixelKitNamePrefix
+import enum PixelKit.PixelKitStandardParameter
+import protocol PixelKit.PixelFiring
 
 public enum AsyncErrorType: String {
     case bookmarksCountLimitExceeded
@@ -149,16 +152,16 @@ private struct UnifiedDeviceListPixel: PixelKit.Event {
     let parameters: [String: String]?
     let standardParameters: [PixelKitStandardParameter]? = nil
     let error: NSError? = nil
+    let namePrefix: PixelKitNamePrefix = .none
 }
 
 final class UnifiedDeviceListPixelHandler: EventMapping<UnifiedDeviceListEvent> {
 
-    init() {
+    init(pixelFiring: PixelFiring? = PixelKit.shared) {
         super.init { event, _, _, onComplete in
-            PixelKit.fire(
+            pixelFiring?.fire(
                 UnifiedDeviceListPixel(name: event.name, parameters: event.parameters),
-                frequency: event.frequency.pixelKitFrequency,
-                options: .unenforcedPrefix)
+                frequency: event.frequency.pixelKitFrequency)
             onComplete(nil)
         }
     }

--- a/iOS/DuckDuckGo/SyncErrorHandler.swift
+++ b/iOS/DuckDuckGo/SyncErrorHandler.swift
@@ -26,10 +26,6 @@ import Foundation
 import SyncDataProviders
 import os.log
 import Core
-import class PixelKit.PixelKit
-import enum PixelKit.PixelKitNamePrefix
-import enum PixelKit.PixelKitStandardParameter
-import protocol PixelKit.PixelFiring
 
 public enum AsyncErrorType: String {
     case bookmarksCountLimitExceeded
@@ -144,39 +140,6 @@ public class SyncErrorHandler: EventMapping<SyncError> {
 
     override init(mapping: @escaping EventMapping<SyncError>.Mapping) {
         fatalError("Use init()")
-    }
-}
-
-private struct UnifiedDeviceListPixel: PixelKit.Event {
-    let name: String
-    let parameters: [String: String]?
-    let standardParameters: [PixelKitStandardParameter]? = nil
-    let error: NSError? = nil
-    let namePrefix: PixelKitNamePrefix = .none
-}
-
-final class UnifiedDeviceListPixelHandler: EventMapping<UnifiedDeviceListEvent> {
-
-    init(pixelFiring: PixelFiring? = PixelKit.shared) {
-        super.init { event, _, _, onComplete in
-            pixelFiring?.fire(
-                UnifiedDeviceListPixel(name: event.name, parameters: event.parameters),
-                frequency: event.frequency.pixelKitFrequency)
-            onComplete(nil)
-        }
-    }
-
-    override init(mapping: @escaping EventMapping<UnifiedDeviceListEvent>.Mapping) {
-        fatalError("Use init()")
-    }
-}
-
-private extension UnifiedDeviceListEvent.Frequency {
-    var pixelKitFrequency: PixelKit.Frequency {
-        switch self {
-        case .standard: return .standard
-        case .daily: return .daily
-        }
     }
 }
 

--- a/iOS/DuckDuckGo/SyncErrorHandler.swift
+++ b/iOS/DuckDuckGo/SyncErrorHandler.swift
@@ -26,6 +26,7 @@ import Foundation
 import SyncDataProviders
 import os.log
 import Core
+import PixelKit
 
 public enum AsyncErrorType: String {
     case bookmarksCountLimitExceeded

--- a/iOS/DuckDuckGo/SyncErrorHandler.swift
+++ b/iOS/DuckDuckGo/SyncErrorHandler.swift
@@ -144,6 +144,39 @@ public class SyncErrorHandler: EventMapping<SyncError> {
     }
 }
 
+private struct UnifiedDeviceListPixel: PixelKit.Event {
+    let name: String
+    let parameters: [String: String]?
+    let standardParameters: [PixelKitStandardParameter]? = nil
+    let error: NSError? = nil
+}
+
+final class UnifiedDeviceListPixelHandler: EventMapping<UnifiedDeviceListEvent> {
+
+    init() {
+        super.init { event, _, _, onComplete in
+            PixelKit.fire(
+                UnifiedDeviceListPixel(name: event.name, parameters: event.parameters),
+                frequency: event.frequency.pixelKitFrequency,
+                options: .unenforcedPrefix)
+            onComplete(nil)
+        }
+    }
+
+    override init(mapping: @escaping EventMapping<UnifiedDeviceListEvent>.Mapping) {
+        fatalError("Use init()")
+    }
+}
+
+private extension UnifiedDeviceListEvent.Frequency {
+    var pixelKitFrequency: PixelKit.Frequency {
+        switch self {
+        case .standard: return .standard
+        case .daily: return .daily
+        }
+    }
+}
+
 // MARK: - Private functions
 extension SyncErrorHandler {
     private func resetBookmarksErrors() {

--- a/iOS/DuckDuckGo/UnifiedDeviceListPixelHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedDeviceListPixelHandler.swift
@@ -1,0 +1,59 @@
+//
+//  UnifiedDeviceListPixelHandler.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Common
+import DDGSync
+import Foundation
+import class PixelKit.PixelKit
+import enum PixelKit.PixelKitNamePrefix
+import enum PixelKit.PixelKitStandardParameter
+import protocol PixelKit.PixelFiring
+
+private struct UnifiedDeviceListPixel: PixelKit.Event {
+    let name: String
+    let parameters: [String: String]?
+    let standardParameters: [PixelKitStandardParameter]? = nil
+    let error: NSError? = nil
+    let namePrefix: PixelKitNamePrefix = .none
+}
+
+final class UnifiedDeviceListPixelHandler: EventMapping<UnifiedDeviceListEvent> {
+
+    init(pixelFiring: PixelFiring? = PixelKit.shared) {
+        super.init { event, _, _, onComplete in
+            pixelFiring?.fire(
+                UnifiedDeviceListPixel(name: event.name, parameters: event.parameters),
+                frequency: event.frequency.pixelKitFrequency)
+            onComplete(nil)
+        }
+    }
+
+    override init(mapping: @escaping EventMapping<UnifiedDeviceListEvent>.Mapping) {
+        fatalError("Use init()")
+    }
+}
+
+private extension UnifiedDeviceListEvent.Frequency {
+    var pixelKitFrequency: PixelKit.Frequency {
+        switch self {
+        case .standard: return .standard
+        case .daily: return .daily
+        }
+    }
+}

--- a/iOS/DuckDuckGoTests/UnifiedDeviceListPixelHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedDeviceListPixelHandlerTests.swift
@@ -1,0 +1,44 @@
+//
+//  UnifiedDeviceListPixelHandlerTests.swift
+//  DuckDuckGoTests
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import DDGSync
+@_spi(Testing) import PixelKit
+@testable import DuckDuckGo
+
+final class UnifiedDeviceListPixelHandlerTests: XCTestCase {
+
+    func testUnifiedDeviceListPixelHandlerMapsStandardAndDailyEvents() throws {
+        let pixelFiring = PixelKitMock()
+        let handler = UnifiedDeviceListPixelHandler(pixelFiring: pixelFiring)
+
+        handler.fire(.accountInfoKeyCreateSuccess)
+        handler.fire(.ownRowResolvedLegacy(.blobAbsent))
+
+        let firstCall = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+        XCTAssertEqual(pixelFiring.actualFireCalls.map(\.pixel.name), [
+            "sync_unified_devices_account_info_key_create_success",
+            "sync_unified_devices_own_row_resolved_legacy"
+        ])
+        XCTAssertEqual(pixelFiring.actualFireCalls.map(\.frequency), [.standard, .daily])
+        XCTAssertEqual(pixelFiring.actualFireCalls.last?.pixel.parameters, ["reason": "blob_absent"])
+        XCTAssertNil(firstCall.pixel.standardParameters)
+        XCTAssertEqual(firstCall.pixel.namePrefix, PixelKitNamePrefix.none)
+    }
+}

--- a/iOS/PixelDefinitions/pixels/definitions/sync_unified_devices.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_unified_devices.json5
@@ -3,14 +3,14 @@
         "description": "Own device row resolved from unified device info while unified reads are enabled",
         "owners": ["amddg44"],
         "triggers": ["other"],
-        "suffixes": ["daily"],
+        "suffixes": ["daily", "platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "sync_unified_devices_own_row_resolved_legacy": {
         "description": "Own device row fell back to legacy encrypted fields while unified reads are enabled",
         "owners": ["amddg44"],
         "triggers": ["other"],
-        "suffixes": ["daily"],
+        "suffixes": ["daily", "platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -25,7 +25,7 @@
         "description": "Own device row fell back to a placeholder while unified reads are enabled",
         "owners": ["amddg44"],
         "triggers": ["other"],
-        "suffixes": ["daily"],
+        "suffixes": ["daily", "platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -40,7 +40,7 @@
         "description": "Account-info key could not be obtained for unified device-list reads",
         "owners": ["amddg44"],
         "triggers": ["other"],
-        "suffixes": ["daily"],
+        "suffixes": ["daily", "platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -62,7 +62,7 @@
         "description": "At least one other device row in a credential category had unified device info that could not be decrypted",
         "owners": ["amddg44"],
         "triggers": ["other"],
-        "suffixes": ["daily"],
+        "suffixes": ["daily", "platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -77,7 +77,7 @@
         "description": "At least one other device row in a credential category resolved to a placeholder",
         "owners": ["amddg44"],
         "triggers": ["other"],
-        "suffixes": ["daily"],
+        "suffixes": ["daily", "platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -92,7 +92,7 @@
         "description": "This device failed to obtain an account-info key already registered on the account",
         "owners": ["amddg44"],
         "triggers": ["other"],
-        "suffixes": ["daily"],
+        "suffixes": ["daily", "platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -107,13 +107,14 @@
         "description": "This device successfully registered a newly minted account-info key",
         "owners": ["amddg44"],
         "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "sync_unified_devices_account_info_key_create_failed": {
         "description": "This device failed to mint or register a new account-info key",
         "owners": ["amddg44"],
         "triggers": ["other"],
-        "suffixes": ["daily"],
+        "suffixes": ["daily", "platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -128,13 +129,14 @@
         "description": "This device successfully added a missing credential wrapper to an existing account-info key",
         "owners": ["amddg44"],
         "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "sync_unified_devices_account_info_key_wrap_failed": {
         "description": "This device failed to add a missing credential wrapper to an existing account-info key",
         "owners": ["amddg44"],
         "triggers": ["other"],
-        "suffixes": ["daily"],
+        "suffixes": ["daily", "platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -149,19 +151,21 @@
         "description": "This device successfully used an account-info key already registered on the account",
         "owners": ["amddg44"],
         "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "sync_unified_devices_own_row_device_info_first_write_success": {
         "description": "This device successfully performed a signup or migration write of its own unified device info",
         "owners": ["amddg44"],
         "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "sync_unified_devices_own_row_device_info_first_write_failed": {
         "description": "This device failed a signup or migration write of its own unified device info",
         "owners": ["amddg44"],
         "triggers": ["other"],
-        "suffixes": ["daily"],
+        "suffixes": ["daily", "platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -176,13 +180,14 @@
         "description": "This device successfully updated its own unified device info during rename",
         "owners": ["amddg44"],
         "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "sync_unified_devices_own_row_device_info_update_failed": {
         "description": "This device failed to update its own unified device info during rename",
         "owners": ["amddg44"],
         "triggers": ["other"],
-        "suffixes": ["daily"],
+        "suffixes": ["daily", "platform", "form_factor"],
         "parameters": [
             "appVersion",
             {
@@ -197,13 +202,14 @@
         "description": "This device successfully repaired its own missing or unreadable unified device info",
         "owners": ["amddg44"],
         "triggers": ["other"],
+        "suffixes": ["platform", "form_factor"],
         "parameters": ["appVersion"]
     },
     "sync_unified_devices_own_row_device_info_repair_failed": {
         "description": "This device failed to repair its own missing or unreadable unified device info",
         "owners": ["amddg44"],
         "triggers": ["other"],
-        "suffixes": ["daily"],
+        "suffixes": ["daily", "platform", "form_factor"],
         "parameters": [
             "appVersion",
             {

--- a/iOS/PixelDefinitions/pixels/definitions/sync_unified_devices.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/sync_unified_devices.json5
@@ -1,0 +1,217 @@
+{
+    "sync_unified_devices_own_row_resolved_device_info": {
+        "description": "Own device row resolved from unified device info while unified reads are enabled",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": ["appVersion"]
+    },
+    "sync_unified_devices_own_row_resolved_legacy": {
+        "description": "Own device row fell back to legacy encrypted fields while unified reads are enabled",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Unified device-info fallback reason",
+                "enum": ["not_published_yet", "blob_absent", "blob_decrypt_failed"]
+            }
+        ]
+    },
+    "sync_unified_devices_own_row_resolved_placeholder": {
+        "description": "Own device row fell back to a placeholder while unified reads are enabled",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Unified device-info fallback reason",
+                "enum": ["not_published_yet", "blob_absent", "blob_decrypt_failed"]
+            }
+        ]
+    },
+    "sync_unified_devices_account_info_key_unavailable": {
+        "description": "Account-info key could not be obtained for unified device-list reads",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Reason the account-info key was unavailable",
+                "enum": [
+                    "no_key_on_server",
+                    "no_wrap_for_our_credential",
+                    "unwrap_failed",
+                    "invalid_key_material",
+                    "keys_fetch_failed",
+                    "rate_limited"
+                ]
+            }
+        ]
+    },
+    "sync_unified_devices_other_row_device_info_failed_decryption": {
+        "description": "At least one other device row in a credential category had unified device info that could not be decrypted",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "credential",
+                "type": "string",
+                "description": "Bounded credential category for a device-list row",
+                "enum": ["ddg", "3party", "none"]
+            }
+        ]
+    },
+    "sync_unified_devices_other_row_resolved_placeholder": {
+        "description": "At least one other device row in a credential category resolved to a placeholder",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "credential",
+                "type": "string",
+                "description": "Bounded credential category for a device-list row",
+                "enum": ["ddg", "3party", "none"]
+            }
+        ]
+    },
+    "sync_unified_devices_account_info_key_adopt_failed": {
+        "description": "This device failed to obtain an account-info key already registered on the account",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Account-info key adoption failure reason",
+                "enum": ["keys_fetch_failed", "rate_limited"]
+            }
+        ]
+    },
+    "sync_unified_devices_account_info_key_create_success": {
+        "description": "This device successfully registered a newly minted account-info key",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": ["appVersion"]
+    },
+    "sync_unified_devices_account_info_key_create_failed": {
+        "description": "This device failed to mint or register a new account-info key",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Account-info key creation failure reason",
+                "enum": ["mint_failed", "request_failed", "rate_limited"]
+            }
+        ]
+    },
+    "sync_unified_devices_account_info_key_wrap_success": {
+        "description": "This device successfully added a missing credential wrapper to an existing account-info key",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": ["appVersion"]
+    },
+    "sync_unified_devices_account_info_key_wrap_failed": {
+        "description": "This device failed to add a missing credential wrapper to an existing account-info key",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Account-info key wrapping failure reason",
+                "enum": ["unwrap_failed", "request_failed", "rate_limited"]
+            }
+        ]
+    },
+    "sync_unified_devices_account_info_key_adopt_success": {
+        "description": "This device successfully used an account-info key already registered on the account",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": ["appVersion"]
+    },
+    "sync_unified_devices_own_row_device_info_first_write_success": {
+        "description": "This device successfully performed a signup or migration write of its own unified device info",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": ["appVersion"]
+    },
+    "sync_unified_devices_own_row_device_info_first_write_failed": {
+        "description": "This device failed a signup or migration write of its own unified device info",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Unified device-info write failure reason",
+                "enum": ["encrypt_failed", "request_failed", "rate_limited", "persist_failed"]
+            }
+        ]
+    },
+    "sync_unified_devices_own_row_device_info_update_success": {
+        "description": "This device successfully updated its own unified device info during rename",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": ["appVersion"]
+    },
+    "sync_unified_devices_own_row_device_info_update_failed": {
+        "description": "This device failed to update its own unified device info during rename",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Unified device-info write failure reason",
+                "enum": ["encrypt_failed", "request_failed", "rate_limited", "persist_failed"]
+            }
+        ]
+    },
+    "sync_unified_devices_own_row_device_info_repair_success": {
+        "description": "This device successfully repaired its own missing or unreadable unified device info",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": ["appVersion"]
+    },
+    "sync_unified_devices_own_row_device_info_repair_failed": {
+        "description": "This device failed to repair its own missing or unreadable unified device info",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Unified device-info write failure reason",
+                "enum": ["encrypt_failed", "request_failed", "rate_limited", "persist_failed"]
+            }
+        ]
+    }
+}

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1538,6 +1538,8 @@
 		37FC2A192CF903080048E226 /* MockPrivacyStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FC2A172CF903060048E226 /* MockPrivacyStats.swift */; };
 		37FD78112A29EBD100B36DB1 /* SyncErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD78102A29EBD100B36DB1 /* SyncErrorHandler.swift */; };
 		37FD78122A29EBD100B36DB1 /* SyncErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FD78102A29EBD100B36DB1 /* SyncErrorHandler.swift */; };
+		A71D000330EEA00100A11A01 /* UnifiedDeviceListPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71D000530EEA00100A11A01 /* UnifiedDeviceListPixelHandler.swift */; };
+		A71D000430EEA00100A11A01 /* UnifiedDeviceListPixelHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71D000530EEA00100A11A01 /* UnifiedDeviceListPixelHandler.swift */; };
 		38935B87BCB54456BFEBB274 /* AIChatSubscriptionUpsellDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F8268B7F214B78ABBD3CAB /* AIChatSubscriptionUpsellDialog.swift */; };
 		3BB9000FD0E24C33A8E285DF /* RebrandedContextualOnboardingDialogs+Trackers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 486DE4DF1E7F43229D062937 /* RebrandedContextualOnboardingDialogs+Trackers.swift */; };
 		3C4D5E6F708192A3B4C5D6E7 /* BookmarksBarMenuCustomPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2C3D4E5F60718293A4B5C6 /* BookmarksBarMenuCustomPopover.swift */; };
@@ -2004,6 +2006,8 @@
 		5681ED442BDBA5F900F59729 /* SyncBookmarksAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5681ED422BDBA5F900F59729 /* SyncBookmarksAdapterTests.swift */; };
 		5681ED462BDBAF6E00F59729 /* SyncErrorHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5681ED452BDBAF6E00F59729 /* SyncErrorHandlerTests.swift */; };
 		5681ED472BDBAF6E00F59729 /* SyncErrorHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5681ED452BDBAF6E00F59729 /* SyncErrorHandlerTests.swift */; };
+		A71D000830EEA00100A11A01 /* UnifiedDeviceListPixelHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71D000A30EEA00100A11A01 /* UnifiedDeviceListPixelHandlerTests.swift */; };
+		A71D000930EEA00100A11A01 /* UnifiedDeviceListPixelHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71D000A30EEA00100A11A01 /* UnifiedDeviceListPixelHandlerTests.swift */; };
 		5682C69429B79B57004DE3C8 /* TabBarViewItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5601FECC29B7973D00068905 /* TabBarViewItemTests.swift */; };
 		5687F6482F30CD1000A5C9B3 /* DefaultSubscriptionFlowsExecuter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5687F6472F30CD1000A5C9B3 /* DefaultSubscriptionFlowsExecuter.swift */; };
 		5687F6492F30CD1000A5C9B3 /* DefaultSubscriptionFlowsExecuter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5687F6472F30CD1000A5C9B3 /* DefaultSubscriptionFlowsExecuter.swift */; };
@@ -5663,6 +5667,7 @@
 		37F9AEB02D1316FE007FD19B /* NewTabPageLinkOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageLinkOpener.swift; sourceTree = "<group>"; };
 		37FC2A172CF903060048E226 /* MockPrivacyStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPrivacyStats.swift; sourceTree = "<group>"; };
 		37FD78102A29EBD100B36DB1 /* SyncErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncErrorHandler.swift; sourceTree = "<group>"; };
+		A71D000530EEA00100A11A01 /* UnifiedDeviceListPixelHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedDeviceListPixelHandler.swift; sourceTree = "<group>"; };
 		38994C5DE0CE5FDD50D36C3E /* SyncFaviconsPromoDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncFaviconsPromoDelegate.swift; sourceTree = "<group>"; };
 		4031C8EC6CF74501D704C00A /* PromoServiceFactory+CookiePopupsBlocked.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PromoServiceFactory+CookiePopupsBlocked.swift"; sourceTree = "<group>"; };
 		40E090D60EAB41E8BB22CA88 /* DuckAIChromeButtonsPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIChromeButtonsPreferences.swift; sourceTree = "<group>"; };
@@ -5934,6 +5939,7 @@
 		5681ED3F2BDB955100F59729 /* SyncCredentialsAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncCredentialsAdapterTests.swift; sourceTree = "<group>"; };
 		5681ED422BDBA5F900F59729 /* SyncBookmarksAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncBookmarksAdapterTests.swift; sourceTree = "<group>"; };
 		5681ED452BDBAF6E00F59729 /* SyncErrorHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncErrorHandlerTests.swift; sourceTree = "<group>"; };
+		A71D000A30EEA00100A11A01 /* UnifiedDeviceListPixelHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedDeviceListPixelHandlerTests.swift; sourceTree = "<group>"; };
 		5687F6472F30CD1000A5C9B3 /* DefaultSubscriptionFlowsExecuter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSubscriptionFlowsExecuter.swift; sourceTree = "<group>"; };
 		56A053FB2C19E8F7007D8FAB /* OnboardingActionsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingActionsManager.swift; sourceTree = "<group>"; };
 		56A053FE2C1AEFA1007D8FAB /* OnboardingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingManagerTests.swift; sourceTree = "<group>"; };
@@ -8638,6 +8644,7 @@
 				C1D3C5722E8ADB080086A2BD /* SyncIdentitiesAdapter.swift */,
 				37CBCA992A8966E60050218F /* SyncSettingsAdapter.swift */,
 				37FD78102A29EBD100B36DB1 /* SyncErrorHandler.swift */,
+				A71D000530EEA00100A11A01 /* UnifiedDeviceListPixelHandler.swift */,
 				372A0FEB2B2379310033BF7F /* SyncMetricsEventsHandler.swift */,
 				37CEFCA82A6737A2001EF741 /* CredentialsCleanupErrorHandling.swift */,
 				C1D3C5662E747BBE0086A2BD /* CreditCardsCleanupErrorHandling.swift */,
@@ -9980,6 +9987,7 @@
 				C1D3C56E2E89D8F30086A2BD /* SyncCreditCardsAdapterTests.swift */,
 				C1D3C5732E89D9280086A2BD /* SyncIdentitiesAdapterTests.swift */,
 				5681ED452BDBAF6E00F59729 /* SyncErrorHandlerTests.swift */,
+				A71D000A30EEA00100A11A01 /* UnifiedDeviceListPixelHandlerTests.swift */,
 			);
 			path = Sync;
 			sourceTree = "<group>";
@@ -16273,6 +16281,7 @@
 				9F56CFAA2B82DC4300BB7F11 /* AddEditBookmarkFolderView.swift in Sources */,
 				567A23D82C8871290010F66C /* OnboardingFireButtonDialogViewModel.swift in Sources */,
 				37FD78122A29EBD100B36DB1 /* SyncErrorHandler.swift in Sources */,
+				A71D000430EEA00100A11A01 /* UnifiedDeviceListPixelHandler.swift in Sources */,
 				1D4B03D62CA4432000224E99 /* BookmarkUrlExtension.swift in Sources */,
 				987799F42999993C005D8EB6 /* LegacyBookmarksStoreMigration.swift in Sources */,
 				3706FB7A293F65D500E42796 /* FileDownloadManager.swift in Sources */,
@@ -17230,6 +17239,7 @@
 				3706FE11293F661700E42796 /* URLSuggestedFilenameTests.swift in Sources */,
 				CC442CB02F6C64AB002E8175 /* DockPreferencesModelTests.swift in Sources */,
 				5681ED472BDBAF6E00F59729 /* SyncErrorHandlerTests.swift in Sources */,
+				A71D000930EEA00100A11A01 /* UnifiedDeviceListPixelHandlerTests.swift in Sources */,
 				CC34456F2E674E7700019518 /* UserScriptErrorTests.swift in Sources */,
 				37F1C19B2FACA6B400260FDC /* TrackerProtectionMemoryGuardrailTests.swift in Sources */,
 				1E8995E02DCD05280093EFBA /* PreferencesSectionTests.swift in Sources */,
@@ -19409,6 +19419,7 @@
 				4B5FF67826B602B100D42879 /* FirefoxDataImporter.swift in Sources */,
 				37AFCE8B27DB69BC00471A10 /* PreferencesGeneralView.swift in Sources */,
 				37FD78112A29EBD100B36DB1 /* SyncErrorHandler.swift in Sources */,
+				A71D000330EEA00100A11A01 /* UnifiedDeviceListPixelHandler.swift in Sources */,
 				3767318B2C7F32C500EB097B /* GradientBackground.swift in Sources */,
 				1D532BDE2EDC3E4800D219FA /* PermissionCenterView.swift in Sources */,
 				BBF17D1A2F7B1309004AFCF4 /* AIChatMenu.swift in Sources */,
@@ -19793,6 +19804,7 @@
 				EE2868502EAFC38200AB597F /* LegacyDataImportViewModelTests.swift in Sources */,
 				373A1AAA283ED86C00586521 /* BookmarksHTMLReaderTests.swift in Sources */,
 				5681ED462BDBAF6E00F59729 /* SyncErrorHandlerTests.swift in Sources */,
+				A71D000830EEA00100A11A01 /* UnifiedDeviceListPixelHandlerTests.swift in Sources */,
 				9FBD84772BB3E54200220859 /* InstallationAttributionPixelHandlerTests.swift in Sources */,
 				B6106BB126A7D8720013B453 /* PermissionStoreTests.swift in Sources */,
 				B5C7792B303DF20500C1B6CB /* DataDirectoryPermissionFixAvailabilityTests.swift in Sources */,

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -2258,6 +2258,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let syncService = DDGSync(
             dataProvidersSource: syncDataProviders,
             errorEvents: SyncErrorHandler(),
+            unifiedDeviceListEvents: UnifiedDeviceListPixelHandler(),
             privacyConfigurationManager: privacyFeatures.contentBlocking.privacyConfigurationManager,
             keyValueStore: keyValueStore,
             environment: environment,

--- a/macOS/DuckDuckGo/Sync/SyncErrorHandler.swift
+++ b/macOS/DuckDuckGo/Sync/SyncErrorHandler.swift
@@ -305,16 +305,16 @@ private struct UnifiedDeviceListPixel: PixelKit.Event {
     let parameters: [String: String]?
     let standardParameters: [PixelKitStandardParameter]? = [.pixelSource]
     let error: NSError? = nil
+    let namePrefix: PixelKitNamePrefix = .none
 }
 
 final class UnifiedDeviceListPixelHandler: EventMapping<UnifiedDeviceListEvent> {
 
-    init() {
+    init(pixelFiring: PixelFiring? = PixelKit.shared) {
         super.init { event, _, _, onComplete in
-            PixelKit.fire(
+            pixelFiring?.fire(
                 UnifiedDeviceListPixel(name: event.name, parameters: event.parameters),
-                frequency: event.frequency.pixelKitFrequency,
-                options: .unenforcedPrefix)
+                frequency: event.frequency.pixelKitFrequency)
             onComplete(nil)
         }
     }

--- a/macOS/DuckDuckGo/Sync/SyncErrorHandler.swift
+++ b/macOS/DuckDuckGo/Sync/SyncErrorHandler.swift
@@ -300,6 +300,39 @@ public class SyncErrorHandler: EventMapping<SyncError>, ObservableObject {
     }
 }
 
+private struct UnifiedDeviceListPixel: PixelKit.Event {
+    let name: String
+    let parameters: [String: String]?
+    let standardParameters: [PixelKitStandardParameter]? = [.pixelSource]
+    let error: NSError? = nil
+}
+
+final class UnifiedDeviceListPixelHandler: EventMapping<UnifiedDeviceListEvent> {
+
+    init() {
+        super.init { event, _, _, onComplete in
+            PixelKit.fire(
+                UnifiedDeviceListPixel(name: event.name, parameters: event.parameters),
+                frequency: event.frequency.pixelKitFrequency,
+                options: .unenforcedPrefix)
+            onComplete(nil)
+        }
+    }
+
+    override init(mapping: @escaping EventMapping<UnifiedDeviceListEvent>.Mapping) {
+        fatalError("Use init()")
+    }
+}
+
+private extension UnifiedDeviceListEvent.Frequency {
+    var pixelKitFrequency: PixelKit.Frequency {
+        switch self {
+        case .standard: return .standard
+        case .daily: return .daily
+        }
+    }
+}
+
 extension SyncErrorHandler: SyncErrorHandling {
 
     func syncCredentialsSucceded() {

--- a/macOS/DuckDuckGo/Sync/SyncErrorHandler.swift
+++ b/macOS/DuckDuckGo/Sync/SyncErrorHandler.swift
@@ -300,39 +300,6 @@ public class SyncErrorHandler: EventMapping<SyncError>, ObservableObject {
     }
 }
 
-private struct UnifiedDeviceListPixel: PixelKit.Event {
-    let name: String
-    let parameters: [String: String]?
-    let standardParameters: [PixelKitStandardParameter]? = [.pixelSource]
-    let error: NSError? = nil
-    let namePrefix: PixelKitNamePrefix = .none
-}
-
-final class UnifiedDeviceListPixelHandler: EventMapping<UnifiedDeviceListEvent> {
-
-    init(pixelFiring: PixelFiring? = PixelKit.shared) {
-        super.init { event, _, _, onComplete in
-            pixelFiring?.fire(
-                UnifiedDeviceListPixel(name: event.name, parameters: event.parameters),
-                frequency: event.frequency.pixelKitFrequency)
-            onComplete(nil)
-        }
-    }
-
-    override init(mapping: @escaping EventMapping<UnifiedDeviceListEvent>.Mapping) {
-        fatalError("Use init()")
-    }
-}
-
-private extension UnifiedDeviceListEvent.Frequency {
-    var pixelKitFrequency: PixelKit.Frequency {
-        switch self {
-        case .standard: return .standard
-        case .daily: return .daily
-        }
-    }
-}
-
 extension SyncErrorHandler: SyncErrorHandling {
 
     func syncCredentialsSucceded() {

--- a/macOS/DuckDuckGo/Sync/UnifiedDeviceListPixelHandler.swift
+++ b/macOS/DuckDuckGo/Sync/UnifiedDeviceListPixelHandler.swift
@@ -1,0 +1,55 @@
+//
+//  UnifiedDeviceListPixelHandler.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Common
+import DDGSync
+import Foundation
+import PixelKit
+
+private struct UnifiedDeviceListPixel: PixelKit.Event {
+    let name: String
+    let parameters: [String: String]?
+    let standardParameters: [PixelKitStandardParameter]? = [.pixelSource]
+    let error: NSError? = nil
+    let namePrefix: PixelKitNamePrefix = .none
+}
+
+final class UnifiedDeviceListPixelHandler: EventMapping<UnifiedDeviceListEvent> {
+
+    init(pixelFiring: PixelFiring? = PixelKit.shared) {
+        super.init { event, _, _, onComplete in
+            pixelFiring?.fire(
+                UnifiedDeviceListPixel(name: event.name, parameters: event.parameters),
+                frequency: event.frequency.pixelKitFrequency)
+            onComplete(nil)
+        }
+    }
+
+    override init(mapping: @escaping EventMapping<UnifiedDeviceListEvent>.Mapping) {
+        fatalError("Use init()")
+    }
+}
+
+private extension UnifiedDeviceListEvent.Frequency {
+    var pixelKitFrequency: PixelKit.Frequency {
+        switch self {
+        case .standard: return .standard
+        case .daily: return .daily
+        }
+    }
+}

--- a/macOS/PixelDefinitions/pixels/definitions/sync_unified_devices.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/sync_unified_devices.json5
@@ -1,0 +1,239 @@
+{
+    "sync_unified_devices_own_row_resolved_device_info": {
+        "description": "Own device row resolved from unified device info while unified reads are enabled",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "sync_unified_devices_own_row_resolved_legacy": {
+        "description": "Own device row fell back to legacy encrypted fields while unified reads are enabled",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Unified device-info fallback reason",
+                "enum": ["not_published_yet", "blob_absent", "blob_decrypt_failed"]
+            }
+        ]
+    },
+    "sync_unified_devices_own_row_resolved_placeholder": {
+        "description": "Own device row fell back to a placeholder while unified reads are enabled",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Unified device-info fallback reason",
+                "enum": ["not_published_yet", "blob_absent", "blob_decrypt_failed"]
+            }
+        ]
+    },
+    "sync_unified_devices_account_info_key_unavailable": {
+        "description": "Account-info key could not be obtained for unified device-list reads",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Reason the account-info key was unavailable",
+                "enum": [
+                    "no_key_on_server",
+                    "no_wrap_for_our_credential",
+                    "unwrap_failed",
+                    "invalid_key_material",
+                    "keys_fetch_failed",
+                    "rate_limited"
+                ]
+            }
+        ]
+    },
+    "sync_unified_devices_other_row_device_info_failed_decryption": {
+        "description": "At least one other device row in a credential category had unified device info that could not be decrypted",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "credential",
+                "type": "string",
+                "description": "Bounded credential category for a device-list row",
+                "enum": ["ddg", "3party", "none"]
+            }
+        ]
+    },
+    "sync_unified_devices_other_row_resolved_placeholder": {
+        "description": "At least one other device row in a credential category resolved to a placeholder",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "credential",
+                "type": "string",
+                "description": "Bounded credential category for a device-list row",
+                "enum": ["ddg", "3party", "none"]
+            }
+        ]
+    },
+    "sync_unified_devices_account_info_key_adopt_failed": {
+        "description": "This device failed to obtain an account-info key already registered on the account",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Account-info key adoption failure reason",
+                "enum": ["keys_fetch_failed", "rate_limited"]
+            }
+        ]
+    },
+    "sync_unified_devices_account_info_key_create_success": {
+        "description": "This device successfully registered a newly minted account-info key",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "sync_unified_devices_account_info_key_create_failed": {
+        "description": "This device failed to mint or register a new account-info key",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Account-info key creation failure reason",
+                "enum": ["mint_failed", "request_failed", "rate_limited"]
+            }
+        ]
+    },
+    "sync_unified_devices_account_info_key_wrap_success": {
+        "description": "This device successfully added a missing credential wrapper to an existing account-info key",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "sync_unified_devices_account_info_key_wrap_failed": {
+        "description": "This device failed to add a missing credential wrapper to an existing account-info key",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Account-info key wrapping failure reason",
+                "enum": ["unwrap_failed", "request_failed", "rate_limited"]
+            }
+        ]
+    },
+    "sync_unified_devices_account_info_key_adopt_success": {
+        "description": "This device successfully used an account-info key already registered on the account",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "sync_unified_devices_own_row_device_info_first_write_success": {
+        "description": "This device successfully performed a signup or migration write of its own unified device info",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "sync_unified_devices_own_row_device_info_first_write_failed": {
+        "description": "This device failed a signup or migration write of its own unified device info",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Unified device-info write failure reason",
+                "enum": ["encrypt_failed", "request_failed", "rate_limited", "persist_failed"]
+            }
+        ]
+    },
+    "sync_unified_devices_own_row_device_info_update_success": {
+        "description": "This device successfully updated its own unified device info during rename",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "sync_unified_devices_own_row_device_info_update_failed": {
+        "description": "This device failed to update its own unified device info during rename",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Unified device-info write failure reason",
+                "enum": ["encrypt_failed", "request_failed", "rate_limited", "persist_failed"]
+            }
+        ]
+    },
+    "sync_unified_devices_own_row_device_info_repair_success": {
+        "description": "This device successfully repaired its own missing or unreadable unified device info",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "sync_unified_devices_own_row_device_info_repair_failed": {
+        "description": "This device failed to repair its own missing or unreadable unified device info",
+        "owners": ["amddg44"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Unified device-info write failure reason",
+                "enum": ["encrypt_failed", "request_failed", "rate_limited", "persist_failed"]
+            }
+        ]
+    }
+}

--- a/macOS/UnitTests/Sync/UnifiedDeviceListPixelHandlerTests.swift
+++ b/macOS/UnitTests/Sync/UnifiedDeviceListPixelHandlerTests.swift
@@ -1,0 +1,43 @@
+//
+//  UnifiedDeviceListPixelHandlerTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import DDGSync
+@_spi(Testing) import PixelKit
+@testable import DuckDuckGo_Privacy_Browser
+
+final class UnifiedDeviceListPixelHandlerTests: XCTestCase {
+
+    func testUnifiedDeviceListPixelHandlerMapsStandardAndDailyEvents() throws {
+        let pixelFiring = PixelKitMock()
+        let handler = UnifiedDeviceListPixelHandler(pixelFiring: pixelFiring)
+
+        handler.fire(.accountInfoKeyCreateSuccess)
+        handler.fire(.ownRowResolvedLegacy(.blobAbsent))
+
+        let firstCall = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+        XCTAssertEqual(pixelFiring.actualFireCalls.map(\.pixel.name), [
+            "sync_unified_devices_account_info_key_create_success",
+            "sync_unified_devices_own_row_resolved_legacy"
+        ])
+        XCTAssertEqual(pixelFiring.actualFireCalls.map(\.frequency), [.standard, .daily])
+        XCTAssertEqual(pixelFiring.actualFireCalls.last?.pixel.parameters, ["reason": "blob_absent"])
+        XCTAssertEqual(firstCall.pixel.standardParameters, [.pixelSource])
+        XCTAssertEqual(firstCall.pixel.namePrefix, PixelKitNamePrefix.none)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1216959071260316?focus=true
Tech Design URL:
CC:

### Description
Adds new pixels for the unified Sync device list rollout

### Testing Steps

#### Prerequisites

- On iOS, start with Sync disabled
- In the Xcode console, filter for `sync_unified_devices_`

#### Core coverage

1. Ensure the following local feature-flag are enabled:
   - `syncCanReadUnifiedDeviceList`
   - `syncCanWriteUnifiedDeviceList`
   - `syncCanUsePatchEndpointForLegacyDeviceRename` (on by default, leave enabled throughout)
2. Enable Sync and create a new account → account creation completes normally, and the console shows:
   - `sync_unified_devices_account_info_key_create_success`
   - `sync_unified_devices_own_row_device_info_first_write_success`
3. View the Sync device list → device names and types display correctly, and the console shows `sync_unified_devices_own_row_resolved_device_info_daily`.
4. Rename the current device → the new name appears, and the console shows:
   - `sync_unified_devices_account_info_key_adopt_success `
   - `sync_unified_devices_own_row_device_info_update_success`
5. Disable `syncCanReadUnifiedDeviceList`, leaving `syncCanWriteUnifiedDeviceList` and `syncCanUsePatchEndpointForLegacyDeviceRename` enabled.
6. View the Sync device list → the legacy list still works, and no new unified read-resolution pixels are produced.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Sync account creation, device fetch mapping, and crypto/key migration flows; behavior changes are mostly observability plus skipping migration when signup already wrote device info, but failures still follow existing fallback paths.
> 
> **Overview**
> Adds **privacy-safe telemetry** for the unified Sync device list by introducing `UnifiedDeviceListEvent` and an optional `unifiedDeviceListEvents` `EventMapping` on `DDGSync` / production dependencies (defaults to no-op).
> 
> **Write path:** signup, device-info migration/rename/repair, scoped `account_info` key create/adopt/wrap, and third-party upgrade now fire bounded success/failure events. `createAccount` returns `AccountCreationResult` with `didPublishDeviceInfo`; when signup already published unified device info, migration is marked complete instead of scheduling background migration.
> 
> **Read path:** `RegisteredDeviceMapper` collects `unifiedReadObservations` during device-list mapping (own/other row resolution, key availability). `fetchDevices` forwards them via `fireUnifiedReadObservations`, with own-row legacy/placeholder fallback pixels gated on `canWriteUnifiedDeviceList`.
> 
> Tests cover event emission, observation gating, and migration short-circuit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 498aae0e7675750bb43bbbee3a689d9fdea41f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->