### PR TITLE
[iOS] Use a serial queue when setting up the speech recognizer

### DIFF
--- a/iOS/DuckDuckGo/SpeechRecognizer.swift
+++ b/iOS/DuckDuckGo/SpeechRecognizer.swift
@@ -30,12 +30,18 @@ enum SpeechRecognizerError: Error {
 }
 
 final class SpeechRecognizer: NSObject, SpeechRecognizerProtocol {
+    private static let speechRecognizerSerialOperationQueue: OperationQueue = {
+        let operationQueue = OperationQueue()
+        operationQueue.qualityOfService = .userInteractive
+        operationQueue.maxConcurrentOperationCount = 1
+        return operationQueue
+    }()
+
     weak var delegate: SpeechRecognizerDelegate?
     private var audioEngine: AVAudioEngine?
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
     private let speechRecognizer: SFSpeechRecognizer?
-    private let operationQueue: OperationQueue
     
     private(set) var isAvailable = false {
         didSet {
@@ -44,15 +50,13 @@ final class SpeechRecognizer: NSObject, SpeechRecognizerProtocol {
     }
     
     override init() {
-        operationQueue = OperationQueue()
-        operationQueue.qualityOfService = .userInteractive
 #if targetEnvironment(simulator)
         speechRecognizer = nil
 #else
         speechRecognizer = SFSpeechRecognizer()
 #endif
-        speechRecognizer?.queue = operationQueue
-        
+        speechRecognizer?.queue = SpeechRecognizer.speechRecognizerSerialOperationQueue
+
         super.init()
         
         speechRecognizer?.delegate = self
@@ -62,7 +66,7 @@ final class SpeechRecognizer: NSObject, SpeechRecognizerProtocol {
     private func updateAvailabilityFlag() {
         // https://app.asana.com/0/0/1201701558793614/1201934552312834
         
-        operationQueue.addOperation { [weak self] in
+        SpeechRecognizer.speechRecognizerSerialOperationQueue.addOperation { [weak self] in
             guard let self = self else { return }
             self.isAvailable = self.supportsOnDeviceRecognition && (self.speechRecognizer?.isAvailable ?? false)
         }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1217876862112466?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

This PR attempts to work around an occasional launch crash related to initialization of the speech recognizer. This happens because the operation queue used by the recognizer is concurrent - this PR converts it into a serial queue.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Smoke test app launch + voice search

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to voice-search speech recognition threading; no auth, data, or network changes. Shared serial queue could theoretically delay concurrent recognizer work but scope is narrow.
> 
> **Overview**
> Addresses an occasional **launch crash** tied to speech recognizer initialization by routing `SFSpeechRecognizer` work through a **shared serial** `OperationQueue` (`maxConcurrentOperationCount = 1`) instead of a per-instance queue that could run work concurrently.
> 
> The static queue keeps **user-interactive** QoS and is used both for `speechRecognizer?.queue` and for `updateAvailabilityFlag()` availability checks, so setup and availability updates are ordered rather than overlapping across instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1cf433e6e237b4861af674c3b12d991610aca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->