### PR TITLE
Add Maestro coverage for the Duck.ai usage-warning footer

### DIFF
--- a/.maestro/shared/seed_duckai_usage_warning.yaml
+++ b/.maestro/shared/seed_duckai_usage_warning.yaml
@@ -1,0 +1,39 @@
+appId: com.duckduckgo.mobile.ios
+
+---
+
+# Seeds a synthetic usage-limit snapshot via Debug ▸ AI Chat ▸ Duck.ai Usage Warnings, which writes
+# the reserved `usageLimits` entry the web app writes, so the real read path drives the footer.
+# Free-tier users get an empty snapshot until a window is already blocked, so there is no way to
+# reach the approaching cards without this. Caller must pass PRESET — one of the labels in
+# AIChatUsageWarningsSection.presets. Starts and ends on the browser, with the omnibar unfocused.
+#
+# The debug row is scrolled to here rather than through shared/open_debug_menu.yaml: it is the last
+# row in Settings, so that flow's `centerElement: true` can never be satisfied and the scroll runs
+# out having walked straight past it.
+- tapOn: "Browsing Menu"
+- tapOn: "Settings"
+- scrollUntilVisible:
+    element:
+        text: "All debug options"
+    direction: DOWN
+    centerElement: false
+- tapOn: "All debug options"
+
+- scrollUntilVisible:
+    element:
+        text: "AI Chat"
+    direction: DOWN
+    centerElement: false
+- tapOn: "AI Chat"
+
+- scrollUntilVisible:
+    element:
+        text: "${PRESET}"
+    direction: DOWN
+    centerElement: false
+- tapOn: "${PRESET}"
+
+- tapOn: "Debug"
+- tapOn: "Settings"
+- tapOn: "Done"

--- a/.maestro/unified_toggle_input/test_uti_duckai_warnings_approaching.yaml
+++ b/.maestro/unified_toggle_input/test_uti_duckai_warnings_approaching.yaml
@@ -1,0 +1,98 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - unified_toggle_input
+name: test_uti_duckai_warnings_approaching
+
+---
+
+# The approaching-usage card behind `utiDuckAIWarnings`: what it renders, that Search mode
+# suppresses it, and that ✕ retires it for the rest of the window.
+#
+# `isInternalUser` is doing double duty — it unlocks the Debug menu that seeds the snapshot, and
+# the resolver only offers approaching warnings to internal or paid users. Without
+# `ff.aiChatNativeStorage` there is no storage bridge, so the store reports inactive and no card
+# renders at all.
+- launchApp:
+    appId: "com.duckduckgo.mobile.ios"
+    clearState: true
+    clearKeychain: true
+    arguments:
+        isOnboardingCompleted: ${ONBOARDING_COMPLETED}
+        currentAppVariant: ${APP_VARIANT}
+        isRunningUITests: true
+        isInternalUser: "true"
+        # Keep quoted — LaunchOptionsHandler silently ignores unquoted YAML booleans.
+        ff.utiDuckAIWarnings: "true"
+        ff.aiChatNativeStorage: "true"
+        ff.browsingMenuSheetEnabledByDefault: "true"
+
+- runFlow:
+    file: ../shared/dismiss_chat_open_modals.yaml
+
+- runFlow:
+    file: ../shared/set_search_and_duckai.yaml
+
+- runFlow:
+    file: ../shared/seed_duckai_usage_warning.yaml
+    env:
+        PRESET: "Weekly 90%"
+
+# The snapshot is picked up the next time the Duck.ai input opens.
+- tapOn:
+    id: "searchEntry"
+- tapOn:
+    id: "AddressBar.Button.DuckAI"
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# A ring rather than an alert glyph: the limit is approaching, not reached.
+- assertVisible:
+    id: "AIChat.Footer.Card"
+- assertVisible:
+    id: "AIChat.Footer.Label.Title"
+    text: "90% of weekly limit"
+# Asserted by identifier only — the reset copy depends on how the seeded 48h interval rounds as
+# the flow itself burns time.
+- assertVisible:
+    id: "AIChat.Footer.Label.Subtitle"
+- assertVisible:
+    id: "AIChat.Footer.Icon.UsageRing"
+- assertNotVisible:
+    id: "AIChat.Footer.Icon.Alert"
+- assertVisible:
+    id: "AIChat.Footer.Button.Dismiss"
+
+# Search mode has no usage limits to warn about, so the card is suppressed there.
+- tapOn:
+    id: "AddressBar.Button.Search"
+- waitForAnimationToEnd:
+    timeout: 3000
+- assertNotVisible:
+    id: "AIChat.Footer.Card"
+
+- tapOn:
+    id: "AddressBar.Button.DuckAI"
+- waitForAnimationToEnd:
+    timeout: 3000
+- assertVisible:
+    id: "AIChat.Footer.Card"
+
+- tapOn:
+    id: "AIChat.Footer.Button.Dismiss"
+- waitForAnimationToEnd:
+    timeout: 3000
+- assertNotVisible:
+    id: "AIChat.Footer.Card"
+
+# The dismissal is recorded against the window, so it outlives the input session.
+- runFlow:
+    file: ../shared/dismiss_address_bar_editing.yaml
+- tapOn:
+    id: "searchEntry"
+- tapOn:
+    id: "AddressBar.Button.DuckAI"
+- waitForAnimationToEnd:
+    timeout: 3000
+- assertNotVisible:
+    id: "AIChat.Footer.Card"

