### PR TITLE
Fix eventhub_pixel_state_persistence_failed live validation failures

### DIFF
--- a/iOS/PixelDefinitions/pixels/definitions/event_hub.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/event_hub.json5
@@ -15,6 +15,8 @@
             "appVersion",
             "errorDomain",
             "errorCode",
+            "underlyingErrorDomain",
+            "underlyingErrorCode",
             {
                 "key": "operation",
                 "type": "string",

--- a/macOS/PixelDefinitions/pixels/definitions/event_hub.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/event_hub.json5
@@ -11,6 +11,8 @@
             "appVersion",
             "errorDomain",
             "errorCode",
+            "underlyingErrorDomain",
+            "underlyingErrorCode",
             {
                 "key": "operation",
                 "type": "string",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203936086921904/task/1217972651561824?focus=true
Tech Design URL: N/A
CC:

### Description
The EventHub persistence-failure pixel failed live validation with "must NOT have additional properties" for `ud`, `ud2` and `ue2`. Those errors are real wrapped Foundation errors, and PixelKit automatically walks the underlying-error chain and appends a domain/code pair per level. The definition only declared the top-level error domain and code, so everything below it was unexpected. This declares the shared underlying-error parameters, whose key patterns cover every level PixelKit emits. The macOS twin has the identical shape and is updated alongside it.

### Testing Steps
1. Run the Pixel Validation CI workflow on this branch → the definitions parse and no schema errors are reported.
2. Confirm the next failing-pixels report no longer lists `eventhub_pixel_state_persistence_failed`.

### Impact
None — pixel definitions only, no app code changes.

### Quality Considerations
The underlying-error parameters are optional, so pixels fired from errors with no wrapped cause still validate. No new data is sent: these parameters were already being transmitted, they just weren't declared.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pixel definition JSON only; no app logic changes and no new data beyond aligning the schema with existing PixelKit output.
> 
> **Overview**
> Fixes **live pixel validation** for `eventhub_pixel_state_persistence_failed` (iOS) and `eventhub_pixel_state_persistence_failed_macos` by adding the shared **`underlyingErrorDomain`** and **`underlyingErrorCode`** parameters to both definitions in `event_hub.json5`.
> 
> PixelKit already walks wrapped Foundation errors and emits extra domain/code pairs (reported as unexpected properties like `ud`, `ud2`, `ue2`). The definitions only listed top-level `errorDomain` / `errorCode`, so real failures failed schema checks. **No runtime or telemetry behavior changes**—only declares parameters that were already being sent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 193b2134481f52a62934bd573e646172128260a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->