### PR TITLE
Fix: Preventing Data Access Notification

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/FileManagerExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/FileManagerExtension.swift
@@ -140,16 +140,8 @@ extension FileManager {
         }
     }
 
-    /// `true` only when the directory exists but listing it failed because of missing permissions.
+    /// `true` only when the directory exists but we don't have the rights to access its contents
     func requiresReadPermission(atPath path: String) -> Bool {
-        do {
-            _ = try contentsOfDirectory(atPath: path)
-        } catch let error as CocoaError where error.code == .fileReadNoPermission {
-            return true
-        } catch {
-            Logger.general.error("Failed to list directory contents: \(error.localizedDescription)")
-        }
-
-        return false
+        directoryExists(atPath: path) && !isReadableFile(atPath: path)
     }
 }

--- a/macOS/DuckDuckGo/DataImport/ThirdPartyBrowser.swift
+++ b/macOS/DuckDuckGo/DataImport/ThirdPartyBrowser.swift
@@ -197,6 +197,10 @@ enum ThirdPartyBrowser: CaseIterable {
             let fm = FileManager()
             let profilesDirectories = self.profilesDirectories(applicationSupportURL: applicationSupportURL)
             return profilesDirectories.reduce(into: []) { result, profilesDir in
+                if fm.requiresReadPermission(atPath: profilesDir.path) {
+                    return
+                }
+
                 result.append(contentsOf: (try? fm.contentsOfDirectory(at: profilesDir,
                                                                        includingPropertiesForKeys: nil,
                                                                        options: [.skipsHiddenFiles])

--- a/macOS/DuckDuckGo/DataImport/ThirdPartyBrowser.swift
+++ b/macOS/DuckDuckGo/DataImport/ThirdPartyBrowser.swift
@@ -197,7 +197,7 @@ enum ThirdPartyBrowser: CaseIterable {
             let fm = FileManager()
             let profilesDirectories = self.profilesDirectories(applicationSupportURL: applicationSupportURL)
             return profilesDirectories.reduce(into: []) { result, profilesDir in
-                if fm.requiresReadPermission(atPath: profilesDir.path) {
+                if detectsInaccessibleProfiles, fm.requiresReadPermission(atPath: profilesDir.path) {
                     return
                 }
 
@@ -348,11 +348,7 @@ extension ThirdPartyBrowser {
         let fileManager = FileManager.default
 
         return profiles.filter { directory in
-            guard fileManager.directoryExists(atPath: directory.path) else {
-                return false
-            }
-
-            return fileManager.requiresReadPermission(atPath: directory.path)
+            fileManager.requiresReadPermission(atPath: directory.path)
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/inbox/1211150618028591/item/1217942133387788/story/1217913288174333?focus=true
Tech Design URL:
CC:

### Description
This PR prevents the `Data Access Blocked` Notification, triggered on macOS 27 when attempting to import Bookmarks fro other browsers.

### Testing Steps
1. Download [this Demo DMG](https://staticcdn.duckduckgo.com/macos-desktop-browser/a81f9679-e41d-404d-81a6-fd4a461d82f7/testbuilds/4c7e48cc/duckduckgo-review-1.206.0.801.dmg)
2. Launch on macOS 27, fresh user
3. Click on `File > Import Bookmarks & Passwords` 
4. Click on `Chrome`

- [ ] Verify you don't get a `Data Access Blocked` System Notification

### Impact
Medium: Could disrupt specific features or user flows

#### What could go wrong?
We could introduce a regression in the import flow

### Quality Considerations
Nothing in particular

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to macOS data-import profile discovery and permission detection; reduces TCC side effects without changing import execution paths for accessible profiles.
> 
> **Overview**
> Fixes unwanted **data access notifications** during third-party browser import on macOS 27+ when another browser’s Application Support folder is TCC-protected.
> 
> **`requiresReadPermission`** no longer lists directory contents to detect permission denial. It now treats a path as needing read access when the directory exists but **`isReadableFile`** reports it isn’t readable—avoiding a listing call that can trigger the system prompt.
> 
> When **`detectsInaccessibleProfiles`** is enabled, profile discovery **skips `contentsOfDirectory`** for profile roots that already need permission, and inaccessible roots are still surfaced as **permission-denied** profiles via the simplified **`inaccessibleProfilesDirectories`** filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c7e48cc5ce44db70763a209337775d09e468a6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->