### PR TITLE
macOS: usage ring on the approaching message, and the high-usage model notice

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageSnapshotSeed.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageSnapshotSeed.swift
@@ -61,9 +61,9 @@ public enum DuckAiUsageSnapshotSeed: String, CaseIterable {
         case .freeDailyReached:
             return "\"Daily limit reached\" with Try for free / Subscribe (whichever the account qualifies for)"
         case .approachingDaily50:
-            return "\"50% of daily limit\", ring in the neutral icon colour"
+            return "\"50% of daily limit\", ring in green"
         case .approachingDaily75:
-            return "\"75% of daily limit\", ring in amber"
+            return "\"75% of daily limit\", ring in orange"
         case .approachingDaily90:
             return "\"90% of daily limit\", ring in red"
         case .dailyReachedWithBypass:

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageSnapshotSeed.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageSnapshotSeed.swift
@@ -26,7 +26,9 @@ public enum DuckAiUsageSnapshotSeed: String, CaseIterable {
     case freeDailyReached
 
     // Paid
-    case approachingDaily
+    case approachingDaily50
+    case approachingDaily75
+    case approachingDaily90
     case dailyReachedWithBypass
     case approachingWeekly
     case weeklyReachedDegraded
@@ -36,13 +38,16 @@ public enum DuckAiUsageSnapshotSeed: String, CaseIterable {
     public static let freeSeeds: [Self] = [.freeDailyReached]
 
     public static let paidSeeds: [Self] = [
-        .approachingDaily, .dailyReachedWithBypass, .approachingWeekly, .weeklyReachedDegraded, .weeklyReached
+        .approachingDaily50, .approachingDaily75, .approachingDaily90,
+        .dailyReachedWithBypass, .approachingWeekly, .weeklyReachedDegraded, .weeklyReached
     ]
 
     public var displayName: String {
         switch self {
         case .freeDailyReached: return "Daily limit reached"
-        case .approachingDaily: return "Approaching daily limit (90%)"
+        case .approachingDaily50: return "Approaching daily limit — 50%"
+        case .approachingDaily75: return "Approaching daily limit — 75% (warning)"
+        case .approachingDaily90: return "Approaching daily limit — 90% (critical)"
         case .dailyReachedWithBypass: return "Daily limit reached"
         case .approachingWeekly: return "Approaching weekly limit (90%)"
         case .weeklyReachedDegraded: return "Weekly limit reached, free models left"
@@ -55,8 +60,12 @@ public enum DuckAiUsageSnapshotSeed: String, CaseIterable {
         switch self {
         case .freeDailyReached:
             return "\"Daily limit reached\" with Try for free / Subscribe (whichever the account qualifies for)"
-        case .approachingDaily:
-            return "\"90% of daily limit\" with Switch to {model} and the chevron"
+        case .approachingDaily50:
+            return "\"50% of daily limit\", ring in the neutral icon colour"
+        case .approachingDaily75:
+            return "\"75% of daily limit\", ring in amber"
+        case .approachingDaily90:
+            return "\"90% of daily limit\", ring in red"
         case .dailyReachedWithBypass:
             return "\"Daily limit reached\" with Start using weekly limit; the card clears once tapped"
         case .approachingWeekly:
@@ -91,9 +100,10 @@ public enum DuckAiUsageSnapshotSeed: String, CaseIterable {
                 "cta": ["id": "subscribe"]
             ]
 
-        case .approachingDaily:
+        case .approachingDaily50, .approachingDaily75, .approachingDaily90:
             return [
-                "notice": notice(id: "approaching", window: "daily", percentUsed: 90, resetsAt: Self.daily(now)),
+                "notice": notice(id: "approaching", window: "daily",
+                                 percentUsed: approachingPercent, resetsAt: Self.daily(now)),
                 "cta": switchCta(id: "switchToCheaper", modelIds: Array(targets.prefix(2)))
             ]
 
@@ -128,6 +138,15 @@ public enum DuckAiUsageSnapshotSeed: String, CaseIterable {
                 "notice": notice(id: "weeklyReached", window: "weekly", percentUsed: 100,
                                  resetsAt: Self.weekly(now), reached: true)
             ]
+        }
+    }
+
+    /// The three steps of the severity ladder, so the ring's colours can be seen without a live account.
+    private var approachingPercent: Int {
+        switch self {
+        case .approachingDaily75: return 75
+        case .approachingDaily90: return 90
+        default: return 50
         }
     }
 

--- a/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiUsageSnapshotTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiUsageSnapshotTests.swift
@@ -319,10 +319,9 @@ final class DuckAiUsageSnapshotTests: XCTestCase {
                 XCTAssertEqual(snapshot.notice?.window, .daily)
                 XCTAssertEqual(snapshot.cta?.id, .subscribe)
                 XCTAssertEqual(snapshot.notice?.dismissible, false)
-            case .approachingDaily:
+            case .approachingDaily50, .approachingDaily75, .approachingDaily90:
                 XCTAssertEqual(snapshot.notice?.id, .approaching)
                 XCTAssertEqual(snapshot.notice?.window, .daily)
-                XCTAssertEqual(snapshot.notice?.percentUsed, 90)
                 XCTAssertEqual(snapshot.cta?.id, .switchToCheaper)
                 XCTAssertEqual(snapshot.cta?.target.candidateModelIds, targets)
             case .dailyReachedWithBypass:
@@ -347,10 +346,20 @@ final class DuckAiUsageSnapshotTests: XCTestCase {
         }
     }
 
+    /// One seed per step of the severity ladder, or the ring's colours can't be seen without a live
+    /// account near its limit.
+    func testTheApproachingSeedsCoverEverySeverityStep() {
+        let percents = [DuckAiUsageSnapshotSeed.approachingDaily50,
+                        .approachingDaily75,
+                        .approachingDaily90].map { make($0.entryValue(now: now)).notice?.percentUsed }
+
+        XCTAssertEqual(percents, [50, 75, 90])
+    }
+
     /// The seeds' own reset times differ per window, so a message that picked the wrong window's
     /// time is visible in the card rather than plausible.
     func testTheSeedsResetTimesFollowTheirWindow() {
-        let daily = make(DuckAiUsageSnapshotSeed.approachingDaily.entryValue(now: now)).notice
+        let daily = make(DuckAiUsageSnapshotSeed.approachingDaily90.entryValue(now: now)).notice
         let weekly = make(DuckAiUsageSnapshotSeed.approachingWeekly.entryValue(now: now)).notice
 
         XCTAssertEqual(daily?.resetsAt, now.addingTimeInterval(5 * 3600))
@@ -359,9 +368,9 @@ final class DuckAiUsageSnapshotTests: XCTestCase {
 
     /// A seed must never offer the model the picker is already on.
     func testSwitchSeedsExcludeTheSelectedModel() {
-        let snapshot = make(DuckAiUsageSnapshotSeed.approachingDaily.entryValue(now: now,
-                                                                                switchTargets: ["haiku", "sonnet"],
-                                                                                selectedModelId: "sonnet"))
+        let snapshot = make(DuckAiUsageSnapshotSeed.approachingDaily90.entryValue(now: now,
+                                                                                  switchTargets: ["haiku", "sonnet"],
+                                                                                  selectedModelId: "sonnet"))
 
         XCTAssertEqual(snapshot.cta?.target.candidateModelIds, ["haiku"])
     }
@@ -369,7 +378,7 @@ final class DuckAiUsageSnapshotTests: XCTestCase {
     /// Seeded without a live model list, the switch seeds render as the hidden-button case rather
     /// than offering a model that isn't in the picker.
     func testSwitchSeedsWithoutTargetsCarryNoModels() {
-        let snapshot = make(DuckAiUsageSnapshotSeed.approachingDaily.entryValue(now: now))
+        let snapshot = make(DuckAiUsageSnapshotSeed.approachingDaily90.entryValue(now: now))
 
         XCTAssertEqual(snapshot.notice?.id, .approaching)
         XCTAssertTrue(snapshot.cta?.target.isEmpty ?? false)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterUsageRingView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterUsageRingView.swift
@@ -106,9 +106,11 @@ final class UTIFooterUsageRingView: UIView {
         progressLayer.strokeColor = UIColor(designSystemColor: Self.progressColor(for: severity)).cgColor
     }
 
+    /// Follows the Duck.ai web app's green → orange → red, as far as this palette goes: it has no
+    /// orange, so the middle step stays yellow where macOS uses one.
     private static func progressColor(for severity: DuckAiUsageSeverity) -> DesignSystemColor {
         switch severity {
-        case .info: return .icons
+        case .info: return .alertGreen
         case .warning: return .alertYellow
         case .critical, .reached: return .destructivePrimary
         }

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -3704,8 +3704,10 @@
 		BB5F46A32C8751F6005F72DF /* BookmarkSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5F46A22C8751F6005F72DF /* BookmarkSortTests.swift */; };
 		BB6082B82F85C63F00F7697D /* AIChatViewAllChatsRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6082B72F85C63F00F7697D /* AIChatViewAllChatsRowView.swift */; };
 		E67ABFCCD8F6C540508229FB /* AIChatUsageWarningCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1C3EF05DE61AEEE58D72C2 /* AIChatUsageWarningCardView.swift */; };
+		0C2F5706F8F1AC422EFF2100 /* AIChatUsageWarningRingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23ED691448E5E289EB84AC41 /* AIChatUsageWarningRingView.swift */; };
 		BB6082B92F85C63F00F7697D /* AIChatViewAllChatsRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6082B72F85C63F00F7697D /* AIChatViewAllChatsRowView.swift */; };
 		838293496EEF4D7177C4776D /* AIChatUsageWarningCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1C3EF05DE61AEEE58D72C2 /* AIChatUsageWarningCardView.swift */; };
+		52F12026E71417B583793C41 /* AIChatUsageWarningRingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23ED691448E5E289EB84AC41 /* AIChatUsageWarningRingView.swift */; };
 		BB6B4EE62EE7483D00FE23E2 /* QuitSurveyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6B4EE42EE7483D00FE23E2 /* QuitSurveyView.swift */; };
 		BB6B4EE72EE7483D00FE23E2 /* QuitSurveyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6B4EE52EE7483D00FE23E2 /* QuitSurveyViewModel.swift */; };
 		BB6B4EE82EE7483D00FE23E2 /* QuitSurveyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6B4EE42EE7483D00FE23E2 /* QuitSurveyView.swift */; };
