### PR TITLE
[iOS] fix tab switcher button responsiveness

### DIFF
--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -81,6 +81,13 @@ enum WebViewPreviewSnapshotGeometry {
     }
 }
 
+enum WebViewPreviewSnapshotPolicy {
+
+    static func shouldCapture(isLoading: Bool) -> Bool {
+        !isLoading
+    }
+}
+
 enum WebViewScrollViewInsetUpdater {
 
     struct AdjustmentBehavior {
@@ -2489,6 +2496,11 @@ extension TabViewController: WKNavigationDelegate {
 
         DispatchQueue.main.async { [weak self] in
             guard let self, let webView else {
+                completion(nil)
+                return
+            }
+
+            guard WebViewPreviewSnapshotPolicy.shouldCapture(isLoading: webView.isLoading) else {
                 completion(nil)
                 return
             }

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -462,6 +462,17 @@ final class WebViewPreviewSnapshotGeometryTests: XCTestCase {
     }
 }
 
+final class WebViewPreviewSnapshotPolicyTests: XCTestCase {
+
+    func testWhenPageIsLoadingThenSnapshotIsSkipped() {
+        XCTAssertFalse(WebViewPreviewSnapshotPolicy.shouldCapture(isLoading: true))
+    }
+
+    func testWhenPageIsNotLoadingThenSnapshotIsCaptured() {
+        XCTAssertTrue(WebViewPreviewSnapshotPolicy.shouldCapture(isLoading: false))
+    }
+}
+
 final class WebViewScrollViewInsetUpdaterTests: XCTestCase {
 
     func testWhenManagingInsetsThenAutomaticAdjustmentIsDisabledAndCanBeRestored() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1217882155818601?focus=true
Tech Design URL:
CC:

### Description
Keeps the tab switcher responsive while the current page is loading. A cached thumbnail is used until loading finishes.

### Testing Steps
1. Open a webpage that takes several seconds to load.
2. While the loading indicator is visible, tap the tab switcher button → the tab switcher opens immediately.
3. Return to the loading tab and wait for the page to finish loading.
4. Tap the tab switcher button → the tab switcher opens and displays the updated thumbnail.

### Impact
Medium: Fixes a flow that could leave users stuck on a loading page.

#### What could go wrong?
A loading tab could temporarily show an older or empty thumbnail → mitigated by refreshing the thumbnail after loading finishes and by focused unit tests.

### Quality Considerations
The optional thumbnail capture is skipped only while a page is loading. There are no privacy, security, analytics, or network behavior changes.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to deferring optional thumbnail updates during load; tab switching and completion callbacks are unchanged.
> 
> **Overview**
> Improves **tab switcher responsiveness** by not running expensive web view snapshot work while the current tab is still loading.
> 
> A new `WebViewPreviewSnapshotPolicy` gates capture in `preparePreview`: when `webView.isLoading` is true, the method completes with **no image** instead of calling `takeSnapshot`. The tab-switcher path already treats previews as optional and always runs its completion, so the switcher can open immediately and keep showing the **cached thumbnail** until load finishes and a fresh capture can run.
> 
> Unit tests cover the policy (`loading` → skip, not loading → capture).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f67d581dc1c8ff65fb5e4d3b937148c66aa60987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->