### PR TITLE
Make UTI edit-menu paste probe cheap

### DIFF
--- a/iOS/Core/PixelEvent.swift
+++ b/iOS/Core/PixelEvent.swift
@@ -1875,6 +1875,7 @@ extension Pixel {
         case unifiedToggleInputReasoningEffortPickerShown
         case unifiedToggleInputImageAttached
         case unifiedToggleInputImageRemoved
+        case unifiedToggleInputImageValidationFailed
         case unifiedToggleInputFileAttached
         case unifiedToggleInputFileRemoved
         case unifiedToggleInputFileValidationFailed
@@ -3783,6 +3784,7 @@ extension Pixel.Event {
         case .unifiedToggleInputReasoningEffortPickerShown: return "m_aichat_unified_input_reasoning_effort_picker_shown"
         case .unifiedToggleInputImageAttached: return "m_aichat_unified_input_image_attached"
         case .unifiedToggleInputImageRemoved: return "m_aichat_unified_input_image_removed"
+        case .unifiedToggleInputImageValidationFailed: return "m_aichat_unified_input_image_validation_failed"
         case .unifiedToggleInputFileAttached: return "m_aichat_unified_input_file_attached"
         case .unifiedToggleInputFileRemoved: return "m_aichat_unified_input_file_removed"
         case .unifiedToggleInputFileValidationFailed: return "m_aichat_unified_input_file_validation_failed"

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIAttachmentController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIAttachmentController.swift
@@ -542,7 +542,7 @@ extension UTIAttachmentController: UnifiedToggleInputPasteDelegate {
     }
 
     /// Reports a load-time-rejected paste as an error banner (no chip, no revalidation) using the reason the loader recorded, so the message and pixel reflect why it was actually rejected.
-    func reportRejectedPaste(reason: PasteRejectionReason) {
+    func reportRejectedPastedFiles(reason: PasteFileRejectionReason) {
         let files = environment.attachmentLimits()?.files
         let message: String
         let pixelReason: String

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIAttachmentController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIAttachmentController.swift
@@ -562,6 +562,18 @@ extension UTIAttachmentController: UnifiedToggleInputPasteDelegate {
         presentTransientValidationError(message)
     }
 
+    /// Recorded even when there is no capacity message to show, so a silently dropped paste is still visible in metrics.
+    func reportRejectedPastedImages(reason: PasteImageRejectionReason) {
+        let pixelReason: String
+        switch reason {
+        case .capacityReached:
+            pixelReason = "count_exceeded"
+        case .allowanceTruncated:
+            pixelReason = "paste_truncated"
+        }
+        pixelReporter.reportImageValidationFailed(reason: pixelReason, source: "paste")
+    }
+
     func presentPasteError(_ message: String) {
         presentTransientValidationError(message)
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
@@ -156,6 +156,16 @@ final class UTIPixelReporter {
         withContext { firing.fireDailyAndCount(.unifiedToggleInputFileAttached, ["surface": $0.surface.rawValue, "source": source]) }
     }
 
+    func reportImageValidationFailed(reason: String, source: String) {
+        withContext {
+            firing.fireDailyAndCount(.unifiedToggleInputImageValidationFailed, [
+                "reason": reason,
+                "surface": $0.surface.rawValue,
+                "source": source
+            ])
+        }
+    }
+
     func reportImageAttached(source: String) {
         withContext { firing.fireDailyAndCount(.unifiedToggleInputImageAttached, ["surface": $0.surface.rawValue, "source": source]) }
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1593,10 +1593,6 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         attachmentController.clearAttachments()
     }
 
-    func reportRejectedPastedImages(reason: PasteImageRejectionReason) {
-        attachmentController.reportRejectedPastedImages(reason: reason)
-    }
-
     func presentPasteError(_ message: String) {
         attachmentController.presentPasteError(message)
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1593,6 +1593,10 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         attachmentController.clearAttachments()
     }
 
+    func reportRejectedPastedImages(reason: PasteImageRejectionReason) {
+        attachmentController.reportRejectedPastedImages(reason: reason)
+    }
+
     func presentPasteError(_ message: String) {
         attachmentController.presentPasteError(message)
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputPasteHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputPasteHandler.swift
@@ -182,7 +182,9 @@ final class UnifiedToggleInputPasteHandler: AttachmentPasteHandling {
         }
 
         if didExceedImageLimit || result.imagesTruncated {
-            delegate.reportRejectedPastedImages(reason: didExceedImageLimit ? .capacityReached : .allowanceTruncated)
+            // Nothing attachable at all — a zero allowance truncates before the first decode, so no add is ever refused.
+            let capacityWasFull = didExceedImageLimit || result.images.isEmpty
+            delegate.reportRejectedPastedImages(reason: capacityWasFull ? .capacityReached : .allowanceTruncated)
             if let message = delegate.imageCapacityMessage() {
                 delegate.presentPasteError(message)
             }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputPasteHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputPasteHandler.swift
@@ -264,9 +264,10 @@ enum PasteboardAttachmentReader {
         return pasteboard.numberOfItems > 0
     }
 
-    /// Not `hasImages`: that only covers `UIPasteboardTypeListImage`, which excludes HEIC and WebP that the loader accepts.
+    /// Not `hasImages` (misses HEIC/WebP) and not `contains(pasteboardTypes:)` (inspects only the first item).
     private static func mayHoldLoadableImage(in pasteboard: UIPasteboard) -> Bool {
-        pasteboard.contains(pasteboardTypes: loadableImageTypeIdentifiers)
+        guard let matches = pasteboard.itemSet(withPasteboardTypes: loadableImageTypeIdentifiers) else { return false }
+        return !matches.isEmpty
     }
 
     /// Reads the pasteboard bytes (surfaces the banner) and builds attachments. Images stop decoding at the allowance and files are

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputPasteHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputPasteHandler.swift
@@ -49,7 +49,7 @@ enum AttachmentPasteRouting {
 }
 
 /// Why a pasted file couldn't be attached, carried from the loader so the error is reported for the actual reason (not recomputed against later state).
-enum PasteRejectionReason: Equatable {
+enum PasteFileRejectionReason: Equatable {
     case fileTooLarge
     case filesExceedTotalSize
     case fileCountLimit
@@ -110,7 +110,7 @@ protocol UnifiedToggleInputPasteDelegate: AnyObject {
     @discardableResult func addPastedImage(_ image: UIImage, fileName: String) -> Bool
     func addPastedFile(_ file: AIChatFileAttachment)
     /// Reports a file rejected during load (over size/count/total) with an error for the given reason; never adds an attachment.
-    func reportRejectedPaste(reason: PasteRejectionReason)
+    func reportRejectedPastedFiles(reason: PasteFileRejectionReason)
     /// Reports pasted images that couldn't be attached, for the limit that was actually hit.
     func reportRejectedPastedImages(reason: PasteImageRejectionReason)
     func presentPasteError(_ message: String)
@@ -170,7 +170,7 @@ final class UnifiedToggleInputPasteHandler: AttachmentPasteHandling {
         }
 
         if let rejection = result.rejection {
-            delegate.reportRejectedPaste(reason: rejection)
+            delegate.reportRejectedPastedFiles(reason: rejection)
         }
 
         var didExceedImageLimit = false
@@ -239,14 +239,14 @@ enum PasteboardAttachmentReader {
         var images: [(image: UIImage, fileName: String)] = []
         var files: [AIChatFileAttachment] = []
         /// The reason the first over-budget file was rejected; capped at one so an exhausted capacity can't flood the strip.
-        var rejection: PasteRejectionReason?
+        var rejection: PasteFileRejectionReason?
         /// More image providers were present than the allowance, so some were dropped without decoding.
         var imagesTruncated = false
     }
 
     private enum LoadedFile {
         case read(AIChatFileAttachment)
-        case rejected(PasteRejectionReason)
+        case rejected(PasteFileRejectionReason)
     }
 
     /// Metadata-only probe (no byte reads, so no paste banner) that mirrors `loadAttachments`' per-provider classification, so a "yes" here means the loader will actually find something.
@@ -343,7 +343,7 @@ enum PasteboardAttachmentReader {
         return result
     }
 
-    private static func recordRejection(_ reason: PasteRejectionReason, in result: inout Result) {
+    private static func recordRejection(_ reason: PasteFileRejectionReason, in result: inout Result) {
         if result.rejection == nil {
             result.rejection = reason
         }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputPasteHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputPasteHandler.swift
@@ -112,9 +112,15 @@ final class UnifiedToggleInputPasteHandler: AttachmentPasteHandling {
 
     weak var delegate: UnifiedToggleInputPasteDelegate?
 
+    private let attachmentProbe: PasteboardAttachmentProbe
+
+    init(attachmentProbe: PasteboardAttachmentProbe = PasteboardAttachmentProbe()) {
+        self.attachmentProbe = attachmentProbe
+    }
+
     func canPasteAttachments(from pasteboard: UIPasteboard) -> Bool {
         guard let support = delegate?.pasteAttachmentSupport, support.isEnabled, support.acceptsAnyAttachment else { return false }
-        return PasteboardAttachmentReader.hasSupportedAttachments(
+        return attachmentProbe.hasSupportedAttachments(
             in: pasteboard,
             allowsImages: support.acceptsImages,
             allowedFileTypes: support.fileTypes
@@ -125,6 +131,7 @@ final class UnifiedToggleInputPasteHandler: AttachmentPasteHandling {
         guard let delegate else { return }
         let support = delegate.pasteAttachmentSupport
         guard support.isEnabled, support.acceptsAnyAttachment else { return }
+        // Read on the main thread: `NSItemProvider` isn't `Sendable`, and this runs once per user-initiated paste rather than per menu build.
         let providers = pasteboard.itemProviders
         let context = delegate.pasteContextIdentity
         delegate.pasteWillBeginExpandingIfNeeded()
@@ -170,6 +177,45 @@ final class UnifiedToggleInputPasteHandler: AttachmentPasteHandling {
     }
 }
 
+/// Answers the edit-menu "can attachments be pasted?" question, memoised per pasteboard `changeCount`.
+/// Repeat menu builds never re-read `itemProviders` — a cross-process read that becomes a network fetch for a Universal Clipboard promise.
+@MainActor
+final class PasteboardAttachmentProbe {
+
+    /// The underlying metadata-only read; injectable so the memoisation can be exercised without a real clipboard.
+    typealias Read = @MainActor (_ pasteboard: UIPasteboard, _ allowsImages: Bool, _ allowedFileTypes: [UTType]) -> Bool
+
+    private struct Query: Equatable {
+        let changeCount: Int
+        let pasteboardName: UIPasteboard.Name
+        let allowsImages: Bool
+        let allowedFileTypes: [UTType]
+    }
+
+    private let read: Read
+    private var lastQuery: Query?
+    private var lastAnswer = false
+
+    nonisolated init(read: @escaping Read = PasteboardAttachmentReader.hasSupportedAttachments) {
+        self.read = read
+    }
+
+    func hasSupportedAttachments(in pasteboard: UIPasteboard, allowsImages: Bool, allowedFileTypes: [UTType]) -> Bool {
+        let query = Query(
+            changeCount: pasteboard.changeCount,
+            pasteboardName: pasteboard.name,
+            allowsImages: allowsImages,
+            allowedFileTypes: allowedFileTypes
+        )
+        guard query != lastQuery else { return lastAnswer }
+
+        let answer = read(pasteboard, allowsImages, allowedFileTypes)
+        lastQuery = query
+        lastAnswer = answer
+        return answer
+    }
+}
+
 /// Extracts image/file attachments from a `UIPasteboard`, mirroring the picker paths so pasted content flows through the same validation and UI as the attach menu.
 @MainActor
 enum PasteboardAttachmentReader {
@@ -194,6 +240,8 @@ enum PasteboardAttachmentReader {
         allowsImages: Bool,
         allowedFileTypes: [UTType]
     ) -> Bool {
+        guard mayContainSupportedAttachments(in: pasteboard, allowsImages: allowsImages, allowedFileTypes: allowedFileTypes) else { return false }
+
         let fileIdentifiers = allowedFileTypes.map(\.identifier)
         return pasteboard.itemProviders.contains { provider in
             if allowsImages, provider.canLoadObject(ofClass: UIImage.self) {
@@ -201,6 +249,17 @@ enum PasteboardAttachmentReader {
             }
             return fileIdentifiers.contains { provider.hasItemConformingToTypeIdentifier($0) }
         }
+    }
+
+    /// Type-metadata gate run before `itemProviders` materialises every provider.
+    /// Rejects only, for the type families the pasteboard declares.
+    private static func mayContainSupportedAttachments(
+        in pasteboard: UIPasteboard,
+        allowsImages: Bool,
+        allowedFileTypes: [UTType]
+    ) -> Bool {
+        guard !allowedFileTypes.isEmpty else { return allowsImages && pasteboard.hasImages }
+        return pasteboard.numberOfItems > 0
     }
 
     /// Reads the pasteboard bytes (surfaces the banner) and builds attachments. Images stop decoding at the allowance and files are

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputPasteHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputPasteHandler.swift
@@ -55,6 +55,14 @@ enum PasteRejectionReason: Equatable {
     case fileCountLimit
 }
 
+/// Why pasted images couldn't all be attached, so the rejection is reported with the limit that was actually hit.
+enum PasteImageRejectionReason: Equatable {
+    /// The conversation's image capacity was already full, so a pasted image was refused.
+    case capacityReached
+    /// The paste held more images than the allowance, so the extras were dropped without decoding.
+    case allowanceTruncated
+}
+
 /// What the current model accepts plus the remaining headroom, snapshotted once per paste so the loader can preflight sizes/counts.
 struct UnifiedToggleInputPasteSupport {
     let isEnabled: Bool
@@ -103,6 +111,8 @@ protocol UnifiedToggleInputPasteDelegate: AnyObject {
     func addPastedFile(_ file: AIChatFileAttachment)
     /// Reports a file rejected during load (over size/count/total) with an error for the given reason; never adds an attachment.
     func reportRejectedPaste(reason: PasteRejectionReason)
+    /// Reports pasted images that couldn't be attached, for the limit that was actually hit.
+    func reportRejectedPastedImages(reason: PasteImageRejectionReason)
     func presentPasteError(_ message: String)
 }
 
@@ -171,8 +181,11 @@ final class UnifiedToggleInputPasteHandler: AttachmentPasteHandling {
             }
         }
 
-        if didExceedImageLimit || result.imagesTruncated, let message = delegate.imageCapacityMessage() {
-            delegate.presentPasteError(message)
+        if didExceedImageLimit || result.imagesTruncated {
+            delegate.reportRejectedPastedImages(reason: didExceedImageLimit ? .capacityReached : .allowanceTruncated)
+            if let message = delegate.imageCapacityMessage() {
+                delegate.presentPasteError(message)
+            }
         }
     }
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputPasteHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputPasteHandler.swift
@@ -251,15 +251,22 @@ enum PasteboardAttachmentReader {
         }
     }
 
-    /// Type-metadata gate run before `itemProviders` materialises every provider.
-    /// Rejects only, for the type families the pasteboard declares.
+    /// The identifiers `canLoadObject(ofClass: UIImage.self)` accepts, so the gate can't reject an image the loader would take.
+    private static let loadableImageTypeIdentifiers = UIImage.readableTypeIdentifiersForItemProvider
+
+    /// Type-metadata gate run before `itemProviders` materialises every provider. Rejects only.
     private static func mayContainSupportedAttachments(
         in pasteboard: UIPasteboard,
         allowsImages: Bool,
         allowedFileTypes: [UTType]
     ) -> Bool {
-        guard !allowedFileTypes.isEmpty else { return allowsImages && pasteboard.hasImages }
+        guard !allowedFileTypes.isEmpty else { return allowsImages && mayHoldLoadableImage(in: pasteboard) }
         return pasteboard.numberOfItems > 0
+    }
+
+    /// Not `hasImages`: that only covers `UIPasteboardTypeListImage`, which excludes HEIC and WebP that the loader accepts.
+    private static func mayHoldLoadableImage(in pasteboard: UIPasteboard) -> Bool {
+        pasteboard.contains(pasteboardTypes: loadableImageTypeIdentifiers)
     }
 
     /// Reads the pasteboard bytes (surfaces the banner) and builds attachments. Images stop decoding at the allowance and files are

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/PasteboardAttachmentReaderTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/PasteboardAttachmentReaderTests.swift
@@ -77,6 +77,25 @@ final class PasteboardAttachmentReaderTests: XCTestCase {
         ))
     }
 
+    func testHasSupportedAttachmentsRejectsTextOnlyPasteboardWhenOnlyImagesAllowed() {
+        let pasteboard = UIPasteboard.withUniqueName()
+        defer { UIPasteboard.remove(withName: pasteboard.name) }
+        pasteboard.string = "duckduckgo.com"
+
+        XCTAssertFalse(PasteboardAttachmentReader.hasSupportedAttachments(
+            in: pasteboard, allowsImages: true, allowedFileTypes: []
+        ))
+    }
+
+    func testHasSupportedAttachmentsRejectsEmptyPasteboard() {
+        let pasteboard = UIPasteboard.withUniqueName()
+        defer { UIPasteboard.remove(withName: pasteboard.name) }
+
+        XCTAssertFalse(PasteboardAttachmentReader.hasSupportedAttachments(
+            in: pasteboard, allowsImages: true, allowedFileTypes: [.pdf]
+        ))
+    }
+
     // MARK: - loadAttachments
 
     func testLoadAttachmentsLoadsImage() async {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/PasteboardAttachmentReaderTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/PasteboardAttachmentReaderTests.swift
@@ -109,6 +109,22 @@ final class PasteboardAttachmentReaderTests: XCTestCase {
         }
     }
 
+    /// The image is not always item 0 — a mixed clipboard must still offer Paste.
+    func testHasSupportedAttachmentsFindsImageThatIsNotTheFirstItem() {
+        for identifier in ["public.png", "public.heic"] {
+            let pasteboard = UIPasteboard.withUniqueName()
+            defer { UIPasteboard.remove(withName: pasteboard.name) }
+            pasteboard.setItems([
+                ["public.plain-text": Data("hello".utf8)],
+                [identifier: Data([0x00, 0x01, 0x02, 0x03])]
+            ])
+
+            XCTAssertTrue(PasteboardAttachmentReader.hasSupportedAttachments(
+                in: pasteboard, allowsImages: true, allowedFileTypes: []
+            ), "\(identifier) at item 1 is loadable but the metadata gate rejected it")
+        }
+    }
+
     // MARK: - loadAttachments
 
     func testLoadAttachmentsLoadsImage() async {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/PasteboardAttachmentReaderTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/PasteboardAttachmentReaderTests.swift
@@ -96,6 +96,19 @@ final class PasteboardAttachmentReaderTests: XCTestCase {
         ))
     }
 
+    /// `hasImages` reports false for HEIC — the iOS default photo format — so gating on it hid Paste for copied photos.
+    func testHasSupportedAttachmentsFindsImageTypesHasImagesMisses() {
+        for identifier in ["public.heic", "org.webmproject.webp", "public.avif"] {
+            let pasteboard = UIPasteboard.withUniqueName()
+            defer { UIPasteboard.remove(withName: pasteboard.name) }
+            pasteboard.setItems([[identifier: Data([0x00, 0x01, 0x02, 0x03])]])
+
+            XCTAssertTrue(PasteboardAttachmentReader.hasSupportedAttachments(
+                in: pasteboard, allowsImages: true, allowedFileTypes: []
+            ), "\(identifier) is loadable as a UIImage but the metadata gate rejected it")
+        }
+    }
+
     // MARK: - loadAttachments
 
     func testLoadAttachmentsLoadsImage() async {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIAttachmentControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIAttachmentControllerTests.swift
@@ -140,7 +140,7 @@ final class UTIAttachmentControllerTests: XCTestCase {
         config.limits = makeLimits()
         let sut = makeController()
 
-        sut.reportRejectedPaste(reason: .fileTooLarge)
+        sut.reportRejectedPastedFiles(reason: .fileTooLarge)
 
         XCTAssertEqual(view.validationMessage, UserText.aiChatAttachmentFileTooLarge(maxFileSizeMB: 5))
         XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.pixelName, Pixel.Event.unifiedToggleInputFileValidationFailed.name)
@@ -154,7 +154,7 @@ final class UTIAttachmentControllerTests: XCTestCase {
         config.inputMode = .aiChat
         let sut = makeController()
 
-        sut.reportRejectedPaste(reason: .fileTooLarge)
+        sut.reportRejectedPastedFiles(reason: .fileTooLarge)
         XCTAssertNotNil(view.validationMessage)
 
         // A re-sync with no attachment-derived error must fall back to the transient banner, not clear it.

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPasteHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPasteHandlerTests.swift
@@ -78,7 +78,22 @@ final class UnifiedToggleInputPasteHandlerTests: XCTestCase {
         handler.applyLoadedAttachments(makeResult(images: 3))
 
         XCTAssertEqual(delegate.addedImages, 1)
+        XCTAssertEqual(delegate.imageRejectionReasons, [.capacityReached])
         XCTAssertEqual(delegate.presentedErrors, ["You can only attach 3 images at a time."])
+    }
+
+    /// The gap this closes: no banner to show, but the drop must still be visible in metrics.
+    func testApplyRecordsImageRejectionEvenWithoutACapacityMessage() {
+        let delegate = MockPasteDelegate()
+        delegate.imageHeadroom = 0
+        delegate.capacityMessage = nil
+        let handler = makeHandler(delegate)
+
+        handler.applyLoadedAttachments(makeResult(images: 2))
+
+        XCTAssertEqual(delegate.addedImages, 0)
+        XCTAssertEqual(delegate.imageRejectionReasons, [.capacityReached])
+        XCTAssertTrue(delegate.presentedErrors.isEmpty)
     }
 
     func testApplyWithinImageHeadroomShowsNoCapacityMessage() {
@@ -136,6 +151,7 @@ final class UnifiedToggleInputPasteHandlerTests: XCTestCase {
         handler.applyLoadedAttachments(result)
 
         XCTAssertEqual(delegate.addedImages, 1)
+        XCTAssertEqual(delegate.imageRejectionReasons, [.allowanceTruncated])
         XCTAssertEqual(delegate.presentedErrors, ["You can only attach 3 images at a time."])
     }
 
@@ -311,6 +327,7 @@ private final class MockPasteDelegate: UnifiedToggleInputPasteDelegate {
     private(set) var addedImages = 0
     private(set) var addedFiles = 0
     private(set) var rejectionReasons: [PasteRejectionReason] = []
+    private(set) var imageRejectionReasons: [PasteImageRejectionReason] = []
     private(set) var presentedErrors: [String] = []
 
     var pasteAttachmentSupport: UnifiedToggleInputPasteSupport { support }
@@ -335,6 +352,10 @@ private final class MockPasteDelegate: UnifiedToggleInputPasteDelegate {
     func reportRejectedPaste(reason: PasteRejectionReason) {
         rejectionReasons.append(reason)
         callLog.append("rejected")
+    }
+
+    func reportRejectedPastedImages(reason: PasteImageRejectionReason) {
+        imageRejectionReasons.append(reason)
     }
 
     func presentPasteError(_ message: String) {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPasteHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPasteHandlerTests.swift
@@ -351,7 +351,7 @@ private final class MockPasteDelegate: UnifiedToggleInputPasteDelegate {
     private(set) var callLog: [String] = []
     private(set) var addedImages = 0
     private(set) var addedFiles = 0
-    private(set) var rejectionReasons: [PasteRejectionReason] = []
+    private(set) var rejectionReasons: [PasteFileRejectionReason] = []
     private(set) var imageRejectionReasons: [PasteImageRejectionReason] = []
     private(set) var presentedErrors: [String] = []
 
@@ -374,7 +374,7 @@ private final class MockPasteDelegate: UnifiedToggleInputPasteDelegate {
         callLog.append("file")
     }
 
-    func reportRejectedPaste(reason: PasteRejectionReason) {
+    func reportRejectedPastedFiles(reason: PasteFileRejectionReason) {
         rejectionReasons.append(reason)
         callLog.append("rejected")
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPasteHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPasteHandlerTests.swift
@@ -152,6 +152,79 @@ final class UnifiedToggleInputPasteHandlerTests: XCTestCase {
         XCTAssertTrue(delegate.presentedErrors.isEmpty)
     }
 
+    // MARK: - Probe memoisation
+
+    func testProbeReadsPasteboardOnceWhileClipboardUnchanged() {
+        let pasteboard = seededPasteboard(image: true)
+        defer { UIPasteboard.remove(withName: pasteboard.name) }
+        let spy = ProbeSpy(answer: true)
+        let probe = PasteboardAttachmentProbe(read: spy.read)
+
+        let answers = (0..<5).map { _ in probe.hasSupportedAttachments(in: pasteboard, allowsImages: true, allowedFileTypes: [.pdf]) }
+
+        XCTAssertEqual(answers, Array(repeating: true, count: 5))
+        XCTAssertEqual(spy.readCount, 1)
+    }
+
+    func testProbeRereadsAfterClipboardChanges() {
+        let pasteboard = seededPasteboard(image: true)
+        defer { UIPasteboard.remove(withName: pasteboard.name) }
+        let spy = ProbeSpy(answer: true)
+        let probe = PasteboardAttachmentProbe(read: spy.read)
+
+        _ = probe.hasSupportedAttachments(in: pasteboard, allowsImages: true, allowedFileTypes: [.pdf])
+        pasteboard.string = "duckduckgo.com"
+        spy.answer = false
+
+        XCTAssertFalse(probe.hasSupportedAttachments(in: pasteboard, allowsImages: true, allowedFileTypes: [.pdf]))
+        XCTAssertEqual(spy.readCount, 2)
+    }
+
+    /// A model change alters what the input accepts, so the cached answer must not survive it even on an unchanged clipboard.
+    func testProbeRereadsWhenAcceptedAttachmentTypesChange() {
+        let pasteboard = seededPasteboard(image: true)
+        defer { UIPasteboard.remove(withName: pasteboard.name) }
+        let spy = ProbeSpy(answer: true)
+        let probe = PasteboardAttachmentProbe(read: spy.read)
+
+        _ = probe.hasSupportedAttachments(in: pasteboard, allowsImages: true, allowedFileTypes: [.pdf])
+        _ = probe.hasSupportedAttachments(in: pasteboard, allowsImages: true, allowedFileTypes: [.plainText])
+        XCTAssertEqual(spy.readCount, 2)
+
+        _ = probe.hasSupportedAttachments(in: pasteboard, allowsImages: false, allowedFileTypes: [.plainText])
+        XCTAssertEqual(spy.readCount, 3)
+    }
+
+    func testProbeRereadsForADifferentPasteboard() {
+        let first = seededPasteboard(image: true)
+        let second = seededPasteboard(image: true)
+        defer {
+            UIPasteboard.remove(withName: first.name)
+            UIPasteboard.remove(withName: second.name)
+        }
+        let spy = ProbeSpy(answer: true)
+        let probe = PasteboardAttachmentProbe(read: spy.read)
+
+        _ = probe.hasSupportedAttachments(in: first, allowsImages: true, allowedFileTypes: [.pdf])
+        _ = probe.hasSupportedAttachments(in: second, allowsImages: true, allowedFileTypes: [.pdf])
+
+        XCTAssertEqual(spy.readCount, 2)
+    }
+
+    func testCanPasteReadsPasteboardOnceForRepeatedMenuBuilds() {
+        let delegate = MockPasteDelegate()
+        let spy = ProbeSpy(answer: true)
+        let handler = makeHandler(delegate, probe: PasteboardAttachmentProbe(read: spy.read))
+        let pasteboard = seededPasteboard(image: true)
+        defer { UIPasteboard.remove(withName: pasteboard.name) }
+
+        for _ in 0..<5 {
+            XCTAssertTrue(handler.canPasteAttachments(from: pasteboard))
+        }
+
+        XCTAssertEqual(spy.readCount, 1)
+    }
+
     // MARK: - Text control paste override
 
     func testTextViewAdvertisesPasteWhenHandlerAccepts() {
@@ -187,8 +260,8 @@ final class UnifiedToggleInputPasteHandlerTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeHandler(_ delegate: MockPasteDelegate) -> UnifiedToggleInputPasteHandler {
-        let handler = UnifiedToggleInputPasteHandler()
+    private func makeHandler(_ delegate: MockPasteDelegate, probe: PasteboardAttachmentProbe = PasteboardAttachmentProbe()) -> UnifiedToggleInputPasteHandler {
+        let handler = UnifiedToggleInputPasteHandler(attachmentProbe: probe)
         handler.delegate = delegate
         return handler
     }
@@ -276,4 +349,19 @@ private final class MockAttachmentPasteHandler: AttachmentPasteHandling {
 
     func canPasteAttachments(from pasteboard: UIPasteboard) -> Bool { canPasteResult }
     func pasteAttachments(from pasteboard: UIPasteboard) { pasteCallCount += 1 }
+}
+
+@MainActor
+private final class ProbeSpy {
+    var answer: Bool
+    private(set) var readCount = 0
+
+    init(answer: Bool) {
+        self.answer = answer
+    }
+
+    func read(_ pasteboard: UIPasteboard, _ allowsImages: Bool, _ allowedFileTypes: [UTType]) -> Bool {
+        readCount += 1
+        return answer
+    }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPasteHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPasteHandlerTests.swift
@@ -96,6 +96,31 @@ final class UnifiedToggleInputPasteHandlerTests: XCTestCase {
         XCTAssertTrue(delegate.presentedErrors.isEmpty)
     }
 
+    /// A full conversation truncates at a zero allowance before any decode, so no add is refused — it must still read as capacity, not truncation.
+    func testApplyReportsCapacityWhenNoImageCouldBeLoadedAtAll() {
+        let delegate = MockPasteDelegate()
+        let handler = makeHandler(delegate)
+        var result = makeResult()
+        result.imagesTruncated = true
+
+        handler.applyLoadedAttachments(result)
+
+        XCTAssertEqual(delegate.imageRejectionReasons, [.capacityReached])
+    }
+
+    /// Some images fit and the rest were dropped — that is genuine truncation.
+    func testApplyReportsTruncationWhenSomeImagesWereLoaded() {
+        let delegate = MockPasteDelegate()
+        let handler = makeHandler(delegate)
+        var result = makeResult(images: 2)
+        result.imagesTruncated = true
+
+        handler.applyLoadedAttachments(result)
+
+        XCTAssertEqual(delegate.addedImages, 2)
+        XCTAssertEqual(delegate.imageRejectionReasons, [.allowanceTruncated])
+    }
+
     func testApplyWithinImageHeadroomShowsNoCapacityMessage() {
         let delegate = MockPasteDelegate()
         delegate.imageHeadroom = 5

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -789,7 +789,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatContextualFloatingInput:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.contextualFloatingInput))
         case .unifiedToggleInputAttachmentPaste:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.unifiedToggleInputAttachmentPaste))
+            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.unifiedToggleInputAttachmentPaste))
         case .freeTrialConversionWideEvent:
             Config(defaultValue: .enabled, source: .remoteReleasable(PrivacyProSubfeature.freeTrialConversionWideEvent))
         case .tabSwitcherTrackerCount:

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_unified_input.json5
@@ -151,6 +151,28 @@
         "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": ["appVersion", "unified_input_surface"]
     },
+    "m_aichat_unified_input_image_validation_failed": {
+        "description": "Fires when a pasted image is rejected by the Unified Toggle Input attachment policy (image capacity reached, or extra images dropped from a multi-image paste).",
+        "owners": ["pikorddg", "aataraxiaa"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "reason",
+                "description": "Reason for the image validation failure.",
+                "type": "string",
+                "enum": ["count_exceeded", "paste_truncated"]
+            },
+            {
+                "key": "source",
+                "description": "Source of the rejected image.",
+                "type": "string",
+                "enum": ["camera", "photo_library", "paste"]
+            }
+        ]
+    },
     "m_aichat_unified_input_file_attached": {
         "description": "Fires when the user attaches a file (file picker or paste) in the Unified Toggle Input (post-validation).",
         "owners": ["pikorddg", "aataraxiaa"],


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217277289250438

### Description
Building the edit menu on the unified input read the most expensive thing on the clipboard. Every long-press asked the pasteboard to materialise its full contents just to decide whether to offer "Paste" — a cross-process call that, for a clipboard shared from another Apple device, can become a network fetch on the main thread.

That answer now comes from cheap type metadata where possible, and is remembered until the clipboard actually changes, so repeat long-presses cost nothing. The real paste action is unchanged.

Also flips `unifiedToggleInputAttachmentPaste` from internal-only to enabled, so image/file paste goes external. The hardening and the enablement ride the same release train deliberately — the feature is never externally reachable without the fix.

### Testing Steps
1. Open the unified input in Duck.ai mode with an image-capable model.
2. Copy an image, long-press the input several times → "Paste" is offered every time; only the first long-press does the expensive read.
3. Tap Paste → the image attaches.
4. Copy a photo from Photos (HEIC) → "Paste" is still offered. (This was the bug in the first revision.)
5. Copy plain text, long-press → normal text paste is unchanged.
6. Switch to a model that does not accept images, long-press → attachment paste is no longer offered.

### Impact
Medium — the feature becomes externally reachable with this change.

#### What could go wrong?
- The metadata gate declines content that is actually attachable, so "Paste" silently disappears → this happened in review: `hasImages` covers only `UIPasteboardTypeListImage` and reports false for HEIC, the iOS default photo format. The gate now matches against `UIImage.readableTypeIdentifiersForItemProvider`, verified to agree with the loader on HEIC, WebP, AVIF, PNG, JPEG, GIF and TIFF, and to still reject PDF and text. Regression test added.
- A stale cached answer offers or hides "Paste" after the clipboard changes → the cache is keyed on the pasteboard's change counter plus the accepted-types set, so a clipboard change and a model change both invalidate it. Covered by tests and confirmed on device.

### Quality Considerations
The memoisation removes the *repeat* reads, not the first one. For a file-capable model the gate cannot rule out file types from metadata, so the first long-press after each copy still materialises the clipboard — the Universal Clipboard stall is made much rarer, not eliminated. Closing that gap needs conformance matching against the pasteboard's declared types and is filed as a follow-up.

Separately, `pasteAttachmentSupport` still runs unmemoised ahead of the probe (pre-existing; in-process CPU rather than blocking IPC). Also a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables attachment paste for all users and changes main-thread pasteboard probing; wrong gating could hide Paste or cause jank, though HEIC/memoization regressions are covered by tests.
> 
> **Overview**
> **Cheap “can paste attachments?” checks** for the unified input edit menu: answers are memoized on pasteboard `changeCount` plus accepted image/file types, so repeated long-presses don’t keep materializing `itemProviders` (including Universal Clipboard stalls). The metadata gate now uses **`UIImage.readableTypeIdentifiersForItemProvider`** so HEIC/WebP and non-first clipboard items still offer Paste when only images are allowed.
> 
> **Attachment paste is enabled externally** via `unifiedToggleInputAttachmentPaste` (default **enabled** instead of internal-only), paired with the probe fix so the feature isn’t broadly reachable without it.
> 
> **Pasted image limit drops are tracked** with a new `m_aichat_unified_input_image_validation_failed` pixel (`count_exceeded` vs `paste_truncated`), fired even when no capacity banner is shown. File paste rejections keep the existing file validation pixel; `PasteRejectionReason` is split into file vs image rejection enums and delegate methods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c95678ea5bf3dcf44441078ea141d1b8b935fa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->