### PR TITLE
[iOS] Improve tab preview thread safety

### DIFF
--- a/iOS/DuckDuckGo/TabManager.swift
+++ b/iOS/DuckDuckGo/TabManager.swift
@@ -1052,8 +1052,10 @@ extension TabManager {
             Pixel.fire(pixel: .cachedTabPreviewsExceedsTabCount, withAdditionalParameters: [
                 PixelParameters.tabPreviewCountDelta: "\(storedPreviews - totalTabs)"
             ])
+            let validTabIDs = Set(allTabsModel.tabs.map { $0.uid })
+            let previewsSourceForCleanup = previewsSource
             Task(priority: .utility) {
-                _ = previewsSource.removePreviewsWithIdNotIn(Set(allTabsModel.tabs.map { $0.uid }))
+                _ = previewsSourceForCleanup.removePreviewsWithIdNotIn(validTabIDs)
             }
         }
     }

--- a/iOS/DuckDuckGo/TabPreviewsSource.swift
+++ b/iOS/DuckDuckGo/TabPreviewsSource.swift
@@ -44,7 +44,7 @@ class DefaultTabPreviewsSource: TabPreviewsSource {
         static let fullScreenCacheCountLimit = 8
     }
 
-    private var cache = [String: UIImage]()
+    private let cache = NSCache<NSString, UIImage>()
     private let fullScreenCache: NSCache<NSString, UIImage> = {
         let cache = NSCache<NSString, UIImage>()
         cache.countLimit = Constants.fullScreenCacheCountLimit
@@ -78,13 +78,13 @@ class DefaultTabPreviewsSource: TabPreviewsSource {
     }
     
     func update(preview: UIImage, forTab tab: Tab) {
-        cache[tab.uid] = preview
+        cache.setObject(preview, forKey: tab.uid as NSString)
         store(preview: preview, forTab: tab)
         tab.didUpdatePreview()
     }
     
     func preview(for tab: Tab) -> UIImage? {
-        if let preview = cache[tab.uid] {
+        if let preview = cache.object(forKey: tab.uid as NSString) {
             return preview
         }
         
@@ -92,14 +92,14 @@ class DefaultTabPreviewsSource: TabPreviewsSource {
             return nil
         }
         
-        cache[tab.uid] = preview
+        cache.setObject(preview, forKey: tab.uid as NSString)
         return preview
     }
     
     func removePreview(forTab tab: Tab) {
         guard let url = previewLocation(for: tab) else { return }
 
-        cache[tab.uid] = nil
+        cache.removeObject(forKey: tab.uid as NSString)
 
         do {
             if FileManager.default.fileExists(atPath: url.filePath) {
@@ -113,7 +113,7 @@ class DefaultTabPreviewsSource: TabPreviewsSource {
     }
     
     func removeAllPreviews() -> Result<Void, Error> {
-        cache.removeAll()
+        cache.removeAllObjects()
         fullScreenCache.removeAllObjects()
         guard let dirUrl = previewStoreDir else { return .success(()) }
 
@@ -144,7 +144,7 @@ class DefaultTabPreviewsSource: TabPreviewsSource {
     }
     
     fileprivate func cleanupCache() {
-        cache.removeAll()
+        cache.removeAllObjects()
     }
 
     func totalStoredPreviews() -> Int? {
@@ -241,7 +241,7 @@ class DefaultTabPreviewsSource: TabPreviewsSource {
             contents.filter { $0.hasSuffix(".png") }.forEach {
                 let id = $0.dropping(suffix: ".png")
                 if !ids.contains(id) {
-                    cache[id] = nil
+                    cache.removeObject(forKey: id as NSString)
                     let previewUrl = directory.appending($0)
                     do {
                         try FileManager.default.removeItem(at: previewUrl)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1217876862713885?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

This PR fixes a threading related crash with tab previews, caused by the main thread trying to access the cache dictionary at the same time that a background Task is doing the same.

The fix is to move away from a plain dictionary and instead use NSCache, which is thread safe.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Check that tab switching works as expected

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to tab switcher preview caching and orphan cleanup; no auth, privacy pipeline, or navigation changes beyond avoiding a concurrency crash.
> 
> **Overview**
> Fixes a crash when the main thread and a background cleanup task both touched the in-memory tab preview cache at the same time.
> 
> **Tab preview cache:** The thumbnail cache is no longer a `[String: UIImage]` dictionary. It now uses `NSCache<NSString, UIImage>`, with the same get/set/remove/clear patterns updated accordingly. That matches the existing full-screen preview cache and allows concurrent access without dictionary corruption.
> 
> **Background cleanup:** When stored preview count exceeds open tab count (on become active), valid tab IDs and the previews source are captured on the main actor before spawning a utility `Task`, so the async cleanup does not read `allTabsModel` from a background context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2935103d38f7f85cefd840c1248ba1c353065daf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->