### PR TITLE
Update CLAUDE.md with a note about the Privacy Config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,12 @@ Detailed rules live in `.cursor/rules/`. Read from the list below when the reque
 | `pixels.mdc` | Defining, naming, or firing pixel events |
 | `project-structure.mdc` | Adding files or directories to the iOS project; buildable folders and Xcode groups |
 
+## Testing against the Privacy Configuration
+
+Do not write unit tests that assert the current state of the Privacy Configuration, such as whether a particular feature or flag is present, absent, enabled, or disabled. The Privacy Configuration is controlled remotely, so tests that rely on it too strongly may be affected.
+
+Instead, arrange each relevant configuration state explicitly and verify the app's behavior in that state. Where applicable, verify behavior when flags are added or removed, enabled or disabled, or changed while the app is running.
+
 ## Opening a PR with snapshot changes
 
 Before opening a monorepo PR, if the working tree has changes under the `SnapshotReferences` submodule, run `./scripts/open-snapshot-submodule-pr.sh` first, then add the submodule PR link it prints to the monorepo PR description.


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1218030284184969?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

This PR adds a note to our CLAUDE.md file about the Privacy Config, to warn LLMs about relying too strongly on the state of the config itself, which can change at any time and break tests which do so.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Check that the text accurately captures the problem

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to AI assistant conventions with no runtime or test behavior impact.
> 
> **Overview**
> Adds a **Testing against the Privacy Configuration** section to `AGENTS.md` so AI assistants follow team conventions when writing tests.
> 
> The new guidance tells assistants **not** to assert the live Privacy Configuration (feature presence, enabled/disabled flags) because it is **remotely controlled** and can change. Tests should **set configuration explicitly** and verify behavior in those states, including when flags are toggled or updated at runtime where relevant.
> 
> This is documentation-only; it mirrors the PR intent for `CLAUDE.md` but lands in the repo’s shared `AGENTS.md` rules index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eb42cf18f11a6b3d2ef97e650412888d48cb928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->