### PR TITLE
macOS: Preventing Download Permissions Prompt at Launch

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -883,12 +883,16 @@ extension URL {
         return isDirectory.boolValue
     }
 
+    /// `true` when the receiver is the user's Downloads folder.
+    ///
+    /// Compared by path components, like `isContained(in:)`, so a trailing slash or a symlinked
+    /// path (`/tmp` vs `/private/tmp`) doesn't change the outcome.
     var isSystemDownloadsDirectory: Bool {
         guard let downloads = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first else {
             return false
         }
 
-        return resolvingSymlinksInPath() == downloads.resolvingSymlinksInPath()
+        return standardizedFileURL.resolvingSymlinksInPath().pathComponents == downloads.standardizedFileURL.resolvingSymlinksInPath().pathComponents
     }
 
     mutating func setFileHidden(_ hidden: Bool) throws {

--- a/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/URLExtension.swift
@@ -883,6 +883,14 @@ extension URL {
         return isDirectory.boolValue
     }
 
+    var isSystemDownloadsDirectory: Bool {
+        guard let downloads = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first else {
+            return false
+        }
+
+        return resolvingSymlinksInPath() == downloads.resolvingSymlinksInPath()
+    }
+
     mutating func setFileHidden(_ hidden: Bool) throws {
         var resourceValues = URLResourceValues()
         resourceValues.isHidden = true

--- a/macOS/DuckDuckGo/Preferences/Model/DownloadsPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/DownloadsPreferences.swift
@@ -138,8 +138,8 @@ final class DownloadsPreferences: ObservableObject {
     private func setSelectedDownloadLocation(_ url: URL?) {
         selectedDownloadLocationController = url.map { SecurityScopedFileURLController(url: $0) }
         let locationString: String?
-        if NSApp.isSandboxed {
-            locationString = (try? url?.bookmarkData(options: .withSecurityScope).base64EncodedString()) ?? url?.absoluteString
+        if NSApp.isSandboxed, let url, url.isSystemDownloadsDirectory == false {
+            locationString = (try? url.bookmarkData(options: .withSecurityScope).base64EncodedString()) ?? url.absoluteString
         } else {
             locationString = url?.absoluteString
         }

--- a/macOS/DuckDuckGo/Preferences/Model/DownloadsPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/DownloadsPreferences.swift
@@ -138,6 +138,10 @@ final class DownloadsPreferences: ObservableObject {
     private func setSelectedDownloadLocation(_ url: URL?) {
         selectedDownloadLocationController = url.map { SecurityScopedFileURLController(url: $0) }
         let locationString: String?
+
+        /// When Sandboxed, we have the `com.apple.security.files.downloads.read-write` entitlement: safe to exclude `~/Downloads`.
+        /// Otherwise `bookmarkData(options: .withSecurityScope)`  will trigger a Permissions Prompt, at launch, before the Window is even visible.
+        ///
         if NSApp.isSandboxed, let url, url.isSystemDownloadsDirectory == false {
             locationString = (try? url.bookmarkData(options: .withSecurityScope).base64EncodedString()) ?? url.absoluteString
         } else {

--- a/macOS/UnitTests/Common/Extensions/URLExtensionTests.swift
+++ b/macOS/UnitTests/Common/Extensions/URLExtensionTests.swift
@@ -1027,4 +1027,52 @@ extension URLExtensionTests {
         #expect(resolvedTemporaryDirectory.isContained(in: temporaryDirectory) == true)
         #expect(temporaryDirectory.appendingPathComponent("file").isContained(in: resolvedTemporaryDirectory) == true)
     }
+
+    // MARK: - isSystemDownloadsDirectory
+
+    @available(iOS 16, macOS 13, *)
+    @Test("The system Downloads folder is recognised", .timeLimit(.minutes(1)))
+    func thatSystemDownloadsDirectoryIsRecognised() throws {
+        let downloads = try #require(FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first)
+
+        #expect(downloads.isSystemDownloadsDirectory)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("The system Downloads folder is recognised without a trailing slash", .timeLimit(.minutes(1)))
+    func thatSystemDownloadsDirectoryIsRecognisedWithoutTrailingSlash() throws {
+        let downloads = try #require(FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first)
+        // NSOpenPanel and URL(fileURLWithPath:) can both yield a slash-less directory URL
+        let withoutTrailingSlash = URL(fileURLWithPath: downloads.path, isDirectory: false)
+
+        #expect(withoutTrailingSlash.isSystemDownloadsDirectory)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("A symlink to the Downloads folder is recognised", .timeLimit(.minutes(1)))
+    func thatSymlinkToSystemDownloadsDirectoryIsRecognised() throws {
+        let downloads = try #require(FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first)
+        let link = FileManager.default.temporaryDirectory
+            .appendingPathComponent("downloads-link-\(UUID().uuidString)")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: downloads)
+        defer { try? FileManager.default.removeItem(at: link) }
+
+        #expect(link.isSystemDownloadsDirectory)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("A folder inside Downloads is not the Downloads folder itself", .timeLimit(.minutes(1)))
+    func thatSubfolderOfSystemDownloadsDirectoryIsNotRecognised() throws {
+        let downloads = try #require(FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first)
+
+        #expect(downloads.appendingPathComponent("Subfolder").isSystemDownloadsDirectory == false)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Unrelated folders are not the Downloads folder", .timeLimit(.minutes(1)))
+    func thatUnrelatedDirectoriesAreNotRecognised() {
+        #expect(FileManager.default.temporaryDirectory.isSystemDownloadsDirectory == false)
+        #expect(FileManager.default.homeDirectoryForCurrentUser.isSystemDownloadsDirectory == false)
+        #expect(URL(fileURLWithPath: "/Users/someone-else/Downloads", isDirectory: true).isSystemDownloadsDirectory == false)
+    }
 }

--- a/macOS/UnitTests/Preferences/DownloadsPreferencesTests.swift
+++ b/macOS/UnitTests/Preferences/DownloadsPreferencesTests.swift
@@ -239,6 +239,42 @@ class DownloadsPreferencesTests: XCTestCase {
         XCTAssertNil(preferences.lastUsedCustomDownloadLocation)
     }
 
+    // MARK: - ~/Downloads needs no security-scoped bookmark
+
+    func testWhenSystemDownloadsFolderIsSelectedThenItIsPersistedAsAPlainURLString() throws {
+        let downloads = try XCTUnwrap(FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first)
+        let persistor = DownloadsPreferencesPersistorMock(selectedDownloadLocation: nil)
+        let preferences = DownloadsPreferences(persistor: persistor)
+
+        preferences.selectedDownloadLocation = downloads
+
+        let persisted = try XCTUnwrap(persistor.selectedDownloadLocation)
+        XCTAssertNil(Data(base64Encoded: persisted))
+        XCTAssertEqual(URL(string: persisted), downloads)
+    }
+
+    func testWhenSystemDownloadsFolderIsPersistedAsPlainStringThenItRoundTrips() throws {
+        let downloads = try XCTUnwrap(FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first)
+        let persistor = DownloadsPreferencesPersistorMock(selectedDownloadLocation: downloads.absoluteString)
+
+        let preferences = DownloadsPreferences(persistor: persistor)
+
+        XCTAssertEqual(preferences.selectedDownloadLocation?.resolvingSymlinksInPath(), downloads.resolvingSymlinksInPath())
+        XCTAssertEqual(persistor.selectedDownloadLocation, downloads.absoluteString,
+                       "a valid persisted value must not be rewritten on launch")
+    }
+
+    func testWhenCustomFolderIsSelectedInSandboxThenABookmarkIsStillPersisted() throws {
+        try XCTSkipUnless(NSApp.isSandboxed, "the security-scoped bookmark branch only runs sandboxed")
+        let testDirectory = createTemporaryTestDirectory()
+        let persistor = DownloadsPreferencesPersistorMock(selectedDownloadLocation: nil)
+        let preferences = DownloadsPreferences(persistor: persistor)
+
+        preferences.selectedDownloadLocation = testDirectory
+
+        let persisted = try XCTUnwrap(persistor.selectedDownloadLocation)
+        XCTAssertNotNil(Data(base64Encoded: persisted), "custom folders still need a security-scoped bookmark")
+    }
 }
 
 private extension DownloadsPreferencesTests {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/inbox/1211150618028591/item/1218020137781512/story/1218012700675040?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

### Testing Steps
1. Select the `macOS Browser AppStore` Scheme
2. Edit `DuckDuckGoAppStore.xcconfig` and paste, at the bottom:
   ```
   MAIN_BUNDLE_IDENTIFIER[config=Debug][sdk=*] = com.duckduckgo.mobile.ios.debug.aaa
   ```
3. Launch the browser

- [ ] Verify we no longer request access to the Downloads Folder as soon as you launch

### Impact
Medium: Could disrupt specific features or user flows

#### What could go wrong?
We could introduce a regression in the Downloads component.

### Quality Considerations
Thank you!!

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how download locations are persisted and restored in the sandbox; a mis-identified Downloads path could break writes or reintroduce prompts, though tests cover symlinks and plain-string round-trip.
> 
> **Overview**
> Fixes the **sandboxed App Store build** showing a Downloads folder permission dialog at launch, often before the main window appears.
> 
> **Downloads preferences** no longer creates security-scoped bookmark data when the selected folder is the system **~/Downloads** directory. Sandboxed builds already have downloads read-write entitlement, so a plain URL string is enough. Custom folders still get security-scoped bookmarks.
> 
> Adds **`isSystemDownloadsDirectory`** on `URL` (path-component comparison with symlink resolution, similar to `isContained(in:)`) so trailing slashes, `NSOpenPanel` URLs, and symlinks to Downloads are treated correctly.
> 
> Unit tests cover Downloads detection edge cases and persistence/round-trip for Downloads vs custom sandbox folders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1f9176929a8bd62d4eaad5c2616624651ae95d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->