### PR TITLE
[iOS] re-add obscured content insets api guard

### DIFF
--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1068,6 +1068,26 @@ class TabViewController: UIViewController {
         }
     }
 
+    /// Assigns `WKWebView.obscuredContentInsets` only when the running OS actually implements it.
+    ///
+    /// `#available(iOS 26, *)` is not sufficient on its own: on early iOS 26 betas (e.g. build
+    /// 23A5297m) the availability check passes but the `obscuredContentInsets` selector is not yet
+    /// implemented, so *both* the getter and setter abort with an unrecognized-selector exception
+    /// (SIGABRT). We therefore gate on the setter's `responds(to:)` and avoid touching the property
+    /// at all — including the getter comparison — when it is unsupported.
+    @discardableResult
+    private func setWebViewObscuredContentInsetsIfSupported(_ insets: UIEdgeInsets) -> Bool {
+        guard #available(iOS 26, *),
+              let webView,
+              webView.responds(to: #selector(setter: WKWebView.obscuredContentInsets)) else {
+            return false
+        }
+        if webView.obscuredContentInsets != insets {
+            webView.obscuredContentInsets = insets
+        }
+        return true
+    }
+
     private func updateWebViewLayoutForFloatingUI(for barsVisibilityPercent: CGFloat) {
         guard #available(iOS 26, *) else {
             assertionFailure("Floating UI requires iOS 26")
@@ -1110,9 +1130,7 @@ class TabViewController: UIViewController {
             WebViewScrollViewInsetUpdater.update(webView.scrollView, insets: obscuredInsets)
             hasAppliedFloatingUIScrollViewInsets = true
         }
-        if webView.obscuredContentInsets != obscuredInsets {
-            webView.obscuredContentInsets = obscuredInsets
-        }
+        setWebViewObscuredContentInsetsIfSupported(obscuredInsets)
     }
 
     private func updateWebViewLayoutForClassicUI(for barsVisibilityPercent: CGFloat) {
@@ -1120,9 +1138,7 @@ class TabViewController: UIViewController {
         borderView.isHidden = false
         borderView.bottomAlpha = AppWidthObserver.shared.isLargeWidth ? 0 : barsVisibilityPercent
         pullToRefreshViewAdapter?.setTopOffset(0)
-        if #available(iOS 26, *) {
-            webView.obscuredContentInsets = .zero
-        }
+        setWebViewObscuredContentInsetsIfSupported(.zero)
         if hasAppliedFloatingUIScrollViewInsets {
             WebViewScrollViewInsetUpdater.update(webView.scrollView, insets: .zero)
             hasAppliedFloatingUIScrollViewInsets = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1217635614181602?focus=true
Tech Design URL:
CC:

### Description
Re-adds API guard. 

### Testing Steps
1. Build is green and app runs.
2. iOS 26 shows floating UI (when internal user and flag is on)
3. iOS 18 shows old UI 

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized layout/crash guard around optional WebKit API; no auth or data changes; main risk is subtle floating-UI inset behavior if the guard is too aggressive on future builds.
> 
> **Overview**
> **Re-introduces a safe path for `WKWebView.obscuredContentInsets`** on iOS 26 floating UI by centralizing updates in `setWebViewObscuredContentInsetsIfSupported` in `TabViewController`.
> 
> On some early iOS 26 betas, `#available(iOS 26, *)` succeeds but the property is not implemented, so direct getter/setter access can **SIGABRT**. The helper also checks `responds(to:)` for the setter and skips the property entirely when unsupported; floating UI still applies scroll insets via `WebViewScrollViewInsetUpdater`.
> 
> `updateWebViewLayoutForFloatingUI` and `updateWebViewLayoutForClassicUI` now call this helper instead of assigning `obscuredContentInsets` directly (classic UI clears insets with `.zero` through the same guard).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59297b69d386ac520bad40c855f95755d28302dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->