### PR TITLE
Anchor the Duck.ai usage-warning seed flow on the debug screen before scrolling

### DIFF
--- a/.maestro/shared/seed_duckai_usage_warning.yaml
+++ b/.maestro/shared/seed_duckai_usage_warning.yaml
@@ -20,10 +20,12 @@ appId: com.duckduckgo.mobile.ios
     centerElement: false
 - tapOn: "All debug options"
 
-# The debug screen is pushed asynchronously. Without this anchor the scroll below can start while
+# The debug screen is pushed asynchronously. Without this wait the scroll below can start while
 # Settings is still up, walk it to the bottom looking for a row it does not have, and fail with
-# `No visible element found: "AI Chat"`. First row of the debug screen, so it needs no scrolling.
-- assertVisible: "Shake to Open Debug Menu"
+# `No visible element found: "AI Chat"`. Deliberately not anchored on a row: the first row sits
+# under the search bar, and asserting it failed on the second seed in a flow that seeds twice.
+- waitForAnimationToEnd:
+    timeout: 5000
 
 - scrollUntilVisible:
     element:

--- a/.maestro/shared/seed_duckai_usage_warning.yaml
+++ b/.maestro/shared/seed_duckai_usage_warning.yaml
@@ -20,6 +20,11 @@ appId: com.duckduckgo.mobile.ios
     centerElement: false
 - tapOn: "All debug options"
 
+# The debug screen is pushed asynchronously. Without this anchor the scroll below can start while
+# Settings is still up, walk it to the bottom looking for a row it does not have, and fail with
+# `No visible element found: "AI Chat"`. First row of the debug screen, so it needs no scrolling.
+- assertVisible: "Shake to Open Debug Menu"
+
 - scrollUntilVisible:
     element:
         text: "AI Chat"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1218012549071850?focus=true

### Description

Follow-up to #6594. That PR fixed the two stale assertions; this fixes the flake that stopped its verification run from proving the first of them.

On the #6594 verification run ([33502310229](https://github.com/duckduckgo/apple-browsers/actions/runs/33502310229)), `test_uti_duckai_warnings_limit_reached` passed but `test_uti_duckai_warnings_approaching` failed with `No visible element found: "AI Chat"` — a step in the shared seed flow, before the assertion #6594 had changed. The sibling flow ran those same seed steps twice in the same job, on the same build, and passed, so the step is intermittent rather than broken.

Cause: `All debug options` pushes `DebugScreensViewController` asynchronously and nothing held the flow until it landed. When the following `scrollUntilVisible` wins that race it scrolls Settings, which has no `AI Chat` row, to the bottom and reports the error above.

The fix anchors on the debug screen's first row before scrolling. Worth noting what it is *not*: `AI Chat` sorts first in the `Screens` section (`DebugScreensViewModel.sorter` compares raw `String`, so `AI` beats `Ad`), so the real scroll is one short hop below the fold and a scroll-budget timeout does not explain the failure.

### Testing Steps

Maestro YAML only, so no local build. Verified by dispatching the release suite on this branch (link in a comment below) — that run also exercises the `approaching` preset rename from #6594, which its own verification run never reached.

### Impact

None — Maestro flows only, no shipping code.

#### What could go wrong?

The anchor row is `Shake to Open Debug Menu`, rendered inside `if !model.isSearching` at `DebugScreensViewController.swift:53`. If that copy changes, all three `test_uti_duckai_warnings_*` flows fail at this step with a clear message naming the string → the comment above the assertion says why it is there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Maestro test orchestration only; no shipping app logic, auth, or data handling.
> 
> **Overview**
> Fixes intermittent Maestro failures (`No visible element found: "AI Chat"`) in the shared **Duck.ai usage-warning seed** flow used by the `test_uti_duckai_warnings_*` suites.
> 
> After tapping **All debug options**, the flow now **waits for animations to end** (5s cap) before `scrollUntilVisible` looks for **AI Chat**. That closes a race where **Settings** was still on screen and the scroll hunted for a row that only exists on the pushed debug screen.
> 
> No product code changes—**Maestro YAML only**. Comments document why the wait uses animation end instead of asserting a specific debug row (search bar overlap and double-seed flows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d73ad200e8c3e236130c8746155d324c3d97c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->