### PR TITLE
Show the info glyph on the Duck.ai high-usage model notice

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/UsageWarnings/DuckAiHighUsageModelNotice.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/UsageWarnings/DuckAiHighUsageModelNotice.swift
@@ -71,6 +71,11 @@ public struct DuckAiHighUsageNoticeDismissalStore: DuckAiHighUsageNoticeDismissa
         try? keyValueStore.set(ids, forKey: Self.key)
     }
 
+    /// The debug menu's reset: there is no product path back once a model's notice is dismissed.
+    public func clearDismissals() {
+        try? keyValueStore.removeObject(forKey: Self.key)
+    }
+
     /// Unreadable reads as "not dismissed": showing the notice again is the safe failure.
     private func dismissedModelIds() -> [String] {
         (try? keyValueStore.object(forKey: Self.key) as? [String]) ?? []

--- a/SharedPackages/AIChat/Tests/AIChatTests/UsageWarnings/DuckAiHighUsageNoticeDismissalStoreTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/UsageWarnings/DuckAiHighUsageNoticeDismissalStoreTests.swift
@@ -70,6 +70,16 @@ final class DuckAiHighUsageNoticeDismissalStoreTests: XCTestCase {
         XCTAssertEqual(stored, ["claude-opus-4-8"])
     }
 
+    func testWhenDismissalsAreClearedThenEveryModelIsShownAgain() {
+        sut.setDismissed(modelId: "claude-opus-4-8")
+        sut.setDismissed(modelId: "some-future-model")
+
+        sut.clearDismissals()
+
+        XCTAssertFalse(sut.isDismissed(modelId: "claude-opus-4-8"))
+        XCTAssertFalse(sut.isDismissed(modelId: "some-future-model"))
+    }
+
     /// Unreadable reads as "not dismissed": showing the notice again is the safe failure.
     func testWhenTheStoredValueIsUnreadableThenNothingIsDismissed() {
         try? keyValueStore.set("not a list", forKey: "aichat.high-usage-notice.dismissed-models")

--- a/iOS/DuckDuckGo/AIChatDebugView.swift
+++ b/iOS/DuckDuckGo/AIChatDebugView.swift
@@ -419,11 +419,13 @@ private struct AIChatUsageWarningsSection: View {
         }
     }
 
-    /// Brings back a message dismissed with its close button, and one whose CTA has been run.
+    /// Brings back a message dismissed with its close button, one whose CTA has been run, and the
+    /// high-usage notice, which is otherwise dismissed once per model for good.
     private func clearDismissals() {
         let store = DuckAiUsageWarningDismissalStore()
         store.setDismissal(nil)
         store.setActedSnapshot(nil)
+        DuckAiHighUsageNoticeDismissalStore().clearDismissals()
         status = "Dismissals cleared."
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterCardView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterCardView.swift
@@ -47,6 +47,7 @@ final class UTIFooterCardView: UIView {
 
     private let usageRing = UTIFooterUsageRingView()
     private let alertIcon = UIImageView(image: DesignSystemImages.Glyphs.Size16.alertRecolorable)
+    private let infoIcon = UIImageView(image: DesignSystemImages.Glyphs.Size16.info)
     private let titleLabel = UILabel()
     private let subtitleLabel = UILabel()
     private let actionButton = UTIFooterActionButton()
@@ -72,13 +73,20 @@ final class UTIFooterCardView: UIView {
         case .none:
             usageRing.isHidden = true
             alertIcon.isHidden = true
+            infoIcon.isHidden = true
         case .usageRing(let progress, let severity):
             usageRing.isHidden = false
             alertIcon.isHidden = true
+            infoIcon.isHidden = true
             usageRing.setProgress(progress, severity: severity, animated: animateIcon)
         case .alert:
             usageRing.isHidden = true
             alertIcon.isHidden = false
+            infoIcon.isHidden = true
+        case .info:
+            usageRing.isHidden = true
+            alertIcon.isHidden = true
+            infoIcon.isHidden = false
         }
         let hasIcon = message.icon != UTIFooterMessage.Icon.none
         iconSlotWidthConstraint?.constant = hasIcon ? Constants.iconSize : 0
@@ -135,7 +143,7 @@ private extension UTIFooterCardView {
         contentView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(contentView)
 
-        [usageRing, alertIcon].forEach {
+        [usageRing, alertIcon, infoIcon].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             $0.setContentHuggingPriority(.required, for: .horizontal)
             $0.setContentCompressionResistancePriority(.required, for: .horizontal)
@@ -143,8 +151,11 @@ private extension UTIFooterCardView {
         }
         usageRing.accessibilityIdentifier = "AIChat.Footer.Icon.UsageRing"
         alertIcon.accessibilityIdentifier = "AIChat.Footer.Icon.Alert"
-        alertIcon.contentMode = .scaleAspectFit
-        alertIcon.isHidden = true
+        infoIcon.accessibilityIdentifier = "AIChat.Footer.Icon.Info"
+        [alertIcon, infoIcon].forEach {
+            $0.contentMode = .scaleAspectFit
+            $0.isHidden = true
+        }
 
         for label in [titleLabel, subtitleLabel] {
             label.numberOfLines = 1
@@ -210,6 +221,11 @@ private extension UTIFooterCardView {
             alertIcon.widthAnchor.constraint(equalToConstant: Constants.iconSize),
             alertIcon.heightAnchor.constraint(equalToConstant: Constants.iconSize),
 
+            infoIcon.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            infoIcon.centerYAnchor.constraint(equalTo: textStack.centerYAnchor),
+            infoIcon.widthAnchor.constraint(equalToConstant: Constants.iconSize),
+            infoIcon.heightAnchor.constraint(equalToConstant: Constants.iconSize),
+
             iconTextGap,
             textStack.topAnchor.constraint(equalTo: contentView.topAnchor),
             textStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
@@ -236,6 +252,7 @@ private extension UTIFooterCardView {
         titleLabel.textColor = UIColor(designSystemColor: .textPrimary)
         subtitleLabel.textColor = UIColor(designSystemColor: .textSecondary)
         alertIcon.tintColor = UIColor(designSystemColor: .icons)
+        infoIcon.tintColor = UIColor(designSystemColor: .icons)
         dismissButton.tintColor = UIColor(designSystemColor: .iconsSecondary)
         actionButton.applyColors()
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterMessage.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterMessage.swift
@@ -26,6 +26,7 @@ struct UTIFooterMessage: Equatable {
         case none
         case usageRing(progress: Double, severity: DuckAiUsageSeverity)
         case alert
+        case info
     }
 
     struct PrimaryAction: Equatable {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterMessageMapper.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterMessageMapper.swift
@@ -42,7 +42,7 @@ struct UTIFooterMessageMapper {
 
     func message(for notice: DuckAiHighUsageModelNotice) -> UTIFooterMessage {
         UTIFooterMessage(
-            icon: .none,
+            icon: .info,
             title: String(format: UserText.utiDuckAIWarningsHighUsageModel, notice.modelShortName),
             subtitle: nil,
             primaryAction: nil,

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterCardViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterCardViewTests.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+import DesignResourcesKitIcons
 import UIKit
 import XCTest
 @testable import DuckDuckGo
@@ -99,9 +100,30 @@ final class UTIFooterCardViewTests: XCTestCase {
         let sut = UTIFooterCardView()
 
         let withIcon = titleLeadingEdge(in: sut, message: makeMessage())
-        let withoutIcon = titleLeadingEdge(in: sut, message: makeNotice())
+        let withoutIcon = titleLeadingEdge(in: sut, message: makeIconlessMessage())
 
         XCTAssertLessThan(withoutIcon, withIcon)
+    }
+
+    /// The notice carries a glyph of its own, so its copy starts where a warning's copy starts.
+    func test_cardWidth_reservesTheIconSlotForTheNotice() {
+        let sut = UTIFooterCardView()
+
+        let withRing = titleLeadingEdge(in: sut, message: makeMessage())
+        let withInfo = titleLeadingEdge(in: sut, message: makeNotice())
+
+        XCTAssertEqual(withInfo, withRing, accuracy: 0.5)
+    }
+
+    func test_icon_showsTheInfoGlyphOnlyForTheNotice() {
+        let sut = UTIFooterCardView()
+
+        sut.configure(with: makeMessage(), animateIcon: false)
+        XCTAssertEqual(infoIcon(in: sut)?.isHidden, true)
+
+        sut.configure(with: makeNotice(), animateIcon: false)
+        XCTAssertEqual(infoIcon(in: sut)?.isHidden, false)
+        XCTAssertEqual(infoIcon(in: sut)?.image, DesignSystemImages.Glyphs.Size16.info)
     }
 
     /// A message with no CTA must leave no gap where the pill would have been.
@@ -163,6 +185,12 @@ final class UTIFooterCardViewTests: XCTestCase {
         return card.convert(subview.bounds, from: subview).maxX
     }
 
+    private func infoIcon(in card: UTIFooterCardView) -> UIImageView? {
+        card.subviews.flatMap(\.subviews)
+            .compactMap { $0 as? UIImageView }
+            .first { $0.accessibilityIdentifier == "AIChat.Footer.Icon.Info" }
+    }
+
     private func actionButton(in card: UTIFooterCardView) -> UTIFooterActionButton? {
         card.subviews.flatMap(\.subviews).compactMap { $0 as? UTIFooterActionButton }.first
     }
@@ -222,10 +250,18 @@ final class UTIFooterCardViewTests: XCTestCase {
     }
 
     private func makeNotice(title: String = "Opus 4.8 uses limits up to 2-5x faster than basic models.") -> UTIFooterMessage {
-        UTIFooterMessage(icon: .none,
+        UTIFooterMessage(icon: .info,
                          title: title,
                          subtitle: nil,
                          primaryAction: nil,
+                         isDismissible: true)
+    }
+
+    private func makeIconlessMessage() -> UTIFooterMessage {
+        UTIFooterMessage(icon: .none,
+                         title: "90% of weekly limit",
+                         subtitle: "Resets in 2 days",
+                         primaryAction: .init(title: "Switch"),
                          isDismissible: true)
     }
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterMessageMapperTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterMessageMapperTests.swift
@@ -153,8 +153,8 @@ final class UTIFooterMessageMapperTests: XCTestCase {
     }
 
     /// Keyed off the selected model, not the allowance, so there is no percentage and no reset line.
-    func test_message_highUsageNoticeShowsNoIconAndNoResetLine() {
-        XCTAssertEqual(sut.message(for: notice).icon, UTIFooterMessage.Icon.none)
+    func test_message_highUsageNoticeShowsTheInfoIconAndNoResetLine() {
+        XCTAssertEqual(sut.message(for: notice).icon, .info)
         XCTAssertNil(sut.message(for: notice).subtitle)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1218007020253569?focus=true
Tech Design URL:
CC:

### Description
The Duck.ai high-usage model notice in the input bar's footer was rendering without the (i) icon the design calls for, leaving its copy flush against the card's leading edge. It now shows the design system's 16pt Info glyph in the same leading slot the usage ring and alert glyph already use.

### Testing Steps
1. Enable the unified toggle input and the Duck.ai usage warnings, then open the Duck.ai input bar.
2. Select an advanced model (e.g. Opus 4.8) so the "uses limits up to 2-5x faster than basic models" notice appears in the footer card → the copy is preceded by an outlined (i) icon, vertically centred on the text.
3. Switch to dark mode → the icon tints with the rest of the card's iconography, and the ✕ still dismisses the notice.

### Impact
Low

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Unable to generate summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3ba8344b8aeb99abdc14a3b3006d30c75485b88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->