### PR TITLE
Add collaborators to merge conflict tasks

### DIFF
--- a/scripts/conflict-watch/conflict-watch.py
+++ b/scripts/conflict-watch/conflict-watch.py
@@ -58,16 +58,16 @@ conditions holds:
 
 Each auto-close adds a one-line story explaining why.
 
-Tagging branch owners
----------------------
+Tagging and following branch owners
+-----------------------------------
 If a user-map file is provided via ``CW_USER_MAP_PATH`` (a flat YAML of
-``github_login: asana_user_gid``), the kickoff comment posted right
-after task creation ``@``-mentions both branch authors using Asana's
-rich-text format (``<a data-asana-gid="…"/>``). Asana auto-adds
-mentioned users as task followers, so a single comment delivers the
-inbox notification *and* the long-term association. When
-``CW_NO_MENTIONS=1`` the mentions collapse to plain author names and
-no notification fires.
+``github_login: asana_user_gid``), mapped branch authors are added as
+task followers at creation time. The kickoff comment posted immediately
+afterwards also ``@``-mentions both authors using Asana's rich-text
+format (``<a data-asana-gid="…"/>``). Adding followers explicitly keeps
+the long-term association independent of Asana's mention behaviour.
+When ``CW_NO_MENTIONS=1`` no followers are added, the mentions collapse
+to plain author names, and no notification fires.
 
 Configuration
 -------------
@@ -98,9 +98,10 @@ Optional (defaults shown):
     CW_MIN_CONFLICT_LINES=20
                           (skip pairs whose hard-conflict regions sum to
                            fewer lines after the always-ignore filter)