--- a/.maestro/unified_toggle_input/test_uti_duckai_warnings_approaching.yaml
+++ b/.maestro/unified_toggle_input/test_uti_duckai_warnings_approaching.yaml
@@ -1,6 +1,7 @@
 appId: com.duckduckgo.mobile.ios
 tags:
     - iphone
+    - release
     - unified_toggle_input
 name: test_uti_duckai_warnings_approaching
 

--- a/.maestro/unified_toggle_input/test_uti_duckai_warnings_disabled.yaml
+++ b/.maestro/unified_toggle_input/test_uti_duckai_warnings_disabled.yaml
@@ -1,6 +1,7 @@
 appId: com.duckduckgo.mobile.ios
 tags:
     - iphone
+    - release
     - unified_toggle_input
 name: test_uti_duckai_warnings_disabled
 

--- a/.maestro/unified_toggle_input/test_uti_duckai_warnings_disabled.yaml
+++ b/.maestro/unified_toggle_input/test_uti_duckai_warnings_disabled.yaml
@@ -1,0 +1,48 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - unified_toggle_input
+name: test_uti_duckai_warnings_disabled
+
+---
+
+# Control for the two warning flows: the same seeded snapshot must produce no card while
+# `utiDuckAIWarnings` is off. Everything else is left on, so a failure here points at the flag
+# gate rather than at the storage bridge or the seeding.
+- launchApp:
+    appId: "com.duckduckgo.mobile.ios"
+    clearState: true
+    clearKeychain: true
+    arguments:
+        isOnboardingCompleted: ${ONBOARDING_COMPLETED}
+        currentAppVariant: ${APP_VARIANT}
+        isRunningUITests: true
+        isInternalUser: "true"
+        # Keep quoted — LaunchOptionsHandler silently ignores unquoted YAML booleans.
+        ff.utiDuckAIWarnings: "false"
+        ff.aiChatNativeStorage: "true"
+        ff.browsingMenuSheetEnabledByDefault: "true"
+
+- runFlow:
+    file: ../shared/dismiss_chat_open_modals.yaml
+
+- runFlow:
+    file: ../shared/set_search_and_duckai.yaml
+
+- runFlow:
+    file: ../shared/seed_duckai_usage_warning.yaml
+    env:
+        PRESET: "Weekly limit reached"
+
+- tapOn:
+    id: "searchEntry"
+- tapOn:
+    id: "AddressBar.Button.DuckAI"
+- waitForAnimationToEnd:
+    timeout: 3000
+
+# The Duck.ai input is up — this is the state that would carry the card.
+- assertVisible:
+    id: "AIChat.Toolbar.Button.ModelChip"
+- assertNotVisible:
+    id: "AIChat.Footer.Card"

--- a/.maestro/unified_toggle_input/test_uti_duckai_warnings_limit_reached.yaml
+++ b/.maestro/unified_toggle_input/test_uti_duckai_warnings_limit_reached.yaml
@@ -1,0 +1,82 @@
+appId: com.duckduckgo.mobile.ios
+tags:
+    - iphone
+    - unified_toggle_input
+name: test_uti_duckai_warnings_limit_reached
+
+---
+
+# The blocked-usage cards behind `utiDuckAIWarnings`. A reached limit reads as an alert rather than
+# a full ring, carries no ✕ (there is nothing to defer), and offers the subscription upsell.
+- launchApp:
+    appId: "com.duckduckgo.mobile.ios"
+    clearState: true
+    clearKeychain: true
+    arguments:
+        isOnboardingCompleted: ${ONBOARDING_COMPLETED}
+        currentAppVariant: ${APP_VARIANT}
+        isRunningUITests: true
+        isInternalUser: "true"
+        # Keep quoted — LaunchOptionsHandler silently ignores unquoted YAML booleans.
+        ff.utiDuckAIWarnings: "true"
+        ff.aiChatNativeStorage: "true"
+        ff.browsingMenuSheetEnabledByDefault: "true"
+
+- runFlow:
+    file: ../shared/dismiss_chat_open_modals.yaml
+
+- runFlow:
+    file: ../shared/set_search_and_duckai.yaml
+
+- runFlow:
+    file: ../shared/seed_duckai_usage_warning.yaml
+    env:
+        PRESET: "Weekly limit reached"
+
+- tapOn:
+    id: "searchEntry"
+- tapOn:
+    id: "AddressBar.Button.DuckAI"
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- assertVisible:
+    id: "AIChat.Footer.Card"
+- assertVisible:
+    id: "AIChat.Footer.Label.Title"
+    text: "Weekly usage limit reached"
+- assertVisible:
+    id: "AIChat.Footer.Icon.Alert"
+- assertNotVisible:
+    id: "AIChat.Footer.Icon.UsageRing"
+- assertNotVisible:
+    id: "AIChat.Footer.Button.Dismiss"
+# By identifier only: the CTA reads "Try for free" or "Subscribe" depending on trial eligibility.
+- assertVisible:
+    id: "AIChat.Footer.Button.Primary"
+
+# A daily block is its own message. Re-seeding in place keeps the second case off a fresh install.
+- runFlow:
+    file: ../shared/dismiss_address_bar_editing.yaml
+
+- runFlow:
+    file: ../shared/seed_duckai_usage_warning.yaml
+    env:
+        PRESET: "Daily limit reached"
+
+- tapOn:
+    id: "searchEntry"
+- tapOn:
+    id: "AddressBar.Button.DuckAI"
+- waitForAnimationToEnd:
+    timeout: 3000
+
+- assertVisible:
+    id: "AIChat.Footer.Card"
+- assertVisible:
+    id: "AIChat.Footer.Label.Title"
+    text: "Daily limit reached"
+- assertVisible:
+    id: "AIChat.Footer.Icon.Alert"
+- assertNotVisible:
+    id: "AIChat.Footer.Button.Dismiss"

