### PR TITLE
[iOS] Measure Duck.ai usage-warning card interactions and outcomes

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/UsageWarnings/DuckAiUsageWarningMeasurement.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/UsageWarnings/DuckAiUsageWarningMeasurement.swift
@@ -1,0 +1,176 @@
+//
+//  DuckAiUsageWarningMeasurement.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Which card the user saw. Each platform puts this in the pixel name rather than in a parameter,
+/// so the three states can be read straight off the event.
+public enum DuckAiUsageWarningExposureKind: String {
+    case approaching
+    case limitReached
+    case highUsageModelNotice
+}
+
+/// What one appearance of the card was about: the state, plus whichever of the window, the rung and
+/// the model id that state has.
+public struct DuckAiUsageWarningExposure: Equatable {
+
+    public let kind: DuckAiUsageWarningExposureKind
+    public let window: DuckAiUsageWindow?
+    /// The rung of the approaching ladder the card was shown at: 50, 75 or 90.
+    public let percentBucket: Int?
+    public let modelId: String?
+
+    public init(kind: DuckAiUsageWarningExposureKind,
+                window: DuckAiUsageWindow? = nil,
+                percentBucket: Int? = nil,
+                modelId: String? = nil) {
+        self.kind = kind
+        self.window = window
+        self.percentBucket = percentBucket
+        self.modelId = modelId
+    }
+}
+
+public extension DuckAiUsageWarningExposure {
+
+    /// Every reached id folds into `.limitReached`: the degraded one leaves free models available,
+    /// but the state the user is looking at is the same blocked one.
+    init(warning: DuckAiUsageWarning) {
+        switch warning.message {
+        case .approaching:
+            self.init(kind: .approaching,
+                      window: warning.window,
+                      percentBucket: Self.rung(forDisplayedPercent: warning.percent))
+        case .freeReached, .dailyReached, .weeklyReachedDegraded, .weeklyReached:
+            self.init(kind: .limitReached, window: warning.window)
+        }
+    }
+
+    init(notice: DuckAiHighUsageModelNotice) {
+        self.init(kind: .highUsageModelNotice, modelId: notice.modelId)
+    }
+
+    /// Keyed off the displayed percentage, so the reported rung can never disagree with the copy or
+    /// the ring. Below the lowest rung there is nothing to report.
+    private static func rung(forDisplayedPercent percent: Int) -> Int? {
+        [90, 75, 50].first { percent >= $0 }
+    }
+}
+
+public enum DuckAiUsageWarningMeasurementEvent: Equatable {
+    case shown(DuckAiUsageWarningExposure)
+    case dismissed(DuckAiUsageWarningExposure)
+    case switchModelTapped(DuckAiUsageWarningExposure)
+    case upsellTapped(DuckAiUsageWarningExposure)
+    case promptSubmitted(DuckAiUsageWarningExposure)
+    case modelSwitched(DuckAiUsageWarningExposure)
+    case abandoned(DuckAiUsageWarningExposure)
+}
+
+public protocol DuckAiUsageWarningPixelFiring {
+    func fire(_ event: DuckAiUsageWarningMeasurementEvent)
+}
+
+public struct NullDuckAiUsageWarningPixelFiring: DuckAiUsageWarningPixelFiring {
+    public init() {}
+    public func fire(_ event: DuckAiUsageWarningMeasurementEvent) {}
+}
+
+/// Turns the card's lifecycle into the events each platform reports: one impression per appearance,
+/// and one follow-through per exposure — what the user did about the message before the input closed.
+///
+/// An exposure outlives the card. Dismissing or acting on the message takes it off screen while the
+/// user carries on typing, and a prompt sent after that still belongs to the warning they saw.
+public final class DuckAiUsageWarningMeasurement {
+
+    public enum CTA {
+        case switchModel
+        case upsell
+    }
+
+    private struct Exposure {
+        let subject: DuckAiUsageWarningExposure
+        var didReportPrompt = false
+        var didReportModelSwitch = false
+        var didTapCTA = false
+
+        var hasFollowThrough: Bool { didReportPrompt || didReportModelSwitch || didTapCTA }
+    }
+
+    private let pixelFiring: DuckAiUsageWarningPixelFiring
+    private var exposure: Exposure?
+
+    public init(pixelFiring: DuckAiUsageWarningPixelFiring = NullDuckAiUsageWarningPixelFiring()) {
+        self.pixelFiring = pixelFiring
+    }
+
+    /// Driven by the card entering the footer slot, never by the message being resolved: the message
+    /// is resolved while the input is still collapsed, and only revealed inside the expand animation.
+    public func cardBecameVisible(_ subject: DuckAiUsageWarningExposure) {
+        // A refresh mid-expand re-applies the same rung once the models land and the CTA copy fills
+        // in. That is one appearance.
+        guard exposure?.subject != subject else { return }
+        endExposure()
+        exposure = Exposure(subject: subject)
+        pixelFiring.fire(.shown(subject))
+    }
+
+    public func warningDismissed() {
+        guard let exposure = exposure else { return }
+        pixelFiring.fire(.dismissed(exposure.subject))
+    }
+
+    public func ctaTapped(_ cta: CTA) {
+        guard var exposure = exposure else { return }
+        exposure.didTapCTA = true
+        self.exposure = exposure
+        switch cta {
+        case .switchModel: pixelFiring.fire(.switchModelTapped(exposure.subject))
+        case .upsell: pixelFiring.fire(.upsellTapped(exposure.subject))
+        }
+    }
+
+    public func promptSubmitted() {
+        guard var exposure = exposure, !exposure.didReportPrompt else { return }
+        exposure.didReportPrompt = true
+        self.exposure = exposure
+        pixelFiring.fire(.promptSubmitted(exposure.subject))
+    }
+
+    /// A switch the user made themselves. The card's own switch CTA is already reported as a tap.
+    public func modelSwitched() {
+        guard var exposure = exposure, !exposure.didReportModelSwitch, !exposure.didTapCTA else { return }
+        exposure.didReportModelSwitch = true
+        self.exposure = exposure
+        pixelFiring.fire(.modelSwitched(exposure.subject))
+    }
+
+    /// The input pane closing, collapsing or leaving Duck.ai mode: whatever the user was going to do
+    /// about the message, they have done it.
+    public func inputSessionEnded() {
+        endExposure()
+    }
+
+    private func endExposure() {
+        guard let exposure = exposure else { return }
+        self.exposure = nil
+        guard !exposure.hasFollowThrough else { return }
+        pixelFiring.fire(.abandoned(exposure.subject))
+    }
+}

