### PR TITLE
iOS: Align Tab Manager select mode controls

### DIFF
--- a/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
+++ b/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
@@ -34,6 +34,8 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         static let bottomFloatingInset: CGFloat = 8
         static let fallbackToolbarHorizontalPadding: CGFloat = 20
         static let fallbackAIButtonSpacing: CGFloat = 12
+        static let menuButtonSize: CGFloat = 36
+        static let fallbackMenuButtonSize: CGFloat = 44
     }
 
     private let navigationBar = UINavigationBar()
@@ -77,7 +79,7 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         let item: UIBarButtonItem
         if #available(iOS 26.0, *) {
             item = UIBarButtonItem(title: nil,
-                                   image: UIImage(systemName: "checkmark"),
+                                   image: DesignSystemImages.Glyphs.Size24.check,
                                    primaryAction: action,
                                    menu: nil)
             item.style = .prominent
@@ -97,15 +99,6 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         return label
     }()
 
-    private lazy var selectionTitleItem: UIBarButtonItem = {
-        let item = UIBarButtonItem(customView: selectionTitleLabel)
-        if #available(iOS 26.0, *) {
-            item.sharesBackground = false
-            item.hidesSharedBackground = true
-        }
-        return item
-    }()
-
     private lazy var selectAllItem = UIBarButtonItem(
         title: UserText.selectAllTabs,
         image: nil,
@@ -118,11 +111,34 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         primaryAction: UIAction { [weak self] _ in self?.actions.onDeselectAllTapped?() },
         menu: nil)
 
-    private lazy var editMenuItem = UIBarButtonItem(
-        title: nil,
-        image: menuImage,
-        primaryAction: nil,
-        menu: UIMenu(children: []))
+    private lazy var editMenuButton: FloatingTabSwitcherMenuButton = {
+        let button = FloatingTabSwitcherMenuButton()
+        button.configuration = .plain()
+        button.configuration?.image = menuImage
+        button.showsMenuAsPrimaryAction = true
+        button.accessibilityLabel = UserText.actionGenericEdit
+        button.translatesAutoresizingMaskIntoConstraints = false
+        let buttonSize: CGFloat
+        if #available(iOS 26.0, *) {
+            buttonSize = Metrics.menuButtonSize
+        } else {
+            buttonSize = Metrics.fallbackMenuButtonSize
+        }
+        NSLayoutConstraint.activate([
+            button.widthAnchor.constraint(equalToConstant: buttonSize),
+            button.heightAnchor.constraint(equalToConstant: buttonSize),
+        ])
+        button.onMenuDismissed = { [weak self] in
+            self?.actions.onEditMenuDismissed?()
+        }
+        return button
+    }()
+
+    private lazy var editMenuItem: UIBarButtonItem = {
+        let item = UIBarButtonItem(customView: editMenuButton)
+        item.title = UserText.actionGenericEdit
+        return item
+    }()
 
     private lazy var multiSelectMenuItem = UIBarButtonItem(
         title: nil,
@@ -178,6 +194,7 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         duckChatItem.accessibilityIdentifier = "TabSwitcher.Button.DuckChat"
         duckChatItem.accessibilityLabel = UserText.duckAiFeatureName
         tabsStyleItem.accessibilityLabel = UserText.tabSwitcherGridViewMenuTitle
+        editMenuItem.accessibilityLabel = UserText.actionGenericEdit
 
         attachTopScrollViewInteraction()
     }
@@ -286,6 +303,7 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         let tint = UIColor(singleUseColor: .toolbarButton)
         navigationBar.tintColor = tint
         toolbar.tintColor = tint
+        editMenuButton.configuration?.baseForegroundColor = tint
         if #available(iOS 26.0, *) {
             doneItem.tintColor = UIColor(designSystemColor: .accentPrimary)
         } else {
@@ -304,11 +322,12 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         tabsStyleItem.image = tabsStyle.image
         tabsStyleItem.primaryAction = nil
         tabsStyleItem.menu = makeTabsStyleMenu(current: tabsStyle)
-        editMenuItem.menu = actions.onEditMenuRequested?()
+        editMenuButton.menu = actions.onEditMenuRequested?()
         multiSelectMenuItem.menu = actions.onMultiSelectMenuRequested?()
         multiSelectMenuItem.isEnabled = canShowSelectionMenu
         editMenuItem.isEnabled = params.totalCount > 1 || params.containsWebPages
-        configureBackgroundSharing(isLarge: params.interfaceMode.isLarge)
+        editMenuButton.isEnabled = editMenuItem.isEnabled
+        configureBackgroundSharing(isLarge: params.interfaceMode.isLarge, isEditing: isEditing)
 
         let isDoneEnabled = params.canDismissOnEmpty || params.totalCount > 0
         doneItem.isEnabled = isDoneEnabled
@@ -331,14 +350,14 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
             navigationItem.rightBarButtonItems = items
             setToolbarItems([])
         } else if isEditing {
-            navigationItem.titleView = nil
             navigationItem.title = nil
-            navigationItem.leftBarButtonItems = [selectionTitleItem]
+            navigationItem.titleView = selectionTitleLabel
+            navigationItem.leftBarButtonItems = [multiSelectMenuItem]
             navigationItem.rightBarButtonItems = [params.selectedCount == params.totalCount ? deselectAllItem : selectAllItem]
 
             closeTabsItem.title = UserText.tabSwitcherCloseTabsButtonTitle(withCount: params.selectedCount)
             closeTabsItem.isEnabled = params.selectedCount > 0
-            setToolbarItems([doneItem, .flexibleSpace(), closeTabsItem, multiSelectMenuItem])
+            setToolbarItems([closeTabsItem, fireItem, .flexibleSpace(), doneItem])
         } else {
             navigationItem.title = nil
             navigationItem.titleView = centerTitleView()
@@ -503,13 +522,16 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         return UIMenu(children: [grid, list])
     }
 