@@ -4793,12 +4795,14 @@
 		FB07BAD2000000000000030A /* PromptBarPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD2000000000000000A /* PromptBarPixel.swift */; };
 		FB07BAD20000000000000501 /* DuckAIPromptSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000401 /* DuckAIPromptSurfaceTests.swift */; };
 		CCBC17F5FE1230434E075AD1 /* AIChatUsageWarningCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7540091F30236CC01253A41F /* AIChatUsageWarningCopyTests.swift */; };
+		321C985EAF5C725987D86DD3 /* AIChatUsageWarningRingViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFBACD03AF738C2EFEAAC7EA /* AIChatUsageWarningRingViewTests.swift */; };
 		FB07BAD20000000000000502 /* EphemeralPromptDraftStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000402 /* EphemeralPromptDraftStoreTests.swift */; };
 		FB07BAD20000000000000503 /* PromptBarOmnibarContentLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000403 /* PromptBarOmnibarContentLayoutTests.swift */; };
 		FB07BAD20000000000000504 /* PromptBarPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000404 /* PromptBarPresenterTests.swift */; };
 		FB07BAD20000000000000505 /* AIChatOmnibarDuckAILogoLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000405 /* AIChatOmnibarDuckAILogoLayoutTests.swift */; };
 		FB07BAD20000000000000601 /* DuckAIPromptSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000401 /* DuckAIPromptSurfaceTests.swift */; };
 		5E3101604A8E2A8F281BF20B /* AIChatUsageWarningCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7540091F30236CC01253A41F /* AIChatUsageWarningCopyTests.swift */; };
+		427305A230AFEE6E5265BBAC /* AIChatUsageWarningRingViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFBACD03AF738C2EFEAAC7EA /* AIChatUsageWarningRingViewTests.swift */; };
 		FB07BAD20000000000000602 /* EphemeralPromptDraftStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000402 /* EphemeralPromptDraftStoreTests.swift */; };
 		FB07BAD20000000000000603 /* PromptBarOmnibarContentLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000403 /* PromptBarOmnibarContentLayoutTests.swift */; };
 		FB07BAD20000000000000604 /* PromptBarPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB07BAD20000000000000404 /* PromptBarPresenterTests.swift */; };