--- a/SharedPackages/AIChat/Tests/AIChatTests/UsageWarnings/DuckAiUsageWarningMeasurementTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/UsageWarnings/DuckAiUsageWarningMeasurementTests.swift
@@ -1,0 +1,261 @@
+//
+//  DuckAiUsageWarningMeasurementTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import AIChat
+
+final class DuckAiUsageWarningMeasurementTests: XCTestCase {
+
+    private var firing: RecordingDuckAiUsageWarningPixelFiring!
+    private var sut: DuckAiUsageWarningMeasurement!
+
+    private let approaching = DuckAiUsageWarningExposure(kind: .approaching, window: .weekly, percentBucket: 75)
+    private let limitReached = DuckAiUsageWarningExposure(kind: .limitReached, window: .weekly)
+    private let notice = DuckAiUsageWarningExposure(kind: .highUsageModelNotice, modelId: "claude-opus-4-8")
+
+    override func setUp() {
+        super.setUp()
+        firing = RecordingDuckAiUsageWarningPixelFiring()
+        sut = DuckAiUsageWarningMeasurement(pixelFiring: firing)
+    }
+
+    override func tearDown() {
+        sut = nil
+        firing = nil
+        super.tearDown()
+    }
+
+    // MARK: - Impressions
+
+    func testWhenTheCardBecomesVisibleThenItIsReportedAsShown() {
+        sut.cardBecameVisible(approaching)
+
+        XCTAssertEqual(firing.events, [.shown(approaching)])
+    }
+
+    /// A refresh mid-expand can re-apply the same rung once the models land and the CTA copy fills
+    /// in; that is one appearance, not two.
+    func testWhenTheSameCardBecomesVisibleAgainThenItIsNotReportedTwice() {
+        sut.cardBecameVisible(approaching)
+        sut.cardBecameVisible(approaching)
+
+        XCTAssertEqual(firing.events, [.shown(approaching)])
+    }
+
+    func testWhenADifferentRungBecomesVisibleThenItIsReportedAsANewImpression() {
+        let ninety = DuckAiUsageWarningExposure(kind: .approaching, window: .weekly, percentBucket: 90)
+
+        sut.cardBecameVisible(approaching)
+        sut.cardBecameVisible(ninety)
+
+        XCTAssertEqual(firing.events, [.shown(approaching), .abandoned(approaching), .shown(ninety)])
+    }
+
+    // MARK: - Terminal outcome
+
+    func testWhenTheInputSessionEndsWithNoFollowUpThenTheExposureIsReportedAsAbandoned() {
+        sut.cardBecameVisible(limitReached)
+
+        sut.inputSessionEnded()
+
+        XCTAssertEqual(firing.events, [.shown(limitReached), .abandoned(limitReached)])
+    }
+
+    func testWhenTheInputSessionEndsTwiceThenAbandonedIsReportedOnce() {
+        sut.cardBecameVisible(limitReached)
+
+        sut.inputSessionEnded()
+        sut.inputSessionEnded()
+
+        XCTAssertEqual(firing.events, [.shown(limitReached), .abandoned(limitReached)])
+    }
+
+    func testWhenAPromptIsSubmittedThenTheExposureIsNotReportedAsAbandoned() {
+        sut.cardBecameVisible(approaching)
+
+        sut.promptSubmitted()
+        sut.inputSessionEnded()
+
+        XCTAssertEqual(firing.events, [.shown(approaching), .promptSubmitted(approaching)])
+    }
+
+    func testWhenTwoPromptsAreSubmittedInOneSessionThenOnlyTheFirstIsReported() {
+        sut.cardBecameVisible(approaching)
+
+        sut.promptSubmitted()
+        sut.promptSubmitted()
+
+        XCTAssertEqual(firing.events, [.shown(approaching), .promptSubmitted(approaching)])
+    }
+
+    func testWhenTheUserSwitchesModelThenTheExposureIsReportedAsAModelSwitch() {
+        sut.cardBecameVisible(notice)
+
+        sut.modelSwitched()
+        sut.inputSessionEnded()
+
+        XCTAssertEqual(firing.events, [.shown(notice), .modelSwitched(notice)])
+    }
+
+    func testWhenTheUserBothSwitchesModelAndPromptsThenBothAreReported() {
+        sut.cardBecameVisible(approaching)
+
+        sut.modelSwitched()
+        sut.promptSubmitted()
+        sut.inputSessionEnded()
+
+        XCTAssertEqual(firing.events, [.shown(approaching), .modelSwitched(approaching), .promptSubmitted(approaching)])
+    }
+
+    func testWhenNothingHasBeenShownThenAFollowUpReportsNothing() {
+        sut.promptSubmitted()
+        sut.modelSwitched()
+        sut.warningDismissed()
+        sut.inputSessionEnded()
+
+        XCTAssertTrue(firing.events.isEmpty)
+    }
+
+    // MARK: - Dismissal
+
+    func testWhenTheCardIsDismissedThenItIsReportedAsDismissed() {
+        sut.cardBecameVisible(approaching)
+
+        sut.warningDismissed()
+
+        XCTAssertEqual(firing.events, [.shown(approaching), .dismissed(approaching)])
+    }
+
+    /// Dismissal is not a terminal outcome: the input session carries on, and a prompt that follows
+    /// still belongs to the warning the user saw.
+    func testWhenTheCardIsDismissedAndAPromptFollowsThenBothAreReported() {
+        sut.cardBecameVisible(approaching)
+
+        sut.warningDismissed()
+        sut.promptSubmitted()
+        sut.inputSessionEnded()
+
+        XCTAssertEqual(firing.events, [.shown(approaching), .dismissed(approaching), .promptSubmitted(approaching)])
+    }
+
+    func testWhenTheCardIsDismissedAndNothingFollowsThenTheExposureIsReportedAsAbandoned() {
+        sut.cardBecameVisible(approaching)
+
+        sut.warningDismissed()
+        sut.inputSessionEnded()
+
+        XCTAssertEqual(firing.events, [.shown(approaching), .dismissed(approaching), .abandoned(approaching)])
+    }
+
+    // MARK: - CTAs
+
+    func testWhenTheSwitchModelCTAIsTappedThenItIsReported() {
+        sut.cardBecameVisible(approaching)
+
+        sut.ctaTapped(.switchModel)
+
+        XCTAssertEqual(firing.events, [.shown(approaching), .switchModelTapped(approaching)])
+    }
+
+    func testWhenTheUpsellCTAIsTappedThenItIsReported() {
+        sut.cardBecameVisible(limitReached)
+
+        sut.ctaTapped(.upsell)
+
+        XCTAssertEqual(firing.events, [.shown(limitReached), .upsellTapped(limitReached)])
+    }
+
+    /// The switch the CTA performs is already reported as a CTA tap; reporting it again as a
+    /// self-initiated switch would double-count it.
+    func testWhenTheSwitchFollowsTheCardsOwnCTAThenItIsNotAlsoReportedAsAModelSwitch() {
+        sut.cardBecameVisible(approaching)
+
+        sut.ctaTapped(.switchModel)
+        sut.modelSwitched()
+        sut.inputSessionEnded()
+
+        XCTAssertEqual(firing.events, [.shown(approaching), .switchModelTapped(approaching)])
+    }
+
+    func testWhenACTAIsTappedThenTheExposureIsNotReportedAsAbandoned() {
+        sut.cardBecameVisible(limitReached)
+
+        sut.ctaTapped(.upsell)
+        sut.inputSessionEnded()
+
+        XCTAssertEqual(firing.events, [.shown(limitReached), .upsellTapped(limitReached)])
+    }
+
+    // MARK: - Exposure from the resolved message
+
+    func testWhenTheWarningIsApproachingThenTheExposureCarriesTheRungItIsShownAt() {
+        XCTAssertEqual(DuckAiUsageWarningExposure(warning: warning(message: .approaching, percent: 75)).percentBucket, 75)
+        XCTAssertEqual(DuckAiUsageWarningExposure(warning: warning(message: .approaching, percent: 99)).percentBucket, 90)
+        XCTAssertEqual(DuckAiUsageWarningExposure(warning: warning(message: .approaching, percent: 50)).percentBucket, 50)
+    }
+
+    func testWhenTheWarningIsApproachingThenTheExposureCarriesItsWindow() {
+        let exposure = DuckAiUsageWarningExposure(warning: warning(message: .approaching, percent: 75, window: .daily))
+
+        XCTAssertEqual(exposure.kind, .approaching)
+        XCTAssertEqual(exposure.window, .daily)
+    }
+
+    /// A reached limit has no rung: it is not on the approaching ladder.
+    func testWhenTheLimitIsReachedThenTheExposureCarriesNoRung() {
+        let exposure = DuckAiUsageWarningExposure(warning: warning(message: .weeklyReached, percent: 100))
+
+        XCTAssertEqual(exposure.kind, .limitReached)
+        XCTAssertEqual(exposure.window, .weekly)
+        XCTAssertNil(exposure.percentBucket)
+    }
+
+    func testWhenTheNoticeIsForAHighUsageModelThenTheExposureCarriesTheModelId() {
+        let exposure = DuckAiUsageWarningExposure(notice: DuckAiHighUsageModelNotice(modelId: "claude-opus-4-8",
+                                                                                     modelShortName: "Opus 4.8"))
+
+        XCTAssertEqual(exposure.kind, .highUsageModelNotice)
+        XCTAssertEqual(exposure.modelId, "claude-opus-4-8")
+        XCTAssertNil(exposure.window)
+        XCTAssertNil(exposure.percentBucket)
+    }
+
+    // MARK: - Helpers
+
+    private func warning(message: DuckAiUsageMessage,
+                         percent: Int,
+                         window: DuckAiUsageWindow = .weekly) -> DuckAiUsageWarning {
+        DuckAiUsageWarning(window: window,
+                           message: message,
+                           severity: message == .approaching ? .warning : .reached,
+                           percent: percent,
+                           resetsIn: .days(2),
+                           isDismissible: message == .approaching)
+    }
+}
+
+// MARK: - Test doubles
+
+private final class RecordingDuckAiUsageWarningPixelFiring: DuckAiUsageWarningPixelFiring {
+
+    private(set) var events: [DuckAiUsageWarningMeasurementEvent] = []
+
+    func fire(_ event: DuckAiUsageWarningMeasurementEvent) {
+        events.append(event)
+    }
+}

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -2621,6 +2621,7 @@
 		FC7EF0040000000000000002 /* UTIFooterMessageMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0030000000000000002 /* UTIFooterMessageMapperTests.swift */; };
 		FC7EF0040000000000000003 /* UTIFooterControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0030000000000000003 /* UTIFooterControllerTests.swift */; };
 		FC7EF0040000000000000004 /* DuckAiUsageLimitsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0030000000000000004 /* DuckAiUsageLimitsStoreTests.swift */; };
