### PR TITLE
Fix PromoQueueUITests

### DIFF
--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+Test.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+Test.swift
@@ -43,6 +43,8 @@ extension PromoServiceFactory {
 /// Test promo delegate that shows an NSAlert with metadata, history, and result buttons.
 /// Used to exercise promo persistence across app restarts.
 final class TestPromoDelegate: InternalPromoDelegate {
+    private typealias Identifiers = AccessibilityIdentifiers.PromoQueue
+
     private let promo: Promo
     private var alert: NSAlert?
     private let isEligibleSubject = CurrentValueSubject<Bool, Never>(true)
@@ -96,14 +98,13 @@ final class TestPromoDelegate: InternalPromoDelegate {
         alert.informativeText = metadataBlock
         alert.alertStyle = .informational
 
-        _ = alert.addButton(withTitle: "Action")
-        _ = alert.addButton(withTitle: "Dismiss Permanently")
-        _ = alert.addButton(withTitle: "Dismiss (1 day cooldown)")
-        _ = alert.addButton(withTitle: "None")
-        _ = alert.addButton(withTitle: "Set Ineligible")
+        alert.addButton(withTitle: "Action").setAccessibilityIdentifier(Identifiers.actionButton)
+        alert.addButton(withTitle: "Dismiss Permanently").setAccessibilityIdentifier(Identifiers.dismissPermanentlyButton)
+        alert.addButton(withTitle: "Dismiss (1 day cooldown)").setAccessibilityIdentifier(Identifiers.dismissWithCooldownButton)
+        alert.addButton(withTitle: "None").setAccessibilityIdentifier(Identifiers.noneButton)
+        alert.addButton(withTitle: "Set Ineligible").setAccessibilityIdentifier(Identifiers.setIneligibleButton)
 
-        let alertId = AccessibilityIdentifiers.PromoQueue.testPromoAlert(promo.id)
-        alert.window.setAccessibilityIdentifier(alertId)
+        alert.window.setAccessibilityIdentifier(Identifiers.testPromoAlert(promo.id))
         self.alert = alert
 
         guard let window = NSApp.delegateTyped.windowControllersManager.mainWindowController?.window ?? NSApp.delegateTyped.windowControllersManager.openNewWindow() else { return .noChange }

--- a/macOS/UITests/PromoQueueUITests.swift
+++ b/macOS/UITests/PromoQueueUITests.swift
@@ -58,6 +58,7 @@ final class PromoQueueUITests: UITestCase {
 
     func testWhenCooldownActive_ThenPromosBlocked() throws {
         app.fireTestTrigger()
+        XCTAssertTrue(app.alertA.waitForExistence(timeout: UITests.Timeouts.elementExistence), "test-promo-a should appear")
         app.alertA.dismissWithCooldownButton.clickAfterExistenceTestSucceeds()
         XCTAssertTrue(app.alertA.waitForNonExistence(timeout: UITests.Timeouts.elementExistence))
 
@@ -75,6 +76,7 @@ final class PromoQueueUITests: UITestCase {
 
     func testWhenDateAdvanced_ThenCooldownsUnblocked() throws {
         app.fireTestTrigger()
+        XCTAssertTrue(app.alertA.waitForExistence(timeout: UITests.Timeouts.elementExistence), "test-promo-a should appear")
         app.alertA.dismissWithCooldownButton.clickAfterExistenceTestSucceeds()
         XCTAssertTrue(app.alertA.waitForNonExistence(timeout: UITests.Timeouts.elementExistence))
 
@@ -213,28 +215,30 @@ private extension XCUIApplication {
 }
 
 private extension XCUIElement {
+    private typealias Identifiers = Utilities.AccessibilityIdentifiers.PromoQueue
+
     var noneButton: XCUIElement {
-        buttons["None"]
+        buttons[Identifiers.noneButton]
     }
 
     var setIneligibleButton: XCUIElement {
-        buttons["Set Ineligible"]
+        buttons[Identifiers.setIneligibleButton]
     }
 
     var dismissWithCooldownButton: XCUIElement {
-        buttons["Dismiss (1 day cooldown)"]
+        buttons[Identifiers.dismissWithCooldownButton]
     }
 
     var dismissPermanentlyButton: XCUIElement {
-        buttons["Dismiss Permanently"]
+        buttons[Identifiers.dismissPermanentlyButton]
     }
 
     var actionButton: XCUIElement {
-        buttons["Action"]
+        buttons[Identifiers.actionButton]
     }
 
     var nextSteps: XCUIElement {
-        webViews.firstMatch.staticTexts["Next Steps"]
+        webViews.firstMatch.staticTexts.containing(\.value, containing: "NEXT STEPS").firstMatch
     }
 
     var tabBarRemoteMessageCloseButton: XCUIElement {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1217891862416541?focus=true
Tech Design URL:
CC:

### Description

PromoQueueUITests were failing due to a mismatch on a title (we were looking for "Next Steps" but it's now "NEXT STEPS"). This fix had previously been made for NextStepsListUITests but also needed making here. Made a few other cleanups as well.

### Testing Steps

1. Check a CI UI test run is happy with these tests – I kicked one off here: https://github.com/duckduckgo/apple-browsers/actions/runs/33075055970

### Impact

None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test promo UI and UI tests; no production promo queue behavior is modified.
> 
> **Overview**
> **PromoQueue UI tests** were failing because Next Steps detection still looked for `"Next Steps"` while the NTP label is now **"NEXT STEPS"**; the matcher is updated to a case-insensitive `containing` check, matching the earlier **NextStepsListUITests** fix.
> 
> **Test promo alerts** now assign `AccessibilityIdentifiers.PromoQueue` to each `NSAlert` button in `TestPromoDelegate`, and the UI test helpers query those identifiers instead of localized button titles—keeping test harness and XCTest in sync.
> 
> Cooldown-related scenarios also **wait for `test-promo-a`** before dismissing, reducing racey clicks when the sheet isn’t ready yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a326171d5c37e627029b3abc2168ced7cdb142. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->