### PR TITLE
Remove feature flag: duckAINativeStorageMigrationLockedLaunchFix

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -480,12 +480,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// legacy App Group path.
     case nativeStoragePathMigration
 
-    /// Once the native-storage path migration is complete (or not needed), opens
-    /// the store on locked / background launches instead of deferring on the
-    /// protected-data gate. Off keeps the legacy behavior where any locked launch
-    /// nils the handler — which makes the Duck.ai front-end re-prompt T&C.
-    case nativeStorageMigrationLockedLaunchFix
-
     /// Enables the rich Duck.ai tab grid card in the iOS tab switcher (rendered from
     /// native-storage chat data). When off, Duck.ai tabs fall back to the standard
     /// screenshot preview.

--- a/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
+++ b/iOS/DuckDuckGo/AIChat/DuckAiNativeStorageContainerMigration.swift
@@ -49,11 +49,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
     let isProtectedDataAvailable: () -> Bool
     let maxAttempts: Int
 
-    /// When true, the protected-data gate only guards the relocation; completed /
-    /// not-needed migrations proceed on locked launches. When false, the legacy
-    /// behavior applies (any locked launch defers). Phased-rollout / kill switch.
-    let lockedLaunchFixEnabled: Bool
-
     private let stateStore: MigrationStateStore
     private let protectionDispatcher: ProtectionDispatcher
 
@@ -66,7 +61,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
          pixelFiring: DuckAiNativeStorageContainerMigrationPixelFiring = NullDuckAiNativeStorageContainerMigrationPixelFiring(),
          isProtectedDataAvailable: @escaping () -> Bool = { DuckAiNativeStorageContainerMigration.defaultIsProtectedDataAvailable() },
          maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts,
-         lockedLaunchFixEnabled: Bool = true,
          protectionDispatcher: @escaping ProtectionDispatcher = { work in
              DispatchQueue.global(qos: .utility).async(execute: work)
          }) {
@@ -78,7 +72,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
         self.isProtectedDataAvailable = isProtectedDataAvailable
         // 0 / negative would give up on the first failure.
         self.maxAttempts = max(1, maxAttempts)
-        self.lockedLaunchFixEnabled = lockedLaunchFixEnabled
         self.stateStore = MigrationStateStore(keyValueStore: keyValueStore, migrationKey: migrationKey)
         self.protectionDispatcher = protectionDispatcher
     }
