### PR TITLE
Remove temporary web extension protected-data pixels

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -2035,8 +2035,6 @@ extension Pixel {
         case webExtensionUninstallAllError
         case webExtensionLoaded
         case webExtensionLoadError
-        case webExtensionDeferredProtectedDataUnavailable
-        case webExtensionResumedProtectedDataAvailable
         case webExtensionEmbeddedInstalled
         case webExtensionEmbeddedUpgraded
         case webExtensionEmbeddedInstallError
@@ -4004,8 +4002,6 @@ extension Pixel.Event {
         case .webExtensionUninstallAllError: return "m_web_extension_uninstall_all_error"
         case .webExtensionLoaded: return "m_web_extension_loaded"
         case .webExtensionLoadError: return "m_web_extension_load_error"
-        case .webExtensionDeferredProtectedDataUnavailable: return "m_web_extension_deferred_protected_data_unavailable"
-        case .webExtensionResumedProtectedDataAvailable: return "m_web_extension_resumed_protected_data_available"
         case .webExtensionEmbeddedInstalled: return "m_web_extension_embedded_installed"
         case .webExtensionEmbeddedUpgraded: return "m_web_extension_embedded_upgraded"
         case .webExtensionEmbeddedInstallError: return "m_web_extension_embedded_install_error"

--- a/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
+++ b/iOS/DuckDuckGo/UICoordination/MainCoordinator.swift
@@ -513,8 +513,6 @@ final class MainCoordinator {
     @available(iOS 18.4, *)
     private func deferUntilProtectedDataAvailable(_ operation: @escaping () -> Void) {
         pendingProtectedDataWork.append(operation)
-        DailyPixel.fireDailyAndCount(pixel: .webExtensionDeferredProtectedDataUnavailable,
-                                     pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes)
 
         guard protectedDataCancellable == nil else { return }
         protectedDataCancellable = NotificationCenter.default
@@ -526,8 +524,6 @@ final class MainCoordinator {
                     let pendingWork = self.pendingProtectedDataWork
                     self.pendingProtectedDataWork.removeAll()
                     guard !pendingWork.isEmpty else { return }
-                    DailyPixel.fireDailyAndCount(pixel: .webExtensionResumedProtectedDataAvailable,
-                                                 pixelNameSuffixes: DailyPixel.Constant.dailyAndStandardSuffixes)
                     pendingWork.forEach { $0() }
                 }
             }

--- a/iOS/PixelDefinitions/pixels/definitions/web_extensions.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/web_extensions.json5
@@ -69,28 +69,6 @@
         ],
         "parameters": ["appVersion"]
     },
-    "m_web_extension_deferred_protected_data_unavailable": {
-        "description": "Fires when web extension loading or embedded install is deferred because protected data is unavailable (e.g. device locked before first unlock).",
-        "owners": ["miasma13"],
-        "triggers": ["other"],
-        "suffixes": [
-            ["daily", "platform", "form_factor"],
-            ["platform", "form_factor"]
-        ],
-        "parameters": ["appVersion"],
-        "expires": "2026-07-15"
-    },
-    "m_web_extension_resumed_protected_data_available": {
-        "description": "Fires when protected data becomes available and previously deferred web extension load/install work is executed.",
-        "owners": ["miasma13"],
-        "triggers": ["other"],
-        "suffixes": [
-            ["daily", "platform", "form_factor"],
-            ["platform", "form_factor"]
-        ],
-        "parameters": ["appVersion"],
-        "expires": "2026-07-15"
-    },
     "m_web_extension_load_error": {
         "description": "Fires during app startup when loading installed web extensions fails (at least one extension failed to load).",
         "owners": ["tomasstrba"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200848783441532/task/1215434988943488
Tech Design URL: N/A
CC:

### Description
Removes the two temporary pixels added in #5235 that measured how often web extension loading was deferred because protected data was unavailable, and how often the deferred work later resumed. The data has been collected, so the pixels and their definitions are gone. The deferral behaviour itself is unchanged.

### Testing Steps
1. Review the diff → deletions only, no functional changes.
2. Confirm CI builds are green.

### Impact
None — pixel removal only, no user-facing behaviour changes.

### Quality Considerations
The pixels are also removed from `iOS/PixelDefinitions` so pixel validation stays in sync. macOS never defined them.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only pixel and definition cleanup with no changes to protected-data deferral behavior.
> 
> **Overview**
> Removes the **temporary analytics pixels** that tracked when web extension load/install work was deferred because protected data was unavailable, and when that deferred work ran after `protectedDataDidBecomeAvailable`. The enum cases, string names, `DailyPixel` fires in `deferUntilProtectedDataAvailable`, and `web_extensions.json5` definitions for `m_web_extension_deferred_protected_data_unavailable` and `m_web_extension_resumed_protected_data_available` are all deleted.
> 
> **Deferral logic is unchanged** — extension loading still queues on `pendingProtectedDataWork` and runs once when protected data becomes available; only telemetry from #5235 is removed after the measurement period.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 911f793a9969e14e1739b00664a81fcc3da8199d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->