### PR TITLE
Prevent shortcut menu crashes during app lifecycle transitions

### DIFF
--- a/iOS/AtbUITests/ApplicationShortcutItemsUITests.swift
+++ b/iOS/AtbUITests/ApplicationShortcutItemsUITests.swift
@@ -1,0 +1,93 @@
+//
+//  ApplicationShortcutItemsUITests.swift
+//  AtbUITests
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+final class ApplicationShortcutItemsUITests: XCTestCase {
+
+    private let app = XCUIApplication()
+    private let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+    private let timeout: TimeInterval = 20
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        continueAfterFailure = false
+
+        app.launchArguments = [
+            "-clearAllDefaults",
+            "isRunningUITests",
+            "-isOnboardingCompleted", "true",
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_GB",
+        ]
+        app.launchEnvironment = ["UITEST_MODE": "1"]
+        app.launch()
+
+        XCTAssertTrue(searchEntry.waitForExistence(timeout: timeout))
+    }
+
+    override func tearDownWithError() throws {
+        app.terminate()
+        try super.tearDownWithError()
+    }
+
+    func testQuickActionsSurviveRepeatedBackgroundTransitions() {
+        for iteration in 1...20 {
+            XCUIDevice.shared.press(.home)
+
+            XCTAssertTrue(waitForAppToLeaveForeground(), "App did not enter the background on iteration \(iteration).")
+            XCTAssertNotEqual(app.state, .notRunning, "App terminated while entering the background on iteration \(iteration).")
+
+            app.activate()
+
+            XCTAssertTrue(app.wait(for: .runningForeground, timeout: timeout), "App did not return on iteration \(iteration).")
+            XCTAssertTrue(searchEntry.waitForExistence(timeout: timeout), "Browser UI did not return on iteration \(iteration).")
+        }
+
+        XCUIDevice.shared.press(.home)
+        XCTAssertTrue(waitForAppToLeaveForeground())
+        XCTAssertNotEqual(app.state, .notRunning)
+
+        let appIcon = springboard.icons["DuckDuckGo"]
+        XCTAssertTrue(appIcon.waitForExistence(timeout: timeout))
+        appIcon.press(forDuration: 1.2)
+
+        XCTAssertTrue(springboard.buttons["Duck.ai"].waitForExistence(timeout: timeout))
+        XCTAssertTrue(springboard.buttons["Paste from Clipboard"].exists)
+        XCTAssertFalse(springboard.buttons["Open VPN"].exists)
+        XCTAssertNotEqual(app.state, .notRunning)
+    }
+
+    private var searchEntry: XCUIElement {
+        app.descendants(matching: .any)["searchEntry"]
+    }
+
+    private func waitForAppToLeaveForeground() -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            switch app.state {
+            case .runningBackground, .runningBackgroundSuspended, .notRunning:
+                return true
+            default:
+                RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+            }
+        }
+        return false
+    }
+}

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A17C00012F9A000100000001 /* ApplicationShortcutItemsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17C00022F9A000100000002 /* ApplicationShortcutItemsService.swift */; };
+		A17C00032F9A000100000003 /* ApplicationShortcutItemsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17C00042F9A000100000004 /* ApplicationShortcutItemsServiceTests.swift */; };
 		02025664298818B200E694E7 /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02025663298818B100E694E7 /* NetworkExtension.framework */; };
 		021440742C7FAB1900426724 /* ConfigurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021440732C7FAB1900426724 /* ConfigurationManager.swift */; };
 		021440762C7FAB4100426724 /* ConfigurationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021440752C7FAB4100426724 /* ConfigurationStore.swift */; };
@@ -1005,6 +1007,7 @@
 		85F200042216F5D8006BB258 /* FindInPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F200032216F5D8006BB258 /* FindInPageView.swift */; };
 		85F200072217032E006BB258 /* AddressDisplayHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F20005221702F7006BB258 /* AddressDisplayHelperTests.swift */; };
 		85F21DB0210F5E32002631A6 /* AtbIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F21DAF210F5E32002631A6 /* AtbIntegrationTests.swift */; };
