### PR TITLE
Fix main build

### DIFF
--- a/macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
+++ b/macOS/DuckDuckGo/Subscription/SubscriptionFunnelOrigin.swift
@@ -155,6 +155,8 @@ extension SubscriptionFunnelOrigin {
                 .duckAIReasoningDropdown,
                 .promptBarModelPicker,
                 .promptBarReasoningDropdown,
+                .addressBarUsageLimit,
+                .promptBarUsageLimit,
                 .duckAIAiSidebar,
                 .duckAIActivateSubscription,
                 .duckAIFreeLabel,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1217881465604597?focus=true

### Description

Fixes the `main` build, broken by a semantic merge conflict between two PRs that were each green on their own branch:

- #6512 added the `addressBarUsageLimit` and `promptBarUsageLimit` cases to `SubscriptionFunnelOrigin`.
- #6463 added an exhaustive `switch self` over that same enum in `purchaseWideEventEntryPoint`.

### Testing Steps

Make sure all checks pass

### Impact

Low — build fix only, no behaviour change beyond the two new origins now reporting `.duckAI` as their wide-event entry point (they previously couldn't compile at all).

#### What could go wrong?

Wrong entry-point grouping would mis-attribute the purchase wide event for those two upsells. `.duckAI` matches every other Duck.ai omnibar origin in the same switch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only exhaustiveness fix; entry-point mapping follows existing Duck.ai omnibar cases.
> 
> **Overview**
> Restores **macOS compile** after two merged PRs left `purchaseWideEventEntryPoint` non-exhaustive: new `addressBarUsageLimit` and `promptBarUsageLimit` enum cases were not handled in the `switch`.
> 
> Both origins are grouped with the other Duck.ai omnibar entry points and return **`.duckAI`** for subscription purchase wide events—matching address bar and Prompt Bar surfaces. No new user-facing behavior beyond correct analytics attribution for usage-limit upsells.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08040634f37de62be0d9d30d06d0f6ae864cb60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->