### PR TITLE
macOS: Fix History menu missing separators on macOS 27

### DIFF
--- a/macOS/DuckDuckGo/Menus/HistoryMenu.swift
+++ b/macOS/DuckDuckGo/Menus/HistoryMenu.swift
@@ -165,10 +165,6 @@ final class HistoryMenu: NSMenu {
 
     private var recentlyVisitedMenuItems = [NSMenuItem]()
 
-    /// Replaces the recently-visited section in place: the fresh items are inserted before the
-    /// old ones are removed, so that no separator is ever adjacent to another or trailing, not
-    /// even transiently. macOS 27 evaluates separator auto-hiding eagerly during item mutations
-    /// and latches the hidden state into the first render of a directly-clicked menu.
     @MainActor
     private func updateRecentlyVisited() {
         let oldMenuItems = recentlyVisitedMenuItems
@@ -177,8 +173,6 @@ final class HistoryMenu: NSMenu {
         oldMenuItems.filter { $0.menu === self }.forEach(removeItem)
     }
 
-    /// The recently-visited section sits directly above the bottom block,
-    /// whose leading separator anchors the insertion.
     private var anchorSeparator: NSMenuItem {
         location == .mainMenu ? showHistorySeparator : clearAllHistorySeparator
     }

--- a/macOS/DuckDuckGo/Menus/HistoryMenu.swift
+++ b/macOS/DuckDuckGo/Menus/HistoryMenu.swift
@@ -32,6 +32,11 @@ final class HistoryMenu: NSMenu {
         case mainMenu, moreOptionsMenu
     }
 
+    private enum Constants {
+        static let maxRecentlyVisitedItems = 12
+        static let itemNotFoundIndex = -1
+    }
+
     let backMenuItem = NSMenuItem(title: UserText.navigateBack, action: #selector(MainViewController.back), keyEquivalent: "[")
         .withImage(DesignSystemImages.Glyphs.Size12.arrowLeft)
     let forwardMenuItem = NSMenuItem(title: UserText.navigateForward, action: #selector(MainViewController.forward), keyEquivalent: "]")
@@ -122,19 +127,9 @@ final class HistoryMenu: NSMenu {
         updateRecentlyClosedMenu()
         updateReopenLastClosedMenuItem()
 
-        clearOldVariableMenuItems()
-        addRecentlyVisited()
-        addClearAllAndShowHistoryOnTheBottom()
+        updateRecentlyVisited()
 
         alignItemTextWithIcons()
-    }
-
-    private func clearOldVariableMenuItems() {
-        items.removeAll { menuItem in
-            recentlyVisitedMenuItems.contains(menuItem) ||
-            menuItem == clearAllHistoryMenuItem ||
-            (menuItem == showHistoryMenuItem && location == .mainMenu)
-        }
     }
 
     // MARK: - Last Closed & Recently Closed
@@ -170,37 +165,46 @@ final class HistoryMenu: NSMenu {
 
     private var recentlyVisitedMenuItems = [NSMenuItem]()
 
+    /// Replaces the recently-visited section in place: the fresh items are inserted before the
+    /// old ones are removed, so that no separator is ever adjacent to another or trailing, not
+    /// even transiently. macOS 27 evaluates separator auto-hiding eagerly during item mutations
+    /// and latches the hidden state into the first render of a directly-clicked menu.
     @MainActor
-    private func addRecentlyVisited() {
-        recentlyVisitedMenuItems = [recentlyVisitedHeaderMenuItem]
-        let recentVisits = historyGroupingProvider.getRecentVisits(maxCount: 12)
-        for (index, visit) in zip(
-            recentVisits.indices, recentVisits
-        ) {
-            let visitMenuItem = VisitMenuItem(visitViewModel: VisitViewModel(visit: visit))
-            visitMenuItem.setAccessibilityIdentifier("HistoryMenu.recentlyVisitedMenuItem.\(index)")
-            recentlyVisitedMenuItems.append(visitMenuItem)
-        }
-        for recentlyVisitedMenuItem in recentlyVisitedMenuItems {
-            addItem(recentlyVisitedMenuItem)
-        }
+    private func updateRecentlyVisited() {
+        let oldMenuItems = recentlyVisitedMenuItems
+        recentlyVisitedMenuItems = makeRecentlyVisitedMenuItems()
+        insert(recentlyVisitedMenuItems, before: anchorSeparator)
+        oldMenuItems.filter { $0.menu === self }.forEach(removeItem)
     }
 
-    // MARK: - Clear All History
+    /// The recently-visited section sits directly above the bottom block,
+    /// whose leading separator anchors the insertion.
+    private var anchorSeparator: NSMenuItem {
+        location == .mainMenu ? showHistorySeparator : clearAllHistorySeparator
+    }
 
-    private func addClearAllAndShowHistoryOnTheBottom() {
-        if location == .mainMenu {
-            if showHistorySeparator.menu != nil {
-                removeItem(showHistorySeparator)
-            }
-            addItem(showHistorySeparator)
-            addItem(showHistoryMenuItem)
+    @MainActor
+    private func makeRecentlyVisitedMenuItems() -> [NSMenuItem] {
+        var menuItems = [recentlyVisitedHeaderMenuItem]
+        let recentVisits = historyGroupingProvider.getRecentVisits(maxCount: Constants.maxRecentlyVisitedItems)
+        for (index, visit) in zip(recentVisits.indices, recentVisits) {
+            let visitMenuItem = VisitMenuItem(visitViewModel: VisitViewModel(visit: visit))
+            visitMenuItem.setAccessibilityIdentifier("HistoryMenu.recentlyVisitedMenuItem.\(index)")
+            menuItems.append(visitMenuItem)
         }
-        if clearAllHistorySeparator.menu != nil {
-            removeItem(clearAllHistorySeparator)
+        return menuItems
+    }
+
+    private func insert(_ menuItems: [NSMenuItem], before anchor: NSMenuItem) {
+        var insertionIndex = index(of: anchor)
+        guard insertionIndex != Constants.itemNotFoundIndex else {
+            assertionFailure("HistoryMenu: anchor separator missing")
+            return
         }
-        addItem(clearAllHistorySeparator)
-        addItem(clearAllHistoryMenuItem)
+        for menuItem in menuItems {
+            insertItem(menuItem, at: insertionIndex)
+            insertionIndex += 1
+        }
     }
 }
 

--- a/macOS/DuckDuckGo/Menus/HistoryMenu.swift
+++ b/macOS/DuckDuckGo/Menus/HistoryMenu.swift
@@ -170,7 +170,7 @@ final class HistoryMenu: NSMenu {
         let oldMenuItems = recentlyVisitedMenuItems
         recentlyVisitedMenuItems = makeRecentlyVisitedMenuItems()
         insert(recentlyVisitedMenuItems, before: anchorSeparator)
-        oldMenuItems.filter { $0.menu === self }.forEach(removeItem)
+        removeMenuItems(oldItems: oldMenuItems)
     }
 
     private var anchorSeparator: NSMenuItem {
@@ -199,6 +199,10 @@ final class HistoryMenu: NSMenu {
             insertItem(menuItem, at: insertionIndex)
             insertionIndex += 1
         }
+    }
+
+    private func removeMenuItems(oldItems: [NSMenuItem]) {
+        oldItems.filter { $0.menu === self }.forEach(removeItem)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216562341335231/task/1217995838139209?focus=true
Tech Design URL: N/A
CC:

### Description

Fixes missing separators in the History menu on macOS 27. The menu now refreshes recently visited entries without temporarily leaving adjacent or trailing separators, while keeping the final item order unchanged.

### Testing Steps

1. On macOS 27, launch the browser and visit several pages.
2. Click History directly in the menu bar → separators appear above Recently Visited, Show All History…, and Delete All History….
3. Close and reopen History several times → separators and recently visited entries remain correctly ordered.
4. Open another menu, then hover to History → the same separators and ordering appear.
5. Open More Options → History → the submenu ordering and separator above Delete All History… remain correct.

### Impact

Low: This is a visual fix limited to the History menu.

#### What could go wrong?

History items or separators could be ordered incorrectly on older macOS versions → mitigated by preserving the existing final menu order for both History menu locations.

### Quality Considerations

The recently visited list remains capped at 12 items. Empty history still includes the Recently Visited header so separators never become adjacent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual menu-layout fix in HistoryMenu only; final item order is intended to match the prior behavior for both menu locations.
> 
> **Overview**
> Fixes **missing separators** in the History menu on macOS 27 by changing how the recently visited section is refreshed on each `update()`.
> 
> Previously, `update()` stripped variable items (recent visits, Show All History, Delete All History, and their separators) and re-appended them at the bottom. That flow left separators missing on macOS 27. The menu now keeps the **anchor separators and trailing actions** from initial `buildItems` and only **replaces the recently visited block in place**: new items are inserted immediately before `showHistorySeparator` (main menu) or `clearAllHistorySeparator` (More Options), then the previous visit items are removed.
> 
> A small `Constants` enum centralizes the 12-item cap and the “anchor not found” index; an assertion fires if the anchor separator is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b593f0d48173b98fc293b91c9453580fd1bf12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->