### PR TITLE
iOS: Lower the collapsed bottom floating capsule

### DIFF
--- a/iOS/DuckDuckGo/FloatingUI/FloatingDomainCapsuleController.swift
+++ b/iOS/DuckDuckGo/FloatingUI/FloatingDomainCapsuleController.swift
@@ -26,12 +26,37 @@ final class FloatingDomainCapsuleController {
 
     static let handoffBandHalfWidth: CGFloat = 0.02
 
-    /// Gap between the pill and the edge of the safe area at its resting position.
+    /// Gap between the pill and the edge of the safe area at its resting position. Top address bar
+    /// uses this as-is; the collapsed bottom capsule sits `restBottomInsetReduction` closer to the
+    /// device bottom so the chrome morphs down into the pill rather than gaining space above it.
     static let restEdgePadding: CGFloat = 8
+
+    /// Extra downward shift of the collapsed bottom capsule, in points, relative to `restEdgePadding`
+    /// above the home indicator. Clamped so the pill cannot leave the screen on devices with no
+    /// home-indicator inset.
+    static let restBottomInsetReduction: CGFloat = 12
 
     /// Extra clearance kept between a page-fixed footer and the top of the resting capsule so the two
     /// don't visually touch.
     static let fixedElementClearance: CGFloat = 4
+
+    /// Distance from the physical bottom of the view to the bottom of the collapsed capsule.
+    static func restPaddingFromPhysicalBottom(safeAreaBottom: CGFloat) -> CGFloat {
+        max(0, safeAreaBottom + restEdgePadding - restBottomInsetReduction)
+    }
+
+    static func restCenterY(addressBarPosition: AddressBarPosition,
+                            boundsMaxY: CGFloat,
+                            safeAreaInsets: UIEdgeInsets,
+                            capsuleHeight: CGFloat) -> CGFloat {
+        let halfHeight = capsuleHeight / 2
+        switch addressBarPosition {
+        case .top:
+            return safeAreaInsets.top + restEdgePadding + halfHeight
+        case .bottom:
+            return boundsMaxY - restPaddingFromPhysicalBottom(safeAreaBottom: safeAreaInsets.bottom) - halfHeight
+        }
+    }
 
     /// The pill's resting height, hugging the domain label. Independent of the label text (driven by
     /// the font line height), so it is stable enough to size the web view's obscured bottom inset.
@@ -39,11 +64,16 @@ final class FloatingDomainCapsuleController {
         domainLabel.intrinsicContentSize.height + 12
     }
 
-    /// Height of the region obscured by the resting capsule, measured from the safe area edge (the
-    /// `restEdgePadding` gap plus the pill height). Used by the floating web view inset so a page-fixed
-    /// footer pins above the capsule once the bars have hidden.
-    var restObscuredHeightAboveSafeArea: CGFloat {
-        Self.restEdgePadding + capsuleHeight
+    /// Height obscured by the resting capsule, measured from the matching screen edge, so a
+    /// page-fixed footer pins above the pill once the bars have hidden.
+    func restObscuredHeightFromScreenEdge(for addressBarPosition: AddressBarPosition,
+                                          safeAreaInsets: UIEdgeInsets) -> CGFloat {
+        switch addressBarPosition {
+        case .top:
+            return safeAreaInsets.top + Self.restEdgePadding + capsuleHeight
+        case .bottom:
+            return Self.restPaddingFromPhysicalBottom(safeAreaBottom: safeAreaInsets.bottom) + capsuleHeight
+        }
     }
 
     private let onTap: () -> Void
@@ -199,9 +229,11 @@ final class FloatingDomainCapsuleController {
         let labelSize = domainLabel.intrinsicContentSize
         let capsuleHeight = self.capsuleHeight
         let capsuleWidth = min(labelSize.width + 24, max(0, view.bounds.width - 32))
-        let restCenterY = addressBarPosition == .top
-            ? view.safeAreaInsets.top + Self.restEdgePadding + capsuleHeight / 2
-            : view.bounds.maxY - view.safeAreaInsets.bottom - Self.restEdgePadding - capsuleHeight / 2
+        let restCenterY = Self.restCenterY(
+            addressBarPosition: addressBarPosition,
+            boundsMaxY: view.bounds.maxY,
+            safeAreaInsets: view.safeAreaInsets,
+            capsuleHeight: capsuleHeight)
 
         let morphP = (reduceMotion || expandedFrame.isEmpty) ? 0 : min(1, p / Self.handoffStart)
         let width = capsuleWidth + (expandedFrame.width - capsuleWidth) * morphP

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4764,8 +4764,9 @@ extension MainViewController: BrowserChromeDelegate {
               !domain.isEmpty else {
             return 0
         }
-        return view.safeAreaInsets.bottom
-            + floatingDomainCapsuleController.restObscuredHeightAboveSafeArea
+        return floatingDomainCapsuleController.restObscuredHeightFromScreenEdge(
+            for: .bottom,
+            safeAreaInsets: view.safeAreaInsets)
             + FloatingDomainCapsuleController.fixedElementClearance
     }
 
@@ -4776,8 +4777,9 @@ extension MainViewController: BrowserChromeDelegate {
               !domain.isEmpty else {
             return 0
         }
-        return view.safeAreaInsets.top
-            + floatingDomainCapsuleController.restObscuredHeightAboveSafeArea
+        return floatingDomainCapsuleController.restObscuredHeightFromScreenEdge(
+            for: .top,
+            safeAreaInsets: view.safeAreaInsets)
             + FloatingDomainCapsuleController.fixedElementClearance
     }
 

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -454,8 +454,10 @@ final class FloatingDomainCapsuleControllerTests: XCTestCase {
     }
 
     @discardableResult
-    private func update(barsVisibilityPercent: CGFloat, reduceMotion: Bool = false) -> UIButton? {
-        controller.update(addressBarPosition: .top,
+    private func update(barsVisibilityPercent: CGFloat,
+                        addressBarPosition: AddressBarPosition = .top,
+                        reduceMotion: Bool = false) -> UIButton? {
+        controller.update(addressBarPosition: addressBarPosition,
                           isFloatingUIEnabled: true,
                           isUnifiedToggleInputActive: false,
                           isAITab: false,
@@ -500,6 +502,70 @@ final class FloatingDomainCapsuleControllerTests: XCTestCase {
         let midWidth = update(barsVisibilityPercent: 0.5, reduceMotion: true)?.bounds.width ?? 0
 
         XCTAssertEqual(midWidth, capsuleWidth, accuracy: 0.5)
+    }
+
+    func testWhenBottomBarsHiddenThenPillRestsAtTheLowerCollapsedCenter() {
+        let button = update(barsVisibilityPercent: 0, addressBarPosition: .bottom)
+        let expectedCenterY = FloatingDomainCapsuleController.restCenterY(
+            addressBarPosition: .bottom,
+            boundsMaxY: containerView.bounds.maxY,
+            safeAreaInsets: containerView.safeAreaInsets,
+            capsuleHeight: controller.capsuleHeight)
+
+        XCTAssertEqual(button?.center.y ?? 0, expectedCenterY, accuracy: 0.5)
+    }
+
+    func testWhenBottomCapsuleRestsThenObscuredHeightTracksThePillNotExtraTopPadding() {
+        update(barsVisibilityPercent: 0, addressBarPosition: .bottom)
+        let insets = UIEdgeInsets(top: 59, left: 0, bottom: 34, right: 0)
+        let padding = FloatingDomainCapsuleController.restPaddingFromPhysicalBottom(safeAreaBottom: insets.bottom)
+        let obscured = controller.restObscuredHeightFromScreenEdge(for: .bottom, safeAreaInsets: insets)
+
+        XCTAssertEqual(obscured, padding + controller.capsuleHeight, accuracy: 0.001)
+        XCTAssertLessThan(obscured, insets.bottom + FloatingDomainCapsuleController.restEdgePadding + controller.capsuleHeight)
+    }
+}
+
+final class FloatingDomainCapsuleGeometryTests: XCTestCase {
+
+    func testWhenHomeIndicatorIsPresentThenBottomRestPaddingIsReducedByTwelvePoints() {
+        let safeAreaBottom: CGFloat = 34
+        let padding = FloatingDomainCapsuleController.restPaddingFromPhysicalBottom(safeAreaBottom: safeAreaBottom)
+
+        XCTAssertEqual(
+            padding,
+            safeAreaBottom + FloatingDomainCapsuleController.restEdgePadding - FloatingDomainCapsuleController.restBottomInsetReduction,
+            accuracy: 0.001)
+    }
+
+    func testWhenSafeAreaCannotAbsorbTheReductionThenBottomRestPaddingClampsToZero() {
+        XCTAssertEqual(FloatingDomainCapsuleController.restPaddingFromPhysicalBottom(safeAreaBottom: 0), 0, accuracy: 0.001)
+    }
+
+    func testWhenBottomAddressBarThenCollapsedRestCenterIsLowerByTheInsetReduction() {
+        let insets = UIEdgeInsets(top: 59, left: 0, bottom: 34, right: 0)
+        let capsuleHeight: CGFloat = 28
+        let boundsMaxY: CGFloat = 844
+        let previousRestCenterY = boundsMaxY - insets.bottom - FloatingDomainCapsuleController.restEdgePadding - capsuleHeight / 2
+        let restCenterY = FloatingDomainCapsuleController.restCenterY(
+            addressBarPosition: .bottom,
+            boundsMaxY: boundsMaxY,
+            safeAreaInsets: insets,
+            capsuleHeight: capsuleHeight)
+
+        XCTAssertEqual(restCenterY, previousRestCenterY + FloatingDomainCapsuleController.restBottomInsetReduction, accuracy: 0.001)
+    }
+
+    func testWhenTopAddressBarThenCollapsedRestCenterKeepsEdgePadding() {
+        let insets = UIEdgeInsets(top: 59, left: 0, bottom: 34, right: 0)
+        let capsuleHeight: CGFloat = 28
+        let restCenterY = FloatingDomainCapsuleController.restCenterY(
+            addressBarPosition: .top,
+            boundsMaxY: 844,
+            safeAreaInsets: insets,
+            capsuleHeight: capsuleHeight)
+
+        XCTAssertEqual(restCenterY, insets.top + FloatingDomainCapsuleController.restEdgePadding + capsuleHeight / 2, accuracy: 0.001)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217377416813355
Tech Design URL: N/A
CC: N/A

### Description
- Sit the collapsed bottom floating capsule 12pt lower on the device by reducing its bottom rest padding, rather than adding space above the pill
- Drive the chrome-collapse morph to that lower rest so the floating bar animates down into the capsule
- Keep the web-view footer inset tracked to the pill so page-fixed content does not gain an extra gap above it
- Leave the top address-bar capsule unchanged; clamp the reduction so the pill cannot leave the screen on devices with no home indicator

### Testing Steps
1. Enable floating UI and use the bottom address bar on a home-indicator iPhone
2. Load a site with a domain, then scroll to collapse the chrome into the capsule pill
3. Confirm the collapsed pill sits lower toward the home indicator, not with extra empty space above it
4. Confirm the collapse animation moves the bar down into that lower rest
5. Confirm a page with a `position: fixed` footer still clears the pill (no overlap, no new 12pt gap)
6. Switch to the top address bar, collapse chrome, and confirm the top capsule rest is unchanged
7. Repeat on a device/simulator without a home indicator and confirm the pill stays on-screen

### Impact
**Impact Level: Low**

#### What could go wrong?
The pill could sit too close to the home indicator or overlap a page-fixed footer → mitigated by clamping rest padding to the screen edge and keeping the web-view inset tracked to the pill (plus `fixedElementClearance`).

### Quality Considerations
- Bottom-only change; top address-bar rest padding is unchanged
- On devices with no home-indicator inset, the 12pt reduction clamps at the screen edge
- Unit tests cover the 12pt lower rest, the clamp, and that obscured height tracks the pill instead of adding top padding

### Notes to Reviewer
This is the base PR for a stacked floating-UI series. Later PRs should target this branch, not `main`.


Made with [Cursor](https://cursor.com)