@@ -87,10 +80,6 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
 
     @discardableResult
     func run() -> DuckAiNativeStorageContainerMigrationOutcome {
-        if !lockedLaunchFixEnabled, let deferred = deferIfProtectedDataUnavailable() {
-            return deferred
-        }
-
         do {
             return try performMigration()
         } catch let kvError as MigrationStateStore.ReadError {
@@ -128,7 +117,7 @@ struct DuckAiNativeStorageContainerMigration: DuckAiNativeStorageContainerMigrat
             return .proceed
         }
 
-        if lockedLaunchFixEnabled, let deferred = deferIfProtectedDataUnavailable() {
+        if let deferred = deferIfProtectedDataUnavailable() {
             return deferred
         }
 

--- a/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
+++ b/iOS/DuckDuckGo/AIChat/FireModeNativeStorageController.swift
@@ -93,8 +93,7 @@ final class FireModeNativeStorageController: DuckAiNativeStorageHandling, DuckAi
                     migrationKey: "com.duckduckgo.duckai.nativeStorage.fireModeMigratedFromAppGroup",
                     label: .fireMode,
                     keyValueStore: keyValueStore,
-                    pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter(),
-                    lockedLaunchFixEnabled: featureFlagger.isFeatureOn(.duckAINativeStorageMigrationLockedLaunchFix)
+                    pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter()
                 ).run()
                 if outcome == .skip {
                     return nil

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -490,8 +490,7 @@ struct Launching: LaunchingHandling {
                     migrationKey: "com.duckduckgo.duckai.nativeStorage.defaultMigratedFromAppGroup",
                     label: .default,
                     keyValueStore: keyValueStore,
-                    pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter(),
-                    lockedLaunchFixEnabled: featureFlagger.isFeatureOn(.duckAINativeStorageMigrationLockedLaunchFix)
+                    pixelFiring: DuckAiNativeStorageContainerMigrationPixelAdapter()
                 ).run()
                 if outcome == .skip {
                     return nil

--- a/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAiNativeStorageContainerMigrationTests.swift
@@ -328,50 +328,6 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
         XCTAssertEqual(pixelSpy.firedEventNames, ["notNeeded"])
     }
 
-    // MARK: - Locked-launch fix kill switch (lockedLaunchFixEnabled == false)
-
-    /// Rollback contract: with the fix disabled, a completed migration must
-    /// reproduce the legacy behavior — defer up front on a locked launch.
-    func testWhenFixDisabledAndMigratedAndProtectedDataIsUnavailableThenStillDefers() throws {
-        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
-        let newURL = sandbox.appendingPathComponent("new/DuckAi")
-        try? keyValueStore.set(true, forKey: migratedKey)
-
-        let outcome = migrate(from: oldURL, to: newURL, isProtectedDataAvailable: { false }, lockedLaunchFixEnabled: false)
-
-        XCTAssertEqual(outcome, .skip)
-        XCTAssertEqual(pixelSpy.firedEventNames, ["protectedDataUnavailable"])
-    }
-
-    /// With the fix disabled, the not-needed case also defers up front rather than
-    /// marking done — the legacy behavior the rollout flips away from.
-    func testWhenFixDisabledAndNotNeededAndProtectedDataIsUnavailableThenStillDefers() throws {
-        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
-        let newURL = sandbox.appendingPathComponent("new/DuckAi")
-
-        let outcome = migrate(from: oldURL, to: newURL, isProtectedDataAvailable: { false }, lockedLaunchFixEnabled: false)
-
-        XCTAssertEqual(outcome, .skip)
-        XCTAssertFalse(keyValueStore.bool(forKey: migratedKey))
-        XCTAssertEqual(pixelSpy.firedEventNames, ["protectedDataUnavailable"])
-    }
-
-    /// With the fix disabled, an unlocked launch must still complete the move —
-    /// the gate moving location must not change the available-data path.
-    func testWhenFixDisabledAndProtectedDataIsAvailableThenMigrationCompletes() throws {
-        let oldURL = sandbox.appendingPathComponent("old/DuckAi")
-        let newURL = sandbox.appendingPathComponent("new/DuckAi")
-        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: true)
-        try Data("chats".utf8).write(to: oldURL.appendingPathComponent("chats.db"))
-
-        let outcome = migrate(from: oldURL, to: newURL, isProtectedDataAvailable: { true }, lockedLaunchFixEnabled: false)
-
-        XCTAssertEqual(outcome, .proceed)
-        XCTAssertTrue(keyValueStore.bool(forKey: migratedKey))
-        XCTAssertEqual(try Data(contentsOf: newURL.appendingPathComponent("chats.db")), Data("chats".utf8))
-        XCTAssertEqual(pixelSpy.firedEventNames, ["success"])
-    }
-
     // MARK: - Exhausted retry budget reset
 
     func testWhenAttemptsAreAtCapWithoutMigratedFlagThenBudgetResetsAndMigrationRuns() throws {
@@ -811,7 +767,6 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
                          fileManager: FileManager = .default,
                          isProtectedDataAvailable: @escaping () -> Bool = { true },
                          maxAttempts: Int = DuckAiNativeStorageContainerMigration.defaultMaxAttempts,
-                         lockedLaunchFixEnabled: Bool = true,
                          protectionDispatcher: @escaping DuckAiNativeStorageContainerMigration.ProtectionDispatcher = { $0() }) -> DuckAiNativeStorageContainerMigrationOutcome {
         DuckAiNativeStorageContainerMigration(
             oldURL: oldURL,
@@ -823,7 +778,6 @@ final class DuckAiNativeStorageContainerMigrationTests: XCTestCase {
             pixelFiring: pixelSpy,
             isProtectedDataAvailable: isProtectedDataAvailable,
             maxAttempts: maxAttempts,
-            lockedLaunchFixEnabled: lockedLaunchFixEnabled,
             protectionDispatcher: protectionDispatcher
         ).run()
     }

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -445,9 +445,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215106459483563?focus=true
     case duckAINativeStoragePathMigration
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1215920422347500?focus=true
-    case duckAINativeStorageMigrationLockedLaunchFix
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214025222413375
     case aiChatNativeDataAccess
 
@@ -871,8 +868,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(AIChatSubfeature.nativeStorage))
         case .duckAINativeStoragePathMigration:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.nativeStoragePathMigration))
-        case .duckAINativeStorageMigrationLockedLaunchFix:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.nativeStorageMigrationLockedLaunchFix))
         case .aiChatNativeDataAccess:
             Config(source: .remoteReleasable(AIChatSubfeature.nativeDataAccess))
         case .omniBarLongPressMenu:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1215920422347500
Tech Design URL:
CC:

### Description
Feature flag `duckAINativeStorageMigrationLockedLaunchFix` approved, removing conditional code. The Duck.ai native-storage container migration's protected-data gate now always guards only the relocation step: a completed or not-needed migration proceeds on a locked launch instead of deferring up front. This was already the flagged-on behavior for rollout users; it is now the only behavior.

Removed the `duckAINativeStorageMigrationLockedLaunchFix` case from `FeatureFlag` and its `AIChatSubfeature.nativeStorageMigrationLockedLaunchFix` mapping, the `lockedLaunchFixEnabled` parameter from `DuckAiNativeStorageContainerMigration` (and both of its call sites in `Launching.swift` and `FireModeNativeStorageController.swift`), and the unit tests that exercised the now-removed disabled/kill-switch path.

`iOS/Core/ios-config.json` was intentionally left untouched (server-managed).

### Testing Steps
1. Fresh-install the app from the main branch, do some prompts on duck.ai, create images.
2. Run this branch on top of the same app, validate if the prompts and images are still there

### Impact
Low — this is a fully-approved flag removal; the enabled code path was already live for rollout users, so there is no user-facing behavior change.

### Quality Considerations
Removed the three unit tests (`testWhenFixDisabled...`) that only existed to verify the now-deleted disabled/kill-switch path; the remaining migration test coverage (locked-launch gate behavior, retries, protection) is unchanged.
