### PR TITLE
iOS: Keep spacing below collapsed top capsule

### DIFF
--- a/iOS/DuckDuckGo/FloatingUI/FloatingDomainCapsuleController.swift
+++ b/iOS/DuckDuckGo/FloatingUI/FloatingDomainCapsuleController.swift
@@ -26,9 +26,9 @@ final class FloatingDomainCapsuleController {
 
     static let handoffBandHalfWidth: CGFloat = 0.02
 
-    /// Gap between the pill and the edge of the safe area at its resting position. Top address bar
-    /// uses this as-is; the collapsed bottom capsule sits `restBottomInsetReduction` closer to the
-    /// device bottom so the chrome morphs down into the pill rather than gaining space above it.
+    /// Gap between the pill and the adjacent edge of its expanded chrome at its resting position.
+    /// The collapsed bottom capsule sits `restBottomInsetReduction` closer to the device bottom so
+    /// the chrome morphs down into the pill rather than gaining space above it.
     static let restEdgePadding: CGFloat = 8
 
     /// Extra downward shift of the collapsed bottom capsule, in points, relative to `restEdgePadding`
@@ -46,13 +46,17 @@ final class FloatingDomainCapsuleController {
     }
 
     static func restCenterY(addressBarPosition: AddressBarPosition,
+                            expandedFrame: CGRect,
                             boundsMaxY: CGFloat,
                             safeAreaInsets: UIEdgeInsets,
                             capsuleHeight: CGFloat) -> CGFloat {
         let halfHeight = capsuleHeight / 2
         switch addressBarPosition {
         case .top:
-            return safeAreaInsets.top + restEdgePadding + halfHeight
+            guard !expandedFrame.isEmpty else {
+                return safeAreaInsets.top + restEdgePadding + halfHeight
+            }
+            return expandedFrame.maxY - restEdgePadding - halfHeight
         case .bottom:
             return boundsMaxY - restPaddingFromPhysicalBottom(safeAreaBottom: safeAreaInsets.bottom) - halfHeight
         }
@@ -67,10 +71,14 @@ final class FloatingDomainCapsuleController {
     /// Height obscured by the resting capsule, measured from the matching screen edge, so a
     /// page-fixed footer pins above the pill once the bars have hidden.
     func restObscuredHeightFromScreenEdge(for addressBarPosition: AddressBarPosition,
-                                          safeAreaInsets: UIEdgeInsets) -> CGFloat {
+                                          safeAreaInsets: UIEdgeInsets,
+                                          expandedFrame: CGRect = .zero) -> CGFloat {
         switch addressBarPosition {
         case .top:
-            return safeAreaInsets.top + Self.restEdgePadding + capsuleHeight
+            guard !expandedFrame.isEmpty else {
+                return safeAreaInsets.top + Self.restEdgePadding + capsuleHeight
+            }
+            return expandedFrame.maxY - Self.restEdgePadding
         case .bottom:
             return Self.restPaddingFromPhysicalBottom(safeAreaBottom: safeAreaInsets.bottom) + capsuleHeight
         }
@@ -231,6 +239,7 @@ final class FloatingDomainCapsuleController {
         let capsuleWidth = min(labelSize.width + 24, max(0, view.bounds.width - 32))
         let restCenterY = Self.restCenterY(
             addressBarPosition: addressBarPosition,
+            expandedFrame: expandedFrame,
             boundsMaxY: view.bounds.maxY,
             safeAreaInsets: view.safeAreaInsets,
             capsuleHeight: capsuleHeight)

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4778,7 +4778,8 @@ extension MainViewController: BrowserChromeDelegate {
         }
         return floatingDomainCapsuleController.restObscuredHeightFromScreenEdge(
             for: .top,
-            safeAreaInsets: view.safeAreaInsets)
+            safeAreaInsets: view.safeAreaInsets,
+            expandedFrame: floatingBarExpandedFrame())
             + FloatingDomainCapsuleController.fixedElementClearance
     }
 

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -587,6 +587,12 @@ final class FloatingDomainCapsuleControllerTests: XCTestCase {
         XCTAssertLessThan(button?.bounds.width ?? .greatestFiniteMagnitude, expandedFrame.width / 2)
     }
 
+    func testWhenTopBarsHiddenThenPillKeepsEightPointsBelowIt() {
+        let button = update(barsVisibilityPercent: 0)
+
+        XCTAssertEqual(expandedFrame.maxY - (button?.frame.maxY ?? 0), FloatingDomainCapsuleController.restEdgePadding, accuracy: 0.5)
+    }
+
     func testWhenPartiallyVisibleThenPillWidthIsBetweenCapsuleAndBarAndFullyOpaque() {
         let capsuleWidth = update(barsVisibilityPercent: 0)?.bounds.width ?? 0
         let midWidth = update(barsVisibilityPercent: 0.5)?.bounds.width ?? 0
@@ -615,6 +621,7 @@ final class FloatingDomainCapsuleControllerTests: XCTestCase {
         let button = update(barsVisibilityPercent: 0, addressBarPosition: .bottom)
         let expectedCenterY = FloatingDomainCapsuleController.restCenterY(
             addressBarPosition: .bottom,
+            expandedFrame: expandedFrame,
             boundsMaxY: containerView.bounds.maxY,
             safeAreaInsets: containerView.safeAreaInsets,
             capsuleHeight: controller.capsuleHeight)
@@ -656,6 +663,7 @@ final class FloatingDomainCapsuleGeometryTests: XCTestCase {
         let previousRestCenterY = boundsMaxY - insets.bottom - FloatingDomainCapsuleController.restEdgePadding - capsuleHeight / 2
         let restCenterY = FloatingDomainCapsuleController.restCenterY(
             addressBarPosition: .bottom,
+            expandedFrame: .zero,
             boundsMaxY: boundsMaxY,
             safeAreaInsets: insets,
             capsuleHeight: capsuleHeight)
@@ -663,16 +671,21 @@ final class FloatingDomainCapsuleGeometryTests: XCTestCase {
         XCTAssertEqual(restCenterY, previousRestCenterY + FloatingDomainCapsuleController.restBottomInsetReduction, accuracy: 0.001)
     }
 
-    func testWhenTopAddressBarThenCollapsedRestCenterKeepsEdgePadding() {
+    func testWhenTopAddressBarThenCollapsedRestCenterKeepsEightPointsBelowCapsule() {
         let insets = UIEdgeInsets(top: 59, left: 0, bottom: 34, right: 0)
         let capsuleHeight: CGFloat = 28
+        let expandedFrame = CGRect(x: 16, y: insets.top, width: 358, height: 60)
         let restCenterY = FloatingDomainCapsuleController.restCenterY(
             addressBarPosition: .top,
+            expandedFrame: expandedFrame,
             boundsMaxY: 844,
             safeAreaInsets: insets,
             capsuleHeight: capsuleHeight)
 
-        XCTAssertEqual(restCenterY, insets.top + FloatingDomainCapsuleController.restEdgePadding + capsuleHeight / 2, accuracy: 0.001)
+        XCTAssertEqual(
+            expandedFrame.maxY - (restCenterY + capsuleHeight / 2),
+            FloatingDomainCapsuleController.restEdgePadding,
+            accuracy: 0.001)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216782882404612?focus=true
Tech Design URL: N/A
CC: N/A

### Description
- Keep 8pt of space below the collapsed top domain capsule
- Anchor the capsule to the bottom edge of the expanded top chrome instead of the safe-area top
- Keep fixed-page content insets synchronized with the capsule’s updated position
- Preserve the existing bottom capsule positioning

### Testing Steps
1. Enable floating UI on an iPhone and set the address bar to Top
2. Open a webpage and scroll until the address bar collapses
3. Confirm there is 8pt between the capsule and the lower edge of the top chrome
4. Scroll the address bar back into view and confirm the transition remains smooth
5. Set the address bar to Bottom and confirm its collapsed capsule position is unchanged

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- The top capsule could overlap page-fixed content → the corresponding obscured-height calculation uses the same geometry
- Bottom capsule positioning could regress → its existing bottom-specific calculation remains unchanged and covered

### Quality Considerations
- Regression tests cover the 8pt top spacing and unchanged bottom geometry
- No privacy, security, analytics, or performance impact

### Notes to Reviewer
This PR is stacked on https://github.com/duckduckgo/apple-browsers/pull/6548 and should be reviewed against `kkoch/floating-top-address-input-spacing`.

Made with [Cursor](https://cursor.com)