### PR TITLE
Fix: macOS Tab Ramp Clipping

### DIFF
--- a/macOS/DuckDuckGo/TabBar/View/TabBackgroundView.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBackgroundView.swift
@@ -35,7 +35,7 @@ final class TabBackgroundView: NSView {
         static let slideOffsetY: CGFloat = -8
     }
 
-    private enum Metrics {
+    enum Metrics {
         static let overlayCornerRadius: CGFloat = 8
         static let overlayInsets: NSEdgeInsets = NSEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
         static let tabCornerRadius: CGFloat = 12

--- a/macOS/DuckDuckGo/TabBar/View/TabBarCollectionView.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarCollectionView.swift
@@ -55,6 +55,9 @@ final class PinnedTabsCollectionView: TabBarCollectionView {
 
 open class TabBarCollectionView: NSCollectionView {
 
+    /// We account for extra room in `TabBarItemView`, as the leading + trailing Ramp(s) are rendered beyond its bounds
+    var horizontalScrollInset: CGFloat = 0
+
     open override var acceptsFirstResponder: Bool {
         return false
     }
@@ -99,18 +102,23 @@ open class TabBarCollectionView: NSCollectionView {
             assertionFailure("TabBarCollectionView: Index path out of bounds")
             return
         }
-        let rect = frameForItem(at: indexPath.item)
+        let rect = scrollTargetRect(for: indexPath)
         performAnimatedUpdate { [self] in
             animator().scrollToVisible(rect)
         } completionHandler: { [weak self] didFinish in
             guard let self, didFinish, isIndexPathValid(indexPath) else { return }
-            let newRect = frameForItem(at: indexPath.item)
+            let newRect = scrollTargetRect(for: indexPath)
             // make extra pass to make sure the cell is really visible after the animation finishes:
             // in overflown mode the cells are expanded when selected and may get partly hidden
             if rect != newRect, !visibleRect.contains(newRect) {
                 self.scroll(to: indexPath)
             }
         }
+    }
+
+    private func scrollTargetRect(for indexPath: IndexPath) -> CGRect {
+        frameForItem(at: indexPath.item)
+            .insetBy(dx: -horizontalScrollInset, dy: 0)
     }
 
     func scrollToEnd(completionHandler: ((Bool) -> Void)? = nil) {

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewController.swift
@@ -336,6 +336,7 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
         setupAsBurnerWindowIfNeeded(theme: theme)
         subscribeToPinnedTabsSettingChanged()
         setupScrollButtons()
+        setupScrollInsets()
         setupTabsContainersHeight()
         subscribeToThemeChanges()
 
@@ -1220,6 +1221,10 @@ final class TabBarViewController: NSViewController, TabBarRemoteMessagePresentin
 
         rightScrollButtonWidth.constant = theme.tabBarButtonSize
         rightScrollButtonHeight.constant = theme.tabBarButtonSize
+    }
+
+    private func setupScrollInsets() {
+        collectionView.horizontalScrollInset = theme.tabStyleProvider.shouldShowSShapedTab ? TabBarViewItem.horizontalInset : 0
     }
 
     private func setupTabsContainersHeight() {
@@ -2209,9 +2214,10 @@ extension TabBarViewController: NSCollectionViewDelegateFlowLayout {
             return NSEdgeInsetsZero
         }
         if theme.tabStyleProvider.shouldShowSShapedTab {
-            let isRightScrollButtonVisible = !isPinnedTabs && !rightScrollButton.isHidden
-            let isLeftScrollButonVisible = !isPinnedTabs && !leftScrollButton.isHidden
-            return NSEdgeInsets(top: 0, left: isLeftScrollButonVisible ? 10 : 12, bottom: 0, right: isRightScrollButtonVisible ? 10 : -12)
+            // With no right scroll button, the trailing ramp bleeds under the footer instead.
+            let inset = TabBarViewItem.horizontalInset
+            return NSEdgeInsets(top: 0, left: inset, bottom: 0, right: rightScrollButton.isHidden ? -inset : inset)
+
         } else if let flowLayout = collectionViewLayout as? NSCollectionViewFlowLayout {
             return flowLayout.sectionInset
         } else {

--- a/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
+++ b/macOS/DuckDuckGo/TabBar/View/TabBarViewItem.swift
@@ -568,6 +568,11 @@ final class TabBarViewItem: NSCollectionViewItem {
         static let maximum: CGFloat = 240
     }
 
+    /// The Background Leading + Trailing Ramp(s) are rendered outside bounds, by design. This constant will be required for accurate frame calculations when scrolling
+    static var horizontalInset: CGFloat {
+        TabBackgroundView.Metrics.tabRampSize.width
+    }
+
     private var widthStage: TabBarItemCellView.WidthStage {
         if isPinned {
             return .pinned


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1215619662601700
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

### Testing Steps
1. Launch the macOS browser
2. Click on `Debug > UI Triggers > Append Tabs > 50 Tabs`
3. Activate the first tab on the left
4. Press **CMD + Shift + [** to switch to the last tab

- [ ] Verify the Trailing Ramp doesn't clip
- [ ] Verify that if you press **CMD + Shift + ]** the first tab gets activated again, and its Leading Ramp doesn't clip


### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
We could introduce a regression in the Tabs Scrolling mechanism

### Quality Considerations
Nothing in particular

### Screenshots

Before: Leading | Now: Leading
-|-
<img width="400" src="https://github.com/user-attachments/assets/840ff249-f0aa-456e-afdf-1e3444c17509" /> | <img width="400" src="https://github.com/user-attachments/assets/2007f0aa-0d01-44cc-b79a-df9f7e7f14d6" />


Before: Trailing | Now: Trailing
-|-
<img width="400" src="https://github.com/user-attachments/assets/1a2a142d-e52f-4582-85bd-0d5c6c7bee93" /> | <img width="400" src="https://github.com/user-attachments/assets/e86b5895-338f-42e6-9eaf-d5dc457a7c24" />

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized tab bar layout and scroll-to-visible math for S-shaped tabs; main regression risk is tab scrolling or edge insets in overflow mode.
> 
> **Overview**
> Fixes **leading and trailing ramp clipping** on S-shaped macOS tab bar tabs when the scroll view auto-scrolls to the first or last tab (for example via **⌘⇧[** / **⌘⇧]** with many overflow tabs).
> 
> The ramps are drawn **outside** each tab item’s bounds (12pt from `tabRampSize`). Scrolling used the item’s layout frame only, so the clip view cut off those extensions.
> 
> **Changes:** `TabBarViewItem.horizontalInset` shares the ramp width; `TabBarCollectionView` expands the scroll-to-visible rect by that inset via `scrollTargetRect`. Section insets for S-shaped tabs use the same constant, with a **negative right inset** when the right scroll button is hidden so the trailing ramp can sit under the footer. `TabBackgroundView.Metrics` is exposed so the inset stays aligned with the background metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cbbd9f1d0ae244a682c47e716ef279be0099390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->