### PR TITLE
Realign the Duck.ai usage-warning Maestro flows with the shipped footer

### DIFF
--- a/.maestro/unified_toggle_input/test_uti_duckai_warnings_approaching.yaml
+++ b/.maestro/unified_toggle_input/test_uti_duckai_warnings_approaching.yaml
@@ -37,7 +37,7 @@ name: test_uti_duckai_warnings_approaching
 - runFlow:
     file: ../shared/seed_duckai_usage_warning.yaml
     env:
-        PRESET: "Weekly 90%"
+        PRESET: "Approaching weekly limit (90%)"
 
 # The snapshot is picked up the next time the Duck.ai input opens.
 - tapOn:

--- a/.maestro/unified_toggle_input/test_uti_duckai_warnings_limit_reached.yaml
+++ b/.maestro/unified_toggle_input/test_uti_duckai_warnings_limit_reached.yaml
@@ -8,7 +8,8 @@ name: test_uti_duckai_warnings_limit_reached
 ---
 
 # The blocked-usage cards behind `utiDuckAIWarnings`. A reached limit reads as an alert rather than
-# a full ring, carries no ✕ (there is nothing to defer), and offers the subscription upsell.
+# a full ring and carries no ✕ (there is nothing to defer). The button is whatever the web app
+# published: a weekly block offers nothing, a free daily block offers the subscription upsell.
 - launchApp:
     appId: "com.duckduckgo.mobile.ios"
     clearState: true
@@ -52,14 +53,14 @@ name: test_uti_duckai_warnings_limit_reached
     id: "AIChat.Footer.Icon.UsageRing"
 - assertNotVisible:
     id: "AIChat.Footer.Button.Dismiss"
-# By identifier only: the CTA reads "Try for free" or "Subscribe" depending on trial eligibility.
-- assertVisible:
+- assertNotVisible:
     id: "AIChat.Footer.Button.Primary"
 
 # A daily block is its own message. Re-seeding in place keeps the second case off a fresh install.
 - runFlow:
     file: ../shared/dismiss_address_bar_editing.yaml
 
+# Two seeds share this label; the free one sorts first, and it is the one with the upsell.
 - runFlow:
     file: ../shared/seed_duckai_usage_warning.yaml
     env:
@@ -81,3 +82,6 @@ name: test_uti_duckai_warnings_limit_reached
     id: "AIChat.Footer.Icon.Alert"
 - assertNotVisible:
     id: "AIChat.Footer.Button.Dismiss"
+# By identifier only: the CTA reads "Try for free" or "Subscribe" depending on trial eligibility.
+- assertVisible:
+    id: "AIChat.Footer.Button.Primary"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1218012549071850?focus=true

### Description

This PR fixes E2E tests on iOS caused by two mismatches:

#6558 moved `"Weekly 90%"` presets onto the shared `DuckAiUsageSnapshotSeed` enum and renamed that row to `"Approaching weekly limit (90%)"`
#6558 made the card render the CTA the web app publishes instead of deriving one, and a weekly hard block publishes no CTA

### Testing Steps

Verify the e2e workflow on this branch (link in a comment below)

To check by hand on an internal build:
1. Launch with `ff.utiDuckAIWarnings` and `ff.aiChatNativeStorage` on.
2. Debug → AI Chat → Duck.ai Usage Warnings, select **Approaching weekly limit (90%)** → focus the address bar in Duck.ai mode → message contains "90% of weekly limit"
3. Select **Weekly limit reached** → mesage contains "Weekly usage limit reached"
4. Select **Daily limit reached** (the row under *Free*) → message contains "Daily limit reached" with **Try for free** or **Subscribe**.

### Impact

None — Maestro flows only, no shipping code.

### Quality Considerations

`freeDailyReached` and `dailyReachedWithBypass` both display as `"Daily limit reached"`, so step 4 above resolves by menu position (the *Free* section scrolls into view first) rather than by name. That is pre-existing and left alone here; a comment in the flow now says so. Worth renaming the paid row separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Maestro YAML only; no production or app code changes.
> 
> **Overview**
> Repairs two nightly iOS Maestro flows that never passed on `main` because they still targeted debug-menu labels and footer assertions from before #6558.
> 
> **Approaching weekly warning:** the seed `PRESET` is updated from `"Weekly 90%"` to `"Approaching weekly limit (90%)"` so the shared seed flow can find the debug row on `DuckAiUsageSnapshotSeed`.
> 
> **Limit reached:** the weekly block case now expects **no** primary CTA (`assertNotVisible` on `AIChat.Footer.Button.Primary`), matching a hard weekly block with no web-published button. The subscription upsell assertion stays on the **Daily limit reached** free seed, with a note that two presets share that menu label and the free row is chosen by sort order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c3d245a0169f8c4736975f8c6ca8ee2a57fa771. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->