### PR TITLE
[macOS] Fix performance test compilation

### DIFF
--- a/macOS/PerformanceTests/MemoryUsageTests.swift
+++ b/macOS/PerformanceTests/MemoryUsageTests.swift
@@ -27,7 +27,7 @@ final class MemoryUsageTests: XCTestCase {
         super.setUp()
 
         /// Avoids First-Run State
-        UITests.dismissNotificationCenterMessages()
+        XCUIApplication.notificationCenter.dismissSystemPermissionPromptIfPresent(logIfNotFound: false)
 
         /// Disable Session Restoration
         UITests.setupInitialState(shouldRestoreSession: false)


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1217960083199336?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

This PR fixes performance test compilation for macOS.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Confirm that [performance tests were green on CI](https://github.com/duckduckgo/apple-browsers/actions/runs/33204898711)

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that swaps an obsolete helper for the current XCUIApplication extension; no production behavior impact.
> 
> **Overview**
> **Fixes macOS performance test compilation** by updating first-run setup in `MemoryUsageTests` to match other UI/performance tests.
> 
> In class `setUp`, the removed `UITests.dismissNotificationCenterMessages()` call is replaced with `XCUIApplication.notificationCenter.dismissSystemPermissionPromptIfPresent(logIfNotFound: false)`. The intent is unchanged: dismiss system permission/notification prompts so memory measurements avoid first-run noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e151946af2dbba9054b0af70aa496132b10b08e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->