-    private func configureBackgroundSharing(isLarge: Bool) {
+    private func configureBackgroundSharing(isLarge: Bool, isEditing: Bool) {
         guard #available(iOS 26.0, *) else { return }
-        let shouldShareBackground = !isLarge
+        let shouldShareBackground = !isLarge && !isEditing
         editMenuItem.sharesBackground = shouldShareBackground
+        editMenuItem.hidesSharedBackground = false
         tabsStyleItem.sharesBackground = shouldShareBackground
         fireItem.sharesBackground = shouldShareBackground
         doneItem.sharesBackground = shouldShareBackground
+        closeTabsItem.sharesBackground = false
+        multiSelectMenuItem.sharesBackground = false
         plusItem.sharesBackground = true
         duckChatItem.sharesBackground = true
     }
@@ -534,6 +556,28 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
         toolbarAppearance.shadowColor = .clear
         toolbar.standardAppearance = toolbarAppearance
         toolbar.compactAppearance = toolbarAppearance
+    }
+}
+
+private final class FloatingTabSwitcherMenuButton: UIButton {
+
+    var onMenuDismissed: (() -> Void)?
+
+    override func contextMenuInteraction(_ interaction: UIContextMenuInteraction,
+                                         willEndFor configuration: UIContextMenuConfiguration,
+                                         animator: UIContextMenuInteractionAnimating?) {
+        super.contextMenuInteraction(interaction, willEndFor: configuration, animator: animator)
+
+        guard let animator else {
+            DispatchQueue.main.async { [weak self] in
+                self?.onMenuDismissed?()
+            }
+            return
+        }
+
+        animator.addCompletion { [weak self] in
+            self?.onMenuDismissed?()
+        }
     }
 }
 

