### PR TITLE
[iOS] Report in-page prompts and navigation on return sessions

### DIFF
--- a/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
@@ -76,8 +76,8 @@ protocol PostIdleSessionInstrumentation: AnyObject {
     /// terminal action covers. Idempotent within a session.
     func promptSubmittedInPage()
 
-    /// User navigated within the app by a route that sets no terminal reason — a bookmark, a form
-    /// submission, or browser history. Idempotent within a session.
+    /// User went somewhere else in the app by a route that sets no terminal reason — a bookmark, a
+    /// form submission, browser history, or a native screen. Idempotent within a session.
     func inAppNavigation()
 
     /// Terminal user action ended the session (submission, return-to-page, etc.).

--- a/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
@@ -72,6 +72,14 @@ protocol PostIdleSessionInstrumentation: AnyObject {
     /// User burned the open tab from the escape hatch's menu. Idempotent within a session.
     func burnTabTapped()
 
+    /// The duck.ai frontend reported a prompt submitted from its own input box, which no native
+    /// terminal action covers. Idempotent within a session.
+    func promptSubmittedInPage()
+
+    /// User navigated within the app by a route that sets no terminal reason — a bookmark, a form
+    /// submission, or browser history. Idempotent within a session.
+    func inAppNavigation()
+
     /// Terminal user action ended the session (submission, return-to-page, etc.).
     func sessionEnded(reason: ReturnSessionWideEventData.StatusReason)
 
@@ -87,6 +95,8 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
     private var postIdleSessionID: String?
     /// Skips `updateFlow` (synchronous disk I/O) on every scroll tick after the first.
     private var pageEngagedSent = false
+    private var promptSubmittedInPageSent = false
+    private var inAppNavigationSent = false
     private var pendingTimeAwayMs: Int?
 
     init(wideEvent: WideEventManaging,
@@ -124,6 +134,8 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
         pendingTimeAwayMs = nil
         returnSessionID = returnData.globalData.id
         pageEngagedSent = false
+        promptSubmittedInPageSent = false
+        inAppNavigationSent = false
         wideEvent.startFlow(returnData)
 
         guard let afterIdleSurface else { return }
@@ -156,6 +168,18 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
 
     func burnTabTapped() {
         recordInteraction { $0.burnTabTapped = true }
+    }
+
+    func promptSubmittedInPage() {
+        guard !promptSubmittedInPageSent else { return }
+        promptSubmittedInPageSent = true
+        recordReturnSessionInteraction { $0.promptSubmittedInPage = true }
+    }
+
+    func inAppNavigation() {
+        guard !inAppNavigationSent else { return }
+        inAppNavigationSent = true
+        recordReturnSessionInteraction { $0.inAppNavigation = true }
     }
 
     func sessionEnded(reason: ReturnSessionWideEventData.StatusReason) {
@@ -215,6 +239,16 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
                 orphan,
                 status: .unknown(reason: PostIdleSessionWideEventData.appTerminatedReason),
                 onComplete: { _, _ in })
+        }
+    }
+
+    /// For fields the older `ios-post-idle-session` payload does not carry, so its schema stays put.
+    private func recordReturnSessionInteraction(_ mutate: @escaping (inout ReturnSessionWideEventData) -> Void) {
+        guard let globalID = returnSessionID else { return }
+        let now = dateProvider()
+        wideEvent.updateFlow(globalID: globalID) { (data: inout ReturnSessionWideEventData) in
+            mutate(&data)
+            markFirstInteractionIfNeeded(on: data, at: now)
         }
     }
 

--- a/iOS/DuckDuckGo/AppLifecycle/ReturnSessionWideEventData.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/ReturnSessionWideEventData.swift
@@ -32,7 +32,7 @@ final class ReturnSessionWideEventData: WideEventData {
         mobileMetaType: "ios-return-session",
         // API requires both; only mobileMetaType is read on iOS.
         desktopMetaType: "macos-return-session",
-        version: "1.0.0"
+        version: "1.1.0"
     )
 
     /// `ntp` is the after-idle NTP; `ntpUserInitiated` is an NTP reached without the treatment.
@@ -73,6 +73,8 @@ final class ReturnSessionWideEventData: WideEventData {
     var openingScreenChanged: Bool
     var closeTabTapped: Bool
     var burnTabTapped: Bool
+    var promptSubmittedInPage: Bool
+    var inAppNavigation: Bool
 
     init(landedOn: LandedOn,
          afterIdle: Bool,
@@ -86,6 +88,8 @@ final class ReturnSessionWideEventData: WideEventData {
          openingScreenChanged: Bool = false,
          closeTabTapped: Bool = false,
          burnTabTapped: Bool = false,
+         promptSubmittedInPage: Bool = false,
+         inAppNavigation: Bool = false,
          contextData: WideEventContextData = WideEventContextData(),
          appData: WideEventAppData = WideEventAppData(),
          globalData: WideEventGlobalData = WideEventGlobalData()) {
@@ -102,6 +106,8 @@ final class ReturnSessionWideEventData: WideEventData {
         self.openingScreenChanged = openingScreenChanged
         self.closeTabTapped = closeTabTapped
         self.burnTabTapped = burnTabTapped
+        self.promptSubmittedInPage = promptSubmittedInPage
+        self.inAppNavigation = inAppNavigation
         self.contextData = contextData
         self.appData = appData
         self.globalData = globalData
@@ -144,6 +150,8 @@ extension ReturnSessionWideEventData {
             (WideEventParameter.ReturnSessionFeature.openingScreenChanged, openingScreenChanged),
             (WideEventParameter.ReturnSessionFeature.closeTabTapped, closeTabTapped),
             (WideEventParameter.ReturnSessionFeature.burnTabTapped, burnTabTapped),
+            (WideEventParameter.ReturnSessionFeature.promptSubmittedInPage, promptSubmittedInPage),
+            (WideEventParameter.ReturnSessionFeature.inAppNavigation, inAppNavigation),
         ])
     }
 }
@@ -178,5 +186,7 @@ extension WideEventParameter {
         static let openingScreenChanged = "feature.data.ext.opening_screen_changed"
         static let closeTabTapped = "feature.data.ext.close_tab_tapped"
         static let burnTabTapped = "feature.data.ext.burn_tab_tapped"
+        static let promptSubmittedInPage = "feature.data.ext.prompt_submitted_in_page"
+        static let inAppNavigation = "feature.data.ext.in_app_navigation"
     }
 }

--- a/iOS/DuckDuckGo/MainViewController+Segues.swift
+++ b/iOS/DuckDuckGo/MainViewController+Segues.swift
@@ -124,6 +124,7 @@ extension MainViewController {
     func segueToHomeRow() {
         Logger.lifecycle.debug(#function)
         hideAllHighlightsIfNeeded()
+        postIdleSessionInstrumentation.inAppNavigation()
         let storyboard = UIStoryboard(name: "HomeRow", bundle: nil)
         guard let controller = storyboard.instantiateInitialViewController() else {
             assertionFailure()
@@ -161,6 +162,7 @@ extension MainViewController {
 
     private func launchBookmarksViewController(completion: ((BookmarksViewController) -> Void)? = nil) {
         Logger.lifecycle.debug(#function)
+        postIdleSessionInstrumentation.inAppNavigation()
 
         let storyboard = UIStoryboard(name: "Bookmarks", bundle: nil)
         let bookmarks = storyboard.instantiateViewController(identifier: "BookmarksViewController") { coder in
@@ -186,6 +188,7 @@ extension MainViewController {
     func segueToReportBrokenSite(entryPoint: PrivacyDashboardEntryPoint = .report) {
         Logger.lifecycle.debug(#function)
         hideAllHighlightsIfNeeded()
+        postIdleSessionInstrumentation.inAppNavigation()
 
         // Reuse the tab's live PrivacyInfo (with its accumulated tracker/protection state) as the
         // dashboard flow does; only build a fresh one if the tab has none yet.
@@ -218,6 +221,7 @@ extension MainViewController {
     func segueToNegativeFeedbackForm() {
         Logger.lifecycle.debug(#function)
         hideAllHighlightsIfNeeded()
+        postIdleSessionInstrumentation.inAppNavigation()
 
         let feedbackPicker = FeedbackPickerViewController.loadFromStoryboard()
 
@@ -233,6 +237,7 @@ extension MainViewController {
     func segueToDownloads() {
         Logger.lifecycle.debug(#function)
         hideAllHighlightsIfNeeded()
+        postIdleSessionInstrumentation.inAppNavigation()
 
         present(DownloadsListHostingController(), animated: true)
     }
@@ -480,6 +485,7 @@ extension MainViewController {
     func launchSettings(completion: ((SettingsViewModel) -> Void)? = nil,
                         deepLinkTarget: SettingsViewModel.SettingsDeepLinkSection? = nil,
                         configure: ((SettingsViewModel, SettingsHostingController) -> Void)? = nil) {
+        postIdleSessionInstrumentation.inAppNavigation()
         let legacyViewProvider = SettingsLegacyViewProvider(syncService: syncService,
                                                             syncDataProviders: syncDataProviders,
                                                             appSettings: appSettings,

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6513,6 +6513,10 @@ extension MainViewController: TabDelegate {
         postIdleSessionInstrumentation.pageEngaged()
     }
 
+    func tabDidNavigateInApp(_ tab: TabViewController) {
+        postIdleSessionInstrumentation.inAppNavigation()
+    }
+
     func tab(_ tab: TabViewController, didFailDuckAINavigationFor url: URL, error: Error) {
         duckAIWideEventInstrumentation.pageLoadFailed(scope: .tab(tab.tabModel.uid), error: error)
     }
@@ -7218,6 +7222,9 @@ extension MainViewController: TabSwitcherDelegate {
 extension MainViewController: BookmarksDelegate {
     func bookmarksDidSelect(url: URL) {
         recordNewTabPageSessionAction { $0.selectBookmark() }
+        // The equivalent NTP action ends the session as `.favoriteSelected`; a bookmark is a
+        // programmatic load, so it reaches no navigation-type hook and has to report itself.
+        postIdleSessionInstrumentation.inAppNavigation()
 
         dismissOmniBar()
         if url.isBookmarklet() {
@@ -8033,6 +8040,7 @@ extension MainViewController: AIChatViewControllerManagerDelegate {
     }
 
     func aiChatViewControllerManagerDidReceivePromptSubmission(_ manager: AIChatViewControllerManager) {
+        postIdleSessionInstrumentation.promptSubmittedInPage()
         reportDuckAIFrontendSubmissionAcknowledged()
     }
 }
@@ -8061,6 +8069,7 @@ extension MainViewController: AIChatContentHandlingDelegate {
     }
 
     func aiChatContentHandlerDidReceivePromptSubmission(_ handler: AIChatContentHandling) {
+        postIdleSessionInstrumentation.promptSubmittedInPage()
         reportDuckAIFrontendSubmissionAcknowledged()
     }
 

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -150,6 +150,9 @@ protocol TabDelegate: AnyObject {
 
     /// User activated an in-page link in this tab.
     func tabDidEngageWithPage(_ tab: TabViewController)
+
+    /// User navigated this tab by submitting a form, or through browser history.
+    func tabDidNavigateInApp(_ tab: TabViewController)
     
     func tabDidRequestFireButtonPulse(tab: TabViewController)
 

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -3240,8 +3240,15 @@ extension TabViewController: WKNavigationDelegate {
     private func decidePolicyFor(navigationAction: WKNavigationAction, completion: @escaping (WKNavigationActionPolicy) -> Void) {
         let allowPolicy = determineAllowPolicy()
 
-        if navigationAction.navigationType == .linkActivated {
+        switch navigationAction.navigationType {
+        case .linkActivated:
             delegate?.tabDidEngageWithPage(self)
+        case .formSubmitted, .backForward, .reload:
+            // `.other` is deliberately excluded: it also covers programmatic loads and redirects,
+            // which would make the signal mean "something loaded" rather than "the user acted".
+            delegate?.tabDidNavigateInApp(self)
+        default:
+            break
         }
 
         let tld = storageCache.tld

--- a/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
@@ -297,6 +297,99 @@ struct PostIdleSessionInstrumentationTests {
     }
 
     @available(iOS 16, *)
+    @Test("promptSubmittedInPage sets the flag and marks first interaction", .timeLimit(.minutes(1)))
+    func promptSubmittedInPageSetsFlagAndFirstInteraction() {
+        let (sut, wideEvent, clock) = makeSUT()
+        sut.sessionStarted(landedOn: .duckAI, afterIdleSurface: nil, focused: false)
+        clock.advance(by: 0.5)
+        sut.promptSubmittedInPage()
+
+        #expect(lastReturnUpdate(wideEvent)?.promptSubmittedInPage == true)
+        #expect(lastReturnUpdate(wideEvent)?.firstInteractionInterval.end == clock.now)
+    }
+
+    @available(iOS 16, *)
+    @Test("promptSubmittedInPage leaves the post-idle flow untouched", .timeLimit(.minutes(1)))
+    func promptSubmittedInPageDoesNotTouchPostIdleFlow() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(landedOn: .duckAI, afterIdleSurface: .lut, focused: false)
+        sut.promptSubmittedInPage()
+
+        #expect(lastReturnUpdate(wideEvent)?.promptSubmittedInPage == true)
+        #expect(lastUpdate(wideEvent) == nil)
+    }
+
+    @available(iOS 16, *)
+    @Test("promptSubmittedInPage only updates the flow once per session", .timeLimit(.minutes(1)))
+    func promptSubmittedInPageIsIdempotentWithinASession() {
+        let (sut, wideEvent, clock) = makeSUT()
+        sut.sessionStarted(landedOn: .duckAI, afterIdleSurface: nil, focused: false)
+        clock.advance(by: 0.5)
+        sut.promptSubmittedInPage()
+        sut.promptSubmittedInPage()
+        sut.promptSubmittedInPage()
+
+        #expect(wideEvent.updates.compactMap { $0 as? ReturnSessionWideEventData }.count == 1)
+    }
+
+    @available(iOS 16, *)
+    @Test("promptSubmittedInPage is recorded again after a new session starts", .timeLimit(.minutes(1)))
+    func promptSubmittedInPageResetsBetweenSessions() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(landedOn: .duckAI, afterIdleSurface: nil, focused: false)
+        sut.promptSubmittedInPage()
+        sut.sessionEnded(reason: .tabSwitcherSelected)
+
+        sut.sessionStarted(landedOn: .duckAI, afterIdleSurface: nil, focused: false)
+        sut.promptSubmittedInPage()
+
+        #expect(wideEvent.updates.compactMap { $0 as? ReturnSessionWideEventData }.count == 2)
+    }
+
+    @available(iOS 16, *)
+    @Test("promptSubmittedInPage outside a session does not update any flow", .timeLimit(.minutes(1)))
+    func promptSubmittedInPageOutsideSessionIsIgnored() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.promptSubmittedInPage()
+
+        #expect(wideEvent.updates.isEmpty)
+    }
+
+    @available(iOS 16, *)
+    @Test("inAppNavigation sets the flag and marks first interaction", .timeLimit(.minutes(1)))
+    func inAppNavigationSetsFlagAndFirstInteraction() {
+        let (sut, wideEvent, clock) = makeSUT()
+        sut.sessionStarted(landedOn: .web, afterIdleSurface: nil, focused: false)
+        clock.advance(by: 0.5)
+        sut.inAppNavigation()
+
+        #expect(lastReturnUpdate(wideEvent)?.inAppNavigation == true)
+        #expect(lastReturnUpdate(wideEvent)?.firstInteractionInterval.end == clock.now)
+    }
+
+    @available(iOS 16, *)
+    @Test("inAppNavigation only updates the flow once per session", .timeLimit(.minutes(1)))
+    func inAppNavigationIsIdempotentWithinASession() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(landedOn: .web, afterIdleSurface: nil, focused: false)
+        sut.inAppNavigation()
+        sut.inAppNavigation()
+
+        #expect(wideEvent.updates.compactMap { $0 as? ReturnSessionWideEventData }.count == 1)
+    }
+
+    @available(iOS 16, *)
+    @Test("The new flags stay false when nothing reports them", .timeLimit(.minutes(1)))
+    func newFlagsDefaultToFalse() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(landedOn: .duckAI, afterIdleSurface: nil, focused: false)
+        sut.sessionCancelledByBackground()
+
+        #expect(lastReturnCompletion(wideEvent)?.0.promptSubmittedInPage == false)
+        #expect(lastReturnCompletion(wideEvent)?.0.inAppNavigation == false)
+    }
+
+    @available(iOS 16, *)
     @Test("First interaction is only set once across multiple updates", .timeLimit(.minutes(1)))
     func firstInteractionMarkedOnlyOnce() {
         let (sut, wideEvent, clock) = makeSUT()

--- a/iOS/DuckDuckGoTests/ReturnSessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/ReturnSessionWideEventDataTests.swift
@@ -56,6 +56,8 @@ struct ReturnSessionWideEventDataTests {
         #expect(params["feature.data.ext.opening_screen_changed"] as? Bool == false)
         #expect(params["feature.data.ext.close_tab_tapped"] as? Bool == false)
         #expect(params["feature.data.ext.burn_tab_tapped"] as? Bool == false)
+        #expect(params["feature.data.ext.prompt_submitted_in_page"] as? Bool == false)
+        #expect(params["feature.data.ext.in_app_navigation"] as? Bool == false)
     }
 
     @available(iOS 16, *)
@@ -124,7 +126,9 @@ struct ReturnSessionWideEventDataTests {
                                               backPressed: true,
                                               openingScreenChanged: true,
                                               closeTabTapped: true,
-                                              burnTabTapped: true)
+                                              burnTabTapped: true,
+                                              promptSubmittedInPage: true,
+                                              inAppNavigation: true)
         let params = data.jsonParameters()
         #expect(params["feature.data.ext.page_engaged"] as? Bool == true)
         #expect(params["feature.data.ext.toggle_used"] as? Bool == true)
@@ -132,6 +136,8 @@ struct ReturnSessionWideEventDataTests {
         #expect(params["feature.data.ext.opening_screen_changed"] as? Bool == true)
         #expect(params["feature.data.ext.close_tab_tapped"] as? Bool == true)
         #expect(params["feature.data.ext.burn_tab_tapped"] as? Bool == true)
+        #expect(params["feature.data.ext.prompt_submitted_in_page"] as? Bool == true)
+        #expect(params["feature.data.ext.in_app_navigation"] as? Bool == true)
     }
 
     // MARK: - Durations
@@ -200,6 +206,8 @@ struct ReturnSessionWideEventDataTests {
         original.openingScreenChanged = true
         original.closeTabTapped = true
         original.burnTabTapped = true
+        original.promptSubmittedInPage = true
+        original.inAppNavigation = true
 
         let encoded = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(ReturnSessionWideEventData.self, from: encoded)
@@ -219,5 +227,7 @@ struct ReturnSessionWideEventDataTests {
         #expect(decoded.openingScreenChanged == true)
         #expect(decoded.closeTabTapped == true)
         #expect(decoded.burnTabTapped == true)
+        #expect(decoded.promptSubmittedInPage == true)
+        #expect(decoded.inAppNavigation == true)
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
@@ -113,6 +113,16 @@
                 "key": "feature.data.ext.burn_tab_tapped",
                 "type": "boolean",
                 "description": "Whether the user burned the open tab from the escape hatch's menu during the session."
+            },
+            {
+                "key": "feature.data.ext.prompt_submitted_in_page",
+                "type": "boolean",
+                "description": "Whether the duck.ai frontend reported a prompt submitted from its own input box during the session. Not a navigation, so no status_reason covers it."
+            },
+            {
+                "key": "feature.data.ext.in_app_navigation",
+                "type": "boolean",
+                "description": "Whether the user navigated by a route that sets no status_reason: a bookmark, a form submission, or browser history. Plain link taps are reported by page_engaged instead."
             }
         ]
     }

--- a/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
@@ -122,7 +122,7 @@
             {
                 "key": "feature.data.ext.in_app_navigation",
                 "type": "boolean",
-                "description": "Whether the user navigated by a route that sets no status_reason: a bookmark, a form submission, or browser history. Plain link taps are reported by page_engaged instead."
+                "description": "Whether the user went somewhere else in the app: a bookmark, a form submission, browser history, or a native screen such as settings, bookmarks, downloads or the site report. Plain link taps are reported by page_engaged instead."
             }
         ]
     }

--- a/iOS/PixelDefinitions/wide_events/definitions/return-session.json5
+++ b/iOS/PixelDefinitions/wide_events/definitions/return-session.json5
@@ -84,7 +84,7 @@
                     },
                     "in_app_navigation": {
                         "type": "boolean",
-                        "description": "True if the user navigated within the app by a route that sets no status_reason: selecting a bookmark, submitting a form, or moving through browser history. Excludes plain link taps, which are reported by page_engaged."
+                        "description": "True if the user went somewhere else in the app during the session: selected a bookmark, submitted a form, moved through browser history, or opened a native screen such as settings, bookmarks, downloads or the site report. Excludes plain link taps, which are reported by page_engaged."
                     }
                 }
             }

--- a/iOS/PixelDefinitions/wide_events/definitions/return-session.json5
+++ b/iOS/PixelDefinitions/wide_events/definitions/return-session.json5
@@ -4,7 +4,7 @@
         "owners": ["Bunn", "SabrinaTardio"],
         "meta": {
             "type": "ios-return-session",
-            "version": "0.0"
+            "version": "1.0"
         },
         "feature": {
             "name": "return-session",
@@ -77,6 +77,14 @@
                     "burn_tab_tapped": {
                         "type": "boolean",
                         "description": "True if the user burned the open tab from the escape hatch's menu during the session"
+                    },
+                    "prompt_submitted_in_page": {
+                        "type": "boolean",
+                        "description": "True if the duck.ai frontend reported a prompt submitted from its own input box during the session. Prompts sent this way are not navigations, so no status_reason covers them and the session still ends as app_backgrounded."
+                    },
+                    "in_app_navigation": {
+                        "type": "boolean",
+                        "description": "True if the user navigated within the app by a route that sets no status_reason: selecting a bookmark, submitting a form, or moving through browser history. Excludes plain link taps, which are reported by page_engaged."
                     }
                 }
             }

--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-return-session-1.1.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-return-session-1.1.0.json
@@ -1,0 +1,145 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Sent at the end of a return session: every return to the app, whether it got an after-idle treatment (the NTP or LUT shown once the After Inactivity threshold elapses) or was an ordinary return. Captures where the user landed, what they did there, and how the session ended. `ios-post-idle-session` stays scoped to after-idle returns and runs alongside this event.",
+    "$comment": "{\"owners\":[\"Bunn\",\"SabrinaTardio\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "ios-return-session" }, "version": { "const": "1.1.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application",
+                    "enum": ["DuckDuckGo", "DuckDuckGo-Alpha", "DuckDuckGo-Experimental", "PacketTunnelProvider"]
+                },
+                "version": { "type": "string", "description": "The version of the application", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+                "form_factor": { "type": "string", "description": "The form factor of the device", "enum": ["phone", "tablet"] }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["iOS"] },
+                "type": { "type": "string", "description": "The type of application", "enum": ["app"] },
+                "sample_rate": { "type": "number", "description": "Sample rate for this event", "minimum": 0, "maximum": 1 },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first occurrence of this event today. Only included when true."
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["return-session"] },
+                "status": {
+                    "type": "string",
+                    "description": "The overall status of the operation",
+                    "enum": ["SUCCESS", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "after_idle": {
+                                    "type": "boolean",
+                                    "description": "True when the session was started by an after-idle treatment; false for an ordinary return. Filtering after_idle=true gives the population `ios-post-idle-session` reports on."
+                                },
+                                "landed_on": {
+                                    "type": "string",
+                                    "description": "What the user actually landed on: the after-idle NTP, an NTP reached without the treatment, or the resumed tab's content type",
+                                    "enum": ["ntp", "ntp_user_initiated", "web", "serp", "duck_ai"]
+                                },
+                                "focused": {
+                                    "type": "boolean",
+                                    "description": "True when the landing surface appeared with the address bar focused (keyboard up)"
+                                },
+                                "time_away_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time the app spent in the background before this return, bucketed (lower end of bucket, in ms). Absent when there was no prior background date.",
+                                    "enum": ["0", "60000", "300000", "900000", "1800000", "3600000"]
+                                },
+                                "status_reason": {
+                                    "type": "string",
+                                    "description": "Terminal reason describing how the session ended. SUCCESS uses one of the user-action reasons; CANCELLED uses app_backgrounded; UNKNOWN uses app_terminated when an in-flight session is recovered after an app crash or termination. The three submission reasons are what `ios-post-idle-session` reports as a single bar_used.",
+                                    "enum": [
+                                        "search_submitted",
+                                        "ai_prompt_submitted",
+                                        "url_submitted",
+                                        "return_to_page_tapped",
+                                        "tab_switcher_selected",
+                                        "app_backgrounded",
+                                        "favorite_selected",
+                                        "chat_selected",
+                                        "app_terminated"
+                                    ]
+                                },
+                                "session_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Total time the landing surface was visible, from session start until the terminal action or background, bucketed (lower end of bucket, in ms). Absent when the session was orphaned (UNKNOWN / app_terminated).",
+                                    "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "time_to_first_interaction_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from session start to the first user interaction with the landing surface (page engagement, toggle, back, or terminal action), bucketed (lower end of bucket, in ms). Absent if the session ended without any interaction.",
+                                    "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "page_engaged": {
+                                    "type": "boolean",
+                                    "description": "True if the user scrolled or activated an in-page link on the landing surface during the session"
+                                },
+                                "toggle_used": {
+                                    "type": "boolean",
+                                    "description": "True if the user toggled between Search and Duck.ai during the session"
+                                },
+                                "back_pressed": {
+                                    "type": "boolean",
+                                    "description": "True if the user pressed back / cancel from the landing surface during the session"
+                                },
+                                "opening_screen_changed": {
+                                    "type": "boolean",
+                                    "description": "True if the user changed the Opening Screen option from the escape hatch's settings menu during the session"
+                                },
+                                "close_tab_tapped": {
+                                    "type": "boolean",
+                                    "description": "True if the user closed the open tab from the escape hatch's menu during the session"
+                                },
+                                "burn_tab_tapped": {
+                                    "type": "boolean",
+                                    "description": "True if the user burned the open tab from the escape hatch's menu during the session"
+                                },
+                                "prompt_submitted_in_page": {
+                                    "type": "boolean",
+                                    "description": "True if the duck.ai frontend reported a prompt submitted from its own input box during the session. Prompts sent this way are not navigations, so no status_reason covers them and the session still ends as app_backgrounded."
+                                },
+                                "in_app_navigation": {
+                                    "type": "boolean",
+                                    "description": "True if the user navigated within the app by a route that sets no status_reason: selecting a bookmark, submitting a form, or moving through browser history. Excludes plain link taps, which are reported by page_engaged."
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-return-session-1.1.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-return-session-1.1.0.json
@@ -133,7 +133,7 @@
                                 },
                                 "in_app_navigation": {
                                     "type": "boolean",
-                                    "description": "True if the user navigated within the app by a route that sets no status_reason: selecting a bookmark, submitting a form, or moving through browser history. Excludes plain link taps, which are reported by page_engaged."
+                                    "description": "True if the user went somewhere else in the app during the session: selected a bookmark, submitted a form, moved through browser history, or opened a native screen such as settings, bookmarks, downloads or the site report. Excludes plain link taps, which are reported by page_engaged."
                                 }
                             }
                         }

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
@@ -123,6 +123,8 @@ final class MockTabDelegate: TabDelegate {
 
     func tabDidEngageWithPage(_ tab: DuckDuckGo.TabViewController) {}
 
+    func tabDidNavigateInApp(_ tab: DuckDuckGo.TabViewController) {}
+
     func tabDidRequestFireButtonPulse(tab: DuckDuckGo.TabViewController) {
         didRequestFireButtonPulseCalled = true
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217869670337205?focus=true
Tech Design URL:
CC:

### Description
adds two fields to the `ios-return-session` wide event `prompt_submitted_in_page` and `in_app_navigation`

### Testing Steps
1. Background and reopen the app on a duck.ai tab (any standard launch starts a return session — the idle threshold only decides `after_idle`), submit a prompt from duck.ai's own input box, then background the app → the `ios-return-session` pixel carries `prompt_submitted_in_page=true` and `status_reason=app_backgrounded`.
2. Reopen the app, open Settings from the browsing menu, then background it → `in_app_navigation=true`. Repeat with Bookmarks and Downloads.
3. Reopen the app on a web page, submit a form or tap back, then background it → `in_app_navigation=true`. In all cases confirm `status_reason` matches today's behaviour, and that the `ios-post-idle-session` pixel is unchanged.

### Impact
Low

#### What could go wrong?
`in_app_navigation` could over-report if a programmatic load or a non-user-initiated screen were counted → mitigated by excluding `.other` navigation types, by leaving onboarding and debug-settings segues unhooked, and by unit tests covering each field's idempotency.
