### PR TITLE
[macOS] Respect promo timeout when force showing a promo (debug menu)

### DIFF
--- a/macOS/DuckDuckGo/Permissions/Promo/AutoplayDiscoverabilityPromoDelegate.swift
+++ b/macOS/DuckDuckGo/Permissions/Promo/AutoplayDiscoverabilityPromoDelegate.swift
@@ -32,10 +32,6 @@ import PrivacyConfig
 ///
 final class AutoplayDiscoverabilityPromoDelegate: InternalPromoDelegate {
 
-    /// How long the Permission Center stays open before the promo is retired. `PromoServiceFactory` hands this to
-    /// `PromoType` as the promo's custom timeout; the debug force-show path has to apply it itself, see `show(history:force:)`.
-    static let displayDuration: TimeInterval = .seconds(5)
-
     private let featureFlagger: FeatureFlagger
     private let windowControllersManager: WindowControllersManagerProtocol
     private let pixelFiring: PixelFiring?
@@ -77,17 +73,17 @@ final class AutoplayDiscoverabilityPromoDelegate: InternalPromoDelegate {
             return .noChange
         }
 
-        if force {
-            addressBarButtonsViewController.forcePresentPermissionCenterForAutoplayPromo()
-            try? await Task.sleep(nanoseconds: UInt64(Self.displayDuration * TimeInterval(NSEC_PER_SEC)))
-            return .ignored()
-        }
+        let didPresent = force
+            ? addressBarButtonsViewController.forcePresentPermissionCenterForAutoplayPromo()
+            : addressBarButtonsViewController.presentPermissionCenterForAutoplayPromoIfPossible()
 
-        guard addressBarButtonsViewController.presentPermissionCenterForAutoplayPromoIfPossible() else {
+        guard didPresent else {
             return .noChange
         }
 
-        pixelFiring?.fire(AutoplayPromoPixel.shown)
+        if !force {
+            pixelFiring?.fire(AutoplayPromoPixel.shown)
+        }
 
         return await withCheckedContinuation { continuation in
             showContinuation = continuation

--- a/macOS/DuckDuckGo/Promotions/PromoDebugMenu.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoDebugMenu.swift
@@ -36,8 +36,9 @@ import Utilities
 /// - When no promos: disabled "No promos registered"
 ///
 /// **Force-show behavior:**
-/// - Does not affect history, cooldowns, or other promos
-/// - Does not add to activeSessions
+/// - Bypasses `checkRules`/`isEligible`/cooldowns to get shown, then behaves like a real show,
+///   including timeouts, retractions, and conflicts with other promos.
+/// - Never writes to persisted history/cooldowns, regardless of how it resolves (click, timeout, retraction)
 final class PromoDebugMenu: NSMenu {
 
     private var cancellables = Set<AnyCancellable>()

--- a/macOS/DuckDuckGo/Promotions/PromoService.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoService.swift
@@ -28,6 +28,11 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
         let delegate: any InternalPromoDelegate
         let promoType: PromoType
 
+        /// Debug "Force Show": reuses this same session machinery (timeout, eligibility retraction) so
+        /// debug behavior can't drift from a real show, but its outcome must never touch persisted
+        /// history/cooldowns
+        let isForceShow: Bool
+
         /// First-write-wins flag. Once true, ignore further results from show(), timeout, or eligibility.
         var isResultRecorded = false
 
@@ -175,7 +180,7 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
         }
     }
 
-    /// Debug: Force-show a promo by ID, bypassing all evaluation rules. Does not affect history or cooldowns.
+    /// Debug: Force-show a promo by ID, bypassing all evaluation rules.
     /// No-op for external promos (ExternalPromoDelegate); they control their own visibility.
     func forceShow(promoId: String) {
         stateQueue.async { [weak self] in
@@ -188,11 +193,12 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
                 Logger.general.warning("PromoService: forceShow - external promos control their own visibility")
                 return
             }
-            let record = historyStore.record(for: promoId)
-            Task { @MainActor in
-                _ = await delegate.show(history: record, force: true)
-                delegate.hide()
+            guard activeSessions[promoId] == nil else {
+                Logger.general.warning("PromoService: forceShow - \(promoId) already has an active session")
+                return
             }
+            let record = historyStore.record(for: promoId)
+            performShow(promo: promo, delegate: delegate, record: record, isRestore: false, isForceShow: true)
         }
     }
 
@@ -557,15 +563,17 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
 
     // MARK: - Show / Session Management
 
-    private func performShow(promo: Promo, delegate: InternalPromoDelegate, record: PromoHistoryRecord, isRestore: Bool = false) {
+    private func performShow(promo: Promo, delegate: InternalPromoDelegate, record: PromoHistoryRecord, isRestore: Bool = false, isForceShow: Bool = false) {
         dispatchPrecondition(condition: .onQueue(stateQueue))
         let promoId = promo.id
         var recordToUse = record
         if !isRestore {
             recordToUse.lastShown = currentDate
         }
-        historyStore.save(recordToUse)
-        notifyRecordChanged(for: promoId, record: recordToUse)
+        if !isForceShow {
+            historyStore.save(recordToUse)
+            notifyRecordChanged(for: promoId, record: recordToUse)
+        }
 
         let eligibilityCancellable = delegate.isEligiblePublisher
             .dropFirst()
@@ -589,7 +597,7 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
 
         let showTask = Task { @MainActor [weak self] in
             guard !Task.isCancelled else { return }
-            let result = await delegate.show(history: recordToUse, force: false)
+            let result = await delegate.show(history: recordToUse, force: isForceShow)
             self?.stateQueue.async { [weak self] in
                 self?.recordResultAndCleanup(promoId: promoId, result: result)
             }
@@ -599,6 +607,7 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
             promoId: promoId,
             delegate: delegate,
             promoType: promo.promoType,
+            isForceShow: isForceShow,
             isResultRecorded: false,
             showTask: showTask,
             timeout: timeout,
@@ -641,7 +650,9 @@ final class PromoService: @unchecked Sendable, PromoHistoryProviding {
         session.eligibilityCancellable?.cancel()
         session.eligibilityCancellable = nil
 
-        applyResult(result, toRecordFor: promoId)
+        if !session.isForceShow {
+            applyResult(result, toRecordFor: promoId)
+        }
 
         activeSessions.removeValue(forKey: promoId)
 

--- a/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+AutoplayDiscoverability.swift
+++ b/macOS/DuckDuckGo/Promotions/Promos/PromoServiceFactory+AutoplayDiscoverability.swift
@@ -23,7 +23,7 @@ extension PromoServiceFactory {
     /// Builds an Autoplay Discoverability Promo.
     @MainActor
     static func autoplayDiscoverability(dependencies: PromoDependencies) -> Promo {
-        let promoType = PromoType(.featureTip, customTimeoutInterval: AutoplayDiscoverabilityPromoDelegate.displayDuration, customTimeoutResult: .ignored())
+        let promoType = PromoType(.featureTip, customTimeoutResult: .ignored())
         let identifier = "autoplay-discoverability"
         let delegate = AutoplayDiscoverabilityPromoDelegate(featureFlagger: dependencies.featureFlagger,
                                                             windowControllersManager: dependencies.windowControllersManager,


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1218051322379228?focus=true
Tech Design URL:
CC:

### Description

This updates the Promo Queue framework to respect a promo's timeout when force-showing a promo from the debug menu. This force-show debug action allows the promo UI to be viewed separately from the promo queue (e.g. triggers, cooldowns), promo eligibility criteria, and other side effects.

Now, the promo's timeout is respected so the debug action better reflects real promo UI (including auto-dismiss) without having to manually enforce the timeout.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Debug menu → Promo Queue → autoplay-discoverability → Force Show.
2. Confirm the Autoplay Discoverability promo is displayed (a popover on the permission center in the address bar).
3. Wait for 5 seconds and confirm the promo is auto-dismissed.
4. Debug menu → Promo Queue → autoplay-discoverability → Force Show.
5. When the Autoplay Discoverability promo appears, hover the mouse over the popover and confirm it isn't auto-dismissed (matches production behavior).

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
7. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
8. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low: Behavior change is limited to debug action (internal tooling)

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are centered on debug force-show and session bookkeeping; production promo evaluation and history updates are unchanged except removing a redundant custom timeout that matched the feature-tip default.
> 
> **Overview**
> Debug **Force Show** in the Promo Queue menu now runs promos through the same `PromoService` active-session path as production shows, so **timeouts, eligibility retraction, and promo conflicts** behave like a real show instead of a one-off delegate call with a manual sleep.
> 
> Force-show sessions are tagged with **`isForceShow`**: they skip writing **`lastShown`**, cooldown/dismissal history, and **`applyResult`** on any outcome, while still driving **`hide()`** and timeout handling via **`PromoType.timeoutInterval`**.
> 
> For **autoplay discoverability**, the delegate no longer owns a 5s **`displayDuration`** or sleeps on force show; it presents the permission center and awaits the continuation until the service times out or cleans up. **`PromoType(.featureTip)`** still uses the default 5s feature-tip timeout. Force show also skips the **shown** pixel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d63638148083fd14090ca34ecb00d8d3fdd2e21b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->