### PR TITLE
[iOS] Bucket the Duck.ai session delta pixel param

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatPixelMetricHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatPixelMetricHandler.swift
@@ -30,6 +30,21 @@ protocol AIChatPixelMetricHandling {
     func firePixelWithMetric(_ metric: AIChatMetric)
 }
 
+/// Maps minutes since the Duck.ai session started into a coarse bucket label,
+/// using the same label dialect as m_app_return's time_away_bucket.
+enum AIChatSessionDeltaBucket {
+    static func bucket(forMinutes minutes: Int) -> String {
+        switch minutes {
+        case ..<5: return "lt_5m"
+        case ..<30: return "5_30m"
+        case ..<60: return "30_60m"
+        case ..<240: return "1_4h"
+        case ..<1440: return "4_24h"
+        default: return "gt_24h"
+        }
+    }
+}
+
 // MARK: - Implementation
 
 final class AIChatPixelMetricHandler: AIChatPixelMetricHandling {
@@ -39,7 +54,7 @@ final class AIChatPixelMetricHandler: AIChatPixelMetricHandling {
     private let timeElapsedInMinutes: Int?
     private let pixelFiring: PixelFiring.Type
     private let featureDiscovery: FeatureDiscovery
-    private let timestampParameterKey = "delta-timestamp-minutes"
+    private let timestampParameterKey = "delta-timestamp-bucket"
 
     /// The metrics the frontend reports when a prompt is submitted through its own composer.
     private static let promptSubmissionMetrics: Set<AIChatMetricName> = [.userDidSubmitPrompt, .userDidSubmitFirstPrompt]
@@ -141,7 +156,7 @@ final class AIChatPixelMetricHandler: AIChatPixelMetricHandling {
 
     private var timestampParameters: [String: String]? {
         guard let timeElapsed = timeElapsedInMinutes else { return nil }
-        return [timestampParameterKey: "\(timeElapsed)"]
+        return [timestampParameterKey: AIChatSessionDeltaBucket.bucket(forMinutes: timeElapsed)]
     }
 }
 

--- a/iOS/DuckDuckGo/AIChat/AIChatPixelMetricHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatPixelMetricHandler.swift
@@ -30,8 +30,6 @@ protocol AIChatPixelMetricHandling {
     func firePixelWithMetric(_ metric: AIChatMetric)
 }
 
-/// Maps minutes since the Duck.ai session started into a coarse bucket label,
-/// using the same label dialect as m_app_return's time_away_bucket.
 enum AIChatSessionDeltaBucket {
     static func bucket(forMinutes minutes: Int) -> String {
         switch minutes {
@@ -54,7 +52,7 @@ final class AIChatPixelMetricHandler: AIChatPixelMetricHandling {
     private let timeElapsedInMinutes: Int?
     private let pixelFiring: PixelFiring.Type
     private let featureDiscovery: FeatureDiscovery
-    private let timestampParameterKey = "delta-timestamp-bucket"
+    private let timestampParameterKey = "delta-timestamp-minutes"
 
     /// The metrics the frontend reports when a prompt is submitted through its own composer.
     private static let promptSubmissionMetrics: Set<AIChatMetricName> = [.userDidSubmitPrompt, .userDidSubmitFirstPrompt]

--- a/iOS/DuckDuckGoTests/AIChat/AIChatPixelMetricHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatPixelMetricHandlerTests.swift
@@ -87,7 +87,7 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
         // Then
         XCTAssertEqual(PixelFiringMock.allPixelsFired.count, 1)
         XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.aiChatOpen.name)
-        XCTAssertEqual(PixelFiringMock.lastParams?["delta-timestamp-minutes"], "10")
+        XCTAssertEqual(PixelFiringMock.lastParams?["delta-timestamp-bucket"], "5_30m")
     }
 
     func testFireOpenAIChatWithZeroTimeElapsed() {
@@ -100,7 +100,7 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
         // Then
         XCTAssertEqual(PixelFiringMock.allPixelsFired.count, 1)
         XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.aiChatOpen.name)
-        XCTAssertEqual(PixelFiringMock.lastParams?["delta-timestamp-minutes"], "0")
+        XCTAssertEqual(PixelFiringMock.lastParams?["delta-timestamp-bucket"], "lt_5m")
     }
 
     // MARK: - firePixelWithMetric Tests
@@ -135,7 +135,7 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
         // Then
         XCTAssertEqual(PixelFiringMock.allPixelsFired.count, 1)
         XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.aiChatMetricStartNewConversation.name)
-        XCTAssertEqual(PixelFiringMock.lastParams?["delta-timestamp-minutes"], "15")
+        XCTAssertEqual(PixelFiringMock.lastParams?["delta-timestamp-bucket"], "5_30m")
     }
 
     func testFirePixelWithMetricForAllKnownMetrics() {
@@ -318,7 +318,33 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
 
         // All pixels should have the same timestamp parameter
         for capturedPixel in PixelFiringMock.allPixelsFired {
-            XCTAssertEqual(capturedPixel.params?["delta-timestamp-minutes"], "20")
+            XCTAssertEqual(capturedPixel.params?["delta-timestamp-bucket"], "5_30m")
+        }
+    }
+
+    // MARK: - Session Delta Bucketing
+
+    func testWhenElapsedMinutesAreBucketedThenBoundaryValuesMapToExpectedLabels() {
+        let expectations: [(minutes: Int, label: String)] = [
+            (-1, "lt_5m"),
+            (0, "lt_5m"),
+            (4, "lt_5m"),
+            (5, "5_30m"),
+            (29, "5_30m"),
+            (30, "30_60m"),
+            (59, "30_60m"),
+            (60, "1_4h"),
+            (239, "1_4h"),
+            (240, "4_24h"),
+            (1439, "4_24h"),
+            (1440, "gt_24h"),
+            (Int.max, "gt_24h")
+        ]
+
+        for expectation in expectations {
+            XCTAssertEqual(AIChatSessionDeltaBucket.bucket(forMinutes: expectation.minutes),
+                           expectation.label,
+                           "\(expectation.minutes) minutes")
         }
     }
 }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatPixelMetricHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatPixelMetricHandlerTests.swift
@@ -87,7 +87,7 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
         // Then
         XCTAssertEqual(PixelFiringMock.allPixelsFired.count, 1)
         XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.aiChatOpen.name)
-        XCTAssertEqual(PixelFiringMock.lastParams?["delta-timestamp-bucket"], "5_30m")
+        XCTAssertEqual(PixelFiringMock.lastParams?["delta-timestamp-minutes"], "5_30m")
     }
 
     func testFireOpenAIChatWithZeroTimeElapsed() {
@@ -100,7 +100,7 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
         // Then
         XCTAssertEqual(PixelFiringMock.allPixelsFired.count, 1)
         XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.aiChatOpen.name)
-        XCTAssertEqual(PixelFiringMock.lastParams?["delta-timestamp-bucket"], "lt_5m")
+        XCTAssertEqual(PixelFiringMock.lastParams?["delta-timestamp-minutes"], "lt_5m")
     }
 
     // MARK: - firePixelWithMetric Tests
@@ -135,7 +135,7 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
         // Then
         XCTAssertEqual(PixelFiringMock.allPixelsFired.count, 1)
         XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.aiChatMetricStartNewConversation.name)
-        XCTAssertEqual(PixelFiringMock.lastParams?["delta-timestamp-bucket"], "5_30m")
+        XCTAssertEqual(PixelFiringMock.lastParams?["delta-timestamp-minutes"], "5_30m")
     }
 
     func testFirePixelWithMetricForAllKnownMetrics() {
@@ -318,7 +318,7 @@ final class AIChatPixelMetricHandlerTests: XCTestCase {
 
         // All pixels should have the same timestamp parameter
         for capturedPixel in PixelFiringMock.allPixelsFired {
-            XCTAssertEqual(capturedPixel.params?["delta-timestamp-bucket"], "5_30m")
+            XCTAssertEqual(capturedPixel.params?["delta-timestamp-minutes"], "5_30m")
         }
     }
 

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_frontend_metrics.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_frontend_metrics.json5
@@ -11,7 +11,7 @@
             "appVersion",
             "aichat_first_prompt_new_install",
             {
-                "key": "delta-timestamp-bucket",
+                "key": "delta-timestamp-minutes",
                 "type": "string",
                 "description": "Bucketed minutes since the Duck.ai session started: lt_5m, 5_30m, 30_60m, 1_4h, 4_24h, gt_24h. Absent when no session timer is available."
             }
@@ -26,7 +26,7 @@
             "appVersion",
             "aichat_first_prompt_new_install",
             {
-                "key": "delta-timestamp-bucket",
+                "key": "delta-timestamp-minutes",
                 "type": "string",
                 "description": "Bucketed minutes since the Duck.ai session started: lt_5m, 5_30m, 30_60m, 1_4h, 4_24h, gt_24h. Absent when no session timer is available."
             }

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_frontend_metrics.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_frontend_metrics.json5
@@ -11,9 +11,9 @@
             "appVersion",
             "aichat_first_prompt_new_install",
             {
-                "key": "delta-timestamp-minutes",
-                "type": "integer",
-                "description": "Minutes elapsed since the Duck.ai session started. Absent when no session timer is available."
+                "key": "delta-timestamp-bucket",
+                "type": "string",
+                "description": "Bucketed minutes since the Duck.ai session started: lt_5m, 5_30m, 30_60m, 1_4h, 4_24h, gt_24h. Absent when no session timer is available."
             }
         ]
     },