--- a/iOS/DuckDuckGo/TabSwitcherChrome.swift
+++ b/iOS/DuckDuckGo/TabSwitcherChrome.swift
@@ -30,6 +30,7 @@ struct TabSwitcherChromeActions {
     /// Done / Cancel / X — exits multi-select when editing, otherwise dismisses.
     var onDoneTapped: (() -> Void)?
     var onEditMenuRequested: (() -> UIMenu?)?
+    var onEditMenuDismissed: (() -> Void)?
     /// Sets a specific grid/list style (used by the floating menu).
     var onSelectTabsStyle: ((TabSwitcherViewController.TabsStyle) -> Void)?
     /// Toggles grid/list (used by the legacy single toggle button).

--- a/iOS/DuckDuckGo/TabSwitcherMenuBuilder.swift
+++ b/iOS/DuckDuckGo/TabSwitcherMenuBuilder.swift
@@ -30,15 +30,12 @@ struct TabSwitcherMultiSelectMenuState {
     let allContainsWebPages: Bool
     var shouldShowSelectionToggleActions = true
     var shouldShowCloseSelectedAction = true
-    var shouldShowCloseOtherActionWhenAllSelected = false
 
     var canShowDeselectAll: Bool { shouldShowSelectionToggleActions && selectedCount > 0 && selectedCount == totalCount }
     var canShowSelectAll: Bool { shouldShowSelectionToggleActions && selectedCount < totalCount }
     var canShare: Bool { selectedContainsWebPages }
     var canAddBookmarks: Bool { selectedContainsWebPages }
-    var canCloseOther: Bool {
-        selectedCount > 0 && (selectedCount < totalCount || shouldShowCloseOtherActionWhenAllSelected)
-    }
+    var canCloseOther: Bool { selectedCount > 0 && selectedCount < totalCount }
     var canBookmarkAll: Bool { selectedCount == 0 && allContainsWebPages }
     var canClose: Bool { shouldShowCloseSelectedAction && selectedCount > 0 }
 

--- a/iOS/DuckDuckGo/TabSwitcherMenuBuilder.swift
+++ b/iOS/DuckDuckGo/TabSwitcherMenuBuilder.swift
@@ -29,14 +29,18 @@ struct TabSwitcherMultiSelectMenuState {
     let selectedContainsWebPages: Bool
     let allContainsWebPages: Bool
     var shouldShowSelectionToggleActions = true
+    var shouldShowCloseSelectedAction = true
+    var shouldShowCloseOtherActionWhenAllSelected = false
 
     var canShowDeselectAll: Bool { shouldShowSelectionToggleActions && selectedCount > 0 && selectedCount == totalCount }
     var canShowSelectAll: Bool { shouldShowSelectionToggleActions && selectedCount < totalCount }
     var canShare: Bool { selectedContainsWebPages }
     var canAddBookmarks: Bool { selectedContainsWebPages }
-    var canCloseOther: Bool { selectedCount > 0 && selectedCount < totalCount }
+    var canCloseOther: Bool {
+        selectedCount > 0 && (selectedCount < totalCount || shouldShowCloseOtherActionWhenAllSelected)
+    }
     var canBookmarkAll: Bool { selectedCount == 0 && allContainsWebPages }
-    var canClose: Bool { selectedCount > 0 }
+    var canClose: Bool { shouldShowCloseSelectedAction && selectedCount > 0 }
 
     var canShowSelectionMenu: Bool {
         canShowDeselectAll || canShowSelectAll || canShare || canAddBookmarks ||
@@ -50,6 +54,7 @@ struct TabSwitcherLongPressMenuState {
     let pressedContainsWebPages: Bool
     let isEditing: Bool
     let title: String
+    var shouldShowDeleteTabAndData = false
 
     var canShare: Bool { pressedContainsWebPages }
     var canAddBookmarks: Bool { pressedContainsWebPages }
@@ -81,6 +86,7 @@ struct TabSwitcherLongPressMenuActions {
     var onSelect: () -> Void
     var onClose: () -> Void
     var onCloseOther: () -> Void
+    var onDeleteTabAndData: () -> Void = {}
 }
 
 struct TabSwitcherEditMenuActions {
@@ -141,12 +147,12 @@ class DefaultTabSwitcherMenuBuilder: TabSwitcherMenuBuilding {
             ].compactMap { $0 }),
 
             UIMenu(title: "", options: .displayInline, children: [
+                state.canAddBookmarks ? action(UserText.bookmarkSelectedTabs(withCount: state.selectedCount),
+                                               DesignSystemImages.Glyphs.Size16.bookmarkAll,
+                                               actions.onBookmarkSelected) : nil,
                 state.canShare ? action(UserText.shareLinks(withCount: state.selectedCount),
                                         DesignSystemImages.Glyphs.Size16.shareApple,
                                         actions.onShare) : nil,
-                state.canAddBookmarks ? action(UserText.bookmarkSelectedTabs(withCount: state.selectedCount),
-                                               DesignSystemImages.Glyphs.Size16.bookmarkAdd,
-                                               actions.onBookmarkSelected) : nil,
             ].compactMap { $0 }),
 
             UIMenu(title: "", options: .displayInline, children: [
@@ -211,6 +217,12 @@ class DefaultTabSwitcherMenuBuilder: TabSwitcherMenuBuilding {
                 state.canCloseOthers ? destructive(UserText.tabSwitcherCloseOtherTabs(withCount: 2),
                                                    imageForCloseTabs(2),
                                                    actions.onCloseOther) : nil,
+            ].compactMap { $0 }),
+
+            UIMenu(title: "", options: .displayInline, children: [
+                state.shouldShowDeleteTabAndData ? destructive(UserText.tabSwitcherDeleteTabAndData,
+                                                               DesignSystemImages.Glyphs.Size16.fireSolid,
+                                                               actions.onDeleteTabAndData) : nil,
             ].compactMap { $0 }),
         ].compactMap { $0 }
     }

--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -293,7 +293,7 @@ extension TabSwitcherViewController {
 
         chrome.update(state: state,
                       tabsStyle: tabsStyle,
-                      canShowSelectionMenu: canShowSelectionMenu,
+                      canShowSelectionMenu: multiSelectMenuState.canShowSelectionMenu,
                       isEditing: isEditing)
         applyCollectionContentInsets()
         chrome.trackScrollEdge(of: collectionView)
@@ -309,11 +309,12 @@ extension TabSwitcherViewController {
         }
     }
     
-    func createMultiSelectionMenu() -> UIMenu {
-        let selectedIndexPaths = selectedTabs
-        let selectedTabObjects = selectedIndexPaths.map { tabsModel.get(tabAt: $0.row) }.compactMap { $0 }
+    /// Describes the selection menu for the current selection, so that both the menu contents and
+    /// the enabled state of the control presenting it are derived from the same, up to date, state.
+    var multiSelectMenuState: TabSwitcherMultiSelectMenuState {
+        let selectedTabObjects = selectedTabs.compactMap { tabsModel.get(tabAt: $0.row) }
         let isFloatingTabSwitcherEnabled = floatingUIManager.isFloatingTabSwitcherEnabled
-        let state = TabSwitcherMultiSelectMenuState(
+        return TabSwitcherMultiSelectMenuState(
             selectedCount: selectedTabObjects.count,
             totalCount: tabsModel.count,
             selectedContainsWebPages: selectedTabObjects.contains(where: { $0.link != nil }),
@@ -321,7 +322,10 @@ extension TabSwitcherViewController {
             shouldShowSelectionToggleActions: !isFloatingTabSwitcherEnabled,
             shouldShowCloseSelectedAction: !isFloatingTabSwitcherEnabled || interfaceMode.isLarge
         )
-        canShowSelectionMenu = state.canShowSelectionMenu
+    }
+
+    func createMultiSelectionMenu() -> UIMenu {
+        let state = multiSelectMenuState
         return menuBuilder.multiSelectionMenu(state: state, actions: TabSwitcherMultiSelectMenuActions(
             onDeselectAll: { [weak self] in self?.deselectAllTabs() },
             onSelectAll: { [weak self] in self?.selectAllTabs() },

--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -319,8 +319,7 @@ extension TabSwitcherViewController {
             selectedContainsWebPages: selectedTabObjects.contains(where: { $0.link != nil }),
             allContainsWebPages: tabsModel.tabs.contains(where: { $0.link != nil }),
             shouldShowSelectionToggleActions: !isFloatingTabSwitcherEnabled,
-            shouldShowCloseSelectedAction: !isFloatingTabSwitcherEnabled || interfaceMode.isLarge,
-            shouldShowCloseOtherActionWhenAllSelected: isFloatingTabSwitcherEnabled
+            shouldShowCloseSelectedAction: !isFloatingTabSwitcherEnabled || interfaceMode.isLarge
         )
         canShowSelectionMenu = state.canShowSelectionMenu
         return menuBuilder.multiSelectionMenu(state: state, actions: TabSwitcherMultiSelectMenuActions(

--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -253,7 +253,9 @@ extension TabSwitcherViewController {
         let otherIndexPaths = Set<IndexPath>(tabsModel.tabs.indices.map {
             IndexPath(row: $0, section: 0)
         }).subtracting(indexPaths)
-        
+
+        guard !otherIndexPaths.isEmpty else { return }
+
         self.closeTabs(withIndexPaths: [IndexPath](otherIndexPaths),
                        confirmTitle: UserText.alertTitleCloseOtherTabs(withCount: otherIndexPaths.count),
                        confirmMessage: UserText.alertMessageCloseOtherTabs(withCount: otherIndexPaths.count))
@@ -310,13 +312,15 @@ extension TabSwitcherViewController {
     func createMultiSelectionMenu() -> UIMenu {
         let selectedIndexPaths = selectedTabs
         let selectedTabObjects = selectedIndexPaths.map { tabsModel.get(tabAt: $0.row) }.compactMap { $0 }
-        let shouldShowSelectionToggleActions = !floatingUIManager.isFloatingTabSwitcherEnabled
+        let isFloatingTabSwitcherEnabled = floatingUIManager.isFloatingTabSwitcherEnabled
         let state = TabSwitcherMultiSelectMenuState(
             selectedCount: selectedTabObjects.count,
             totalCount: tabsModel.count,
             selectedContainsWebPages: selectedTabObjects.contains(where: { $0.link != nil }),
             allContainsWebPages: tabsModel.tabs.contains(where: { $0.link != nil }),
-            shouldShowSelectionToggleActions: shouldShowSelectionToggleActions
+            shouldShowSelectionToggleActions: !isFloatingTabSwitcherEnabled,
+            shouldShowCloseSelectedAction: !isFloatingTabSwitcherEnabled || interfaceMode.isLarge,
+            shouldShowCloseOtherActionWhenAllSelected: isFloatingTabSwitcherEnabled
         )
         canShowSelectionMenu = state.canShowSelectionMenu
         return menuBuilder.multiSelectionMenu(state: state, actions: TabSwitcherMultiSelectMenuActions(
@@ -352,14 +356,19 @@ extension TabSwitcherViewController {
             totalCount: tabsModel.count,
             pressedContainsWebPages: containsWebPages,
             isEditing: isEditing,
-            title: title
+            title: title,
+            shouldShowDeleteTabAndData: floatingUIManager.isFloatingTabSwitcherEnabled && tabs.count == 1 && containsWebPages
         )
         return menuBuilder.longPressMenu(state: state, actions: TabSwitcherLongPressMenuActions(
             onShare: { [weak self] in self?.longPressMenuShareLinks(tabs: tabs) },
             onBookmark: { [weak self] in self?.longPressMenuBookmarkTabs(indexPaths: indexPaths) },
             onSelect: { [weak self] in self?.longPressMenuSelectTabs(indexPaths: indexPaths) },
             onClose: { [weak self] in self?.longPressMenuCloseTabs(indexPaths: indexPaths) },
-            onCloseOther: { [weak self] in self?.longPressMenuCloseOtherTabs(retainingIndexPaths: indexPaths) }
+            onCloseOther: { [weak self] in self?.longPressMenuCloseOtherTabs(retainingIndexPaths: indexPaths) },
+            onDeleteTabAndData: { [weak self] in
+                guard let tab = tabs.first, let indexPath = indexPaths.first else { return }
+                self?.longPressMenuDeleteTabAndData(tab: tab, at: indexPath)
+            }
         ))
     }
 
@@ -383,6 +392,18 @@ extension TabSwitcherViewController {
     func editMenuEnterSelectMode() {
         Pixel.fire(pixel: .tabSwitcherEditMenuSelectTabs)
         DailyPixel.fire(pixel: .tabSwitcherEditMenuSelectTabsDaily)
+
+        guard floatingUIManager.isFloatingTabSwitcherEnabled else {
+            transitionToMultiSelect()
+            return
+        }
+
+        shouldEnterMultiSelectAfterEditMenuDismissal = true
+    }
+
+    func editMenuDidDismiss() {
+        guard shouldEnterMultiSelectAfterEditMenuDismissal, !isEditing else { return }
+        shouldEnterMultiSelectAfterEditMenuDismissal = false
         transitionToMultiSelect()
     }
 
@@ -494,6 +515,24 @@ extension TabSwitcherViewController {
         closeOtherTabs(retainingIndexPaths: indexPaths,
                        pixel: .tabSwitcherLongPressCloseOtherTabs,
                        dailyPixel: .tabSwitcherLongPressCloseOtherTabsDaily)
+    }
+
+    func longPressMenuDeleteTabAndData(tab: Tab, at indexPath: IndexPath) {
+        guard tabsModel.tabs.contains(where: { $0 === tab }) else { return }
+
+        guard let sourceView = collectionView.cellForItem(at: indexPath) ?? view else { return }
+        let presenter = FireConfirmationPresenter()
+        presenter.presentFireConfirmation(
+            on: self,
+            attachPopoverTo: sourceView,
+            tabViewModel: tabManager.viewModel(for: tab),
+            pixelSource: .tabSwitcher,
+            fireContext: .singleTab,
+            browsingMode: tab.mode,
+            onConfirm: { [weak self] fireRequest in
+                self?.forgetAll(fireRequest)
+            },
+            onCancel: {})
     }
 
 }

--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -143,6 +143,7 @@ class TabSwitcherViewController: UIViewController {
     var tabsStyle: TabsStyle = .list
     var interfaceMode: InterfaceMode = .regularSize
     var canShowSelectionMenu = false
+    var shouldEnterMultiSelectAfterEditMenuDismissal = false
     var menuBuilder: TabSwitcherMenuBuilding = DefaultTabSwitcherMenuBuilder()
 
     let floatingUIManager: FloatingUIManaging
@@ -433,6 +434,10 @@ class TabSwitcherViewController: UIViewController {
 
         actions.onEditMenuRequested = { [weak self] in
             return self?.createEditMenu()
+        }
+
+        actions.onEditMenuDismissed = { [weak self] in
+            self?.editMenuDidDismiss()
         }
 
         actions.onSelectTabsStyle = { [weak self] style in

--- a/iOS/DuckDuckGo/TabSwitcherViewController.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController.swift
@@ -142,7 +142,6 @@ class TabSwitcherViewController: UIViewController {
 
     var tabsStyle: TabsStyle = .list
     var interfaceMode: InterfaceMode = .regularSize
-    var canShowSelectionMenu = false
     var shouldEnterMultiSelectAfterEditMenuDismissal = false
     var menuBuilder: TabSwitcherMenuBuilding = DefaultTabSwitcherMenuBuilder()
 

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -464,6 +464,11 @@ public struct UserText {
 
     public static let tabSwitcherBookmarkAllTabs = NSLocalizedString("tab.switcher.bookmarkAll", value: "Bookmark All Tabs", comment: "Bookmark all tabs menu item")
 
+    public static let tabSwitcherDeleteTabAndData = NSLocalizedString(
+        "tab.switcher.delete.tab.and.data",
+        value: "Delete Tab and Data",
+        comment: "Delete a tab and its site data menu item")
+
     public static func tabSwitcherSelectTabs(withCount count: Int) -> String {
         let format = Bundle.main.localizedString(forKey: "tab.switcher.select-tabs.withCount", value: nil, table: nil)
         return String.localizedStringWithFormat(format, count)

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -464,7 +464,7 @@ public struct UserText {
 
     public static let tabSwitcherBookmarkAllTabs = NSLocalizedString("tab.switcher.bookmarkAll", value: "Bookmark All Tabs", comment: "Bookmark all tabs menu item")
 
-    public static let tabSwitcherDeleteTabAndData = NSLocalizedString(
+    public static let tabSwitcherDeleteTabAndData = NotLocalizedString(
         "tab.switcher.delete.tab.and.data",
         value: "Delete Tab and Data",
         comment: "Delete a tab and its site data menu item")

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -5062,9 +5062,6 @@ Take back control of your personal information with the browser designed for dat
 /* Bookmark all tabs menu item */
 "tab.switcher.bookmarkAll" = "Bookmark All Tabs";
 
-/* Delete a tab and its site data menu item */
-"tab.switcher.delete.tab.and.data" = "Delete Tab and Data";
-
 /* Action button to hide tracker count banner */
 "tab.switcher.tracker.count.hide.action" = "Hide";
 

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -5062,6 +5062,9 @@ Take back control of your personal information with the browser designed for dat
 /* Bookmark all tabs menu item */
 "tab.switcher.bookmarkAll" = "Bookmark All Tabs";
 
+/* Delete a tab and its site data menu item */
+"tab.switcher.delete.tab.and.data" = "Delete Tab and Data";
+
 /* Action button to hide tracker count banner */
 "tab.switcher.tracker.count.hide.action" = "Hide";
 

--- a/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
+++ b/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
@@ -81,7 +81,7 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
         }
     }
 
-    func testWhenEditingThenTopBarHasLeadingTitleAndSelectAll() {
+    func testWhenEditingThenTopBarHasMenuSelectionCountAndSelectAll() {
         let chrome = makeInstalledChrome()
         chrome.setTitle("2 Selected")
 
@@ -90,10 +90,10 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
                       canShowSelectionMenu: true,
                       isEditing: true)
 
-        XCTAssertEqual((chrome.navigationItem.leftBarButtonItems?.first?.customView as? UILabel)?.text, "2 Selected")
+        XCTAssertNotNil(chrome.navigationItem.leftBarButtonItems?.first?.menu)
         XCTAssertEqual(chrome.navigationItem.leftBarButtonItems?.count, 1)
         XCTAssertNil(chrome.navigationItem.title)
-        XCTAssertNil(chrome.navigationItem.titleView)
+        XCTAssertEqual((chrome.navigationItem.titleView as? UILabel)?.text, "2 Selected")
         XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.first?.title, UserText.selectAllTabs)
     }
 
@@ -105,7 +105,7 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
                       canShowSelectionMenu: true,
                       isEditing: true)
 
-        guard let titleLabel = chrome.navigationItem.leftBarButtonItems?.first?.customView as? UILabel else {
+        guard let titleLabel = chrome.navigationItem.titleView as? UILabel else {
             XCTFail("Missing selection title label")
             return
         }
@@ -117,7 +117,7 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(titleLabel.frame.width, titleLabel.intrinsicContentSize.width)
     }
 
-    func testWhenEditingThenBottomBarHasDoneCloseTabsAndMenu() {
+    func testWhenEditingThenBottomBarHasCloseTabsFireAndDone() {
         let chrome = makeInstalledChrome()
         chrome.actions.onMultiSelectMenuRequested = { UIMenu(children: []) }
 
@@ -127,16 +127,24 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
                       isEditing: true)
 
         let items = chrome.toolbar.items ?? []
-        let doneIndex = items.firstIndex { $0.accessibilityLabel == UserText.navigationTitleDone }
         let closeTabsIndex = items.firstIndex { $0.title == UserText.tabSwitcherCloseTabsButtonTitle(withCount: 2) }
-        let menuIndex = items.firstIndex { $0.menu != nil }
+        let fireIndex = items.firstIndex { $0.accessibilityIdentifier == "Browser.Toolbar.Button.Fire" }
+        let doneIndex = items.firstIndex { $0.accessibilityLabel == UserText.navigationTitleDone }
 
-        guard let doneIndex, let closeTabsIndex, let menuIndex else {
+        guard let closeTabsIndex, let fireIndex, let doneIndex else {
             XCTFail("Missing selection toolbar items")
             return
         }
-        XCTAssertLessThan(doneIndex, closeTabsIndex)
-        XCTAssertLessThan(closeTabsIndex, menuIndex)
+        XCTAssertLessThan(closeTabsIndex, fireIndex)
+        XCTAssertLessThan(fireIndex, doneIndex)
+        XCTAssertNil(items[doneIndex].title)
+        XCTAssertNotNil(items[doneIndex].image)
+        XCTAssertNotNil(chrome.navigationItem.leftBarButtonItems?.first?.menu)
+
+        if #available(iOS 26.0, *) {
+            XCTAssertEqual(items.count, 4)
+            XCTAssertEqual([items[closeTabsIndex], items[fireIndex], items[doneIndex]].map(\.sharesBackground), [false, false, false])
+        }
     }
 
     func testWhenAllSelectedWhileEditingThenShowsDeselectAll() {
@@ -160,7 +168,7 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
                       isEditing: false)
 
         XCTAssertEqual(chrome.navigationItem.leftBarButtonItems?.count, 2)
-        XCTAssertNotNil(chrome.navigationItem.leftBarButtonItems?.first?.menu)
+        XCTAssertNotNil((chrome.navigationItem.leftBarButtonItems?.first?.customView as? UIButton)?.menu)
         XCTAssertNotNil(chrome.navigationItem.leftBarButtonItems?.last?.menu)
         XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.first?.accessibilityLabel, UserText.navigationTitleDone)
         XCTAssertEqual(chrome.navigationItem.rightBarButtonItems?.count, 3)

--- a/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
+++ b/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
@@ -138,11 +138,12 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
         }
         XCTAssertLessThan(closeTabsIndex, fireIndex)
         XCTAssertLessThan(fireIndex, doneIndex)
-        XCTAssertNil(items[doneIndex].title)
-        XCTAssertNotNil(items[doneIndex].image)
         XCTAssertNotNil(chrome.navigationItem.leftBarButtonItems?.first?.menu)
 
         if #available(iOS 26.0, *) {
+            // On iOS 26 Done is a title-less glyph; earlier versions still use the system Done item.
+            XCTAssertNil(items[doneIndex].title)
+            XCTAssertNotNil(items[doneIndex].image)
             XCTAssertEqual(items.count, 4)
             XCTAssertEqual([items[closeTabsIndex], items[fireIndex], items[doneIndex]].map(\.sharesBackground), [false, false, false])
         }

--- a/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
+++ b/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
@@ -83,6 +83,7 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
 
     func testWhenEditingThenTopBarHasMenuSelectionCountAndSelectAll() {
         let chrome = makeInstalledChrome()
+        chrome.actions.onMultiSelectMenuRequested = { UIMenu(children: []) }
         chrome.setTitle("2 Selected")
 
         chrome.update(state: .editingRegularSize(selectedCount: 2, totalCount: 4),

--- a/iOS/DuckDuckGoTests/TabSwitcherMenuBuilderTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherMenuBuilderTests.swift
@@ -130,7 +130,7 @@ class DefaultTabSwitcherMenuBuilderTests: XCTestCase {
         ])
     }
 
-    func testMultiSelectMenu_whenFloatingAndAllTabsSelected_showsBookmarkShareAndCloseOtherTabs() {
+    func testMultiSelectMenu_whenFloatingAndAllBrowsingTabsSelected_hidesCloseOtherTabs() {
         let actions = floatingMenuActions(
             selectedCount: 4,
             totalCount: 4,
@@ -140,8 +140,17 @@ class DefaultTabSwitcherMenuBuilderTests: XCTestCase {
         XCTAssertEqual(actions.map(\.title), [
             UserText.bookmarkSelectedTabs(withCount: 4),
             UserText.shareLinks(withCount: 4),
-            UserText.tabSwitcherCloseOtherTabs(withCount: 2),
         ])
+    }
+
+    func testMultiSelectMenu_whenFloatingAndAllEmptyTabsSelected_hasNoActions() {
+        let actions = floatingMenuActions(
+            selectedCount: 4,
+            totalCount: 4,
+            selectedContainsWebPages: false,
+            allContainsWebPages: false)
+
+        XCTAssertTrue(actions.isEmpty)
     }
 
     func testMultiSelectMenu_whenAllSelected_showsDeselectAllAndClose() {
@@ -392,8 +401,7 @@ class DefaultTabSwitcherMenuBuilderTests: XCTestCase {
             selectedContainsWebPages: selectedContainsWebPages,
             allContainsWebPages: allContainsWebPages,
             shouldShowSelectionToggleActions: false,
-            shouldShowCloseSelectedAction: false,
-            shouldShowCloseOtherActionWhenAllSelected: true)
+            shouldShowCloseSelectedAction: false)
         return flatActions(builder.multiSelectionMenuItems(state: state, actions: noopMultiSelectActions))
     }
 

--- a/iOS/DuckDuckGoTests/TabSwitcherMenuBuilderTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherMenuBuilderTests.swift
@@ -86,6 +86,64 @@ class DefaultTabSwitcherMenuBuilderTests: XCTestCase {
         XCTAssertFalse(actions.contains(title: UserText.deselectAllTabs))
     }
 
+    func testMultiSelectMenu_whenFloatingAndNothingSelected_showsOnlyBookmarkAll() {
+        let actions = floatingMenuActions(
+            selectedCount: 0,
+            selectedContainsWebPages: false,
+            allContainsWebPages: true)
+
+        XCTAssertEqual(actions.map(\.title), [UserText.tabSwitcherBookmarkAllTabs])
+    }
+
+    func testMultiSelectMenu_whenFloatingAndEmptyTabSelected_showsOnlyCloseOtherTabs() {
+        let actions = floatingMenuActions(
+            selectedCount: 1,
+            selectedContainsWebPages: false,
+            allContainsWebPages: true)
+
+        XCTAssertEqual(actions.map(\.title), [UserText.tabSwitcherCloseOtherTabs(withCount: 2)])
+    }
+
+    func testMultiSelectMenu_whenFloatingAndBrowsingTabSelected_showsBookmarkShareAndCloseOtherTabs() {
+        let actions = floatingMenuActions(
+            selectedCount: 1,
+            selectedContainsWebPages: true,
+            allContainsWebPages: true)
+
+        XCTAssertEqual(actions.map(\.title), [
+            UserText.bookmarkSelectedTabs(withCount: 1),
+            UserText.shareLinks(withCount: 1),
+            UserText.tabSwitcherCloseOtherTabs(withCount: 2),
+        ])
+    }
+
+    func testMultiSelectMenu_whenFloatingAndMultipleTabsSelected_showsBookmarkShareAndCloseOtherTabs() {
+        let actions = floatingMenuActions(
+            selectedCount: 2,
+            selectedContainsWebPages: true,
+            allContainsWebPages: true)
+
+        XCTAssertEqual(actions.map(\.title), [
+            UserText.bookmarkSelectedTabs(withCount: 2),
+            UserText.shareLinks(withCount: 2),
+            UserText.tabSwitcherCloseOtherTabs(withCount: 2),
+        ])
+    }
+
+    func testMultiSelectMenu_whenFloatingAndAllTabsSelected_showsBookmarkShareAndCloseOtherTabs() {
+        let actions = floatingMenuActions(
+            selectedCount: 4,
+            totalCount: 4,
+            selectedContainsWebPages: true,
+            allContainsWebPages: true)
+
+        XCTAssertEqual(actions.map(\.title), [
+            UserText.bookmarkSelectedTabs(withCount: 4),
+            UserText.shareLinks(withCount: 4),
+            UserText.tabSwitcherCloseOtherTabs(withCount: 2),
+        ])
+    }
+
     func testMultiSelectMenu_whenAllSelected_showsDeselectAllAndClose() {
         let state = TabSwitcherMultiSelectMenuState(
             selectedCount: 3, totalCount: 3,
@@ -201,6 +259,28 @@ class DefaultTabSwitcherMenuBuilderTests: XCTestCase {
         XCTAssertTrue(actions.contains(title: UserText.tabSwitcherSelectTabs(withCount: 1)))
         XCTAssertTrue(actions.contains(title: UserText.closeTabs(withCount: 1)))
         XCTAssertTrue(actions.contains(title: UserText.tabSwitcherCloseOtherTabs(withCount: 2)))
+        XCTAssertFalse(actions.contains(title: UserText.tabSwitcherDeleteTabAndData))
+    }
+
+    func testLongPressMenu_whenFloatingWebPageTab_showsDesignActionsInOrder() {
+        let state = TabSwitcherLongPressMenuState(
+            pressedCount: 1,
+            totalCount: 3,
+            pressedContainsWebPages: true,
+            isEditing: false,
+            title: "example.com",
+            shouldShowDeleteTabAndData: true)
+        let actions = flatActions(builder.longPressMenuItems(state: state, actions: noopLongPressActions))
+
+        XCTAssertEqual(actions.map(\.title), [
+            UserText.shareLinks(withCount: 1),
+            UserText.bookmarkSelectedTabs(withCount: 1),
+            UserText.tabSwitcherSelectTabs(withCount: 1),
+            UserText.closeTabs(withCount: 1),
+            UserText.tabSwitcherCloseOtherTabs(withCount: 2),
+            UserText.tabSwitcherDeleteTabAndData,
+        ])
+        XCTAssertTrue(actions.last?.attributes.contains(.destructive) == true)
     }
 
     func testLongPressMenu_homePageTab_hidesShareAndBookmarkButShowsSelect() {
@@ -301,6 +381,21 @@ class DefaultTabSwitcherMenuBuilderTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    private func floatingMenuActions(selectedCount: Int,
+                                     totalCount: Int = 3,
+                                     selectedContainsWebPages: Bool,
+                                     allContainsWebPages: Bool) -> [UIAction] {
+        let state = TabSwitcherMultiSelectMenuState(
+            selectedCount: selectedCount,
+            totalCount: totalCount,
+            selectedContainsWebPages: selectedContainsWebPages,
+            allContainsWebPages: allContainsWebPages,
+            shouldShowSelectionToggleActions: false,
+            shouldShowCloseSelectedAction: false,
+            shouldShowCloseOtherActionWhenAllSelected: true)
+        return flatActions(builder.multiSelectionMenuItems(state: state, actions: noopMultiSelectActions))
+    }
 
     /// Recursively collects all UIActions from a menu element tree.
     private func flatActions(_ elements: [UIMenuElement]) -> [UIAction] {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216033800174503/task/1216167808982814
Tech Design URL: N/A
CC: N/A

### Description
- Align the floating Tab Manager select-mode navigation and toolbar controls with the updated design.
- Show context-appropriate selection and long-press menu actions, including scoped “Delete Tab and Data.”
- Synchronize the overflow menu’s dismissal with toolbar updates to prevent a lingering liquid-glass control.
- Add unit coverage for the revised toolbar layout and menu states.

### Testing Steps
1. Open the floating Tab Manager with multiple normal and empty tabs.
2. Open the overflow menu and select “Select Tabs.”
3. Verify the overflow control dismisses cleanly and select mode shows the tab count, selection controls, Close Tabs, Fire, and Done in the expected positions.
4. Check the overflow actions with zero, one, multiple, and all tabs selected.
5. Long-press a browsing tab and verify “Delete Tab and Data” presents the scoped confirmation.
6. Exit select mode and verify the overflow control matches the other toolbar controls in size and liquid-glass appearance.
7. Repeat in light and dark appearance.

### Impact and Risks
**Impact Level: Medium**

#### What could go wrong?
Selection-state menus or toolbar controls could show incorrect actions or counts. The revised state tests cover the menu combinations, and the toolbar transition waits for UIKit’s menu dismissal completion before replacing its source control.

### Quality Considerations
No new data collection, networking, or persistence is introduced. “Delete Tab and Data” uses the existing scoped Fire confirmation flow. The UI changes use existing design-system assets and system liquid-glass behavior.

### Notes to Reviewer
This PR is stacked on [#6565](https://github.com/duckduckgo/apple-browsers/pull/6565). The focused local test run was interrupted after Simulator diagnostics stalled; CI should provide automated verification.

Made with [Cursor](https://cursor.com)