--- a/.maestro/unified_toggle_input/test_uti_duckai_warnings_limit_reached.yaml
+++ b/.maestro/unified_toggle_input/test_uti_duckai_warnings_limit_reached.yaml
@@ -1,6 +1,7 @@
 appId: com.duckduckgo.mobile.ios
 tags:
     - iphone
+    - release
     - unified_toggle_input
 name: test_uti_duckai_warnings_limit_reached
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterCardView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterCardView.swift
@@ -130,6 +130,7 @@ private extension UTIFooterCardView {
         layer.cornerCurve = .continuous
         layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
         clipsToBounds = true
+        accessibilityIdentifier = "AIChat.Footer.Card"
 
         contentView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(contentView)
@@ -140,6 +141,8 @@ private extension UTIFooterCardView {
             $0.setContentCompressionResistancePriority(.required, for: .horizontal)
             contentView.addSubview($0)
         }
+        usageRing.accessibilityIdentifier = "AIChat.Footer.Icon.UsageRing"
+        alertIcon.accessibilityIdentifier = "AIChat.Footer.Icon.Alert"
         alertIcon.contentMode = .scaleAspectFit
         alertIcon.isHidden = true
 
@@ -150,7 +153,9 @@ private extension UTIFooterCardView {
             label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         }
         titleLabel.font = .daxFootnoteSemibold()
+        titleLabel.accessibilityIdentifier = "AIChat.Footer.Label.Title"
         subtitleLabel.font = .daxCaption1()
+        subtitleLabel.accessibilityIdentifier = "AIChat.Footer.Label.Subtitle"
 
         let textStack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
         textStack.axis = .vertical
@@ -166,6 +171,7 @@ private extension UTIFooterCardView {
         dismissButton.translatesAutoresizingMaskIntoConstraints = false
         dismissButton.setImage(DesignSystemImages.Glyphs.Size16.close, for: .normal)
         dismissButton.accessibilityLabel = UserText.utiDuckAIWarningsDismissAccessibilityLabel
+        dismissButton.accessibilityIdentifier = "AIChat.Footer.Button.Dismiss"
         dismissButton.setContentHuggingPriority(.required, for: .horizontal)
         dismissButton.addTarget(self, action: #selector(dismissTapped), for: .primaryActionTriggered)
         contentView.addSubview(dismissButton)
@@ -288,6 +294,7 @@ final class UTIFooterActionButton: UIView {
         layer.borderWidth = Constants.strokeWidth
 
         primaryButton.translatesAutoresizingMaskIntoConstraints = false
+        primaryButton.accessibilityIdentifier = "AIChat.Footer.Button.Primary"
         primaryButton.configuration = Self.makePrimaryConfiguration()
         // The label gives before the pill does, so a zero-width collapse can't break the layout.
         primaryButton.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217605036256293?focus=true
Tech Design URL:
CC:

### Description
Adds Maestro flows covering the Duck.ai usage-warning footer behind `utiDuckAIWarnings`: the approaching-limit card, both limit-reached cards, and a flag-off control. The states are seeded through the AI Chat debug menu so the real read path drives the UI, since a free-tier account never reaches these cards on its own. The only production change is a set of `AIChat.Footer.*` accessibility identifiers, so the flows keep working once the placeholder copy is localised.

### Testing Steps
1. Check if https://github.com/duckduckgo/apple-browsers/actions/runs/33192059824 is passing

### Impact
None — test-only, apart from accessibility identifiers that add no behaviour.

#### What could go wrong?
The three flows are tagged `unified_toggle_input`, which no CI leg currently runs, so they only execute when someone runs that tag by hand.