@@ -6016,6 +6020,7 @@
 		7BAB1A0100000000A0000001 /* AIChatTabAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabAttachment.swift; sourceTree = "<group>"; };
 		7BAB1A0100000000A0000008 /* AIChatTabAttachmentCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabAttachmentCardView.swift; sourceTree = "<group>"; };
 		EA1C3EF05DE61AEEE58D72C2 /* AIChatUsageWarningCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatUsageWarningCardView.swift; sourceTree = "<group>"; };
+		23ED691448E5E289EB84AC41 /* AIChatUsageWarningRingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatUsageWarningRingView.swift; sourceTree = "<group>"; };
 		7BAB1A0100000000A000000C /* AIChatAttachmentsCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatAttachmentsCarouselView.swift; sourceTree = "<group>"; };
 		7BAB1A0100000000A0000010 /* AIChatPanelAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatPanelAttachment.swift; sourceTree = "<group>"; };
 		7BAB1A0100000000A0000014 /* AIChatFileAttachmentCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatFileAttachmentCardView.swift; sourceTree = "<group>"; };
@@ -7358,6 +7363,7 @@
 		FB07BAD2000000000000000A /* PromptBarPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPixel.swift; sourceTree = "<group>"; };
 		FB07BAD20000000000000401 /* DuckAIPromptSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIPromptSurfaceTests.swift; sourceTree = "<group>"; };
 		7540091F30236CC01253A41F /* AIChatUsageWarningCopyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatUsageWarningCopyTests.swift; sourceTree = "<group>"; };
+		EFBACD03AF738C2EFEAAC7EA /* AIChatUsageWarningRingViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatUsageWarningRingViewTests.swift; sourceTree = "<group>"; };
 		FB07BAD20000000000000402 /* EphemeralPromptDraftStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EphemeralPromptDraftStoreTests.swift; sourceTree = "<group>"; };
 		FB07BAD20000000000000403 /* PromptBarOmnibarContentLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarOmnibarContentLayoutTests.swift; sourceTree = "<group>"; };
 		FB07BAD20000000000000404 /* PromptBarPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBarPresenterTests.swift; sourceTree = "<group>"; };
@@ -8207,6 +8213,7 @@
 				7BAB1A0100000000A00000D0 /* AIChatAttachTabsModal.swift */,
 				7BAB1A0100000000A0000008 /* AIChatTabAttachmentCardView.swift */,
 				EA1C3EF05DE61AEEE58D72C2 /* AIChatUsageWarningCardView.swift */,
+				23ED691448E5E289EB84AC41 /* AIChatUsageWarningRingView.swift */,
 				7BAB1A0100000000A000000C /* AIChatAttachmentsCarouselView.swift */,
 				7BAB1A0100000000A0000010 /* AIChatPanelAttachment.swift */,
 				7BAB1A0100000000A0000014 /* AIChatFileAttachmentCardView.swift */,
@@ -8333,6 +8340,7 @@
 				FB07BAD20000000000000402 /* EphemeralPromptDraftStoreTests.swift */,
 				FB07BAD20000000000000401 /* DuckAIPromptSurfaceTests.swift */,
 				7540091F30236CC01253A41F /* AIChatUsageWarningCopyTests.swift */,
+				EFBACD03AF738C2EFEAAC7EA /* AIChatUsageWarningRingViewTests.swift */,
 				FB07BAD20000000000000405 /* AIChatOmnibarDuckAILogoLayoutTests.swift */,
 				FB07BAE20000000000000001 /* DuckAIPromptPixelFiringTests.swift */,
 				BB027E8B2FBB4D3A009B4FE4 /* DuckAiVoiceChatShieldScopeTests.swift */,
@@ -16072,6 +16080,7 @@
 				CCF40A672ED7432800CBF271 /* UserChurnService.swift in Sources */,
 				BB6082B82F85C63F00F7697D /* AIChatViewAllChatsRowView.swift in Sources */,
 				E67ABFCCD8F6C540508229FB /* AIChatUsageWarningCardView.swift in Sources */,
+				0C2F5706F8F1AC422EFF2100 /* AIChatUsageWarningRingView.swift in Sources */,
 				37598EF12D5A187900720EAF /* HistoryViewErrorHandler.swift in Sources */,
 				3706FB6F293F65D500E42796 /* BookmarkListViewController.swift in Sources */,
 				1E15F6972DF08EDD0061395E /* AIChatSidebarHosting.swift in Sources */,
@@ -16896,6 +16905,7 @@
 				FB07BAD20000000000000502 /* EphemeralPromptDraftStoreTests.swift in Sources */,
 				FB07BAD20000000000000501 /* DuckAIPromptSurfaceTests.swift in Sources */,
 				CCBC17F5FE1230434E075AD1 /* AIChatUsageWarningCopyTests.swift in Sources */,
+				321C985EAF5C725987D86DD3 /* AIChatUsageWarningRingViewTests.swift in Sources */,
 				FB07BAD20000000000000505 /* AIChatOmnibarDuckAILogoLayoutTests.swift in Sources */,
 				FB07BAE20000000000000002 /* DuckAIPromptPixelFiringTests.swift in Sources */,
 				FB07BAD10000000000000026 /* PromptBarPromptSubmitterTests.swift in Sources */,
@@ -18473,6 +18483,7 @@
 				BB6EE5302F33DB6D009420FA /* MemoryUsageThresholdReporter.swift in Sources */,
 				BB6082B92F85C63F00F7697D /* AIChatViewAllChatsRowView.swift in Sources */,
 				838293496EEF4D7177C4776D /* AIChatUsageWarningCardView.swift in Sources */,
+				52F12026E71417B583793C41 /* AIChatUsageWarningRingView.swift in Sources */,
 				B6C416A7294A4AE500C4F2E7 /* DuckPlayerTabExtension.swift in Sources */,
 				BDBA859F2C5D25B700BC54F5 /* VPNMetadataCollector.swift in Sources */,
 				AA5C1DD5285C780C0089850C /* RecentlyClosedCoordinator.swift in Sources */,
@@ -19284,6 +19295,7 @@
 				FB07BAD20000000000000602 /* EphemeralPromptDraftStoreTests.swift in Sources */,
 				FB07BAD20000000000000601 /* DuckAIPromptSurfaceTests.swift in Sources */,
 				5E3101604A8E2A8F281BF20B /* AIChatUsageWarningCopyTests.swift in Sources */,
+				427305A230AFEE6E5265BBAC /* AIChatUsageWarningRingViewTests.swift in Sources */,
 				FB07BAD20000000000000605 /* AIChatOmnibarDuckAILogoLayoutTests.swift in Sources */,
 				FB07BAE20000000000000003 /* DuckAIPromptPixelFiringTests.swift in Sources */,
 				FB07BAD10000000000000025 /* PromptBarPromptSubmitterTests.swift in Sources */,

