### PR TITLE
Report ai_prompt_submitted for Duck.ai prompts with no navigation

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
@@ -52,7 +52,7 @@ enum AIChatEntryPointPixel: PixelKit.Event {
     }
 }
 
-enum AIChatEntryPointSource: String {
+public enum AIChatEntryPointSource: String {
     case addressBarPrompt = "address_bar_prompt"
     case addressBarIcon = "address_bar_icon"
     case addressBarShortcutChip = "address_bar_shortcut_chip"

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -72,7 +72,6 @@ protocol AIChatContextualSheetCoordinatorDelegate: AnyObject {
     /// Called when the user requests a new Duck.ai voice chat.
     func aiChatContextualSheetCoordinatorDidRequestNewVoiceChat(_ coordinator: AIChatContextualSheetCoordinator)
 
-    /// Called when the sheet's input submits a prompt. Nothing navigates, so the browser reports it.
     func aiChatContextualSheetCoordinator(_ coordinator: AIChatContextualSheetCoordinator,
                                           didSubmitDuckAIPromptWithOrigin origin: AIChatEntryPointSource?)
 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -71,6 +71,10 @@ protocol AIChatContextualSheetCoordinatorDelegate: AnyObject {
 
     /// Called when the user requests a new Duck.ai voice chat.
     func aiChatContextualSheetCoordinatorDidRequestNewVoiceChat(_ coordinator: AIChatContextualSheetCoordinator)
+
+    /// Called when the sheet's input submits a prompt. Nothing navigates, so the browser reports it.
+    func aiChatContextualSheetCoordinator(_ coordinator: AIChatContextualSheetCoordinator,
+                                          didSubmitDuckAIPromptWithOrigin origin: AIChatEntryPointSource?)
 }
 
 /// Coordinates the presentation and lifecycle of the contextual AI chat sheet.
@@ -752,6 +756,10 @@ private extension AIChatContextualSheetCoordinator {
         }
         host.onPromptDelivered = { [weak self] in
             self?.sessionState.markUTIContextDelivered()
+        }
+        host.onDuckAIPromptSubmitted = { [weak self] origin in
+            guard let self else { return }
+            self.delegate?.aiChatContextualSheetCoordinator(self, didSubmitDuckAIPromptWithOrigin: origin)
         }
         host.onAttachmentsChanged = { [weak self] in
             self?.sessionState.refreshForAttachmentChange()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -1173,6 +1173,7 @@ extension AIChatContextualSheetCoordinator: AIChatContextualSheetViewControllerD
         sheetViewController?.notifyInitialNativePromptSubmitted(hasPageContext: hasPageContext)
         selectionJourneyInstrumentation.promptSubmitted()
         sessionState.handlePromptSubmission(prompt)
+        delegate?.aiChatContextualSheetCoordinator(self, didSubmitDuckAIPromptWithOrigin: .contextualChat)
     }
 
     func aiChatContextualSheetViewController(_ viewController: AIChatContextualSheetViewController,

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -51,7 +51,6 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate, AIChatContextua
     var onPromptSubmitted: (() -> Void)?
     /// Fires on every prompt delivery so the session state can mark context delivered and re-render the chip.
     var onPromptDelivered: (() -> Void)?
-    /// Every prompt this input submits, for measurement that needs the submission's entry point.
     var onDuckAIPromptSubmitted: ((AIChatEntryPointSource?) -> Void)?
     var onAIVoiceChatRequested: (() -> Void)?
     var onEditModeChange: ((Bool) -> Void)?

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -51,6 +51,8 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate, AIChatContextua
     var onPromptSubmitted: (() -> Void)?
     /// Fires on every prompt delivery so the session state can mark context delivered and re-render the chip.
     var onPromptDelivered: (() -> Void)?
+    /// Every prompt this input submits, for measurement that needs the submission's entry point.
+    var onDuckAIPromptSubmitted: ((AIChatEntryPointSource?) -> Void)?
     var onAIVoiceChatRequested: (() -> Void)?
     var onEditModeChange: ((Bool) -> Void)?
 
@@ -476,6 +478,10 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate, AIChatContextua
 
     func unifiedToggleInputDidSubmitPromptToBoundChat() {
         reportFirstPromptSubmission()
+    }
+
+    func unifiedToggleInputDidSubmitDuckAIPrompt(origin: AIChatEntryPointSource?) {
+        onDuckAIPromptSubmitted?(origin)
     }
 
     func unifiedToggleInputDidSubmitPrompt(_ prompt: String,

--- a/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
@@ -82,6 +82,11 @@ protocol PostIdleSessionInstrumentation: AnyObject {
     /// to its own terminal so its shipped `bar_used` series stays comparable.
     func promptSubmittedWithoutNavigation(origin: AIChatEntryPointSource?)
 
+    /// Duck.ai was opened from the bar with no prompt auto-submitted. Ends the post-idle flow only:
+    /// its shipped `bar_used` series counts the open either way, while the return session stays
+    /// active until a real prompt terminal lands.
+    func duckAIOpenedWithoutPrompt()
+
     /// App was backgrounded with a session still active. Completes as CANCELLED.
     func sessionCancelledByBackground()
 }
@@ -180,6 +185,10 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
 
     func promptSubmittedWithoutNavigation(origin: AIChatEntryPointSource?) {
         completeReturnSession(reason: .aiPromptSubmitted, promptOrigin: origin, at: dateProvider())
+    }
+
+    func duckAIOpenedWithoutPrompt() {
+        completePostIdleSession(reason: .aiPromptSubmitted, at: dateProvider())
     }
 
     func sessionCancelledByBackground() {

--- a/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
@@ -77,6 +77,11 @@ protocol PostIdleSessionInstrumentation: AnyObject {
     /// ignored for every other reason.
     func sessionEnded(reason: ReturnSessionWideEventData.StatusReason, promptOrigin: AIChatEntryPointSource?)
 
+    /// A Duck.ai prompt was submitted with nothing navigating behind it — the contextual sheet, or
+    /// the chat already bound to the input. Ends the return session only, leaving the post-idle flow
+    /// to its own terminal so its shipped `bar_used` series stays comparable.
+    func promptSubmittedWithoutNavigation(origin: AIChatEntryPointSource?)
+
     /// App was backgrounded with a session still active. Completes as CANCELLED.
     func sessionCancelledByBackground()
 }
@@ -169,26 +174,12 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
 
     func sessionEnded(reason: ReturnSessionWideEventData.StatusReason, promptOrigin: AIChatEntryPointSource?) {
         let now = dateProvider()
+        completeReturnSession(reason: reason, promptOrigin: promptOrigin, at: now)
+        completePostIdleSession(reason: reason, at: now)
+    }
 
-        if let globalID = returnSessionID,
-           let data = wideEvent.getFlowData(ReturnSessionWideEventData.self, globalID: globalID) {
-            data.statusReason = reason
-            data.promptOrigin = reason == .aiPromptSubmitted ? promptOrigin?.rawValue : nil
-            data.sessionInterval.end = now
-            markFirstInteractionIfNeeded(on: data, at: now)
-            wideEvent.completeFlow(data, status: .success(reason: reason.rawValue), onComplete: { _, _ in })
-        }
-        returnSessionID = nil
-
-        if let globalID = postIdleSessionID,
-           let data = wideEvent.getFlowData(PostIdleSessionWideEventData.self, globalID: globalID) {
-            let postIdleReason = reason.postIdleReason
-            data.statusReason = postIdleReason
-            data.sessionInterval.end = now
-            markFirstInteractionIfNeeded(on: data, at: now)
-            wideEvent.completeFlow(data, status: .success(reason: postIdleReason.rawValue), onComplete: { _, _ in })
-        }
-        postIdleSessionID = nil
+    func promptSubmittedWithoutNavigation(origin: AIChatEntryPointSource?) {
+        completeReturnSession(reason: .aiPromptSubmitted, promptOrigin: origin, at: dateProvider())
     }
 
     func sessionCancelledByBackground() {
@@ -212,6 +203,32 @@ final class DefaultPostIdleSessionInstrumentation: PostIdleSessionInstrumentatio
     }
 
     // MARK: - Helpers
+
+    private func completeReturnSession(reason: ReturnSessionWideEventData.StatusReason,
+                                       promptOrigin: AIChatEntryPointSource?,
+                                       at now: Date) {
+        if let globalID = returnSessionID,
+           let data = wideEvent.getFlowData(ReturnSessionWideEventData.self, globalID: globalID) {
+            data.statusReason = reason
+            data.promptOrigin = reason == .aiPromptSubmitted ? promptOrigin?.rawValue : nil
+            data.sessionInterval.end = now
+            markFirstInteractionIfNeeded(on: data, at: now)
+            wideEvent.completeFlow(data, status: .success(reason: reason.rawValue), onComplete: { _, _ in })
+        }
+        returnSessionID = nil
+    }
+
+    private func completePostIdleSession(reason: ReturnSessionWideEventData.StatusReason, at now: Date) {
+        if let globalID = postIdleSessionID,
+           let data = wideEvent.getFlowData(PostIdleSessionWideEventData.self, globalID: globalID) {
+            let postIdleReason = reason.postIdleReason
+            data.statusReason = postIdleReason
+            data.sessionInterval.end = now
+            markFirstInteractionIfNeeded(on: data, at: now)
+            wideEvent.completeFlow(data, status: .success(reason: postIdleReason.rawValue), onComplete: { _, _ in })
+        }
+        postIdleSessionID = nil
+    }
 
     private func completeOrphanedFlows() {
         for orphan in wideEvent.getAllFlowData(ReturnSessionWideEventData.self) {

--- a/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/PostIdleSessionInstrumentation.swift
@@ -77,14 +77,8 @@ protocol PostIdleSessionInstrumentation: AnyObject {
     /// ignored for every other reason.
     func sessionEnded(reason: ReturnSessionWideEventData.StatusReason, promptOrigin: AIChatEntryPointSource?)
 
-    /// A Duck.ai prompt was submitted with nothing navigating behind it — the contextual sheet, or
-    /// the chat already bound to the input. Ends the return session only, leaving the post-idle flow
-    /// to its own terminal so its shipped `bar_used` series stays comparable.
     func promptSubmittedWithoutNavigation(origin: AIChatEntryPointSource?)
 
-    /// Duck.ai was opened from the bar with no prompt auto-submitted. Ends the post-idle flow only:
-    /// its shipped `bar_used` series counts the open either way, while the return session stays
-    /// active until a real prompt terminal lands.
     func duckAIOpenedWithoutPrompt()
 
     /// App was backgrounded with a session still active. Completes as CANCELLED.

--- a/iOS/DuckDuckGo/AppLifecycle/ReturnSessionWideEventData.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/ReturnSessionWideEventData.swift
@@ -28,11 +28,11 @@ final class ReturnSessionWideEventData: WideEventData {
 
     static let metadata = WideEventMetadata(
         pixelName: "return_session",
-        featureName: "return-session",
+        featureName: "return_session",
         mobileMetaType: "ios-return-session",
         // API requires both; only mobileMetaType is read on iOS.
         desktopMetaType: "macos-return-session",
-        version: "1.1.0"
+        version: "1.2.0"
     )
 
     /// `ntp` is the after-idle NTP; `ntpUserInitiated` is an NTP reached without the treatment.
@@ -133,13 +133,14 @@ extension ReturnSessionWideEventData {
 
     func jsonParameters() -> [String: Encodable] {
         let bucket = Self.durationBucket
+        let source = statusReason == .aiPromptSubmitted ? promptOrigin : nil
         return Dictionary(compacting: [
             (WideEventParameter.ReturnSessionFeature.landedOn, landedOn.rawValue),
             (WideEventParameter.ReturnSessionFeature.afterIdle, afterIdle),
             (WideEventParameter.ReturnSessionFeature.timeAwayMsBucketed, timeAwayMs.map { String(Self.timeAwayBucketMs($0)) }),
             (WideEventParameter.ReturnSessionFeature.focused, focused),
             (WideEventParameter.Feature.statusReason, statusReason?.rawValue),
-            (WideEventParameter.ReturnSessionFeature.promptOrigin, promptOrigin),
+            (WideEventParameter.ReturnSessionFeature.source, source),
             (WideEventParameter.ReturnSessionFeature.sessionDurationMsBucketed, sessionInterval.stringValue(bucket)),
             (WideEventParameter.ReturnSessionFeature.timeToFirstInteractionMsBucketed, firstInteractionInterval.stringValue(bucket)),
             (WideEventParameter.ReturnSessionFeature.pageEngaged, pageEngaged),
@@ -174,7 +175,7 @@ extension WideEventParameter {
         static let afterIdle = "feature.data.ext.after_idle"
         static let timeAwayMsBucketed = "feature.data.ext.time_away_ms_bucketed"
         static let focused = "feature.data.ext.focused"
-        static let promptOrigin = "feature.data.ext.prompt_origin"
+        static let source = "feature.data.ext.source"
         static let sessionDurationMsBucketed = "feature.data.ext.session_duration_ms_bucketed"
         static let timeToFirstInteractionMsBucketed = "feature.data.ext.time_to_first_interaction_ms_bucketed"
         static let pageEngaged = "feature.data.ext.page_engaged"

--- a/iOS/DuckDuckGo/AppLifecycle/ReturnSessionWideEventData.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/ReturnSessionWideEventData.swift
@@ -55,6 +55,11 @@ final class ReturnSessionWideEventData: WideEventData {
         case chatSelected = "chat_selected"
     }
 
+    /// Fallback for `source` when an `ai_prompt_submitted` terminal has no attributed entry point.
+    enum PromptSourceFallback: String {
+        case unknown
+    }
+
     var globalData: WideEventGlobalData
     var contextData: WideEventContextData
     var appData: WideEventAppData
@@ -133,7 +138,7 @@ extension ReturnSessionWideEventData {
 
     func jsonParameters() -> [String: Encodable] {
         let bucket = Self.durationBucket
-        let source = statusReason == .aiPromptSubmitted ? promptOrigin : nil
+        let source = statusReason == .aiPromptSubmitted ? (promptOrigin ?? PromptSourceFallback.unknown.rawValue) : nil
         return Dictionary(compacting: [
             (WideEventParameter.ReturnSessionFeature.landedOn, landedOn.rawValue),
             (WideEventParameter.ReturnSessionFeature.afterIdle, afterIdle),

--- a/iOS/DuckDuckGo/AppLifecycle/ReturnSessionWideEventData.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/ReturnSessionWideEventData.swift
@@ -28,7 +28,7 @@ final class ReturnSessionWideEventData: WideEventData {
 
     static let metadata = WideEventMetadata(
         pixelName: "return_session",
-        featureName: "return_session",
+        featureName: "return-session",
         mobileMetaType: "ios-return-session",
         // API requires both; only mobileMetaType is read on iOS.
         desktopMetaType: "macos-return-session",

--- a/iOS/DuckDuckGo/MainViewController+AIChatHistoryViewModelDelegate.swift
+++ b/iOS/DuckDuckGo/MainViewController+AIChatHistoryViewModelDelegate.swift
@@ -24,6 +24,8 @@ extension MainViewController: AIChatHistoryViewModelDelegate {
 
     func viewModelDidRequestOpenNewChat() {
         if let tab = currentTab, tab.isAITab {
+            fireAIChatEntryPointPixel(source: .chatHistoryNewChat, opensNewTab: false, hasPrompt: false)
+            stampDuckAIEntrySourceOnCurrentTab(.chatHistoryNewChat)
             unifiedToggleInputCoordinator?.startNewChat()
             tab.submitStartChatAction()
             dismiss(animated: true) { [weak self] in

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6814,6 +6814,7 @@ extension MainViewController: TabDelegate {
     func tabDidRequestNewAIChatTab(tab: TabViewController) {
         let source: AIChatEntryPointSource = tab.link == nil ? .browsingMenuNTP : .browsingMenuWebpage
         fireAIChatEntryPointPixel(source: source, opensNewTab: true, hasPrompt: false)
+        postIdleSessionInstrumentation.duckAIOpenedWithoutPrompt()
         tab.openNewChatInNewTab(source: source)
     }
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6814,7 +6814,6 @@ extension MainViewController: TabDelegate {
     func tabDidRequestNewAIChatTab(tab: TabViewController) {
         let source: AIChatEntryPointSource = tab.link == nil ? .browsingMenuNTP : .browsingMenuWebpage
         fireAIChatEntryPointPixel(source: source, opensNewTab: true, hasPrompt: false)
-        postIdleSessionInstrumentation.duckAIOpenedWithoutPrompt()
         tab.openNewChatInNewTab(source: source)
     }
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6531,6 +6531,10 @@ extension MainViewController: TabDelegate {
         postIdleSessionInstrumentation.pageEngaged()
     }
 
+    func tab(_ tab: TabViewController, didSubmitDuckAIPromptWithOrigin origin: AIChatEntryPointSource?) {
+        postIdleSessionInstrumentation.promptSubmittedWithoutNavigation(origin: origin)
+    }
+
     func tab(_ tab: TabViewController, didFailDuckAINavigationFor url: URL, error: Error) {
         duckAIWideEventInstrumentation.pageLoadFailed(scope: .tab(tab.tabModel.uid), error: error)
     }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2546,8 +2546,6 @@ class MainViewController: UIViewController {
     ///     Timing relative to UI refresh differs by exit path: the URL-reuse branch fires this before
     ///     `refreshOmniBar`/tab-bar refresh; all other branches fire it after. Callers should not rely
     ///     on chrome state being settled inside the closure.
-    /// `completion` receives the tab hosting the load, so per-tab state is stamped on the right tab
-    /// even when a clear defers the whole load and "current" still points at the outgoing tab.
     func loadUrlInNewTab(_ url: URL, reuseExisting: ExistingTabReusePolicy? = .none, inheritedAttribution: AdClickAttributionLogic.State?, fromExternalLink: Bool = false, voiceMode: Bool = false, completion: ((Tab) -> Void)? = nil) {
 
         func worker() {
@@ -4296,9 +4294,6 @@ class MainViewController: UIViewController {
                                    hasPrompt: hasPrompt)
     }
 
-    /// Stamps the entry on the tab hosting the chat, where it persists as the `origin` of
-    /// follow-up prompts — surviving restarts and Duck.ai entries made from other tabs.
-    /// New-tab paths stamp the tab handed to their load completion instead.
     func stampDuckAIEntrySourceOnCurrentTab(_ source: AIChatEntryPointSource) {
         tabManager.currentTabsModel.currentTab?.duckAIEntrySource = source
     }
@@ -4978,8 +4973,6 @@ extension MainViewController: BrowserChromeDelegate {
         showHomeRowReminder()
     }
 
-    /// `completion` receives the tab hosting the load, so callers can stamp per-tab state that the
-    /// new-tab branch could not set up front (the tab does not exist yet).
     func loadUrlRespectingAIBoundary(_ url: URL, fromExternalLink: Bool = false, completion: ((Tab) -> Void)? = nil) {
         let decision = AIBoundaryNavigationDecision.forProgrammaticNavigation(
             currentIsAI: currentTab?.isAITab == true,

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -225,8 +225,6 @@ class MainViewController: UIViewController {
     /// VPN connection state as the user left the New Tab Page for the VPN screen, so a toggle made
     /// there can be told apart from a reconnect that happened on its own.
     var vpnConnectedWhenLeavingNewTabPage: Bool?
-    /// The most recent Duck.ai entry, consumed as the `origin` of prompts sent on the opened surface.
-    private(set) var lastDuckAIEntrySource: AIChatEntryPointSource?
     let duckAIWideEventInstrumentation: DuckAIWideEventInstrumentation
     let syncAutoRestoreHandler: SyncAutoRestoreHandling
     private let lastActiveTabStore: LastActiveTabStoring
@@ -2548,21 +2546,26 @@ class MainViewController: UIViewController {
     ///     Timing relative to UI refresh differs by exit path: the URL-reuse branch fires this before
     ///     `refreshOmniBar`/tab-bar refresh; all other branches fire it after. Callers should not rely
     ///     on chrome state being settled inside the closure.
-    func loadUrlInNewTab(_ url: URL, reuseExisting: ExistingTabReusePolicy? = .none, inheritedAttribution: AdClickAttributionLogic.State?, fromExternalLink: Bool = false, voiceMode: Bool = false, completion: (() -> Void)? = nil) {
+    /// `completion` receives the tab hosting the load, so per-tab state is stamped on the right tab
+    /// even when a clear defers the whole load and "current" still points at the outgoing tab.
+    func loadUrlInNewTab(_ url: URL, reuseExisting: ExistingTabReusePolicy? = .none, inheritedAttribution: AdClickAttributionLogic.State?, fromExternalLink: Bool = false, voiceMode: Bool = false, completion: ((Tab) -> Void)? = nil) {
 
         func worker() {
             allowContentUnderflow = false
             viewCoordinator.navigationBarContainer.alpha = 1
             loadViewIfNeeded()
 
+            let hostingTab: Tab
+
             // Check if a specific tab ID should be reused.
             if case .tabWithId(let id) = reuseExisting, let existing = tabManager.first(withId: id) {
                 selectTab(existing)
+                hostingTab = existing
             }
             // Check if an existing tab with the same URL should be reused.
             else if reuseExisting != .none, let existing = tabManager.first(withUrl: url) {
                 selectTab(existing)
-                completion?()
+                completion?(existing)
                 return
             }
             // Check if a tab presenting a New Tab page should be reused.
@@ -2572,10 +2575,11 @@ class MainViewController: UIViewController {
                 }
                 tabManager.select(existing, dismissCurrent: false)
                 loadUrl(url, fromExternalLink: fromExternalLink)
+                hostingTab = existing
             }
             // Add a new tab if no existing tab is reused.
             else {
-                addTab(url: url, inheritedAttribution: inheritedAttribution, fromExternalLink: fromExternalLink, voiceMode: voiceMode)
+                hostingTab = addTab(url: url, inheritedAttribution: inheritedAttribution, fromExternalLink: fromExternalLink, voiceMode: voiceMode)
             }
 
             refreshOmniBar()
@@ -2583,7 +2587,7 @@ class MainViewController: UIViewController {
             refreshControls()
             tabsBarController?.refresh(tabsModel: tabManager.currentTabsModel, scrollToSelected: true)
             swipeTabsCoordinator?.refresh(tabsModel: tabManager.currentTabsModel, scrollToSelected: true)
-            completion?()
+            completion?(hostingTab)
         }
 
         if clearInProgress {
@@ -2605,7 +2609,7 @@ class MainViewController: UIViewController {
         }
     }
 
-    func loadQuery(_ query: String) {
+    func loadQuery(_ query: String, completion: ((Tab) -> Void)? = nil) {
         guard let url = URL.makeSearchURL(query: query, useUnifiedLogic: isUnifiedURLPredictionEnabled, queryContext: currentTab?.url) else {
             Logger.general.error("Couldn't form URL for query \"\(query, privacy: .public)\" with context \"\(self.currentTab?.url?.shortDescription ?? "<nil>", privacy: .public)\"")
             return
@@ -2613,7 +2617,7 @@ class MainViewController: UIViewController {
         // Make sure that once query is submitted, we don't trigger the non-SERP flow
         skipSERPFlow = false
         endNewTabPageSessionWithLoad(of: url)
-        loadUrlRespectingAIBoundary(url)
+        loadUrlRespectingAIBoundary(url, completion: completion)
     }
 
     func postIdleSubmissionReason(for query: String) -> ReturnSessionWideEventData.StatusReason {
@@ -2621,6 +2625,12 @@ class MainViewController: UIViewController {
             return .searchSubmitted
         }
         return url.isDuckDuckGoSearch ? .searchSubmitted : .urlSubmitted
+    }
+
+    static func hasAutoSubmittedDuckAIPrompt(query: String?, autoSend: Bool, hasAttachments: Bool) -> Bool {
+        guard autoSend else { return false }
+        let hasText = query?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        return hasText || hasAttachments
     }
 
     func stopLoading() {
@@ -2661,7 +2671,12 @@ class MainViewController: UIViewController {
         if currentTab.tabModel.link == nil {
             ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: currentTab.tabModel.openedAfterIdle)
         }
-        postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted, promptOrigin: source)
+        let hasAttachments = images?.isEmpty == false || files?.isEmpty == false
+        if Self.hasAutoSubmittedDuckAIPrompt(query: query, autoSend: autoSend, hasAttachments: hasAttachments) {
+            postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted, promptOrigin: source)
+        } else {
+            postIdleSessionInstrumentation.duckAIOpenedWithoutPrompt()
+        }
         prepareTabForRequest {
             currentTab.load(
                 query,
@@ -2705,7 +2720,8 @@ class MainViewController: UIViewController {
         transitionTo(tab: tab, from: nil)
     }
 
-    private func addTab(url: URL?, inheritedAttribution: AdClickAttributionLogic.State?, fromExternalLink: Bool = false, voiceMode: Bool = false) {
+    @discardableResult
+    private func addTab(url: URL?, inheritedAttribution: AdClickAttributionLogic.State?, fromExternalLink: Bool = false, voiceMode: Bool = false) -> Tab {
         let tab = tabManager.add(url: url, inheritedAttribution: inheritedAttribution)
         tab.inferredOpenerContext = .external
         tab.isVoiceModeRequested = voiceMode
@@ -2722,6 +2738,7 @@ class MainViewController: UIViewController {
         dismissOmniBar()
         resetUnifiedToggleInputForTabTransition(to: tab)
         attachTab(tab: tab)
+        return tab.tabModel
     }
 
     private func resetUnifiedToggleInputForTabTransition(to tab: TabViewController) {
@@ -4272,12 +4289,18 @@ class MainViewController: UIViewController {
     }
 
     func fireAIChatEntryPointPixel(source: AIChatEntryPointSource, opensNewTab: Bool, hasPrompt: Bool) {
-        lastDuckAIEntrySource = source
         AIChatEntryPointPixel.fire(source: source,
                                    duckAIEnabled: aiChatSettings.isAIChatEnabled,
                                    toggleEnabled: aiChatSettings.isAIChatSearchInputUserSettingsEnabled,
                                    opensNewTab: opensNewTab,
                                    hasPrompt: hasPrompt)
+    }
+
+    /// Stamps the entry on the tab hosting the chat, where it persists as the `origin` of
+    /// follow-up prompts — surviving restarts and Duck.ai entries made from other tabs.
+    /// New-tab paths stamp the tab handed to their load completion instead.
+    func stampDuckAIEntrySourceOnCurrentTab(_ source: AIChatEntryPointSource) {
+        tabManager.currentTabsModel.currentTab?.duckAIEntrySource = source
     }
 
     /// Reads the tab model, not `currentTab`: home tabs have no `TabViewController`, so
@@ -4291,7 +4314,7 @@ class MainViewController: UIViewController {
         if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
             ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: tab.openedAfterIdle)
         }
-        postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted, promptOrigin: .voice)
+        postIdleSessionInstrumentation.duckAIOpenedWithoutPrompt()
         openAIChatInVoiceMode()
     }
 
@@ -4326,7 +4349,7 @@ class MainViewController: UIViewController {
 
         if openInNewTab {
             let voiceURL = currentTab.aiChatContentHandler.buildVoiceModeURL()
-            loadUrlInNewTab(voiceURL, inheritedAttribution: nil, voiceMode: true)
+            loadUrlInNewTab(voiceURL, inheritedAttribution: nil, voiceMode: true) { $0.duckAIEntrySource = source }
             if fromDeepLink {
                 // Collapse the input that was auto-expanded for the restored tab.
                 // This cancels any pending async activateInput because showCollapsed
@@ -4337,6 +4360,7 @@ class MainViewController: UIViewController {
             return
         }
 
+        stampDuckAIEntrySourceOnCurrentTab(source)
         prepareTabForRequest {
             currentTab.loadVoiceMode()
         }
@@ -4391,14 +4415,21 @@ class MainViewController: UIViewController {
             let chatURL = currentTab.aiChatContentHandler.buildQueryURL(query: query, autoSend: autoSend, flowType: flowType, tools: tools)
             // Mirror the in-place `.aiPromptSubmitted` so the new-tab branch keeps idle-session parity.
             // Gated on `!fromDeepLink` so external entries aren't reclassified as address-bar submissions.
+            let hasAttachments = images?.isEmpty == false || files?.isEmpty == false
             if !fromDeepLink {
-                postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted, promptOrigin: source)
+                if Self.hasAutoSubmittedDuckAIPrompt(query: query, autoSend: autoSend, hasAttachments: hasAttachments) {
+                    postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted, promptOrigin: source)
+                } else {
+                    postIdleSessionInstrumentation.duckAIOpenedWithoutPrompt()
+                }
             }
             // Stage prompt singleton before `loadUrlInNewTab` — matches legacy `setData → load` order.
             // Per-tab payload runs in completion since it targets the newly-selected chat tab.
-            if let query, !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let hasPromptContent = query?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+                || hasAttachments
+            if hasPromptContent {
                 let prompt = AIChatNativePrompt.queryPrompt(
-                    query,
+                    query ?? "",
                     autoSubmit: autoSend,
                     toolChoice: tools?.map(\.rawValue),
                     images: images,
@@ -4408,7 +4439,8 @@ class MainViewController: UIViewController {
                 )
                 AIChatPromptHandler.shared.setData(prompt)
             }
-            loadUrlInNewTab(chatURL, inheritedAttribution: nil) { [weak self] in
+            loadUrlInNewTab(chatURL, inheritedAttribution: nil) { [weak self] tab in
+                tab.duckAIEntrySource = source
                 if let modelId {
                     self?.unifiedToggleInputCoordinator?.updateSelectedModel(modelId)
                 }
@@ -4419,6 +4451,7 @@ class MainViewController: UIViewController {
             return
         }
 
+        stampDuckAIEntrySourceOnCurrentTab(source)
         load(query, autoSend: autoSend, payload: payload, flowType: flowType, tools: tools, modelId: modelId, reasoningEffort: reasoningEffort, images: images, files: files, source: source)
         if let modelId {
             unifiedToggleInputCoordinator?.updateSelectedModel(modelId)
@@ -4945,7 +4978,9 @@ extension MainViewController: BrowserChromeDelegate {
         showHomeRowReminder()
     }
 
-    func loadUrlRespectingAIBoundary(_ url: URL, fromExternalLink: Bool = false) {
+    /// `completion` receives the tab hosting the load, so callers can stamp per-tab state that the
+    /// new-tab branch could not set up front (the tab does not exist yet).
+    func loadUrlRespectingAIBoundary(_ url: URL, fromExternalLink: Bool = false, completion: ((Tab) -> Void)? = nil) {
         let decision = AIBoundaryNavigationDecision.forProgrammaticNavigation(
             currentIsAI: currentTab?.isAITab == true,
             currentHasContent: currentTab?.tabModel.link != nil,
@@ -4958,10 +4993,13 @@ extension MainViewController: BrowserChromeDelegate {
             if let tab = currentTab {
                 tab.contextualOnboardingPresenter.dismissContextualOnboardingIfNeeded(from: tab)
             }
-            loadUrlInNewTab(url, inheritedAttribution: nil, fromExternalLink: fromExternalLink)
+            loadUrlInNewTab(url, inheritedAttribution: nil, fromExternalLink: fromExternalLink, completion: completion)
         case .loadInPlace:
             currentTab?.isDuckAIDeepLinkSurfaceRequested = url.isDuckAIChatProtectionOpen
             loadUrl(url, fromExternalLink: fromExternalLink)
+            if let currentTab = tabManager.currentTabsModel.currentTab {
+                completion?(currentTab)
+            }
         }
     }
 
@@ -5072,7 +5110,7 @@ extension MainViewController: OmniBarDelegate {
         ) == .openInNewTab
         fireAIChatEntryPointPixel(source: .chatHistoryOpenChat, opensNewTab: opensNewTab, hasPrompt: false)
         // Route through boundary helper so NTP transforms in-place; web→chat spawns a new tab; chat→chat stays. Matches `onPromptSubmitted`.
-        loadUrlRespectingAIBoundary(url)
+        loadUrlRespectingAIBoundary(url) { $0.duckAIEntrySource = .chatHistoryOpenChat }
     }
 
     func onViewAllChatsSelected() {
@@ -6679,6 +6717,22 @@ extension MainViewController: TabDelegate {
              didRequestNewTabForUrl url: URL,
              openedByPage: Bool,
              inheritingAttribution attribution: AdClickAttributionLogic.State?) {
+        openNewTab(from: tab, url: url, openedByPage: openedByPage, inheritedAttribution: attribution)
+    }
+
+    func tab(_ tab: TabViewController,
+             didRequestNewDuckAITabForUrl url: URL,
+             entrySource: AIChatEntryPointSource) {
+        openNewTab(from: tab, url: url, openedByPage: false, inheritedAttribution: nil) {
+            $0.duckAIEntrySource = entrySource
+        }
+    }
+
+    private func openNewTab(from tab: TabViewController,
+                            url: URL,
+                            openedByPage: Bool,
+                            inheritedAttribution attribution: AdClickAttributionLogic.State?,
+                            completion: ((Tab) -> Void)? = nil) {
         _ = findInPageView?.resignFirstResponder()
         hideNotificationBarIfBrokenSitePromptShown()
         tab.aiChatContextualSheetCoordinator.dismissSheet()
@@ -6694,7 +6748,7 @@ extension MainViewController: TabDelegate {
             capturePreviewForTab(tab)
             showBars()
             newTabAnimation {
-                self.loadUrlInNewTab(url, inheritedAttribution: attribution)
+                self.loadUrlInNewTab(url, inheritedAttribution: attribution, completion: completion)
                 self.currentTab?.openedByPage = true
                 self.currentTab?.openingTab = tab
             }
@@ -6705,7 +6759,7 @@ extension MainViewController: TabDelegate {
                 self.omniBarTabSwitcherButton?.tabCount += 1
             }
         } else {
-            loadUrlInNewTab(url, inheritedAttribution: attribution)
+            loadUrlInNewTab(url, inheritedAttribution: attribution, completion: completion)
             self.currentTab?.adClickExternalOpenDetector.invalidateForUserInitiated()
             self.currentTab?.openingTab = tab
         }
@@ -6765,10 +6819,9 @@ extension MainViewController: TabDelegate {
     }
 
     func tabDidRequestNewAIChatTab(tab: TabViewController) {
-        fireAIChatEntryPointPixel(source: tab.link == nil ? .browsingMenuNTP : .browsingMenuWebpage,
-                                  opensNewTab: true,
-                                  hasPrompt: false)
-        tab.openNewChatInNewTab()
+        let source: AIChatEntryPointSource = tab.link == nil ? .browsingMenuNTP : .browsingMenuWebpage
+        fireAIChatEntryPointPixel(source: source, opensNewTab: true, hasPrompt: false)
+        tab.openNewChatInNewTab(source: source)
     }
 
     func tab(_ tab: TabViewController, didRequestAIChatForSelectedText text: String) {
@@ -7954,7 +8007,8 @@ extension MainViewController: VoiceSearchViewControllerDelegate {
                 if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
                     ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: tab.openedAfterIdle)
                 }
-                postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted, promptOrigin: .voice)
+                let source = tabManager.currentTabsModel.currentTab?.duckAIEntrySource
+                postIdleSessionInstrumentation.sessionEnded(reason: .aiPromptSubmitted, promptOrigin: source)
                 coordinator.submitVoicePrompt(query)
             } else {
                 performCancel()
@@ -8055,6 +8109,7 @@ extension MainViewController: AIChatViewControllerManagerDelegate {
     }
 
     func aiChatViewControllerManagerDidReceivePromptSubmission(_ manager: AIChatViewControllerManager) {
+        postIdleSessionInstrumentation.promptSubmittedWithoutNavigation(origin: nil)
         reportDuckAIFrontendSubmissionAcknowledged()
     }
 }
@@ -8083,6 +8138,7 @@ extension MainViewController: AIChatContentHandlingDelegate {
     }
 
     func aiChatContentHandlerDidReceivePromptSubmission(_ handler: AIChatContentHandling) {
+        postIdleSessionInstrumentation.promptSubmittedWithoutNavigation(origin: nil)
         reportDuckAIFrontendSubmissionAcknowledged()
     }
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -8131,7 +8131,8 @@ extension MainViewController: AIChatContentHandlingDelegate {
     }
 
     func aiChatContentHandlerDidReceivePromptSubmission(_ handler: AIChatContentHandling) {
-        postIdleSessionInstrumentation.promptSubmittedWithoutNavigation(origin: nil)
+        let origin = currentTab?.aiChatContentHandler === handler ? currentTab?.tabModel.duckAIEntrySource : nil
+        postIdleSessionInstrumentation.promptSubmittedWithoutNavigation(origin: origin)
         reportDuckAIFrontendSubmissionAcknowledged()
     }
 

--- a/iOS/DuckDuckGo/Tab.swift
+++ b/iOS/DuckDuckGo/Tab.swift
@@ -141,8 +141,6 @@ public class Tab: NSObject, NSCoding {
     /// NSCoding so reopening the app restores the tab's selected AI settings.
     var unifiedInputState: UnifiedInputTabState
 
-    /// How the user entered Duck.ai in this tab; reported as the `origin` of prompts
-    /// submitted here. Persisted so follow-ups keep their attribution across restarts.
     var duckAIEntrySource: AIChatEntryPointSource?
 
     /// Type of tab: web or AI Chat, derived from the current URL

--- a/iOS/DuckDuckGo/Tab.swift
+++ b/iOS/DuckDuckGo/Tab.swift
@@ -54,6 +54,7 @@ public class Tab: NSObject, NSCoding {
         static let selectedModelID = "selectedModelID"
         static let selectedReasoningMode = "selectedReasoningMode"
         static let selectedTool = "selectedTool"
+        static let duckAIEntrySource = "duckAIEntrySource"
     }
 
     private var observersHolder = [WeaklyHeldTabObserver]()
@@ -140,6 +141,10 @@ public class Tab: NSObject, NSCoding {
     /// NSCoding so reopening the app restores the tab's selected AI settings.
     var unifiedInputState: UnifiedInputTabState
 
+    /// How the user entered Duck.ai in this tab; reported as the `origin` of prompts
+    /// submitted here. Persisted so follow-ups keep their attribution across restarts.
+    var duckAIEntrySource: AIChatEntryPointSource?
+
     /// Type of tab: web or AI Chat, derived from the current URL
     private var type: TabType {
         if let link, link.url.isDuckAIURL(debugSettings: aichatDebugSettings) {
@@ -162,6 +167,7 @@ public class Tab: NSObject, NSCoding {
                 isExternalLaunch: Bool = false,
                 shouldSuppressTrackerAnimationOnFirstLoad: Bool = false,
                 unifiedInputState: UnifiedInputTabState = UnifiedInputTabState(),
+                duckAIEntrySource: AIChatEntryPointSource? = nil,
                 aichatDebugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings()) {
         self.uid = uid ?? UUID().uuidString
         self.link = link
@@ -175,6 +181,7 @@ public class Tab: NSObject, NSCoding {
         self.isExternalLaunch = isExternalLaunch
         self.shouldSuppressTrackerAnimationOnFirstLoad = shouldSuppressTrackerAnimationOnFirstLoad
         self.unifiedInputState = unifiedInputState
+        self.duckAIEntrySource = duckAIEntrySource
         self.aichatDebugSettings = aichatDebugSettings
     }
 
@@ -202,10 +209,12 @@ public class Tab: NSObject, NSCoding {
             selectedReasoningMode: selectedReasoningMode,
             selectedTool: selectedTool
         )
+        let duckAIEntrySourceRaw = decoder.decodeObject(forKey: NSCodingKeys.duckAIEntrySource) as? String
+        let duckAIEntrySource = duckAIEntrySourceRaw.flatMap(AIChatEntryPointSource.init(rawValue:))
 
         Logger.daxEasterEgg.debug("Tab decode - Restoring logo URL: \(daxEasterEggLogoURL ?? "nil") for tab [\(uid ?? "no-uid")]")
 
-        self.init(uid: uid, link: link, viewed: viewed, desktop: desktop, lastViewedDate: lastViewedDate, daxEasterEggLogoURL: daxEasterEggLogoURL, contextualChatURL: contextualChatURL, supportsTabHistory: supportsTabHistory, fireTab: fireTab, isExternalLaunch: isExternalLaunch, shouldSuppressTrackerAnimationOnFirstLoad: shouldSuppressTrackerAnimationOnFirstLoad, unifiedInputState: unifiedInputState)
+        self.init(uid: uid, link: link, viewed: viewed, desktop: desktop, lastViewedDate: lastViewedDate, daxEasterEggLogoURL: daxEasterEggLogoURL, contextualChatURL: contextualChatURL, supportsTabHistory: supportsTabHistory, fireTab: fireTab, isExternalLaunch: isExternalLaunch, shouldSuppressTrackerAnimationOnFirstLoad: shouldSuppressTrackerAnimationOnFirstLoad, unifiedInputState: unifiedInputState, duckAIEntrySource: duckAIEntrySource)
     }
 
     public func encode(with coder: NSCoder) {
@@ -223,6 +232,7 @@ public class Tab: NSObject, NSCoding {
         coder.encode(unifiedInputState.selectedModelID, forKey: NSCodingKeys.selectedModelID)
         coder.encode(unifiedInputState.selectedReasoningMode?.rawValue, forKey: NSCodingKeys.selectedReasoningMode)
         coder.encode(unifiedInputState.selectedTool?.rawValue, forKey: NSCodingKeys.selectedTool)
+        coder.encode(duckAIEntrySource?.rawValue, forKey: NSCodingKeys.duckAIEntrySource)
         // Note: isExternalLaunch and shouldSuppressTrackerAnimationOnFirstLoad are not encoded as they are transient flags
         // Note: type is not encoded as it's now a computed property based on the link URL
     }
@@ -238,7 +248,8 @@ public class Tab: NSObject, NSCoding {
             contextualChatURL: contextualChatURL,
             supportsTabHistory: supportsTabHistory,
             fireTab: fireTab,
-            unifiedInputState: unifiedInputState)
+            unifiedInputState: unifiedInputState,
+            duckAIEntrySource: duckAIEntrySource)
     }
 
     public override func isEqual(_ other: Any?) -> Bool {

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -191,6 +191,10 @@ protocol TabDelegate: AnyObject {
     func tabDidRequestSetYouTubeAdBlockingEnabled(_ enabled: Bool, tab: TabViewController)
 
     func tabDidRequestYouTubeAdBlockUnavailableDialog(tab: TabViewController)
+
+    /// A Duck.ai prompt was submitted from this tab's contextual sheet. `origin` is the entry
+    /// point the submission pixels report.
+    func tab(_ tab: TabViewController, didSubmitDuckAIPromptWithOrigin origin: AIChatEntryPointSource?)
 }
 
 extension TabDelegate {
@@ -204,6 +208,8 @@ extension TabDelegate {
     func tabDidRequestNewVoiceChat(_ tab: TabViewController) {}
 
     func tab(_ tab: TabViewController, didFailDuckAINavigationFor url: URL, error: Error) {}
+
+    func tab(_ tab: TabViewController, didSubmitDuckAIPromptWithOrigin origin: AIChatEntryPointSource?) {}
 
     func searchToken(for tab: TabViewController) -> String? { nil }
 

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -59,6 +59,12 @@ protocol TabDelegate: AnyObject {
              openedByPage: Bool,
              inheritingAttribution: AdClickAttributionLogic.State?)
 
+    /// Same as `didRequestNewTabForUrl`, plus it stamps `entrySource` on the opened tab so prompts
+    /// submitted there report the Duck.ai entry that led to it.
+    func tab(_ tab: TabViewController,
+             didRequestNewDuckAITabForUrl url: URL,
+             entrySource: AIChatEntryPointSource)
+
     /// Called on navigate forward on a tab that had just closed a link-opened tab via back.
     /// Re-open that tab at `url` as a child of `tab` again.
     func tab(_ tab: TabViewController, didRequestReopenClosedTabAt url: URL)

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -59,8 +59,6 @@ protocol TabDelegate: AnyObject {
              openedByPage: Bool,
              inheritingAttribution: AdClickAttributionLogic.State?)
 
-    /// Same as `didRequestNewTabForUrl`, plus it stamps `entrySource` on the opened tab so prompts
-    /// submitted there report the Duck.ai entry that led to it.
     func tab(_ tab: TabViewController,
              didRequestNewDuckAITabForUrl url: URL,
              entrySource: AIChatEntryPointSource)
@@ -198,8 +196,6 @@ protocol TabDelegate: AnyObject {
 
     func tabDidRequestYouTubeAdBlockUnavailableDialog(tab: TabViewController)
 
-    /// A Duck.ai prompt was submitted from this tab's contextual sheet. `origin` is the entry
-    /// point the submission pixels report.
     func tab(_ tab: TabViewController, didSubmitDuckAIPromptWithOrigin origin: AIChatEntryPointSource?)
 }
 

--- a/iOS/DuckDuckGo/TabViewControllerAIChatExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerAIChatExtension.swift
@@ -39,8 +39,8 @@ protocol AITabController {
     /// Submits a toggle sidebar action to open/close the sidebar.
     func submitToggleSidebarAction()
 
-    /// Opens a new AI chat in a new tab.
-    func openNewChatInNewTab()
+    /// Opens a new AI chat in a new tab, stamping `source` as its Duck.ai entry.
+    func openNewChatInNewTab(source: AIChatEntryPointSource)
 }
 
 // MARK: - AITabController
@@ -59,10 +59,11 @@ extension TabViewController: AITabController {
         isVoiceModeRequested = false
 
         aiChatContentHandler.setPayload(payload: payload)
+        let hasText = query?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
         let hasAttachments = images?.isEmpty == false || files?.isEmpty == false
-        if let query, !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || hasAttachments {
+        if hasText || hasAttachments {
             let prompt = AIChatNativePrompt.queryPrompt(
-                query,
+                query ?? "",
                 autoSubmit: autoSend,
                 toolChoice: tools?.map(\.rawValue),
                 images: images,
@@ -108,14 +109,14 @@ extension TabViewController: AITabController {
     }
     
     /// Opens a new AI chat in a new tab.
-    func openNewChatInNewTab() {
+    func openNewChatInNewTab(source: AIChatEntryPointSource) {
         let newChatURL = aiChatContentHandler.buildQueryURL(
             query: nil,
             autoSend: false,
             flowType: .default,
             tools: nil
         )
-        delegate?.tab(self, didRequestNewTabForUrl: newChatURL, openedByPage: false, inheritingAttribution: nil)
+        delegate?.tab(self, didRequestNewDuckAITabForUrl: newChatURL, entrySource: source)
     }
 
     /// Opens the Duck.ai chats sidebar in a new tab. Mirrors the contextual sheet's "View all chats"

--- a/iOS/DuckDuckGo/TabViewControllerAIChatExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerAIChatExtension.swift
@@ -39,7 +39,7 @@ protocol AITabController {
     /// Submits a toggle sidebar action to open/close the sidebar.
     func submitToggleSidebarAction()
 
-    /// Opens a new AI chat in a new tab, stamping `source` as its Duck.ai entry.
+    /// Opens a new AI chat in a new tab.
     func openNewChatInNewTab(source: AIChatEntryPointSource)
 }
 

--- a/iOS/DuckDuckGo/TabViewControllerContextualAIChatExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerContextualAIChatExtension.swift
@@ -139,4 +139,9 @@ extension TabViewController: AIChatContextualSheetCoordinatorDelegate {
     func aiChatContextualSheetCoordinatorDidRequestNewVoiceChat(_ coordinator: AIChatContextualSheetCoordinator) {
         delegate?.tabDidRequestNewVoiceChat(self)
     }
+
+    func aiChatContextualSheetCoordinator(_ coordinator: AIChatContextualSheetCoordinator,
+                                          didSubmitDuckAIPromptWithOrigin origin: AIChatEntryPointSource?) {
+        delegate?.tab(self, didSubmitDuckAIPromptWithOrigin: origin)
+    }
 }

--- a/iOS/DuckDuckGo/TabViewControllerContextualAIChatExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerContextualAIChatExtension.swift
@@ -108,7 +108,7 @@ extension TabViewController: AIChatContextualSheetCoordinatorDelegate {
     }
 
     func aiChatContextualSheetCoordinator(_ coordinator: AIChatContextualSheetCoordinator, didRequestExpandWithURL url: URL) {
-        delegate?.tab(self, didRequestNewTabForUrl: url, openedByPage: false, inheritingAttribution: nil)
+        delegate?.tab(self, didRequestNewDuckAITabForUrl: url, entrySource: .contextualChat)
     }
 
     func aiChatContextualSheetCoordinatorDidRequestViewAllChats(_ coordinator: AIChatContextualSheetCoordinator) {

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -1012,7 +1012,7 @@ extension MainViewController: TabsBarDelegate {
         if let currentTab, currentTab.tabModel.link != nil {
             // Bypasses `openAIChat`, so fire the entry pixel directly.
             fireAIChatEntryPointPixel(source: .tabsBarButton, opensNewTab: true, hasPrompt: false)
-            currentTab.openNewChatInNewTab()
+            currentTab.openNewChatInNewTab(source: .tabsBarButton)
         } else {
             openAIChat(source: .tabsBarButton)
         }

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -1010,8 +1010,9 @@ extension MainViewController: TabsBarDelegate {
     func tabsBarDidRequestAIChat(_ controller: TabsBarViewController) {
         // Chrome button always opens Duck.ai in a new tab unless current tab is blank — matches macOS.
         if let currentTab, currentTab.tabModel.link != nil {
-            // Bypasses `openAIChat`, so fire the entry pixel directly.
+            // Bypasses `openAIChat`, so report the entry pixel and post-idle completion directly.
             fireAIChatEntryPointPixel(source: .tabsBarButton, opensNewTab: true, hasPrompt: false)
+            postIdleSessionInstrumentation.duckAIOpenedWithoutPrompt()
             currentTab.openNewChatInNewTab(source: .tabsBarButton)
         } else {
             openAIChat(source: .tabsBarButton)

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -1010,9 +1010,8 @@ extension MainViewController: TabsBarDelegate {
     func tabsBarDidRequestAIChat(_ controller: TabsBarViewController) {
         // Chrome button always opens Duck.ai in a new tab unless current tab is blank — matches macOS.
         if let currentTab, currentTab.tabModel.link != nil {
-            // Bypasses `openAIChat`, so report the entry pixel and post-idle completion directly.
+            // Bypasses `openAIChat`, so fire the entry pixel directly.
             fireAIChatEntryPointPixel(source: .tabsBarButton, opensNewTab: true, hasPrompt: false)
-            postIdleSessionInstrumentation.duckAIOpenedWithoutPrompt()
             currentTab.openNewChatInNewTab(source: .tabsBarButton)
         } else {
             openAIChat(source: .tabsBarButton)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
@@ -249,8 +249,6 @@ final class UTIPixelReporter {
         }
     }
 
-    /// The origin the submission pixels report, so anything else measuring the same submission
-    /// resolves it identically. Nil once the coordinator is gone.
     func currentPromptOrigin() -> AIChatEntryPointSource? {
         guard let context = context() else { return nil }
         return Self.promptOrigin(for: context)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIPixelReporter.swift
@@ -249,6 +249,13 @@ final class UTIPixelReporter {
         }
     }
 
+    /// The origin the submission pixels report, so anything else measuring the same submission
+    /// resolves it identically. Nil once the coordinator is gone.
+    func currentPromptOrigin() -> AIChatEntryPointSource? {
+        guard let context = context() else { return nil }
+        return Self.promptOrigin(for: context)
+    }
+
     static func promptOrigin(for context: UTIPixelContext) -> AIChatEntryPointSource? {
         switch context.surface {
         case .addressBar: return .addressBarPrompt

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -90,7 +90,7 @@ extension MainViewController {
         )
         coordinator.delegate = self
         coordinator.pageTypeProvider = { [weak self] in self?.currentPromptPageType() }
-        coordinator.duckAIEntrySourceProvider = { [weak self] in self?.lastDuckAIEntrySource }
+        coordinator.duckAIEntrySourceProvider = { [weak self] in self?.tabManager.currentTabsModel.currentTab?.duckAIEntrySource }
         coordinator.updateVoiceSearchAvailability(voiceSearchHelper.isVoiceSearchEnabled)
         coordinator.updateAIVoiceChatAvailability(voiceShortcutFeature.isAvailable)
         coordinator.updateAIChatShortcutAvailability(aiChatAddressBarExperience.shouldShowDuckAIAddressBarButton)
@@ -1210,22 +1210,28 @@ extension MainViewController {
     }
 
     func handleUnifiedToggleInputSearchSubmission(_ query: String) {
-        fireDirectDuckAINavigationPixelIfNeeded(for: query)
+        let duckAIEntrySource = fireDirectDuckAINavigationPixelIfNeeded(for: query)
         if let tab = tabManager.currentTabsModel.currentTab, tab.link == nil {
             ntpAfterIdleInstrumentation.barUsedFromNTP(afterIdle: tab.openedAfterIdle)
         }
         postIdleSessionInstrumentation.sessionEnded(reason: postIdleSubmissionReason(for: query))
         recordNewTabPageSessionAction { $0.hitSubmit() }
-        loadQuery(query)
+        // Stamped via the load completion: the new-tab case has no tab to stamp until `loadQuery` creates it.
+        loadQuery(query) { tab in
+            if let duckAIEntrySource {
+                tab.duckAIEntrySource = duckAIEntrySource
+            }
+        }
     }
 
     /// The only place a typed duck.ai address can be told apart from an in-page or deep link.
     /// Mirrors `loadQuery`'s URL resolution so detection matches what gets navigated.
-    private func fireDirectDuckAINavigationPixelIfNeeded(for query: String) {
+    /// Returns the entry source the caller must stamp on the tab hosting the load.
+    private func fireDirectDuckAINavigationPixelIfNeeded(for query: String) -> AIChatEntryPointSource? {
         guard let url = URL.makeSearchURL(query: query,
                                           useUnifiedLogic: isUnifiedURLPredictionEnabled,
                                           queryContext: currentTab?.url),
-              url.isDuckAIURL else { return }
+              url.isDuckAIURL else { return nil }
 
         DailyPixel.fireDailyAndCount(pixel: .aiChatDuckAIDirectNavigation, withAdditionalParameters: [
             "duckai_enabled": String(aiChatSettings.isAIChatEnabled),
@@ -1247,6 +1253,7 @@ extension MainViewController {
         fireAIChatEntryPointPixel(source: .directURL,
                                   opensNewTab: decision == .openInNewTab,
                                   hasPrompt: false)
+        return .directURL
     }
 
 }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1216,7 +1216,6 @@ extension MainViewController {
         }
         postIdleSessionInstrumentation.sessionEnded(reason: postIdleSubmissionReason(for: query))
         recordNewTabPageSessionAction { $0.hitSubmit() }
-        // Stamped via the load completion: the new-tab case has no tab to stamp until `loadQuery` creates it.
         loadQuery(query) { tab in
             if let duckAIEntrySource {
                 tab.duckAIEntrySource = duckAIEntrySource
@@ -1226,7 +1225,6 @@ extension MainViewController {
 
     /// The only place a typed duck.ai address can be told apart from an in-page or deep link.
     /// Mirrors `loadQuery`'s URL resolution so detection matches what gets navigated.
-    /// Returns the entry source the caller must stamp on the tab hosting the load.
     private func fireDirectDuckAINavigationPixelIfNeeded(for query: String) -> AIChatEntryPointSource? {
         guard let url = URL.makeSearchURL(query: query,
                                           useUnifiedLogic: isUnifiedURLPredictionEnabled,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1295,6 +1295,10 @@ extension MainViewController: UnifiedToggleInputDelegate {
         // The app-wide last-used is written through `UnifiedInputStateStore.commitToggleMode` on submit, which fires this delegate.
     }
 
+    func unifiedToggleInputDidSubmitDuckAIPrompt(origin: AIChatEntryPointSource?) {
+        postIdleSessionInstrumentation.promptSubmittedWithoutNavigation(origin: origin)
+    }
+
     func unifiedToggleInputDidSubmitPrompt(_ prompt: String, modelId: String?, tools: [AIChatRAGTool]?, reasoningEffort: AIChatReasoningEffort?, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?) {
         // Recorded before the branches below, which end the visit on their own terminals.
         recordNewTabPageSessionAction { $0.hitSubmit() }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1767,6 +1767,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
                 images: images,
                 files: files
             )
+            delegate?.unifiedToggleInputDidSubmitDuckAIPrompt(origin: pixelReporter.currentPromptOrigin())
             recordDuckAIPromptDelivered(wasQueued: false, didSendBridgeMessage: nil)
             clearAttachments()
             setText("")
@@ -1793,6 +1794,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
         if let userScript {
             let didSendBridgeMessage = userScript.canDispatchBridgeMessages
             userScript.submitPrompt(text, images: images, files: files, modelId: configuration.modelId, tools: tools, reasoningEffort: configuration.reasoningEffort)
+            delegate?.unifiedToggleInputDidSubmitDuckAIPrompt(origin: pixelReporter.currentPromptOrigin())
             recordDuckAIPromptDelivered(wasQueued: false, didSendBridgeMessage: didSendBridgeMessage)
         } else {
             delegate?.unifiedToggleInputDidSubmitPrompt(text, modelId: configuration.modelId, tools: tools, reasoningEffort: configuration.reasoningEffort, images: images, files: files)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputDelegate.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputDelegate.swift
@@ -24,9 +24,6 @@ protocol UnifiedToggleInputDelegate: AnyObject {
     func unifiedToggleInputDidSubmitPrompt(_ prompt: String, modelId: String?, tools: [AIChatRAGTool]?, reasoningEffort: AIChatReasoningEffort?, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?)
     /// Nothing to deliver, only the moment — reported before the keyboard takes the surface with it.
     func unifiedToggleInputDidSubmitPromptToBoundChat()
-    /// A prompt was delivered with nothing navigating behind it to report the submission — the
-    /// contextual sheet, or the chat already bound to this input. `origin` matches the `origin`
-    /// the submission pixels carry.
     func unifiedToggleInputDidSubmitDuckAIPrompt(origin: AIChatEntryPointSource?)
     func unifiedToggleInputDidSubmitQuery(_ query: String)
     func unifiedToggleInputDidRequestVoiceSearch()

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputDelegate.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputDelegate.swift
@@ -24,6 +24,10 @@ protocol UnifiedToggleInputDelegate: AnyObject {
     func unifiedToggleInputDidSubmitPrompt(_ prompt: String, modelId: String?, tools: [AIChatRAGTool]?, reasoningEffort: AIChatReasoningEffort?, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?)
     /// Nothing to deliver, only the moment — reported before the keyboard takes the surface with it.
     func unifiedToggleInputDidSubmitPromptToBoundChat()
+    /// A prompt was delivered with nothing navigating behind it to report the submission — the
+    /// contextual sheet, or the chat already bound to this input. `origin` matches the `origin`
+    /// the submission pixels carry.
+    func unifiedToggleInputDidSubmitDuckAIPrompt(origin: AIChatEntryPointSource?)
     func unifiedToggleInputDidSubmitQuery(_ query: String)
     func unifiedToggleInputDidRequestVoiceSearch()
     func unifiedToggleInputDidRequestAIVoiceChat()
@@ -43,6 +47,7 @@ protocol UnifiedToggleInputDelegate: AnyObject {
 
 extension UnifiedToggleInputDelegate {
     func unifiedToggleInputDidSubmitPromptToBoundChat() {}
+    func unifiedToggleInputDidSubmitDuckAIPrompt(origin: AIChatEntryPointSource?) {}
     func unifiedToggleInputDismissSnapshot() -> UTIDismissSnapshot { .empty }
     func unifiedToggleInputDidTapClearText() {}
     func unifiedToggleInputDidTapToActivate() {}

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -131,6 +131,13 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         func aiChatContextualSheetCoordinatorDidRequestNewVoiceChat(_ coordinator: AIChatContextualSheetCoordinator) {
             newVoiceChatCallCount += 1
         }
+
+        var submittedPromptOrigins: [AIChatEntryPointSource?] = []
+
+        func aiChatContextualSheetCoordinator(_ coordinator: AIChatContextualSheetCoordinator,
+                                              didSubmitDuckAIPromptWithOrigin origin: AIChatEntryPointSource?) {
+            submittedPromptOrigins.append(origin)
+        }
     }
 
     private final class MockPresentingViewController: UIViewController {

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -270,13 +270,30 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
     }
 
     @MainActor
-    func testNativePromptSubmissionCompletesSelectionJourney() async throws {
+    func testNativePromptSubmissionWithoutPageContextCompletesSelectionJourneyAndReportsContextualOrigin() async throws {
         await sut.handleSelectionAction(.ask, selection: .init(text: "selected text", url: nil, faviconBase64: nil), from: mockPresentingVC)
         let sheet = try XCTUnwrap(sut.sheetViewController)
+        XCTAssertEqual(sut.sessionState.chipState, .placeholder)
 
         sut.aiChatContextualSheetViewController(sheet, didSubmitPrompt: "What does this mean?")
 
         XCTAssertEqual(mockSelectionJourneyInstrumentation.promptSubmittedCount, 1)
+        XCTAssertEqual(mockDelegate.submittedPromptOrigins, [.contextualChat])
+    }
+
+    @MainActor
+    func testNativePromptSubmissionWithPageContextReportsContextualOrigin() async throws {
+        await sut.presentSheet(from: mockPresentingVC)
+        let sheet = try XCTUnwrap(sut.sheetViewController)
+        sut.sessionState.attachContextFromSuggestionTap(makeTestContext())
+        guard case .attached = sut.sessionState.chipState else {
+            XCTFail("Expected page context to be attached")
+            return
+        }
+
+        sut.aiChatContextualSheetViewController(sheet, didSubmitPrompt: "Summarize this page")
+
+        XCTAssertEqual(mockDelegate.submittedPromptOrigins, [.contextualChat])
     }
 
     @MainActor

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualUTIHostTests.swift
@@ -90,6 +90,16 @@ final class AIChatContextualUTIHostTests: XCTestCase {
         XCTAssertEqual(voiceCallCount, 1)
     }
 
+    func test_duckAIPromptSubmission_forwardsContextualOrigin() {
+        var submittedOrigins: [AIChatEntryPointSource?] = []
+        makeSUT()
+        sut.onDuckAIPromptSubmitted = { submittedOrigins.append($0) }
+
+        sut.unifiedToggleInputDidSubmitDuckAIPrompt(origin: .contextualChat)
+
+        XCTAssertEqual(submittedOrigins, [.contextualChat])
+    }
+
     func test_chipRemoveAction_firesRemoveCallbackOnly() {
         let url = URL(string: "https://example.com/a")!
         var removeCallCount = 0

--- a/iOS/DuckDuckGoTests/AIChat/OpenAIChatFromAddressBarHandlingTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/OpenAIChatFromAddressBarHandlingTests.swift
@@ -106,6 +106,15 @@ final class OpenAIChatFromAddressBarHandlingTests: XCTestCase {
         wait(for: [ex], timeout: 1.0) // Timeout not strictly needed as it's sync
     }
 
+    func testAutoSubmittedDuckAIPromptRequiresContentAndAutoSend() {
+        XCTAssertFalse(MainViewController.hasAutoSubmittedDuckAIPrompt(query: nil, autoSend: true, hasAttachments: false))
+        XCTAssertFalse(MainViewController.hasAutoSubmittedDuckAIPrompt(query: "   ", autoSend: true, hasAttachments: false))
+        XCTAssertFalse(MainViewController.hasAutoSubmittedDuckAIPrompt(query: "prompt", autoSend: false, hasAttachments: false))
+        XCTAssertFalse(MainViewController.hasAutoSubmittedDuckAIPrompt(query: nil, autoSend: false, hasAttachments: true))
+        XCTAssertTrue(MainViewController.hasAutoSubmittedDuckAIPrompt(query: "prompt", autoSend: true, hasAttachments: false))
+        XCTAssertTrue(MainViewController.hasAutoSubmittedDuckAIPrompt(query: nil, autoSend: true, hasAttachments: true))
+    }
+
 }
 
 private extension URL {

--- a/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
@@ -366,6 +366,75 @@ struct PostIdleSessionInstrumentationTests {
         #expect(lastReturnCompletion(wideEvent)?.0.promptOrigin == nil)
     }
 
+    // MARK: - Prompt submissions with no navigation
+
+    @available(iOS 16, *)
+    @Test("promptSubmittedWithoutNavigation ends the return session with the origin", .timeLimit(.minutes(1)))
+    func promptSubmittedWithoutNavigationEndsReturnSessionWithOrigin() {
+        let (sut, wideEvent, clock) = makeSUT()
+        sut.sessionStarted(landedOn: .duckAI, afterIdleSurface: nil, focused: false)
+        clock.advance(by: 3)
+        sut.promptSubmittedWithoutNavigation(origin: .addressBarIcon)
+
+        guard let completion = lastReturnCompletion(wideEvent) else {
+            Issue.record("Expected a return-session completion")
+            return
+        }
+        #expect(completion.0.statusReason == .aiPromptSubmitted)
+        #expect(completion.0.promptOrigin == "address_bar_icon")
+        #expect(completion.0.sessionInterval.end == clock.now)
+        if case .success(let reason) = completion.1 {
+            #expect(reason == "ai_prompt_submitted")
+        } else {
+            Issue.record("Expected .success status, got \(completion.1)")
+        }
+    }
+
+    @available(iOS 16, *)
+    @Test("promptSubmittedWithoutNavigation leaves the post-idle flow running", .timeLimit(.minutes(1)))
+    func promptSubmittedWithoutNavigationLeavesPostIdleFlowRunning() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(landedOn: .duckAI, afterIdleSurface: .lut, focused: false)
+        sut.promptSubmittedWithoutNavigation(origin: .addressBarIcon)
+
+        #expect(lastCompletion(wideEvent) == nil)
+
+        sut.sessionCancelledByBackground()
+        #expect(lastCompletion(wideEvent)?.0.statusReason == .appBackgrounded)
+    }
+
+    @available(iOS 16, *)
+    @Test("promptSubmittedWithoutNavigation omits the origin when the caller has none", .timeLimit(.minutes(1)))
+    func promptSubmittedWithoutNavigationOmitsOriginWhenAbsent() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(landedOn: .duckAI, afterIdleSurface: nil, focused: false)
+        sut.promptSubmittedWithoutNavigation(origin: nil)
+
+        #expect(lastReturnCompletion(wideEvent)?.0.statusReason == .aiPromptSubmitted)
+        #expect(lastReturnCompletion(wideEvent)?.0.promptOrigin == nil)
+    }
+
+    @available(iOS 16, *)
+    @Test("A second no-navigation submission in the same session is a no-op", .timeLimit(.minutes(1)))
+    func secondPromptSubmittedWithoutNavigationIsNoop() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(landedOn: .duckAI, afterIdleSurface: nil, focused: false)
+        sut.promptSubmittedWithoutNavigation(origin: .addressBarIcon)
+        sut.promptSubmittedWithoutNavigation(origin: .contextualChat)
+
+        let returnCompletions = wideEvent.completions.filter { $0.0 is ReturnSessionWideEventData }
+        #expect(returnCompletions.count == 1)
+        #expect(lastReturnCompletion(wideEvent)?.0.promptOrigin == "address_bar_icon")
+    }
+
+    @available(iOS 16, *)
+    @Test("When no active session then promptSubmittedWithoutNavigation is a no-op", .timeLimit(.minutes(1)))
+    func promptSubmittedWithoutNavigationWithoutActiveSessionIsNoop() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.promptSubmittedWithoutNavigation(origin: .addressBarIcon)
+        #expect(wideEvent.completions.isEmpty)
+    }
+
     @available(iOS 16, *)
     @Test("The post-idle flow collapses the submission split back onto bar_used", .timeLimit(.minutes(1)))
     func postIdleFlowCollapsesSubmissionsOntoBarUsed() {

--- a/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/PostIdleSessionInstrumentationTests.swift
@@ -436,6 +436,28 @@ struct PostIdleSessionInstrumentationTests {
     }
 
     @available(iOS 16, *)
+    @Test("duckAIOpenedWithoutPrompt ends the post-idle flow as bar_used and leaves the return session running", .timeLimit(.minutes(1)))
+    func duckAIOpenedWithoutPromptEndsPostIdleOnly() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.sessionStarted(landedOn: .ntp, afterIdleSurface: .lut, focused: false)
+        sut.duckAIOpenedWithoutPrompt()
+
+        #expect(lastCompletion(wideEvent)?.0.statusReason == .barUsed)
+        #expect(lastReturnCompletion(wideEvent) == nil)
+
+        sut.sessionCancelledByBackground()
+        #expect(lastReturnCompletion(wideEvent)?.0.statusReason == .appBackgrounded)
+    }
+
+    @available(iOS 16, *)
+    @Test("When no active session then duckAIOpenedWithoutPrompt is a no-op", .timeLimit(.minutes(1)))
+    func duckAIOpenedWithoutPromptWithoutActiveSessionIsNoop() {
+        let (sut, wideEvent, _) = makeSUT()
+        sut.duckAIOpenedWithoutPrompt()
+        #expect(wideEvent.completions.isEmpty)
+    }
+
+    @available(iOS 16, *)
     @Test("The post-idle flow collapses the submission split back onto bar_used", .timeLimit(.minutes(1)))
     func postIdleFlowCollapsesSubmissionsOntoBarUsed() {
         for reason in [ReturnSessionWideEventData.StatusReason.searchSubmitted, .aiPromptSubmitted, .urlSubmitted] {

--- a/iOS/DuckDuckGoTests/ReturnSessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/ReturnSessionWideEventDataTests.swift
@@ -31,7 +31,7 @@ struct ReturnSessionWideEventDataTests {
     @Test("Metadata exposes expected pixel and feature names", .timeLimit(.minutes(1)))
     func metadataExposesExpectedNames() {
         #expect(ReturnSessionWideEventData.metadata.pixelName == "return_session")
-        #expect(ReturnSessionWideEventData.metadata.featureName == "return_session")
+        #expect(ReturnSessionWideEventData.metadata.featureName == "return-session")
         #expect(ReturnSessionWideEventData.metadata.type == "ios-return-session")
         #expect(ReturnSessionWideEventData.metadata.version == "1.2.0")
     }

--- a/iOS/DuckDuckGoTests/ReturnSessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/ReturnSessionWideEventDataTests.swift
@@ -31,9 +31,9 @@ struct ReturnSessionWideEventDataTests {
     @Test("Metadata exposes expected pixel and feature names", .timeLimit(.minutes(1)))
     func metadataExposesExpectedNames() {
         #expect(ReturnSessionWideEventData.metadata.pixelName == "return_session")
-        #expect(ReturnSessionWideEventData.metadata.featureName == "return-session")
+        #expect(ReturnSessionWideEventData.metadata.featureName == "return_session")
         #expect(ReturnSessionWideEventData.metadata.type == "ios-return-session")
-        #expect(ReturnSessionWideEventData.metadata.version == "1.1.0")
+        #expect(ReturnSessionWideEventData.metadata.version == "1.2.0")
     }
 
     // MARK: - jsonParameters
@@ -48,7 +48,7 @@ struct ReturnSessionWideEventDataTests {
         #expect(params["feature.data.ext.focused"] as? Bool == false)
         #expect(params["feature.data.ext.time_away_ms_bucketed"] == nil)
         #expect(params["feature.data.ext.status_reason"] == nil)
-        #expect(params["feature.data.ext.prompt_origin"] == nil)
+        #expect(params["feature.data.ext.source"] == nil)
         #expect(params["feature.data.ext.session_duration_ms_bucketed"] == nil)
         #expect(params["feature.data.ext.time_to_first_interaction_ms_bucketed"] == nil)
         #expect(params["feature.data.ext.page_engaged"] as? Bool == false)
@@ -103,24 +103,43 @@ struct ReturnSessionWideEventDataTests {
     }
 
     @available(iOS 16, *)
-    @Test("Prompt origin emits its value when set", .timeLimit(.minutes(1)))
-    func promptOriginEmitsWhenSet() {
+    @Test("Prompt source emits its value when set", .timeLimit(.minutes(1)))
+    func promptSourceEmitsWhenSet() {
         let data = ReturnSessionWideEventData(landedOn: .ntp, afterIdle: true)
         data.statusReason = .aiPromptSubmitted
         data.promptOrigin = AIChatEntryPointSource.addressBarPrompt.rawValue
 
         let params = data.jsonParameters()
         #expect(params["feature.data.ext.status_reason"] as? String == "ai_prompt_submitted")
-        #expect(params["feature.data.ext.prompt_origin"] as? String == "address_bar_prompt")
+        #expect(params["feature.data.ext.source"] as? String == "address_bar_prompt")
+        #expect(params["feature.data.ext.prompt_origin"] == nil)
     }
 
     @available(iOS 16, *)
-    @Test("Prompt origin is absent when nil", .timeLimit(.minutes(1)))
-    func promptOriginAbsentWhenNil() {
+    @Test("Prompt source is absent when nil", .timeLimit(.minutes(1)))
+    func promptSourceAbsentWhenNil() {
         let data = ReturnSessionWideEventData(landedOn: .ntp, afterIdle: true)
         data.statusReason = .searchSubmitted
 
-        #expect(data.jsonParameters()["feature.data.ext.prompt_origin"] == nil)
+        #expect(data.jsonParameters()["feature.data.ext.source"] == nil)
+    }
+
+    @available(iOS 16, *)
+    @Test("Prompt source is omitted for non-AI terminals", .timeLimit(.minutes(1)))
+    func promptSourceOmittedForNonAITerminal() {
+        let data = ReturnSessionWideEventData(landedOn: .ntp, afterIdle: true)
+        data.statusReason = .searchSubmitted
+        data.promptOrigin = AIChatEntryPointSource.addressBarPrompt.rawValue
+
+        #expect(data.jsonParameters()["feature.data.ext.source"] == nil)
+    }
+
+    @available(iOS 16, *)
+    @Test("Return sessions are sampled at 100 percent", .timeLimit(.minutes(1)))
+    func returnSessionsUseFullSampling() {
+        let data = ReturnSessionWideEventData(landedOn: .ntp, afterIdle: false)
+
+        #expect(data.globalData.sampleRate == 1.0)
     }
 
     @available(iOS 16, *)

--- a/iOS/DuckDuckGoTests/ReturnSessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/ReturnSessionWideEventDataTests.swift
@@ -116,6 +116,15 @@ struct ReturnSessionWideEventDataTests {
     }
 
     @available(iOS 16, *)
+    @Test("Prompt source reports unknown for unattributed AI submissions", .timeLimit(.minutes(1)))
+    func promptSourceReportsUnknownWhenUnattributed() {
+        let data = ReturnSessionWideEventData(landedOn: .ntp, afterIdle: true)
+        data.statusReason = .aiPromptSubmitted
+
+        #expect(data.jsonParameters()["feature.data.ext.source"] as? String == "unknown")
+    }
+
+    @available(iOS 16, *)
     @Test("Prompt source is absent when nil", .timeLimit(.minutes(1)))
     func promptSourceAbsentWhenNil() {
         let data = ReturnSessionWideEventData(landedOn: .ntp, afterIdle: true)

--- a/iOS/DuckDuckGoTests/TabTests.swift
+++ b/iOS/DuckDuckGoTests/TabTests.swift
@@ -504,6 +504,24 @@ class TabTests: XCTestCase {
         XCTAssertNil(tab?.unifiedInputState.selectedTool)
     }
 
+    func testWhenTabEncodedBeforeDuckAIEntrySourceAddedThenDecodesWithNil() {
+        let tab = Tab(coder: CoderStub(properties: ["link": link(), "viewed": false]))
+
+        XCTAssertNotNil(tab)
+        XCTAssertNil(tab?.duckAIEntrySource)
+    }
+
+    func testWhenTabHasInvalidDuckAIEntrySourceRawValueThenDecodesAsNil() {
+        let tab = Tab(coder: CoderStub(properties: [
+            "link": link(),
+            "viewed": false,
+            "duckAIEntrySource": "not-a-real-source"
+        ]))
+
+        XCTAssertNotNil(tab)
+        XCTAssertNil(tab?.duckAIEntrySource)
+    }
+
     // MARK: - promptPageType
 
     func testWhenTabHasNoLinkThenPromptPageTypeIsNTP() {

--- a/iOS/DuckDuckGoTests/TabsModelTests.swift
+++ b/iOS/DuckDuckGoTests/TabsModelTests.swift
@@ -370,6 +370,56 @@ class TabsModelTests: XCTestCase {
         XCTAssertNil(model.currentIndex)
     }
 
+    // MARK: - Duck.ai Entry Source
+
+    func testWhenSwitchingDuckAITabsThenEachTabKeepsItsOriginalEntrySource() {
+        let firstTab = Tab(link: exampleLink, duckAIEntrySource: .addressBarPrompt)
+        let secondTab = Tab(link: exampleLink, duckAIEntrySource: .contextualChat)
+        let model = TabsModel(tabs: [firstTab, secondTab], currentIndex: 0, desktop: false)
+
+        XCTAssertEqual(model.currentTab?.duckAIEntrySource, .addressBarPrompt)
+
+        model.select(tab: secondTab)
+
+        XCTAssertEqual(model.currentTab?.duckAIEntrySource, .contextualChat)
+        XCTAssertEqual(firstTab.duckAIEntrySource, .addressBarPrompt)
+    }
+
+    func testWhenTabWithDuckAIEntrySourceIsArchivedThenUnarchivedTabRestoresIt() throws {
+        let tab = Tab(link: exampleLink)
+        tab.duckAIEntrySource = .serp
+
+        let data = try NSKeyedArchiver.archivedData(withRootObject: tab, requiringSecureCoding: false)
+        let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+        unarchiver.requiresSecureCoding = false
+        let decoded = unarchiver.decodeObject(of: Tab.self, forKey: NSKeyedArchiveRootObjectKey)
+
+        XCTAssertEqual(decoded?.duckAIEntrySource, .serp)
+    }
+
+    func testWhenTabWithoutDuckAIEntrySourceIsArchivedThenUnarchivedTabHasNilSource() throws {
+        let tab = Tab(link: exampleLink)
+
+        let data = try NSKeyedArchiver.archivedData(withRootObject: tab, requiringSecureCoding: false)
+        let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+        unarchiver.requiresSecureCoding = false
+        let decoded = unarchiver.decodeObject(of: Tab.self, forKey: NSKeyedArchiveRootObjectKey)
+
+        XCTAssertNil(decoded?.duckAIEntrySource)
+    }
+
+    func testWhenFireTabWithDuckAIEntrySourceIsArchivedThenUnarchivedTabRestoresIt() throws {
+        let tab = Tab(link: exampleLink, fireTab: true)
+        tab.duckAIEntrySource = .addressBarPrompt
+
+        let data = try NSKeyedArchiver.archivedData(withRootObject: tab, requiringSecureCoding: false)
+        let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+        unarchiver.requiresSecureCoding = false
+        let decoded = unarchiver.decodeObject(of: Tab.self, forKey: NSKeyedArchiveRootObjectKey)
+
+        XCTAssertEqual(decoded?.duckAIEntrySource, .addressBarPrompt)
+    }
+
     // MARK: - NSCopying
 
     func testWhenTabSnapshotTakenThenAllPersistedFieldsArePreserved() {
@@ -387,7 +437,8 @@ class TabsModelTests: XCTestCase {
                       contextualChatURL: "https://chat.example.com",
                       supportsTabHistory: true,
                       fireTab: false,
-                      unifiedInputState: unifiedState)
+                      unifiedInputState: unifiedState,
+                      duckAIEntrySource: .widgetFavorite)
 
         let snapshot = tab.archivalSnapshot()
 
@@ -405,6 +456,7 @@ class TabsModelTests: XCTestCase {
         XCTAssertEqual(snapshot.supportsTabHistory, true)
         XCTAssertEqual(snapshot.fireTab, false)
         XCTAssertEqual(snapshot.unifiedInputState, unifiedState)
+        XCTAssertEqual(snapshot.duckAIEntrySource, .widgetFavorite)
     }
 
     func testWhenModelSnapshotTakenThenMutatingSourceDoesNotAffectSnapshot() {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIPixelReporterTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UTIPixelReporterTests.swift
@@ -114,6 +114,23 @@ final class UTIPixelReporterTests: XCTestCase {
         ])
     }
 
+    // MARK: - Prompt origin
+
+    func testCurrentPromptOriginMatchesTheSurfaceTheSubmissionPixelsReport() {
+        XCTAssertEqual(makeReporter { self.context(surface: .addressBar) }.currentPromptOrigin(), .addressBarPrompt)
+        XCTAssertEqual(makeReporter { self.context(surface: .contextualChat) }.currentPromptOrigin(), .contextualChat)
+        XCTAssertEqual(makeReporter { self.context(surface: .duckAI, duckAIEntrySource: .tabSwitcher) }.currentPromptOrigin(),
+                       .tabSwitcher)
+    }
+
+    func testCurrentPromptOriginIsNilOnADuckAISurfaceWithNoRecordedEntry() {
+        XCTAssertNil(makeReporter { self.context(surface: .duckAI, duckAIEntrySource: nil) }.currentPromptOrigin())
+    }
+
+    func testCurrentPromptOriginIsNilWhenTheCoordinatorIsGone() {
+        XCTAssertNil(makeReporter { nil }.currentPromptOrigin())
+    }
+
     // MARK: - Prompt submission (daily, non-trivial params)
 
     func testReportPromptSubmittedFiresDailyWithResolvedSurface() {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -380,6 +380,26 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
                       "Empty model list ⇒ no access-checked selectedModel ⇒ block must remain")
     }
 
+    // MARK: - Bound-chat prompt submission reporting
+
+    func testWhenPromptGoesToBoundChatThenTheSubmissionIsReportedOnce() {
+        sut.duckAIEntrySourceProvider = { .addressBarIcon }
+        let userScript = makeBridgeReadyUserScript()
+        sut.bindToTab(userScript, hasExistingChat: true)
+
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "follow-up", mode: .aiChat)
+
+        XCTAssertEqual(mockDelegate.duckAIPromptSubmissionOrigins.count, 1)
+        XCTAssertNil(mockDelegate.submittedPrompt, "A bound chat takes the prompt directly, without navigation")
+    }
+
+    func testWhenNoChatIsBoundThenTheSubmissionIsNotReportedAsBoundChat() {
+        sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "a new prompt", mode: .aiChat)
+
+        XCTAssertTrue(mockDelegate.duckAIPromptSubmissionOrigins.isEmpty)
+        XCTAssertEqual(mockDelegate.submittedPrompt, "a new prompt")
+    }
+
     // MARK: - Recovery Picker Session Pixels
 
     func test_recoveryPickerSession_fullFunnel_smokeTest() {
@@ -3021,6 +3041,10 @@ private final class MockUnifiedToggleInputDelegate: UnifiedToggleInputDelegate {
     }
     func unifiedToggleInputDidRequestFire() {}
     func unifiedToggleInputDidRequestAppMenu() { didRequestAppMenuCount += 1 }
+    var duckAIPromptSubmissionOrigins: [AIChatEntryPointSource?] = []
+    func unifiedToggleInputDidSubmitDuckAIPrompt(origin: AIChatEntryPointSource?) {
+        duckAIPromptSubmissionOrigins.append(origin)
+    }
 }
 
 private final class MockAIChatPreferences: AIChatPreferencesPersisting {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -389,7 +389,7 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
 
         sut.unifiedToggleInputVC(sut.viewController, didSubmitText: "follow-up", mode: .aiChat)
 
-        XCTAssertEqual(mockDelegate.duckAIPromptSubmissionOrigins.count, 1)
+        XCTAssertEqual(mockDelegate.duckAIPromptSubmissionOrigins, [.addressBarIcon])
         XCTAssertNil(mockDelegate.submittedPrompt, "A bound chat takes the prompt directly, without navigation")
     }
 

--- a/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
@@ -30,7 +30,7 @@
                 "key": "feature.name",
                 "type": "string",
                 "description": "Feature identifier for this wide pixel",
-                "enum": ["return_session"]
+                "enum": ["return-session"]
             },
 
             // Feature data

--- a/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
@@ -30,7 +30,7 @@
                 "key": "feature.name",
                 "type": "string",
                 "description": "Feature identifier for this wide pixel",
-                "enum": ["return-session"]
+                "enum": ["return_session"]
             },
 
             // Feature data
@@ -73,9 +73,9 @@
                 ]
             },
             {
-                "key": "feature.data.ext.prompt_origin",
+                "key": "feature.data.ext.source",
                 "type": "string",
-                "description": "What triggered the Duck.ai prompt submission that ended the session, as an m_aichat_entry_point source value. Present only when status_reason is ai_prompt_submitted.",
+                "description": "The Duck.ai entry point that triggered the session's ai_prompt_submitted terminal, as an m_aichat_entry_point source value. Present only when status_reason is ai_prompt_submitted.",
                 "enum": [
                     "address_bar_prompt",
                     "address_bar_icon",

--- a/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/return_session_wide_event.json5
@@ -75,7 +75,7 @@
             {
                 "key": "feature.data.ext.source",
                 "type": "string",
-                "description": "The Duck.ai entry point that triggered the session's ai_prompt_submitted terminal, as an m_aichat_entry_point source value. Present only when status_reason is ai_prompt_submitted.",
+                "description": "The Duck.ai entry point that triggered the session's ai_prompt_submitted terminal, as an m_aichat_entry_point source value, or unknown when the entry point could not be attributed. Present only when status_reason is ai_prompt_submitted.",
                 "enum": [
                     "address_bar_prompt",
                     "address_bar_icon",
@@ -101,7 +101,8 @@
                     "widget_lock_screen",
                     "widget_control_center",
                     "siri",
-                    "deep_link_other"
+                    "deep_link_other",
+                    "unknown"
                 ]
             },
             {

--- a/iOS/PixelDefinitions/wide_events/definitions/return-session.json5
+++ b/iOS/PixelDefinitions/wide_events/definitions/return-session.json5
@@ -4,10 +4,10 @@
         "owners": ["Bunn", "SabrinaTardio"],
         "meta": {
             "type": "ios-return-session",
-            "version": "1.0"
+            "version": "2.0"
         },
         "feature": {
-            "name": "return-session",
+            "name": "return_session",
             "status": ["SUCCESS", "CANCELLED", "UNKNOWN"],
             "data": {
                 "ext": {
@@ -44,9 +44,9 @@
                             "app_terminated"
                         ]
                     },
-                    "prompt_origin": {
+                    "source": {
                         "type": "string",
-                        "description": "What triggered the Duck.ai prompt submission that ended the session, as an m_aichat_entry_point source value. Present only when status_reason is ai_prompt_submitted; absent otherwise.",
+                        "description": "The Duck.ai entry point that triggered the session's ai_prompt_submitted terminal, as an m_aichat_entry_point source value. Present only when status_reason is ai_prompt_submitted; absent otherwise.",
                         "enum": [
                             "address_bar_prompt",
                             "address_bar_icon",

--- a/iOS/PixelDefinitions/wide_events/definitions/return-session.json5
+++ b/iOS/PixelDefinitions/wide_events/definitions/return-session.json5
@@ -1,7 +1,7 @@
 {
     "ios-return-session": {
         "description": "Sent at the end of a return session: every return to the app, whether it got an after-idle treatment (the NTP or LUT shown once the After Inactivity threshold elapses) or was an ordinary return. Captures where the user landed, what they did there, and how the session ended. `ios-post-idle-session` stays scoped to after-idle returns and runs alongside this event.",
-        "owners": ["Bunn", "SabrinaTardio"],
+        "owners": ["Bunn"],
         "meta": {
             "type": "ios-return-session",
             "version": "2.0"

--- a/iOS/PixelDefinitions/wide_events/definitions/return-session.json5
+++ b/iOS/PixelDefinitions/wide_events/definitions/return-session.json5
@@ -7,7 +7,7 @@
             "version": "2.0"
         },
         "feature": {
-            "name": "return_session",
+            "name": "return-session",
             "status": ["SUCCESS", "CANCELLED", "UNKNOWN"],
             "data": {
                 "ext": {

--- a/iOS/PixelDefinitions/wide_events/definitions/return-session.json5
+++ b/iOS/PixelDefinitions/wide_events/definitions/return-session.json5
@@ -46,7 +46,7 @@
                     },
                     "source": {
                         "type": "string",
-                        "description": "The Duck.ai entry point that triggered the session's ai_prompt_submitted terminal, as an m_aichat_entry_point source value. Present only when status_reason is ai_prompt_submitted; absent otherwise.",
+                        "description": "The Duck.ai entry point that triggered the session's ai_prompt_submitted terminal, as an m_aichat_entry_point source value, or unknown when the entry point could not be attributed. Present only when status_reason is ai_prompt_submitted; absent otherwise.",
                         "enum": [
                             "address_bar_prompt",
                             "address_bar_icon",
@@ -72,7 +72,8 @@
                             "widget_lock_screen",
                             "widget_control_center",
                             "siri",
-                            "deep_link_other"
+                            "deep_link_other",
+                            "unknown"
                         ]
                     },
                     "session_duration_ms_bucketed": {

--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-return-session-1.2.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-return-session-1.2.0.json
@@ -95,7 +95,7 @@
                                 },
                                 "source": {
                                     "type": "string",
-                                    "description": "The Duck.ai entry point that triggered the session's ai_prompt_submitted terminal, as an m_aichat_entry_point source value. Present only when status_reason is ai_prompt_submitted; absent otherwise.",
+                                    "description": "The Duck.ai entry point that triggered the session's ai_prompt_submitted terminal, as an m_aichat_entry_point source value, or unknown when the entry point could not be attributed. Present only when status_reason is ai_prompt_submitted; absent otherwise.",
                                     "enum": [
                                         "address_bar_prompt",
                                         "address_bar_icon",
@@ -121,7 +121,8 @@
                                         "widget_lock_screen",
                                         "widget_control_center",
                                         "siri",
-                                        "deep_link_other"
+                                        "deep_link_other",
+                                        "unknown"
                                     ]
                                 },
                                 "session_duration_ms_bucketed": {

--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-return-session-1.2.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-return-session-1.2.0.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Sent at the end of a return session: every return to the app, whether it got an after-idle treatment (the NTP or LUT shown once the After Inactivity threshold elapses) or was an ordinary return. Captures where the user landed, what they did there, and how the session ended. `ios-post-idle-session` stays scoped to after-idle returns and runs alongside this event.",
-    "$comment": "{\"owners\":[\"Bunn\",\"SabrinaTardio\"]}",
+    "$comment": "{\"owners\":[\"Bunn\"]}",
     "type": "object",
     "required": ["meta", "global", "feature", "app"],
     "additionalProperties": false,

--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-return-session-1.2.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-return-session-1.2.0.json
@@ -45,7 +45,7 @@
             "required": ["name", "status", "data"],
             "additionalProperties": false,
             "properties": {
-                "name": { "type": "string", "description": "The feature name for this event", "enum": ["return_session"] },
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["return-session"] },
                 "status": {
                     "type": "string",
                     "description": "The overall status of the operation",

--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-return-session-1.2.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-return-session-1.2.0.json
@@ -1,0 +1,168 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Sent at the end of a return session: every return to the app, whether it got an after-idle treatment (the NTP or LUT shown once the After Inactivity threshold elapses) or was an ordinary return. Captures where the user landed, what they did there, and how the session ended. `ios-post-idle-session` stays scoped to after-idle returns and runs alongside this event.",
+    "$comment": "{\"owners\":[\"Bunn\",\"SabrinaTardio\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "ios-return-session" }, "version": { "const": "1.2.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application",
+                    "enum": ["DuckDuckGo", "DuckDuckGo-Alpha", "DuckDuckGo-Experimental", "PacketTunnelProvider"]
+                },
+                "version": { "type": "string", "description": "The version of the application", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+                "form_factor": { "type": "string", "description": "The form factor of the device", "enum": ["phone", "tablet"] }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["iOS"] },
+                "type": { "type": "string", "description": "The type of application", "enum": ["app"] },
+                "sample_rate": { "type": "number", "description": "Sample rate for this event", "minimum": 0, "maximum": 1 },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first occurrence of this event today. Only included when true."
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["return_session"] },
+                "status": {
+                    "type": "string",
+                    "description": "The overall status of the operation",
+                    "enum": ["SUCCESS", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "after_idle": {
+                                    "type": "boolean",
+                                    "description": "True when the session was started by an after-idle treatment; false for an ordinary return. Filtering after_idle=true gives the population `ios-post-idle-session` reports on."
+                                },
+                                "landed_on": {
+                                    "type": "string",
+                                    "description": "What the user actually landed on: the after-idle NTP, an NTP reached without the treatment, or the resumed tab's content type",
+                                    "enum": ["ntp", "ntp_user_initiated", "web", "serp", "duck_ai"]
+                                },
+                                "focused": {
+                                    "type": "boolean",
+                                    "description": "True when the landing surface appeared with the address bar focused (keyboard up)"
+                                },
+                                "time_away_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time the app spent in the background before this return, bucketed (lower end of bucket, in ms). Absent when there was no prior background date.",
+                                    "enum": ["0", "60000", "300000", "900000", "1800000", "3600000"]
+                                },
+                                "status_reason": {
+                                    "type": "string",
+                                    "description": "Terminal reason describing how the session ended. SUCCESS uses one of the user-action reasons; CANCELLED uses app_backgrounded; UNKNOWN uses app_terminated when an in-flight session is recovered after an app crash or termination. The three submission reasons are what `ios-post-idle-session` reports as a single bar_used.",
+                                    "enum": [
+                                        "search_submitted",
+                                        "ai_prompt_submitted",
+                                        "url_submitted",
+                                        "return_to_page_tapped",
+                                        "tab_switcher_selected",
+                                        "app_backgrounded",
+                                        "favorite_selected",
+                                        "chat_selected",
+                                        "app_terminated"
+                                    ]
+                                },
+                                "source": {
+                                    "type": "string",
+                                    "description": "The Duck.ai entry point that triggered the session's ai_prompt_submitted terminal, as an m_aichat_entry_point source value. Present only when status_reason is ai_prompt_submitted; absent otherwise.",
+                                    "enum": [
+                                        "address_bar_prompt",
+                                        "address_bar_icon",
+                                        "address_bar_shortcut_chip",
+                                        "address_bar_editing_state",
+                                        "suggestion_ask_ai",
+                                        "ipad_toggle_prompt",
+                                        "browsing_menu_ntp",
+                                        "browsing_menu_webpage",
+                                        "tab_switcher",
+                                        "tabs_bar_button",
+                                        "chat_history_new_chat",
+                                        "chat_history_open_chat",
+                                        "voice",
+                                        "onboarding",
+                                        "direct_url",
+                                        "serp",
+                                        "icon_shortcut",
+                                        "contextual_chat",
+                                        "widget_quick_actions",
+                                        "widget_quick_actions_medium",
+                                        "widget_favorite",
+                                        "widget_lock_screen",
+                                        "widget_control_center",
+                                        "siri",
+                                        "deep_link_other"
+                                    ]
+                                },
+                                "session_duration_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Total time the landing surface was visible, from session start until the terminal action or background, bucketed (lower end of bucket, in ms). Absent when the session was orphaned (UNKNOWN / app_terminated).",
+                                    "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "time_to_first_interaction_ms_bucketed": {
+                                    "type": "string",
+                                    "description": "Time from session start to the first user interaction with the landing surface (page engagement, toggle, back, or terminal action), bucketed (lower end of bucket, in ms). Absent if the session ended without any interaction.",
+                                    "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+                                },
+                                "page_engaged": {
+                                    "type": "boolean",
+                                    "description": "True if the user scrolled or activated an in-page link on the landing surface during the session"
+                                },
+                                "toggle_used": {
+                                    "type": "boolean",
+                                    "description": "True if the user toggled between Search and Duck.ai during the session"
+                                },
+                                "back_pressed": {
+                                    "type": "boolean",
+                                    "description": "True if the user pressed back / cancel from the landing surface during the session"
+                                },
+                                "opening_screen_changed": {
+                                    "type": "boolean",
+                                    "description": "True if the user changed the Opening Screen option from the escape hatch's settings menu during the session"
+                                },
+                                "close_tab_tapped": {
+                                    "type": "boolean",
+                                    "description": "True if the user closed the open tab from the escape hatch's menu during the session"
+                                },
+                                "burn_tab_tapped": {
+                                    "type": "boolean",
+                                    "description": "True if the user burned the open tab from the escape hatch's menu during the session"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
@@ -61,6 +61,8 @@ final class MockTabDelegate: TabDelegate {
 
     func tab(_ tab: DuckDuckGo.TabViewController, didRequestNewTabForUrl url: URL, openedByPage: Bool, inheritingAttribution: BrowserServicesKit.AdClickAttributionLogic.State?) {}
 
+    func tab(_ tab: DuckDuckGo.TabViewController, didRequestNewDuckAITabForUrl url: URL, entrySource: DuckDuckGo.AIChatEntryPointSource) {}
+
     func tab(_ tab: DuckDuckGo.TabViewController, didRequestReopenClosedTabAt url: URL) {}
 
     func tab(_ tab: DuckDuckGo.TabViewController, didRequestNewBackgroundTabForUrl url: URL, inheritingAttribution: BrowserServicesKit.AdClickAttributionLogic.State?) {}

--- a/iOS/SharedTestUtils/Tab+ConvenienceInitializer.swift
+++ b/iOS/SharedTestUtils/Tab+ConvenienceInitializer.swift
@@ -33,7 +33,8 @@ extension Tab {
                             supportsTabHistory: Bool = true,
                             isExternalLaunch: Bool = false,
                             shouldSuppressTrackerAnimationOnFirstLoad: Bool = false,
+                            duckAIEntrySource: AIChatEntryPointSource? = nil,
                             aichatDebugSettings: AIChatDebugSettingsHandling = AIChatDebugSettings()) {
-        self.init(uid: uid, link: link, viewed: viewed, desktop: desktop, lastViewedDate: lastViewedDate, daxEasterEggLogoURL: daxEasterEggLogoURL, contextualChatURL: contextualChatURL, supportsTabHistory: supportsTabHistory, fireTab: false, isExternalLaunch: isExternalLaunch, shouldSuppressTrackerAnimationOnFirstLoad: shouldSuppressTrackerAnimationOnFirstLoad, aichatDebugSettings: aichatDebugSettings)
+        self.init(uid: uid, link: link, viewed: viewed, desktop: desktop, lastViewedDate: lastViewedDate, daxEasterEggLogoURL: daxEasterEggLogoURL, contextualChatURL: contextualChatURL, supportsTabHistory: supportsTabHistory, fireTab: false, isExternalLaunch: isExternalLaunch, shouldSuppressTrackerAnimationOnFirstLoad: shouldSuppressTrackerAnimationOnFirstLoad, duckAIEntrySource: duckAIEntrySource, aichatDebugSettings: aichatDebugSettings)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/69071770703008/task/1217798816774829?focus=true
Tech Design URL:
CC:

### Description
Return sessions now end as ai_prompt_submitted when a prompt is sent from an existing Duck.ai chat or the contextual sheet, even when no navigation occurs. The event  includes the original Duck.ai entry source.

This also:
  - Renames prompt_origin to source and bumps the schema to 1.2.0.
  - Stores the entry source per tab so follow-up prompts keep the correct attribution
    after relaunch.

  - Ensures opening Duck.ai without submitting a prompt does not count as
    ai_prompt_submitted. Existing post-idle reporting remains unchanged.

### Testing Steps
Each step starts a fresh return session: press Home, then reopen the app. The session completes on the first qualifying action after reopening (later actions report nothing), so do the step's action right after reopening. Unless another event is named, every assertion below is on the `m_ios_wide_return_session` wide event.

1. Enable the `wideEvents` and related wide-event flags in internal settings, force-quit and relaunch.
2. Open Duck.ai from the address bar and submit a prompt, then in a fresh session submit a follow-up in that same chat → `m_ios_wide_return_session` reports `status_reason=ai_prompt_submitted` with `source` set to whatever opened the chat, matching the `origin` on `m_aichat_unified_input_prompt_submitted`; the event carries `meta.version=1.2.0` (`feature.name` stays `return-session`).
3. Force-quit with that chat tab still open, relaunch into it, and submit another follow-up → `source` still reports the chat's original entry point (persisted on the tab).
4. Open a second chat from a different entry point (e.g. the browsing menu), then submit follow-ups in each tab → each reports its own tab's `source`, not the most recent entry.
5. On a web page, open the contextual sheet and submit a prompt → the wide event ends `ai_prompt_submitted` with `source=contextual_chat` (`m_aichat_unified_input_prompt_submitted` carries the matching `origin=contextual_chat`).
6. Open Duck.ai from the browsing menu and submit nothing → the return session stays open; backgrounding afterwards reports `status_reason=app_backgrounded`.
7. In an open chat, trigger a page-dispatched prompt — the page's own composer is hidden when the native input is enabled, so edit a previously sent prompt in the page and resubmit it → `ai_prompt_submitted` with no `source` key (same accepted gap as Android's frontend path).
8. From the NTP in Duck.ai mode, dictate a prompt with the microphone (not the live Voice mode button — its `m_aichat_unified_input_voice_tapped` reports the hosting surface, e.g. `source=address_bar`) → the wide event reports `source=voice`; a dictated prompt into an already-open chat reports that chat's original entry point instead.
9. In the native input, attach an image with no text and send → the prompt is delivered to the chat and the session reports `ai_prompt_submitted`.
10. Right after reopening, submit a plain non-URL search from the omnibar → `status_reason=search_submitted` and no `source` key at all (a URL or a website/history suggestion reports `url_submitted` instead).

### Impact
Low

#### What could go wrong?
These submissions deliberately end only the return session, not `m_ios_wide_post_idle_session`, so its shipped `bar_used` volume stays comparable across versions — the trade-off is that keyboard-into-open-chat follow-ups are still absent from that series, while voice ones (which already ended both) remain present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to analytics and Duck.ai navigation attribution; no auth, data handling, or security surfaces. Risk is mainly mis-bucketed wide-event volumes if session terminals fire in the wrong order.
> 
> **Overview**
> Return sessions can now end as **`ai_prompt_submitted`** when the user sends a Duck.ai prompt from an **already-open chat**, the **contextual sheet**, or the **unified toggle input**—paths that do not navigate away from the landing surface. **`m_ios_wide_return_session`** reports the entry point on **`feature.data.ext.source`** (schema **1.2.0**), with **`unknown`** when attribution is missing; the old **`prompt_origin`** parameter is removed.
> 
> **Per-tab `duckAIEntrySource`** replaces the app-wide “last entry” so follow-ups and relaunched tabs keep the source that opened that chat. New-tab and in-place Duck.ai opens stamp the tab via **`loadUrlInNewTab`** / **`stampDuckAIEntrySourceOnCurrentTab`** completions and a dedicated **`didRequestNewDuckAITabForUrl`** delegate path.
> 
> **Session completion is split:** **`promptSubmittedWithoutNavigation`** finishes only the return-session flow with **`source`**; **`duckAIOpenedWithoutPrompt`** ends the post-idle flow as **`bar_used`** when Duck.ai is opened without an auto-submitted prompt (text or attachments). Navigation that auto-sends still uses **`sessionEnded(..., promptOrigin:)`** via **`hasAutoSubmittedDuckAIPrompt`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b402d06e4b0bcdac5e10267179267d4e94fe0f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->