+		A17C00052F9A000100000005 /* ApplicationShortcutItemsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17C00062F9A000100000006 /* ApplicationShortcutItemsUITests.swift */; };
 		85F21DC621145DD5002631A6 /* global.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8512BCBF2061B6110085E862 /* global.swift */; };
 		85F2FFCD2211F615006BB258 /* MainViewController+KeyCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F2FFCC2211F615006BB258 /* MainViewController+KeyCommands.swift */; };
 		85F2FFCF2211F8E5006BB258 /* TabSwitcherViewController+KeyCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F2FFCE2211F8E5006BB258 /* TabSwitcherViewController+KeyCommands.swift */; };
@@ -2936,6 +2939,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		A17C00022F9A000100000002 /* ApplicationShortcutItemsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationShortcutItemsService.swift; sourceTree = "<group>"; };
+		A17C00042F9A000100000004 /* ApplicationShortcutItemsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationShortcutItemsServiceTests.swift; sourceTree = "<group>"; };
 		02025662298818B100E694E7 /* PacketTunnelProvider.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = PacketTunnelProvider.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		02025663298818B100E694E7 /* NetworkExtension.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NetworkExtension.framework; path = System/Library/Frameworks/NetworkExtension.framework; sourceTree = SDKROOT; };
 		02025668298818B200E694E7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -3859,6 +3864,7 @@
 		85F20005221702F7006BB258 /* AddressDisplayHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressDisplayHelperTests.swift; sourceTree = "<group>"; };
 		85F21DAD210F5E32002631A6 /* AtbUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AtbUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		85F21DAF210F5E32002631A6 /* AtbIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtbIntegrationTests.swift; sourceTree = "<group>"; };
+		A17C00062F9A000100000006 /* ApplicationShortcutItemsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationShortcutItemsUITests.swift; sourceTree = "<group>"; };
 		85F21DB1210F5E32002631A6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		85F21DBD21121147002631A6 /* AtbServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtbServerTests.swift; sourceTree = "<group>"; };
 		85F2FFCC2211F615006BB258 /* MainViewController+KeyCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewController+KeyCommands.swift"; sourceTree = "<group>"; };
@@ -7048,6 +7054,7 @@
 		369E692B2E5F6E9F00F98A8F /* AppServices */ = {
 			isa = PBXGroup;
 			children = (
+				A17C00042F9A000100000004 /* ApplicationShortcutItemsServiceTests.swift */,
 				369E692C2E5F6EB500F98A8F /* InactivityNotificationSchedulerServiceTests.swift */,
 				9BC32EC2491F40BF921F07B4 /* InactivityNotificationStateStoreTests.swift */,
 				CB3B4D552D649DC8006DAD63 /* AutoClearServiceTests.swift */,
@@ -8532,6 +8539,7 @@
 			isa = PBXGroup;
 			children = (
 				85F21DAF210F5E32002631A6 /* AtbIntegrationTests.swift */,
+				A17C00062F9A000100000006 /* ApplicationShortcutItemsUITests.swift */,
 				85F21DB1210F5E32002631A6 /* Info.plist */,
 				842625613000E9CA001B4B87 /* SubscriptionPromoUITests.swift */,
 				F0A1B2C3D4E5F60718293A10 /* FloatingUIXCUITests.swift */,
@@ -10848,6 +10856,7 @@
 		CBAD0F0E2D006291006267B8 /* AppServices */ = {
 			isa = PBXGroup;
 			children = (
+				A17C00022F9A000100000002 /* ApplicationShortcutItemsService.swift */,
 				98DA8E8E2EBA361800BB34B0 /* ContentBlockingService.swift */,
 				BB77957E2E9D4B4D00CF58F4 /* WinBackOfferService.swift */,
 				85E803722E786B95008E87CA /* AIChatService.swift */,
@@ -13419,6 +13428,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A17C00012F9A000100000001 /* ApplicationShortcutItemsService.swift in Sources */,
 				9F678B892C9BAA4800CA0E19 /* Debouncer.swift in Sources */,
 				9875E00722316B8400B1373F /* Instruments.swift in Sources */,
 				983AB2312E12CFBF00F0223F /* QRunInBackgroundAssertion.swift in Sources */,
@@ -15327,6 +15337,7 @@
 				9F06EB922D10740500905426 /* MaliciousSiteProtectionPreferencesManagerTests.swift in Sources */,
 				98983096255B5019003339A2 /* BookmarksCachingSearchTests.swift in Sources */,
 				CB3B4D522D63CDA0006DAD63 /* AppStateMachineTests.swift in Sources */,
+				A17C00032F9A000100000003 /* ApplicationShortcutItemsServiceTests.swift in Sources */,
 				9FD6E6092DF9026300C2B032 /* AudioSessionManagerTests.swift in Sources */,
 				85F200072217032E006BB258 /* AddressDisplayHelperTests.swift in Sources */,
 				B6AD9E3728D4510A0019CDE9 /* ContentBlockingUpdatingTests.swift in Sources */,
@@ -15546,6 +15557,7 @@
 			files = (
 				4BEE4ACD2DB60FCE0061470B /* SnapshotHelper.swift in Sources */,
 				85F21DB0210F5E32002631A6 /* AtbIntegrationTests.swift in Sources */,
+				A17C00052F9A000100000005 /* ApplicationShortcutItemsUITests.swift in Sources */,
 				842625623000E9CA001B4B87 /* SubscriptionPromoUITests.swift in Sources */,
 				F0A1B2C3D4E5F60718293B10 /* FloatingUIXCUITests.swift in Sources */,
 			);

--- a/iOS/DuckDuckGo/AppLifecycle/AppDependencies.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppDependencies.swift
@@ -55,6 +55,7 @@ struct AppServices {
     let inactivityNotificationSchedulerService: InactivityNotificationSchedulerService
     let wideEventService: WideEventService
     let aiChatService: AIChatService
+    let applicationShortcutItemsService: ApplicationShortcutItemsService
     let eventHubService: EventHubService
 
 }

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Background.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Background.swift
@@ -55,6 +55,7 @@ struct Background: BackgroundHandling {
     func onTransition() {
         Logger.lifecycle.info("\(type(of: self)): \(#function)")
 
+        services.applicationShortcutItemsService.suspend()
         try? lastBackgroundDateStorage.set(Date(), for: \.lastBackgroundDate)
         appDependencies.backgroundTaskManager.startBackgroundTask()
 
@@ -70,7 +71,6 @@ struct Background: BackgroundHandling {
 
         appDependencies.mainCoordinator.onBackground()
 
-        updateApplicationShortcutItems()
         cleanScreenTimeDataOniOS26()
     }
 
@@ -80,15 +80,6 @@ struct Background: BackgroundHandling {
 
         ScreenTimeDataCleaningBackgroundTask().start {
             await ScreenTimeDataCleaner().removeScreenTimeData()
-        }
-    }
-
-    private func updateApplicationShortcutItems() {
-        Task { @MainActor in
-            UIApplication.shared.shortcutItems = [
-                services.aiChatService.shortcutItem(),
-                await services.vpnService.shortcutItem()
-            ].compactMap { $0 }
         }
     }
 

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Foreground.swift
@@ -238,6 +238,7 @@ extension Foreground {
     /// Use this method only to pause specific tasks, like video playback, when the app displays a system alert.
     func willLeave() {
         Logger.lifecycle.info("\(type(of: self)): \(#function)")
+        services.applicationShortcutItemsService.suspend()
     }
 
     /// Called when the app resumes activity after being **paused** or when transitioning from launching or background.
@@ -246,6 +247,7 @@ extension Foreground {
     /// Use this method to revert any actions performed in `willLeave()` (if applicable).
     func didReturn() {
         Logger.lifecycle.info("\(type(of: self)): \(#function)")
+        services.applicationShortcutItemsService.resume()
     }
 
 }

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -382,6 +382,14 @@ struct Launching: LaunchingHandling {
         )
 
         let vpnService = VPNService(mainCoordinator: mainCoordinator, notificationServiceManager: notificationServiceManager)
+        let aiChatService = AIChatService(aiChatSettings: aiChatSettings)
+        let applicationShortcutItemsService = ApplicationShortcutItemsService(shortcutItemProviders: [
+            { aiChatService.shortcutItem() },
+            { await vpnService.shortcutItem() }
+        ], shortcutItemsFilter: { shortcutItems in
+            guard !vpnService.isSubscriptionPresent else { return shortcutItems }
+            return shortcutItems.filter { $0.type != ShortcutKey.openVPNSettings }
+        })
         let inactivityNotificationSchedulerService = InactivityNotificationSchedulerService(
             featureFlagger: featureFlagger,
             notificationServiceManager: notificationServiceManager,
@@ -416,7 +424,8 @@ struct Launching: LaunchingHandling {
                                systemSettingsPiPTutorialService: systemSettingsPiPTutorialService,
                                inactivityNotificationSchedulerService: inactivityNotificationSchedulerService,
                                wideEventService: wideEventService,
-                               aiChatService: AIChatService(aiChatSettings: aiChatSettings),
+                               aiChatService: aiChatService,
+                               applicationShortcutItemsService: applicationShortcutItemsService,
                                eventHubService: eventHubService
         )
 

--- a/iOS/DuckDuckGo/AppServices/ApplicationShortcutItemsService.swift
+++ b/iOS/DuckDuckGo/AppServices/ApplicationShortcutItemsService.swift
@@ -1,0 +1,111 @@
+//
+//  ApplicationShortcutItemsService.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Subscription
+import UIKit
+
+@MainActor
+final class ApplicationShortcutItemsService {
+
+    typealias ShortcutItemProvider = @MainActor () async -> UIApplicationShortcutItem?
+    typealias ApplicationStateProvider = @MainActor () -> UIApplication.State
+    typealias CurrentShortcutItemsProvider = @MainActor () -> [UIApplicationShortcutItem]
+    typealias ShortcutItemsFilter = @MainActor ([UIApplicationShortcutItem]) -> [UIApplicationShortcutItem]
+    typealias ShortcutItemsUpdater = @MainActor ([UIApplicationShortcutItem]) -> Void
+
+    private let shortcutItemProviders: [ShortcutItemProvider]
+    private let applicationStateProvider: ApplicationStateProvider
+    private let currentShortcutItemsProvider: CurrentShortcutItemsProvider
+    private let shortcutItemsFilter: ShortcutItemsFilter
+    private let shortcutItemsUpdater: ShortcutItemsUpdater
+    private var refreshTask: Task<Void, Never>?
+    private var isActive = false
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(shortcutItemProviders: [ShortcutItemProvider],
+         notificationCenter: NotificationCenter = .default,
+         applicationStateProvider: @escaping ApplicationStateProvider = { UIApplication.shared.applicationState },
+         currentShortcutItemsProvider: @escaping CurrentShortcutItemsProvider = { UIApplication.shared.shortcutItems ?? [] },
+         shortcutItemsFilter: @escaping ShortcutItemsFilter = { $0 },
+         shortcutItemsUpdater: @escaping ShortcutItemsUpdater = { UIApplication.shared.shortcutItems = $0 }) {
+        self.shortcutItemProviders = shortcutItemProviders
+        self.applicationStateProvider = applicationStateProvider
+        self.currentShortcutItemsProvider = currentShortcutItemsProvider
+        self.shortcutItemsFilter = shortcutItemsFilter
+        self.shortcutItemsUpdater = shortcutItemsUpdater
+
+        Publishers.MergeMany([
+            notificationCenter.publisher(for: .aiChatSettingsChanged),
+            notificationCenter.publisher(for: .accountDidSignIn),
+            notificationCenter.publisher(for: .accountDidSignOut),
+            notificationCenter.publisher(for: .entitlementsDidChange),
+            notificationCenter.publisher(for: .subscriptionDidChange)
+        ])
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] _ in
+            Task { @MainActor in
+                self?.refresh()
+            }
+        }
+        .store(in: &cancellables)
+    }
+
+    func resume() {
+        isActive = true
+        refresh()
+    }
+
+    func suspend() {
+        isActive = false
+        refreshTask?.cancel()
+        refreshTask = nil
+
+        guard applicationStateProvider() != .background else { return }
+
+        let currentShortcutItems = currentShortcutItemsProvider()
+        let filteredShortcutItems = shortcutItemsFilter(currentShortcutItems)
+        guard currentShortcutItems.map(\.type) != filteredShortcutItems.map(\.type) else { return }
+
+        shortcutItemsUpdater(filteredShortcutItems)
+    }
+
+    private func refresh() {
+        guard isActive else { return }
+
+        refreshTask?.cancel()
+        refreshTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            var shortcutItems: [UIApplicationShortcutItem] = []
+            for shortcutItemProvider in self.shortcutItemProviders {
+                if let shortcutItem = await shortcutItemProvider() {
+                    shortcutItems.append(shortcutItem)
+                }
+            }
+
+            guard !Task.isCancelled,
+                  self.isActive,
+                  self.applicationStateProvider() == .active else { return }
+
+            self.shortcutItemsUpdater(shortcutItems)
+        }
+    }
+
+}

--- a/iOS/DuckDuckGo/AppServices/VPNService.swift
+++ b/iOS/DuckDuckGo/AppServices/VPNService.swift
@@ -116,6 +116,11 @@ final class VPNService: NSObject {
         // No-op
     }
 
+    @MainActor
+    var isSubscriptionPresent: Bool {
+        subscriptionManager.isSubscriptionPresent()
+    }
+
     /// Checks if the shortcut item should be shown by asking if a subscription is present, and if so, is the network protection feature included - avoiding calls to the API.
     @MainActor
     func shortcutItem() async -> UIApplicationShortcutItem? {

--- a/iOS/DuckDuckGoTests/AppServices/ApplicationShortcutItemsServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/ApplicationShortcutItemsServiceTests.swift
@@ -1,0 +1,192 @@
+//
+//  ApplicationShortcutItemsServiceTests.swift
+//  DuckDuckGoTests
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Testing
+import UIKit
+@testable import DuckDuckGo
+
+@MainActor
+@Suite("Application Shortcut Items Service")
+struct ApplicationShortcutItemsServiceTests {
+
+    @Test("Resume updates shortcut items while the application is active")
+    func resumeUpdatesShortcutItemsWhileActive() async {
+        let shortcutItem = UIApplicationShortcutItem(type: "test", localizedTitle: "Test")
+        let recorder = ShortcutItemsRecorder()
+        var updates = recorder.updates.makeAsyncIterator()
+        let service = ApplicationShortcutItemsService(
+            shortcutItemProviders: [{ shortcutItem }],
+            notificationCenter: NotificationCenter(),
+            applicationStateProvider: { .active },
+            shortcutItemsUpdater: recorder.record)
+
+        service.resume()
+
+        let updatedItems = await updates.next()
+        #expect(updatedItems?.map(\.type) == [shortcutItem.type])
+    }
+
+    @Test("Resume does not update shortcut items while the application is in the background")
+    func resumeDoesNotUpdateShortcutItemsWhileBackgrounded() async {
+        let shortcutItem = UIApplicationShortcutItem(type: "test", localizedTitle: "Test")
+        let providerCalled = AsyncSignal<Void>()
+        var providerCalls = providerCalled.values.makeAsyncIterator()
+        let recorder = ShortcutItemsRecorder()
+        let service = ApplicationShortcutItemsService(
+            shortcutItemProviders: [{
+                providerCalled.send(())
+                return shortcutItem
+            }],
+            notificationCenter: NotificationCenter(),
+            applicationStateProvider: { .background },
+            shortcutItemsUpdater: recorder.record)
+
+        service.resume()
+        _ = await providerCalls.next()
+        await Task.yield()
+
+        #expect(recorder.recordedItems.isEmpty)
+    }
+
+    @Test("Suspend prevents an in-flight refresh from updating shortcut items")
+    func suspendPreventsInFlightRefreshFromUpdatingShortcutItems() async {
+        let shortcutItem = UIApplicationShortcutItem(type: "test", localizedTitle: "Test")
+        let provider = SuspendedShortcutItemProvider()
+        var providerCalls = provider.didStart.values.makeAsyncIterator()
+        let recorder = ShortcutItemsRecorder()
+        let service = ApplicationShortcutItemsService(
+            shortcutItemProviders: [provider.shortcutItem],
+            notificationCenter: NotificationCenter(),
+            applicationStateProvider: { .active },
+            shortcutItemsUpdater: recorder.record)
+
+        service.resume()
+        _ = await providerCalls.next()
+        service.suspend()
+        provider.finish(with: shortcutItem)
+        await Task.yield()
+
+        #expect(recorder.recordedItems.isEmpty)
+    }
+
+    @Test("Suspend removes shortcut items that are no longer eligible")
+    func suspendRemovesIneligibleShortcutItems() {
+        let retainedShortcutItem = UIApplicationShortcutItem(type: "retained", localizedTitle: "Retained")
+        let removedShortcutItem = UIApplicationShortcutItem(type: "removed", localizedTitle: "Removed")
+        let recorder = ShortcutItemsRecorder()
+        let service = ApplicationShortcutItemsService(
+            shortcutItemProviders: [],
+            notificationCenter: NotificationCenter(),
+            applicationStateProvider: { .inactive },
+            currentShortcutItemsProvider: { [retainedShortcutItem, removedShortcutItem] },
+            shortcutItemsFilter: { $0.filter { $0.type != removedShortcutItem.type } },
+            shortcutItemsUpdater: recorder.record)
+
+        service.suspend()
+
+        #expect(recorder.recordedItems.map { $0.map(\.type) } == [[retainedShortcutItem.type]])
+    }
+
+    @Test("Suspend does not update shortcut items after entering the background")
+    func suspendDoesNotUpdateShortcutItemsAfterEnteringBackground() {
+        let shortcutItem = UIApplicationShortcutItem(type: "removed", localizedTitle: "Removed")
+        let recorder = ShortcutItemsRecorder()
+        let service = ApplicationShortcutItemsService(
+            shortcutItemProviders: [],
+            notificationCenter: NotificationCenter(),
+            applicationStateProvider: { .background },
+            currentShortcutItemsProvider: { [shortcutItem] },
+            shortcutItemsFilter: { _ in [] },
+            shortcutItemsUpdater: recorder.record)
+
+        service.suspend()
+
+        #expect(recorder.recordedItems.isEmpty)
+    }
+
+    @Test("Settings changes refresh shortcut items while active")
+    func settingsChangesRefreshShortcutItemsWhileActive() async {
+        let notificationCenter = NotificationCenter()
+        let shortcutItem = UIApplicationShortcutItem(type: "test", localizedTitle: "Test")
+        let recorder = ShortcutItemsRecorder()
+        var updates = recorder.updates.makeAsyncIterator()
+        let service = ApplicationShortcutItemsService(
+            shortcutItemProviders: [{ shortcutItem }],
+            notificationCenter: notificationCenter,
+            applicationStateProvider: { .active },
+            shortcutItemsUpdater: recorder.record)
+
+        service.resume()
+        _ = await updates.next()
+        notificationCenter.post(name: .aiChatSettingsChanged, object: nil)
+
+        _ = await updates.next()
+        #expect(recorder.recordedItems.count == 2)
+    }
+
+}
+
+@MainActor
+private final class ShortcutItemsRecorder {
+
+    private let signal = AsyncSignal<[UIApplicationShortcutItem]>()
+    private(set) var recordedItems: [[UIApplicationShortcutItem]] = []
+    var updates: AsyncStream<[UIApplicationShortcutItem]> { signal.values }
+
+    func record(_ shortcutItems: [UIApplicationShortcutItem]) {
+        recordedItems.append(shortcutItems)
+        signal.send(shortcutItems)
+    }
+
+}
+
+@MainActor
+private final class SuspendedShortcutItemProvider {
+
+    let didStart = AsyncSignal<Void>()
+    private var continuation: CheckedContinuation<UIApplicationShortcutItem?, Never>?
+
+    func shortcutItem() async -> UIApplicationShortcutItem? {
+        didStart.send(())
+        return await withCheckedContinuation { continuation = $0 }
+    }
+
+    func finish(with shortcutItem: UIApplicationShortcutItem?) {
+        continuation?.resume(returning: shortcutItem)
+        continuation = nil
+    }
+
+}
+
+private final class AsyncSignal<Value> {
+
+    let values: AsyncStream<Value>
+    private let continuation: AsyncStream<Value>.Continuation
+
+    init() {
+        let stream = AsyncStream<Value>.makeStream()
+        values = stream.stream
+        continuation = stream.continuation
+    }
+
+    func send(_ value: Value) {
+        continuation.yield(value)
+    }
+
+}

--- a/iOS/DuckDuckGoTests/AppServices/ApplicationShortcutItemsServiceTests.swift
+++ b/iOS/DuckDuckGoTests/AppServices/ApplicationShortcutItemsServiceTests.swift
@@ -25,7 +25,8 @@ import UIKit
 @Suite("Application Shortcut Items Service")
 struct ApplicationShortcutItemsServiceTests {
 
-    @Test("Resume updates shortcut items while the application is active")
+    @available(iOS 16.0, *)
+    @Test("Resume updates shortcut items while the application is active", .timeLimit(.minutes(1)))
     func resumeUpdatesShortcutItemsWhileActive() async {
         let shortcutItem = UIApplicationShortcutItem(type: "test", localizedTitle: "Test")
         let recorder = ShortcutItemsRecorder()
@@ -42,7 +43,8 @@ struct ApplicationShortcutItemsServiceTests {
         #expect(updatedItems?.map(\.type) == [shortcutItem.type])
     }
 
-    @Test("Resume does not update shortcut items while the application is in the background")
+    @available(iOS 16.0, *)
+    @Test("Resume does not update shortcut items while the application is in the background", .timeLimit(.minutes(1)))
     func resumeDoesNotUpdateShortcutItemsWhileBackgrounded() async {
         let shortcutItem = UIApplicationShortcutItem(type: "test", localizedTitle: "Test")
         let providerCalled = AsyncSignal<Void>()
@@ -64,7 +66,8 @@ struct ApplicationShortcutItemsServiceTests {
         #expect(recorder.recordedItems.isEmpty)
     }
 
-    @Test("Suspend prevents an in-flight refresh from updating shortcut items")
+    @available(iOS 16.0, *)
+    @Test("Suspend prevents an in-flight refresh from updating shortcut items", .timeLimit(.minutes(1)))
     func suspendPreventsInFlightRefreshFromUpdatingShortcutItems() async {
         let shortcutItem = UIApplicationShortcutItem(type: "test", localizedTitle: "Test")
         let provider = SuspendedShortcutItemProvider()
@@ -85,7 +88,8 @@ struct ApplicationShortcutItemsServiceTests {
         #expect(recorder.recordedItems.isEmpty)
     }
 
-    @Test("Suspend removes shortcut items that are no longer eligible")
+    @available(iOS 16.0, *)
+    @Test("Suspend removes shortcut items that are no longer eligible", .timeLimit(.minutes(1)))
     func suspendRemovesIneligibleShortcutItems() {
         let retainedShortcutItem = UIApplicationShortcutItem(type: "retained", localizedTitle: "Retained")
         let removedShortcutItem = UIApplicationShortcutItem(type: "removed", localizedTitle: "Removed")
@@ -103,7 +107,8 @@ struct ApplicationShortcutItemsServiceTests {
         #expect(recorder.recordedItems.map { $0.map(\.type) } == [[retainedShortcutItem.type]])
     }
 
-    @Test("Suspend does not update shortcut items after entering the background")
+    @available(iOS 16.0, *)
+    @Test("Suspend does not update shortcut items after entering the background", .timeLimit(.minutes(1)))
     func suspendDoesNotUpdateShortcutItemsAfterEnteringBackground() {
         let shortcutItem = UIApplicationShortcutItem(type: "removed", localizedTitle: "Removed")
         let recorder = ShortcutItemsRecorder()
@@ -120,7 +125,8 @@ struct ApplicationShortcutItemsServiceTests {
         #expect(recorder.recordedItems.isEmpty)
     }
 
-    @Test("Settings changes refresh shortcut items while active")
+    @available(iOS 16.0, *)
+    @Test("Settings changes refresh shortcut items while active", .timeLimit(.minutes(1)))
     func settingsChangesRefreshShortcutItemsWhileActive() async {
         let notificationCenter = NotificationCenter()
         let shortcutItem = UIApplicationShortcutItem(type: "test", localizedTitle: "Test")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1217730122168336?focus=true
Tech Design URL:
CC: @jaceklyp @diegoreymendez @samsymons 

### Description
Prepares Home Screen quick actions before the app enters the background, preventing a rare crash. It also ensures the VPN action is removed immediately when the user no longer has a subscription.

### Testing Steps
1. Launch the app and complete onboarding → the browser opens normally.
2. Return to the Home Screen and long-press the DuckDuckGo icon → Duck.ai and the standard quick actions appear.
3. Open and background the app repeatedly → the app remains running without crashing.
4. With an eligible subscription, return to the Home Screen and long-press the icon → Open VPN appears.
5. Remove the subscription and immediately return to the Home Screen → Open VPN no longer appears.

### Impact
Medium: A regression could cause incorrect Home Screen quick actions or reintroduce the backgrounding crash.

#### What could go wrong?
The app could update quick actions after entering the background → mitigated by application-state guards and lifecycle stress coverage.

The VPN action could remain after subscription removal → mitigated by synchronous eligibility filtering and focused tests.

### Quality Considerations
Covered active, inactive, and background application states.
Covered cancellation of an update already in progress.
The UI test performs 20 background/foreground cycles and inspects the resulting Home Screen menu.
No privacy or security impact.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app lifecycle timing for `shortcutItems` updates, which previously caused rare crashes; regressions could restore the crash or show wrong quick actions (especially VPN eligibility).
> 
> **Overview**
> Introduces **`ApplicationShortcutItemsService`** to own updates to `UIApplication.shared.shortcutItems`, replacing the background-time refresh that could crash when the app was leaving the foreground.
> 
> Quick actions are **refreshed while the app is active** (`resume` / notification-driven refresh with an `.active` guard) and **suspended** on `willLeave` and when entering background. On suspend, in-flight updates are cancelled; while still foreground/inactive, items are **filtered** (e.g. **Open VPN** removed when there is no subscription via `VPNService.isSubscriptionPresent`).
> 
> Lifecycle wiring: **`Foreground.didReturn`** resumes the service; **`Background.onTransition`** and **`Foreground.willLeave`** suspend it. Launch registers AI chat and VPN providers plus the VPN eligibility filter.
> 
> Adds unit tests for active/background/inactive behavior, cancellation, and subscription-related refresh, plus a UI test that backgrounds the app 20 times and verifies the long-press menu (Duck.ai present, Open VPN absent without subscription).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 605c85bec5072158d1eddcf10d090a7e25e871c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->