### PR TITLE
EventHub metrics #1: hub-level de-duplication

### DIFF
--- a/DuckDuckGo.xcworkspace/contents.xcworkspacedata
+++ b/DuckDuckGo.xcworkspace/contents.xcworkspacedata
@@ -31,6 +31,9 @@
       <FileRef
          location = "group:DDGError">
       </FileRef>
+      <FileRef
+         location = "group:EventHub">
+      </FileRef>
       <FileSystemSynchronizedGroup
          location = "group:Infrastructure"
          name = "Infrastructure">

--- a/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfig.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfig.swift
@@ -20,11 +20,16 @@ import Foundation
 
 /// When a pixel fires. Raw values are the strings remote config authors and the persisted config
 /// snapshot carries, so they must not change.
+///
+/// The one exception, deliberate: the immediate trigger was renamed from `immediate` to
+/// `immediate_v2` when web events began de-duplicating at the hub. Clients already in the wild parse
+/// `immediate` and would fire on every occurrence, so config carrying the new semantics needs a name
+/// they ignore. Safe for the persisted snapshot too: only `period` pixels ever have state to persist.
 public enum TelemetryTriggerType: String, Equatable, Sendable {
     /// Aggregated over a period, and the default when config omits the type.
     case period
-    /// One pixel per event.
-    case immediate
+    /// One pixel per delivered event.
+    case immediateV2 = "immediate_v2"
 }
 
 /// What a parameter measures. Raw values are the strings remote config authors and the persisted config

