### PR TITLE
Fix attributed.metric.subscribed month=0/1/2+ over-reporting (iOS & Mac)

### DIFF
--- a/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricDataStorage.swift
+++ b/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricDataStorage.swift
@@ -46,7 +46,7 @@ public protocol AttributedMetricDataStoring {
     var subscriptionDate: Date? { get set }
     var subscriptionFreeTrialFired: Bool { get set }
     var subscriptionMonth1Fired: Bool { get set }
-    /// Highest month value already reported for the ongoing-month (month=2+) pixel, so it fires once per month rather than once per active day.
+    /// Highest month value already reported
     var subscriptionLastMonthFired: Int? { get set }
 
     // Sync

--- a/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricDataStorage.swift
+++ b/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricDataStorage.swift
@@ -46,6 +46,8 @@ public protocol AttributedMetricDataStoring {
     var subscriptionDate: Date? { get set }
     var subscriptionFreeTrialFired: Bool { get set }
     var subscriptionMonth1Fired: Bool { get set }
+    /// Highest month value already reported for the ongoing-month (month=2+) pixel, so it fires once per month rather than once per active day.
+    var subscriptionLastMonthFired: Int? { get set }
 
     // Sync
     var syncDevicesCount: Int { get set }
@@ -130,6 +132,7 @@ public final class AttributedMetricDataStorage: AttributedMetricDataStoring {
         case subscriptionDate
         case subscriptionFreeTrial
         case subscriptionMonth1
+        case subscriptionLastMonthFired
         case syncDevicesCount
         case debugDate
         case debugOrigin
@@ -236,6 +239,11 @@ public final class AttributedMetricDataStorage: AttributedMetricDataStoring {
     public var subscriptionMonth1Fired: Bool {
         get { return decode(from: userDefaults, key: .subscriptionMonth1) ?? false }
         set { encode(newValue, to: userDefaults, key: .subscriptionMonth1) }
+    }
+
+    public var subscriptionLastMonthFired: Int? {
+        get { return decode(from: userDefaults, key: .subscriptionLastMonthFired) }
+        set { encode(newValue, to: userDefaults, key: .subscriptionLastMonthFired) }
     }
 
     // MARK: - Sync

--- a/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricManager.swift
+++ b/SharedPackages/AttributedMetric/Sources/AttributedMetric/AttributedMetricManager.swift
@@ -594,6 +594,7 @@ public final class AttributedMetricManager: @unchecked Sendable {
             // At each app startup, check the subscription state. If the a month=1 pixel was sent, the state is autoRenewable or notAutoRenewable, and the subscription has been active for more than a month, send this pixel with month=2+.
             do {
                 let subscriptionMonth = Int(monthsActive.rounded(.up))
+                guard subscriptionMonth > (dataStorage.subscriptionLastMonthFired ?? 1) else { return }
                 let bucket = try bucketModifier.bucket(value: subscriptionMonth, pixelName: .userSubscribed)
                 pixelKit?.fire(AttributedMetricPixel.userSubscribed(origin: originOrInstall.origin,
                                                                     installDate: originOrInstall.installDate,
@@ -601,6 +602,7 @@ public final class AttributedMetricManager: @unchecked Sendable {
                                                                     bucketVersion: bucket.version),
                                frequency: .legacyDailyNoSuffix,
                                includeAppVersionParameter: false)
+                dataStorage.subscriptionLastMonthFired = subscriptionMonth
             } catch {
                 Logger.attributedMetric.error("Failed to bucket length value: \(error, privacy: .public)")
             }

--- a/SharedPackages/AttributedMetric/Tests/AttributedMetricTests/AttributedMetricManagerTests.swift
+++ b/SharedPackages/AttributedMetric/Tests/AttributedMetricTests/AttributedMetricManagerTests.swift
@@ -1022,8 +1022,6 @@ final class AttributedMetricManagerTests: XCTestCase {
         XCTAssertEqual(capturedMonth, 2, "Converted trial user must advance to month=2+, not re-fire month=1")
     }
 
-    /// The ongoing-month (month=2+) pixel must fire once per month, not on every active day within the same month.
-    /// (month=2 and month=3 both bucket to param value 2, so this counts pixel fires, not the param.)
     func testProcessSubscriptionCheck_month2Plus_firesOncePerMonthNotPerDay() async {
         let firstMonthFire = XCTestExpectation(description: "month bucket fired for month 2")
         let noRefireSameMonth = XCTestExpectation(description: "not re-fired within same month")

--- a/SharedPackages/AttributedMetric/Tests/AttributedMetricTests/AttributedMetricManagerTests.swift
+++ b/SharedPackages/AttributedMetric/Tests/AttributedMetricTests/AttributedMetricManagerTests.swift
@@ -1022,6 +1022,51 @@ final class AttributedMetricManagerTests: XCTestCase {
         XCTAssertEqual(capturedMonth, 2, "Converted trial user must advance to month=2+, not re-fire month=1")
     }
 
+    /// The ongoing-month (month=2+) pixel must fire once per month, not on every active day within the same month.
+    /// (month=2 and month=3 both bucket to param value 2, so this counts pixel fires, not the param.)
+    func testProcessSubscriptionCheck_month2Plus_firesOncePerMonthNotPerDay() async {
+        let firstMonthFire = XCTestExpectation(description: "month bucket fired for month 2")
+        let noRefireSameMonth = XCTestExpectation(description: "not re-fired within same month")
+        noRefireSameMonth.isInverted = true
+        let nextMonthFire = XCTestExpectation(description: "fired again for month 3")
+        var subscribedFireCount = 0
+
+        let fixture = createTestFixture(
+            pixelHandler: { pixelName, _, _, _, _, _ in
+                guard pixelName == "attributed_metric_subscribed" else { return }
+                subscribedFireCount += 1
+                switch subscribedFireCount {
+                case 1: firstMonthFire.fulfill()
+                case 2: nextMonthFire.fulfill()
+                default: noRefireSameMonth.fulfill()
+                }
+            },
+            subscriptionStateProvider: SubscriptionStateProviderMock(isFreeTrial: false, isActive: true)
+        )
+        defer { fixture.cleanup() }
+
+        fixture.installDateProvider.installDate = fixture.timeMachine.now()
+        fixture.dataStorage.subscriptionDate = fixture.timeMachine.now()
+        fixture.dataStorage.subscriptionMonth1Fired = true
+
+        // Day 31: first launch past one month → fires once.
+        fixture.timeMachine.travel(by: .day, value: 31)
+        fixture.attributionManager.process(trigger: .appDidStart)
+        await fulfillment(of: [firstMonthFire], timeout: 5.0)
+
+        // Day 32: still the same month bucket → must NOT re-fire.
+        fixture.timeMachine.travel(by: .day, value: 1)
+        fixture.attributionManager.process(trigger: .appDidStart)
+        await fulfillment(of: [noRefireSameMonth], timeout: 2.0)
+
+        // Day 57: crosses into month 3 → fires again.
+        fixture.timeMachine.travel(by: .day, value: 25)
+        fixture.attributionManager.process(trigger: .appDidStart)
+        await fulfillment(of: [nextMonthFire], timeout: 5.0)
+
+        XCTAssertEqual(subscribedFireCount, 2, "month=2+ must fire once per month, not once per active day")
+    }
+
     // MARK: - Sync Tests
 
     /// Tests sync pixel for valid device counts (< 3 devices)

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -268,7 +268,6 @@ public final class DefaultAppStorePurchaseFlow: AppStorePurchaseFlow {
                     return .failure(.missingEntitlements)
                 } else {
                     pendingTransactionHandler?.handleSubscriptionActivated()
-                    // Posted here, after confirmation, so listeners read the confirmed subscription (incl. its trial offer) rather than pre-confirmation cache.
                     NotificationCenter.default.post(name: .userDidPurchaseSubscription, object: self)
                     return .success(.completed)
                 }

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/AppStore/AppStorePurchaseFlow.swift
@@ -199,7 +199,6 @@ public final class DefaultAppStorePurchaseFlow: AppStorePurchaseFlow {
         // Make the purchase
         switch await storePurchaseManager.purchaseSubscription(with: subscriptionIdentifier, externalID: externalID, includeProTier: includeProTier) {
         case .success(let transactionJWS):
-            NotificationCenter.default.post(name: .userDidPurchaseSubscription, object: self)
             return .success((transactionJWS: transactionJWS, accountCreationDuration: accountCreationDuration))
         case .failure(let error):
             Logger.subscriptionAppStorePurchaseFlow.error("purchaseSubscription error: \(String(describing: error), privacy: .public)")
@@ -269,6 +268,8 @@ public final class DefaultAppStorePurchaseFlow: AppStorePurchaseFlow {
                     return .failure(.missingEntitlements)
                 } else {
                     pendingTransactionHandler?.handleSubscriptionActivated()
+                    // Posted here, after confirmation, so listeners read the confirmed subscription (incl. its trial offer) rather than pre-confirmation cache.
+                    NotificationCenter.default.post(name: .userDidPurchaseSubscription, object: self)
                     return .success(.completed)
                 }
             } else {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/Stripe/StripePurchaseFlow.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/Stripe/StripePurchaseFlow.swift
@@ -138,6 +138,8 @@ public final class DefaultStripePurchaseFlow: StripePurchaseFlow {
         Logger.subscriptionStripePurchaseFlow.log("Completing subscription purchase")
         subscriptionManager.clearSubscriptionCache()
         _ = try? await subscriptionManager.getTokenContainer(policy: .localForceRefresh)
+        // Fetch the confirmed subscription before notifying, so listeners read its trial offer rather than the just-cleared cache.
+        _ = try? await subscriptionManager.getSubscription(forceRefresh: true)
         NotificationCenter.default.post(name: .userDidPurchaseSubscription, object: self)
     }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/Stripe/StripePurchaseFlow.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/Stripe/StripePurchaseFlow.swift
@@ -136,7 +136,6 @@ public final class DefaultStripePurchaseFlow: StripePurchaseFlow {
 
     public func completeSubscriptionPurchase() async {
         Logger.subscriptionStripePurchaseFlow.log("Completing subscription purchase")
-        subscriptionManager.clearSubscriptionCache()
         _ = try? await subscriptionManager.getTokenContainer(policy: .localForceRefresh)
         _ = try? await subscriptionManager.getSubscription(forceRefresh: true)
         NotificationCenter.default.post(name: .userDidPurchaseSubscription, object: self)

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/Stripe/StripePurchaseFlow.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/Flows/Stripe/StripePurchaseFlow.swift
@@ -138,7 +138,6 @@ public final class DefaultStripePurchaseFlow: StripePurchaseFlow {
         Logger.subscriptionStripePurchaseFlow.log("Completing subscription purchase")
         subscriptionManager.clearSubscriptionCache()
         _ = try? await subscriptionManager.getTokenContainer(policy: .localForceRefresh)
-        // Fetch the confirmed subscription before notifying, so listeners read its trial offer rather than the just-cleared cache.
         _ = try? await subscriptionManager.getSubscription(forceRefresh: true)
         NotificationCenter.default.post(name: .userDidPurchaseSubscription, object: self)
     }

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Flows/AppStorePurchaseFlowTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/Flows/AppStorePurchaseFlowTests.swift
@@ -192,6 +192,35 @@ final class AppStorePurchaseFlowTests: XCTestCase {
         }
     }
 
+    // MARK: - userDidPurchaseSubscription Notification Tests
+
+    func test_completeSubscriptionPurchase_withSuccess_postsUserDidPurchaseSubscription() async {
+        subscriptionManagerMock.resultTokenContainer = OAuthTokensFactory.makeValidTokenContainerWithEntitlements()
+        let subscription = SubscriptionMockFactory.appleSubscription
+        subscriptionManagerMock.resultSubscription = .success(subscription)
+        subscriptionManagerMock.confirmPurchaseResponse = .success(subscription)
+
+        let notificationPosted = expectation(forNotification: .userDidPurchaseSubscription, object: nil, notificationCenter: .default)
+
+        _ = await sut.completeSubscriptionPurchase(with: "transactionJWS", additionalParams: nil)
+
+        await fulfillment(of: [notificationPosted], timeout: 1.0)
+    }
+
+    func test_completeSubscriptionPurchase_withMissingEntitlements_doesNotPostUserDidPurchaseSubscription() async {
+        subscriptionManagerMock.resultTokenContainer = OAuthTokensFactory.makeValidTokenContainer()
+        let subscription = SubscriptionMockFactory.appleSubscription
+        subscriptionManagerMock.resultSubscription = .success(subscription)
+        subscriptionManagerMock.confirmPurchaseResponse = .success(subscription)
+
+        let notificationPosted = expectation(forNotification: .userDidPurchaseSubscription, object: nil, notificationCenter: .default)
+        notificationPosted.isInverted = true
+
+        _ = await sut.completeSubscriptionPurchase(with: "transactionJWS", additionalParams: nil)
+
+        await fulfillment(of: [notificationPosted], timeout: 1.0)
+    }
+
     // MARK: - PendingTransactionHandler Tests
 
     func test_completeSubscriptionPurchase_withSuccess_callsHandleSubscriptionActivated() async {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1218089571925205?focus=true
Tech Design URL: N/A
CC:

### Description
Two follow-up fixes to the earlier `attributed.metric.subscribed` work, addressing the remaining inconsistencies flagged on the task:

**1. `month=2+` (ongoing month) was over-reporting.** It fired on every active day a subscription had been running for more than a month, instead of once per month. Now dedups per month, mirroring the retention pixels.

**2. `month=1` (paid start) is potentially over-reporting at the expense of `month=0` (trial start).** The purchase notification that drives the trial-vs-paid classification was posted right after the store transaction, before the subscription was confirmed. The notification now fires once the confirmed subscription (with its trial offer) is available, so trial starts are classified correctly.

### Testing Steps
Use an alpha build (StoreKit sandbox). Watch the Xcode console (subsystem `PixelKit`) for `attributed_metric_subscribed` and check `month`; relaunch between date changes so the startup check runs.

Trial → paid → renewals:
1. In Debug -> Attributed Metrics click Reset stored data
1. Subscribe with a **free trial** → fires once with `month=0`.
2. Move the device date past the trial so it converts, relaunch → fires once with `month=1`.
3. Set current time in  Debug -> Attributed Metrics one day later, relaunch → nothing new (no duplicate `month=1`).
4. Set current time in  Debug -> Attributed Metrics ~a month later, relaunch → fires once with `month=2`.
5. Set current time in  Debug -> Attributed Metrics forward one day, relaunch → **no** duplicate `month=2`.
6. Set current time in  Debug -> Attributed Metrics forward another month, relaunch → fires once with `month=2`.

Direct paid (no trial):
1. Subscribe **without** a trial → fires once with `month=1` (no `month=0`).

### Impact
Low — telemetry only. No user-facing behaviour and no change to what data is collected. If wrong, the affected subscription-start metrics stay inconsistent.

#### What could go wrong?
- `month=2+` guard too strict → never advances → mitigated by a test asserting it fires once per month across launches and advances on the next month boundary.
- Moving the purchase notification later → a purchase whose confirmation fails no longer counts as a start → intended: an unconfirmed purchase is not a real start. Notification-timing covered by tests (posts on success, not on missing-entitlements failure).

### Quality Considerations
- Shared package — one change covers iOS and macOS.
- Persists the highest reported month so `month=2+` dedup survives relaunches.
- `.userDidPurchaseSubscription` is consumed only by the attributed-metric managers, so moving when it's posted has no other listeners to affect.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry and notification timing only; purchase flows now signal subscription start after confirmation, which is intentional and covered by tests.
> 
> **Overview**
> Fixes **over-reporting** of `attributed_metric_subscribed` for ongoing subscriptions and improves **trial vs paid** classification at purchase time.
> 
> **Month 2+:** Startup checks used to emit the subscribed pixel on every launch once the subscription was past the first month. The manager now compares the computed month bucket to persisted `subscriptionLastMonthFired` and only fires when the month advances, then stores the new high water mark (survives relaunches).
> 
> **Purchase timing:** For App Store, `.userDidPurchaseSubscription` is no longer posted right after the StoreKit transaction; it posts only after `completeSubscriptionPurchase` succeeds with active subscription and entitlements, so attributed metrics can read confirmed trial state. Stripe completion refreshes subscription via `getSubscription(forceRefresh:)` instead of only clearing cache before posting the same notification.
> 
> Tests cover once-per-month month=2+ behavior and notification posting on success vs missing entitlements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e3477641aef4ba3203002df076dffda7f76e35f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->