### PR TITLE
iOS: Keep unified input outline in search mode

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -1197,8 +1197,7 @@ final class UnifiedToggleInputView: UIView {
         cardView.layer.maskedCorners = Constants.allCorners
         cardView.clipsToBounds = expanded && (usesOmnibarMargins || !isToggleEnabled)
 
-        cardView.layer.borderWidth = showToolbar ? Constants.expandedBorderWidth : 0
-        cardView.layer.borderColor = showToolbar ? expandedBorderColor : UIColor.clear.cgColor
+        updateExpandedBorderVisibility(expanded && showsToggle)
         let changes = {
             self.setCardFlanked(layout == .flanked)
             // Bottom collapsed pose is a capsule to match the floating omnibar pill; everything
@@ -1450,8 +1449,7 @@ final class UnifiedToggleInputView: UIView {
         applyInlineDismissVisibility(true)
         inputTopConstraint.constant = Constants.toggleBottomPadding
         toolbarBottomConstraint.constant = showToolbar ? 0 : -Constants.inputBottomPadding
-        cardView.layer.borderWidth = showToolbar ? Constants.expandedBorderWidth : 0
-        cardView.layer.borderColor = showToolbar ? expandedBorderColor : UIColor.clear.cgColor
+        updateExpandedBorderVisibility(true)
         toolbarHeightConstraint.constant = showToolbar ? Constants.toolbarHeight : 0
         toolsToolbar.alpha = showToolbar ? 1 : 0
         updateAttachmentsStripLayout()
@@ -1530,8 +1528,7 @@ final class UnifiedToggleInputView: UIView {
         if isToggleEnabled {
             toolbarBottomConstraint.constant = showToolbar ? 0 : -Constants.inputBottomPadding
         }
-        cardView.layer.borderWidth = showToolbar ? Constants.expandedBorderWidth : 0
-        cardView.layer.borderColor = showToolbar ? expandedBorderColor : UIColor.clear.cgColor
+        updateExpandedBorderVisibility(isToggleEnabled)
         updateAttachmentsStripLayout()
 
         guard animated else {
@@ -1554,6 +1551,11 @@ final class UnifiedToggleInputView: UIView {
                 self.toolsToolbar.finalizeToolbarShown()
             }
         }
+    }
+
+    private func updateExpandedBorderVisibility(_ isVisible: Bool) {
+        cardView.layer.borderWidth = isVisible ? Constants.expandedBorderWidth : 0
+        cardView.layer.borderColor = isVisible ? expandedBorderColor : UIColor.clear.cgColor
     }
 
     private func updateAttachmentsStripLayout() {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -780,7 +780,7 @@ final class UnifiedToggleInputView: UIView {
             expandedShadowView.shadows = currentLayout == .flanked ? flankedShadows : expandedShadows
             // The disclaimer card's shadowColor is a snapshotted cgColor; re-resolve it here.
             editReplaceDisclaimerCard.layer.shadowColor = UIColor(designSystemColor: .shadowSecondary).cgColor
-            if isExpanded {
+            if cardView.layer.borderWidth > 0 {
                 cardView.layer.borderColor = expandedBorderColor
             }
             refreshGlassAITabAccessoryConfigurations()
@@ -1128,7 +1128,10 @@ final class UnifiedToggleInputView: UIView {
             aiTabCollapsedFireButton.isHidden = true
             aiTabCollapsedMenuButton.isHidden = true
         }
-        guard layout != currentLayout else { return }
+        guard layout != currentLayout else {
+            updateExpandedBorderVisibility(expanded && layout.showsToggle)
+            return
+        }
         currentLayout = layout
 
         let showsToggle = layout.showsToggle
@@ -1439,6 +1442,7 @@ final class UnifiedToggleInputView: UIView {
     /// Designed to be invoked inside an animation context (UIView.animate or UIViewPropertyAnimator).
     func applyToggleRevealChanges() {
         let showToolbar = toggleView.selectedMode == .aiChat
+        currentLayout = .expanded(showsToggle: true, showsToolbar: showToolbar)
         cardView.layer.cornerRadius = Constants.cardCornerRadiusExpanded
         // Width animation: this reveal path bypasses `applyCardLayout`, so set the expanded margins here.
         cardLeadingConstraint.constant = expandedCardHorizontalMargin
@@ -1458,6 +1462,7 @@ final class UnifiedToggleInputView: UIView {
     /// The property mutations that hide the toggle, returning the card to its slim
     /// omnibar-editing pose. Designed to be invoked inside an animation context.
     func applyToggleHideChanges() {
+        currentLayout = .expanded(showsToggle: false, showsToolbar: false)
         cardView.layer.cornerRadius = Constants.cardCornerRadiusCollapsed
         toggleTopConstraint.constant = 0
         toggleHeightConstraint.constant = 0
@@ -1470,6 +1475,7 @@ final class UnifiedToggleInputView: UIView {
         attachmentsStripHeightConstraint.constant = 0
         attachmentsStrip.alpha = 0
         textEntryView.isExpandable = false
+        updateExpandedBorderVisibility(false)
     }
 
     func setInactiveCardAppearance(_ inactive: Bool) {
@@ -1528,7 +1534,9 @@ final class UnifiedToggleInputView: UIView {
         if isToggleEnabled {
             toolbarBottomConstraint.constant = showToolbar ? 0 : -Constants.inputBottomPadding
         }
-        updateExpandedBorderVisibility(currentLayout.showsToggle)
+        if case .expanded(let showsToggle, _) = currentLayout {
+            currentLayout = .expanded(showsToggle: showsToggle, showsToolbar: showToolbar)
+        }
         updateAttachmentsStripLayout()
 
         guard animated else {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -1528,7 +1528,7 @@ final class UnifiedToggleInputView: UIView {
         if isToggleEnabled {
             toolbarBottomConstraint.constant = showToolbar ? 0 : -Constants.inputBottomPadding
         }
-        updateExpandedBorderVisibility(isToggleEnabled)
+        updateExpandedBorderVisibility(currentLayout.showsToggle)
         updateAttachmentsStripLayout()
 
         guard animated else {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -29,6 +29,27 @@ import UniformTypeIdentifiers
 
 final class UnifiedToggleInputViewTests: XCTestCase {
 
+    func testWhenExpandedInputSwitchesToSearchThenCardKeepsOutline() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+        sut.setInputMode(.aiChat, animated: false)
+        sut.applyCardLayout(.expanded(showsToggle: true, showsToolbar: true), animated: false)
+        let outlinedCard = try XCTUnwrap(sut.subviews.first { $0.layer.borderWidth > 0 })
+
+        sut.setInputMode(.search, animated: false)
+
+        XCTAssertEqual(outlinedCard.layer.borderWidth, 0.5)
+    }
+
+    func testWhenExpandedSearchOnlyInputIsShownThenCardHasNoOutline() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler, isToggleEnabled: false)
+
+        sut.applyCardLayout(.expanded(showsToggle: false, showsToolbar: false), animated: false)
+
+        XCTAssertFalse(sut.subviews.contains { $0.layer.borderWidth > 0 })
+    }
+
     func test_searchModeTextSubmitStaysEnabledWhenInvalidDuckAIAttachmentIsHidden() {
         let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
         let sut = UnifiedToggleInputView(handler: handler)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -60,6 +60,44 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertFalse(sut.subviews.contains { $0.layer.borderWidth > 0 })
     }
 
+    func testWhenTopInputRevealsToggleThenModeSwitchKeepsOutline() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+        sut.cardPosition = .top
+        sut.setInputMode(.aiChat, animated: false)
+        sut.prepareForOmnibarEditingShow()
+        XCTAssertFalse(sut.subviews.contains { $0.layer.borderWidth > 0 })
+
+        sut.applyOmnibarEditingShowPose()
+        let outlinedCard = try XCTUnwrap(sut.subviews.first { $0.layer.borderWidth > 0 })
+        sut.setInputMode(.search, animated: false)
+
+        XCTAssertEqual(outlinedCard.layer.borderWidth, 0.5)
+    }
+
+    func testWhenTopInputHidesToggleThenOutlineIsRemoved() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+        sut.cardPosition = .top
+        sut.prepareForOmnibarEditingShow()
+        sut.applyOmnibarEditingShowPose()
+        let outlinedCard = try XCTUnwrap(sut.subviews.first { $0.layer.borderWidth > 0 })
+
+        sut.applyToggleHideChanges()
+
+        XCTAssertEqual(outlinedCard.layer.borderWidth, 0)
+    }
+
+    func testWhenToggleIsEnabledOnExpandedSearchInputThenOutlineAppears() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler, isToggleEnabled: false)
+        sut.applyCardLayout(.expanded(showsToggle: false, showsToolbar: false), animated: false)
+
+        sut.updateToggleEnabled(true, showsToolbar: false)
+
+        XCTAssertTrue(sut.subviews.contains { $0.layer.borderWidth > 0 })
+    }
+
     func test_searchModeTextSubmitStaysEnabledWhenInvalidDuckAIAttachmentIsHidden() {
         let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
         let sut = UnifiedToggleInputView(handler: handler)

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -50,6 +50,16 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertFalse(sut.subviews.contains { $0.layer.borderWidth > 0 })
     }
 
+    func testWhenExpandedInputHidesToggleThenModeSyncDoesNotShowOutline() {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+        sut.applyCardLayout(.expanded(showsToggle: false, showsToolbar: false), animated: false)
+
+        sut.setInputMode(.aiChat, animated: false)
+
+        XCTAssertFalse(sut.subviews.contains { $0.layer.borderWidth > 0 })
+    }
+
     func test_searchModeTextSubmitStaysEnabledWhenInvalidDuckAIAttachmentIsHidden() {
         let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
         let sut = UnifiedToggleInputView(handler: handler)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217636674570185?focus=true
Tech Design URL: N/A
CC: N/A

### Description
- Keep the expanded unified input’s subtle outline visible when switching from Duck.ai to Search
- Tie outline visibility to the expanded mode toggle rather than the Duck.ai-only toolbar
- Preserve the existing outline-free Search-only layout
- Add regression coverage for both configurations

Stacked on https://github.com/duckduckgo/apple-browsers/pull/6549

### Testing Steps
1. Enable the unified toggle input
2. Focus the input and select Duck.ai
3. Confirm the expanded card has a subtle outline separating it from the background
4. Switch to Search and confirm the same outline remains visible
5. Disable the Duck.ai toggle and confirm the Search-only input retains its existing appearance

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
The outline could appear in Search-only configurations. Regression coverage verifies it remains limited to the toggle-enabled expanded card.

### Quality Considerations
No privacy, analytics, performance, or accessibility behavior changes.

### Notes to Reviewer
The existing outline was coupled to Duck.ai toolbar visibility; this change couples it to the expanded mode-toggle card instead.

Made with [Cursor](https://cursor.com)