+		FC7EF0040000000000000005 /* DuckAiUsageWarningPixelAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0030000000000000005 /* DuckAiUsageWarningPixelAdapterTests.swift */; };
 		FC7EF0040000000000000101 /* UTIFooterCardViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7EF0030000000000000101 /* UTIFooterCardViewTests.swift */; };
 		FCFC00031F00000000010001 /* DDGError in Frameworks */ = {isa = PBXBuildFile; productRef = FCFC00021F00000000010001 /* DDGError */; };
 		FCFC00031F00000000020001 /* DDGError in Frameworks */ = {isa = PBXBuildFile; productRef = FCFC00021F00000000020001 /* DDGError */; };
@@ -5389,6 +5390,7 @@
 		FC7EF0030000000000000002 /* UTIFooterMessageMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterMessageMapperTests.swift; sourceTree = "<group>"; };
 		FC7EF0030000000000000003 /* UTIFooterControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterControllerTests.swift; sourceTree = "<group>"; };
 		FC7EF0030000000000000004 /* DuckAiUsageLimitsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAiUsageLimitsStoreTests.swift; sourceTree = "<group>"; };
+		FC7EF0030000000000000005 /* DuckAiUsageWarningPixelAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAiUsageWarningPixelAdapterTests.swift; sourceTree = "<group>"; };
 		FC7EF0030000000000000101 /* UTIFooterCardViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFooterCardViewTests.swift; sourceTree = "<group>"; };
 		FD63EDD2D1E5E97F3084B04F /* SearchTokenRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchTokenRequest.swift; sourceTree = "<group>"; };
 		FDEC1A2B30260001000000F2 /* IOSMonthlyFreeTrialDeciderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSMonthlyFreeTrialDeciderTests.swift; sourceTree = "<group>"; };
@@ -11633,6 +11635,7 @@
 				FC7EF0030000000000000002 /* UTIFooterMessageMapperTests.swift */,
 				FC7EF0030000000000000003 /* UTIFooterControllerTests.swift */,
 				FC7EF0030000000000000004 /* DuckAiUsageLimitsStoreTests.swift */,
+				FC7EF0030000000000000005 /* DuckAiUsageWarningPixelAdapterTests.swift */,
 			);
 			path = Footer;
 			sourceTree = "<group>";
@@ -14292,6 +14295,7 @@
 				FC7EF0040000000000000101 /* UTIFooterCardViewTests.swift in Sources */,
 				FC7EF0040000000000000002 /* UTIFooterMessageMapperTests.swift in Sources */,
 				FC7EF0040000000000000003 /* UTIFooterControllerTests.swift in Sources */,
+				FC7EF0040000000000000005 /* DuckAiUsageWarningPixelAdapterTests.swift in Sources */,
 				FC7EF0040000000000000004 /* DuckAiUsageLimitsStoreTests.swift in Sources */,
 				AABB00010001000100010101 /* UnifiedToggleInputViewTests.swift in Sources */,
 				AABB00010001000100010201 /* UnifiedToggleInputToggleViewTests.swift in Sources */,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIModelSelector.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIModelSelector.swift
@@ -58,6 +58,8 @@ final class UTIModelSelector {
         let onUserChoiceRecorded: () -> Void
         let clearSubmitRecoveryBlock: () -> Void
         let onModelApplied: (String) -> Void
+        /// A model the user actually changed to, as opposed to a re-application of the current one.
+        let onModelSelectionChanged: (String) -> Void
     }
 
     private let modelStore: UTIModelStore
