### PR TITLE
Remove feature flag: systemFindInPage

### DIFF
--- a/iOS/DuckDuckGo/MainViewController+KeyCommands.swift
+++ b/iOS/DuckDuckGo/MainViewController+KeyCommands.swift
@@ -192,7 +192,7 @@ extension MainViewController {
     
     @objc func keyboardEscape() {
         guard tabSwitcherController == nil else { return }
-        if #available(iOS 16.0, *), featureFlagger.isFeatureOn(.systemFindInPage) {
+        if #available(iOS 16.0, *) {
             dismissSystemFindNavigator(for: currentTab)
         } else {
             findInPageView?.done()

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3697,7 +3697,7 @@ class MainViewController: UIViewController {
     }
 
     func dismissSystemFindNavigator(for tab: TabViewController?) {
-        guard #available(iOS 16.0, *), featureFlagger.isFeatureOn(.systemFindInPage) else { return }
+        guard #available(iOS 16.0, *) else { return }
         rememberFindInPageQuery(for: tab)
         tab?.webView.findInteraction?.dismissFindNavigator()
         restoreChromeIfHiddenByFindInPage()
@@ -3705,8 +3705,7 @@ class MainViewController: UIViewController {
 
     @available(iOS 16.0, *)
     private func hideChromeForConfirmedFindInPage() {
-        guard featureFlagger.isFeatureOn(.systemFindInPage),
-              currentTab?.webView.findInteraction?.isFindNavigatorVisible == true,
+        guard currentTab?.webView.findInteraction?.isFindNavigatorVisible == true,
               !AppWidthObserver.shared.isPad || !AppWidthObserver.shared.isLargeWidth,
               !isFindInPageChromeLockActive else { return }
 
@@ -4707,7 +4706,7 @@ extension MainViewController: BrowserChromeDelegate {
     var isChromeScrollInteractionDisabled: Bool {
         if isAddressBarMoveInProgress { return true }
         if isBottomAddressBarHiddenForWebKeyboard { return true }
-        if #available(iOS 16.0, *), featureFlagger.isFeatureOn(.systemFindInPage),
+        if #available(iOS 16.0, *),
            currentTab?.webView.findInteraction?.isFindNavigatorVisible == true {
             return true
         }
@@ -6983,7 +6982,7 @@ extension MainViewController: TabDelegate {
     }
 
     func closeFindInPage(tab: TabViewController) {
-        if #available(iOS 16.0, *), featureFlagger.isFeatureOn(.systemFindInPage) {
+        if #available(iOS 16.0, *) {
             dismissSystemFindNavigator(for: tab)
             return
         }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -4277,7 +4277,7 @@ extension TabViewController: UIGestureRecognizerDelegate {
     }
 
     func requestFindInPage() {
-        if #available(iOS 16.0, *), featureFlagger.isFeatureOn(.systemFindInPage) {
+        if #available(iOS 16.0, *) {
             webView.isFindInteractionEnabled = true
             let findInteraction = webView.findInteraction
             // Ignore repeat invocations while find is open so in-progress text isn't replaced with a stored query.

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -523,9 +523,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216782867888622?focus=true
     case blankSnapshotCaching
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216629730083154?focus=true
-    case systemFindInPage
-
     /// Experiment for removing monthly free trials — second run, enrolling only free-trial eligible users.
     /// https://app.asana.com/1/137249556945/task/1217334233390728
     case monthlyFreeTrialExperiment2
@@ -911,8 +908,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(SyncSubfeature.simplifiedSyncSetupV2))
         case .blankSnapshotCaching:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.blankSnapshotCaching))
-        case .systemFindInPage:
-            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.systemFindInPage))
         case .iPadTabsBarInWindowControlsRow:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.iPadTabsBarInWindowControlsRow))
         case .nativeAIPromptEditing:

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
@@ -143,9 +143,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// Caches the blank-snapshot overlay off the suspend path to avoid the background scene-update watchdog.
     case blankSnapshotCaching
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216629730083154?focus=true
-    case systemFindInPage
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217015452646368?focus=true
     case iPadTabsBarInWindowControlsRow
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1216629730083154
Tech Design URL:
CC:

### Description
Feature flag `systemFindInPage` approved, removing conditional code. The `iOSBrowserConfigSubfeature.systemFindInPage` subfeature case and the corresponding `FeatureFlag.systemFindInPage` case (and its remote-config mapping) are deleted. All call sites now unconditionally take the enabled path — the system find-in-page navigator (`UIFindInteraction`) is used on iOS 16+, with the pre-existing legacy `FindInPageView` fallback preserved for iOS 15 devices via the existing `#available(iOS 16.0, *)` check.

### Testing Steps
1. On an iOS 16+ device/simulator, open a web page and trigger Find in Page (toolbar menu or ⌘F) → the system find navigator appears and behaves as before (search, dismiss, chrome hiding/restoring while it's visible).
2. On an iOS 15 device/simulator, trigger Find in Page → the legacy in-app find bar appears and behaves as before.
3. With the system find navigator open, press Escape (hardware keyboard) or switch tabs/close tab → navigator dismisses and chrome is restored as before.

### Impact
Low — this is a fully-approved feature flag removal with no user-facing behavior change; the previously-enabled code path is now unconditional.

### Quality Considerations
No new logic introduced; purely removes the flag check and dead disabled-path branches. Did not touch `iOS/Core/ios-config.json` or any bundled privacy config JSON, per policy.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0118wi6PWMFXSDFkzbR75EY2)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag removal with no new logic; behavior matches the previously enabled path on iOS 16+ and unchanged legacy fallback on iOS 15.
> 
> **Overview**
> Removes the approved **`systemFindInPage`** feature flag and its **`iOSBrowserConfigSubfeature`** / **`FeatureFlag`** definitions so find-in-page no longer branches on remote config.
> 
> On **iOS 16+**, call sites in **`MainViewController`**, **`TabViewController`**, and keyboard handling now always use the system **`UIFindInteraction`** navigator (present/dismiss, chrome hide/restore, scroll interaction lock). The legacy **`FindInPageView`** path remains only behind the existing **`#available(iOS 16.0, *)`** check for older OS versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7033314b99a35227f6c5cb85d2804ba0c1be6cfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->