### PR TITLE
[iOS] Don't use website theme color for edge gradients

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -413,7 +413,8 @@ class MainViewController: UIViewController {
         SiteThemeColorManager(viewCoordinator: viewCoordinator,
                               currentTabViewController: { [weak self] in self?.currentTab }(),
                               appSettings: appSettings,
-                              themeManager: themeManager)
+                              themeManager: themeManager,
+                              isFloatingUIEnabled: isFloatingUIEnabled)
     }()
 
     private lazy var aiChatViewControllerManager: AIChatViewControllerManager = {

--- a/iOS/DuckDuckGo/SiteThemeColorManager.swift
+++ b/iOS/DuckDuckGo/SiteThemeColorManager.swift
@@ -24,6 +24,7 @@ final class SiteThemeColorManager {
     private let viewCoordinator: MainViewCoordinator
     private let themeManager: ThemeManaging
     private let appSettings: AppSettings
+    private let isFloatingUIEnabled: Bool
     private let currentTabViewController: () -> TabViewController?
 
     private weak var tabViewController: TabViewController?
@@ -33,10 +34,12 @@ final class SiteThemeColorManager {
     init(viewCoordinator: MainViewCoordinator,
          currentTabViewController: @autoclosure @escaping () -> TabViewController?,
          appSettings: AppSettings,
-         themeManager: ThemeManaging) {
+         themeManager: ThemeManaging,
+         isFloatingUIEnabled: Bool) {
         self.viewCoordinator = viewCoordinator
         self.appSettings = appSettings
         self.themeManager = themeManager
+        self.isFloatingUIEnabled = isFloatingUIEnabled
         self.currentTabViewController = currentTabViewController
     }
 
@@ -149,7 +152,7 @@ final class SiteThemeColorManager {
         }
         viewCoordinator.setStandardStatusBackgroundColor(statusBackgroundColor)
         tabViewController?.pullToRefreshViewAdapter?.backgroundColor = newColor
-        tabViewController?.webView?.underPageBackgroundColor = newColor
+        tabViewController?.webView?.underPageBackgroundColor = isFloatingUIEnabled ? UIColor(designSystemColor: .surfaceCanvas) : newColor
         tabViewController?.webView?.scrollView.backgroundColor = newColor
     }
 

--- a/iOS/DuckDuckGo/SiteThemeColorManager.swift
+++ b/iOS/DuckDuckGo/SiteThemeColorManager.swift
@@ -152,8 +152,9 @@ final class SiteThemeColorManager {
         }
         viewCoordinator.setStandardStatusBackgroundColor(statusBackgroundColor)
         tabViewController?.pullToRefreshViewAdapter?.backgroundColor = newColor
-        tabViewController?.webView?.underPageBackgroundColor = isFloatingUIEnabled ? UIColor(designSystemColor: .surfaceCanvas) : newColor
-        tabViewController?.webView?.scrollView.backgroundColor = newColor
+        let webViewBackgroundColor = isFloatingUIEnabled ? UIColor(designSystemColor: .surfaceCanvas) : newColor
+        tabViewController?.webView?.underPageBackgroundColor = webViewBackgroundColor
+        tabViewController?.webView?.scrollView.backgroundColor = webViewBackgroundColor
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1217636674570180?focus=true
Tech Design URL:
CC:

### Description
Don't apply website theme color to webkit's under page background color in order to disable the coloured edges.

### Testing Steps
1. Floating UI flag on (restart required/expected)
2. Check the fixed elements pages on privacy-test-pages.site > view port test
3. Browse a few pages 
4. Floating UI flag off (restart required/expected) - validate no leakage

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
Could break colour on some other UI elements that not expected -> Limited to floatingUI internal users.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only change behind the floating UI flag; no auth, data, or security impact. Residual risk is minor color mismatches on other web view chrome for internal floating UI users.
> 
> **Overview**
> When **floating UI** is enabled, site theme colors no longer drive the web view’s `underPageBackgroundColor` and scroll view background. Those layers now use the design-system **surface canvas** color instead of the adjusted site theme color, which stops WebKit from showing colored edge gradients while status bar and pull-to-refresh styling still follow the site theme.
> 
> `SiteThemeColorManager` takes a new `isFloatingUIEnabled` flag; `MainViewController` passes its existing floating UI state when constructing the manager. With floating UI off, behavior is unchanged (theme color applies everywhere as before).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e81bc03b663d7fcff22acd9c53aad43932df7eaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->