-    CW_NO_MENTIONS=0      (1 to render kickoff comments with plain author
-                           names instead of Asana @-mentions — no inbox
-                           notification fires; useful for first-run pilots)
+    CW_NO_MENTIONS=0      (1 to skip creation-time followers and render
+                           kickoff comments with plain author names instead
+                           of Asana @-mentions — no inbox notification fires;
+                           useful for first-run pilots)
     CW_BOT_AUTHORS=…      (comma-separated GitHub logins to skip)
     CW_BRANCH_SKIP_PATTERNS=…
                           (comma-separated fnmatch globs on branch name;
@@ -207,9 +208,9 @@ ALWAYS_IGNORE_PATTERNS = [
     if p.strip()
 ]
 MIN_CONFLICT_LINES = int(os.environ.get("CW_MIN_CONFLICT_LINES", "20"))
-# When set, suppress all Asana @-mentions and skip the addFollowers call so
-# the run writes tasks without notifying anyone. Useful for the first real
-# write while the team is still inspecting filter output.
+# When set, suppress all Asana @-mentions and creation-time followers so the
+# run writes tasks without notifying anyone. Useful for the first real write
+# while the team is still inspecting filter output.
 NO_MENTIONS = os.environ.get("CW_NO_MENTIONS", "0").lower() in ("1", "true", "yes")
 
 DEFAULT_BOT_AUTHORS = (
@@ -981,18 +982,21 @@ class AsanaClient:
                 break
         return out
 
-    def create_task(self, name: str, html_notes: str) -> dict:
+    def create_task(self, name: str, html_notes: str,
+                    follower_gids: Optional[list[str]] = None) -> dict:
         if self.dry_run:
-            logger.info("[dry-run] would create task: %s", name)
+            logger.info("[dry-run] would create task: %s (followers=%s)",
+                        name, ", ".join(follower_gids or []) or "none")
             return {"gid": "dry-run", "name": name, "permalink_url": ""}
-        body = {
-            "data": {
-                "name": name,
-                "html_notes": html_notes,
-                "workspace": self.workspace_gid,
-                "projects": [self.project_gid],
-            }
+        task_data = {
+            "name": name,
+            "html_notes": html_notes,
+            "workspace": self.workspace_gid,
+            "projects": [self.project_gid],
         }
+        if follower_gids:
+            task_data["followers"] = follower_gids
+        body = {"data": task_data}
         data = self._request("POST", "/tasks", body=body)
         return data.get("data", {})
 
@@ -1049,6 +1053,17 @@ def _branches_alpha(pair: ConflictPair) -> tuple[Branch, Branch]:
     if pair.a.name <= pair.b.name:
         return pair.a, pair.b
     return pair.b, pair.a
+
+
+def _follower_gids(pair: ConflictPair) -> list[str]:
+    """Mapped branch-owner gids to add as followers at task creation."""
+    if NO_MENTIONS:
+        return []
+    return list(dict.fromkeys(
+        branch.asana_gid
+        for branch in _branches_alpha(pair)
+        if branch.asana_gid
+    ))
 
 
 def render_task_body_html(pair: ConflictPair, today_local: str) -> str:
@@ -1110,10 +1125,10 @@ def render_task_body_html(pair: ConflictPair, today_local: str) -> str:
 
 
 def render_creation_comment_html(pair: ConflictPair) -> str:
-    """Kickoff comment posted right after task creation. Carries the
-    @-mentions (so this is what fires the inbox notification) and a
-    short next-steps prompt. In NO_MENTIONS mode the lead-in switches
-    to plain author names and no notification fires.
+    """Kickoff comment posted after mapped authors become task followers.
+
+    Carries @-mentions and a short next-steps prompt. In NO_MENTIONS mode
+    the lead-in switches to plain author names and no notification fires.
     """
     a_branch, b_branch = _branches_alpha(pair)
     rest = (
@@ -1177,15 +1192,17 @@ def reconcile(asana: AsanaClient, conflicts: list[ConflictPair],
             continue
 
         body_html = render_task_body_html(pair, today_local)
+        follower_gids = _follower_gids(pair)
         try:
-            created = asana.create_task(title, body_html)
+            created = asana.create_task(
+                title, body_html, follower_gids=follower_gids
+            )
             gid = created.get("gid", "")
             logger.info("Created Asana task %s for %s", gid, title)
             summary.tasks_created += 1
             _record_state(state, title, pair, gid, "new", today_utc)
-            # Kickoff comment carries the @-mentions (and therefore the
-            # inbox notification + auto-follow). Without it, the task
-            # would be silently created with no one notified.
+            # Mapped authors are already followers because create_task added
+            # them atomically. Post the kickoff comment only afterwards.
             if gid and gid != "dry-run":
                 comment_html = render_creation_comment_html(pair)
                 asana.add_comment(gid, comment_html, plain_preview="")


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1199333091098016/task/1218040796932981?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

This PR updates the merge conflict detector to add collaborators before commenting, so that the affected developers get a notification in their inbox.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Check that [this workflow run](https://github.com/duckduckgo/apple-browsers/actions/runs/33564457824/job/100044338837) successfully created new conflict tasks and added collaborators - see an example task [here](https://app.asana.com/1/137249556945/project/1214448335754394/task/1218075434651477?focus=true)

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal automation script only; changes how Asana tasks notify and associate users, with no auth or product code impact.
> 
> **Overview**
> Merge conflict Asana tasks now **add mapped branch authors as followers when the task is created**, instead of relying only on @-mentions in the kickoff comment to associate them with the task.
> 
> `create_task` accepts optional `follower_gids` (from `CW_USER_MAP_PATH`) and sends them in the Asana `followers` field on the same POST that creates the task. A new `_follower_gids` helper collects deduplicated Asana user GIDs for both branch owners. The kickoff comment with @-mentions is still posted **after** creation so notifications still go out, but long-term follower association no longer depends on Asana’s mention behavior.
> 
> **`CW_NO_MENTIONS=1`** now skips follower assignment as well as rich-text mentions (docs and comments updated accordingly). Dry-run logging includes which followers would be added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b6e3eb3bf715f694ec8fb02078267e024263556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->