### PR TITLE
iOS: Align top floating toolbar to spacing spec

### DIFF
--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -115,8 +115,7 @@ final class BrowserToolbarView: UIView {
     private static let floatingUICornerRadius: CGFloat = 40
 
     static let floatingEmbeddedHorizontalInset: CGFloat = 16
-    /// Outer side inset of the standalone top-address-bar toolbar. 24pt is the spec; 28pt was the
-    /// fallback if we needed to match another bar — the combined bottom chrome stays at 16pt.
+    /// Outer side inset of the standalone top-address-bar toolbar.
     static let floatingStandaloneHorizontalInset: CGFloat = 24
     private static let floatingEmbeddedBarOuterInsets = UIEdgeInsets(top: 0, left: floatingEmbeddedHorizontalInset, bottom: 0, right: floatingEmbeddedHorizontalInset)
     private static let floatingStandaloneBarOuterInsets = UIEdgeInsets(top: 0, left: floatingStandaloneHorizontalInset, bottom: 0, right: floatingStandaloneHorizontalInset)

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -105,22 +105,28 @@ final class BrowserToolbarView: UIView {
     /// buttons sit where the production `UIToolbar` placed them. Tuned to match production's
     /// end-button centres; the floating style keeps the tighter `horizontalEdgePadding`.
     private static let legacyButtonRowHorizontalPadding: CGFloat = 20
-    /// Inset for the floating button row so the outer buttons' centres line up with the embedded
-    /// omnibar's leading/trailing icons (loupe/shield ↔ back, AI chat ↔ menu). Separate from
-    /// `horizontalEdgePadding` so tuning it doesn't shift the omnibar field.
-    private static let floatingButtonRowHorizontalPadding: CGFloat = 16
-
+    /// Inset for the combined (bottom) floating button row so the outer buttons' centres line up
+    /// with the embedded omnibar's leading/trailing icons. Separate from `horizontalEdgePadding`
+    /// so tuning it doesn't shift the omnibar field.
+    static let floatingEmbeddedButtonRowHorizontalPadding: CGFloat = 16
+    /// Inner side inset of the standalone (top address bar) floating toolbar.
+    static let floatingStandaloneButtonRowHorizontalPadding: CGFloat = 16
     // This is only used in floating UI
     private static let floatingUICornerRadius: CGFloat = 40
 
-    private static let floatingBarOuterInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+    static let floatingEmbeddedHorizontalInset: CGFloat = 16
+    /// Outer side inset of the standalone top-address-bar toolbar. 24pt is the spec; 28pt was the
+    /// fallback if we needed to match another bar — the combined bottom chrome stays at 16pt.
+    static let floatingStandaloneHorizontalInset: CGFloat = 24
+    private static let floatingEmbeddedBarOuterInsets = UIEdgeInsets(top: 0, left: floatingEmbeddedHorizontalInset, bottom: 0, right: floatingEmbeddedHorizontalInset)
+    private static let floatingStandaloneBarOuterInsets = UIEdgeInsets(top: 0, left: floatingStandaloneHorizontalInset, bottom: 0, right: floatingStandaloneHorizontalInset)
     private static let legacyBarOuterInsets = UIEdgeInsets.zero
 
     /// In the floating style the toolbar is laid out against the safe-area bottom (so the chrome
     /// hide/show math stays valid), but the capsule should float this close to the physical device
     /// bottom. The glass is shifted down into the home-indicator region by the difference.
     private static let floatingBottomMarginWithEmbedded: CGFloat = 16
-    private static let floatingBottomMarginStandalone: CGFloat = 21
+    static let floatingStandaloneBottomMargin: CGFloat = 21
 
     /// Inner padding of the combined bottom floating chrome (address field + buttons). The standalone
     /// floating toolbar used in top-address-bar mode keeps the original 2pt padding.
@@ -154,10 +160,6 @@ final class BrowserToolbarView: UIView {
         let stack = UIStackView()
         stack.axis = .horizontal
         stack.alignment = .center
-        // Equal center-to-center spacing (not equal gaps) so a wider button — e.g. the tab-count
-        // control — doesn't shift the other columns. With equal-width end buttons this keeps the
-        // centre (fire) button at the bar's midpoint, matching the tab switcher's bottom bar so the
-        // buttons stay put across the tab-switcher transition.
         stack.distribution = .equalCentering
         stack.isLayoutMarginsRelativeArrangement = true
         stack.layoutMargins = UIEdgeInsets(top: 0, left: BrowserToolbarView.horizontalEdgePadding, bottom: 0, right: BrowserToolbarView.horizontalEdgePadding)
@@ -166,7 +168,7 @@ final class BrowserToolbarView: UIView {
         stack.translatesAutoresizingMaskIntoConstraints = false
         return stack
     }()
-    
+
     private let contentStack: UIStackView = {
         let stack = UIStackView()
         stack.axis = .vertical
@@ -202,12 +204,14 @@ final class BrowserToolbarView: UIView {
         return constraint
     }()
     private lazy var expandedContentHeightConstraint = expandedContentContainer.heightAnchor.constraint(equalToConstant: 0)
-    private lazy var materialBackgroundTopConstraint = materialBackgroundView.topAnchor.constraint(equalTo: topAnchor, constant: Self.barOuterInsets.top)
+    private lazy var materialBackgroundTopConstraint = materialBackgroundView.topAnchor.constraint(equalTo: topAnchor)
     private lazy var contentStackTopConstraint = contentStack.topAnchor.constraint(equalTo: materialBackgroundView.contentView.topAnchor, constant: Self.defaultVerticalContentPadding)
     private lazy var contentStackBottomConstraint = contentStack.bottomAnchor.constraint(equalTo: materialBackgroundView.contentView.bottomAnchor, constant: -Self.defaultVerticalContentPadding)
     private var materialBackgroundLeadingConstraint: NSLayoutConstraint!
     private var materialBackgroundTrailingConstraint: NSLayoutConstraint!
     private var materialBackgroundBottomConstraint: NSLayoutConstraint!
+    private var contentStackLeadingConstraint: NSLayoutConstraint!
+    private var contentStackTrailingConstraint: NSLayoutConstraint!
     private weak var hostedOmnibarView: UIView?
     private weak var swipeIncomingOmnibarView: UIView?
     private var swipeIncomingOmnibarConstraints: [NSLayoutConstraint] = []
@@ -227,9 +231,7 @@ final class BrowserToolbarView: UIView {
     /// The tab switcher reuses this bar purely for button-position parity with the browser, but
     /// paints its own backdrop — so in the non-floating style its own background must stay clear.
     private var isLegacyBackgroundTransparent = false
-    private static var barOuterInsets: UIEdgeInsets {
-        floatingBarOuterInsets
-    }
+    private var toolbarButtonViews: [UIView] = []
     
     private var hasEmbeddedOmnibar: Bool {
         omnibarHeightConstraint.constant > 0
@@ -237,6 +239,26 @@ final class BrowserToolbarView: UIView {
 
     private var hasExpandedContent: Bool {
         expandedContentHeightConstraint.constant > 0
+    }
+
+    private var usesStandaloneFloatingChrome: Bool {
+        isFloatingStyleEnabled && !hasEmbeddedOmnibar
+    }
+
+    private var currentBarOuterInsets: UIEdgeInsets {
+        guard isFloatingStyleEnabled else { return Self.legacyBarOuterInsets }
+        return usesEmbeddedBottomChromeMetrics ? Self.floatingEmbeddedBarOuterInsets : Self.floatingStandaloneBarOuterInsets
+    }
+
+    private var currentButtonRowHorizontalPadding: CGFloat {
+        guard isFloatingStyleEnabled else { return Self.legacyButtonRowHorizontalPadding }
+        return usesEmbeddedBottomChromeMetrics
+            ? Self.floatingEmbeddedButtonRowHorizontalPadding
+            : Self.floatingStandaloneButtonRowHorizontalPadding
+    }
+
+    private var currentContentStackHorizontalInset: CGFloat {
+        usesStandaloneFloatingChrome ? 0 : Self.horizontalEdgePadding
     }
 
     /// Buttons-only bar height for the current style. Floating standalone (top address bar) keeps the
@@ -298,6 +320,8 @@ final class BrowserToolbarView: UIView {
         materialBackgroundLeadingConstraint = materialBackgroundView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Self.legacyBarOuterInsets.left)
         materialBackgroundTrailingConstraint = materialBackgroundView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Self.legacyBarOuterInsets.right)
         materialBackgroundBottomConstraint = materialBackgroundView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Self.legacyBarOuterInsets.bottom)
+        contentStackLeadingConstraint = contentStack.leadingAnchor.constraint(equalTo: materialBackgroundView.contentView.leadingAnchor, constant: Self.horizontalEdgePadding)
+        contentStackTrailingConstraint = contentStack.trailingAnchor.constraint(equalTo: materialBackgroundView.contentView.trailingAnchor, constant: -Self.horizontalEdgePadding)
 
         NSLayoutConstraint.activate([
             materialBackgroundLeadingConstraint,
@@ -305,8 +329,8 @@ final class BrowserToolbarView: UIView {
             materialBackgroundTopConstraint,
             materialBackgroundBottomConstraint,
             buttonsHeightConstraint,
-            contentStack.leadingAnchor.constraint(equalTo: materialBackgroundView.contentView.leadingAnchor, constant: Self.horizontalEdgePadding),
-            contentStack.trailingAnchor.constraint(equalTo: materialBackgroundView.contentView.trailingAnchor, constant: -Self.horizontalEdgePadding),
+            contentStackLeadingConstraint,
+            contentStackTrailingConstraint,
             contentStackTopConstraint,
             contentStackBottomConstraint,
             expandedContentHeightConstraint,
@@ -322,7 +346,7 @@ final class BrowserToolbarView: UIView {
     }
 
     var arrangedToolbarButtonViews: [UIView] {
-        buttonStack.arrangedSubviews
+        toolbarButtonViews
     }
 
     func setFloatingStyleEnabled(_ enabled: Bool, animated: Bool = false) {
@@ -340,16 +364,22 @@ final class BrowserToolbarView: UIView {
     }
 
     func setToolbarButtons(_ views: [UIView]) {
+        toolbarButtonViews = views
+        rebuildButtonRow()
+    }
+
+    private func rebuildButtonRow() {
         buttonStack.arrangedSubviews.forEach {
             buttonStack.removeArrangedSubview($0)
             $0.removeFromSuperview()
         }
-        for view in views {
+        buttonStack.distribution = .equalCentering
+        toolbarButtonViews.forEach { view in
             view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
             buttonStack.addArrangedSubview(view)
         }
     }
-    
+
     private func applyContentStackMetrics() {
         contentStackTopConstraint.constant = currentVerticalContentPadding
         if !hasExpandedContent {
@@ -363,6 +393,21 @@ final class BrowserToolbarView: UIView {
         } else {
             buttonRowHeightConstraint.isActive = false
         }
+        applyHorizontalChromeMetrics()
+    }
+
+    private func applyHorizontalChromeMetrics() {
+        let insets = currentBarOuterInsets
+        materialBackgroundLeadingConstraint.constant = insets.left
+        materialBackgroundTrailingConstraint.constant = -insets.right
+        if !hasExpandedContent {
+            materialBackgroundTopConstraint.constant = insets.top
+        }
+        materialBackgroundBottomConstraint.constant = -insets.bottom
+        contentStackLeadingConstraint.constant = currentContentStackHorizontalInset
+        contentStackTrailingConstraint.constant = -currentContentStackHorizontalInset
+        let buttonRowPadding = currentButtonRowHorizontalPadding
+        buttonStack.layoutMargins = UIEdgeInsets(top: 0, left: buttonRowPadding, bottom: 0, right: buttonRowPadding)
     }
 
     func setOmnibarView(_ view: UIView?, height: CGFloat) {
@@ -380,6 +425,7 @@ final class BrowserToolbarView: UIView {
         omnibarHeightConstraint.constant = height
         buttonsHeightConstraint.constant = Self.totalHeight(withOmnibarHeight: height, isFloating: isFloatingStyleEnabled)
         applyContentStackMetrics()
+        rebuildButtonRow()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.isUserInteractionEnabled = true
         (view as? DefaultOmniBarView)?.safeAreaManagedByContainer = false
@@ -408,6 +454,7 @@ final class BrowserToolbarView: UIView {
         omnibarHeightConstraint.constant = 0
         buttonsHeightConstraint.constant = buttonsOnlyHeight
         applyContentStackMetrics()
+        rebuildButtonRow()
         updateCornerStyle()
     }
 
@@ -418,6 +465,7 @@ final class BrowserToolbarView: UIView {
         omnibarHeightConstraint.constant = height
         buttonsHeightConstraint.constant = Self.totalHeight(withOmnibarHeight: height, isFloating: true)
         applyContentStackMetrics()
+        rebuildButtonRow()
         updateCornerStyle()
     }
 
@@ -594,7 +642,7 @@ final class BrowserToolbarView: UIView {
                 self.expandedContentHeightConstraint.constant = 0
                 self.contentStack.setCustomSpacing(0, after: self.expandedContentContainer)
                 self.contentStackBottomConstraint.constant = -self.currentVerticalContentPadding
-                self.materialBackgroundTopConstraint.constant = Self.barOuterInsets.top
+                self.materialBackgroundTopConstraint.constant = self.currentBarOuterInsets.top
                 self.layoutIfNeeded()
             }
             if animated {
@@ -626,7 +674,7 @@ final class BrowserToolbarView: UIView {
         expandedContentContainer.isHidden = false
         contentStack.setCustomSpacing(Self.expandedContentToOmnibarSpacing, after: expandedContentContainer)
         contentStackBottomConstraint.constant = -(currentVerticalContentPadding + Self.expandedButtonsBottomPadding)
-        materialBackgroundTopConstraint.constant = Self.barOuterInsets.top - expandedContainerHeight - Self.expandedContentToOmnibarSpacing
+        materialBackgroundTopConstraint.constant = currentBarOuterInsets.top - expandedContainerHeight - Self.expandedContentToOmnibarSpacing
 
         view.translatesAutoresizingMaskIntoConstraints = false
         expandedContentContainer.addSubview(view)
@@ -665,7 +713,7 @@ final class BrowserToolbarView: UIView {
     }
 
     var floatingBottomMargin: CGFloat {
-        hasEmbeddedOmnibar ? Self.floatingBottomMarginWithEmbedded : Self.floatingBottomMarginStandalone
+        hasEmbeddedOmnibar ? Self.floatingBottomMarginWithEmbedded : Self.floatingStandaloneBottomMargin
     }
 
     var visibleCapsuleRect: CGRect {
@@ -679,7 +727,7 @@ final class BrowserToolbarView: UIView {
         guard isFloatingStyleEnabled else { return .zero }
         let bounds = view.bounds
         let safeBottom = view.safeAreaInsets.bottom
-        let insets = Self.floatingBarOuterInsets
+        let insets = currentBarOuterInsets
         let width = bounds.width - insets.left - insets.right
         let height = hasEmbeddedOmnibar
             ? Self.singleRowHeight(withOmnibarHeight: omnibarHeightConstraint.constant)
@@ -769,20 +817,14 @@ final class BrowserToolbarView: UIView {
     }
 
     private func applyCurrentStyle(animated: Bool) {
-        let insets = isFloatingStyleEnabled ? Self.floatingBarOuterInsets : Self.legacyBarOuterInsets
         let legacyBackgroundColor: UIColor = isLegacyBackgroundTransparent ? .clear : ThemeManager.shared.currentTheme.barBackgroundColor
         let updates = {
-            self.materialBackgroundLeadingConstraint.constant = insets.left
-            self.materialBackgroundTrailingConstraint.constant = -insets.right
-            self.materialBackgroundTopConstraint.constant = insets.top
-            self.materialBackgroundBottomConstraint.constant = -insets.bottom
             self.materialBackgroundView.layer.shadowOpacity = self.isFloatingStyleEnabled ? 0.12 : 0
             self.materialBackgroundView.effect = self.isFloatingStyleEnabled ? self.materialEffect() : nil
             self.materialBackgroundView.backgroundColor = self.isFloatingStyleEnabled ? .clear : legacyBackgroundColor
             self.materialBackgroundView.contentView.backgroundColor = self.isFloatingStyleEnabled ? .clear : legacyBackgroundColor
-            let buttonRowPadding = self.isFloatingStyleEnabled ? Self.floatingButtonRowHorizontalPadding : Self.legacyButtonRowHorizontalPadding
-            self.buttonStack.layoutMargins = UIEdgeInsets(top: 0, left: buttonRowPadding, bottom: 0, right: buttonRowPadding)
             self.applyContentStackMetrics()
+            self.rebuildButtonRow()
             // Keep the buttons-only height in sync with the style (49 legacy / 62 floating standalone).
             // The embedded-omnibar height is floating-only and owned by `setOmnibarView`, so leave it.
             if !self.hasEmbeddedOmnibar {
@@ -854,7 +896,7 @@ final class BrowserToolbarView: UIView {
             }
         }
 
-        for subview in buttonStack.arrangedSubviews {
+        for subview in toolbarButtonViews {
             let location = convert(point, to: subview)
             if let hit = subview.hitTest(location, with: event) {
                 return hit

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -137,6 +137,80 @@ final class BrowserToolbarViewTests: XCTestCase {
             accuracy: 0.01)
     }
 
+    func testWhenStandaloneFloatingThenOuterInsetIsTwentyFourPoints() {
+        let sut = makeSUT(embeddedOmnibar: false)
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        container.addSubview(sut)
+
+        let frame = sut.restingCapsuleFrame(in: container)
+
+        XCTAssertEqual(BrowserToolbarView.floatingStandaloneHorizontalInset, 24)
+        XCTAssertEqual(BrowserToolbarView.floatingStandaloneButtonRowHorizontalPadding, 16)
+        XCTAssertEqual(frame.minX, 24, accuracy: 0.01)
+        XCTAssertEqual(container.bounds.width - frame.maxX, 24, accuracy: 0.01)
+    }
+
+    func testWhenEmbeddedFloatingThenOuterInsetStaysSixteenPoints() {
+        let sut = makeSUT(embeddedOmnibar: true)
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        container.addSubview(sut)
+
+        let frame = sut.restingCapsuleFrame(in: container)
+
+        XCTAssertEqual(BrowserToolbarView.floatingEmbeddedHorizontalInset, 16)
+        XCTAssertEqual(frame.minX, 16, accuracy: 0.01)
+        XCTAssertEqual(container.bounds.width - frame.maxX, 16, accuracy: 0.01)
+    }
+
+    func testWhenStandaloneFloatingThenBottomMarginIsTwentyOnePoints() {
+        let sut = makeSUT(embeddedOmnibar: false)
+
+        XCTAssertEqual(BrowserToolbarView.floatingStandaloneBottomMargin, 21)
+        XCTAssertEqual(sut.floatingBottomMargin, 21, accuracy: 0.01)
+    }
+
+    func testWhenStandaloneFloatingThenButtonsAreEvenlySpacedAndFireButtonIsCentered() {
+        let sut = makeSUT(embeddedOmnibar: false)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        sut.translatesAutoresizingMaskIntoConstraints = false
+        window.addSubview(sut)
+        NSLayoutConstraint.activate([
+            sut.leadingAnchor.constraint(equalTo: window.leadingAnchor),
+            sut.trailingAnchor.constraint(equalTo: window.trailingAnchor),
+            sut.bottomAnchor.constraint(equalTo: window.bottomAnchor),
+            sut.heightAnchor.constraint(equalToConstant: 62)
+        ])
+        let fire = makeToolbarButton(identifier: "Browser.Toolbar.Button.Fire", width: 44)
+        sut.setToolbarButtons([
+            makeToolbarButton(identifier: "back", width: 44),
+            makeToolbarButton(identifier: "forward", width: 44),
+            fire,
+            makeToolbarButton(identifier: "tabs", width: 44),
+            makeToolbarButton(identifier: "menu", width: 44)
+        ])
+        window.layoutIfNeeded()
+
+        let centers = sut.arrangedToolbarButtonViews.map { view in
+            sut.convert(view.center, from: view.superview).x
+        }
+        let spacings = zip(centers.dropFirst(), centers).map { $0 - $1 }
+        let fireCenterInToolbar = sut.convert(fire.center, from: fire.superview)
+
+        XCTAssertEqual(fireCenterInToolbar.x, sut.bounds.midX, accuracy: 0.5)
+        spacings.dropFirst().forEach {
+            XCTAssertEqual($0, spacings[0], accuracy: 0.5)
+        }
+    }
+
+    private func makeToolbarButton(identifier: String, width: CGFloat) -> UIView {
+        let view = UIView()
+        view.accessibilityIdentifier = identifier
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.widthAnchor.constraint(equalToConstant: width).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        return view
+    }
+
     func testWhenButtonRowCollapsesThenEmbeddedOmnibarKeepsItsHeight() {
         let fieldHeight: CGFloat = 48
         let omnibar = UIView()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216033800174503/task/1216033800174496?focus=true
Tech Design URL: N/A
CC: N/A

### Description
- Align the standalone floating toolbar used with the top address bar to the specified 62pt height, 21pt bottom spacing, 24pt outer spacing, and 16pt internal side spacing
- Distribute all toolbar buttons evenly and keep the Fire button centered
- Preserve the existing bottom combined floating chrome layout

### Testing Steps
1. Enable floating UI on an iPhone and set the address bar to Top
2. Confirm the bottom toolbar is 62pt high and sits 21pt above the bottom edge
3. Confirm the toolbar has 24pt outer side spacing and 16pt internal side spacing
4. Confirm all five toolbar buttons are evenly spaced and the Fire button is centered
5. Set the address bar to Bottom and confirm the combined floating chrome layout is unchanged
6. Rotate to landscape and confirm the floating toolbar remains correctly laid out

### Impact
**Impact Level: Low**

#### What could go wrong?
- The standalone toolbar could inherit the combined bottom chrome insets → mode-specific metrics and unit coverage keep the layouts separate
- Toolbar actions could shift or become harder to tap → the button row retains equal center-to-center spacing and existing hit testing

### Quality Considerations
- Unit tests cover standalone and embedded outer insets, standalone bottom spacing, equal button spacing, and Fire-button centering
- No privacy, security, analytics, or performance impact

### Notes to Reviewer
This PR is stacked on https://github.com/duckduckgo/apple-browsers/pull/6529 and should be reviewed against `kkoch/floating-bottom-bar-spacing`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI layout-only changes in the floating toolbar with mode-specific metrics and unit tests; no auth, data, or networking impact.
> 
> **Overview**
> Aligns the **standalone** floating bottom toolbar (top address bar mode) to design spacing while keeping the **embedded** bottom combined chrome on its existing 16pt outer inset layout.
> 
> `BrowserToolbarView` now picks horizontal metrics by mode: standalone uses **24pt** capsule side inset, **16pt** button-row padding, **21pt** bottom margin, and **0** content-stack edge inset; embedded omnibar chrome keeps the prior embedded constants. Updates flow through `currentBarOuterInsets`, `applyHorizontalChromeMetrics()`, and `restingCapsuleFrame`.
> 
> Toolbar buttons are stored in `toolbarButtonViews` and **`rebuildButtonRow()`** reapplies equal center-to-center spacing when floating style or omnibar attachment changes, so the Fire button stays centered and spacing stays even. Hit testing follows the same button list.
> 
> Unit tests cover standalone vs embedded outer insets, standalone bottom margin, and Fire-button centering with equal button spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22356a48603afb8eecdc6cb0cc9bc41207d66906. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->