### PR TITLE
Allow Duck Player tabs to burn 'This tab'

### DIFF
--- a/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
+++ b/macOS/DuckDuckGo/Fire/ViewModel/FireDialogViewModel.swift
@@ -307,7 +307,13 @@ final class FireDialogViewModel: ObservableObject {
         // In that case such tab isn't recorded in history and we're unable to present a history item for it,
         // and effectively burning a tab wouldn't delete any history items.
         let hasVisitWithHistoryItems = tab.localHistory.contains(where: { $0.historyEntry != nil })
-        guard hasVisitWithHistoryItems else { return false }
+
+        // Duck Player set to "always open in new tab" would show a tab with no history
+        // that should still allow burning, i.e. closing the tab. In reality, the Duck Player visit
+        // is not recorded in history (only the YouTube visit in another tab is recorded).
+        // Therefore, always allow to close Duck Player tab.
+        let isDuckPlayer = tab.content.urlForWebView?.isDuckPlayer == true
+        guard hasVisitWithHistoryItems || isDuckPlayer else { return false }
 
         return tab.content.isExternalUrl || tab.canGoBack || tab.canGoForward
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1218059022048075?focus=true

### Description
This change restores the behavior known from the old Fire Dialog. On Duck Player tabs, allow burning current tab
even though tab local history is empty (in this case, allow to close the tab).

### Testing Steps
1. Enable Duck Player, e.g. this way:

<img width="905" height="388" alt="Screenshot 2026-09-01 at 17 55 33" src="https://github.com/user-attachments/assets/7acdf573-cd4b-4bce-8cde-a4ad8a110121" />

2. Go to YouTube and open a video so that it opens a new tab with Duck Player
3. Click Fire Button and verify that you can burn current tab, but no history will be deleted. The "Delete & Close" button will be enabled only if "Close tab" checkbox is enabled:

<img width="441" height="544" alt="Screenshot 2026-09-01 at 17 57 08" src="https://github.com/user-attachments/assets/fb002cda-fafb-46be-b377-e000783b7b44" />

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Fire dialog eligibility logic for Duck Player tabs; no changes to data clearing, auth, or persistence.
> 
> **Overview**
> The simplified Fire dialog no longer disables **This tab** when the active tab has no visit history **if** that tab is Duck Player (e.g. “always open in new tab” from YouTube). Duck Player visits are not stored in tab local history, so the previous guard wrongly forced **All data** and blocked closing the tab via Fire.
> 
> `isCurrentTabOptionEnabled` now treats Duck Player like a special case alongside `hasVisitWithHistoryItems`, so users can burn/close the tab even when no history rows would be deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 504322b71aa3a2db26e23cf5eab08398f12e595e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->