@@ -26,9 +26,9 @@
             "appVersion",
             "aichat_first_prompt_new_install",
             {
-                "key": "delta-timestamp-minutes",
-                "type": "integer",
-                "description": "Minutes elapsed since the Duck.ai session started. Absent when no session timer is available."
+                "key": "delta-timestamp-bucket",
+                "type": "string",
+                "description": "Bucketed minutes since the Duck.ai session started: lt_5m, 5_30m, 30_60m, 1_4h, 4_24h, gt_24h. Absent when no session timer is available."
             }
         ]
     }

--- a/iOS/PixelDefinitions/pixels/definitions/aichat_frontend_metrics.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/aichat_frontend_metrics.json5
@@ -12,8 +12,9 @@
             "aichat_first_prompt_new_install",
             {
                 "key": "delta-timestamp-minutes",
+                "description": "Bucketed minutes since the Duck.ai session started. Absent when no session timer is available.",
                 "type": "string",
-                "description": "Bucketed minutes since the Duck.ai session started: lt_5m, 5_30m, 30_60m, 1_4h, 4_24h, gt_24h. Absent when no session timer is available."
+                "enum": ["lt_5m", "5_30m", "30_60m", "1_4h", "4_24h", "gt_24h"]
             }
         ]
     },
@@ -27,8 +28,9 @@
             "aichat_first_prompt_new_install",
             {
                 "key": "delta-timestamp-minutes",
+                "description": "Bucketed minutes since the Duck.ai session started. Absent when no session timer is available.",
                 "type": "string",
-                "description": "Bucketed minutes since the Duck.ai session started: lt_5m, 5_30m, 30_60m, 1_4h, 4_24h, gt_24h. Absent when no session timer is available."
+                "enum": ["lt_5m", "5_30m", "30_60m", "1_4h", "4_24h", "gt_24h"]
             }
         ]
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217881001033273?focus=true
Tech Design URL:
CC:

### Description
The `delta-timestamp-minutes` pixel param now reports a bucketed label instead of an exact minute count, per the privacy review on #6502. Values are one of `lt_5m, 5_30m, 30_60m, 1_4h, 4_24h, gt_24h`, so open-ended outliers cap at `gt_24h` and the edges sit on the 60-minute keep-session timeout and the 24h boundary. The param name is unchanged; its JSON5 type moves from integer to string.

### Testing Steps
1. Run `AIChatPixelMetricHandlerTests` in the iOS Browser scheme — includes a boundary test covering both sides of every bucket edge.
2. Run `npm run validate-pixel-defs` from `iOS/` — validates the updated JSON5 definitions.

### Impact and Risks
Low — measurement-only change; on current builds this param is only attached when a Duck.ai keep-session timer snapshot exists, which is a legacy modal-flow path.

#### What could go wrong?
The same param key now carries two value formats across app versions, so queries parsing it as an integer will return null for new versions instead of failing loudly.

### Notes to Reviewer
Android sends this param on its six equivalent pixels at ~1.6M/day and still reports raw minutes, including an unset-timestamp case that yields ~29.8M (minutes since the Unix epoch); bucketing there is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Measurement-only change with no auth or data-path impact; downstream analytics that cast this param to integer will see null on newer iOS builds while the key name stays the same.
> 
> **Overview**
> Replaces raw minute counts in the **`delta-timestamp-minutes`** pixel param with privacy-oriented bucket labels (`lt_5m`, `5_30m`, `30_60m`, `1_4h`, `4_24h`, `gt_24h`) via new **`AIChatSessionDeltaBucket`** mapping in **`AIChatPixelMetricHandler`**.
> 
> Pixel definition JSON5 for the two frontend-reported metrics updates the param from **integer** to **string** with the same enum. Tests and a boundary table cover every bucket edge (including negative minutes mapping to `lt_5m`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f94167c2cfd5433cd188b79d294895b2126c67b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->