### PR TITLE
Enables dataImportDataDirectoryAccess by default

### DIFF
--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -679,7 +679,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .dataImportNewExperience:
             Config(source: .remoteReleasable(DataImportSubfeature.newDataImportExperience))
         case .dataImportDataDirectoryAccess:
-            Config(defaultValue: .disabled, source: .remoteReleasable(DataImportSubfeature.dataDirectoryAccess))
+            Config(defaultValue: .enabled, source: .remoteReleasable(DataImportSubfeature.dataDirectoryAccess))
         case .attributedMetrics:
             Config(defaultValue: .enabled, source: .remoteReleasable(AttributedMetricsSubfeature.featureEnabled))
         case .standaloneMigration:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217685130715318?focus=true
Tech Design URL:
CC:

### Description
This PR enables the `dataImportDataDirectoryAccess` Feature Flag, by default.

### Testing Steps
- [x] Verify the CI is green

### Impact
None: Internal tooling, documentation

#### What could go wrong?
Nothing really!

### Quality Considerations
Thank you 😄 

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default-value change on a remote-releasable flag; behavior can still be disabled remotely, and the flow only applies on macOS 27+ for data import.
> 
> **Overview**
> Turns on the **`dataImportDataDirectoryAccess`** feature flag by default in `FeatureFlag.swift` (was `.disabled`, now `.enabled`), still tied to remote privacy config via `DataImportSubfeature.dataDirectoryAccess`.
> 
> On macOS 27+, that flag gates **`DataDirectoryPermissionFixAvailability`**, so the data-import path that prompts for access to other apps’ Application Support directories becomes active for users unless remote config turns the subfeature off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80050674fa5c74eb60d0aab825a785d4006410bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->