### PR TITLE
macOS: Enable tab attachments in Duck.ai

### DIFF
--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -739,9 +739,9 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatOmnibarVoiceChatAccess:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.omnibarVoiceChatAccess), category: .duckAI)
         case .aiChatSidebarAttachMoreTabs:
-            Config(source: .remoteReleasable(AIChatSubfeature.sidebarAttachMoreTabs), category: .duckAI)
+            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.sidebarAttachMoreTabs), category: .duckAI)
         case .aiChatOmnibarAttachMoreTabs:
-            Config(source: .remoteReleasable(AIChatSubfeature.omnibarAttachMoreTabs), category: .duckAI)
+            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.omnibarAttachMoreTabs), category: .duckAI)
         case .aiChatTabAttachmentLimit:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.tabAttachmentLimit), category: .duckAI)
         case .aiChatSidebarResizable:
@@ -757,7 +757,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .aiChatNtpWebSearch:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.ntpWebSearch), category: .duckAI)
         case .aiChatNtpAttachMoreTabs:
-            Config(source: .remoteReleasable(AIChatSubfeature.ntpAttachMoreTabs), category: .duckAI)
+            Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.ntpAttachMoreTabs), category: .duckAI)
         case .aiChatNtpSuggestionsDeletion:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.ntpSuggestionsDeletion), category: .duckAI)
         case .aiChatSidebarFloating:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1217736570120346?focus=true
Tech Design URL:
CC:

### Description

Flips the default for the "attach more tabs" flags (sidebar, omnibar, NTP) from disabled to `.enabled`, so tab attachments are on unless remote config turns them off.

### Testing Steps
1. Open Duck.ai from the omnibar — tab attachment picker is available.
2. Same from the sidebar and from an NTP Duck.ai entry point.

### Impact
Low. Still remote-releasable; can be killed via privacy config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only default flip for Duck.ai UI gates; behavior remains remote-killable via privacy config.
> 
> **Overview**
> Turns on **multi-tab attachment** in Duck.ai by default for the sidebar, address-bar omnibar, and New Tab Page entry points.
> 
> Each of `aiChatSidebarAttachMoreTabs`, `aiChatOmnibarAttachMoreTabs`, and `aiChatNtpAttachMoreTabs` now uses `defaultValue: .enabled` in `FeatureFlag.swift` (previously the implicit **disabled** default). Remote-releasable privacy config can still turn the surfaces off without a client release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b92c53bc712659a526664805c74d8c0b91061a8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->