### PR TITLE
iOS: Apply 12pt spacing to portrait bottom floating chrome

### DIFF
--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -90,6 +90,8 @@ final class BrowserToolbarView: UIView {
 
     static let extendedHitWidth: CGFloat = 45
     static let floatingButtonsHeight: CGFloat = 62
+    /// Button row height when the address field is hosted in the bottom floating chrome.
+    static let floatingEmbeddedButtonsHeight: CGFloat = 44
     static let buttonRowCollapseScaleAmount: CGFloat = 0.2
     static let buttonRowCollapseTranslationY: CGFloat = 8
 
@@ -120,8 +122,12 @@ final class BrowserToolbarView: UIView {
     private static let floatingBottomMarginWithEmbedded: CGFloat = 16
     private static let floatingBottomMarginStandalone: CGFloat = 21
 
-    private static let verticalContentPadding: CGFloat = 2
-    private static let omnibarToButtonsSpacing: CGFloat = 2
+    /// Inner padding of the combined bottom floating chrome (address field + buttons). The standalone
+    /// floating toolbar used in top-address-bar mode keeps the original 2pt padding.
+    private static let floatingEmbeddedVerticalContentPadding: CGFloat = 12
+    private static let floatingEmbeddedOmnibarToButtonsSpacing: CGFloat = 12
+    private static let defaultVerticalContentPadding: CGFloat = 2
+    private static let defaultOmnibarToButtonsSpacing: CGFloat = 2
     private static let expandedContentToOmnibarSpacing: CGFloat = 8
     private static let expandedButtonsBottomPadding: CGFloat = 10
     private static let expandedContentTopPadding: CGFloat = 8
@@ -155,6 +161,8 @@ final class BrowserToolbarView: UIView {
         stack.distribution = .equalCentering
         stack.isLayoutMarginsRelativeArrangement = true
         stack.layoutMargins = UIEdgeInsets(top: 0, left: BrowserToolbarView.horizontalEdgePadding, bottom: 0, right: BrowserToolbarView.horizontalEdgePadding)
+        stack.clipsToBounds = true
+        stack.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         stack.translatesAutoresizingMaskIntoConstraints = false
         return stack
     }()
@@ -164,7 +172,7 @@ final class BrowserToolbarView: UIView {
         stack.axis = .vertical
         stack.alignment = .fill
         stack.distribution = .fill
-        stack.spacing = omnibarToButtonsSpacing
+        stack.spacing = defaultOmnibarToButtonsSpacing
         stack.translatesAutoresizingMaskIntoConstraints = false
         return stack
     }()
@@ -181,11 +189,22 @@ final class BrowserToolbarView: UIView {
         return view
     }()
     
-    private lazy var omnibarHeightConstraint = omnibarContainer.heightAnchor.constraint(equalToConstant: 0)
+    private lazy var omnibarHeightConstraint: NSLayoutConstraint = {
+        let constraint = omnibarContainer.heightAnchor.constraint(equalToConstant: 0)
+        omnibarContainer.setContentCompressionResistancePriority(.required, for: .vertical)
+        omnibarContainer.setContentHuggingPriority(.required, for: .vertical)
+        return constraint
+    }()
     private lazy var buttonsHeightConstraint = materialBackgroundView.heightAnchor.constraint(equalToConstant: Self.legacyButtonsHeight)
+    private lazy var buttonRowHeightConstraint: NSLayoutConstraint = {
+        let constraint = buttonStack.heightAnchor.constraint(equalToConstant: 0)
+        constraint.isActive = false
+        return constraint
+    }()
     private lazy var expandedContentHeightConstraint = expandedContentContainer.heightAnchor.constraint(equalToConstant: 0)
     private lazy var materialBackgroundTopConstraint = materialBackgroundView.topAnchor.constraint(equalTo: topAnchor, constant: Self.barOuterInsets.top)
-    private lazy var contentStackBottomConstraint = contentStack.bottomAnchor.constraint(equalTo: materialBackgroundView.contentView.bottomAnchor, constant: -Self.verticalContentPadding)
+    private lazy var contentStackTopConstraint = contentStack.topAnchor.constraint(equalTo: materialBackgroundView.contentView.topAnchor, constant: Self.defaultVerticalContentPadding)
+    private lazy var contentStackBottomConstraint = contentStack.bottomAnchor.constraint(equalTo: materialBackgroundView.contentView.bottomAnchor, constant: -Self.defaultVerticalContentPadding)
     private var materialBackgroundLeadingConstraint: NSLayoutConstraint!
     private var materialBackgroundTrailingConstraint: NSLayoutConstraint!
     private var materialBackgroundBottomConstraint: NSLayoutConstraint!
@@ -202,6 +221,9 @@ final class BrowserToolbarView: UIView {
     /// safe-area inset in `layoutSubviews`; also widens the hit-test region.
     private var floatingBottomOffset: CGFloat = 0
     private var standaloneCollapseScale: CGFloat = 1
+    /// 0 = button row fully in layout, 1 = button row and field-to-buttons gap collapsed out of layout
+    /// so the address field keeps its height while the chrome shrinks around it.
+    private var buttonRowCollapseProgress: CGFloat = 0
     /// The tab switcher reuses this bar purely for button-position parity with the browser, but
     /// paints its own backdrop — so in the non-floating style its own background must stay clear.
     private var isLegacyBackgroundTransparent = false
@@ -217,22 +239,39 @@ final class BrowserToolbarView: UIView {
         expandedContentHeightConstraint.constant > 0
     }
 
-    /// Buttons-only bar height for the current style. Floating uses the taller `buttonsHeight`; the
-    /// non-floating style matches the original `UIToolbar` height so flag-off chrome is unchanged.
+    /// Buttons-only bar height for the current style. Floating standalone (top address bar) keeps the
+    /// original 62pt row; the non-floating style matches the original `UIToolbar` height.
     private var buttonsOnlyHeight: CGFloat {
         isFloatingStyleEnabled ? Self.floatingButtonsHeight : Self.legacyButtonsHeight
     }
 
+    private var usesEmbeddedBottomChromeMetrics: Bool {
+        isFloatingStyleEnabled && hasEmbeddedOmnibar
+    }
+
+    private var currentVerticalContentPadding: CGFloat {
+        usesEmbeddedBottomChromeMetrics ? Self.floatingEmbeddedVerticalContentPadding : Self.defaultVerticalContentPadding
+    }
+
+    private var currentOmnibarToButtonsSpacing: CGFloat {
+        usesEmbeddedBottomChromeMetrics ? Self.floatingEmbeddedOmnibarToButtonsSpacing : Self.defaultOmnibarToButtonsSpacing
+    }
+
     static func totalHeight(withOmnibarHeight omnibarHeight: CGFloat, isFloating: Bool) -> CGFloat {
-        let targetHeight = isFloating ? floatingButtonsHeight : legacyButtonsHeight
         guard omnibarHeight > 0 else {
-            return targetHeight
+            return isFloating ? floatingButtonsHeight : legacyButtonsHeight
         }
-        return (verticalContentPadding * 2) + targetHeight + omnibarHeight + omnibarToButtonsSpacing
+        if isFloating {
+            return (floatingEmbeddedVerticalContentPadding * 2)
+                + floatingEmbeddedButtonsHeight
+                + omnibarHeight
+                + floatingEmbeddedOmnibarToButtonsSpacing
+        }
+        return (defaultVerticalContentPadding * 2) + legacyButtonsHeight + omnibarHeight + defaultOmnibarToButtonsSpacing
     }
 
     static func singleRowHeight(withOmnibarHeight omnibarHeight: CGFloat) -> CGFloat {
-        (verticalContentPadding * 2) + omnibarHeight
+        (floatingEmbeddedVerticalContentPadding * 2) + omnibarHeight
     }
 
     override init(frame: CGRect) {
@@ -268,7 +307,7 @@ final class BrowserToolbarView: UIView {
             buttonsHeightConstraint,
             contentStack.leadingAnchor.constraint(equalTo: materialBackgroundView.contentView.leadingAnchor, constant: Self.horizontalEdgePadding),
             contentStack.trailingAnchor.constraint(equalTo: materialBackgroundView.contentView.trailingAnchor, constant: -Self.horizontalEdgePadding),
-            contentStack.topAnchor.constraint(equalTo: materialBackgroundView.contentView.topAnchor, constant: Self.verticalContentPadding),
+            contentStackTopConstraint,
             contentStackBottomConstraint,
             expandedContentHeightConstraint,
             omnibarHeightConstraint,
@@ -306,15 +345,32 @@ final class BrowserToolbarView: UIView {
             $0.removeFromSuperview()
         }
         for view in views {
+            view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
             buttonStack.addArrangedSubview(view)
         }
     }
     
+    private func applyContentStackMetrics() {
+        contentStackTopConstraint.constant = currentVerticalContentPadding
+        if !hasExpandedContent {
+            contentStackBottomConstraint.constant = -currentVerticalContentPadding
+        }
+        let collapse = usesEmbeddedBottomChromeMetrics ? buttonRowCollapseProgress.clamped(to: 0...1) : 0
+        contentStack.spacing = currentOmnibarToButtonsSpacing * (1 - collapse)
+        if usesEmbeddedBottomChromeMetrics {
+            buttonRowHeightConstraint.constant = Self.floatingEmbeddedButtonsHeight * (1 - collapse)
+            buttonRowHeightConstraint.isActive = true
+        } else {
+            buttonRowHeightConstraint.isActive = false
+        }
+    }
+
     func setOmnibarView(_ view: UIView?, height: CGFloat) {
         endOmnibarSwipe()
         hostedOmnibarView?.removeFromSuperview()
         hostedOmnibarView = nil
         isOmnibarMorphing = false
+        buttonRowCollapseProgress = 0
         
         guard let view else {
             applyOmnibarDetachmentPose()
@@ -323,6 +379,7 @@ final class BrowserToolbarView: UIView {
         
         omnibarHeightConstraint.constant = height
         buttonsHeightConstraint.constant = Self.totalHeight(withOmnibarHeight: height, isFloating: isFloatingStyleEnabled)
+        applyContentStackMetrics()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.isUserInteractionEnabled = true
         (view as? DefaultOmniBarView)?.safeAreaManagedByContainer = false
@@ -347,16 +404,20 @@ final class BrowserToolbarView: UIView {
     }
 
     func applyOmnibarDetachmentPose() {
+        buttonRowCollapseProgress = 0
         omnibarHeightConstraint.constant = 0
         buttonsHeightConstraint.constant = buttonsOnlyHeight
+        applyContentStackMetrics()
         updateCornerStyle()
     }
 
     func prepareForOmnibarAttachment(height: CGFloat) {
         guard isFloatingStyleEnabled, hostedOmnibarView == nil else { return }
         isOmnibarMorphing = true
+        buttonRowCollapseProgress = 0
         omnibarHeightConstraint.constant = height
         buttonsHeightConstraint.constant = Self.totalHeight(withOmnibarHeight: height, isFloating: true)
+        applyContentStackMetrics()
         updateCornerStyle()
     }
 
@@ -532,7 +593,7 @@ final class BrowserToolbarView: UIView {
             let collapseLayout = {
                 self.expandedContentHeightConstraint.constant = 0
                 self.contentStack.setCustomSpacing(0, after: self.expandedContentContainer)
-                self.contentStackBottomConstraint.constant = -Self.verticalContentPadding
+                self.contentStackBottomConstraint.constant = -self.currentVerticalContentPadding
                 self.materialBackgroundTopConstraint.constant = Self.barOuterInsets.top
                 self.layoutIfNeeded()
             }
@@ -564,7 +625,7 @@ final class BrowserToolbarView: UIView {
         expandedContentHeightConstraint.constant = expandedContainerHeight
         expandedContentContainer.isHidden = false
         contentStack.setCustomSpacing(Self.expandedContentToOmnibarSpacing, after: expandedContentContainer)
-        contentStackBottomConstraint.constant = -(Self.verticalContentPadding + Self.expandedButtonsBottomPadding)
+        contentStackBottomConstraint.constant = -(currentVerticalContentPadding + Self.expandedButtonsBottomPadding)
         materialBackgroundTopConstraint.constant = Self.barOuterInsets.top - expandedContainerHeight - Self.expandedContentToOmnibarSpacing
 
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -633,13 +694,17 @@ final class BrowserToolbarView: UIView {
         let fullHeight = Self.totalHeight(withOmnibarHeight: omnibarHeightConstraint.constant, isFloating: isFloatingStyleEnabled)
 
         guard isFloatingStyleEnabled, hasEmbeddedOmnibar, !hasExpandedContent, !reduceMotion else {
+            buttonRowCollapseProgress = 0
             buttonStack.alpha = 1
             buttonStack.transform = .identity
             buttonsHeightConstraint.constant = fullHeight
+            applyContentStackMetrics()
             return fullHeight
         }
 
         let progress = collapseProgress.clamped(to: 0...1)
+        buttonRowCollapseProgress = progress
+        applyContentStackMetrics()
         buttonStack.alpha = 1 - progress
         let scale = 1 - Self.buttonRowCollapseScaleAmount * progress
         buttonStack.transform = CGAffineTransform(scaleX: scale, y: scale)
@@ -717,8 +782,9 @@ final class BrowserToolbarView: UIView {
             self.materialBackgroundView.contentView.backgroundColor = self.isFloatingStyleEnabled ? .clear : legacyBackgroundColor
             let buttonRowPadding = self.isFloatingStyleEnabled ? Self.floatingButtonRowHorizontalPadding : Self.legacyButtonRowHorizontalPadding
             self.buttonStack.layoutMargins = UIEdgeInsets(top: 0, left: buttonRowPadding, bottom: 0, right: buttonRowPadding)
-            // Keep the buttons-only height in sync with the style (49 legacy / 56 floating). The
-            // embedded-omnibar height is floating-only and owned by `setOmnibarView`, so leave it.
+            self.applyContentStackMetrics()
+            // Keep the buttons-only height in sync with the style (49 legacy / 62 floating standalone).
+            // The embedded-omnibar height is floating-only and owned by `setOmnibarView`, so leave it.
             if !self.hasEmbeddedOmnibar {
                 self.buttonsHeightConstraint.constant = self.buttonsOnlyHeight
             }

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -63,7 +63,9 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
     var customizableButton: UIButton! { searchAreaView.customizableButton }
     var privacyIconView: UIView? { privacyInfoContainer.privacyIcon }
     var searchContainer: UIView! { searchAreaContainerView }
-    let expectedHeight: CGFloat = DefaultOmniBarView.expectedHeight
+    var expectedHeight: CGFloat {
+        isBottomFloatingField ? Metrics.floatingEmbeddedHeight : Metrics.height
+    }
     static let expectedHeight: CGFloat = Metrics.height
 
     private var readableSearchAreaWidthConstraint: NSLayoutConstraint?
@@ -248,6 +250,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         stackView.spacing = isExpandedPhone ? Metrics.expandedPhoneSizeSpacing : Metrics.expandedPadSizeSpacing
         stackViewLeadingConstraint?.constant = isExpandedPhone ? Metrics.expandedPhoneSizeMargins.leading : Metrics.textAreaHorizontalPadding
         stackViewTrailingConstraint?.constant = isExpandedPhone ? -Metrics.expandedPhoneSizeMargins.trailing : -Metrics.textAreaHorizontalPadding
+        updateVerticalSpacing()
     }
 
     var isUsingSmallTopSpacing: Bool = false {
@@ -1356,8 +1359,20 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
     }
 
     private func updateVerticalSpacing() {
-        textAreaTopPaddingConstraint?.constant = isUsingSmallTopSpacing ? Metrics.textAreaTopPaddingAdjustedSpacing : Metrics.textAreaVerticalPaddingRegularSpacing
-        textAreaBottomPaddingConstraint?.constant = -(isUsingSmallTopSpacing ? Metrics.textAreaBottomPaddingAdjustedSpacing : Metrics.textAreaVerticalPaddingRegularSpacing)
+        let topPadding: CGFloat
+        let bottomPadding: CGFloat
+        if isBottomFloatingField {
+            topPadding = Metrics.floatingEmbeddedTextAreaPadding
+            bottomPadding = Metrics.floatingEmbeddedTextAreaPadding
+        } else if isUsingSmallTopSpacing {
+            topPadding = Metrics.textAreaTopPaddingAdjustedSpacing
+            bottomPadding = Metrics.textAreaBottomPaddingAdjustedSpacing
+        } else {
+            topPadding = Metrics.textAreaVerticalPaddingRegularSpacing
+            bottomPadding = Metrics.textAreaVerticalPaddingRegularSpacing
+        }
+        textAreaTopPaddingConstraint?.constant = topPadding
+        textAreaBottomPaddingConstraint?.constant = -bottomPadding
         updateFireModeAppearance()
     }
 
@@ -1529,6 +1544,12 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
     private struct Metrics {
         static let itemSize: CGFloat = 44
         static let height: CGFloat = 60
+        /// Height of the address field when it is hosted inside the floating bottom toolbar, matching
+        /// the 48pt search pill in the chrome spec.
+        static let floatingEmbeddedHeight: CGFloat = 48
+        /// Tight inner padding so the 44pt controls sit inside the 48pt embedded field (12 + 2 = 14
+        /// from the glass edge to the control, per spec).
+        static let floatingEmbeddedTextAreaPadding: CGFloat = 2
         static var cornerRadius: CGFloat { OmniBarMetrics.cornerRadius }
 
         /// Sits 2pt outside `cornerRadius` so the active outline stays concentric with the field.
@@ -1629,10 +1650,10 @@ private extension DefaultOmniBarView {
     }
 
     /// The floating omnibar field when hosted at the bottom (embedded in the toolbar's glass
-    /// capsule). Unlike the top position it isn't a glass surface itself, so it takes an explicit
-    /// resting fill rather than `.backgroundTertiary`.
+    /// capsule) in compact portrait layout. Landscape / iPad use the standalone three-pill chrome
+    /// and must keep the original field metrics.
     var isBottomFloatingField: Bool {
-        isFloatingUIEnabled && isUsingSmallTopSpacing
+        isFloatingUIEnabled && isUsingSmallTopSpacing && layoutMode == .compact
     }
 
     /// Resting field fill: the bottom floating field is `T-Input/Resting` so it reads clearly

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -1637,11 +1637,10 @@ class MainViewController: UIViewController {
             swipeTabsCoordinator?.addressBarPositionChanged(isTop: false)
         }
 
+        omniBar.adjust(for: position)
         viewCoordinator.updateToolbarLayoutForAddressBarPosition(position)
         reconcileAIChromeForCurrentTab()
         swipeTabsCoordinator?.refresh(tabsModel: tabManager.currentTabsModel, scrollToSelected: true)
-
-        omniBar.adjust(for: position)
         adjustNewTabPageSafeAreaInsets(for: position)
         updateChromeForDuckPlayer()
         updateFloatingDomainCapsuleVisibility(for: lastChromeVisibilityPercent)
@@ -7800,6 +7799,7 @@ extension MainViewController {
         guard floatingUIManager.isFloatingUIEnabled else { return }
         viewCoordinator.setFloatingUIEnabled(floatingUIManager.isFloatingUIEnabled)
         FloatingUIChromeStyler().decorateMainViewIfNeeded(manager: floatingUIManager, coordinator: viewCoordinator)
+        viewCoordinator.omniBar.adjust(for: appSettings.currentAddressBarPosition)
         viewCoordinator.updateToolbarLayoutForAddressBarPosition(appSettings.currentAddressBarPosition)
         viewCoordinator.bringFloatingTopNavigationBarToFrontIfNeeded()
         (viewCoordinator.omniBar as? DefaultOmniBarViewController)?.reconcileShadowClip()

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -115,4 +115,46 @@ final class BrowserToolbarViewTests: XCTestCase {
 
         XCTAssertEqual(height, BrowserToolbarView.floatingButtonsHeight, accuracy: 0.01)
     }
+
+    func testWhenFloatingThenCombinedChromeHeightMatchesTheTwelvePointSpacingSpec() {
+        // 12 top + 48 field + 12 gap + 44 buttons + 12 bottom — bottom address bar only.
+        XCTAssertEqual(BrowserToolbarView.floatingEmbeddedButtonsHeight, 44)
+        XCTAssertEqual(
+            BrowserToolbarView.totalHeight(withOmnibarHeight: 48, isFloating: true),
+            128,
+            accuracy: 0.01)
+        XCTAssertEqual(
+            BrowserToolbarView.singleRowHeight(withOmnibarHeight: 48),
+            72,
+            accuracy: 0.01)
+    }
+
+    func testWhenFloatingWithoutEmbeddedOmnibarThenStandaloneButtonHeightIsUnchanged() {
+        XCTAssertEqual(BrowserToolbarView.floatingButtonsHeight, 62)
+        XCTAssertEqual(
+            BrowserToolbarView.totalHeight(withOmnibarHeight: 0, isFloating: true),
+            BrowserToolbarView.floatingButtonsHeight,
+            accuracy: 0.01)
+    }
+
+    func testWhenButtonRowCollapsesThenEmbeddedOmnibarKeepsItsHeight() {
+        let fieldHeight: CGFloat = 48
+        let omnibar = UIView()
+        let toolbar = BrowserToolbarView(frame: .zero)
+        toolbar.setFloatingStyleEnabled(true)
+        toolbar.setOmnibarView(omnibar, height: fieldHeight)
+
+        let collapsedHeight = toolbar.setButtonRowCollapseProgress(1, reduceMotion: false)
+        toolbar.frame = CGRect(x: 0, y: 0, width: 390, height: collapsedHeight)
+        toolbar.layoutIfNeeded()
+
+        XCTAssertEqual(omnibar.bounds.height, fieldHeight, accuracy: 0.5)
+    }
+
+    func testWhenNotFloatingThenCombinedChromeHeightKeepsLegacyPadding() {
+        XCTAssertEqual(
+            BrowserToolbarView.totalHeight(withOmnibarHeight: 60, isFloating: false),
+            115,
+            accuracy: 0.01)
+    }
 }

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -422,6 +422,36 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
 
         XCTAssertGreaterThan(barView.searchContainer.layer.cornerRadius, 0)
     }
+
+    func testWhenBottomFloatingFieldThenExpectedHeightIsTheFortyEightPointPill() {
+        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        barView.isUsingSmallTopSpacing = true
+
+        XCTAssertEqual(barView.expectedHeight, 48)
+    }
+
+    func testWhenTopFloatingFieldThenExpectedHeightStaysAtTheStandardBarHeight() {
+        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        barView.isUsingSmallTopSpacing = false
+
+        XCTAssertEqual(barView.expectedHeight, DefaultOmniBarView.expectedHeight)
+    }
+
+    func testWhenBottomFloatingLandscapeChromeThenExpectedHeightStaysAtTheStandardBarHeight() {
+        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        barView.isUsingSmallTopSpacing = true
+        barView.setLayoutMode(.expandedPhone, animated: false)
+
+        XCTAssertEqual(barView.expectedHeight, DefaultOmniBarView.expectedHeight)
+    }
+
+    func testWhenBottomFloatingPadChromeThenExpectedHeightStaysAtTheStandardBarHeight() {
+        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        barView.isUsingSmallTopSpacing = true
+        barView.setLayoutMode(.expandedPad, animated: false)
+
+        XCTAssertEqual(barView.expectedHeight, DefaultOmniBarView.expectedHeight)
+    }
 }
 
 final class FloatingDomainCapsuleControllerTests: XCTestCase {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216033800174503/task/1216033800174500
Tech Design URL: N/A
CC: N/A

### Description
- Apply the 12pt combined-chrome spec (12 + 48 + 12 + 44 + 12 = 128) to the **portrait bottom** floating address bar only
- Keep the address field at 48pt while collapsing, so it slides into the remaining space instead of squashing
- Leave top-position chrome and landscape / iPad three-pill chrome unchanged

Stacked on https://github.com/duckduckgo/apple-browsers/pull/6528

### Testing Steps
1. Enable floating UI and set the address bar to **Bottom**, in portrait
2. Confirm the expanded chrome matches 12pt glass padding, a 48pt field, 12pt gap, and a 44pt button row
3. Scroll to hide chrome → the field keeps its height and moves down rather than compressing
4. Switch the address bar to **Top** → standalone bottom buttons stay 62pt with original padding
5. Rotate to landscape → the three pills stay 60pt and the center field stays centered
6. Disable floating UI → legacy chrome is unchanged

### Impact
**Impact Level: Low**

#### What could go wrong?
- Landscape or top-position chrome could pick up the 48pt field metrics → gated on compact portrait bottom (embedded omnibar) only
- Collapse animation could still squash the field → button row and field-to-buttons gap are removed from layout as chrome shrinks

### Quality Considerations
- Unit tests cover combined height (128), standalone 62pt height, 48pt bottom field vs 60pt top/landscape/iPad, and collapse preserving field height

### Notes to Reviewer
Base this PR on `kkoch/lower-collapsed-capsule` (#6528), not `main`.


Made with [Cursor](https://cursor.com)