--- a/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfigParser.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfigParser.swift
@@ -89,17 +89,19 @@ public final class EventHubConfigParser {
 
     private static func toTrigger(_ dto: TriggerDTO, pixelName: String) -> TelemetryTriggerConfig? {
         // An omitted type means `period`; a present but unrecognised one is a config we cannot honour.
+        // That includes the retired `immediate`, which this client no longer understands — see
+        // `TelemetryTriggerType`.
         guard let type = dto.type.map(TelemetryTriggerType.init(rawValue:)) ?? .period else {
             Logger.eventHub.error("config: pixel \(pixelName, privacy: .public) skipped, unknown trigger type \(dto.type ?? "<none>", privacy: .public)")
             return nil
         }
         switch type {
-        case .immediate:
+        case .immediateV2:
             guard let source = dto.source, !source.isEmpty else {
                 Logger.eventHub.error("config: pixel \(pixelName, privacy: .public) skipped, immediate trigger with no source")
                 return nil
             }
-            return TelemetryTriggerConfig(type: .immediate, source: source)
+            return TelemetryTriggerConfig(type: .immediateV2, source: source)
         case .period:
             guard let period = dto.period, period.seconds > 0 else {
                 Logger.eventHub.error("config: pixel \(pixelName, privacy: .public) skipped, period seconds missing or not positive")

--- a/SharedPackages/EventHub/Sources/EventHub/Core/DedupStore.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/DedupStore.swift
@@ -17,27 +17,49 @@
 //
 
 import Foundation
+import os.log
 
-/// Per-tab de-duplication state, keyed pixel×param×source within a tab.
+/// Per-tab de-duplication state for web events, keyed `event type × event data` within a tab.
 ///
-/// Owned by `EventHub` rather than by the parameters that consult it, because dedup is *page*-scoped,
-/// not *period*-scoped: it must survive both a period rollover and the window where a period fires
-/// while backgrounded, each of which destroys the owning `Telemetry` and its parameters. It is cleared
-/// only when a tab navigates to a genuinely different URL, when a tab closes, or when the whole feature
-/// is disabled — never at a period boundary, which would let a long-lived page inflate the first count
-/// of every new period.
+/// Owned and consulted by `EventHub` itself: the decision is taken once at ingestion, before any
+/// handler runs, so a duplicate reaches no handler at all and a first occurrence reaches every one of
+/// them. That is deliberately *not* per-handler — handlers must not each reimplement it, and a single
+/// page load firing the same event from several frames would otherwise inflate every consumer's count.
+///
+/// State is *page*-scoped, not *period*-scoped: it survives both a period rollover and the window
+/// where a period fires while backgrounded. It is cleared only when a tab navigates to a genuinely
+/// different URL, when a tab closes, or when the whole feature is disabled — never at a period
+/// boundary, which would let a long-lived page inflate the first count of every new period.
+///
+/// The per-tab key set is unbounded, since it is cleared on every navigation and tab close: the
+/// ceiling is the distinct `(type, data)` pairs one page emits before it navigates away.
 ///
 /// In-memory only, never persisted: after a restart a page counts once more, which is intended.
 ///
 /// Not thread-safe on its own — like all other EventHub state, access is confined to the hub's serial
 /// queue.
 final class DedupStore {
-    private var seenByTab: [EventHubTabID: Set<String>] = [:]
+    /// A struct rather than a joined string: event types come from remote config, so any separator
+    /// character could in principle appear in one and collide with a different `(type, data)` pair.
+    private struct Key: Hashable {
+        let type: String
+        /// The payload as canonical JSON, or `""` when there is no payload. See `canonicalPayload`.
+        let payload: String
+    }
 
-    /// Records `key` as seen for `tabID`, returning `true` when it was *not* already present — i.e.
-    /// this is the first occurrence on the tab's current page, so the caller should count it.
-    func markSeen(key: String, tabID: EventHubTabID) -> Bool {
-        seenByTab[tabID, default: []].insert(key).inserted
+    private var seenByTab: [EventHubTabID: Set<Key>] = [:]
+
+    /// Records this event as seen for `tabID`, returning `true` when it was *not* already present —
+    /// i.e. this is the first occurrence on the tab's current page, so the caller should deliver it.
+    func markSeen(type: String, data: [String: Any]?, tabID: EventHubTabID) -> Bool {
+        guard let payload = Self.canonicalPayload(data) else {
+            // A payload we cannot canonicalise is delivered but not recorded. Under-de-duplicating is
+            // the safe failure here: payloads reach us as JSON from the content-scope-scripts bridge,
+            // so this is defence only, and dropping the event would lose data outright.
+            Logger.eventHub.error("event \(type, privacy: .private) payload could not be canonicalised, event not de-duplicated")
+            return true
+        }
+        return seenByTab[tabID, default: []].insert(Key(type: type, payload: payload)).inserted
     }
 
     /// Drops everything recorded for a tab — used on navigation to a different URL and on tab close.
@@ -47,5 +69,18 @@ final class DedupStore {
 
     func clearAll() {
         seenByTab.removeAll()
+    }
+
+    /// Payloads equal as JSON values are one key: `.sortedKeys` orders object members (recursively,
+    /// so nested objects compare irrespective of order too) while leaving array elements in place. An
+    /// omitted payload and an empty one are both `""`, so they are the same key.
+    ///
+    /// `nil` means "not canonicalisable", which is distinct from the empty `""` payload.
+    private static func canonicalPayload(_ data: [String: Any]?) -> String? {
+        guard let data, !data.isEmpty else { return "" }
+        guard let encoded = try? JSONSerialization.data(withJSONObject: data, options: [.sortedKeys]) else {
+            return nil
+        }
+        return String(data: encoded, encoding: .utf8)
     }
 }

--- a/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
@@ -26,15 +26,19 @@ import os.log
 public protocol EventHubManaging: AnyObject {
     /// Processes an incoming `webEvent` envelope (`{ "type": ..., "data": ... }`) from the tab
     /// identified by `tabID` against the active telemetry configs.
+    ///
+    /// De-duplicated once at ingestion, keyed `type × data × tabID` against the tab's current page: a
+    /// repeat reaches no handler, a first occurrence reaches every handler. See `DedupStore`.
     func handleWebEvent(_ webEventData: [String: Any], tabID: EventHubTabID)
 
     /// Fires any enabled immediate-trigger telemetry whose `trigger.source` equals `type`. For
-    /// browser-native events (not content-scope-scripts); there is no tab context.
+    /// browser-native events (not content-scope-scripts): there is no tab context, so no page to
+    /// de-duplicate against, and every call is a genuine occurrence.
     func handleImmediateEvent(_ type: String, data: Encodable?)
 
     /// Counts a browser-native event toward any enabled period/aggregated telemetry whose parameter
-    /// `source` equals `type`. Unlike web events there is no per-tab dedup: each call is a genuine
-    /// occurrence.
+    /// `source` equals `type`. Like `handleImmediateEvent`, and unlike web events, this never passes
+    /// through de-duplication: each call is a genuine occurrence.
     func handleAggregatedEvent(_ type: String, data: Encodable?)
 
     /// Signals that the given tab has navigated to `url` (clears per-tab dedup on URL change).
@@ -91,8 +95,9 @@ public final class EventHub: EventHubManaging {
     private var telemetries: [String: Telemetry] = [:]
     private var dirtyNames: Set<String> = []
     private var tabURLs: [EventHubTabID: String] = [:]
-    /// Hub-lifetime so per-tab dedup outlives the `Telemetry` objects that consult it — a period
-    /// rollover, and a period firing while backgrounded, both replace those. See `DedupStore`.
+    /// The one de-duplication decision, taken in `handleWebEvent` before any handler runs. Hub-owned
+    /// and hub-lifetime, so it outlives the `Telemetry` objects a period rollover replaces — dedup is
+    /// page-scoped, not period-scoped. See `DedupStore`.
     private let dedupStore = DedupStore()
     private var latestConfigs: [TelemetryPixelConfig] = []
     private var latestEnabled = false
@@ -171,8 +176,8 @@ public final class EventHub: EventHubManaging {
             Logger.eventHub.debug("[EventHub] web event ignored, `type` was missing or empty")
             return
         }
-        Logger.eventHub.debug("[EventHub] web event received: \(type, privacy: .private), tab \(tabID.rawValue.uuidString, privacy: .private)")
         let data = webEventData["data"] as? [String: Any]
+        Logger.eventHub.debug("[EventHub] web event received: \(type, privacy: .private), tab \(tabID.rawValue.uuidString, privacy: .private), data \(Self.payloadDescription(data), privacy: .private)")
         // Sampled here, not in the block: `now` decides whether the event still belongs to the running
         // period, so it has to be the arrival time. Read on the queue it would be the drain time, and an
         // event arriving just before `periodEnd` could be dropped for landing in no period at all.
@@ -182,8 +187,16 @@ public final class EventHub: EventHubManaging {
                 Logger.eventHub.debug("[EventHub] \(type, privacy: .private) dropped, the eventHub feature is disabled")
                 return
             }
+            // The single de-duplication decision, taken before fan-out: a duplicate reaches no
+            // handler at all, a first occurrence reaches every one of them. Deliberately after the
+            // `latestEnabled` guard — an event dropped because the feature is off must not record a
+            // key that would then suppress the real occurrence once it is switched back on.
+            guard dedupStore.markSeen(type: type, data: data, tabID: tabID) else {
+                Logger.eventHub.debug("[EventHub] \(type, privacy: .private) dropped, already seen on this tab's current page")
+                return
+            }
             fireImmediateLocked(source: type, data: data)
-            countPeriodLocked(source: type, data: data, tabID: tabID, nowMillis: nowMillis)
+            countPeriodLocked(source: type, data: data, nowMillis: nowMillis)
         }
     }
 
@@ -214,22 +227,29 @@ public final class EventHub: EventHubManaging {
                 Logger.eventHub.debug("[EventHub] \(type, privacy: .public) dropped, the eventHub feature is disabled")
                 return
             }
-            countPeriodLocked(source: type, data: encoded, tabID: .empty, nowMillis: nowMillis)
+            countPeriodLocked(source: type, data: encoded, nowMillis: nowMillis)
         }
     }
 
     private func fireImmediateLocked(source: String, data: [String: Any]?) {
-        let matching = latestConfigs.filter { $0.isEnabled && $0.trigger.type == .immediate && $0.trigger.source == source }
+        let matching = latestConfigs.filter { $0.isEnabled && $0.trigger.type == .immediateV2 && $0.trigger.source == source }
         Logger.eventHub.debug("[EventHub] immediate routing for \(source, privacy: .private) → \(matching.isEmpty ? "no immediate telemetry is triggered by it" : matching.map(\.name).joined(separator: ", "), privacy: .public)")
         for config in matching {
             var params: [String: String] = [:]
+            var declaresDataParameters = false
             for (paramName, paramConfig) in config.parameters where paramConfig.template == .data {
-                // Transient: an immediate pixel has no period and no dedup, so this parameter reports the
-                // triggering event's own payload and is discarded straight after firing.
+                declaresDataParameters = true
+                // Transient: an immediate pixel has no period, so this parameter reports the triggering
+                // event's own payload and is discarded straight after firing.
                 let parameter = DataParameter(dataKey: paramConfig.dataKey)
-                if parameter.handle(data: data, tabID: .empty), let value = parameter.queryValue() {
-                    params[paramName] = value
-                }
+                parameter.handle(data: data)
+                if let value = parameter.queryValue() { params[paramName] = value }
+            }
+            // A pixel that declares data parameters but resolved none of them has nothing to report, so
+            // it does not fire. A pixel declaring no parameters at all still fires on the event alone.
+            guard !declaresDataParameters || !params.isEmpty else {
+                Logger.eventHub.debug("[EventHub] \(config.name, privacy: .public) not fired, none of its data parameters resolved")
+                continue
             }
             pixelFiring.enqueueFirePixel(named: config.name, parameters: params)
         }
@@ -244,7 +264,7 @@ public final class EventHub: EventHubManaging {
     ///   onto the queue. The timer is best-effort, so it can legitimately be past `periodEnd` before the
     ///   sweep has run (notably on macOS, where a period can end while the app runs unfocused). An event
     ///   arriving in that window belongs to no period and must not be counted into the elapsed one.
-    private func countPeriodLocked(source: String, data: [String: Any]?, tabID: EventHubTabID, nowMillis now: Int64) {
+    private func countPeriodLocked(source: String, data: [String: Any]?, nowMillis now: Int64) {
         // Every period telemetry this event was offered to, and what became of it. Logged as one line so
         // "the pixel never fired" can be answered from a single entry: whether anything was listening,
         // and if so why it did or did not count.
@@ -259,11 +279,11 @@ public final class EventHub: EventHubManaging {
                 outcomes.append("\(config.name): period already ended")
                 continue
             }
-            if telemetry.handleEvent(source: source, data: data, tabID: tabID) {
+            if telemetry.handleEvent(source: source, data: data) {
                 dirtyNames.insert(config.name)
                 outcomes.append("\(config.name): counted")
             } else {
-                outcomes.append("\(config.name): no change (already counted on this tab, or the counter is capped)")
+                outcomes.append("\(config.name): no change (the counter is capped, or no parameter had a value to record)")
             }
         }
         let summary = outcomes.isEmpty
@@ -298,7 +318,7 @@ public final class EventHub: EventHubManaging {
 
     private func startNewPeriodLocked(_ config: TelemetryPixelConfig) {
         guard isForeground, latestEnabled, config.isEnabled, config.trigger.periodSeconds != nil else { return }
-        let telemetry = Telemetry(config: config, periodStartMillis: scheduler.nowMillis(), dedupStore: dedupStore)
+        let telemetry = Telemetry(config: config, periodStartMillis: scheduler.nowMillis())
         telemetries[config.name] = telemetry
         dirtyNames.insert(config.name)
     }
@@ -338,7 +358,7 @@ public final class EventHub: EventHubManaging {
     private func checkPixelsLocked() {
         guard latestEnabled else { return }
         for stored in store.allPixelStates() where telemetries[stored.pixelName] == nil {
-            telemetries[stored.pixelName] = Telemetry(restoring: stored, dedupStore: dedupStore)
+            telemetries[stored.pixelName] = Telemetry(restoring: stored)
         }
         let now = scheduler.nowMillis()
         // Snapshot the values: fireLocked mutates `telemetries` (removes the fired entry and may add a
@@ -443,6 +463,17 @@ public final class EventHub: EventHubManaging {
             tabURLs.removeValue(forKey: tabID)
             dedupStore.clear(tabID: tabID)
         }
+    }
+
+    /// The payload rendered for the debug log, in the same canonical form `DedupStore` keys on — so a
+    /// "dropped, already seen" line can be read against the event that first claimed that key.
+    ///
+    /// Page-derived, so it is only ever interpolated as `.private` and only at `debug` level.
+    private static func payloadDescription(_ data: [String: Any]?) -> String {
+        guard let data, !data.isEmpty else { return "<none>" }
+        guard let encoded = try? JSONSerialization.data(withJSONObject: data, options: [.sortedKeys]),
+              let json = String(data: encoded, encoding: .utf8) else { return "<unserialisable>" }
+        return json
     }
 
     private static func encode(_ data: Encodable?) -> [String: Any]? {

--- a/SharedPackages/EventHub/Sources/EventHub/Core/Parameter.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/Parameter.swift
@@ -20,13 +20,13 @@ import Foundation
 import os.log
 
 /// A single pixel parameter's runtime behavior. `CounterParameter` owns its counter value and the
-/// stop-at-max-bucket logic, and makes the per-tab dedup decision against the hub-owned `DedupStore`
-/// (native/`.empty`-tab events are never deduped). `DataParameter` owns only its last-seen value.
+/// stop-at-max-bucket logic; `DataParameter` owns only its last-seen value. Neither de-duplicates:
+/// the hub takes that decision once at ingestion, so everything reaching a parameter is a delivery.
 protocol Parameter: AnyObject {
     /// Processes an event whose source already matched this parameter's config source (or, for an
     /// immediate-trigger's data param, the triggering event itself). Returns `true` if state changed.
     @discardableResult
-    func handle(data: [String: Any]?, tabID: EventHubTabID) -> Bool
+    func handle(data: [String: Any]?) -> Bool
 
     var state: ParamState { get }
     func restoreState(_ state: ParamState)
@@ -37,11 +37,10 @@ protocol Parameter: AnyObject {
 }
 
 enum ParameterFactory {
-    /// Builds the parameter for a pixel's running period. `dedupKey` identifies this parameter within
-    /// its pixel (pixel×param×source) for `dedupStore` lookups.
-    static func make(_ config: TelemetryParameterConfig, dedupKey: String, dedupStore: DedupStore) -> Parameter? {
+    /// Builds the parameter for a pixel's running period.
+    static func make(_ config: TelemetryParameterConfig) -> Parameter? {
         if config.template == .counter, let buckets = config.buckets {
-            return CounterParameter(buckets: buckets, dedupKey: dedupKey, dedupStore: dedupStore)
+            return CounterParameter(buckets: buckets)
         }
         if config.template == .data {
             return DataParameter(dataKey: config.dataKey)
@@ -53,28 +52,18 @@ enum ParameterFactory {
 
 final class CounterParameter: Parameter {
     private let buckets: BucketList
-    /// Identifies this parameter (pixel×param×source) inside the shared, tab-keyed `DedupStore`.
-    private let dedupKey: String
-    /// Hub-owned, so dedup outlives this parameter — see `DedupStore`.
-    private let dedupStore: DedupStore
     private var value: Int
     private var stopCounting: Bool
 
-    init(buckets: BucketList, dedupKey: String, dedupStore: DedupStore, initialState: ParamState = ParamState(value: 0)) {
+    init(buckets: BucketList, initialState: ParamState = ParamState(value: 0)) {
         self.buckets = buckets
-        self.dedupKey = dedupKey
-        self.dedupStore = dedupStore
         self.value = initialState.value
         self.stopCounting = initialState.stopCounting
     }
 
     @discardableResult
-    func handle(data: [String: Any]?, tabID: EventHubTabID) -> Bool {
+    func handle(data: [String: Any]?) -> Bool {
         guard !stopCounting else { return false }
-        // Native events (tabID == .empty) opt out of dedup: every call is a genuine occurrence.
-        if tabID != .empty {
-            guard dedupStore.markSeen(key: dedupKey, tabID: tabID) else { return false }
-        }
         if BucketCounter.shouldStopCounting(value, buckets: buckets) {
             stopCounting = true
         } else {
@@ -106,15 +95,28 @@ final class DataParameter: Parameter {
         self.lastValue = initialState.lastDataValue
     }
 
+    /// Every event of the parameter's source assigns, so an event whose payload lacks `dataKey`
+    /// leaves the parameter with *no* value rather than the previous one — the pixel then reports what
+    /// the latest event carried, not a stale reading from an earlier one.
     @discardableResult
-    func handle(data: [String: Any]?, tabID: EventHubTabID) -> Bool {
-        guard let dataKey, let data, let raw = data[dataKey] else { return false }
+    func handle(data: [String: Any]?) -> Bool {
+        guard let dataKey else { return false }
+        guard let raw = data?[dataKey] else { return clear() }
         guard let encoded = try? JSONSerialization.data(withJSONObject: raw, options: [.fragmentsAllowed]),
               let compact = String(data: encoded, encoding: .utf8) else {
             Logger.eventHub.error("data parameter for key \(dataKey, privacy: .public) is not JSON-serialisable, value dropped")
-            return false
+            return clear()
         }
-        lastValue = compact.addingPercentEncoding(withAllowedCharacters: Self.unreservedCharacters)
+        let encodedValue = compact.addingPercentEncoding(withAllowedCharacters: Self.unreservedCharacters)
+        guard lastValue != encodedValue else { return false }
+        lastValue = encodedValue
+        return true
+    }
+
+    /// Drops any recorded value, reporting whether that was a change.
+    private func clear() -> Bool {
+        guard lastValue != nil else { return false }
+        lastValue = nil
         return true
     }
 

--- a/SharedPackages/EventHub/Sources/EventHub/Core/Telemetry.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/Telemetry.swift
@@ -28,22 +28,22 @@ final class Telemetry {
     private var parameters: [String: Parameter]
 
     /// Starts a fresh period from `config`, beginning at `periodStartMillis`.
-    init(config: TelemetryPixelConfig, periodStartMillis: Int64, dedupStore: DedupStore) {
+    init(config: TelemetryPixelConfig, periodStartMillis: Int64) {
         self.name = config.name
         self.config = config
         self.periodStartMillis = periodStartMillis
         self.periodEndMillis = periodStartMillis + (config.trigger.periodSeconds ?? 0) * 1000
-        self.parameters = Self.makeParameters(config: config, dedupStore: dedupStore)
+        self.parameters = Self.makeParameters(config: config)
     }
 
-    /// Rehydrates from persisted state (restart / foreground catch-up). Dedup is deliberately not
-    /// restored: it is in-memory only, so after a restart a page legitimately counts once more.
-    init(restoring persisted: PixelState, dedupStore: DedupStore) {
+    /// Rehydrates from persisted state (restart / foreground catch-up). The hub's de-duplication state
+    /// is deliberately not restored: it is in-memory only, so after a restart a page counts once more.
+    init(restoring persisted: PixelState) {
         self.name = persisted.pixelName
         self.config = persisted.config
         self.periodStartMillis = persisted.periodStartMillis
         self.periodEndMillis = persisted.periodEndMillis
-        self.parameters = Self.makeParameters(config: persisted.config, dedupStore: dedupStore)
+        self.parameters = Self.makeParameters(config: persisted.config)
         for (paramName, parameter) in parameters {
             if let restored = persisted.params[paramName] {
                 parameter.restoreState(restored)
@@ -51,13 +51,10 @@ final class Telemetry {
         }
     }
 
-    /// Builds this pixel's parameters, giving each counter a dedup key scoped to pixel×param×source so
-    /// two pixels sharing a parameter name and source still de-duplicate independently.
-    private static func makeParameters(config: TelemetryPixelConfig, dedupStore: DedupStore) -> [String: Parameter] {
+    private static func makeParameters(config: TelemetryPixelConfig) -> [String: Parameter] {
         var result: [String: Parameter] = [:]
         for (paramName, paramConfig) in config.parameters {
-            let dedupKey = "\(config.name):\(paramName):\(paramConfig.source ?? "")"
-            if let parameter = ParameterFactory.make(paramConfig, dedupKey: dedupKey, dedupStore: dedupStore) {
+            if let parameter = ParameterFactory.make(paramConfig) {
                 result[paramName] = parameter
             }
         }
@@ -73,14 +70,15 @@ final class Telemetry {
         config.parameters.values.contains { $0.source == source }
     }
 
-    /// Routes a matching event to every parameter whose config `source` equals `source`. Returns
-    /// `true` if any parameter's state changed.
+    /// Routes a delivered event to every parameter whose config `source` equals `source`. Returns
+    /// `true` if any parameter's state changed. De-duplication has already happened at the hub, so
+    /// every event reaching here is a genuine occurrence.
     @discardableResult
-    func handleEvent(source: String, data: [String: Any]?, tabID: EventHubTabID) -> Bool {
+    func handleEvent(source: String, data: [String: Any]?) -> Bool {
         var changed = false
         for (paramName, paramConfig) in config.parameters where paramConfig.source == source {
             guard let parameter = parameters[paramName] else { continue }
-            if parameter.handle(data: data, tabID: tabID) { changed = true }
+            if parameter.handle(data: data) { changed = true }
         }
         return changed
     }

--- a/SharedPackages/EventHub/Sources/EventHub/EventHubTabID.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/EventHubTabID.swift
@@ -18,8 +18,8 @@
 
 import Foundation
 
-/// Identifies a browser tab for EventHub's per-tab web-event dedup. `.empty` stands in for "no tab"
-/// (used by native/aggregated events, which have no page/tab lifecycle to dedup against).
+/// Identifies a browser tab for EventHub's per-tab web-event de-duplication. Native events carry no
+/// tab at all — they never reach the code that takes a tab, rather than passing a placeholder.
 public struct EventHubTabID: Hashable, Sendable {
     public let rawValue: UUID
 
@@ -28,6 +28,4 @@ public struct EventHubTabID: Hashable, Sendable {
     }
 
     public static func new() -> EventHubTabID { EventHubTabID() }
-
-    public static let empty = EventHubTabID(rawValue: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!)
 }

--- a/SharedPackages/EventHub/Sources/EventHub/Logger+EventHub.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Logger+EventHub.swift
@@ -27,7 +27,8 @@ public extension Logger {
     /// activity filterable as one stream.
     ///
     /// Only config-governed identifiers (pixel names, parameter names, bucket names, data keys) and
-    /// error descriptions are interpolated as `.public`; web-page-derived event payloads are never
-    /// logged at all, at any privacy level.
+    /// error descriptions are interpolated as `.public`. Web-page-derived values — event types, event
+    /// payloads and tab identifiers — are interpolated as `.private` and only at `debug` level, so they
+    /// are redacted unless someone deliberately enables private-data logging on a development device.
     static let eventHub = Logger(subsystem: "EventHub", category: "")
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Functional/EventHubFunctionalTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Functional/EventHubFunctionalTests.swift
@@ -64,7 +64,7 @@ struct EventHubFunctionalTests {
     static let immediateConfig = """
     { "telemetry": { "webEvent_impression": {
         "state": "enabled",
-        "trigger": { "type": "immediate", "source": "impression" },
+        "trigger": { "type": "immediate_v2", "source": "impression" },
         "parameters": {}
     } } }
     """

--- a/SharedPackages/EventHub/Sources/EventHubTests/Spec/DeduplicationSpecTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Spec/DeduplicationSpecTests.swift
@@ -1,0 +1,270 @@
+//
+//  DeduplicationSpecTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Testing
+import Foundation
+@testable import EventHub
+
+/// Apple's coverage of the cross-platform de-duplication specification
+/// (`docs/event-hub/tests/deduplication.md` in `duckduckgo/ddg-workflow`). Each case ID from that
+/// document leads the test name so coverage is greppable and a failure names the spec case.
+///
+/// The properties the cases evidence:
+/// - **D-DEL-P1** — for every web event the hub makes exactly one de-duplication decision at
+///   ingestion, keyed `(event type, event data, tab)` against the tab's current page, before any
+///   handler is invoked. The first occurrence of a key on a page goes to every handler, later ones to
+///   none. Payloads equal as JSON values are one key.
+/// - **D-NAV-P1** — that state is scoped to a tab's *current* page: cleared on navigation to a
+///   different URL, untouched by a same-URL reload, independent between tabs.
+/// - **D-NAT-P1** — events with no tab context are never de-duplicated.
+///
+/// De-duplication is observed through telemetry pixels, per the suite's assertion-boundary
+/// convention: the immediate pixels are the direct delivery observer (one pixel per delivered event)
+/// and `dedupProbe_day` is a counter on the same stream, showing the fan-out sharing one decision.
+@Suite("Spec: hub de-duplication")
+struct DeduplicationSpecTests {
+
+    /// The specification's fixture, verbatim. `dedupProbe_day` deliberately has **no zero bucket**, so
+    /// it is silent in any case where nothing was counted.
+    static let config = """
+    { "telemetry": {
+        "dedupProbe_immediate": {
+            "state": "enabled",
+            "trigger": { "type": "immediate_v2", "source": "probeDetected" },
+            "parameters": { "reason": { "template": "data", "dataKey": "reason" } }
+        },
+        "dedupProbe_day": {
+            "state": "enabled",
+            "trigger": { "period": { "seconds": 86400 } },
+            "parameters": { "count": { "template": "counter", "source": "probeDetected", "buckets": {
+                "1":  {"gte": 1, "lt": 2},
+                "2":  {"gte": 2, "lt": 3},
+                "3+": {"gte": 3}
+            } } }
+        },
+        "dedupOther_immediate": {
+            "state": "enabled",
+            "trigger": { "type": "immediate_v2", "source": "otherDetected" },
+            "parameters": { "reason": { "template": "data", "dataKey": "reason" } }
+        },
+        "dedupAppLaunch_immediate": {
+            "state": "enabled",
+            "trigger": { "type": "immediate_v2", "source": "appLaunch" },
+            "parameters": { "launchType": { "template": "data", "dataKey": "launchType" } }
+        }
+    } }
+    """
+
+    static let periodSeconds: TimeInterval = 86400
+
+    // MARK: One decision before fan-out
+
+    @Test("D-DEL-1: repeated occurrences on one page are delivered once")
+    func repeatedOccurrencesOnOnePageAreDeliveredOnce() {
+        let f = SpecFixture(Self.config)
+        let page = f.openPage()
+        // Three frames of one page each report the same thing; the hub sees three identical events.
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.send("probeDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=1",
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    @Test("D-DEL-2: the payload is part of the key")
+    func thePayloadIsPartOfTheKey() {
+        let f = SpecFixture(Self.config)
+        let page = f.openPage()
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.send("probeDetected", reason: "redirect", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=2",
+            #"dedupProbe_immediate?reason="overlay""#,
+            #"dedupProbe_immediate?reason="redirect""#,
+        ])
+    }
+
+    @Test("D-DEL-3: event types de-duplicate independently")
+    func eventTypesDeduplicateIndependently() {
+        let f = SpecFixture(Self.config)
+        let page = f.openPage()
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.send("otherDetected", reason: "overlay", on: page)
+        f.send("probeDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"dedupOther_immediate?reason="overlay""#,
+            "dedupProbe_day?count=1",
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    @Test("D-DEL-4: every handler observes the same single delivery")
+    func everyHandlerObservesTheSameSingleDelivery() {
+        // The immediate pixel fires exactly once *and* the counter reports exactly one: both handlers
+        // act on one decision rather than each taking their own. The metrics handler's leg of this
+        // evidence is the metrics suite, M-DED-1.
+        let f = SpecFixture(Self.config)
+        let page = f.openPage()
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.send("probeDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=1",
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    @Test("D-DEL-5: payload member order does not change the key")
+    func payloadMemberOrderDoesNotChangeTheKey() {
+        // Built from two JSON strings whose members are written in opposite orders. Swift's
+        // `[String: Any]` is unordered, so the *authored* order is already lost by the time the hub
+        // sees it — but two dictionaries with the same contents and different insertion history can
+        // still iterate differently, so this pins that the key is built from sorted members rather
+        // than from iteration order.
+        let f = SpecFixture(Self.config)
+        let page = f.openPage()
+        f.sendRaw("probeDetected", dataJSON: #"{ "reason": "overlay", "stage": 1 }"#, on: page)
+        f.sendRaw("probeDetected", dataJSON: #"{ "stage": 1, "reason": "overlay" }"#, on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=1",
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    @Test("D-DEL-6: an omitted payload and an empty payload are one key")
+    func omittedAndEmptyPayloadAreOneKey() {
+        let f = SpecFixture(Self.config)
+        let page = f.openPage()
+        f.sendWithoutData("probeDetected", on: page)
+        f.sendRaw("probeDetected", dataJSON: "{}", on: page)
+
+        f.endPeriod()
+
+        // No immediate pixel fires: its only parameter reads `reason`, which resolves to nothing.
+        #expect(f.fired == ["dedupProbe_day?count=1"])
+    }
+
+    // MARK: Navigation resets the page
+
+    @Test("D-NAV-1: navigating to a different URL makes the next occurrence deliverable")
+    func navigatingToADifferentURLMakesTheNextOccurrenceDeliverable() {
+        let f = SpecFixture(Self.config)
+        let page = f.openPage()
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.navigate(page, to: "https://example.com/second")
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.navigate(page, to: "https://example.com/third")
+        f.send("probeDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=3+",
+            #"dedupProbe_immediate?reason="overlay""#,
+            #"dedupProbe_immediate?reason="overlay""#,
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    @Test("D-NAV-2: a same-URL reload does not start a new page")
+    func aSameURLReloadDoesNotStartANewPage() {
+        let f = SpecFixture(Self.config)
+        let page = f.openPage(url: "https://example.com/first")
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.navigate(page, to: "https://example.com/first")
+        f.send("probeDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=1",
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    @Test("D-NAV-3: returning to a previously seen URL delivers again")
+    func returningToAPreviouslySeenURLDeliversAgain() {
+        // State is per current page, not per URL ever seen.
+        let f = SpecFixture(Self.config)
+        let page = f.openPage(url: "https://example.com/a")
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.navigate(page, to: "https://example.com/b")
+        f.navigate(page, to: "https://example.com/a")
+        f.send("probeDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=2",
+            #"dedupProbe_immediate?reason="overlay""#,
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    @Test("D-NAV-4: separate tabs are independent")
+    func separateTabsAreIndependent() {
+        let f = SpecFixture(Self.config)
+        let url = "https://example.com/shared"
+        for _ in 0..<3 {
+            f.send("probeDetected", reason: "overlay", on: f.openPage(url: url))
+        }
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=3+",
+            #"dedupProbe_immediate?reason="overlay""#,
+            #"dedupProbe_immediate?reason="overlay""#,
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    // MARK: Native events are exempt
+
+    @Test("D-NAT-1: repeated native events are all delivered")
+    func repeatedNativeEventsAreAllDelivered() {
+        // No tab and no URL, so "once per page" has no meaning: every occurrence is delivered. The
+        // counter is a web-event stream and has no zero bucket, so it stays silent.
+        let f = SpecFixture(Self.config)
+        f.sendNative("appLaunch", payload: ["launchType": "cold"])
+        f.sendNative("appLaunch", payload: ["launchType": "warm"])
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"dedupAppLaunch_immediate?launchType="cold""#,
+            #"dedupAppLaunch_immediate?launchType="warm""#,
+        ])
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/Spec/TelemetrySpecTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Spec/TelemetrySpecTests.swift
@@ -1,0 +1,138 @@
+//
+//  TelemetrySpecTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+import Testing
+import Foundation
+@testable import EventHub
+
+/// Apple's coverage of the cross-platform telemetry specification
+/// (`docs/event-hub/tests/telemetry.md` in `duckduckgo/ddg-workflow`), for the cases that exist
+/// because telemetry now consumes the hub's de-duplicated stream.
+///
+/// The properties they evidence:
+/// - **T-IMM-P1** — immediate pixels fire once per *delivered* event. Because the hub de-duplicates
+///   before fan-out (D-DEL-P1), repeats of an event type carrying the same payload on one page fire
+///   once, while each distinct payload fires.
+/// - **T-DAT-P1** — a data parameter carries the payload value of the most recent delivered event
+///   whose type equals its `source`. Every such event assigns, so an event whose payload lacks the
+///   key leaves the parameter with no value, and a parameter with no value is omitted from the pixel.
+///
+/// The rest of this suite is not de-duplication behaviour and lands with the telemetry conformance
+/// pass. Only IDs appearing in a `@Test` name are covered here.
+@Suite("Spec: telemetry")
+struct TelemetrySpecTests {
+
+    /// The specification's fixture, less the two `state: disabled` entries, which only T-GEN-P1,
+    /// T-CNT-4 and T-IMM-3 need. `webTelemetry_adwallDetection_day` deliberately has **no zero
+    /// bucket**.
+    static let config = """
+    { "telemetry": {
+        "webTelemetry_captchaDetection_day": {
+            "state": "enabled",
+            "trigger": { "period": { "seconds": 86400 } },
+            "parameters": { "count": { "template": "counter", "source": "captchaDetected", "buckets": {
+                "0": {"gte": 0, "lt": 1}, "1-2": {"gte": 1, "lt": 3}, "3-5": {"gte": 3, "lt": 6}, "6+": {"gte": 6}
+            } } }
+        },
+        "webTelemetry_captchaDetection_week": {
+            "state": "enabled",
+            "trigger": { "period": { "seconds": 604800 } },
+            "parameters": { "count": { "template": "counter", "source": "captchaDetected", "buckets": {
+                "0": {"gte": 0, "lt": 1}, "1-2": {"gte": 1, "lt": 3}, "3-5": {"gte": 3, "lt": 6}, "6+": {"gte": 6}
+            } } }
+        },
+        "webTelemetry_adwallDetection_day": {
+            "state": "enabled",
+            "trigger": { "period": { "seconds": 86400 } },
+            "parameters": {
+                "count": { "template": "counter", "source": "adwallDetected", "buckets": {
+                    "1-2": {"gte": 1, "lt": 3}, "3+": {"gte": 3}
+                } },
+                "reason": { "template": "data", "source": "adwallDetected", "dataKey": "reason" }
+            }
+        },
+        "webTelemetry_adwallDetection_immediate": {
+            "state": "enabled",
+            "trigger": { "type": "immediate_v2", "source": "adwallDetected" },
+            "parameters": { "reason": { "template": "data", "dataKey": "reason" } }
+        }
+    } }
+    """
+
+    /// Cases observe the day boundary, where the day pixels' current period ends exactly once.
+    /// `webTelemetry_captchaDetection_week` is correctly still running at that point and so does not
+    /// appear in any expected set below; the week leg of these cases arrives with the counter case
+    /// that exercises day and week counters side by side.
+    private static func fixture() -> SpecFixture {
+        SpecFixture(config, periodSeconds: 86400)
+    }
+
+    @Test("T-IMM-1: one immediate pixel per event type and payload per page")
+    func oneImmediatePixelPerEventTypeAndPayloadPerPage() {
+        // The second occurrence is dropped at the hub (D-DEL-1), so the immediate pixel fires once and
+        // the day pixel counts the page once.
+        let f = Self.fixture()
+        let page = f.openPage()
+        f.send("adwallDetected", reason: "overlay", on: page)
+        f.send("adwallDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason="overlay""#,
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+            "webTelemetry_captchaDetection_day?count=0",
+        ])
+    }
+
+    @Test("T-IMM-4: distinct payloads on one page each fire")
+    func distinctPayloadsOnOnePageEachFire() {
+        // Both occurrences are delivered (D-DEL-2), and the day pixel's data parameter keeps the last.
+        let f = Self.fixture()
+        let page = f.openPage()
+        f.send("adwallDetected", reason: "overlay", on: page)
+        f.send("adwallDetected", reason: "redirect", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason="redirect""#,
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+            #"webTelemetry_adwallDetection_immediate?reason="redirect""#,
+            "webTelemetry_captchaDetection_day?count=0",
+        ])
+    }
+
+    @Test("T-DAT-2: a matching event without the key leaves no value")
+    func aMatchingEventWithoutTheKeyLeavesNoValue() {
+        // On distinct pages, so de-duplication does not collapse the two. The second event assigns
+        // like any other, and assigns nothing — so the day pixel reports no `reason` at all rather
+        // than the first event's. Its own immediate pixel does not fire: the only parameter that
+        // pixel declares produces no value.
+        let f = Self.fixture()
+        f.send("adwallDetected", reason: "overlay", on: f.openPage())
+        f.sendRaw("adwallDetected", dataJSON: "{}", on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "webTelemetry_adwallDetection_day?count=1-2",
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+            "webTelemetry_captchaDetection_day?count=0",
+        ])
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpecFixture.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpecFixture.swift
@@ -1,0 +1,103 @@
+//
+//  SpecFixture.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import EventHub
+
+/// Harness for the cross-platform behavioural specifications in `docs/event-hub/tests/`
+/// (`duckduckgo/ddg-workflow`). Wraps `EventHubFixture` in the vocabulary those documents use —
+/// pages, events, payloads, period end — so a spec case reads as the document writes it.
+final class SpecFixture {
+    private let fixture: EventHubFixture
+    private let periodSeconds: TimeInterval
+
+    init(_ settingsJSON: String, periodSeconds: TimeInterval = 86400) {
+        self.fixture = EventHubFixture.active(settingsJSON)
+        self.periodSeconds = periodSeconds
+    }
+
+    var manager: EventHub { fixture.manager }
+
+    // MARK: Pages
+
+    /// Opens `url` in a new tab and returns it.
+    ///
+    /// Every case starts a page this way, and that matters: the hub's tab→URL map begins empty, so a
+    /// tab's *first* navigation records the URL without clearing anything. That is right in
+    /// production, where a page loads before any content script can fire, but it means an event sent
+    /// before a tab's first navigation would be wrongly treated as a repeat by the navigation that
+    /// follows it. Opening the page first models the real sequence.
+    func openPage(url: String = "https://example.com/page") -> EventHubTabID {
+        let tab = EventHubTabID.new()
+        navigate(tab, to: url)
+        return tab
+    }
+
+    func navigate(_ tab: EventHubTabID, to url: String) {
+        fixture.manager.onNavigationStarted(tabID: tab, url: url)
+    }
+
+    // MARK: Events
+
+    /// A web event carrying a single `reason` payload member — the shape most cases use.
+    func send(_ type: String, reason: String, on tab: EventHubTabID) {
+        sendRaw(type, dataJSON: #"{ "reason": "\#(reason)" }"#, on: tab)
+    }
+
+    /// A web event whose payload is written out as JSON, for cases that care about its exact shape.
+    func sendRaw(_ type: String, dataJSON: String, on tab: EventHubTabID) {
+        fixture.manager.handleWebEvent(EventHubFixture.eventWithData(type, dataJSON: dataJSON), tabID: tab)
+    }
+
+    /// A web event with the `data` member absent altogether, as distinct from present and empty.
+    func sendWithoutData(_ type: String, on tab: EventHubTabID) {
+        fixture.manager.handleWebEvent(EventHubFixture.webEvent(type), tabID: tab)
+    }
+
+    /// A browser-native event: no tab, no URL, and so never de-duplicated.
+    func sendNative(_ type: String, payload: [String: String]) {
+        fixture.manager.handleImmediateEvent(type, data: payload)
+    }
+
+    // MARK: Observation
+
+    /// Ends each running period once, per the suites' model: events are delivered, then the current
+    /// period ends.
+    func endPeriod() {
+        fixture.advance(by: periodSeconds)
+    }
+
+    /// Every pixel fired, written as the specifications write them — `name?param=value`, sorted so a
+    /// case can state its complete expected set and an over-fire fails as loudly as a missing pixel.
+    ///
+    /// Data values are percent-decoded back to the compact JSON the cases quote (`reason="overlay"`
+    /// rather than `reason=%22overlay%22`); the encoding itself is pinned separately, by
+    /// `EventHubDataParameterTests`. The time-derived `attributionPeriod` is excluded, as the suites
+    /// specify.
+    var fired: [String] {
+        fixture.fired.map { pixel in
+            let parameters = pixel.parameters
+                .filter { $0.key != "attributionPeriod" }
+                .sorted { $0.key < $1.key }
+                .map { "\($0.key)=\($0.value.removingPercentEncoding ?? $0.value)" }
+                .joined(separator: "&")
+            return parameters.isEmpty ? pixel.name : "\(pixel.name)?\(parameters)"
+        }
+        .sorted()
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/EventHubConfigParserTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/EventHubConfigParserTests.swift
@@ -209,6 +209,35 @@ struct EventHubConfigParserTests {
         #expect(parser.parseTelemetry(json).isEmpty)
     }
 
+    @Test("the retired immediate trigger type is skipped")
+    func retiredImmediateTriggerTypeIsSkipped() {
+        // `immediate` was renamed to `immediate_v2` when web events began de-duplicating at the hub.
+        // Config still written for the old name belongs to clients that fire on every occurrence, so
+        // this client must not honour it — see `TelemetryTriggerType`.
+        let json = settingsDictionary("""
+        { "telemetry": { "test": {
+            "state": "enabled",
+            "trigger": { "type": "immediate", "source": "e" },
+            "parameters": { "d": { "template": "data", "dataKey": "k" } }
+        } } }
+        """)
+
+        #expect(parser.parseTelemetry(json).isEmpty)
+    }
+
+    @Test("the immediate_v2 trigger type is parsed")
+    func immediateV2TriggerTypeIsParsed() {
+        let json = settingsDictionary("""
+        { "telemetry": { "test": {
+            "state": "enabled",
+            "trigger": { "type": "immediate_v2", "source": "e" },
+            "parameters": { "d": { "template": "data", "dataKey": "k" } }
+        } } }
+        """)
+
+        #expect(parser.parseTelemetry(json).first?.trigger.type == .immediateV2)
+    }
+
     @Test("parseSinglePixelConfig with malformed JSON returns nil")
     func parseSinglePixelConfigWithMalformedJSONReturnsNil() {
         #expect(parser.parseSinglePixelConfig(name: "test", json: "not json") == nil)
@@ -260,12 +289,12 @@ struct EventHubConfigParserTests {
         let config = TelemetryPixelConfig(
             name: "test",
             state: "enabled",
-            trigger: TelemetryTriggerConfig(type: .immediate, source: "e"),
+            trigger: TelemetryTriggerConfig(type: .immediateV2, source: "e"),
             parameters: ["d": TelemetryParameterConfig(template: .data, dataKey: "k")])
 
         let json = try #require(parser.serializePixelConfig(config))
 
-        #expect(json.contains("\"type\":\"immediate\""))
+        #expect(json.contains("\"type\":\"immediate_v2\""))
         #expect(json.contains("\"template\":\"data\""))
     }
 

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubDataParameterTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubDataParameterTests.swift
@@ -24,7 +24,7 @@ struct EventHubDataParameterTests {
     static let immediateDataConfig = """
     { "telemetry": { "webEvent_login": {
         "state": "enabled",
-        "trigger": { "type": "immediate", "source": "login" },
+        "trigger": { "type": "immediate_v2", "source": "login" },
         "parameters": { "loginState": { "template": "data", "dataKey": "loginState" } }
     } } }
     """
@@ -42,7 +42,7 @@ struct EventHubDataParameterTests {
         let config = """
         { "telemetry": { "webEvent_login": {
             "state": "enabled",
-            "trigger": { "type": "immediate", "source": "login" },
+            "trigger": { "type": "immediate_v2", "source": "login" },
             "parameters": { "payload": { "template": "data", "dataKey": "payload" } }
         } } }
         """
@@ -60,12 +60,14 @@ struct EventHubDataParameterTests {
         #expect(f.fired.first?.parameters["loginState"] == "null")
     }
 
-    @Test("immediate data param is omitted when the key is absent")
-    func immediateDataParamOmittedWhenKeyAbsent() {
+    @Test("an immediate pixel does not fire when its only data param is absent")
+    func immediatePixelDoesNotFireWhenOnlyDataParamAbsent() {
+        // A pixel that declares data parameters but resolves none of them has nothing to report. A
+        // pixel declaring no parameters at all still fires on the event alone — see
+        // `EventHubImmediatePixelTests`.
         let f = EventHubFixture.active(Self.immediateDataConfig)
         f.manager.handleWebEvent(EventHubFixture.eventWithData("login", dataJSON: #"{ "other": "x" }"#), tabID: .new())
-        #expect(f.fired.count == 1)
-        #expect(f.fired.first?.parameters["loginState"] == nil)
+        #expect(f.fired.isEmpty)
     }
 
     @Test("aggregate data param uses the last value from a matching source")

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubImmediatePixelTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubImmediatePixelTests.swift
@@ -24,7 +24,7 @@ struct EventHubImmediatePixelTests {
     static let immediateConfig = """
     { "telemetry": { "webEvent_impression": {
         "state": "enabled",
-        "trigger": { "type": "immediate", "source": "impression" },
+        "trigger": { "type": "immediate_v2", "source": "impression" },
         "parameters": {}
     } } }
     """
@@ -37,14 +37,18 @@ struct EventHubImmediatePixelTests {
         #expect(f.fired.first?.name == "webEvent_impression")
     }
 
-    @Test("immediate pixels are not deduplicated")
-    func immediatePixelsAreNotDeduplicated() {
+    @Test("immediate pixels are de-duplicated per page")
+    func immediatePixelsAreDeduplicatedPerPage() {
+        // The hub de-duplicates before fan-out, so immediate pixels are subject to it like any other
+        // handler. Covers the parameterless config specifically — the spec fixtures all carry a data
+        // parameter, so the empty-payload key path is only exercised here.
         let f = EventHubFixture.active(Self.immediateConfig)
         let tab = EventHubTabID.new()
+        f.manager.onNavigationStarted(tabID: tab, url: "https://example.com/page")
         f.manager.handleWebEvent(EventHubFixture.webEvent("impression"), tabID: tab)
         f.manager.handleWebEvent(EventHubFixture.webEvent("impression"), tabID: tab)
         f.manager.handleWebEvent(EventHubFixture.webEvent("impression"), tabID: tab)
-        #expect(f.fired.count == 3)
+        #expect(f.fired.count == 1)
     }
 
     @Test("immediate pixels fire without the app being foregrounded")

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubNativeIngressTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubNativeIngressTests.swift
@@ -27,7 +27,7 @@ struct EventHubNativeIngressTests {
     static let immediateConfig = """
     { "telemetry": { "webEvent_impression": {
         "state": "enabled",
-        "trigger": { "type": "immediate", "source": "impression" },
+        "trigger": { "type": "immediate_v2", "source": "impression" },
         "parameters": {}
     } } }
     """
@@ -35,7 +35,7 @@ struct EventHubNativeIngressTests {
     static let immediateDataConfig = """
     { "telemetry": { "webEvent_login": {
         "state": "enabled",
-        "trigger": { "type": "immediate", "source": "login" },
+        "trigger": { "type": "immediate_v2", "source": "login" },
         "parameters": { "loginState": { "template": "data", "dataKey": "loginState" } }
     } } }
     """
@@ -60,7 +60,7 @@ struct EventHubNativeIngressTests {
     // method can be shown to drive only its own trigger type.
     static let bothConfig = """
     { "telemetry": {
-        "imm": { "state": "enabled", "trigger": { "type": "immediate", "source": "test" }, "parameters": {} },
+        "imm": { "state": "enabled", "trigger": { "type": "immediate_v2", "source": "test" }, "parameters": {} },
         "per": { "state": "enabled", "trigger": { "period": { "seconds": 86400 } },
             "parameters": { "count": { "template": "counter", "source": "test", "buckets": { "0": {"gte": 0, "lt": 1}, "1+": {"gte": 1} } } } }
     } }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubTests.swift
@@ -103,45 +103,10 @@ struct EventHubTests {
 
     // MARK: Per-tab de-duplication
 
-    @Test("same tab, same source is deduplicated")
-    func sameTabSameSourceIsDeduplicated() {
-        let f = EventHubFixture.active(Self.dayConfig)
-        let tab = EventHubTabID.new()
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: tab)
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: tab)
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: tab)
-        #expect(f.count(of: Self.pixel1) == 1)
-    }
-
-    @Test("navigation to a new URL resets dedup")
-    func navigationToNewURLResetsDedup() {
-        let f = EventHubFixture.active(Self.dayConfig)
-        let tab = EventHubTabID.new()
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: tab)
-        f.manager.onNavigationStarted(tabID: tab, url: "https://example.com/page1")
-        f.manager.onNavigationStarted(tabID: tab, url: "https://example.com/page2")
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: tab)
-        #expect(f.count(of: Self.pixel1) == 2)
-    }
-
-    @Test("reloading the same URL does not reset dedup")
-    func reloadSameURLDoesNotResetDedup() {
-        let f = EventHubFixture.active(Self.dayConfig)
-        let tab = EventHubTabID.new()
-        f.manager.onNavigationStarted(tabID: tab, url: "https://example.com/page")
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: tab)
-        f.manager.onNavigationStarted(tabID: tab, url: "https://example.com/page")
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: tab)
-        #expect(f.count(of: Self.pixel1) == 1)
-    }
-
-    @Test("different tabs count independently")
-    func differentTabsCountIndependently() {
-        let f = EventHubFixture.active(Self.dayConfig)
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: .new())
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: .new())
-        #expect(f.count(of: Self.pixel1) == 2)
-    }
+    // The page-scoped rules themselves (repeat, navigation, reload, per-tab independence) are the
+    // cross-platform spec's, covered as D-DEL-1 / D-NAV-1 / D-NAV-2 / D-NAV-4 in
+    // `DeduplicationSpecTests`. What remains here is Apple-specific lifecycle: tab close, and dedup
+    // surviving the period machinery.
 
     @Test("closing a tab clears its dedup state")
     func closingATabClearsItsDedupState() {

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/ParameterTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/ParameterTests.swift
@@ -28,87 +28,41 @@ struct CounterParameterTests {
         OrderedBucket(name: "2+", config: BucketConfig(gte: 2)),
     ]
 
-    /// Builds a parameter alongside the store it dedups against, so a test can clear dedup the way
-    /// `EventHub` does (the parameter consults the store; it no longer owns the state itself).
-    private static func makeParameter() -> (parameter: CounterParameter, dedupStore: DedupStore) {
-        let dedupStore = DedupStore()
-        let parameter = CounterParameter(buckets: buckets, dedupKey: "pixel:count:test", dedupStore: dedupStore)
-        return (parameter, dedupStore)
+    private static func makeParameter() -> CounterParameter {
+        CounterParameter(buckets: buckets)
     }
 
-    @Test("increments on each distinct-tab event")
-    func incrementsOnEachDistinctTabEvent() {
-        let (parameter, _) = Self.makeParameter()
-        #expect(parameter.handle(data: nil, tabID: .new()))
-        #expect(parameter.handle(data: nil, tabID: .new()))
+    @Test("counts every delivered event")
+    func countsEveryDeliveredEvent() {
+        // De-duplication happens at the hub, before fan-out, so everything reaching a parameter is a
+        // genuine occurrence — the parameter itself never suppresses anything. See `DedupStore`.
+        let parameter = Self.makeParameter()
+        #expect(parameter.handle(data: nil))
+        #expect(parameter.handle(data: nil))
         #expect(parameter.state.value == 2)
-    }
-
-    @Test("dedups repeated events on the same tab")
-    func dedupsRepeatedEventsOnSameTab() {
-        let (parameter, _) = Self.makeParameter()
-        let tab = EventHubTabID.new()
-        #expect(parameter.handle(data: nil, tabID: tab))
-        #expect(!parameter.handle(data: nil, tabID: tab))
-        #expect(parameter.state.value == 1)
-    }
-
-    @Test("native events (.empty tab) are never deduped")
-    func nativeEventsAreNeverDeduped() {
-        let (parameter, _) = Self.makeParameter()
-        #expect(parameter.handle(data: nil, tabID: .empty))
-        #expect(parameter.handle(data: nil, tabID: .empty))
-        #expect(parameter.state.value == 2)
-    }
-
-    @Test("clearing the tab's dedup entry lets it count again")
-    func clearingTabDedupLetsItCountAgain() {
-        // `EventHub` clears the store on navigation to a different URL and on tab close; from the
-        // parameter's side both look the same, so one test covers each caller.
-        let (parameter, dedupStore) = Self.makeParameter()
-        let tab = EventHubTabID.new()
-        #expect(parameter.handle(data: nil, tabID: tab))
-        dedupStore.clear(tabID: tab)
-        #expect(parameter.handle(data: nil, tabID: tab))
-        #expect(parameter.state.value == 2)
-    }
-
-    @Test("two parameters sharing a store dedup independently")
-    func parametersSharingStoreDedupIndependently() {
-        // The store is hub-wide, so the dedup key must keep pixels/params from shadowing each other.
-        let dedupStore = DedupStore()
-        let first = CounterParameter(buckets: Self.buckets, dedupKey: "pixelA:count:test", dedupStore: dedupStore)
-        let second = CounterParameter(buckets: Self.buckets, dedupKey: "pixelB:count:test", dedupStore: dedupStore)
-        let tab = EventHubTabID.new()
-
-        #expect(first.handle(data: nil, tabID: tab))
-        #expect(second.handle(data: nil, tabID: tab))
-
-        #expect(first.state.value == 1)
-        #expect(second.state.value == 1)
     }
 
     @Test("stops counting at the open-ended bucket and further events are no-ops")
     func stopsCountingAtOpenEndedBucket() {
-        let (parameter, _) = Self.makeParameter()
-        for _ in 0..<5 { parameter.handle(data: nil, tabID: .new()) }
+        let parameter = Self.makeParameter()
+        for _ in 0..<5 { parameter.handle(data: nil) }
         #expect(parameter.state.stopCounting)
         let valueAtStop = parameter.state.value
-        #expect(!parameter.handle(data: nil, tabID: .new()))
+        #expect(!parameter.handle(data: nil))
         #expect(parameter.state.value == valueAtStop)
     }
 
     @Test("queryValue reflects the matching bucket")
     func queryValueReflectsMatchingBucket() {
-        let (parameter, _) = Self.makeParameter()
+        let parameter = Self.makeParameter()
         #expect(parameter.queryValue() == "0")
-        parameter.handle(data: nil, tabID: .new())
+        parameter.handle(data: nil)
         #expect(parameter.queryValue() == "1")
     }
 
     @Test("restoreState round trips value and stopCounting")
     func restoreStateRoundTrips() {
-        let (parameter, _) = Self.makeParameter()
+        let parameter = Self.makeParameter()
         parameter.restoreState(ParamState(value: 3, stopCounting: true))
         #expect(parameter.state.value == 3)
         #expect(parameter.state.stopCounting)
@@ -120,22 +74,39 @@ struct DataParameterTests {
     @Test("captures and percent-encodes a matching data key")
     func capturesAndEncodesMatchingKey() {
         let parameter = DataParameter(dataKey: "loginState")
-        #expect(parameter.handle(data: ["loginState": "logged-in"], tabID: .new()))
+        #expect(parameter.handle(data: ["loginState": "logged-in"]))
         #expect(parameter.queryValue() != nil)
     }
 
-    @Test("ignores events with no matching data key")
-    func ignoresEventsWithNoMatchingKey() {
+    @Test("an event without the key clears a previously captured value")
+    func eventWithoutKeyClearsPreviousValue() {
+        // Every delivered event of the parameter's source assigns, so the pixel reports what the
+        // latest event carried rather than a stale reading from an earlier one.
         let parameter = DataParameter(dataKey: "loginState")
-        #expect(!parameter.handle(data: ["other": "x"], tabID: .new()))
+        parameter.handle(data: ["loginState": "logged-in"])
+        #expect(parameter.handle(data: ["other": "x"]))
         #expect(parameter.queryValue() == nil)
+    }
+
+    @Test("an event without the key is no change when there is nothing to clear")
+    func eventWithoutKeyIsNoChangeWhenEmpty() {
+        let parameter = DataParameter(dataKey: "loginState")
+        #expect(!parameter.handle(data: ["other": "x"]))
+        #expect(parameter.queryValue() == nil)
+    }
+
+    @Test("re-reporting the same value is no change")
+    func reReportingSameValueIsNoChange() {
+        let parameter = DataParameter(dataKey: "loginState")
+        #expect(parameter.handle(data: ["loginState": "a"]))
+        #expect(!parameter.handle(data: ["loginState": "a"]))
     }
 
     @Test("keeps the last value across multiple matching events")
     func keepsLastValueAcrossMultipleEvents() {
         let parameter = DataParameter(dataKey: "loginState")
-        parameter.handle(data: ["loginState": "a"], tabID: .new())
-        parameter.handle(data: ["loginState": "b"], tabID: .new())
+        parameter.handle(data: ["loginState": "a"])
+        parameter.handle(data: ["loginState": "b"])
         #expect(parameter.queryValue()?.contains("b") == true)
     }
 

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/TelemetryTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/TelemetryTests.swift
@@ -35,43 +35,43 @@ struct TelemetryTests {
 
     @Test("computes periodEndMillis from the trigger period")
     func computesPeriodEndFromTriggerPeriod() {
-        let telemetry = Telemetry(config: Self.config, periodStartMillis: 1000, dedupStore: DedupStore())
+        let telemetry = Telemetry(config: Self.config, periodStartMillis: 1000)
         #expect(telemetry.periodEndMillis == 1000 + 60_000)
     }
 
     @Test("isElapsed reflects the current time against periodEndMillis")
     func isElapsedReflectsCurrentTime() {
-        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0, dedupStore: DedupStore())
+        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0)
         #expect(!telemetry.isElapsed(atMillis: 59_999))
         #expect(telemetry.isElapsed(atMillis: 60_000))
     }
 
     @Test("handleEvent routes only to parameters whose source matches")
     func handleEventRoutesOnlyToMatchingSource() {
-        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0, dedupStore: DedupStore())
-        #expect(!telemetry.handleEvent(source: "unrelated", data: nil, tabID: .new()))
-        #expect(telemetry.handleEvent(source: "test", data: nil, tabID: .new()))
+        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0)
+        #expect(!telemetry.handleEvent(source: "unrelated", data: nil))
+        #expect(telemetry.handleEvent(source: "test", data: nil))
     }
 
     @Test("buildPixelParameters reports the matched bucket")
     func buildPixelParametersReportsMatchedBucket() {
-        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0, dedupStore: DedupStore())
-        telemetry.handleEvent(source: "test", data: nil, tabID: .new())
+        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0)
+        telemetry.handleEvent(source: "test", data: nil)
         #expect(telemetry.buildPixelParameters()?["count"] == "1+")
     }
 
     @Test("snapshot round trips through restoring init")
     func snapshotRoundTripsThroughRestoringInit() {
-        let original = Telemetry(config: Self.config, periodStartMillis: 500, dedupStore: DedupStore())
-        original.handleEvent(source: "test", data: nil, tabID: .new())
-        let restored = Telemetry(restoring: original.snapshot(), dedupStore: DedupStore())
+        let original = Telemetry(config: Self.config, periodStartMillis: 500)
+        original.handleEvent(source: "test", data: nil)
+        let restored = Telemetry(restoring: original.snapshot())
         #expect(restored.periodStartMillis == 500)
         #expect(restored.buildPixelParameters()?["count"] == "1+")
     }
 
     @Test("config snapshot is frozen — mutating the source config after construction has no effect")
     func configSnapshotIsFrozen() {
-        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0, dedupStore: DedupStore())
+        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0)
         let originalSource = telemetry.config.parameters["count"]?.source
         // Telemetry copies TelemetryPixelConfig (a value type) at construction; there is no live
         // reference back to a "current" config to mutate — this test documents that guarantee.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218062429029803
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1216911265362552
CC:

### Description
First in the `michal/eventhub-metrics` stack. Reworks how the hub decides whether a web event is a repeat, ahead of the config-driven experiment metrics handler that lands next.

Until now each pixel counter made its own de-duplication decision, and immediate-fire pixels made none at all. The hub now makes one decision when the event arrives, before anything is told about it: a repeat reaches no handler, a first occurrence reaches every handler.

Additional behavioural changes:
- event's payload is also part of the de-duplication key, so a detector that reports different values is no longer collapsed into a single occurrence
- immediate type trigger is renamed to `immediate_v2`, change is meant to reflect the expectations that it is now subject to de-duplication

Fixes to update behaviour in line with the cross-platform specification: 
- immediate type pixel whose data parameters all resolve to nothing no longer fires
- nil data parameter now clears preexisting value

Cross-platform tech designs: [event-driven metrics](https://app.asana.com/1/137249556945/project/72649045549333/task/1217052832008956) and [de-duplication with data payload](https://app.asana.com/1/137249556945/project/481882893211075/task/1217874991729731).

### Testing Steps
Use the setup in https://app.asana.com/1/137249556945/project/414235014887631/task/1218049910864102?focus=true and use Xcode debugger to see EventHub logs

**Test case 1:**
1. Navigate to https://www.wikihow.com/Disable-Your-Ad-Blocker  (detector needs to find "disable your ad blocker" text on the page)
- [x] Event is properly recorded on the initial page load in a given tab
- [x] Event is blocked by de-duplication logic when reloading the same tab
- [x] After navigating to some to some other page and returning back makes the event being recorded again (navigation clears de-dup state)
- [x] Opening new multiple new tabs with the test page causes each event to be properly recorded

**Test case 2:**
1.  Navigate to https://privacy-test-pages.site/features/web-interference-detection/youtube-detection-events.html
2. Click "Show Ad-Blocker Modal" button
- [x] Triggering the event properly records is with `unknown` login state
- [x] Repeated re-triggering (without page reload) is blocked by de-duplication logic (including the immediate type event)

**Test case 3:**
1. Navigate to https://privacy-test-pages.site/features/web-interference-detection/youtube-detection-events.html
2. Select "Login state" from the drop down
3. Click "Reload with this state" (causes page reload navigation event)
4. Click "Show Ad-Blocker Modal" button
- [x] Triggering the event properly records is with preselected login state

**Test case 4:**
1. Navigate to https://privacy-test-pages.site/features/web-interference-detection/youtube-detection-events.html?loginState=premium&loginStateDelayMs=3000 (page will load with unknown login state but will dynamically update to premium after 3s)
2. Click "Show Ad-Blocker Modal" button when the page loads (needs to happen within first 3s) - this will record event with unknown login state.
3. Click "Show Ad-Blocker Modal" button twice to disable and re-enable it (do it after more than 3s from the page load) - this will record event with premium login state.
- [x] Triggering the event properly records is first with the `unknown` login state and then with `premium` (no de-duplication happens)
- [x] Without page reload click "Show Ad-Blocker Modal" button twice causes the `premium` event to be re-triggered but it is now de-duplicated since the `data` param is unchanged.


### Impact
High — changes what already-released telemetry reports, and the trigger rename stops shipped pixels until remote config catches up.

#### What could go wrong?
- The five shipped `webTelemetry_captcha_*` immediate pixels stop firing until privacy config ships `immediate_v2` entries → the config change must land before this reaches users. Embedded configs pick it up via `scripts/update_embedded.sh`, so no in-app change is needed.
- Those same captcha pixels drop in volume once they do return, since immediate pixels now de-duplicate per page → intended, but worth flagging to Data Science as a step change rather than a regression.
- The five `webTelemetry_youtube_*_day` counters can over-count: each pairs a counter with a `loginState` data parameter on one source, and `loginState` starts `unknown` before resolving, so an early detection and a later one now count separately where they previously counted once → accepted trade-off per the de-duplication tech design, but it lands on the pixel carrying the public disclaimer.
- An immediate pixel that resolves none of its data parameters now stays silent → required by the specification, covered by tests, but it is a behaviour change for any config relying on the old unconditional fire.

### Quality Considerations
- Covers the cross-platform specification suite: D-DEL-1…6, D-NAV-1…4, D-NAT-1, plus T-IMM-1, T-IMM-4 and T-DAT-2 from the telemetry suite. Each case ID leads its test name, so coverage greps cleanly and a failure names the spec case.
- Not covered here: the week-counter leg of the three telemetry cases, which needs a decision on modelling "each period ends exactly once" when a seven-day period passes seven daily boundaries. It belongs with the rest of the telemetry suite.
- Payload identity uses canonical JSON with sorted members, so member order does not matter and an absent payload equals an empty one. A payload that cannot be serialised is delivered rather than dropped — under-de-duplicating is the safer failure.
- The per-tab key set is unbounded, cleared on navigation and tab close. With the payload in the key a page emitting many distinct payloads grows it until it navigates away; left uncapped deliberately, since a cap would be an undeclared divergence from the other platforms.
- Privacy: the received-event log line now includes the payload. It is `.private` and `debug`-only, so redacted unless private-data logging is deliberately enabled. The logger's documentation previously stated payloads were never logged and has been updated to match.
- De-duplication state remains in-memory only, so a restart lets a page be counted once more. Unchanged, but it now governs metric conversions too.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes shipped telemetry semantics (hub dedup, payload-aware keys, immediate_v2 rename) and can silence or reshape pixel volume until remote config updates; requires coordinated privacy-config rollout.
> 
> **Overview**
> Moves **web event de-duplication** from per-counter logic into `EventHub` at ingestion: each `(event type, canonical payload, tab)` is decided once per page before immediate and period handlers run, so repeats never fan out and multi-frame duplicates no longer inflate every consumer.
> 
> **`DedupStore`** keys on sorted-key JSON (member order irrelevant; missing vs empty `data` match), clears on real URL change, tab close, or feature disable—not on period boundaries. Native ingress still bypasses dedup. **`immediate`** config is no longer parsed; **`immediate_v2`** is the trigger for one pixel per *delivered* event.
> 
> **Telemetry behavior** aligned with spec: immediate pixels with data parameters fire only when at least one resolves; **`DataParameter`** clears when a later event omits its key instead of keeping a stale value. **`EventHubTabID.empty`** is removed for native paths.
> 
> Adds cross-platform **spec test suites** (`DeduplicationSpecTests`, `TelemetrySpecTests`, `SpecFixture`) and wires **EventHub** into the workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d1b6240b62e266aa7fc0869d949e7d0f70900f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->