### PR TITLE
iOS: Match focused UTI inset to the resting address bar

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -99,13 +99,12 @@ final class UnifiedToggleInputView: UIView {
         /// (see `flankedHorizontalInset` in `setupConstraints`). Keeps the flanked input's left/right
         /// padding consistent end-to-end.
         static let flankedCardHorizontalMargin: CGFloat = 16
-        /// Card container's outer horizontal margin in the non-flanked layouts.
-        static let cardHorizontalMargin: CGFloat = 8
         static let cardVerticalMargin: CGFloat = 8
         static let cardHorizontalMarginExpanded: CGFloat = 16
         static let cardVerticalMarginBottom: CGFloat = 8
-        /// Omnibar pill's horizontal inset; the card's hand-off start width so it animates to the
-        /// narrower editing margins. Mirrors `DefaultOmniBarView`'s portrait value (landscape/iPad differ).
+        /// Resting address-bar inset (`DefaultOmniBarView.Metrics.textAreaHorizontalPadding`). Used
+        /// for the omnibar hand-off and for the focused card in the top/split session so the
+        /// field doesn't shrink horizontally when editing begins.
         static let omnibarMatchingHorizontalMargin: CGFloat = 16
         static let cardCornerRadiusExpanded: CGFloat = 28
         static let toggleTopPadding: CGFloat = 8
@@ -1169,12 +1168,9 @@ final class UnifiedToggleInputView: UIView {
         if expanded && !usesOmnibarMargins {
             hLeadingMargin = Constants.cardHorizontalMarginExpanded
             hTrailingMargin = Constants.cardHorizontalMarginExpanded
-        } else if layout == .collapsed {
+        } else {
             hLeadingMargin = Constants.omnibarMatchingHorizontalMargin
             hTrailingMargin = Constants.omnibarMatchingHorizontalMargin
-        } else {
-            hLeadingMargin = Constants.cardHorizontalMargin
-            hTrailingMargin = cardTrailingMargin
         }
 
         let topMargin: CGFloat
@@ -1376,8 +1372,6 @@ final class UnifiedToggleInputView: UIView {
             // would stretch the pinned 44pt height to 46pt (defaultHigh priority loses to bottom).
             cardTopConstraint.constant = Constants.cardVerticalMargin
             cardBottomConstraint.constant = -Constants.cardVerticalMargin
-            // Start width matches the omnibar so the expanded pose (set inside the animation block)
-            // can animate the card's width rather than snap it.
             cardLeadingConstraint.constant = Constants.omnibarMatchingHorizontalMargin
             cardTrailingConstraint.constant = -Constants.omnibarMatchingHorizontalMargin
         case .bottom:
@@ -1460,7 +1454,7 @@ final class UnifiedToggleInputView: UIView {
         let showToolbar = toggleView.selectedMode == .aiChat
         currentLayout = .expanded(showsToggle: true, showsToolbar: showToolbar)
         cardView.layer.cornerRadius = Constants.cardCornerRadiusExpanded
-        // Width animation: this reveal path bypasses `applyCardLayout`, so set the expanded margins here.
+        // This reveal path bypasses `applyCardLayout`, so keep the focused margins in sync here.
         cardLeadingConstraint.constant = expandedCardHorizontalMargin
         cardTrailingConstraint.constant = -expandedCardHorizontalMargin
         toggleTopConstraint.constant = Constants.toggleTopPadding
@@ -1531,15 +1525,8 @@ final class UnifiedToggleInputView: UIView {
 
     // MARK: - Private
 
-    /// Card trailing margin for the current state. The card spans the full width since the
-    /// inline X is hosted inside the card (in the toggle row when the toggle is shown, or in
-    /// the field row alongside the inline buttons when the toggle is hidden at `.top`).
-    private var cardTrailingMargin: CGFloat {
-        Constants.cardHorizontalMargin
-    }
-
     private var expandedCardHorizontalMargin: CGFloat {
-        usesOmnibarMargins ? Constants.cardHorizontalMargin : Constants.cardHorizontalMarginExpanded
+        usesOmnibarMargins ? Constants.omnibarMatchingHorizontalMargin : Constants.cardHorizontalMarginExpanded
     }
 
     private func updateToolbarVisibility(for mode: TextEntryMode, animated: Bool) {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -88,6 +88,21 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertEqual(outlinedCard.layer.borderWidth, 0)
     }
 
+    func testWhenFocusedInSplitOmnibarSessionThenCardMatchesRestingAddressBarInset() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+        sut.cardPosition = .top
+        sut.usesOmnibarMargins = true
+        sut.prepareForOmnibarEditingShow()
+        sut.applyOmnibarEditingShowPose()
+        prepareForFitting(sut, width: 402, height: 192)
+        applyFittingHeight(to: sut, width: 402)
+
+        let inset = try XCTUnwrap(activeCardHorizontalInset(in: sut))
+
+        XCTAssertEqual(inset, 16)
+    }
+
     func testWhenToggleIsEnabledOnExpandedSearchInputThenOutlineAppears() {
         let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
         let sut = UnifiedToggleInputView(handler: handler, isToggleEnabled: false)
@@ -747,6 +762,16 @@ final class UnifiedToggleInputViewTests: XCTestCase {
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 1)
+    }
+
+    private func activeCardHorizontalInset(in view: UnifiedToggleInputView) -> CGFloat? {
+        view.constraints.first { constraint in
+            constraint.isActive
+                && constraint.firstAttribute == .leading
+                && constraint.secondAttribute == .leading
+                && constraint.secondItem === view
+                && (constraint.firstItem as? UIView)?.isUserInteractionEnabled == false
+        }?.constant
     }
 
     private func prepareForFitting(_ view: UIView, width: CGFloat = 320, height: CGFloat = 68) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217904396397158
Tech Design URL: N/A
CC: N/A

### Description
- Keep the focused unified input in split mode (top address bar) at the same 16pt horizontal inset as the resting address bar
- Stop the focused card shrinking to 8pt when editing begins
- Leave bottom-bar and flanked AI-tab layouts unchanged

Stacked on https://github.com/duckduckgo/apple-browsers/pull/6563

### Testing Steps
1. Enable floating UI and set the address bar to Top (split mode)
2. Note the resting address bar’s left and right inset
3. Tap the address bar to focus the unified input
4. Confirm the focused card lines up with that same horizontal inset, rather than sitting closer to the screen edges
5. Dismiss the input and confirm the resting address bar is unchanged
6. Switch the address bar to Bottom, focus it, and confirm that layout is unaffected

### Impact
**Impact Level: Low**

#### What could go wrong?
The focused top/split card stays 8pt wider than before. If surrounding chrome or suggestions assumed the narrower width, they could look slightly tighter → mitigated by keeping the 16pt value that the resting address bar and the hand-off pose already use.

### Quality Considerations
- Bottom-bar focused UTI already used the 16pt expanded inset; this only changes the top/split omnibar session
- Landscape / iPad still inherit the same 16pt token as the portrait address bar
- No privacy or analytics impact

### Notes to Reviewer
Parent of this stack is #6563.


Made with [Cursor](https://cursor.com)