### PR TITLE
[iOS] Fix edge-case failure to reload tab after eviction

### DIFF
--- a/iOS/DuckDuckGo/TabManager.swift
+++ b/iOS/DuckDuckGo/TabManager.swift
@@ -175,6 +175,7 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
     private let toggleModeStorage: ToggleModeStoring
     private let duckAiNativeStorageHandler: DuckAiNativeStorageHandling?
     private let duckAiFireModeStorageHandler: DuckAiNativeStorageHandling?
+    private weak var controllerPendingTerminationRecovery: TabViewController?
 
     // Save debouncing. Fires after `saveDebounceInterval` of quiet, or `saveMaxWait` since
     // the first call in the burst (whichever comes first) so sustained activity cannot push
@@ -670,6 +671,9 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
 
     @MainActor
     private func removeFromCache(_ controller: TabViewController) {
+        if controllerPendingTerminationRecovery === controller {
+            controllerPendingTerminationRecovery = nil
+        }
         if let index = tabControllerCache.firstIndex(of: controller) {
             tabControllerCache.remove(at: index)
         }
@@ -743,6 +747,8 @@ class TabManager: TabManaging, TrackerAnimationSuppressing {
                 }
 
                 current()?.reload()
+            } else {
+                controllerPendingTerminationRecovery = controller
             }
         } else {
             evictFromCache(controller, reason: .webContentProcessTermination)
@@ -1023,6 +1029,10 @@ extension TabManager {
     @MainActor
     @objc
     private func onApplicationBecameActive(_ notification: NSNotification) {
+        if let controllerPendingTerminationRecovery {
+            self.controllerPendingTerminationRecovery = nil
+            invalidateCache(forController: controllerPendingTerminationRecovery, reloadCurrent: true)
+        }
         assertTabPreviewCount()
     }
 

--- a/iOS/DuckDuckGoTests/TabManagerTests.swift
+++ b/iOS/DuckDuckGoTests/TabManagerTests.swift
@@ -635,7 +635,63 @@ final class TabManagerTests: XCTestCase {
         XCTAssertTrue(try XCTUnwrap(controller.makeBreakageAdditionalInfo()).isAfterTabTermination)
     }
 
-    func testWhenCurrentTabTerminatesWithoutReloadThenTerminationIsNotRecorded() throws {
+    func testWhenCurrentTabTerminatesInBackgroundThenItReloadsOnceAfterBecomingActive() throws {
+        let detector = MockTabTerminationErrorPageDetector(shouldShowErrorPage: false)
+        let tabsModel = TabsModel(desktop: false)
+        tabsModel.insert(
+            tab: Tab(link: Link(title: "example", url: URL(string: "https://example.com")!)),
+            placement: .atEnd,
+            selectNewTab: true)
+        let manager = try makeManager(
+            tabsModel,
+            tabTerminationErrorPageDetector: detector)
+        let controller = try XCTUnwrap(manager.current(createIfNeeded: true))
+
+        manager.invalidateCache(forController: controller, reloadCurrent: false)
+
+        XCTAssertTrue(detector.checkedTabIDs.isEmpty)
+
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        XCTAssertEqual(detector.checkedTabIDs, [controller.tabModel.uid])
+    }
+
+    func testWhenCurrentTabTerminatesInBackgroundAndIsNoLongerCurrentThenItIsEvictedAfterBecomingActive() throws {
+        let tabs = (0..<2).map {
+            Tab(link: Link(title: "tab-\($0)", url: URL(string: "https://example.com/\($0)")!))
+        }
+        let tabsModel = TabsModel(tabs: tabs, desktop: false)
+        let cacheDelegate = MockTabControllerCacheDelegate()
+        let manager = try makeManager(tabsModel)
+        manager.cacheDelegate = cacheDelegate
+        let controller = try XCTUnwrap(manager.current(createIfNeeded: true))
+
+        manager.invalidateCache(forController: controller, reloadCurrent: false)
+        _ = manager.select(tabs[1])
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        XCTAssertNil(manager.controller(for: tabs[0]))
+        XCTAssertEqual(cacheDelegate.evictionReasons, [.webContentProcessTermination])
+    }
+
+    func testWhenControllerPendingTerminationRecoveryIsRemovedThenItDoesNotReloadAfterBecomingActive() throws {
+        let detector = MockTabTerminationErrorPageDetector(shouldShowErrorPage: false)
+        let tab = Tab(link: Link(title: "example", url: URL(string: "https://example.com")!))
+        let tabsModel = TabsModel(tabs: [tab], desktop: false)
+        let manager = try makeManager(
+            tabsModel,
+            tabTerminationErrorPageDetector: detector)
+        let controller = try XCTUnwrap(manager.current(createIfNeeded: true))
+
+        manager.invalidateCache(forController: controller, reloadCurrent: false)
+        manager.remove(tab: tab)
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        XCTAssertTrue(detector.checkedTabIDs.isEmpty)
+    }
+
+    func testWhenCurrentTabTerminatesInBackgroundThenTerminationThresholdIsCheckedAfterBecomingActive() throws {
         let detector = MockTabTerminationErrorPageDetector(shouldShowErrorPage: true)
         let tabsModel = TabsModel(desktop: false)
         tabsModel.insert(
@@ -653,6 +709,12 @@ final class TabManagerTests: XCTestCase {
         XCTAssertTrue(detector.checkedTabIDs.isEmpty)
         XCTAssertTrue(controller.error.isHidden)
         XCTAssertFalse(try XCTUnwrap(controller.makeBreakageAdditionalInfo()).isAfterTabTermination)
+
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        XCTAssertEqual(detector.checkedTabIDs, [controller.tabModel.uid])
+        XCTAssertFalse(controller.error.isHidden)
+        XCTAssertTrue(try XCTUnwrap(controller.makeBreakageAdditionalInfo()).isAfterTabTermination)
     }
 
     func makeManager(_ model: TabsModel,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1218051328517216?focus=true
Tech Design URL:
CC:

### Description
Restores the current tab after its web content process is terminated while the app is backgrounded. Recovery waits until the app becomes active, preventing frozen navigation while preserving the tab’s history.

### Testing Steps
1. Open a page in a tab.
2. Navigate to a second page in the same tab → the Back button becomes available.
3. Send the app to the background.
4. Terminate the simulator’s WebKit WebContent process.
5. Bring the app to the foreground → the current page reloads and remains responsive.
6. Tap Back → the first page loads.
7. Long-press Back → the history menu opens.
8. Select an entry from the history menu → the selected page loads.
9. Open the tab switcher → the tab switcher responds normally.
10. Tap New Tab → a new tab opens.
11. Run TabManagerTests using the iOS Unit Tests scheme → all 35 tests pass.

### Impact
Medium: A regression could leave a tab unresponsive after returning to the app or cause an unexpected reload.

#### What could go wrong?
A terminated tab could recover more than once → mitigated by clearing the pending recovery before it runs and by unit coverage for repeated activation notifications.

A tab that is closed or is no longer current could be reloaded incorrectly → mitigated by clearing or evicting it and by focused unit coverage.

### Quality Considerations
Background tabs continue to be evicted immediately.
Existing repeated-termination handling and telemetry are unchanged.
Recovery preserves the tab’s back/forward history.
No privacy or security impact.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebKit termination recovery for the foregrounded current tab; a bug could leave tabs unresponsive or reload/evict the wrong controller, though clearing pending state and new tests mitigate double-reload and stale-tab cases.
> 
> **Overview**
> Fixes **frozen or unresponsive tabs** when WebKit kills the web content process while the app is in the background. Instead of leaving the current tab stuck, `TabManager` now **defers recovery** until the app becomes active.
> 
> When `invalidateCache` runs for the current tab with `reloadCurrent: false`, it stores the controller in `controllerPendingTerminationRecovery`. On `UIApplication.didBecomeActive`, it clears that reference and runs the same invalidation path with `reloadCurrent: true` (reload or termination error page), so **back/forward history** stays intact. Pending recovery is cleared if the tab is removed from the cache, and if the tab is no longer current at activation it is **evicted** like a background tab.
> 
> Unit tests cover single reload after repeated activation notifications, eviction after tab switch, no reload after tab close, and deferred termination error-page handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a95bdedf181158bde5baece8b54056d0ec9ea444. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->