### PR TITLE
iOS: Match tab manager spacing to floating browsing chrome

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1690,6 +1690,7 @@
 		A8440B0101C0DE0000000004 /* FloatingOmnibarTransitionMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8440B0101C0DE0000000003 /* FloatingOmnibarTransitionMetricsTests.swift */; };
 		A8452A0101C0DE0000000002 /* HomeScreenTransitionGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8452A0101C0DE0000000001 /* HomeScreenTransitionGeometry.swift */; };
 		A8452A0101C0DE0000000004 /* HomeScreenTransitionGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8452A0101C0DE0000000003 /* HomeScreenTransitionGeometryTests.swift */; };
+		A8452A0101C0DE0000000006 /* BrowserToolbarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8452A0101C0DE0000000005 /* BrowserToolbarViewTests.swift */; };
 		AA10B5022FA0000100AB12CD /* WebExtensionAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10B5012FA0000100AB12CD /* WebExtensionAvailabilityTests.swift */; };
 		AA2000010000000000000002 /* TabSwitcherTrackerInfoHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000010000000000000002 /* TabSwitcherTrackerInfoHeaderView.swift */; };
 		AA2000040000000000000004 /* TabSwitcherTrackerCountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000040000000000000004 /* TabSwitcherTrackerCountViewModel.swift */; };
@@ -4295,6 +4296,7 @@
 		A8440B0101C0DE0000000003 /* FloatingOmnibarTransitionMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingOmnibarTransitionMetricsTests.swift; sourceTree = "<group>"; };
 		A8452A0101C0DE0000000001 /* HomeScreenTransitionGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenTransitionGeometry.swift; sourceTree = "<group>"; };
 		A8452A0101C0DE0000000003 /* HomeScreenTransitionGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreenTransitionGeometryTests.swift; sourceTree = "<group>"; };
+		A8452A0101C0DE0000000005 /* BrowserToolbarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserToolbarViewTests.swift; sourceTree = "<group>"; };
 		AA1000010000000000000002 /* TabSwitcherTrackerInfoHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherTrackerInfoHeaderView.swift; sourceTree = "<group>"; };
 		AA1000040000000000000004 /* TabSwitcherTrackerCountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherTrackerCountViewModel.swift; sourceTree = "<group>"; };
 		AA1000050000000000000005 /* TabSwitcherTrackerCountViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSwitcherTrackerCountViewModelTests.swift; sourceTree = "<group>"; };
@@ -7440,6 +7442,7 @@
 				CB6EF0502FE020D6000C75BA /* IPadOmnibarFocusModelTests.swift */,
 				CB27DAE82FFFE6BC00EEEADB /* WebViewTransitionGeometryTests.swift */,
 				A8452A0101C0DE0000000003 /* HomeScreenTransitionGeometryTests.swift */,
+				A8452A0101C0DE0000000005 /* BrowserToolbarViewTests.swift */,
 			);
 			name = UnitTests;
 			path = DuckDuckGoTests;
@@ -13710,6 +13713,7 @@
 				A1B2C3D40E1F202122232402 /* TabViewControllerGestureArbitrationTests.swift in Sources */,
 				CB27DAE92FFFE6BC00EEEADB /* WebViewTransitionGeometryTests.swift in Sources */,
 				A8452A0101C0DE0000000004 /* HomeScreenTransitionGeometryTests.swift in Sources */,
