### PR TITLE
iOS: Loading chip while a PDF's bytes are read

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/iOS/Views/ContextChip/AIChatContextChipView.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/Views/ContextChip/AIChatContextChipView.swift
@@ -61,9 +61,12 @@ public final class AIChatContextChipView: UIView {
     public enum State {
         case placeholder
         case attached(title: String, favicon: UIImage?)
+        case loading
     }
 
     private var currentState: State = .placeholder
+
+    private var loadingView: AIChatSuggestionsLoadingView?
 
     /// Only live in the placeholder state. Left enabled in the attached state it would recognise taps on
     /// the remove button and cancel them, since it spans the whole chip.
@@ -212,7 +215,31 @@ private extension AIChatContextChipView {
     }
 
     func updateUI(for state: State) {
+        hideLoadingView()
+        faviconView.isHidden = false
+        titleLabel.isHidden = false
+
         switch state {
+        case .loading:
+            isHidden = false
+            faviconView.isHidden = true
+            titleLabel.isHidden = true
+            removeButton.isHidden = true
+            // The chip draws the pill (same size as the attached chip); the loading view lends only its
+            // dots. Hug them rather than the fixed attached width.
+            backgroundColor = UIColor(designSystemColor: .controlsFillPrimary)
+            applyBorder(width: Constants.borderWidth)
+            fixedWidthConstraint.isActive = false
+            titleTrailingToRemoveButtonConstraint.isActive = false
+            titleTrailingToEdgeConstraint.isActive = false
+            showLoadingView()
+            isUserInteractionEnabled = false
+            placeholderTapRecognizer.isEnabled = false
+            isAccessibilityElement = true
+            accessibilityIdentifier = "AIChat.ContextChip.Loading"
+            accessibilityLabel = UserText.askAboutPage
+            accessibilityTraits = .none
+
         case .placeholder:
             // Reads as a button, since tapping it re-attaches the page the user removed. Keeping it in
             // the strip means removing and re-attaching never changes the input's height.
@@ -337,6 +364,26 @@ private extension AIChatContextChipView {
 
     func placeholderFavicon() -> UIImage? {
         return DesignSystemImages.Glyphs.Size24.globe.withRenderingMode(.alwaysTemplate)
+    }
+
+    func showLoadingView() {
+        guard loadingView == nil else { return }
+        let view = AIChatSuggestionsLoadingView()
+        view.backgroundColor = .clear
+        view.layer.borderWidth = 0
+        view.translatesAutoresizingMaskIntoConstraints = false
+        chipContentView.addSubview(view)
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: chipContentView.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: chipContentView.trailingAnchor),
+            view.centerYAnchor.constraint(equalTo: chipContentView.centerYAnchor)
+        ])
+        loadingView = view
+    }
+
+    func hideLoadingView() {
+        loadingView?.removeFromSuperview()
+        loadingView = nil
     }
 
     @objc func removeButtonTapped() {

--- a/SharedPackages/AIChat/Sources/AIChat/iOS/Views/ContextChip/AIChatContextChipView.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/iOS/Views/ContextChip/AIChatContextChipView.swift
@@ -225,8 +225,6 @@ private extension AIChatContextChipView {
             faviconView.isHidden = true
             titleLabel.isHidden = true
             removeButton.isHidden = true
-            // The chip draws the pill (same size as the attached chip); the loading view lends only its
-            // dots. Hug them rather than the fixed attached width.
             backgroundColor = UIColor(designSystemColor: .controlsFillPrimary)
             applyBorder(width: Constants.borderWidth)
             fixedWidthConstraint.isActive = false

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -171,8 +171,8 @@ final class AIChatContextualChatSessionState {
     private var isManualAttachInProgress = false
     private var isManualAttachFromFrontend = false
 
-    /// True while a document's bytes are read
-    private var isDocumentReadInProgress = false
+    /// True while the loading chip is showing; the start surface is suppressed only then.
+    private var isDocumentChipLoading = false
 
     /// Flag to prevent duplicate navigation processing
     private var isProcessingNavigation = false
@@ -399,6 +399,7 @@ final class AIChatContextualChatSessionState {
         userDowngradedToPlaceholder = false
         isManualAttachInProgress = false
         isManualAttachFromFrontend = false
+        isDocumentChipLoading = false
         isProcessingNavigation = false
         pendingSignalsOnlyCollection = false
         suggestionsResolveTask?.cancel()
@@ -560,9 +561,9 @@ final class AIChatContextualChatSessionState {
         suppressesAutoAttachForSelectionEntry = false
     }
 
-    func setDocumentReadInProgress(_ inProgress: Bool) {
-        guard isDocumentReadInProgress != inProgress else { return }
-        isDocumentReadInProgress = inProgress
+    func setDocumentChipLoading(_ isLoading: Bool) {
+        guard isDocumentChipLoading != isLoading else { return }
+        isDocumentChipLoading = isLoading
         rebuildViewState()
     }
 
@@ -838,11 +839,11 @@ private extension AIChatContextualChatSessionState {
     /// Beyond one attachment a single-line suggestion can no longer say which part of the prompt it
     /// acts on.
     private var shouldHideSuggestions: Bool {
-        attachmentCount > 1 || isDocumentReadInProgress
+        attachmentCount > 1 || isDocumentChipLoading
     }
 
     private func resolveQuickActions() -> [AIChatContextualQuickAction] {
-        if isDocumentReadInProgress {
+        if isDocumentChipLoading {
             return []
         }
         if !attachedSelections.isEmpty, frontendState == .noChat {
@@ -932,7 +933,7 @@ private extension AIChatContextualChatSessionState {
             chipState: chipState,
             quickActions: quickActions,
             suggestions: shouldHideSuggestions ? [] : visibleSuggestions(reserving: quickActions.count),
-            suggestionsLoadState: isDocumentReadInProgress ? .loaded : suggestionsLoadState,
+            suggestionsLoadState: isDocumentChipLoading ? .loaded : suggestionsLoadState,
             suggestionsAreSmart: suggestionsAreSmart,
             suggestionsPageType: suggestionsPageType,
             suggestionsScope: suggestionsScope

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -171,7 +171,7 @@ final class AIChatContextualChatSessionState {
     private var isManualAttachInProgress = false
     private var isManualAttachFromFrontend = false
 
-    /// True while the loading chip is showing; the start surface is suppressed only then.
+    /// True while the loading chip is showing;
     private var isDocumentChipLoading = false
 
     /// Flag to prevent duplicate navigation processing

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualChatSessionState.swift
@@ -171,6 +171,9 @@ final class AIChatContextualChatSessionState {
     private var isManualAttachInProgress = false
     private var isManualAttachFromFrontend = false
 
+    /// True while a document's bytes are read
+    private var isDocumentReadInProgress = false
+
     /// Flag to prevent duplicate navigation processing
     private var isProcessingNavigation = false
 
@@ -557,6 +560,12 @@ final class AIChatContextualChatSessionState {
         suppressesAutoAttachForSelectionEntry = false
     }
 
+    func setDocumentReadInProgress(_ inProgress: Bool) {
+        guard isDocumentReadInProgress != inProgress else { return }
+        isDocumentReadInProgress = inProgress
+        rebuildViewState()
+    }
+
     func beginLoadingSuggestions() {
         guard featureFlagger.isFeatureOn(.contextualSuggestedPrompts), !hasActiveChat else { return }
         suggestionsResolveTask?.cancel()
@@ -829,11 +838,13 @@ private extension AIChatContextualChatSessionState {
     /// Beyond one attachment a single-line suggestion can no longer say which part of the prompt it
     /// acts on.
     private var shouldHideSuggestions: Bool {
-        attachmentCount > 1
+        attachmentCount > 1 || isDocumentReadInProgress
     }
 
     private func resolveQuickActions() -> [AIChatContextualQuickAction] {
-        // These are all page-scoped, so beside an attached selection they act on the wrong thing.
+        if isDocumentReadInProgress {
+            return []
+        }
         if !attachedSelections.isEmpty, frontendState == .noChat {
             return []
         }
@@ -921,7 +932,7 @@ private extension AIChatContextualChatSessionState {
             chipState: chipState,
             quickActions: quickActions,
             suggestions: shouldHideSuggestions ? [] : visibleSuggestions(reserving: quickActions.count),
-            suggestionsLoadState: suggestionsLoadState,
+            suggestionsLoadState: isDocumentReadInProgress ? .loaded : suggestionsLoadState,
             suggestionsAreSmart: suggestionsAreSmart,
             suggestionsPageType: suggestionsPageType,
             suggestionsScope: suggestionsScope

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -236,15 +236,15 @@ final class AIChatContextualSheetCoordinator {
             }
         self.documentReadCancellable = pageContextHandler.documentReadInProgressPublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] inProgress in
-                self?.sessionState.setDocumentReadInProgress(inProgress)
-                guard let chip = self?.persistentUTIHost?.chipViewModel else { return }
-                if inProgress {
-                    chip.beginLoading()
-                } else {
-                    chip.endLoading()
-                }
-            }
+            .sink { [weak self] in self?.handleDocumentReadInProgress($0) }
+    }
+
+    /// Drives both loading effects together: the chip shows the dots, and the start surface hides
+    /// only when that chip is actually loading (needs the UTI host), so they can't decouple.
+    private func handleDocumentReadInProgress(_ inProgress: Bool) {
+        let chip = persistentUTIHost?.chipViewModel
+        if inProgress { chip?.beginLoading() } else { chip?.endLoading() }
+        sessionState.setDocumentChipLoading(inProgress && chip != nil)
     }
 
     // MARK: - Public Methods

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -239,8 +239,6 @@ final class AIChatContextualSheetCoordinator {
             .sink { [weak self] in self?.handleDocumentReadInProgress($0) }
     }
 
-    /// Drives both loading effects together: the chip shows the dots, and the start surface hides
-    /// only when that chip is actually loading (needs the UTI host), so they can't decouple.
     private func handleDocumentReadInProgress(_ inProgress: Bool) {
         let chip = persistentUTIHost?.chipViewModel
         if inProgress { chip?.beginLoading() } else { chip?.endLoading() }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -105,6 +105,7 @@ final class AIChatContextualSheetCoordinator {
     private var sessionEffectCancellable: AnyCancellable?
     private var currentPageURLCancellable: AnyCancellable?
     private var didFinishURLCancellable: AnyCancellable?
+    private var documentReadCancellable: AnyCancellable?
     private var currentPageURL: URL?
     private(set) var persistentUTIHost: AIChatContextualUTIHost?
     private var latestDidFinishURL: URL?
@@ -231,6 +232,17 @@ final class AIChatContextualSheetCoordinator {
                 Task { [weak self] in
                     self?.latestDidFinishURL = url
                     await self?.notifyPageChanged()
+                }
+            }
+        self.documentReadCancellable = pageContextHandler.documentReadInProgressPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] inProgress in
+                self?.sessionState.setDocumentReadInProgress(inProgress)
+                guard let chip = self?.persistentUTIHost?.chipViewModel else { return }
+                if inProgress {
+                    chip.beginLoading()
+                } else {
+                    chip.endLoading()
                 }
             }
     }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatPageContextHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatPageContextHandler.swift
@@ -77,6 +77,9 @@ protocol AIChatPageContextHandling: AnyObject {
     /// Publisher for context updates. Subscribe to receive results after triggering collection.
     var contextPublisher: AnyPublisher<AIChatPageContext?, Never> { get }
 
+    /// True while a document tab's bytes are being read; drives the attachment chip's loading state.
+    var documentReadInProgressPublisher: AnyPublisher<Bool, Never> { get }
+
     /// Triggers context collection from JS. Does not return the result directly.
     /// Callers should subscribe to `contextPublisher` for results.
     /// Note: First call also starts observing auto-updates from the page.
@@ -132,12 +135,17 @@ final class AIChatPageContextHandler: AIChatPageContextHandling {
     private static let collectionTimeout: TimeInterval = 30
 
     private let contextSubject = CurrentValueSubject<AIChatPageContext?, Never>(nil)
+    private let documentReadInProgressSubject = CurrentValueSubject<Bool, Never>(false)
     private var updatesCancellable: AnyCancellable?
 
     // MARK: - AIChatPageContextHandling
 
     var contextPublisher: AnyPublisher<AIChatPageContext?, Never> {
         contextSubject.eraseToAnyPublisher()
+    }
+
+    var documentReadInProgressPublisher: AnyPublisher<Bool, Never> {
+        documentReadInProgressSubject.eraseToAnyPublisher()
     }
 
     // MARK: - Initialization
@@ -298,7 +306,6 @@ private extension AIChatPageContextHandler {
         publishContextUpdate(context)
     }
 
-    /// Reads the document out of the web view and delivers it as page context.
     func collectDocumentContext(for url: URL, trigger: PageContextExtractionTrigger) {
         guard let webView = webViewProvider() else {
             Logger.aiChat.debug("[PageContext] Document collect skipped - no web view available")
@@ -309,8 +316,10 @@ private extension AIChatPageContextHandler {
 
         let title = documentTitle(for: url, webView: webView)
         let startedAt = Date()
+        documentReadInProgressSubject.send(true)
         Task { @MainActor [weak self] in
             guard let self else { return }
+            defer { self.documentReadInProgressSubject.send(false) }
             let result = await self.makeDocumentContext(webView, url, title)
             let latency = PageContextExtractionLatencyBucket(seconds: Date().timeIntervalSince(startedAt))
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatPageContextHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatPageContextHandler.swift
@@ -365,6 +365,8 @@ private extension AIChatPageContextHandler {
         extractionResolver.reset()
         didReportExtractionForCurrentNavigation = false
         lastCollectedURL = nil
+        // Clear the loading flag so an abandoned read can't keep the start surface hidden.
+        documentReadInProgressSubject.send(false)
     }
 
     /// No pending request => a duplicate or a collect we didn't initiate; skip.

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatPageContextHandler.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatPageContextHandler.swift
@@ -77,7 +77,7 @@ protocol AIChatPageContextHandling: AnyObject {
     /// Publisher for context updates. Subscribe to receive results after triggering collection.
     var contextPublisher: AnyPublisher<AIChatPageContext?, Never> { get }
 
-    /// True while a document tab's bytes are being read; drives the attachment chip's loading state.
+    /// True while a document tab's bytes are being read;
     var documentReadInProgressPublisher: AnyPublisher<Bool, Never> { get }
 
     /// Triggers context collection from JS. Does not return the result directly.
@@ -365,7 +365,6 @@ private extension AIChatPageContextHandler {
         extractionResolver.reset()
         didReportExtractionForCurrentNavigation = false
         lastCollectedURL = nil
-        // Clear the loading flag so an abandoned read can't keep the start surface hidden.
         documentReadInProgressSubject.send(false)
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
@@ -59,7 +59,6 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     /// Presentation-only pending/delivered flag; set solely by `setAttached`, never decided by the chip.
     private var attachmentDeliveryState: PageContextAttachmentDeliveryState = .pendingSubmit
     private var isShowingAttachAffordance = false
-    /// True while the page's bytes are read; shows the loading chip.
     private var isLoading = false
     private var cancellables = Set<AnyCancellable>()
 
@@ -165,7 +164,7 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
         let isMatching = attachedURL != nil && attachedURL == originatingURL
         let branch: String
 
-        if isLoading, attachedContext == nil {
+        if isLoading {
             state = .loading
             isVisible = true
             branch = "loading"

--- a/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
@@ -59,6 +59,8 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
     /// Presentation-only pending/delivered flag; set solely by `setAttached`, never decided by the chip.
     private var attachmentDeliveryState: PageContextAttachmentDeliveryState = .pendingSubmit
     private var isShowingAttachAffordance = false
+    /// True while the page's bytes are read; shows the loading chip.
+    private var isLoading = false
     private var cancellables = Set<AnyCancellable>()
 
     init(
@@ -85,6 +87,7 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
 
     func setAttached(_ context: AIChatPageContext, deliveryState: PageContextAttachmentDeliveryState = .pendingSubmit) {
         isShowingAttachAffordance = false
+        isLoading = false
         updateAttachment(context, deliveryState: deliveryState)
         Logger.contextualUTI.debug("PageContextChip attached")
         recompute()
@@ -92,8 +95,23 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
 
     func clearAttached() {
         isShowingAttachAffordance = false
+        isLoading = false
         clearAttachmentState()
         Logger.contextualUTI.debug("PageContextChip detached")
+        recompute()
+    }
+
+    /// Show the loading chip until `setAttached` lands, or `endLoading` clears it if the read fails.
+    func beginLoading() {
+        guard !isLoading else { return }
+        isLoading = true
+        Logger.contextualUTI.debug("PageContextChip loading")
+        recompute()
+    }
+
+    func endLoading() {
+        guard isLoading else { return }
+        isLoading = false
         recompute()
     }
 
@@ -147,7 +165,11 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
         let isMatching = attachedURL != nil && attachedURL == originatingURL
         let branch: String
 
-        if isShowingAttachAffordance {
+        if isLoading, attachedContext == nil {
+            state = .loading
+            isVisible = true
+            branch = "loading"
+        } else if isShowingAttachAffordance {
             state = .placeholder
             isVisible = false
             branch = "attachAffordance"
@@ -165,6 +187,7 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
             switch state {
             case .placeholder: return "placeholder"
             case .attached(let title, _): return "attached(\(title))"
+            case .loading: return "loading"
             }
         }()
         Logger.contextualUTI.debug("ChipViewModel recompute → \(branch, privacy: .public) state=\(stateDesc, privacy: .public) isVisible=\(self.isVisible, privacy: .public) auto=\(self.isAutoAttachEnabled(), privacy: .public) attached=\(self.attachedContext != nil, privacy: .public) attachedURL=\(self.attachedURL?.shortDescription ?? "nil", privacy: .private) originatingURL=\(self.originatingURL?.shortDescription ?? "nil", privacy: .private)")

--- a/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/PageContextChip/UnifiedToggleInputPageContextChipViewModel.swift
@@ -100,7 +100,6 @@ final class UnifiedToggleInputPageContextChipViewModel: ObservableObject {
         recompute()
     }
 
-    /// Show the loading chip until `setAttached` lands, or `endLoading` clears it if the read fails.
     func beginLoading() {
         guard !isLoading else { return }
         isLoading = true

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -44,8 +44,17 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
             contextSubject.eraseToAnyPublisher()
         }
 
+        private let documentReadInProgressSubject = CurrentValueSubject<Bool, Never>(false)
+        var documentReadInProgressPublisher: AnyPublisher<Bool, Never> {
+            documentReadInProgressSubject.eraseToAnyPublisher()
+        }
+
         func sendContext(_ context: AIChatPageContext?) {
             contextSubject.send(context)
+        }
+
+        func sendDocumentReadInProgress(_ inProgress: Bool) {
+            documentReadInProgressSubject.send(inProgress)
         }
 
         var isCurrentPageAttachableReturnValue = true

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputPageContextChipViewModelTests.swift
@@ -69,6 +69,37 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         XCTAssertEqual(removeCalls, 1)
     }
 
+    // MARK: - Loading
+
+    func test_beginLoading_showsLoadingChip() {
+        makeSUT()
+        sut.beginLoading()
+        XCTAssertTrue(sut.isVisible)
+        XCTAssertEqualState(sut.state, .loading)
+    }
+
+    func test_setAttached_replacesLoadingWithAttachedChip() {
+        let url = "https://example.com/spec.pdf"
+        originatingURL.send(URL(string: url))
+        makeSUT()
+        sut.beginLoading()
+
+        sut.setAttached(makeContext(title: "Spec", url: url), deliveryState: .pendingSubmit)
+
+        XCTAssertTrue(sut.isVisible)
+        XCTAssertEqualState(sut.state, .attached(title: "Spec", favicon: nil))
+    }
+
+    func test_endLoading_afterFailedRead_leavesNoLoadingChip() {
+        makeSUT()
+        sut.beginLoading()
+
+        sut.endLoading()
+
+        XCTAssertFalse(sut.isVisible)
+        XCTAssertEqualState(sut.state, .placeholder)
+    }
+
     // MARK: - State transitions
 
     func test_initial_attachedAndOriginatingMatches_isAttached() {
@@ -480,6 +511,8 @@ final class UnifiedToggleInputPageContextChipViewModelTests: XCTestCase {
         case (.placeholder, .placeholder):
             return
         case (.attached(let lt, _), .attached(let rt, _)) where lt == rt:
+            return
+        case (.loading, .loading):
             return
         default:
             XCTFail("State mismatch: \(lhs) vs \(rhs)", file: file, line: line)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204186595873227/task/1218023815227728?focus=true


### Description
On iOS, attaching a PDF to Duck.ai re-fetches the document over the network, so there is a silent pause between tapping "Ask about page" (or auto-attach) and the attachment appearing. This adds a loading state: the page-context attachment chip shows an animated dots indicator while the bytes are read, and the start surface (suggestions and the "Ask about page" action) is hidden during the read so the chip is the only loading indicator. The loading chip matches the size/shape of the attached chip it becomes.

### Testing Steps

1. In Debug → Custom Configuration → set the Duck.ai URL to https://euw-serp-dev-testing20.duck.ai/ (the FE support for the new payload isn't in production yet). 
2. Load full Duck.ai in order to go through the authentication
3. **Manual attach**: open Duck.ai with auto-add-page-content off → tap "Ask about page" → the attachment chip shows animated dots, and "Ask about page"/suggestions disappear while it loads → the attached PDF chip replaces the dots once ready.
4. **Auto attach**: with auto-add-page-content on, open Duck.ai on a PDF → the attachment chip shows the dots, then the attached chip.
5. Attach a normal web page → no loading chip (bytes aren't re-fetched); behaves as before.

### Impact

Low — a loading affordance on the contextual Duck.ai attachment; no change to what's attached or sent.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Subscription notification timing shifts for App Store purchases (post-confirmation only), which could affect listeners that relied on the earlier post; PDF loading is localized UI with no payload changes.
> 
> **Overview**
> Adds a **loading** state to the Duck.ai page-context attachment chip while document bytes are read from the web view (e.g. PDF re-fetch). The chip shows the existing animated-dots loader, stays non-interactive, and session UI hides suggestions and quick actions (including “Ask about page”) so only the chip signals progress until attach completes or fails.
> 
> **Wiring:** `AIChatPageContextHandler` publishes `documentReadInProgress` around async document collection; the contextual sheet coordinator drives the chip view model and `setDocumentChipLoading` on session state. Regular HTML pages skip this path.
> 
> **Also in this PR:** `userDidPurchaseSubscription` is no longer posted immediately after a successful App Store `purchaseSubscription` call; it fires only after `completeSubscriptionPurchase` succeeds (with entitlements). Stripe `completeSubscriptionPurchase` now force-refreshes subscription before posting so listeners see confirmed trial/offer data instead of a cleared cache. Tests cover notification posting on success vs missing entitlements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20862acdabb146f4a0f3a4181c24b34dc52f2f0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->