### PR TITLE
Do not change Bookmarks Bar selection when hovering a menu above it

### DIFF
--- a/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
+++ b/macOS/DuckDuckGo/BookmarksBar/View/BookmarksBarViewController.swift
@@ -657,7 +657,14 @@ extension BookmarksBarViewController: BookmarksBarMenuPopoverDelegate {
 
     private func dispatchBookmarksBarHover() {
         guard let mainWindow = view.window else { return }
-        let windowPoint = mainWindow.convertPoint(fromScreen: NSEvent.mouseLocation)
+        let mouseLocation = NSEvent.mouseLocation
+        // In a short window a folder menu can cover the Bookmarks Bar. The local
+        // mouse-moved monitor also receives events sent to the menu window, so ignore
+        // the hover when a menu is displayed above the point: without this the
+        // Bookmarks Bar selection changes and the menu closes while the user moves
+        // the cursor over the menu items.
+        guard !isBookmarksBarMenuDisplayed(at: mouseLocation) else { return }
+        let windowPoint = mainWindow.convertPoint(fromScreen: mouseLocation)
         let cvPoint = bookmarksBarCollectionView.convert(windowPoint, from: nil)
         if bookmarksBarCollectionView.bounds.contains(cvPoint),
            let indexPath = bookmarksBarCollectionView.indexPathForItem(at: cvPoint),
@@ -671,6 +678,12 @@ extension BookmarksBarViewController: BookmarksBarMenuPopoverDelegate {
                 mouseDidHover(over: clippedItemsIndicator as Any)
             }
         }
+    }
+
+    /// Is a bookmarks menu window the frontmost window at the given screen point?
+    private func isBookmarksBarMenuDisplayed(at screenPoint: NSPoint) -> Bool {
+        let windowNumber = NSWindow.windowNumber(at: screenPoint, belowWindowWithWindowNumber: 0)
+        return NSApp.window(withWindowNumber: windowNumber) is BookmarksBarMenuWindow
     }
 
     func openNextBookmarksMenu(_ sender: any BookmarksBarMenuPopoverPresenting) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201048563534612/task/1217906921279459?focus=true

### Description
A bookmarks bar folder menu can cover the bar when the window is short (or when the folder is long).
The mouse-moved monitor installed while a menu is open would interfere with the current highlight in
the folder menu, effectively closing the menu. This change adds a check to skip hovering bookmarks bar item
if the window on top is the bookmarks bar folder menu.

### Testing Steps
1. Have bookmarks with folders
2. Display bookmarks bar
3. Drag the window to the bottom of the screen, so that when you show a bookmarks bar folder menu, it touches the bottom edge of the screen and extends to the top. Like this:
<img width="674" height="220" alt="Screenshot 2026-08-27 at 16 46 15" src="https://github.com/user-attachments/assets/d6687aab-658c-45d9-9ba4-447582be1736" />

4. While the folder menu is shown, move the cursor alongside the bookmarks bar (to the right) and verify that the folder menu doesn't get cancelled so long as the cursor is within the folder menu.
5. Try the same in the release app to see how the bug looks like.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bookmarks bar UI interaction only; no changes to data, sync, or security-sensitive paths.
> 
> **Overview**
> Fixes folder menus on the bookmarks bar closing while the user moves the mouse over menu items when the menu overlaps the bar (e.g. short window at the bottom of the screen).
> 
> The local **mouse-moved** monitor used for bar-to-folder switching still sees moves over the menu window. **`dispatchBookmarksBarHover()`** now bails out when the frontmost window at the cursor is a **`BookmarksBarMenuWindow`**, via new helper **`isBookmarksBarMenuDisplayed(at:)`**, so bar hover/selection does not fire under an open menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77eaf01fcf94c6c1ebebd30acca6f2eb887219a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->