+				A8452A0101C0DE0000000006 /* BrowserToolbarViewTests.swift in Sources */,
 				F1A83D872E0AB27E00054B03 /* MockFeatureFlagger.swift in Sources */,
 				9FE59CE72E3307AD00C4B65D /* SystemSettingsPiPTutorialPixelHandlerTests.swift in Sources */,
 				F13B4BFB1F18E3D900814661 /* TabsModelPersistenceTests.swift in Sources */,

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -306,7 +306,8 @@ final class BrowserToolbarView: UIView {
 
     /// Horizontal compensation for the combined bottom chrome. Its host is pinned to the
     /// corner-adapted guide, so this keeps the glass at the same physical inset on every edge
-    /// unless the guide already exceeds that inset.
+    /// unless the guide already exceeds that inset. Each edge is compensated from its own guide:
+    /// in landscape the Dynamic Island only enlarges the guide on one side.
     @available(iOS 26.0, *)
     private var embeddedRestStateOuterInsets: UIEdgeInsets {
         guard let host = superview, host.bounds.width > 0 else {
@@ -316,10 +317,20 @@ final class BrowserToolbarView: UIView {
                 bottom: 0,
                 right: Self.floatingEmbeddedConcentricInset)
         }
-        let guide = host.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
-        let guideInset = max(0, guide.layoutFrame.minX)
-        let inner = Self.embeddedRestStateInnerInset(guideInset: guideInset)
-        return UIEdgeInsets(top: 0, left: inner, bottom: 0, right: inner)
+        let guideInsets = Self.horizontalGuideInsets(in: host)
+        return UIEdgeInsets(
+            top: 0,
+            left: Self.embeddedRestStateInnerInset(guideInset: guideInsets.left),
+            bottom: 0,
+            right: Self.embeddedRestStateInnerInset(guideInset: guideInsets.right))
+    }
+
+    /// Distance from each physical edge of `view` to its corner-adapted safe area guide.
+    @available(iOS 26.0, *)
+    static func horizontalGuideInsets(in view: UIView) -> (left: CGFloat, right: CGFloat) {
+        let guide = view.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
+        return (max(0, guide.layoutFrame.minX),
+                max(0, view.bounds.maxX - guide.layoutFrame.maxX))
     }
 
     private var currentButtonRowHorizontalPadding: CGFloat {
@@ -481,8 +492,10 @@ final class BrowserToolbarView: UIView {
 
     private func applyHorizontalChromeMetrics() {
         let insets = currentBarOuterInsets
-        materialBackgroundLeadingConstraint.constant = insets.left
-        materialBackgroundTrailingConstraint.constant = -insets.right
+        // `insets` are physical (left/right); these constraints are directional, so mirror in RTL.
+        let isRightToLeft = effectiveUserInterfaceLayoutDirection == .rightToLeft
+        materialBackgroundLeadingConstraint.constant = isRightToLeft ? insets.right : insets.left
+        materialBackgroundTrailingConstraint.constant = isRightToLeft ? -insets.left : -insets.right
         if !hasExpandedContent {
             materialBackgroundTopConstraint.constant = insets.top
         }
@@ -836,12 +849,9 @@ final class BrowserToolbarView: UIView {
         let bottom: CGFloat
         if #available(iOS 26.0, *) {
             if usesCombinedBottomChromeGeometry {
-                let horizontalGuide = view.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
-                let leftGuideInset = max(0, horizontalGuide.layoutFrame.minX)
-                let rightGuideInset = max(0, bounds.maxX - horizontalGuide.layoutFrame.maxX)
-                let inner = Self.embeddedRestStateInnerInset(guideInset: leftGuideInset)
-                left = leftGuideInset + inner
-                right = rightGuideInset + inner
+                let guideInsets = Self.horizontalGuideInsets(in: view)
+                left = guideInsets.left + Self.embeddedRestStateInnerInset(guideInset: guideInsets.left)
+                right = guideInsets.right + Self.embeddedRestStateInnerInset(guideInset: guideInsets.right)
                 bottom = bounds.maxY - Self.floatingEmbeddedConcentricInset
             } else {
                 let horizontalGuide = view.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -325,12 +325,33 @@ final class BrowserToolbarView: UIView {
             right: Self.embeddedRestStateInnerInset(guideInset: guideInsets.right))
     }
 
+    /// Distance from the physical bottom edge of `view` to its corner-adapted safe area guide.
+    /// Reports zero for an unresolved guide, for the same reason as `horizontalGuideInsets(in:)`.
+    @available(iOS 26.0, *)
+    static func verticalGuideBottomInset(in view: UIView) -> CGFloat {
+        let layoutFrame = view.layoutGuide(for: .safeArea(cornerAdaptation: .vertical)).layoutFrame
+        guard !layoutFrame.isEmpty else { return 0 }
+        return max(0, view.bounds.maxY - layoutFrame.maxY)
+    }
+
+    /// Shift that puts combined bottom chrome `floatingEmbeddedConcentricInset` from the physical
+    /// bottom. The layout slot's bottom sits on the guide, so a guide gap wider than the inset
+    /// shifts the glass down and a narrower one shifts it up; it is not clamped to a downward
+    /// shift, or the glass would sit flush on devices whose guide already reaches the bottom.
+    static func embeddedRestStateBottomOffset(guideBottomGap: CGFloat) -> CGFloat {
+        guideBottomGap - floatingEmbeddedConcentricInset
+    }
+
     /// Distance from each physical edge of `view` to its corner-adapted safe area guide.
+    /// The guide only resolves once the view is in a window; until then its layout frame is
+    /// empty, which carries no inset information. Reporting zero keeps callers from reading an
+    /// unresolved guide as "the whole width is unsafe".
     @available(iOS 26.0, *)
     static func horizontalGuideInsets(in view: UIView) -> (left: CGFloat, right: CGFloat) {
-        let guide = view.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
-        return (max(0, guide.layoutFrame.minX),
-                max(0, view.bounds.maxX - guide.layoutFrame.maxX))
+        let layoutFrame = view.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal)).layoutFrame
+        guard !layoutFrame.isEmpty else { return (0, 0) }
+        return (max(0, layoutFrame.minX),
+                max(0, view.bounds.maxX - layoutFrame.maxX))
     }
 
     private var currentButtonRowHorizontalPadding: CGFloat {
@@ -854,12 +875,11 @@ final class BrowserToolbarView: UIView {
                 right = guideInsets.right + Self.embeddedRestStateInnerInset(guideInset: guideInsets.right)
                 bottom = bounds.maxY - Self.floatingEmbeddedConcentricInset
             } else {
-                let horizontalGuide = view.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
-                let verticalGuide = view.layoutGuide(for: .safeArea(cornerAdaptation: .vertical))
+                let guideInsets = Self.horizontalGuideInsets(in: view)
                 let glassInset = currentBarOuterInsets.left
-                left = max(0, horizontalGuide.layoutFrame.minX) + glassInset
-                right = max(0, bounds.maxX - horizontalGuide.layoutFrame.maxX) + glassInset
-                bottom = verticalGuide.layoutFrame.maxY
+                left = guideInsets.left + glassInset
+                right = guideInsets.right + glassInset
+                bottom = bounds.maxY - Self.verticalGuideBottomInset(in: view)
             }
         } else {
             let insets = currentBarOuterInsets
@@ -870,7 +890,7 @@ final class BrowserToolbarView: UIView {
             bottom = bounds.maxY - safeBottom + offset
         }
 
-        let width = bounds.width - left - right
+        let width = max(0, bounds.width - left - right)
         return CGRect(x: bounds.minX + left, y: bottom - height, width: width, height: height)
     }
 
@@ -924,9 +944,8 @@ final class BrowserToolbarView: UIView {
         let target: CGFloat
         if #available(iOS 26.0, *), isFloatingStyleEnabled {
             if usesCombinedBottomChromeGeometry, let host = superview, host.bounds.height > 0 {
-                let verticalGuide = host.layoutGuide(for: .safeArea(cornerAdaptation: .vertical))
-                let guideBottomGap = max(0, host.bounds.maxY - verticalGuide.layoutFrame.maxY)
-                target = max(0, guideBottomGap - Self.floatingEmbeddedConcentricInset)
+                let guideBottomGap = Self.verticalGuideBottomInset(in: host)
+                target = Self.embeddedRestStateBottomOffset(guideBottomGap: guideBottomGap)
             } else {
                 target = 0
             }

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -115,10 +115,12 @@ final class BrowserToolbarView: UIView {
     private static let floatingUICornerRadius: CGFloat = 40
 
     static let floatingEmbeddedHorizontalInset: CGFloat = 16
+    static let floatingEmbeddedConcentricInset: CGFloat = 20
     /// Outer side inset of the standalone top-address-bar toolbar.
     static let floatingStandaloneHorizontalInset: CGFloat = 24
-    /// Extra inset of the custom glass inside the concentric layout-guide pin. iOS 26 `UIToolbar`
-    /// applies this itself; `BrowserToolbarView` fills its bounds, so it has to be explicit.
+    /// Extra inset of the custom glass inside the concentric layout-guide pin. Used by the
+    /// standalone (split, top-address-bar) pill so it matches iOS 26 `UIToolbar` glass padding.
+    /// Combined bottom chrome instead keeps its own equal rest-state inset on every edge.
     static let floatingConcentricGlassInset: CGFloat = 20
     private static let floatingConcentricGlassInsets = UIEdgeInsets(top: 0, left: floatingConcentricGlassInset, bottom: 0, right: floatingConcentricGlassInset)
     private static let floatingEmbeddedBarOuterInsets = UIEdgeInsets(top: 0, left: floatingEmbeddedHorizontalInset, bottom: 0, right: floatingEmbeddedHorizontalInset)
@@ -132,11 +134,17 @@ final class BrowserToolbarView: UIView {
     static let floatingStandaloneBottomMargin: CGFloat = 21
 
     static func floatingOuterHorizontalInset(for addressBarPosition: AddressBarPosition) -> CGFloat {
-        addressBarPosition.isBottom ? floatingEmbeddedHorizontalInset : floatingStandaloneHorizontalInset
+        if #available(iOS 26.0, *), addressBarPosition.isBottom {
+            return floatingEmbeddedConcentricInset
+        }
+        return addressBarPosition.isBottom ? floatingEmbeddedHorizontalInset : floatingStandaloneHorizontalInset
     }
 
     static func floatingBottomMargin(for addressBarPosition: AddressBarPosition) -> CGFloat {
-        addressBarPosition.isBottom ? floatingEmbeddedBottomMargin : floatingStandaloneBottomMargin
+        if #available(iOS 26.0, *), addressBarPosition.isBottom {
+            return floatingEmbeddedConcentricInset
+        }
+        return addressBarPosition.isBottom ? floatingEmbeddedBottomMargin : floatingStandaloneBottomMargin
     }
 
     /// Inner padding of the combined bottom floating chrome (address field + buttons). The standalone
@@ -277,12 +285,33 @@ final class BrowserToolbarView: UIView {
         isFloatingStyleEnabled && !hasEmbeddedOmnibar
     }
 
+    private var usesCombinedBottomChromeGeometry: Bool {
+        isFloatingStyleEnabled && (hasEmbeddedOmnibar || isOmnibarMorphing)
+    }
+
     private var currentBarOuterInsets: UIEdgeInsets {
         guard isFloatingStyleEnabled else { return Self.legacyBarOuterInsets }
         if #available(iOS 26.0, *) {
-            return Self.floatingConcentricGlassInsets
+            return usesCombinedBottomChromeGeometry ? embeddedRestStateOuterInsets : Self.floatingConcentricGlassInsets
         }
         return usesEmbeddedBottomChromeMetrics ? Self.floatingEmbeddedBarOuterInsets : Self.floatingStandaloneBarOuterInsets
+    }
+
+    /// Horizontal compensation for the combined bottom chrome. Its host is pinned to the
+    /// corner-adapted guide, so this keeps the glass at the same physical inset on every edge.
+    @available(iOS 26.0, *)
+    private var embeddedRestStateOuterInsets: UIEdgeInsets {
+        guard let host = superview, host.bounds.width > 0 else {
+            return UIEdgeInsets(
+                top: 0,
+                left: Self.floatingEmbeddedConcentricInset,
+                bottom: 0,
+                right: Self.floatingEmbeddedConcentricInset)
+        }
+        let guide = host.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
+        let guideInset = max(0, guide.layoutFrame.minX)
+        let inner = Self.floatingEmbeddedConcentricInset - guideInset
+        return UIEdgeInsets(top: 0, left: inner, bottom: 0, right: inner)
     }
 
     private var currentButtonRowHorizontalPadding: CGFloat {
@@ -494,6 +523,7 @@ final class BrowserToolbarView: UIView {
         hostedOmnibarView?.removeFromSuperview()
         hostedOmnibarView = nil
         isOmnibarMorphing = true
+        updateCornerStyle()
     }
 
     func applyOmnibarDetachmentPose() {
@@ -766,14 +796,17 @@ final class BrowserToolbarView: UIView {
     }
     
     override func layoutSubviews() {
-        super.layoutSubviews()
         applyHorizontalChromeMetrics()
+        super.layoutSubviews()
         updateFloatingBottomOffset()
         updateCornerStyle()
     }
 
     var floatingBottomMargin: CGFloat {
-        hasEmbeddedOmnibar ? Self.floatingEmbeddedBottomMargin : Self.floatingStandaloneBottomMargin
+        if #available(iOS 26.0, *), usesCombinedBottomChromeGeometry {
+            return Self.floatingEmbeddedConcentricInset
+        }
+        return hasEmbeddedOmnibar ? Self.floatingEmbeddedBottomMargin : Self.floatingStandaloneBottomMargin
     }
 
     var visibleCapsuleRect: CGRect {
@@ -794,12 +827,18 @@ final class BrowserToolbarView: UIView {
         let right: CGFloat
         let bottom: CGFloat
         if #available(iOS 26.0, *) {
-            let horizontalGuide = view.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
-            let verticalGuide = view.layoutGuide(for: .safeArea(cornerAdaptation: .vertical))
-            let glassInset = currentBarOuterInsets.left
-            left = max(0, horizontalGuide.layoutFrame.minX) + glassInset
-            right = max(0, bounds.maxX - horizontalGuide.layoutFrame.maxX) + glassInset
-            bottom = verticalGuide.layoutFrame.maxY
+            if usesCombinedBottomChromeGeometry {
+                left = Self.floatingEmbeddedConcentricInset
+                right = Self.floatingEmbeddedConcentricInset
+                bottom = bounds.maxY - Self.floatingEmbeddedConcentricInset
+            } else {
+                let horizontalGuide = view.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
+                let verticalGuide = view.layoutGuide(for: .safeArea(cornerAdaptation: .vertical))
+                let glassInset = currentBarOuterInsets.left
+                left = max(0, horizontalGuide.layoutFrame.minX) + glassInset
+                right = max(0, bounds.maxX - horizontalGuide.layoutFrame.maxX) + glassInset
+                bottom = verticalGuide.layoutFrame.maxY
+            }
         } else {
             let insets = currentBarOuterInsets
             left = insets.left
@@ -855,13 +894,20 @@ final class BrowserToolbarView: UIView {
         chromeContainer.transform = CGAffineTransform(translationX: 0, y: floatingBottomOffset + standaloneHideTranslation)
     }
 
-    /// On iOS 26 the host pins this bar to the concentric vertical guide, so the glass stays put.
-    /// Below iOS 26 the layout slot sits on the safe area and the glass is shifted down toward the
-    /// device bottom, leaving `floatingBottomMargin`.
+    /// On iOS 26 the host pins this bar to the concentric vertical guide. Split (standalone) chrome
+    /// stays there. Combined bottom chrome is shifted down to keep the same physical inset on every
+    /// edge. Below iOS 26 the layout slot sits on the safe area and the glass is shifted down toward
+    /// the device bottom, leaving `floatingBottomMargin`.
     private func updateFloatingBottomOffset() {
         let target: CGFloat
         if #available(iOS 26.0, *), isFloatingStyleEnabled {
-            target = 0
+            if usesCombinedBottomChromeGeometry, let host = superview, host.bounds.height > 0 {
+                let verticalGuide = host.layoutGuide(for: .safeArea(cornerAdaptation: .vertical))
+                let guideBottomGap = max(0, host.bounds.maxY - verticalGuide.layoutFrame.maxY)
+                target = max(0, guideBottomGap - Self.floatingEmbeddedConcentricInset)
+            } else {
+                target = 0
+            }
         } else {
             let hostBottomInset = superview?.safeAreaInsets.bottom ?? 0
             target = isFloatingStyleEnabled ? hostBottomInset - floatingBottomMargin : 0
@@ -878,23 +924,25 @@ final class BrowserToolbarView: UIView {
             return
         }
 
-        // During focus/defocus morph the shell is still tall, so `.capsule()` would read as an
-        // oversized pill. Keep the same concentric corners as the resting combined floating UI
-        // so the round-rect lands without a radius pop.
-        let usesConcentricCorners = isOmnibarMorphing || hasEmbeddedOmnibar || hasExpandedContent
-
-        let radius = usesConcentricCorners
-            ? Self.floatingUICornerRadius
-            : max(chromeContentHost.bounds.height, materialBackgroundView.bounds.height) / 2
-        chromeContentHost.layer.cornerRadius = radius
+        let usesRestStateCorners = isOmnibarMorphing || hasEmbeddedOmnibar || hasExpandedContent
 
         if #available(iOS 26, *) {
-            materialBackgroundView.cornerConfiguration = usesConcentricCorners
-                ? .corners(radius: UICornerRadius.containerConcentric(minimum: Self.floatingUICornerRadius))
-                : .capsule()
+            if usesRestStateCorners {
+                let configuration = UICornerConfiguration.corners(
+                    radius: .containerConcentric(minimum: Self.floatingUICornerRadius))
+                materialBackgroundView.cornerConfiguration = configuration
+                chromeContentHost.cornerConfiguration = configuration
+            } else {
+                materialBackgroundView.cornerConfiguration = .capsule()
+                chromeContentHost.cornerConfiguration = .capsule()
+            }
             return
         }
 
+        let radius = usesRestStateCorners
+            ? Self.floatingUICornerRadius
+            : max(chromeContentHost.bounds.height, materialBackgroundView.bounds.height) / 2
+        chromeContentHost.layer.cornerRadius = radius
         materialBackgroundView.contentView.layer.cornerRadius = radius
     }
 

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -140,6 +140,13 @@ final class BrowserToolbarView: UIView {
         return addressBarPosition.isBottom ? floatingEmbeddedHorizontalInset : floatingStandaloneHorizontalInset
     }
 
+    /// Extra inset inside the corner-adapted guide so combined bottom chrome sits
+    /// `floatingEmbeddedConcentricInset` from the physical screen edges. Zero when the guide is
+    /// already larger (landscape Dynamic Island) so the glass never leaves the toolbar.
+    static func embeddedRestStateInnerInset(guideInset: CGFloat) -> CGFloat {
+        max(0, floatingEmbeddedConcentricInset - max(0, guideInset))
+    }
+
     static func floatingBottomMargin(for addressBarPosition: AddressBarPosition) -> CGFloat {
         if #available(iOS 26.0, *), addressBarPosition.isBottom {
             return floatingEmbeddedConcentricInset
@@ -298,7 +305,8 @@ final class BrowserToolbarView: UIView {
     }
 
     /// Horizontal compensation for the combined bottom chrome. Its host is pinned to the
-    /// corner-adapted guide, so this keeps the glass at the same physical inset on every edge.
+    /// corner-adapted guide, so this keeps the glass at the same physical inset on every edge
+    /// unless the guide already exceeds that inset.
     @available(iOS 26.0, *)
     private var embeddedRestStateOuterInsets: UIEdgeInsets {
         guard let host = superview, host.bounds.width > 0 else {
@@ -310,7 +318,7 @@ final class BrowserToolbarView: UIView {
         }
         let guide = host.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
         let guideInset = max(0, guide.layoutFrame.minX)
-        let inner = Self.floatingEmbeddedConcentricInset - guideInset
+        let inner = Self.embeddedRestStateInnerInset(guideInset: guideInset)
         return UIEdgeInsets(top: 0, left: inner, bottom: 0, right: inner)
     }
 
@@ -828,8 +836,12 @@ final class BrowserToolbarView: UIView {
         let bottom: CGFloat
         if #available(iOS 26.0, *) {
             if usesCombinedBottomChromeGeometry {
-                left = Self.floatingEmbeddedConcentricInset
-                right = Self.floatingEmbeddedConcentricInset
+                let horizontalGuide = view.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
+                let leftGuideInset = max(0, horizontalGuide.layoutFrame.minX)
+                let rightGuideInset = max(0, bounds.maxX - horizontalGuide.layoutFrame.maxX)
+                let inner = Self.embeddedRestStateInnerInset(guideInset: leftGuideInset)
+                left = leftGuideInset + inner
+                right = rightGuideInset + inner
                 bottom = bounds.maxY - Self.floatingEmbeddedConcentricInset
             } else {
                 let horizontalGuide = view.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -117,6 +117,10 @@ final class BrowserToolbarView: UIView {
     static let floatingEmbeddedHorizontalInset: CGFloat = 16
     /// Outer side inset of the standalone top-address-bar toolbar.
     static let floatingStandaloneHorizontalInset: CGFloat = 24
+    /// Extra inset of the custom glass inside the concentric layout-guide pin. iOS 26 `UIToolbar`
+    /// applies this itself; `BrowserToolbarView` fills its bounds, so it has to be explicit.
+    static let floatingConcentricGlassInset: CGFloat = 20
+    private static let floatingConcentricGlassInsets = UIEdgeInsets(top: 0, left: floatingConcentricGlassInset, bottom: 0, right: floatingConcentricGlassInset)
     private static let floatingEmbeddedBarOuterInsets = UIEdgeInsets(top: 0, left: floatingEmbeddedHorizontalInset, bottom: 0, right: floatingEmbeddedHorizontalInset)
     private static let floatingStandaloneBarOuterInsets = UIEdgeInsets(top: 0, left: floatingStandaloneHorizontalInset, bottom: 0, right: floatingStandaloneHorizontalInset)
     private static let legacyBarOuterInsets = UIEdgeInsets.zero
@@ -124,8 +128,16 @@ final class BrowserToolbarView: UIView {
     /// In the floating style the toolbar is laid out against the safe-area bottom (so the chrome
     /// hide/show math stays valid), but the capsule should float this close to the physical device
     /// bottom. The glass is shifted down into the home-indicator region by the difference.
-    private static let floatingBottomMarginWithEmbedded: CGFloat = 16
+    static let floatingEmbeddedBottomMargin: CGFloat = 16
     static let floatingStandaloneBottomMargin: CGFloat = 21
+
+    static func floatingOuterHorizontalInset(for addressBarPosition: AddressBarPosition) -> CGFloat {
+        addressBarPosition.isBottom ? floatingEmbeddedHorizontalInset : floatingStandaloneHorizontalInset
+    }
+
+    static func floatingBottomMargin(for addressBarPosition: AddressBarPosition) -> CGFloat {
+        addressBarPosition.isBottom ? floatingEmbeddedBottomMargin : floatingStandaloneBottomMargin
+    }
 
     /// Inner padding of the combined bottom floating chrome (address field + buttons). The standalone
     /// floating toolbar used in top-address-bar mode keeps the original 2pt padding.
@@ -267,6 +279,9 @@ final class BrowserToolbarView: UIView {
 
     private var currentBarOuterInsets: UIEdgeInsets {
         guard isFloatingStyleEnabled else { return Self.legacyBarOuterInsets }
+        if #available(iOS 26.0, *) {
+            return Self.floatingConcentricGlassInsets
+        }
         return usesEmbeddedBottomChromeMetrics ? Self.floatingEmbeddedBarOuterInsets : Self.floatingStandaloneBarOuterInsets
     }
 
@@ -752,12 +767,13 @@ final class BrowserToolbarView: UIView {
     
     override func layoutSubviews() {
         super.layoutSubviews()
+        applyHorizontalChromeMetrics()
         updateFloatingBottomOffset()
         updateCornerStyle()
     }
 
     var floatingBottomMargin: CGFloat {
-        hasEmbeddedOmnibar ? Self.floatingBottomMarginWithEmbedded : Self.floatingStandaloneBottomMargin
+        hasEmbeddedOmnibar ? Self.floatingEmbeddedBottomMargin : Self.floatingStandaloneBottomMargin
     }
 
     var visibleCapsuleRect: CGRect {
@@ -770,15 +786,31 @@ final class BrowserToolbarView: UIView {
     func restingCapsuleFrame(in view: UIView) -> CGRect {
         guard isFloatingStyleEnabled else { return .zero }
         let bounds = view.bounds
-        let safeBottom = view.safeAreaInsets.bottom
-        let insets = currentBarOuterInsets
-        let width = bounds.width - insets.left - insets.right
         let height = hasEmbeddedOmnibar
             ? Self.singleRowHeight(withOmnibarHeight: omnibarHeightConstraint.constant)
             : buttonsHeightConstraint.constant
-        let offset = max(0, safeBottom - floatingBottomMargin)
-        let bottom = bounds.maxY - safeBottom + offset
-        return CGRect(x: bounds.minX + insets.left, y: bottom - height, width: width, height: height)
+
+        let left: CGFloat
+        let right: CGFloat
+        let bottom: CGFloat
+        if #available(iOS 26.0, *) {
+            let horizontalGuide = view.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
+            let verticalGuide = view.layoutGuide(for: .safeArea(cornerAdaptation: .vertical))
+            let glassInset = currentBarOuterInsets.left
+            left = max(0, horizontalGuide.layoutFrame.minX) + glassInset
+            right = max(0, bounds.maxX - horizontalGuide.layoutFrame.maxX) + glassInset
+            bottom = verticalGuide.layoutFrame.maxY
+        } else {
+            let insets = currentBarOuterInsets
+            left = insets.left
+            right = insets.right
+            let safeBottom = view.safeAreaInsets.bottom
+            let offset = max(0, safeBottom - floatingBottomMargin)
+            bottom = bounds.maxY - safeBottom + offset
+        }
+
+        let width = bounds.width - left - right
+        return CGRect(x: bounds.minX + left, y: bottom - height, width: width, height: height)
     }
 
     @discardableResult
@@ -823,12 +855,17 @@ final class BrowserToolbarView: UIView {
         chromeContainer.transform = CGAffineTransform(translationX: 0, y: floatingBottomOffset + standaloneHideTranslation)
     }
 
-    /// Shifts the glass capsule down from its safe-area-anchored position toward the device bottom,
-    /// leaving `floatingBottomMargin`. Done as a transform (not a constraint change) so it doesn't
-    /// disturb the toolbar's layout slot or the runtime chrome hide/show constant logic.
+    /// On iOS 26 the host pins this bar to the concentric vertical guide, so the glass stays put.
+    /// Below iOS 26 the layout slot sits on the safe area and the glass is shifted down toward the
+    /// device bottom, leaving `floatingBottomMargin`.
     private func updateFloatingBottomOffset() {
-        let hostBottomInset = superview?.safeAreaInsets.bottom ?? 0
-        let target = isFloatingStyleEnabled ? max(0, hostBottomInset - floatingBottomMargin) : 0
+        let target: CGFloat
+        if #available(iOS 26.0, *), isFloatingStyleEnabled {
+            target = 0
+        } else {
+            let hostBottomInset = superview?.safeAreaInsets.bottom ?? 0
+            target = isFloatingStyleEnabled ? hostBottomInset - floatingBottomMargin : 0
+        }
         guard target != floatingBottomOffset else { return }
         floatingBottomOffset = target
         applyMaterialBackgroundTransform()

--- a/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
+++ b/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
@@ -162,6 +162,9 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
 
         navigationBar.translatesAutoresizingMaskIntoConstraints = false
         toolbar.translatesAutoresizingMaskIntoConstraints = false
+        toolbar.insetsLayoutMarginsFromSafeArea = false
+        toolbar.preservesSuperviewLayoutMargins = false
+        toolbar.layoutMargins = .zero
 
         navigationBar.setItems([navigationItem], animated: false)
 
@@ -177,7 +180,6 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         tabsStyleItem.accessibilityLabel = UserText.tabSwitcherGridViewMenuTitle
 
         attachTopScrollViewInteraction()
-        attachBottomScrollViewInteraction()
     }
 
     var scrollViewTopInteraction: UIInteraction?
@@ -204,8 +206,8 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
     }
 
     func attachBottomScrollViewInteraction() {
-        guard #available(iOS 26, *) else { return }
-        scrollViewBottomInteraction = attachScrollViewInteractionToView(toolbar, onEdge: .bottom, removingExistingInteraction: scrollViewBottomInteraction)
+        // Intentionally empty: the toolbar is inset to match the webview capsule.
+        // A scroll-edge interaction would apply a second, larger device-concentric inset.
     }
 
     func trackScrollEdge(of scrollView: UIScrollView) {
@@ -213,7 +215,6 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         scrollEdgeScrollView = scrollView
         guard #available(iOS 26, *) else { return }
         (scrollViewTopInteraction as? UIScrollEdgeElementContainerInteraction)?.scrollView = scrollView
-        (scrollViewBottomInteraction as? UIScrollEdgeElementContainerInteraction)?.scrollView = scrollView
     }
 
     func setCenterView(_ view: UIView?) {
@@ -357,11 +358,42 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         toolbar.isHidden = params.interfaceMode.isLarge
     }
 
+    /// Distance from the host's top to the bottom of the floating navigation bar.
+    /// Both pages use this so tab cards keep the same top spacing during a paging swipe.
+    var topBarBottomOffset: CGFloat {
+        if navigationBar.frame.maxY > 0 {
+            return navigationBar.frame.maxY
+        }
+        return Metrics.topFloatingInset + Metrics.estimatedNavBarHeight
+    }
+
     func applyCollectionContentInset(to collectionView: UICollectionView) {
-        let navHeight = navigationBar.frame.height > 0 ? navigationBar.frame.height : Metrics.estimatedNavBarHeight
+        collectionView.contentInsetAdjustmentBehavior = .never
+
+        let topInset = topBarBottomOffset
         let toolbarHeight = toolbar.frame.height > 0 ? toolbar.frame.height : Metrics.estimatedToolbarHeight
-        collectionView.contentInset.top = navHeight + Metrics.topFloatingInset
-        collectionView.contentInset.bottom = interfaceMode.isLarge ? 0 : toolbarHeight + Metrics.bottomFloatingInset
+        let bottomClearance: CGFloat
+        if interfaceMode.isLarge {
+            bottomClearance = 0
+        } else if let hostView, toolbar.frame.height > 0 {
+            let toolbarFrameInHost = toolbar.convert(toolbar.bounds, to: hostView)
+            bottomClearance = hostView.bounds.maxY - toolbarFrameInHost.minY + Metrics.bottomFloatingInset
+        } else {
+            bottomClearance = toolbarHeight + Metrics.bottomFloatingInset
+        }
+
+        let previousTopInset = collectionView.contentInset.top
+        let wasScrolledToTop = abs(collectionView.contentOffset.y + previousTopInset) < 1
+
+        collectionView.contentInset.top = topInset
+        collectionView.contentInset.bottom = bottomClearance
+        collectionView.verticalScrollIndicatorInsets = collectionView.contentInset
+
+        if wasScrolledToTop {
+            collectionView.contentOffset.y = -topInset
+        } else {
+            collectionView.contentOffset.y += previousTopInset - topInset
+        }
     }
 
     func layout(addressBarPosition: AddressBarPosition,
@@ -404,11 +436,23 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
             contentView.leadingAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.trailingAnchor),
             contentView.bottomAnchor.constraint(equalTo: hostView.bottomAnchor),
-
-            toolbar.leadingAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.leadingAnchor),
-            toolbar.trailingAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.trailingAnchor),
-            toolbar.bottomAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.bottomAnchor),
         ]
+
+        if #available(iOS 26.0, *) {
+            let horizontalGuide = hostView.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
+            let verticalGuide = hostView.layoutGuide(for: .safeArea(cornerAdaptation: .vertical))
+            constraints.append(contentsOf: [
+                toolbar.leadingAnchor.constraint(equalTo: horizontalGuide.leadingAnchor),
+                toolbar.trailingAnchor.constraint(equalTo: horizontalGuide.trailingAnchor),
+                toolbar.bottomAnchor.constraint(equalTo: verticalGuide.bottomAnchor),
+            ])
+        } else {
+            constraints.append(contentsOf: [
+                toolbar.leadingAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.leadingAnchor),
+                toolbar.trailingAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.trailingAnchor),
+                toolbar.bottomAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.bottomAnchor),
+            ])
+        }
         if #unavailable(iOS 26.0) {
             constraints.append(contentsOf: [
                 fallbackTopBackgroundView.topAnchor.constraint(equalTo: hostView.topAnchor),

--- a/iOS/DuckDuckGo/MainView.swift
+++ b/iOS/DuckDuckGo/MainView.swift
@@ -633,14 +633,26 @@ extension MainViewFactory {
 
         // Changing this?  Best change TabSwitcherViewController too
         let isFloatingUIEnabled = floatingUIManager.isFloatingUIEnabled
-        let toolbarWidthMod = isFloatingUIEnabled ? 0.0 : (isiOS26 ? 14.0 : 4.0)
-
         let toolbar = coordinator.toolbar!
-        coordinator.constraints.toolbarBottom = toolbar.constrainView(superview.safeAreaLayoutGuide, by: .bottom)
-        // Match the toolbar's internal buttons-only height for the current style so the initial
-        // constraint doesn't conflict before `updateToolbarLayoutForAddressBarPosition` runs.
+
         let initialToolbarHeight = isFloatingUIEnabled ? BrowserToolbarView.totalHeight(withOmnibarHeight: 0, isFloating: isFloatingUIEnabled) : BrowserToolbarView.legacyButtonsHeight
         coordinator.constraints.toolbarHeight = toolbar.constrainAttribute(.height, to: initialToolbarHeight)
+
+        if #available(iOS 26.0, *), isFloatingUIEnabled {
+            let horizontalGuide = superview.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
+            let verticalGuide = superview.layoutGuide(for: .safeArea(cornerAdaptation: .vertical))
+            coordinator.constraints.toolbarBottom = toolbar.bottomAnchor.constraint(equalTo: verticalGuide.bottomAnchor)
+            NSLayoutConstraint.activate([
+                toolbar.leadingAnchor.constraint(equalTo: horizontalGuide.leadingAnchor),
+                toolbar.trailingAnchor.constraint(equalTo: horizontalGuide.trailingAnchor),
+                coordinator.constraints.toolbarHeight,
+                coordinator.constraints.toolbarBottom,
+            ])
+            return
+        }
+
+        let toolbarWidthMod = isiOS26 ? 14.0 : 4.0
+        coordinator.constraints.toolbarBottom = toolbar.constrainView(superview.safeAreaLayoutGuide, by: .bottom)
         NSLayoutConstraint.activate([
             toolbar.constrainView(superview, by: .width, constant: toolbarWidthMod),
             toolbar.constrainView(superview, by: .centerX),

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5612,7 +5612,8 @@ extension MainViewController: OmniBarDelegate {
             // on it makes UIGlassEffect move independently of the icons.
         } else {
             attach(to: floatingDomainCapsuleController.button, onEdge: .bottom)
-            attach(to: viewCoordinator.toolbar, onEdge: .bottom)
+            // The toolbar is already pinned to the concentric layout guides. A scroll-edge
+            // interaction would apply a second, larger device-concentric inset.
         }
     }
 

--- a/iOS/DuckDuckGo/TabSwitcherChrome.swift
+++ b/iOS/DuckDuckGo/TabSwitcherChrome.swift
@@ -78,6 +78,10 @@ protocol TabSwitcherChrome: AnyObject {
     /// Applies the appropriate content insets so collection content clears the bars.
     func applyCollectionContentInset(to collectionView: UICollectionView)
 
+    /// Distance from the content view's top to the bottom of the top bar.
+    /// Overlaying content (tab cards, Fire Tabs empty state) uses this so both pages match during a swipe.
+    var topBarBottomOffset: CGFloat { get }
+
     /// Points the system scroll-edge glass effect at the scroll view the user actually scrolls
     /// (the active page's collection view), so the effect tracks vertical tab scrolling rather
     /// than the horizontally-paging container.
@@ -85,6 +89,8 @@ protocol TabSwitcherChrome: AnyObject {
 }
 
 extension TabSwitcherChrome {
+    var topBarBottomOffset: CGFloat { 0 }
+
     func trackScrollEdge(of scrollView: UIScrollView) {}
 }
 

--- a/iOS/DuckDuckGo/TabSwitcherPageViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherPageViewController.swift
@@ -99,6 +99,7 @@ class TabSwitcherPageViewController: UIViewController {
     private var lastAppliedTrackerCountState: TabSwitcherTrackerCountViewModel.State?
     private var trackerInfoModel: InfoPanelView.Model?
     private var fireModeEmptyStateHostingController: UIHostingController<FireModeEmptyStateView>?
+    private var fireModeEmptyStateTopConstraint: NSLayoutConstraint?
     private let duckAIGridContentProvider: DuckAIGridContentProviding?
     private let duckAIVoiceSessionTracker: DuckAIVoiceSessionTracking?
     private var voiceSessionChangesCancellable: AnyCancellable?
@@ -159,6 +160,9 @@ class TabSwitcherPageViewController: UIViewController {
         collectionView.allowsSelection = true
         collectionView.allowsMultipleSelection = true
         collectionView.allowsMultipleSelectionDuringEditing = true
+        if isFloatingTabSwitcherEnabled {
+            collectionView.contentInsetAdjustmentBehavior = .never
+        }
 
         collectionView.register(TabViewGridCell.self, forCellWithReuseIdentifier: TabViewGridCell.reuseIdentifier)
         collectionView.register(TabViewListCell.self, forCellWithReuseIdentifier: TabViewListCell.reuseIdentifier)
@@ -226,10 +230,18 @@ class TabSwitcherPageViewController: UIViewController {
         view.addSubview(hostingController.view)
         hostingController.didMove(toParent: self)
 
-        let topConstraint = isFloatingTabSwitcherEnabled
-            ? hostingController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor,
-                                                          constant: FireModeEmptyStateMetrics.floatingNavigationBarClearance)
-            : hostingController.view.topAnchor.constraint(equalTo: view.topAnchor)
+        let topConstraint: NSLayoutConstraint
+        if isFloatingTabSwitcherEnabled {
+            // Pin to the page top (same coordinate space as the collection view) so clearance
+            // matches the chrome inset: navbar bottom + 10pt. The empty state's own
+            // `mainTopPadding` then adds 24pt above the pictogram.
+            topConstraint = hostingController.view.topAnchor.constraint(
+                equalTo: view.topAnchor,
+                constant: FireModeEmptyStateMetrics.estimatedFloatingTopClearance)
+            fireModeEmptyStateTopConstraint = topConstraint
+        } else {
+            topConstraint = hostingController.view.topAnchor.constraint(equalTo: view.topAnchor)
+        }
 
         NSLayoutConstraint.activate([
             topConstraint,
@@ -241,8 +253,16 @@ class TabSwitcherPageViewController: UIViewController {
         fireModeEmptyStateHostingController = hostingController
     }
 
-    private enum FireModeEmptyStateMetrics {
-        static let floatingNavigationBarClearance: CGFloat = 60
+    enum FireModeEmptyStateMetrics {
+        /// Gap between the top navbar buttons and the empty-state container.
+        static let spacingBelowNavbar: CGFloat = 10
+        /// Fallback until the chrome reports a laid-out nav bar: estimated nav (50) + floating inset (8) + 10.
+        static let estimatedFloatingTopClearance: CGFloat = 68
+    }
+
+    func applyFloatingTopClearance(_ topBarBottomOffset: CGFloat) {
+        guard isFloatingTabSwitcherEnabled else { return }
+        fireModeEmptyStateTopConstraint?.constant = topBarBottomOffset + FireModeEmptyStateMetrics.spacingBelowNavbar
     }
 
     func updateEmptyStateVisibility() {

--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -299,8 +299,11 @@ extension TabSwitcherViewController {
 
     func applyCollectionContentInsets() {
         chrome.applyCollectionContentInset(to: normalPageController.collectionView)
-        if let fireCollectionView = firePageController?.collectionView {
-            chrome.applyCollectionContentInset(to: fireCollectionView)
+        if let firePageController {
+            if let fireCollectionView = firePageController.collectionView {
+                chrome.applyCollectionContentInset(to: fireCollectionView)
+            }
+            firePageController.applyFloatingTopClearance(chrome.topBarBottomOffset)
         }
     }
     

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -254,6 +254,48 @@ final class BrowserToolbarViewTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(container.bounds.width - frame.maxX, concentric - 0.01)
     }
 
+    func testWhenGuideGapExceedsConcentricInsetThenGlassShiftsDown() {
+        let concentric = BrowserToolbarView.floatingEmbeddedConcentricInset
+        // Home indicator: the guide stops short of the bottom, so the glass moves down to it.
+        XCTAssertEqual(
+            BrowserToolbarView.embeddedRestStateBottomOffset(guideBottomGap: 34),
+            34 - concentric,
+            accuracy: 0.01)
+    }
+
+    func testWhenGuideReachesPhysicalBottomThenGlassShiftsUpToKeepTheInset() {
+        let concentric = BrowserToolbarView.floatingEmbeddedConcentricInset
+        // No home indicator: the guide already sits at the bottom, so the glass must move up to
+        // leave the same inset that restingCapsuleFrame reports, rather than sitting flush.
+        XCTAssertEqual(
+            BrowserToolbarView.embeddedRestStateBottomOffset(guideBottomGap: 0),
+            -concentric,
+            accuracy: 0.01)
+        XCTAssertEqual(
+            BrowserToolbarView.embeddedRestStateBottomOffset(guideBottomGap: concentric),
+            0,
+            accuracy: 0.01)
+    }
+
+    func testWhenSafeAreaGuideIsUnresolvedThenCapsuleStaysWithinBounds() {
+        guard #available(iOS 26.0, *) else { return }
+        // No window, so the corner-adapted guide never resolves and its layout frame is empty.
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+
+        for embedded in [true, false] {
+            let sut = makeSUT(embeddedOmnibar: embedded)
+            container.addSubview(sut)
+            container.layoutIfNeeded()
+
+            let frame = sut.restingCapsuleFrame(in: container)
+
+            XCTAssertGreaterThanOrEqual(frame.width, 0, "embedded: \(embedded)")
+            XCTAssertGreaterThanOrEqual(frame.minX, 0, "embedded: \(embedded)")
+            XCTAssertLessThanOrEqual(frame.maxX, container.bounds.maxX, "embedded: \(embedded)")
+            sut.removeFromSuperview()
+        }
+    }
+
     func testWhenBottomOmnibarDetachesForFocusThenOuterInsetsStayUnchanged() {
         let sut = makeSUT(embeddedOmnibar: true)
         let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -193,7 +193,7 @@ final class BrowserToolbarViewTests: XCTestCase {
         }
     }
 
-    func testWhenEmbeddedFloatingThenOuterInsetFollowsConcentricSafeArea() {
+    func testWhenEmbeddedFloatingThenOuterInsetIsEqualOnEveryEdge() {
         let sut = makeSUT(embeddedOmnibar: true)
         let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
         container.addSubview(sut)
@@ -202,14 +202,30 @@ final class BrowserToolbarViewTests: XCTestCase {
         let frame = sut.restingCapsuleFrame(in: container)
 
         if #available(iOS 26.0, *) {
-            let guide = container.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
-            let expected = guide.layoutFrame.minX + BrowserToolbarView.floatingConcentricGlassInset
-            XCTAssertEqual(frame.minX, expected, accuracy: 0.01)
-            XCTAssertEqual(container.bounds.width - frame.maxX, expected, accuracy: 0.01)
+            XCTAssertEqual(frame.minX, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.width - frame.maxX, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.maxY - frame.maxY, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
         } else {
             XCTAssertEqual(BrowserToolbarView.floatingEmbeddedHorizontalInset, 16)
             XCTAssertEqual(frame.minX, 16, accuracy: 0.01)
             XCTAssertEqual(container.bounds.width - frame.maxX, 16, accuracy: 0.01)
+        }
+    }
+
+    func testWhenBottomOmnibarDetachesForFocusThenOuterInsetsStayUnchanged() {
+        let sut = makeSUT(embeddedOmnibar: true)
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        container.addSubview(sut)
+        sut.prepareForOmnibarDetachment()
+        sut.applyOmnibarDetachmentPose()
+        container.layoutIfNeeded()
+
+        let frame = sut.restingCapsuleFrame(in: container)
+
+        if #available(iOS 26.0, *) {
+            XCTAssertEqual(frame.minX, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.width - frame.maxX, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.maxY - frame.maxY, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
         }
     }
 
@@ -222,13 +238,19 @@ final class BrowserToolbarViewTests: XCTestCase {
         XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .top), 21)
     }
 
-    func testWhenEmbeddedFloatingThenBottomMarginIsSixteenPoints() {
+    func testWhenEmbeddedFloatingThenBottomMarginMatchesPlatformGeometry() {
         let sut = makeSUT(embeddedOmnibar: true)
 
         XCTAssertEqual(BrowserToolbarView.floatingEmbeddedBottomMargin, 16)
-        XCTAssertEqual(sut.floatingBottomMargin, 16, accuracy: 0.01)
-        XCTAssertEqual(BrowserToolbarView.floatingOuterHorizontalInset(for: .bottom), 16)
-        XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .bottom), 16)
+        if #available(iOS 26.0, *) {
+            XCTAssertEqual(sut.floatingBottomMargin, 20, accuracy: 0.01)
+            XCTAssertEqual(BrowserToolbarView.floatingOuterHorizontalInset(for: .bottom), 20)
+            XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .bottom), 20)
+        } else {
+            XCTAssertEqual(sut.floatingBottomMargin, 16, accuracy: 0.01)
+            XCTAssertEqual(BrowserToolbarView.floatingOuterHorizontalInset(for: .bottom), 16)
+            XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .bottom), 16)
+        }
     }
 
     func testWhenStandaloneFloatingThenButtonsAreEvenlySpacedAndFireButtonIsCentered() {

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -172,29 +172,45 @@ final class BrowserToolbarViewTests: XCTestCase {
             accuracy: 0.01)
     }
 
-    func testWhenStandaloneFloatingThenOuterInsetIsTwentyFourPoints() {
+    func testWhenStandaloneFloatingThenOuterInsetFollowsConcentricSafeArea() {
         let sut = makeSUT(embeddedOmnibar: false)
         let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
         container.addSubview(sut)
+        container.layoutIfNeeded()
 
         let frame = sut.restingCapsuleFrame(in: container)
 
-        XCTAssertEqual(BrowserToolbarView.floatingStandaloneHorizontalInset, 24)
         XCTAssertEqual(BrowserToolbarView.floatingStandaloneButtonRowHorizontalPadding, 16)
-        XCTAssertEqual(frame.minX, 24, accuracy: 0.01)
-        XCTAssertEqual(container.bounds.width - frame.maxX, 24, accuracy: 0.01)
+        if #available(iOS 26.0, *) {
+            let guide = container.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
+            let expected = guide.layoutFrame.minX + BrowserToolbarView.floatingConcentricGlassInset
+            XCTAssertEqual(frame.minX, expected, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.width - frame.maxX, expected, accuracy: 0.01)
+        } else {
+            XCTAssertEqual(BrowserToolbarView.floatingStandaloneHorizontalInset, 24)
+            XCTAssertEqual(frame.minX, 24, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.width - frame.maxX, 24, accuracy: 0.01)
+        }
     }
 
-    func testWhenEmbeddedFloatingThenOuterInsetStaysSixteenPoints() {
+    func testWhenEmbeddedFloatingThenOuterInsetFollowsConcentricSafeArea() {
         let sut = makeSUT(embeddedOmnibar: true)
         let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
         container.addSubview(sut)
+        container.layoutIfNeeded()
 
         let frame = sut.restingCapsuleFrame(in: container)
 
-        XCTAssertEqual(BrowserToolbarView.floatingEmbeddedHorizontalInset, 16)
-        XCTAssertEqual(frame.minX, 16, accuracy: 0.01)
-        XCTAssertEqual(container.bounds.width - frame.maxX, 16, accuracy: 0.01)
+        if #available(iOS 26.0, *) {
+            let guide = container.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
+            let expected = guide.layoutFrame.minX + BrowserToolbarView.floatingConcentricGlassInset
+            XCTAssertEqual(frame.minX, expected, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.width - frame.maxX, expected, accuracy: 0.01)
+        } else {
+            XCTAssertEqual(BrowserToolbarView.floatingEmbeddedHorizontalInset, 16)
+            XCTAssertEqual(frame.minX, 16, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.width - frame.maxX, 16, accuracy: 0.01)
+        }
     }
 
     func testWhenStandaloneFloatingThenBottomMarginIsTwentyOnePoints() {
@@ -202,6 +218,17 @@ final class BrowserToolbarViewTests: XCTestCase {
 
         XCTAssertEqual(BrowserToolbarView.floatingStandaloneBottomMargin, 21)
         XCTAssertEqual(sut.floatingBottomMargin, 21, accuracy: 0.01)
+        XCTAssertEqual(BrowserToolbarView.floatingOuterHorizontalInset(for: .top), 24)
+        XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .top), 21)
+    }
+
+    func testWhenEmbeddedFloatingThenBottomMarginIsSixteenPoints() {
+        let sut = makeSUT(embeddedOmnibar: true)
+
+        XCTAssertEqual(BrowserToolbarView.floatingEmbeddedBottomMargin, 16)
+        XCTAssertEqual(sut.floatingBottomMargin, 16, accuracy: 0.01)
+        XCTAssertEqual(BrowserToolbarView.floatingOuterHorizontalInset(for: .bottom), 16)
+        XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .bottom), 16)
     }
 
     func testWhenStandaloneFloatingThenButtonsAreEvenlySpacedAndFireButtonIsCentered() {

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -90,10 +90,13 @@ final class BrowserToolbarViewTests: XCTestCase {
             return view.subviews.lazy.compactMap { visualEffectView(in: $0) }.first
         }
 
-        let glass = visualEffectView(in: sut)
-        XCTAssertEqual(glass?.transform.a, 1, accuracy: 0.001)
-        XCTAssertEqual(glass?.transform.d, 1, accuracy: 0.001)
-        XCTAssertEqual(glass?.transform.ty, 0, accuracy: 0.001)
+        guard let glass = visualEffectView(in: sut) else {
+            XCTFail("Missing glass effect view")
+            return
+        }
+        XCTAssertEqual(glass.transform.a, 1, accuracy: 0.001)
+        XCTAssertEqual(glass.transform.d, 1, accuracy: 0.001)
+        XCTAssertEqual(glass.transform.ty, 0, accuracy: 0.001)
     }
 
     func testWhenStandaloneCollapseProgressIsAppliedThenIconsAreNotInsideGlassContentView() {
@@ -174,7 +177,12 @@ final class BrowserToolbarViewTests: XCTestCase {
 
     func testWhenStandaloneFloatingThenOuterInsetFollowsConcentricSafeArea() {
         let sut = makeSUT(embeddedOmnibar: false)
-        let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        // The safe area layout guide only resolves inside a window; without one it stays empty
+        // and the trailing edge is measured against a degenerate guide.
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        let container = UIView(frame: window.bounds)
+        window.addSubview(container)
+        window.makeKeyAndVisible()
         container.addSubview(sut)
         container.layoutIfNeeded()
 
@@ -224,6 +232,26 @@ final class BrowserToolbarViewTests: XCTestCase {
         XCTAssertEqual(BrowserToolbarView.embeddedRestStateInnerInset(guideInset: concentric + 1), 0, accuracy: 0.01)
         XCTAssertEqual(BrowserToolbarView.embeddedRestStateInnerInset(guideInset: 59), 0, accuracy: 0.01)
         XCTAssertEqual(BrowserToolbarView.embeddedRestStateInnerInset(guideInset: -8), concentric, accuracy: 0.01)
+    }
+
+    func testWhenGuidesAreAsymmetricThenEachEdgeIsCompensatedFromItsOwnGuide() {
+        guard #available(iOS 26.0, *) else { return }
+        let concentric = BrowserToolbarView.floatingEmbeddedConcentricInset
+        // Landscape with the Dynamic Island on the leading edge only.
+        let container = SafeAreaStubView(frame: CGRect(x: 0, y: 0, width: 844, height: 390))
+        container.stubbedSafeAreaInsets = UIEdgeInsets(top: 0, left: concentric + 39, bottom: 21, right: 0)
+        let sut = makeSUT(embeddedOmnibar: true)
+        container.addSubview(sut)
+        container.layoutIfNeeded()
+
+        let frame = sut.restingCapsuleFrame(in: container)
+        let guideInsets = BrowserToolbarView.horizontalGuideInsets(in: container)
+
+        // Each edge sits at its own guide, or at the concentric inset when the guide is smaller.
+        XCTAssertEqual(frame.minX, max(guideInsets.left, concentric), accuracy: 0.01)
+        XCTAssertEqual(container.bounds.width - frame.maxX, max(guideInsets.right, concentric), accuracy: 0.01)
+        // The wide leading guide must not pull the opposite edge inside the concentric inset.
+        XCTAssertGreaterThanOrEqual(container.bounds.width - frame.maxX, concentric - 0.01)
     }
 
     func testWhenBottomOmnibarDetachesForFocusThenOuterInsetsStayUnchanged() {
@@ -329,4 +357,16 @@ final class BrowserToolbarViewTests: XCTestCase {
             115,
             accuracy: 0.01)
     }
+}
+
+private final class SafeAreaStubView: UIView {
+
+    var stubbedSafeAreaInsets: UIEdgeInsets = .zero {
+        didSet { setNeedsLayout() }
+    }
+
+    override var safeAreaInsets: UIEdgeInsets {
+        stubbedSafeAreaInsets
+    }
+
 }

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -212,6 +212,20 @@ final class BrowserToolbarViewTests: XCTestCase {
         }
     }
 
+    func testWhenHorizontalGuideInsetIsSmallerThanConcentricInsetThenInnerInsetFillsTheGap() {
+        let concentric = BrowserToolbarView.floatingEmbeddedConcentricInset
+        XCTAssertEqual(BrowserToolbarView.embeddedRestStateInnerInset(guideInset: 0), concentric, accuracy: 0.01)
+        XCTAssertEqual(BrowserToolbarView.embeddedRestStateInnerInset(guideInset: 16), concentric - 16, accuracy: 0.01)
+        XCTAssertEqual(BrowserToolbarView.embeddedRestStateInnerInset(guideInset: concentric), 0, accuracy: 0.01)
+    }
+
+    func testWhenHorizontalGuideInsetExceedsConcentricInsetThenInnerInsetIsClampedToZero() {
+        let concentric = BrowserToolbarView.floatingEmbeddedConcentricInset
+        XCTAssertEqual(BrowserToolbarView.embeddedRestStateInnerInset(guideInset: concentric + 1), 0, accuracy: 0.01)
+        XCTAssertEqual(BrowserToolbarView.embeddedRestStateInnerInset(guideInset: 59), 0, accuracy: 0.01)
+        XCTAssertEqual(BrowserToolbarView.embeddedRestStateInnerInset(guideInset: -8), concentric, accuracy: 0.01)
+    }
+
     func testWhenBottomOmnibarDetachesForFocusThenOuterInsetsStayUnchanged() {
         let sut = makeSUT(embeddedOmnibar: true)
         let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))

--- a/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
+++ b/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
@@ -232,6 +232,34 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
         chrome.applyCollectionContentInset(to: collectionView)
 
         XCTAssertEqual(collectionView.contentInset.top, 58)
+        XCTAssertEqual(collectionView.contentInsetAdjustmentBehavior, .never)
+        XCTAssertEqual(collectionView.contentOffset.y, -58)
+        XCTAssertEqual(chrome.topBarBottomOffset, 58)
+    }
+
+    func testWhenCollectionContentInsetIsAppliedToBothPagesThenTopInsetsMatch() {
+        let chrome = FloatingTabSwitcherChrome()
+        let normalPage = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        let firePage = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+
+        chrome.applyCollectionContentInset(to: normalPage)
+        chrome.applyCollectionContentInset(to: firePage)
+
+        XCTAssertEqual(normalPage.contentInset.top, firePage.contentInset.top)
+        XCTAssertEqual(normalPage.contentOffset.y, firePage.contentOffset.y)
+        XCTAssertEqual(normalPage.contentInsetAdjustmentBehavior, .never)
+        XCTAssertEqual(firePage.contentInsetAdjustmentBehavior, .never)
+    }
+
+    func testWhenEmptyStateClearanceIsAppliedThenItSitsBelowNavbarAndAbovePictogram() {
+        XCTAssertEqual(TabSwitcherPageViewController.FireModeEmptyStateMetrics.spacingBelowNavbar, 10)
+        XCTAssertEqual(TabSwitcherPageViewController.FireModeEmptyStateMetrics.estimatedFloatingTopClearance, 68)
+        XCTAssertEqual(FireModeEmptyStateView.Constants.mainTopPadding, 24)
+
+        let chrome = FloatingTabSwitcherChrome()
+        XCTAssertEqual(
+            chrome.topBarBottomOffset + TabSwitcherPageViewController.FireModeEmptyStateMetrics.spacingBelowNavbar,
+            TabSwitcherPageViewController.FireModeEmptyStateMetrics.estimatedFloatingTopClearance)
     }
 
     func testWhenLargeSizeHasSingleEmptyTabThenEditMenuIsDisabled() {
@@ -333,6 +361,31 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
             $0.firstItem is UINavigationBar && $0.firstAttribute == .top
         }
         XCTAssertTrue((topConstraint?.secondItem as? UILayoutGuide) === host.layoutMarginsGuide)
+    }
+
+    func testWhenLayoutIsAppliedThenToolbarUsesDeviceConcentricInsets() {
+        let chrome = FloatingTabSwitcherChrome()
+        let host = UIView()
+        let content = UIScrollView()
+        chrome.install(in: host, contentView: content)
+
+        chrome.layout(addressBarPosition: .top, interfaceMode: .regularSize)
+
+        let leading = host.constraints.first { $0.firstItem === chrome.toolbar && $0.firstAttribute == .leading }
+        let trailing = host.constraints.first { $0.firstItem === chrome.toolbar && $0.firstAttribute == .trailing }
+        let bottom = host.constraints.first { $0.firstItem === chrome.toolbar && $0.firstAttribute == .bottom }
+
+        if #available(iOS 26.0, *) {
+            let horizontalGuide = host.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
+            let verticalGuide = host.layoutGuide(for: .safeArea(cornerAdaptation: .vertical))
+            XCTAssertTrue((leading?.secondItem as? UILayoutGuide) === horizontalGuide)
+            XCTAssertTrue((trailing?.secondItem as? UILayoutGuide) === horizontalGuide)
+            XCTAssertTrue((bottom?.secondItem as? UILayoutGuide) === verticalGuide)
+        } else {
+            XCTAssertTrue((leading?.secondItem as? UILayoutGuide) === host.safeAreaLayoutGuide)
+            XCTAssertTrue((trailing?.secondItem as? UILayoutGuide) === host.safeAreaLayoutGuide)
+            XCTAssertTrue((bottom?.secondItem as? UILayoutGuide) === host.safeAreaLayoutGuide)
+        }
     }
 
     func testWhenLayoutIsAppliedThenFallbackTopBackgroundCoversContentBeforeIOS26() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216033800174503/task/1216167808982814
Tech Design URL: N/A
CC: N/A

Stacked on https://github.com/duckduckgo/apple-browsers/pull/6561

### Description
- Keep Fire Tabs empty state 10pt below the top navbar (and 24pt above the pictogram) by pinning it to the chrome's laid-out nav bottom instead of `safeArea + 60`
- Apply matching collection top insets to both Normal and Fire pages during the swipe so cards do not jump when the transition settles
- Pin the tab switcher toolbar and split-mode bottom capsule to the same iOS 26 concentric safe-area guides, including UIToolbar's extra 20pt glass inset
- Keep combined bottom chrome at an equal 20pt inset on every edge and preserve its native concentric corner configuration through focus transitions

### Testing Steps
- On iPhone running iOS 26, open Tab Manager with no Fire tabs and confirm the empty state sits below the navbar buttons and above the fire pictogram
- Swipe Normal ↔ Fire and confirm tab cards do not jump when the page settles
- With the address bar at the top, compare the webview buttons-only bar and tab switcher bar and confirm their side and bottom insets match
- With the address bar at the bottom, confirm the combined chrome has equal 20pt leading, trailing, and bottom insets
- Focus and dismiss the bottom address bar and confirm its outer frame and corner shape do not change

### Impact and Risks
**Impact Level: Low**

#### What could go wrong?
- Chrome hide/show morph could drift if `restingCapsuleFrame` and the live glass disagree; split mode shares the guide-based geometry, while combined bottom mode shares one 20pt edge inset
- Scroll-edge interactions were removed from the bottom bars so they do not apply a second concentric inset; if a future OS change relies on that interaction, glass could drift from the icons

### Quality Considerations
- iPad / large-size tab switcher still hides the toolbar and skips the concentric pin
- Pre-iOS 26 keeps the previous safe-area pin and 24/16pt fallbacks
- No privacy or network changes

### Notes to Reviewer
- The 20pt `floatingConcentricGlassInset` matches the extra inset `UIToolbar` applies to the split-mode buttons-only capsule
- Combined bottom chrome uses its own equal 20pt edge inset and `containerConcentric(minimum: 40)` corners
- Combined portrait-bottom internal metrics (12pt spacing, 48pt field, embedded buttons) are unchanged


Made with [Cursor](https://cursor.com)