@@ -111,6 +113,7 @@ final class UTIModelSelector {
             updateSelectedModel(modelId)
             if isNewSelection {
                 pixelReporter.reportModelSelected(modelId: modelId)
+                callbacks.onModelSelectionChanged(modelId)
             }
             callbacks.onModelApplied(modelId)
         } else {
@@ -159,6 +162,7 @@ final class UTIModelSelector {
         updateSelectedModel(modelId)
         if isNewSelection {
             pixelReporter.reportModelSelected(modelId: modelId)
+            callbacks.onModelSelectionChanged(modelId)
         }
         callbacks.onModelApplied(modelId)
         return true

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/DuckAiUsageWarningPixel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/DuckAiUsageWarningPixel.swift
@@ -1,0 +1,199 @@
+//
+//  DuckAiUsageWarningPixel.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import os.log
+import PixelKit
+
+/// The Duck.ai usage-warning card's pixels. Which message the user saw is in the name rather than in
+/// a parameter, so each state is one series; the window, the rung and the model id are parameters.
+enum DuckAiUsageWarningPixel: PixelKit.Event {
+
+    /// What the card was about when the pixel fired. Only the fields the state has are sent.
+    struct Context: Equatable {
+        let surface: UnifiedToggleInputPixelSurface
+        let window: DuckAiUsageWindow?
+        let percentBucket: Int?
+        let modelId: String?
+
+        init(exposure: DuckAiUsageWarningExposure, surface: UnifiedToggleInputPixelSurface) {
+            self.surface = surface
+            self.window = exposure.window
+            self.percentBucket = exposure.percentBucket
+            self.modelId = exposure.modelId
+        }
+    }
+
+    private enum Parameter {
+        static let surface = "surface"
+        static let window = "window"
+        static let percentBucket = "percent_bucket"
+        static let modelId = "model_id"
+    }
+
+    case approachingShown(Context)
+    case approachingDismissed(Context)
+    case approachingPromptSubmitted(Context)
+    case approachingModelSwitched(Context)
+    case approachingAbandoned(Context)
+
+    case limitReachedShown(Context)
+    case limitReachedPromptSubmitted(Context)
+    case limitReachedModelSwitched(Context)
+    case limitReachedAbandoned(Context)
+
+    case switchModelTapped(Context)
+    case upsellTapped(Context)
+
+    case highUsageModelNoticeShown(Context)
+    case highUsageModelNoticeDismissed(Context)
+    case highUsageModelNoticePromptSubmitted(Context)
+    case highUsageModelNoticeModelSwitched(Context)
+    case highUsageModelNoticeAbandoned(Context)
+
+    var name: String {
+        switch self {
+        case .approachingShown: return "aichat_usage_warning_approaching_shown"
+        case .approachingDismissed: return "aichat_usage_warning_approaching_dismissed"
+        case .approachingPromptSubmitted: return "aichat_usage_warning_approaching_prompt_submitted"
+        case .approachingModelSwitched: return "aichat_usage_warning_approaching_model_switched"
+        case .approachingAbandoned: return "aichat_usage_warning_approaching_abandoned"
+        case .limitReachedShown: return "aichat_usage_warning_limit_reached_shown"
+        case .limitReachedPromptSubmitted: return "aichat_usage_warning_limit_reached_prompt_submitted"
+        case .limitReachedModelSwitched: return "aichat_usage_warning_limit_reached_model_switched"
+        case .limitReachedAbandoned: return "aichat_usage_warning_limit_reached_abandoned"
+        case .switchModelTapped: return "aichat_usage_warning_switch_model_tapped"
+        case .upsellTapped: return "aichat_usage_warning_upsell_tapped"
+        case .highUsageModelNoticeShown: return "aichat_high_usage_model_notice_shown"
+        case .highUsageModelNoticeDismissed: return "aichat_high_usage_model_notice_dismissed"
+        case .highUsageModelNoticePromptSubmitted: return "aichat_high_usage_model_notice_prompt_submitted"
+        case .highUsageModelNoticeModelSwitched: return "aichat_high_usage_model_notice_model_switched"
+        case .highUsageModelNoticeAbandoned: return "aichat_high_usage_model_notice_abandoned"
+        }
+    }
+
+    var parameters: [String: String]? {
+        var parameters = [Parameter.surface: context.surface.rawValue]
+        if let window = context.window {
+            parameters[Parameter.window] = window.rawValue
+        }
+        if let percentBucket = context.percentBucket {
+            parameters[Parameter.percentBucket] = String(percentBucket)
+        }
+        if let modelId = context.modelId {
+            parameters[Parameter.modelId] = modelId
+        }
+        return parameters
+    }
+
+    var standardParameters: [PixelKitStandardParameter]? { nil }
+
+    private var context: Context {
+        switch self {
+        case .approachingShown(let context),
+             .approachingDismissed(let context),
+             .approachingPromptSubmitted(let context),
+             .approachingModelSwitched(let context),
+             .approachingAbandoned(let context),
+             .limitReachedShown(let context),
+             .limitReachedPromptSubmitted(let context),
+             .limitReachedModelSwitched(let context),
+             .limitReachedAbandoned(let context),
+             .switchModelTapped(let context),
+             .upsellTapped(let context),
+             .highUsageModelNoticeShown(let context),
+             .highUsageModelNoticeDismissed(let context),
+             .highUsageModelNoticePromptSubmitted(let context),
+             .highUsageModelNoticeModelSwitched(let context),
+             .highUsageModelNoticeAbandoned(let context):
+            return context
+        }
+    }
+}
+
+extension DuckAiUsageWarningPixel {
+
+    /// `nil` where the state cannot produce the interaction, so an impossible combination reports
+    /// nothing rather than landing on another state's series. A reached limit has no close button.
+    init?(event: DuckAiUsageWarningMeasurementEvent, surface: UnifiedToggleInputPixelSurface) {
+        switch event {
+        case .shown(let exposure):
+            let context = Context(exposure: exposure, surface: surface)
+            switch exposure.kind {
+            case .approaching: self = .approachingShown(context)
+            case .limitReached: self = .limitReachedShown(context)
+            case .highUsageModelNotice: self = .highUsageModelNoticeShown(context)
+            }
+        case .dismissed(let exposure):
+            let context = Context(exposure: exposure, surface: surface)
+            switch exposure.kind {
+            case .approaching: self = .approachingDismissed(context)
+            case .highUsageModelNotice: self = .highUsageModelNoticeDismissed(context)
+            case .limitReached: return nil
+            }
+        case .promptSubmitted(let exposure):
+            let context = Context(exposure: exposure, surface: surface)
+            switch exposure.kind {
+            case .approaching: self = .approachingPromptSubmitted(context)
+            case .limitReached: self = .limitReachedPromptSubmitted(context)
+            case .highUsageModelNotice: self = .highUsageModelNoticePromptSubmitted(context)
+            }
+        case .modelSwitched(let exposure):
+            let context = Context(exposure: exposure, surface: surface)
+            switch exposure.kind {
+            case .approaching: self = .approachingModelSwitched(context)
+            case .limitReached: self = .limitReachedModelSwitched(context)
+            case .highUsageModelNotice: self = .highUsageModelNoticeModelSwitched(context)
+            }
+        case .abandoned(let exposure):
+            let context = Context(exposure: exposure, surface: surface)
+            switch exposure.kind {
+            case .approaching: self = .approachingAbandoned(context)
+            case .limitReached: self = .limitReachedAbandoned(context)
+            case .highUsageModelNotice: self = .highUsageModelNoticeAbandoned(context)
+            }
+        // The CTA identifies itself, so these two are one series each across the states offering them.
+        case .switchModelTapped(let exposure):
+            self = .switchModelTapped(Context(exposure: exposure, surface: surface))
+        case .upsellTapped(let exposure):
+            self = .upsellTapped(Context(exposure: exposure, surface: surface))
+        }
+    }
+}
+
+// MARK: - Adapter
+
+/// Fires the shared measurement's events as this app's pixels. The surface is resolved per fire: one
+/// coordinator serves the address bar, the Duck.ai tab and the contextual sheet.
+struct DuckAiUsageWarningPixelAdapter: DuckAiUsageWarningPixelFiring {
+
+    private let firing: UTIPixelFiring
+    private let surface: () -> UnifiedToggleInputPixelSurface
+
+    init(firing: UTIPixelFiring = .live, surface: @escaping () -> UnifiedToggleInputPixelSurface) {
+        self.firing = firing
+        self.surface = surface
+    }
+
+    func fire(_ event: DuckAiUsageWarningMeasurementEvent) {
+        guard let pixel = DuckAiUsageWarningPixel(event: event, surface: surface()) else { return }
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] pixel \(pixel.name, privacy: .public) \(String(describing: pixel.parameters), privacy: .public)")
+        firing.fire(pixel, frequency: .dailyAndCount)
+    }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
@@ -46,21 +46,26 @@ final class UTIFooterController {
     private let viewModel: DuckAiUsageWarningViewModel
     private let highUsageNotice: UTIFooterHighUsageNoticeSource?
     private let mapper: UTIFooterMessageMapper
+    private let measurement: DuckAiUsageWarningMeasurement
     private let animator: Animator
 
     private var isSuppressed = false
     /// The message the user acted on, held so the CTA can retire one that carries no close button.
     private var actedOnMessage: UTIFooterMessage?
+    /// What the current message is about, for the pixels. Kept in step with `currentMessage`.
+    private var currentExposure: DuckAiUsageWarningExposure?
 
     private(set) var currentMessage: UTIFooterMessage?
 
     init(viewModel: DuckAiUsageWarningViewModel,
          highUsageNotice: UTIFooterHighUsageNoticeSource? = nil,
          mapper: UTIFooterMessageMapper = UTIFooterMessageMapper(),
+         measurement: DuckAiUsageWarningMeasurement = DuckAiUsageWarningMeasurement(),
          animator: Animator? = nil) {
         self.viewModel = viewModel
         self.highUsageNotice = highUsageNotice
         self.mapper = mapper
+        self.measurement = measurement
         self.animator = animator ?? Self.springAnimator
     }
 
@@ -75,9 +80,11 @@ final class UTIFooterController {
     func resetForPoseChange() {
         Logger.duckAIUsageWarnings.debug("[UsageWarnings] controller reset for pose change")
         // Not a dismissal: the next refresh re-reads the snapshot and the message comes back.
+        measurement.inputSessionEnded()
         viewModel.clear()
         highUsageNotice?.clear()
         currentMessage = nil
+        currentExposure = nil
         // Keeps the view's copy in lockstep — otherwise a later refresh that resolves to no
         // warning no-ops (nil == nil) and the view resurrects the stale card on the next expand.
         presenter?.clearPendingFooterMessage()
@@ -87,11 +94,54 @@ final class UTIFooterController {
         guard isSuppressed != suppressed else { return }
         Logger.duckAIUsageWarnings.debug("[UsageWarnings] controller suppressed=\(suppressed, privacy: .public)")
         isSuppressed = suppressed
+        // Editing a previous prompt, or leaving Duck.ai mode, settles what the user did about the message.
+        if suppressed {
+            measurement.inputSessionEnded()
+        }
         applyCurrentState()
     }
 
-    /// The two dismissals are recorded separately, so each message spends only its own.
+    /// The user closing the card.
     func dismissCurrent() {
+        measurement.warningDismissed()
+        retireCurrent()
+    }
+
+    /// The card entering or leaving the footer slot. Only entering is an impression: the exposure
+    /// outlives the card, so a prompt sent after a dismissal still belongs to the message.
+    func footerVisibilityChanged(isVisible: Bool) {
+        guard isVisible, let exposure = currentExposure else { return }
+        measurement.cardBecameVisible(exposure)
+    }
+
+    func recordPromptSubmitted() {
+        measurement.promptSubmitted()
+    }
+
+    /// A switch the user made themselves; the card's own switch CTA reports its own tap.
+    func recordModelSwitched() {
+        measurement.modelSwitched()
+    }
+
+    func performPrimaryAction() {
+        guard let message = currentMessage, message.primaryAction != nil else { return }
+
+        if let cta = Self.cta(for: viewModel.warning?.action) {
+            measurement.ctaTapped(cta)
+        }
+        let switchesModel = currentActionSwitchesModel
+        viewModel.performAction()
+        // The upsell leaves the user just as blocked, so only a switch retires its message.
+        guard switchesModel else { return applyCurrentState() }
+
+        actedOnMessage = message
+        retireCurrent()
+    }
+
+    /// Spends the message's own dismissal record without reporting a close: also how a taken CTA
+    /// retires a card that carries no close button.
+    private func retireCurrent() {
+        // The two dismissals are recorded separately, so each message spends only its own.
         if viewModel.warning != nil {
             viewModel.dismiss()
         } else {
@@ -100,16 +150,12 @@ final class UTIFooterController {
         applyCurrentState()
     }
 
-    func performPrimaryAction() {
-        guard let message = currentMessage, message.primaryAction != nil else { return }
-
-        let switchesModel = currentActionSwitchesModel
-        viewModel.performAction()
-        // The upsell leaves the user just as blocked, so only a switch retires its message.
-        guard switchesModel else { return applyCurrentState() }
-
-        actedOnMessage = message
-        dismissCurrent()
+    private static func cta(for action: DuckAiUsageAction?) -> DuckAiUsageWarningMeasurement.CTA? {
+        switch action {
+        case .switchToModel, .switchToFreeModel: return .switchModel
+        case .tryForFree: return .upsell
+        case .startUsingWeeklyLimit, .none: return nil
+        }
     }
 
     private var currentActionSwitchesModel: Bool {
@@ -120,29 +166,40 @@ final class UTIFooterController {
     }
 
     private func applyCurrentState() {
-        let message = resolveMessage()
+        let card = resolveCard()
+        let message = card?.message
         guard message != currentMessage else {
             Logger.duckAIUsageWarnings.debug("[UsageWarnings] controller no-op: message unchanged (\(message == nil ? "nil" : "visible", privacy: .public))")
             return
         }
         Logger.duckAIUsageWarnings.debug("[UsageWarnings] controller applying: \(message?.title ?? "nil", privacy: .public)")
         currentMessage = message
+        // Set before the presenter runs: applying can reveal the card synchronously, and the
+        // impression that reports needs the exposure it belongs to.
+        currentExposure = card?.exposure
         animator { [weak self] in
             self?.presenter?.applyFooterMessage(message)
         }
     }
 
+    private struct ResolvedCard {
+        let message: UTIFooterMessage
+        let exposure: DuckAiUsageWarningExposure
+    }
+
     /// One slot: an actionable warning outranks the informational notice.
-    private func resolveMessage() -> UTIFooterMessage? {
+    private func resolveCard() -> ResolvedCard? {
         guard !isSuppressed else {
             Logger.duckAIUsageWarnings.debug("[UsageWarnings] nothing to show: suppressed (editing or Search mode)")
             return nil
         }
         if let warning = viewModel.warning {
-            return unlessActedOn(mapper.message(for: warning))
+            guard let message = unlessActedOn(mapper.message(for: warning)) else { return nil }
+            return ResolvedCard(message: message, exposure: DuckAiUsageWarningExposure(warning: warning))
         }
         if let notice = highUsageNotice?.notice {
-            return unlessActedOn(mapper.message(for: notice))
+            guard let message = unlessActedOn(mapper.message(for: notice)) else { return nil }
+            return ResolvedCard(message: message, exposure: DuckAiUsageWarningExposure(notice: notice))
         }
         return nil
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -436,7 +436,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
                 onModelsUpdated: { [weak self] in self?.handleModelsUpdated() },
                 onUserChoiceRecorded: { [weak self] in self?.recordUserChoiceToStore() },
                 clearSubmitRecoveryBlock: { [weak self] in self?.isSubmitBlockedByRecoveryCard = false },
-                onModelApplied: { [weak self] in self?.notifyFrontendOfActiveChatModelChange($0) }
+                onModelApplied: { [weak self] in self?.notifyFrontendOfActiveChatModelChange($0) },
+                onModelSelectionChanged: { [weak self] _ in self?.footerController?.recordModelSwitched() }
             ),
             isUpdatedModelPickerEnabled: isUpdatedModelPickerEnabled
         )
@@ -904,7 +905,8 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             self?.handleUsageWarningAction(action)
         }
         footerController = UTIFooterController(viewModel: viewModel,
-                                              highUsageNotice: makeHighUsageNoticeSource())
+                                              highUsageNotice: makeHighUsageNoticeSource(),
+                                              measurement: makeUsageWarningMeasurement())
         footerController?.presenter = viewController
 
         // Also what brings a message back after the user has acted on the previous one.
@@ -922,6 +924,14 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             needsImageUpload: attachments.contains(where: \.isImage),
             requiredMimeTypes: attachments.compactMap { $0.fileAttachment?.mimeType },
             requiredTools: toolsController.selectedTool.map { [$0] } ?? []
+        )
+    }
+
+    /// The surface is read per fire: this one coordinator serves the address bar, the Duck.ai tab
+    /// and the contextual sheet.
+    private func makeUsageWarningMeasurement() -> DuckAiUsageWarningMeasurement {
+        DuckAiUsageWarningMeasurement(
+            pixelFiring: DuckAiUsageWarningPixelAdapter(surface: { [weak self] in self?.pixelSurface ?? .addressBar })
         )
     }
 
@@ -1740,6 +1750,7 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
             selectedTool: toolsController.selectedTool,
             attachments: viewController.currentAttachments
         )
+        footerController?.recordPromptSubmitted()
 
         let configuration = promptSubmissionConfiguration
         recordDuckAISubmissionStarted(
@@ -1870,6 +1881,10 @@ extension UnifiedToggleInputCoordinator: UnifiedToggleInputViewControllerDelegat
 
     func unifiedToggleInputVCDidDismissFooter(_ vc: UnifiedToggleInputViewController) {
         footerController?.dismissCurrent()
+    }
+
+    func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didChangeFooterVisibility isVisible: Bool) {
+        footerController?.footerVisibilityChanged(isVisible: isVisible)
     }
 
     func unifiedToggleInputVCDidChangeHeight(_ vc: UnifiedToggleInputViewController) {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -364,6 +364,8 @@ final class UnifiedToggleInputView: UIView {
     var onAIChatShortcutTapped: (() -> Void)?
     var onFooterPrimaryTapped: (() -> Void)?
     var onFooterDismissTapped: (() -> Void)?
+    /// The footer card entering or leaving the bottom slot, i.e. actually appearing on screen.
+    var onFooterVisibilityChanged: ((Bool) -> Void)?
 
     // MARK: - Attachment API
 
@@ -451,6 +453,7 @@ final class UnifiedToggleInputView: UIView {
     }
 
     private func applyBottomSlot(_ slot: BottomCardSlot) {
+        let wasShowingFooter = bottomCardSlot == .footer
         bottomCardSlot = slot
         cardBottomConstraint.isActive = slot == .none
         cardEditBottomConstraint.isActive = slot == .editDisclaimer
@@ -460,6 +463,9 @@ final class UnifiedToggleInputView: UIView {
         expandedShadowFooterBottomConstraint.isActive = slot == .footer
         footerCollapsedHeightConstraint.isActive = slot != .footer
         footerCard.alpha = slot == .footer ? 1 : 0
+        if wasShowingFooter != (slot == .footer) {
+            onFooterVisibilityChanged?(slot == .footer)
+        }
     }
 
     private static func makeEditReplaceDisclaimerCard() -> UIView {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -47,6 +47,7 @@ protocol UnifiedToggleInputViewControllerDelegate: AnyObject {
     func unifiedToggleInputVCDidShowReasoningPicker(_ vc: UnifiedToggleInputViewController)
     func unifiedToggleInputVCDidTapFooterPrimaryAction(_ vc: UnifiedToggleInputViewController)
     func unifiedToggleInputVCDidDismissFooter(_ vc: UnifiedToggleInputViewController)
+    func unifiedToggleInputVC(_ vc: UnifiedToggleInputViewController, didChangeFooterVisibility isVisible: Bool)
 }
 
 // MARK: - View Controller
@@ -468,6 +469,10 @@ final class UnifiedToggleInputViewController: UIViewController {
         barView.onFooterDismissTapped = { [weak self] in
             guard let self else { return }
             delegate?.unifiedToggleInputVCDidDismissFooter(self)
+        }
+        barView.onFooterVisibilityChanged = { [weak self] isVisible in
+            guard let self else { return }
+            delegate?.unifiedToggleInputVC(self, didChangeFooterVisibility: isVisible)
         }
         let containerView = UnifiedToggleInputContainerView(inputView: barView)
         containerView.cardPosition = barView.cardPosition

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/DuckAiUsageWarningPixelAdapterTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/DuckAiUsageWarningPixelAdapterTests.swift
@@ -1,0 +1,196 @@
+//
+//  DuckAiUsageWarningPixelAdapterTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+@_spi(Testing) import PixelKit
+import XCTest
+@testable import DuckDuckGo
+
+@MainActor
+final class DuckAiUsageWarningPixelAdapterTests: XCTestCase {
+
+    private var pixelKitMock: PixelKitMock!
+    private var surface: UnifiedToggleInputPixelSurface = .duckAI
+    private var sut: DuckAiUsageWarningPixelAdapter!
+
+    private let approaching = DuckAiUsageWarningExposure(kind: .approaching, window: .weekly, percentBucket: 75)
+    private let limitReached = DuckAiUsageWarningExposure(kind: .limitReached, window: .daily)
+    private let notice = DuckAiUsageWarningExposure(kind: .highUsageModelNotice, modelId: "claude-opus-4-8")
+
+    override func setUp() {
+        super.setUp()
+        pixelKitMock = PixelKitMock()
+        surface = .duckAI
+        sut = DuckAiUsageWarningPixelAdapter(firing: UTIPixelFiring(pixelKit: { [unowned self] in pixelKitMock }),
+                                            surface: { [unowned self] in surface })
+    }
+
+    override func tearDown() {
+        sut = nil
+        pixelKitMock = nil
+        super.tearDown()
+    }
+
+    // MARK: - Approaching
+
+    func testWhenAnApproachingWarningIsShownThenItReportsTheRungAndWindow() {
+        sut.fire(.shown(approaching))
+
+        XCTAssertEqual(firedNames, ["aichat_usage_warning_approaching_shown"])
+        XCTAssertEqual(lastParameters, ["surface": "duck_ai", "window": "weekly", "percent_bucket": "75"])
+    }
+
+    func testWhenAnApproachingWarningIsDismissedThenItIsReportedUnderItsOwnName() {
+        sut.fire(.dismissed(approaching))
+
+        XCTAssertEqual(firedNames, ["aichat_usage_warning_approaching_dismissed"])
+    }
+
+    func testWhenAnApproachingWarningLeadsToAPromptThenItIsReportedUnderItsOwnName() {
+        sut.fire(.promptSubmitted(approaching))
+
+        XCTAssertEqual(firedNames, ["aichat_usage_warning_approaching_prompt_submitted"])
+    }
+
+    func testWhenAnApproachingWarningLeadsToAModelSwitchThenItIsReportedUnderItsOwnName() {
+        sut.fire(.modelSwitched(approaching))
+
+        XCTAssertEqual(firedNames, ["aichat_usage_warning_approaching_model_switched"])
+    }
+
+    func testWhenAnApproachingWarningLeadsNowhereThenItIsReportedUnderItsOwnName() {
+        sut.fire(.abandoned(approaching))
+
+        XCTAssertEqual(firedNames, ["aichat_usage_warning_approaching_abandoned"])
+    }
+
+    // MARK: - Limit reached
+
+    /// A reached limit is not on the approaching ladder, so it reports no rung.
+    func testWhenAReachedLimitIsShownThenItReportsTheWindowWithoutARung() {
+        sut.fire(.shown(limitReached))
+
+        XCTAssertEqual(firedNames, ["aichat_usage_warning_limit_reached_shown"])
+        XCTAssertEqual(lastParameters, ["surface": "duck_ai", "window": "daily"])
+    }
+
+    func testWhenAReachedLimitLeadsToAPromptThenItIsReportedUnderItsOwnName() {
+        sut.fire(.promptSubmitted(limitReached))
+
+        XCTAssertEqual(firedNames, ["aichat_usage_warning_limit_reached_prompt_submitted"])
+    }
+
+    func testWhenAReachedLimitLeadsToAModelSwitchThenItIsReportedUnderItsOwnName() {
+        sut.fire(.modelSwitched(limitReached))
+
+        XCTAssertEqual(firedNames, ["aichat_usage_warning_limit_reached_model_switched"])
+    }
+
+    func testWhenAReachedLimitLeadsNowhereThenItIsReportedUnderItsOwnName() {
+        sut.fire(.abandoned(limitReached))
+
+        XCTAssertEqual(firedNames, ["aichat_usage_warning_limit_reached_abandoned"])
+    }
+
+    /// A reached limit has no close button, so there is no pixel to report — and no silent misfire
+    /// under another name either.
+    func testWhenAReachedLimitReportsADismissalThenNothingIsFired() {
+        sut.fire(.dismissed(limitReached))
+
+        XCTAssertTrue(pixelKitMock.actualFireCalls.isEmpty)
+    }
+
+    // MARK: - CTAs
+
+    func testWhenTheSwitchModelCTAIsTappedThenItIsReportedWithTheRungItWasOfferedAt() {
+        sut.fire(.switchModelTapped(approaching))
+
+        XCTAssertEqual(firedNames, ["aichat_usage_warning_switch_model_tapped"])
+        XCTAssertEqual(lastParameters, ["surface": "duck_ai", "window": "weekly", "percent_bucket": "75"])
+    }
+
+    func testWhenTheUpsellCTAIsTappedThenItIsReportedWithItsWindow() {
+        sut.fire(.upsellTapped(limitReached))
+
+        XCTAssertEqual(firedNames, ["aichat_usage_warning_upsell_tapped"])
+        XCTAssertEqual(lastParameters, ["surface": "duck_ai", "window": "daily"])
+    }
+
+    // MARK: - High-usage model notice
+
+    func testWhenTheHighUsageNoticeIsShownThenItReportsTheModelItIsAbout() {
+        sut.fire(.shown(notice))
+
+        XCTAssertEqual(firedNames, ["aichat_high_usage_model_notice_shown"])
+        XCTAssertEqual(lastParameters, ["surface": "duck_ai", "model_id": "claude-opus-4-8"])
+    }
+
+    func testWhenTheHighUsageNoticeIsDismissedThenItIsReportedUnderItsOwnName() {
+        sut.fire(.dismissed(notice))
+
+        XCTAssertEqual(firedNames, ["aichat_high_usage_model_notice_dismissed"])
+    }
+
+    func testWhenTheHighUsageNoticeLeadsToAModelSwitchThenItIsReportedUnderItsOwnName() {
+        sut.fire(.modelSwitched(notice))
+
+        XCTAssertEqual(firedNames, ["aichat_high_usage_model_notice_model_switched"])
+    }
+
+    func testWhenTheHighUsageNoticeLeadsToAPromptThenItIsReportedUnderItsOwnName() {
+        sut.fire(.promptSubmitted(notice))
+
+        XCTAssertEqual(firedNames, ["aichat_high_usage_model_notice_prompt_submitted"])
+    }
+
+    func testWhenTheHighUsageNoticeLeadsNowhereThenItIsReportedUnderItsOwnName() {
+        sut.fire(.abandoned(notice))
+
+        XCTAssertEqual(firedNames, ["aichat_high_usage_model_notice_abandoned"])
+    }
+
+    // MARK: - Firing
+
+    func testWhenAWarningPixelIsFiredThenItIsSentAsADailyAndCountPixel() {
+        sut.fire(.shown(approaching))
+
+        XCTAssertEqual(pixelKitMock.actualFireCalls.last?.frequency, .dailyAndCount)
+    }
+
+    /// One coordinator serves the address bar, the Duck.ai tab and the contextual sheet, so the
+    /// surface has to be read when the pixel fires rather than when the adapter is built.
+    func testWhenTheSurfaceChangesThenTheNextPixelReportsTheNewSurface() {
+        sut.fire(.shown(approaching))
+        surface = .contextualChat
+
+        sut.fire(.shown(limitReached))
+
+        XCTAssertEqual(lastParameters?["surface"], "contextual_chat")
+    }
+
+    // MARK: - Helpers
+
+    private var firedNames: [String] {
+        pixelKitMock.actualFireCalls.map(\.pixel.name)
+    }
+
+    private var lastParameters: [String: String]? {
+        pixelKitMock.actualFireCalls.last?.pixel.parameters
+    }
+}

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterControllerTests.swift
@@ -27,6 +27,7 @@ final class UTIFooterControllerTests: XCTestCase {
     private var limitsProvider: StubUsageLimitsProvider!
     private var presenter: SpyUTIFooterPresenter!
     private var viewModel: DuckAiUsageWarningViewModel!
+    private var measurementFiring: RecordingUsageWarningPixelFiring!
     private var selectedModel: (id: String?, shortName: String?) = (nil, nil)
     private var animationCount = 0
     private var sut: UTIFooterController!
@@ -37,11 +38,13 @@ final class UTIFooterControllerTests: XCTestCase {
         super.setUp()
         limitsProvider = StubUsageLimitsProvider()
         presenter = SpyUTIFooterPresenter()
+        measurementFiring = RecordingUsageWarningPixelFiring()
         selectedModel = (nil, nil)
         animationCount = 0
         viewModel = makeViewModel()
         sut = UTIFooterController(viewModel: viewModel,
                                   highUsageNotice: makeNoticeSource(),
+                                  measurement: DuckAiUsageWarningMeasurement(pixelFiring: measurementFiring),
                                   animator: { [unowned self] changes in
                                       animationCount += 1
                                       changes()
@@ -53,6 +56,7 @@ final class UTIFooterControllerTests: XCTestCase {
         sut = nil
         viewModel = nil
         presenter = nil
+        measurementFiring = nil
         limitsProvider = nil
         super.tearDown()
     }
@@ -363,7 +367,117 @@ final class UTIFooterControllerTests: XCTestCase {
         XCTAssertTrue(presenter.appliedMessages.last??.title.contains("Opus 4.8") ?? false)
     }
 
+    // MARK: - Measurement
+
+    /// The card is resolved while the input is still collapsed and revealed inside the expand
+    /// animation, so resolving a message is not yet an appearance.
+    func test_refresh_reportsNoImpressionUntilTheCardIsOnScreen() {
+        limitsProvider.limits = weeklyUsage(75)
+
+        sut.refresh()
+
+        XCTAssertTrue(measurementFiring.events.isEmpty)
+    }
+
+    func test_footerVisibilityChanged_reportsAnImpressionForTheVisibleMessage() {
+        limitsProvider.limits = weeklyUsage(75)
+        sut.refresh()
+
+        sut.footerVisibilityChanged(isVisible: true)
+
+        XCTAssertEqual(measurementFiring.events, [.shown(approachingExposure(percentBucket: 75))])
+    }
+
+    func test_footerVisibilityChanged_reportsTheNoticesModelWhenTheNoticeIsVisible() {
+        selectedModel = (id: "claude-opus-4-8", shortName: "Opus 4.8")
+        limitsProvider.limits = .noData
+        sut.refresh()
+
+        sut.footerVisibilityChanged(isVisible: true)
+
+        XCTAssertEqual(measurementFiring.events,
+                       [.shown(DuckAiUsageWarningExposure(kind: .highUsageModelNotice, modelId: "claude-opus-4-8"))])
+    }
+
+    func test_dismissCurrent_reportsADismissal() {
+        limitsProvider.limits = weeklyUsage(75)
+        sut.refresh()
+        sut.footerVisibilityChanged(isVisible: true)
+
+        sut.dismissCurrent()
+
+        XCTAssertEqual(measurementFiring.events.last, .dismissed(approachingExposure(percentBucket: 75)))
+    }
+
+    /// Acting on the message retires it internally, which is not the user closing it.
+    func test_performPrimaryAction_reportsTheCTATapAndNoDismissal() {
+        limitsProvider.limits = weeklyUsage(75)
+        sut.refresh()
+        sut.footerVisibilityChanged(isVisible: true)
+
+        sut.performPrimaryAction()
+
+        XCTAssertEqual(measurementFiring.events,
+                       [.shown(approachingExposure(percentBucket: 75)),
+                        .switchModelTapped(approachingExposure(percentBucket: 75))])
+    }
+
+    func test_performPrimaryAction_reportsTheUpsellCTAWhenTheBlockedStateOffersTheSubscription() {
+        limitsProvider.limits = weeklyReachedWithUpsell()
+        sut.refresh()
+        sut.footerVisibilityChanged(isVisible: true)
+
+        sut.performPrimaryAction()
+
+        XCTAssertEqual(measurementFiring.events.last,
+                       .upsellTapped(DuckAiUsageWarningExposure(kind: .limitReached, window: .weekly)))
+    }
+
+    func test_recordPromptSubmitted_reportsAgainstTheWarningTheUserSaw() {
+        limitsProvider.limits = weeklyUsage(75)
+        sut.refresh()
+        sut.footerVisibilityChanged(isVisible: true)
+
+        sut.recordPromptSubmitted()
+
+        XCTAssertEqual(measurementFiring.events.last, .promptSubmitted(approachingExposure(percentBucket: 75)))
+    }
+
+    func test_recordModelSwitched_reportsAgainstTheWarningTheUserSaw() {
+        limitsProvider.limits = weeklyUsage(75)
+        sut.refresh()
+        sut.footerVisibilityChanged(isVisible: true)
+
+        sut.recordModelSwitched()
+
+        XCTAssertEqual(measurementFiring.events.last, .modelSwitched(approachingExposure(percentBucket: 75)))
+    }
+
+    func test_resetForPoseChange_endsTheExposureWithNoFollowThrough() {
+        limitsProvider.limits = weeklyUsage(75)
+        sut.refresh()
+        sut.footerVisibilityChanged(isVisible: true)
+
+        sut.resetForPoseChange()
+
+        XCTAssertEqual(measurementFiring.events.last, .abandoned(approachingExposure(percentBucket: 75)))
+    }
+
+    func test_setSuppressed_endsTheExposure() {
+        limitsProvider.limits = weeklyUsage(75)
+        sut.refresh()
+        sut.footerVisibilityChanged(isVisible: true)
+
+        sut.setSuppressed(true)
+
+        XCTAssertEqual(measurementFiring.events.last, .abandoned(approachingExposure(percentBucket: 75)))
+    }
+
     // MARK: - Helpers
+
+    private func approachingExposure(percentBucket: Int) -> DuckAiUsageWarningExposure {
+        DuckAiUsageWarningExposure(kind: .approaching, window: .weekly, percentBucket: percentBucket)
+    }
 
     private func makeNoticeSource() -> UTIFooterHighUsageNoticeSource {
         UTIFooterHighUsageNoticeSource(dismissalStore: InMemoryDuckAiHighUsageNoticeDismissalStore(),
@@ -391,6 +505,20 @@ final class UTIFooterControllerTests: XCTestCase {
             cta: DuckAiUsageCta(id: .switchToCheaper,
                                 target: .init(modelId: "gpt-5.4-mini", modelIds: ["gpt-5.4-mini"])),
             signature: "snapshot-\(percent)"
+        )
+    }
+
+    /// A blocked state whose only offer is the subscription upsell.
+    private func weeklyReachedWithUpsell() -> DuckAiUsageSnapshot {
+        DuckAiUsageSnapshot(
+            notice: DuckAiUsageNotice(id: .weeklyReached,
+                                      window: .weekly,
+                                      percentUsed: 100,
+                                      resetsAt: now.addingTimeInterval(172_800),
+                                      reached: true,
+                                      dismissible: false),
+            cta: DuckAiUsageCta(id: .subscribe),
+            signature: "snapshot-reached-upsell"
         )
     }
 
@@ -423,6 +551,14 @@ private final class StubUsageLimitsProvider: DuckAiUsageSnapshotProviding {
 private struct StubCheaperModelSuggester: DuckAiModelSuggesting {
     func resolve(_ cta: DuckAiUsageCta) -> DuckAiModelSuggestionOutcome {
         .suggestion(DuckAiModelSuggestion(modelId: "gpt-5.4-mini", modelShortName: "5.4 mini"))
+    }
+}
+
+private final class RecordingUsageWarningPixelFiring: DuckAiUsageWarningPixelFiring {
+    private(set) var events: [DuckAiUsageWarningMeasurementEvent] = []
+
+    func fire(_ event: DuckAiUsageWarningMeasurementEvent) {
+        events.append(event)
     }
 }
 

--- a/iOS/PixelDefinitions/pixels/definitions/duckai_usage_warnings.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/duckai_usage_warnings.json5
@@ -1,0 +1,305 @@
+// Duck.ai usage-warning footer pixels - the card under the Duck.ai input, gated by the
+// `utiDuckAIWarnings` feature flag.
+//
+// Which message the user saw is in the pixel name, so each of the three states is its own series:
+// `approaching` (50/75/90% of an allowance), `limit_reached` (the allowance is spent) and the
+// high-usage model notice. The window, the rung and the model id are parameters.
+//
+// Each state reports one impression per appearance, and one follow-through per exposure: what the
+// user did about the message before the input closed. An exposure outlives the card - dismissing or
+// acting on the message takes it off screen while the user carries on typing - so `_dismissed` and a
+// following `_prompt_submitted` can both fire for one appearance, while `_prompt_submitted`,
+// `_model_switched` and `_abandoned` are the mutually exclusive ways an exposure ends.
+//
+// Not defined on purpose: a dismissal of a reached limit (that card carries no close button), and
+// anything for "Advanced AI models limit reached" (the payload cannot name that allowance yet, so
+// the message is unreachable and folds into `limit_reached`).
+{
+    "aichat_usage_warning_approaching_shown": {
+        "description": "Fires when the approaching-limit card appears under the Duck.ai input. One per appearance: re-expanding the input reports again, while a refresh that only fills in the card's CTA does not.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "window",
+                "description": "Which allowance the message was about.",
+                "type": "string",
+                "enum": ["daily", "weekly"]
+            },
+            {
+                "key": "percent_bucket",
+                "description": "The rung of the approaching ladder the card was shown at.",
+                "type": "string",
+                "enum": ["50", "75", "90"]
+            }
+        ]
+    },
+    "aichat_usage_warning_approaching_dismissed": {
+        "description": "Fires when the user closes the approaching-limit card with its close button. Not a terminal outcome: the input session carries on, and a prompt sent afterwards is still reported against this exposure.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "window",
+                "description": "Which allowance the message was about.",
+                "type": "string",
+                "enum": ["daily", "weekly"]
+            },
+            {
+                "key": "percent_bucket",
+                "description": "The rung of the approaching ladder the card was shown at.",
+                "type": "string",
+                "enum": ["50", "75", "90"]
+            }
+        ]
+    },
+    "aichat_usage_warning_approaching_prompt_submitted": {
+        "description": "Fires for the first prompt the user sends after seeing the approaching-limit card, in the same input session. Once per exposure.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "window",
+                "description": "Which allowance the message was about.",
+                "type": "string",
+                "enum": ["daily", "weekly"]
+            },
+            {
+                "key": "percent_bucket",
+                "description": "The rung of the approaching ladder the card was shown at.",
+                "type": "string",
+                "enum": ["50", "75", "90"]
+            }
+        ]
+    },
+    "aichat_usage_warning_approaching_model_switched": {
+        "description": "Fires when the user changes model themselves after seeing the approaching-limit card, in the same input session. Once per exposure, and never for the switch the card's own CTA performs - that reports aichat_usage_warning_switch_model_tapped instead.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "window",
+                "description": "Which allowance the message was about.",
+                "type": "string",
+                "enum": ["daily", "weekly"]
+            },
+            {
+                "key": "percent_bucket",
+                "description": "The rung of the approaching ladder the card was shown at.",
+                "type": "string",
+                "enum": ["50", "75", "90"]
+            }
+        ]
+    },
+    "aichat_usage_warning_approaching_abandoned": {
+        "description": "Fires when the input session ends after an approaching-limit card with no follow-through: no prompt, no model change and no CTA taken.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "window",
+                "description": "Which allowance the message was about.",
+                "type": "string",
+                "enum": ["daily", "weekly"]
+            },
+            {
+                "key": "percent_bucket",
+                "description": "The rung of the approaching ladder the card was shown at.",
+                "type": "string",
+                "enum": ["50", "75", "90"]
+            }
+        ]
+    },
+    "aichat_usage_warning_limit_reached_shown": {
+        "description": "Fires when the limit-reached card appears under the Duck.ai input. One per appearance.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "window",
+                "description": "Which allowance is spent.",
+                "type": "string",
+                "enum": ["daily", "weekly"]
+            }
+        ]
+    },
+    "aichat_usage_warning_limit_reached_prompt_submitted": {
+        "description": "Fires for the first prompt the user sends after seeing the limit-reached card, in the same input session. Once per exposure.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "window",
+                "description": "Which allowance is spent.",
+                "type": "string",
+                "enum": ["daily", "weekly"]
+            }
+        ]
+    },
+    "aichat_usage_warning_limit_reached_model_switched": {
+        "description": "Fires when the user changes model themselves after seeing the limit-reached card, in the same input session. Once per exposure.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "window",
+                "description": "Which allowance is spent.",
+                "type": "string",
+                "enum": ["daily", "weekly"]
+            }
+        ]
+    },
+    "aichat_usage_warning_limit_reached_abandoned": {
+        "description": "Fires when the input session ends after a limit-reached card with no follow-through: no prompt, no model change and no CTA taken.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "window",
+                "description": "Which allowance is spent.",
+                "type": "string",
+                "enum": ["daily", "weekly"]
+            }
+        ]
+    },
+    "aichat_usage_warning_switch_model_tapped": {
+        "description": "Fires when the user taps the card's model-switch CTA. In practice this is the approaching-limit card's Switch button; the rung is absent when a card without one offers it.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "window",
+                "description": "Which allowance the message was about.",
+                "type": "string",
+                "enum": ["daily", "weekly"]
+            },
+            {
+                "key": "percent_bucket",
+                "description": "The rung of the approaching ladder the card was shown at, when the card is an approaching one.",
+                "type": "string",
+                "enum": ["50", "75", "90"]
+            }
+        ]
+    },
+    "aichat_usage_warning_upsell_tapped": {
+        "description": "Fires when the user taps the card's subscription CTA (Try for free / Subscribe), offered on a limit-reached card to a user without a paid tier.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "window",
+                "description": "Which allowance is spent.",
+                "type": "string",
+                "enum": ["daily", "weekly"]
+            }
+        ]
+    },
+    "aichat_high_usage_model_notice_shown": {
+        "description": "Fires when the high-usage model notice appears under the Duck.ai input. Keyed off the selected model rather than an allowance, and shown once per model until dismissed.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "model_id",
+                "description": "The id of the high-usage model the notice is about.",
+                "type": "string"
+            }
+        ]
+    },
+    "aichat_high_usage_model_notice_dismissed": {
+        "description": "Fires when the user closes the high-usage model notice with its close button, which retires it for that model.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "model_id",
+                "description": "The id of the high-usage model the notice is about.",
+                "type": "string"
+            }
+        ]
+    },
+    "aichat_high_usage_model_notice_prompt_submitted": {
+        "description": "Fires for the first prompt the user sends after seeing the high-usage model notice, in the same input session. Once per exposure.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "model_id",
+                "description": "The id of the high-usage model the notice is about.",
+                "type": "string"
+            }
+        ]
+    },
+    "aichat_high_usage_model_notice_model_switched": {
+        "description": "Fires when the user changes model after seeing the high-usage model notice, in the same input session. The notice's reason for existing, so worth reading against its impressions.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "model_id",
+                "description": "The id of the high-usage model the notice was about, i.e. the model the user switched away from.",
+                "type": "string"
+            }
+        ]
+    },
+    "aichat_high_usage_model_notice_abandoned": {
+        "description": "Fires when the input session ends after a high-usage model notice with no follow-through: no prompt and no model change.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": [
+            "appVersion",
+            "unified_input_surface",
+            {
+                "key": "model_id",
+                "description": "The id of the high-usage model the notice is about.",
+                "type": "string"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217605036256291?focus=true
Tech Design URL:
CC:

### Description
Adds measurement for the Duck.ai usage-warning card behind `utiDuckAIWarnings`, so we can see which message users get, how often it appears, and what they do about it. Each of the three states (approaching a limit, limit reached, high-usage model notice) reports its own impression, dismissal and CTA taps, plus one follow-through per exposure: whether the user sent a prompt, changed model themselves, or left without doing either. The decision layer sits in `SharedPackages/AIChat` so macOS can adopt the same names later; only iOS fires in this change.

### Testing Steps
1. Launch with `-ff.utiDuckAIWarnings 1 -ff.aiChatNativeStorage 1 -isInternalUser 1`, then seed a snapshot from Debug ▸ AI Chat ▸ Duck.ai Usage Warnings (e.g. 75% weekly).
2. Open Duck.ai, expand the input → the card appears and `aichat_usage_warning_approaching_shown` fires with `window=weekly`, `percent_bucket=75` (watch the `[UsageWarnings] pixel …` os_log line, subsystem `com.duckduckgo.mobile.ios`).
3. Tap Switch → `aichat_usage_warning_switch_model_tapped` fires and no `_model_switched` follows; repeat with ✕ then send a prompt → `_dismissed` and `_prompt_submitted` both fire; repeat and dismiss the omnibar without prompting → `_abandoned` fires.

### Impact and Risks
Low

#### What could go wrong?
The impression could over-count if the card's visibility signal fires on a layout pass rather than a real slot change → the callback only fires on `.footer` membership transitions, covered by unit tests for the shown/dedupe cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive analytics and UI callback wiring for an existing feature-flagged card; main risk is mis-counting impressions or double-reporting model switches, which the diff explicitly guards with visibility transitions and CTA vs self-switch deduplication.
> 
> **Overview**
> Adds **analytics for the Duck.ai usage-warning footer card** (approaching limit, limit reached, high-usage model notice) behind the existing warnings UI, with shared logic in **AIChat** and iOS **PixelKit** firing.
> 
> **Shared measurement (`DuckAiUsageWarningMeasurement`)** models one **exposure** per card appearance (kind, window, percent rung, or model id). It emits **shown** only when the card actually enters the footer slot—not when the message is resolved while collapsed—and dedupes repeat visibility for the same exposure. Follow-through events cover **dismiss**, **switch/upsell CTA**, **first prompt** in the session, **user-initiated model change** (not the card’s switch CTA), and **abandoned** when the input session ends with no follow-through.
> 
> **iOS wiring** connects `UTIFooterController` to that measurement, adds footer **visibility** callbacks through `UnifiedToggleInputView` → coordinator, records **prompt submit** on send, and routes **model picker** changes via `UTIModelSelector.onModelSelectionChanged`. **`DuckAiUsageWarningPixel`** maps events to named pixels (`aichat_usage_warning_*`, `aichat_high_usage_model_notice_*`) with `surface`, `window`, `percent_bucket`, and `model_id` parameters; limit-reached **dismiss** is intentionally omitted. **`duckai_usage_warnings.json5`** documents the new daily/count pixel set.
> 
> Unit tests cover measurement rules, pixel adapter mapping, and footer controller measurement hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f420808274ff439a8d8e60dfd8034b332a95c74f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->