--- a/macOS/DuckDuckGo/AIChat/AIChatDebugMenu.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatDebugMenu.swift
@@ -29,8 +29,6 @@ final class AIChatDebugMenu: NSMenu {
     private let debugStorage: any KeyedStoring<AIChatDebugURLSettings>
 
     private var storageDebugServer: DuckAiStorageDebugServer?
-    /// So "re-seed" can rewrite the same case with fresh reset times, which is what a republish looks like.
-    private var lastSeededCase: DuckAiUsageSnapshotSeed?
     private lazy var storageServerMenuItem = NSMenuItem(
         title: "Start Storage Server",
         action: #selector(toggleStorageServer),
@@ -79,9 +77,6 @@ final class AIChatDebugMenu: NSMenu {
         addSeeds(DuckAiUsageSnapshotSeed.paidSeeds, to: submenu)
         submenu.addItem(.separator())
 
-        submenu.addItem(menuItem(title: "Re-seed the last case (simulates a republish)",
-                                 action: #selector(reseedLastUsageSnapshot)))
-        submenu.addItem(.separator())
         submenu.addItem(menuItem(title: "Clear usage snapshot", action: #selector(clearUsageSnapshot)))
         submenu.addItem(menuItem(title: "Clear dismissals", action: #selector(clearUsageDismissals)))
 
@@ -114,22 +109,11 @@ final class AIChatDebugMenu: NSMenu {
         guard let rawValue = sender.representedObject as? String,
               let seed = DuckAiUsageSnapshotSeed(rawValue: rawValue) else { return }
 
-        lastSeededCase = seed
         writeUsageSnapshot(seed)
-    }
-
-    /// A fresh reset time makes a new signature, which is what releases an acted-on message.
-    @objc private func reseedLastUsageSnapshot() {
-        guard let lastSeededCase else {
-            showAlert("Nothing to re-seed", "Pick a case first.")
-            return
-        }
-        writeUsageSnapshot(lastSeededCase)
     }
 
     @objc private func clearUsageSnapshot() {
         guard let handler = storageHandlerOrAlert() else { return }
-        lastSeededCase = nil
         try? handler.deleteEntry(key: DuckAiNativeStorageReservedEntryKeys.usageLimits.rawValue)
     }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -1178,6 +1178,9 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         }
 
         subscribeToUsageWarnings()
+        omnibarController.onUsageWarningsRefreshed = { [weak self] in
+            self?.refreshUsageCard()
+        }
         highUsageNoticeSource?.refresh()
     }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -1156,7 +1156,13 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             self?.omnibarController.usageWarningViewModel?.performAction()
         }
         usageWarningCardView.onDismiss = { [weak self] in
-            self?.omnibarController.usageWarningViewModel?.dismiss()
+            guard let self else { return }
+            if omnibarController.usageWarningViewModel?.warning != nil {
+                omnibarController.usageWarningViewModel?.dismiss()
+            } else {
+                highUsageNoticeSource?.dismissCurrent()
+            }
+            refreshUsageCard()
         }
         usageWarningCardView.onOpenModelPicker = { [weak self] in
             self?.omnibarController.usageWarningViewModel?.openModelPicker()
@@ -1172,6 +1178,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         }
 
         subscribeToUsageWarnings()
+        highUsageNoticeSource?.refresh()
     }
 
     private func subscribeToUsageWarnings() {
@@ -1190,8 +1197,26 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     private func applyUsageWarning(_ warning: DuckAiUsageWarning?) {
         if let warning {
             usageWarningCardView.update(with: warning)
+            setUsageWarningVisible(!isSuggestionsCollapsedByUnfocus)
+            return
         }
-        setUsageWarningVisible(warning != nil && !isSuggestionsCollapsedByUnfocus)
+        applyHighUsageNotice()
+    }
+
+    /// The fallback when no allowance message applies: web shows the same one, and shows it here too.
+    private func applyHighUsageNotice() {
+        guard let notice = highUsageNoticeSource?.notice else {
+            return setUsageWarningVisible(false)
+        }
+        usageWarningCardView.update(with: notice)
+        setUsageWarningVisible(!isSuggestionsCollapsedByUnfocus)
+    }
+
+    /// Re-resolves the notice and re-applies whichever message wins. The warning half is published,
+    /// so it only needs re-reading when the selected model changes.
+    private func refreshUsageCard() {
+        highUsageNoticeSource?.refresh()
+        applyUsageWarning(omnibarController.usageWarningViewModel?.warning)
     }
 
     private func setUsageWarningVisible(_ visible: Bool) {
@@ -1225,6 +1250,12 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     }
 
     private var isPresentingModelPickerFromUsageCard = false
+
+    /// Beside the usage warnings rather than part of them: it keys off the selected model, not the
+    /// allowance. The warning wins the card when both apply.
+    private lazy var highUsageNoticeSource: AIChatHighUsageNoticeSource? = {
+        omnibarController.makeHighUsageNoticeSource()
+    }()
 
     /// The last known suggestions height before image gen mode suppressed it.
     private var lastKnownSuggestionsHeight: CGFloat = 0
@@ -1319,6 +1350,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         suggestionsHeight = 0
         suggestionsHeightConstraint?.constant = 0
         // The reservation has to come off too, or the next open sizes the panel as if it were up.
+        highUsageNoticeSource?.clear()
         applyUsageWarningVisibility(false)
         usageWarningShadowView.removeFromSuperview()
     }
@@ -2141,6 +2173,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     /// Everything keyed off the selected model — the tools button would otherwise pop an empty menu
     /// for a model that supports none of them.
     private func refreshForSelectedModel() {
+        refreshUsageCard()
         modelPickerButton.isHidden = !shouldShowModelPicker
         modelPickerButton.modelName = persistedModelShortName
         updateImageUploadVisibility(supportsImageUpload: omnibarController.selectedModelSupportsImageUpload)

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -338,6 +338,15 @@ final class AIChatOmnibarController {
         setUpUsageWarnings()
     }
 
+    /// The persisted id, matching what the warning's own suggester reasons about.
+    func makeHighUsageNoticeSource() -> AIChatHighUsageNoticeSource? {
+        usageLimitsStore?.makeHighUsageNoticeSource(modelProvider: { [weak self] in
+            guard let self else { return (nil, nil) }
+            let modelId = persistedModelId
+            return (modelId, models.first { $0.id == modelId }?.shortName ?? cachedModelShortName)
+        })
+    }
+
     private func setUpUsageWarnings() {
         usageWarningViewModel = usageLimitsStore?.makeWarningViewModel(
             modelSuggester: DuckAiModelSuggester(

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -145,6 +145,10 @@ final class AIChatOmnibarController {
     /// selected model, and the picker menu is not the only thing that can change it.
     var onSelectedModelChanged: (() -> Void)?
 
+    /// The high-usage notice has no publisher of its own, so it re-resolves on the same beats the
+    /// warning does — activation included, which is what `cleanup()` dropped it for.
+    var onUsageWarningsRefreshed: (() -> Void)?
+
     private func performUsageWarningAction(_ action: DuckAiUsageAction) {
         switch action {
         case .switchToModel(let suggestion), .switchToFreeModel(let suggestion):
@@ -461,6 +465,7 @@ final class AIChatOmnibarController {
         guard hasBeenActivated else { return }
 
         usageWarningViewModel?.refresh()
+        onUsageWarningsRefreshed?()
     }
 
     private func fetchModels() {

--- a/macOS/DuckDuckGo/AIChat/AIChatUsageWarningCardView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatUsageWarningCardView.swift
@@ -128,8 +128,7 @@ final class AIChatUsageWarningCardView: NSView {
         let imageView = NSImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.imageScaling = .scaleProportionallyDown
-        imageView.image = DesignSystemImages.Glyphs.Size16.alert
-        imageView.contentTintColor = NSColor(designSystemColor: .destructivePrimary)
+        imageView.image = DesignSystemImages.Glyphs.Size16.alertRecolorable
         return imageView
     }()
 
@@ -361,8 +360,6 @@ final class AIChatUsageWarningCardView: NSView {
         NSAppearance.withAppearance(appearance) {
             tintView.backgroundColor = NSColor(designSystemColor: .surfacePrimary)
                 .withAlphaComponent(Constants.tintAlpha)
-            // The same red the ring uses at its top step, so the two icon states agree.
-            iconImageView.contentTintColor = NSColor(designSystemColor: .destructivePrimary)
         }
         // Re-assert last, or an appearance change repaints a fill the style had hidden.
         apply(backgroundStyle)

--- a/macOS/DuckDuckGo/AIChat/AIChatUsageWarningCardView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatUsageWarningCardView.swift
@@ -132,6 +132,16 @@ final class AIChatUsageWarningCardView: NSView {
         return imageView
     }()
 
+    /// So a reopen on the same message doesn't replay the fill animation.
+    private var lastShownApproachingPercent: Int?
+
+    private let ringView: AIChatUsageWarningRingView = {
+        let view = AIChatUsageWarningRingView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.isHidden = true
+        return view
+    }()
+
     private let titleLabel: NSTextField = {
         let label = NSTextField(labelWithString: "")
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -224,6 +234,7 @@ final class AIChatUsageWarningCardView: NSView {
         addSubview(tintView)
         addLayoutGuide(contentGuide)
         addSubview(iconImageView)
+        addSubview(ringView)
         addSubview(titleLabel)
         addSubview(actionButton)
         addSubview(closeButton)
@@ -256,6 +267,11 @@ final class AIChatUsageWarningCardView: NSView {
             iconImageView.widthAnchor.constraint(equalToConstant: Constants.iconSize),
             iconImageView.heightAnchor.constraint(equalToConstant: Constants.iconSize),
 
+            ringView.leadingAnchor.constraint(equalTo: iconImageView.leadingAnchor),
+            ringView.centerYAnchor.constraint(equalTo: iconImageView.centerYAnchor),
+            ringView.widthAnchor.constraint(equalToConstant: AIChatUsageWarningRingView.Constants.size),
+            ringView.heightAnchor.constraint(equalToConstant: AIChatUsageWarningRingView.Constants.size),
+
             titleLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: Constants.iconTitleSpacing),
             titleLabel.centerYAnchor.constraint(equalTo: contentGuide.centerYAnchor),
 
@@ -285,6 +301,7 @@ final class AIChatUsageWarningCardView: NSView {
 
     /// Lays the row out for `warning`. Whether the card shows at all is the host's call.
     func update(with warning: DuckAiUsageWarning) {
+        applyIcon(for: warning)
         titleLabel.attributedStringValue = Self.attributedTitle(headline: warning.localizedHeadline,
                                                                 resetsIn: warning.localizedResetsIn)
         titleLabel.setAccessibilityLabel("\(warning.localizedHeadline). \(warning.localizedResetsIn)")
@@ -306,6 +323,21 @@ final class AIChatUsageWarningCardView: NSView {
     }
 
     /// Bold headline, regular reset detail, one string so the two can never wrap apart.
+    /// The ring tracks the percentage while the limit is only approaching; a reached limit reads as an
+    /// alert, where a nearly-full ring would say less than the copy already does.
+    private func applyIcon(for warning: DuckAiUsageWarning) {
+        let isApproaching = warning.message == .approaching
+        ringView.isHidden = !isApproaching
+        iconImageView.isHidden = isApproaching
+
+        guard isApproaching else { return }
+        // Animated only between two messages, so the ring doesn't wind up from zero every time the
+        // panel reopens on the same one.
+        let animated = lastShownApproachingPercent != nil && lastShownApproachingPercent != warning.percent
+        lastShownApproachingPercent = warning.percent
+        ringView.setProgress(Double(warning.percent) / 100, severity: warning.severity, animated: animated)
+    }
+
     private static func attributedTitle(headline: String, resetsIn: String) -> NSAttributedString {
         let textColor = NSColor(designSystemColor: .textPrimary)
         let result = NSMutableAttributedString(

--- a/macOS/DuckDuckGo/AIChat/AIChatUsageWarningCardView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatUsageWarningCardView.swift
@@ -128,7 +128,8 @@ final class AIChatUsageWarningCardView: NSView {
         let imageView = NSImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.imageScaling = .scaleProportionallyDown
-        imageView.image = DesignSystemImages.Glyphs.Size16.alertRecolorable
+        imageView.image = DesignSystemImages.Glyphs.Size16.alert
+        imageView.contentTintColor = NSColor(designSystemColor: .destructivePrimary)
         return imageView
     }()
 
@@ -360,6 +361,8 @@ final class AIChatUsageWarningCardView: NSView {
         NSAppearance.withAppearance(appearance) {
             tintView.backgroundColor = NSColor(designSystemColor: .surfacePrimary)
                 .withAlphaComponent(Constants.tintAlpha)
+            // The same red the ring uses at its top step, so the two icon states agree.
+            iconImageView.contentTintColor = NSColor(designSystemColor: .destructivePrimary)
         }
         // Re-assert last, or an appearance change repaints a fill the style had hidden.
         apply(backgroundStyle)

--- a/macOS/DuckDuckGo/AIChat/AIChatUsageWarningCardView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatUsageWarningCardView.swift
@@ -299,6 +299,22 @@ final class AIChatUsageWarningCardView: NSView {
 
     // MARK: - Content
 
+    /// Lays the row out for the high-usage model notice: no reset detail and no CTA, since it is
+    /// about which model is selected rather than about an allowance running out.
+    func update(with notice: DuckAiHighUsageModelNotice) {
+        let text = UserText.aiChatUsageWarningsHighUsageModel(notice.modelShortName)
+        applyInfoIcon()
+        titleLabel.attributedStringValue = Self.attributedNotice(text)
+        titleLabel.setAccessibilityLabel(text)
+
+        actionButton.isHidden = true
+        actionButton.collapse()
+
+        closeButton.isHidden = false
+        closeButtonWidthConstraint?.constant = Constants.closeButtonSize
+        actionCloseSpacingConstraint?.constant = Constants.actionCloseSpacing
+    }
+
     /// Lays the row out for `warning`. Whether the card shows at all is the host's call.
     func update(with warning: DuckAiUsageWarning) {
         applyIcon(for: warning)
@@ -325,10 +341,23 @@ final class AIChatUsageWarningCardView: NSView {
     /// Bold headline, regular reset detail, one string so the two can never wrap apart.
     /// The ring tracks the percentage while the limit is only approaching; a reached limit reads as an
     /// alert, where a nearly-full ring would say less than the copy already does.
+    private func applyInfoIcon() {
+        ringView.isHidden = true
+        iconImageView.isHidden = false
+        lastShownApproachingPercent = nil
+        iconImageView.image = DesignSystemImages.Glyphs.Size16.info
+        NSAppearance.withAppearance(appearance) {
+            iconImageView.contentTintColor = NSColor(designSystemColor: .iconsPrimary)
+        }
+    }
+
     private func applyIcon(for warning: DuckAiUsageWarning) {
         let isApproaching = warning.message == .approaching
         ringView.isHidden = !isApproaching
         iconImageView.isHidden = isApproaching
+        // The notice swaps in the info glyph, so the alert has to be put back.
+        iconImageView.image = DesignSystemImages.Glyphs.Size16.alertRecolorable
+        iconImageView.contentTintColor = nil
 
         guard isApproaching else { return }
         // Animated only between two messages, so the ring doesn't wind up from zero every time the
@@ -336,6 +365,15 @@ final class AIChatUsageWarningCardView: NSView {
         let animated = lastShownApproachingPercent != nil && lastShownApproachingPercent != warning.percent
         lastShownApproachingPercent = warning.percent
         ringView.setProgress(Double(warning.percent) / 100, severity: warning.severity, animated: animated)
+    }
+
+    /// Regular weight throughout: the notice is a sentence, where the warnings lead with a headline.
+    private static func attributedNotice(_ text: String) -> NSAttributedString {
+        NSAttributedString(
+            string: text,
+            attributes: [.font: NSFont.systemFont(ofSize: Constants.fontSize, weight: .regular),
+                         .foregroundColor: NSColor(designSystemColor: .textPrimary)]
+        )
     }
 
     private static func attributedTitle(headline: String, resetsIn: String) -> NSAttributedString {

--- a/macOS/DuckDuckGo/AIChat/AIChatUsageWarningRingView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatUsageWarningRingView.swift
@@ -117,13 +117,13 @@ final class AIChatUsageWarningRingView: NSView {
         }
     }
 
-    /// Same three steps as iOS, under this platform's palette names: macOS is on the newer palette,
-    /// where the icon colour gained a `Primary` suffix and destructive split into fill and content.
+    /// Same three steps as iOS, under this platform's palette names. `destructivePrimary` is the red
+    /// itself; `destructiveContentPrimary` is what gets drawn *on* it, and is white.
     private static func progressColor(for severity: DuckAiUsageSeverity) -> DesignSystemColor {
         switch severity {
         case .info: return .iconsPrimary
         case .warning: return .alertYellow
-        case .critical, .reached: return .destructiveContentPrimary
+        case .critical, .reached: return .destructivePrimary
         }
     }
 }

--- a/macOS/DuckDuckGo/AIChat/AIChatUsageWarningRingView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatUsageWarningRingView.swift
@@ -117,13 +117,13 @@ final class AIChatUsageWarningRingView: NSView {
         }
     }
 
-    /// Same three steps as iOS, under this platform's palette names. `destructivePrimary` is the red
-    /// itself; `destructiveContentPrimary` is what gets drawn *on* it, and is white.
+    /// The status triad, so the ring reads the same as the Duck.ai web app's: green, then orange, then
+    /// red. iOS still steps grey → yellow → red; its palette has no orange to move to.
     private static func progressColor(for severity: DuckAiUsageSeverity) -> DesignSystemColor {
         switch severity {
-        case .info: return .iconsPrimary
-        case .warning: return .alertYellow
-        case .critical, .reached: return .destructivePrimary
+        case .info: return .statusGreen
+        case .warning: return .statusYellowPrimary
+        case .critical, .reached: return .statusRed
         }
     }
 }

--- a/macOS/DuckDuckGo/AIChat/AIChatUsageWarningRingView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatUsageWarningRingView.swift
@@ -1,0 +1,129 @@
+//
+//  AIChatUsageWarningRingView.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import AppKit
+import DesignResourcesKit
+
+/// How much of the allowance is spent, on the approaching message. AppKit twin of iOS's
+/// `UTIFooterUsageRingView`: same size, line width, timing and colour table.
+final class AIChatUsageWarningRingView: NSView {
+
+    enum Constants {
+        static let size: CGFloat = 16
+    }
+
+    private enum Metrics {
+        static let lineWidth: CGFloat = 2
+        static let progressChangeDuration: TimeInterval = 0.25
+    }
+
+    private let trackLayer = CAShapeLayer()
+    private let progressLayer = CAShapeLayer()
+
+    private var progress: Double = 0
+    private var severity: DuckAiUsageSeverity = .info
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: Constants.size, height: Constants.size)
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        for shape in [trackLayer, progressLayer] {
+            shape.fillColor = NSColor.clear.cgColor
+            shape.lineWidth = Metrics.lineWidth
+            shape.lineCap = .round
+            layer?.addSublayer(shape)
+        }
+        progressLayer.strokeEnd = 0
+        applyColors()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setProgress(_ progress: Double, severity: DuckAiUsageSeverity, animated: Bool) {
+        if severity != self.severity {
+            self.severity = severity
+            applyColors()
+        }
+        let clamped = min(max(progress, 0), 1)
+        guard clamped != self.progress else { return }
+        self.progress = clamped
+
+        guard animated else {
+            progressLayer.removeAnimation(forKey: "strokeEnd")
+            progressLayer.strokeEnd = clamped
+            return
+        }
+        let animation = CABasicAnimation(keyPath: "strokeEnd")
+        animation.fromValue = progressLayer.presentation()?.value(forKey: "strokeEnd") ?? progressLayer.strokeEnd
+        animation.toValue = clamped
+        animation.duration = Metrics.progressChangeDuration
+        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        progressLayer.strokeEnd = clamped
+        progressLayer.add(animation, forKey: "strokeEnd")
+    }
+
+    override func layout() {
+        super.layout()
+
+        let inset = Metrics.lineWidth / 2
+        let rect = bounds.insetBy(dx: inset, dy: inset)
+        let path = CGMutablePath()
+        // Starts at twelve o'clock and fills clockwise. AppKit's y runs up, so the sweep ends a full
+        // turn *below* the start angle rather than above it as on iOS.
+        path.addArc(center: CGPoint(x: rect.midX, y: rect.midY),
+                    radius: min(rect.width, rect.height) / 2,
+                    startAngle: .pi / 2,
+                    endAngle: .pi / 2 - 2 * .pi,
+                    clockwise: true)
+
+        for shape in [trackLayer, progressLayer] {
+            shape.frame = bounds
+            shape.path = path
+        }
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyColors()
+    }
+
+    private func applyColors() {
+        // `CGColor` resolves once, so the drawing appearance has to be current when it is read.
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            trackLayer.strokeColor = NSColor(designSystemColor: .lines).cgColor
+            progressLayer.strokeColor = NSColor(designSystemColor: Self.progressColor(for: severity)).cgColor
+        }
+    }
+
+    /// Same three steps as iOS, under this platform's palette names: macOS is on the newer palette,
+    /// where the icon colour gained a `Primary` suffix and destructive split into fill and content.
+    private static func progressColor(for severity: DuckAiUsageSeverity) -> DesignSystemColor {
+        switch severity {
+        case .info: return .iconsPrimary
+        case .warning: return .alertYellow
+        case .critical, .reached: return .destructiveContentPrimary
+        }
+    }
+}

--- a/macOS/DuckDuckGo/AIChat/DuckAiUsageLimitsStore.swift
+++ b/macOS/DuckDuckGo/AIChat/DuckAiUsageLimitsStore.swift
@@ -52,6 +52,16 @@ final class DuckAiUsageLimitsStore {
         )
     }
 
+    /// `nil` when the feature is inactive, matching `makeWarningViewModel` — the notice shares the
+    /// card, so it must not outlive the flag that gates it.
+    func makeHighUsageNoticeSource(
+        modelProvider: @escaping () -> (id: String?, shortName: String?)
+    ) -> AIChatHighUsageNoticeSource? {
+        guard featureFlagger.isFeatureOn(.aiChatUsageWarnings) else { return nil }
+
+        return AIChatHighUsageNoticeSource(modelProvider: modelProvider)
+    }
+
     /// Lets an open surface update instead of waiting for the next activation, and is what releases
     /// a message the user has already acted on.
     var snapshotUpdates: AnyPublisher<Void, Never>? {
@@ -86,5 +96,51 @@ final class DuckAiUsageLimitsStore {
             }
         }
         return didWriteAll
+    }
+}
+
+/// The "this model spends your allowance quickly" notice. Keyed off the selected model rather than
+/// the allowance, so it sits beside the usage warnings instead of being one. AppKit twin of iOS's
+/// `UTIFooterHighUsageNoticeSource`.
+final class AIChatHighUsageNoticeSource {
+
+    private let resolver: DuckAIHighUsageModelNoticeResolver
+    private let dismissalStore: DuckAiHighUsageNoticeDismissalStoring
+    /// Re-read per refresh, so switching models mid-session is picked up.
+    private let modelProvider: () -> (id: String?, shortName: String?)
+
+    private(set) var notice: DuckAiHighUsageModelNotice?
+
+    init(dismissalStore: DuckAiHighUsageNoticeDismissalStoring = DuckAiHighUsageNoticeDismissalStore(),
+         modelProvider: @escaping () -> (id: String?, shortName: String?)) {
+        self.dismissalStore = dismissalStore
+        self.resolver = DuckAIHighUsageModelNoticeResolver(dismissalStore: dismissalStore)
+        self.modelProvider = modelProvider
+    }
+
+    func refresh() {
+        let model = modelProvider()
+        switch resolver.resolve(modelId: model.id, modelShortName: model.shortName) {
+        case .notice(let notice):
+            self.notice = notice
+            Logger.aiChat.debug("Duck.ai high-usage notice: model=\(notice.modelId, privacy: .public)")
+        case .none(let reason):
+            notice = nil
+            Logger.aiChat.debug("Duck.ai high-usage notice: none — reason=\(reason.rawValue, privacy: .public)")
+        }
+    }
+
+    /// One-time per model: there is no reset window for it to expire against.
+    func dismissCurrent() {
+        guard let notice else { return }
+
+        dismissalStore.setDismissed(modelId: notice.modelId)
+        self.notice = nil
+        Logger.aiChat.debug("Duck.ai high-usage notice dismissed: model=\(notice.modelId, privacy: .public)")
+    }
+
+    /// Teardown: drops the notice without recording a dismissal.
+    func clear() {
+        notice = nil
     }
 }

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -972,6 +972,10 @@ struct UserText {
     static let aiChatUsageWarningsDailyLimitReached = NotLocalizedString("aichat.usageWarnings.daily-limit-reached", value: "Daily limit reached", comment: "Headline on the Duck.ai usage card when the user's daily allowance is fully spent")
     static let aiChatUsageWarningsWeeklyLimitReached = NotLocalizedString("aichat.usageWarnings.weekly-limit-reached", value: "Weekly usage limit reached", comment: "Headline on the Duck.ai usage card when the user's weekly allowance is fully spent")
     static let aiChatUsageWarningsAdvancedModelsLimitReached = NotLocalizedString("aichat.usageWarnings.advanced-models-limit-reached", value: "Advanced AI models limit reached", comment: "Headline on the Duck.ai usage card when the allowance for advanced AI models specifically is spent, while free models remain available")
+    static func aiChatUsageWarningsHighUsageModel(_ modelShortName: String) -> String {
+        let message = NotLocalizedString("aichat.usageWarnings.high-usage-model", value: "%@ reaches usage limits 2-5x sooner than basic models.", comment: "Duck.ai usage card notice shown while a model that spends the allowance quickly is selected. Parameter is the model's short name, e.g. \"Opus 4.8\".")
+        return String(format: message, modelShortName)
+    }
     static func aiChatUsageWarningsResetsIn(_ interval: String) -> String {
         let message = NotLocalizedString("aichat.usageWarnings.resets-in", value: "Resets in %@", comment: "Trailing detail on the Duck.ai usage card saying when the limit resets. Parameter is a short interval such as \"7d\" or \"12h\".")
         return String(format: message, interval)

--- a/macOS/UnitTests/AIChat/AIChatUsageWarningCopyTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUsageWarningCopyTests.swift
@@ -104,6 +104,23 @@ final class AIChatUsageWarningCopyTests: XCTestCase {
         XCTAssertNil(warning(.weeklyReached, window: .weekly, action: nil).localizedActionTitle)
     }
 
+    // MARK: - High-usage model notice
+
+    /// The web app's and Windows' sentence, with the model named. iOS words it differently for now.
+    func testHighUsageNoticeNamesTheModel() {
+        let notice = DuckAiHighUsageModelNotice(modelId: "claude-opus-4-8", modelShortName: "Opus 4.8")
+
+        XCTAssertEqual(UserText.aiChatUsageWarningsHighUsageModel(notice.modelShortName),
+                       "Opus 4.8 reaches usage limits 2-5x sooner than basic models.")
+    }
+
+    /// Only the model the web app calls high-usage, since the models payload carries no such field.
+    func testOnlyOpusCountsAsHighUsage() {
+        XCTAssertTrue(DuckAiHighUsageModels.includes("claude-opus-4-8"))
+        XCTAssertFalse(DuckAiHighUsageModels.includes("claude-sonnet-4-6"))
+        XCTAssertFalse(DuckAiHighUsageModels.includes(nil))
+    }
+
     // MARK: - Helpers
 
     private func warning(_ message: DuckAiUsageMessage,

--- a/macOS/UnitTests/AIChat/AIChatUsageWarningRingViewTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUsageWarningRingViewTests.swift
@@ -1,0 +1,109 @@
+//
+//  AIChatUsageWarningRingViewTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import AppKit
+import XCTest
+@testable import DuckDuckGo_Privacy_Browser
+
+final class AIChatUsageWarningRingViewTests: XCTestCase {
+
+    private var sut: AIChatUsageWarningRingView!
+
+    override func setUp() {
+        super.setUp()
+        sut = AIChatUsageWarningRingView()
+        sut.frame = NSRect(x: 0, y: 0,
+                           width: AIChatUsageWarningRingView.Constants.size,
+                           height: AIChatUsageWarningRingView.Constants.size)
+        sut.layoutSubtreeIfNeeded()
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    func testProgressFillsTheStroke() {
+        sut.setProgress(0.9, severity: .critical, animated: false)
+
+        XCTAssertEqual(progressLayer.strokeEnd, 0.9, accuracy: 0.001)
+    }
+
+    /// The percentage arrives capped web-side, but a payload we haven't seen shouldn't draw past the ring.
+    func testProgressIsClamped() {
+        sut.setProgress(1.4, severity: .critical, animated: false)
+        XCTAssertEqual(progressLayer.strokeEnd, 1, accuracy: 0.001)
+
+        sut.setProgress(-0.2, severity: .info, animated: false)
+        XCTAssertEqual(progressLayer.strokeEnd, 0, accuracy: 0.001)
+    }
+
+    /// Each step is a different colour, and the same step never repaints — that is the whole point of
+    /// the ring over a plain glyph.
+    func testEachSeverityStepDrawsItsOwnColour() {
+        var colours: [DuckAiUsageSeverity: CGColor] = [:]
+        for (index, severity) in [DuckAiUsageSeverity.info, .warning, .critical].enumerated() {
+            sut.setProgress(Double(index + 1) / 10, severity: severity, animated: false)
+            colours[severity] = progressLayer.strokeColor
+        }
+
+        XCTAssertEqual(colours.count, 3)
+        XCTAssertNotEqual(colours[.info], colours[.warning])
+        XCTAssertNotEqual(colours[.warning], colours[.critical])
+    }
+
+    /// A reached limit shares the critical colour: both mean "out of room", and the card swaps to the
+    /// alert glyph there anyway.
+    func testReachedMatchesCritical() {
+        sut.setProgress(0.9, severity: .critical, animated: false)
+        let critical = progressLayer.strokeColor
+
+        sut.setProgress(1, severity: .reached, animated: false)
+
+        XCTAssertEqual(progressLayer.strokeColor, critical)
+    }
+
+    /// Both arcs need a path, or the ring draws nothing at all.
+    func testLayoutGivesBothArcsAPath() {
+        XCTAssertNotNil(trackLayer.path)
+        XCTAssertNotNil(progressLayer.path)
+        XCTAssertEqual(trackLayer.path, progressLayer.path)
+    }
+
+    /// Starts at twelve o'clock: the track's own bounding box is the tell, since an arc that began
+    /// elsewhere would not be centred on the view.
+    func testTheRingIsCentredOnTheView() {
+        let box = try? XCTUnwrap(trackLayer.path).boundingBox
+
+        XCTAssertEqual(box?.midX ?? 0, sut.bounds.midX, accuracy: 0.01)
+        XCTAssertEqual(box?.midY ?? 0, sut.bounds.midY, accuracy: 0.01)
+    }
+
+    private var trackLayer: CAShapeLayer {
+        shapeLayers[0]
+    }
+
+    private var progressLayer: CAShapeLayer {
+        shapeLayers[1]
+    }
+
+    private var shapeLayers: [CAShapeLayer] {
+        (sut.layer?.sublayers ?? []).compactMap { $0 as? CAShapeLayer }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1218001053294535?focus=true

### Description

Two bits of polish on the macOS Duck.ai usage card, following the web app.

**The usage ring.** instead of icon for approaching message

New **high-usage model warning.** for Opus 

Note: iOS gets one change: green at 50%

### Testing Steps

Use main menu **Debug → AI Chat → Duck.ai Usage Warnings** to:

1. Seed `Approaching daily limit — 50%` → focus the address bar in Duck.ai mode → ring filled a half turn, in green.
2. Seed `— 75% (warning)` → ring in orange. 
3. Seed `— 90% (critical)` → ring in red
4. Seed `Daily limit reached` → the alert icon replaces the ring
6. Open the Prompt Bar and repeat 1–3 — same card, same colours.
7. Toggle light/dark while a ring is up → colours follow the appearance.

**High-usage notice**
8. Oick **Claude Opus 4.8** in the model picker → See "Opus 4.8 reaches usage limits 2-5x sooner than basic models." message
9. Switch to another model → the notice goes. Switch back to Opus → it returns.
10. Dismiss it with ✕ → gone, and it stays gone for that model.

### Impact

Low — behind the internal-only `aiChatUsageWarnings` flag on both platforms.

#### What could go wrong?

- The ring's colours come from the palette rather than hardcoded hexes, so a palette change moves them → the three steps are asserted as distinct in `AIChatUsageWarningRingViewTests`, though not against exact values.
- macOS and iOS now differ at the 75% step (orange vs yellow) → deliberate, see the description.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes behind `aiChatUsageWarnings`; no auth or data-path changes. Minor risk of layout or dismiss/precedence bugs on the omnibar card.
> 
> **Overview**
> Polishes the Duck.ai **usage card** on macOS (and one iOS ring color) so approaching limits and Opus-style models match the web app.
> 
> **Approaching limits** now show a **progress ring** at the card icon instead of the alert glyph. Fill tracks `percentUsed`; colors step **green → orange/yellow → red** with severity (`info` / `warning` / `critical`). Reached limits still use the alert icon. macOS adds `AIChatUsageWarningRingView` and wires it through `AIChatUsageWarningCardView`; iOS `UTIFooterUsageRingView` uses **green** at the low step (no orange in that palette).
> 
> **High-usage model notice** appears when no allowance warning is active: copy that the selected model (e.g. Opus) hits limits faster, info icon, dismissible once per model. `AIChatHighUsageNoticeSource` on macOS mirrors iOS; the omnibar **refreshes** the card on model change and activation; **usage warnings win** when both apply. Close routes to warning dismiss or notice dismiss.
> 
> **Debug / tests**: `approachingDaily` splits into **50 / 75 / 90** seeds so testers can see each ring color without a live account; tests assert those percents and ring behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0a58307f6750e892d4ede5916c2d5efec2afd4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->