### PR TITLE
Update Create Image flow on macOS

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModel.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModel.swift
@@ -69,6 +69,12 @@ public struct AIChatModel {
         }
     }
 
+    /// Picks the preferred accessible model that supports Create Image across native surfaces.
+    public static func preferredImageGenerationModel(in models: [AIChatModel]) -> AIChatModel? {
+        let candidates = models.filter { $0.entityHasAccess && $0.supportsTool(.imageGeneration) }
+        return candidates.first(where: \.isSuggestedForImageCreation) ?? candidates.first
+    }
+
     /// Whether this is an advanced (paid-tier) model — i.e. not available on the free tier. Single source
     /// of truth for the basic/advanced split in the model picker and the "PLUS" marker in onboarding.
     public var isAdvanced: Bool {

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModel.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModel.swift
@@ -60,6 +60,15 @@ public struct AIChatModel {
         !supportedFileTypes.isEmpty
     }
 
+    public var isSuggestedForImageCreation: Bool {
+        switch label {
+        case .everydayUse:
+            return true
+        case .usesLimitsFaster, .unknown, .none:
+            return false
+        }
+    }
+
     /// Whether this is an advanced (paid-tier) model — i.e. not available on the free tier. Single source
     /// of truth for the basic/advanced split in the model picker and the "PLUS" marker in onboarding.
     public var isAdvanced: Bool {

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -349,6 +349,9 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
 
     case updatedModelPicker
 
+    /// Enables updated `Create Image` tool behavior.
+    case updatedCreateImage
+
     /// Hides the Search↔Duck.ai toggle in the unified input when the user is on a Duck.ai tab,
     /// regardless of the user's `Settings → Address Bar → Show Duck.ai Toggle` preference. Lets us
     /// roll out the new Duck.ai-tab nav UI (no toggle on chat) independently of the master flag.

--- a/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
@@ -93,6 +93,17 @@ final class AIChatModelPickerButton: NSView {
         }
     }
 
+    var isReadOnly = false {
+        didSet {
+            guard isReadOnly != oldValue else { return }
+            chevronImageView.isHidden = isReadOnly
+            isHovered = false
+            isMouseDown = false
+            setAccessibilityRole(isReadOnly ? .staticText : .popUpButton)
+            invalidateIntrinsicContentSize()
+        }
+    }
+
     var tintColor: NSColor? {
         didSet {
             updateAppearance()
@@ -143,7 +154,8 @@ final class AIChatModelPickerButton: NSView {
 
     override var intrinsicContentSize: NSSize {
         let labelWidth = nameLabel.intrinsicContentSize.width
-        let totalWidth = horizontalPadding + labelWidth + Constants.iconTextSpacing + Constants.chevronSize + horizontalPadding
+        let menuIndicatorWidth = isReadOnly ? 0 : Constants.iconTextSpacing + Constants.chevronSize
+        let totalWidth = horizontalPadding + labelWidth + menuIndicatorWidth + horizontalPadding
         return NSSize(width: totalWidth, height: Constants.height)
     }
 
@@ -159,8 +171,8 @@ final class AIChatModelPickerButton: NSView {
 
     var onTabPressed: (() -> Void)?
 
-    override var acceptsFirstResponder: Bool { true }
-    override var canBecomeKeyView: Bool { true }
+    override var acceptsFirstResponder: Bool { !isReadOnly }
+    override var canBecomeKeyView: Bool { !isReadOnly }
 
     override func becomeFirstResponder() -> Bool {
         let didBecome = super.becomeFirstResponder()
@@ -178,6 +190,7 @@ final class AIChatModelPickerButton: NSView {
     }
 
     func takeKeyboardFocus() {
+        guard !isReadOnly else { return }
         wantsFocusRing = true
         window?.makeFirstResponder(self)
     }
@@ -273,10 +286,10 @@ final class AIChatModelPickerButton: NSView {
         CATransaction.setDisableActions(true)
 
         NSAppearance.withAppAppearance {
-            if isMouseDown {
+            if !isReadOnly && isMouseDown {
                 backgroundLayer.backgroundColor = pressedBackgroundColor.cgColor
                 backgroundLayer.opacity = 1
-            } else if isHovered {
+            } else if !isReadOnly && isHovered {
                 backgroundLayer.backgroundColor = hoverBackgroundColor.cgColor
                 backgroundLayer.opacity = 1
             } else {
@@ -319,7 +332,7 @@ final class AIChatModelPickerButton: NSView {
     }
 
     override func mouseEntered(with event: NSEvent) {
-        isHovered = true
+        isHovered = !isReadOnly
         NSCursor.arrow.set()
     }
 
@@ -346,16 +359,19 @@ final class AIChatModelPickerButton: NSView {
     }
 
     override func mouseDown(with event: NSEvent) {
+        guard !isReadOnly else { return }
         wantsFocusRing = false
         isMouseDown = true
     }
 
     override func mouseDragged(with event: NSEvent) {
+        guard !isReadOnly else { return }
         let locationInView = convert(event.locationInWindow, from: nil)
         isMouseDown = bounds.contains(locationInView)
     }
 
     override func mouseUp(with event: NSEvent) {
+        guard !isReadOnly else { return }
         let locationInView = convert(event.locationInWindow, from: nil)
         if bounds.contains(locationInView) && isMouseDown {
             if let action, let target {
@@ -369,6 +385,14 @@ final class AIChatModelPickerButton: NSView {
     }
 
     override func keyDown(with event: NSEvent) {
+        guard !isReadOnly else {
+            if event.keyCode == 48 {
+                onTabPressed?()
+            } else {
+                super.keyDown(with: event)
+            }
+            return
+        }
         switch event.keyCode {
         case 48: // Tab
             if let onTabPressed {
@@ -393,7 +417,7 @@ final class AIChatModelPickerButton: NSView {
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
-        guard !isHidden, frame.contains(point) else { return nil }
+        guard !isHidden, !isReadOnly, frame.contains(point) else { return nil }
         return self
     }
 

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -213,6 +213,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
 
     /// Mirrors the card's constraint so the reservation and the layout can't disagree.
     private var isUsageWarningVisible = false
+    private var createImageModelSwitchNotice: AIChatCreateImageModelSwitchNotice?
 
     /// Only the exposed band counts; the rest is behind the panel and costs nothing.
     private var usageWarningReservation: CGFloat {
@@ -529,6 +530,9 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
+                if !self.omnibarController.isImageGenerationMode {
+                    self.clearCreateImageModelSwitchNotice()
+                }
                 self.updateToolButtonsVisibility(isEnabled: self.omnibarController.isOmnibarToolsEnabled)
                 self.updateImageUploadVisibility(supportsImageUpload: self.omnibarController.selectedModelSupportsImageUpload)
                 // Re-evaluate the submit button so voice mode is suppressed/restored when
@@ -638,7 +642,8 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     }
 
     private var isImageGenerationItemVisible: Bool {
-        omnibarController.isImageGenerationEnabled && omnibarController.selectedModelSupportsImageGeneration
+        omnibarController.isImageGenerationEnabled
+            && (omnibarController.isUpdatedCreateImageEnabled || omnibarController.selectedModelSupportsImageGeneration)
     }
 
     private var isWebSearchItemVisible: Bool {
@@ -1157,7 +1162,10 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         }
         usageWarningCardView.onDismiss = { [weak self] in
             guard let self else { return }
-            if omnibarController.usageWarningViewModel?.warning != nil {
+            if createImageModelSwitchNotice != nil {
+                clearCreateImageModelSwitchNotice()
+                return
+            } else if omnibarController.usageWarningViewModel?.warning != nil {
                 omnibarController.usageWarningViewModel?.dismiss()
             } else {
                 highUsageNoticeSource?.dismissCurrent()
@@ -1198,6 +1206,11 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     /// Not gated on `shouldSuppressSuggestions`: image-gen mode and attachments still spend the
     /// allowance, so the message stays up where suggestions don't.
     private func applyUsageWarning(_ warning: DuckAiUsageWarning?) {
+        if let createImageModelSwitchNotice {
+            usageWarningCardView.update(with: createImageModelSwitchNotice)
+            setUsageWarningVisible(!isSuggestionsCollapsedByUnfocus)
+            return
+        }
         if let warning {
             usageWarningCardView.update(with: warning)
             setUsageWarningVisible(!isSuggestionsCollapsedByUnfocus)
@@ -1220,6 +1233,17 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     private func refreshUsageCard() {
         highUsageNoticeSource?.refresh()
         applyUsageWarning(omnibarController.usageWarningViewModel?.warning)
+    }
+
+    private func showCreateImageModelSwitchNotice(_ notice: AIChatCreateImageModelSwitchNotice) {
+        createImageModelSwitchNotice = notice
+        refreshUsageCard()
+    }
+
+    private func clearCreateImageModelSwitchNotice() {
+        guard createImageModelSwitchNotice != nil else { return }
+        createImageModelSwitchNotice = nil
+        refreshUsageCard()
     }
 
     private func setUsageWarningVisible(_ visible: Bool) {
@@ -1339,6 +1363,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         // The pick-time rejection error is transient panel UI, so drop it on teardown rather than
         // letting it resurface when the panel is reopened.
         lastAttachmentError = nil
+        createImageModelSwitchNotice = nil
 
         // Restore model picker to persisted value
         modelPickerButton.modelName = persistedModelShortName
@@ -1437,6 +1462,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     @objc private func imageGenActiveButtonClicked() {
         omnibarController.pixelHandler.fire(.imageGenerationDeactivated)
         omnibarController.toggleImageGenerationMode()
+        clearCreateImageModelSwitchNotice()
     }
 
     @objc private func webSearchActiveButtonClicked() {
@@ -1525,7 +1551,11 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         if !omnibarController.isImageGenerationMode {
             omnibarController.pixelHandler.fire(.imageGenerationActivated)
         }
-        omnibarController.toggleImageGenerationMode()
+        if let notice = omnibarController.toggleImageGenerationMode() {
+            showCreateImageModelSwitchNotice(notice)
+        } else if !omnibarController.isImageGenerationMode {
+            clearCreateImageModelSwitchNotice()
+        }
     }
 
     @objc private func toolsMenuWebSearchClicked() {
@@ -2255,6 +2285,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
 
     @objc private func modelSelected(_ sender: NSMenuItem) {
         guard let model = sender.representedObject as? AIChatModel else { return }
+        clearCreateImageModelSwitchNotice()
         // `updateSelectedModel` calls back into `refreshForSelectedModel`, whichever route changed it.
         omnibarController.updateSelectedModel(model.id)
         if isPresentingModelPickerFromUsageCard {

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -324,7 +324,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     }
 
     var isModelPickerButtonAvailableForFocus: Bool {
-        !modelPickerButton.isHidden
+        !modelPickerButton.isHidden && !modelPickerButton.isReadOnly
     }
 
     /// Returns the first visible and enabled tool button available for focus.
@@ -704,9 +704,13 @@ final class AIChatOmnibarContainerViewController: NSViewController {
     }
 
     private var shouldShowModelPicker: Bool {
-        guard !omnibarController.isImageGenerationMode else { return false }
         let hasContent = !omnibarController.models.isEmpty || omnibarController.cachedModelShortName != nil
-        return omnibarController.isOmnibarToolsEnabled && hasContent
+        guard omnibarController.isOmnibarToolsEnabled && hasContent else { return false }
+        return !omnibarController.isImageGenerationMode || omnibarController.isUpdatedCreateImageEnabled
+    }
+
+    private var shouldMakeModelPickerReadOnly: Bool {
+        omnibarController.isUpdatedCreateImageEnabled && omnibarController.isImageGenerationMode
     }
 
     private func updateToolButtonsVisibility(isEnabled: Bool) {
@@ -719,6 +723,11 @@ final class AIChatOmnibarContainerViewController: NSViewController {
         // omits the image item itself when full), so the outer button stays interactive.
         imageUploadButton.isEnabled = omnibarController.isOmnibarTabPickerEnabled || !omnibarController.isActiveTabImageAttachmentsFull
         modelPickerButton.isHidden = !shouldShowModelPicker
+        modelPickerButton.isReadOnly = shouldMakeModelPickerReadOnly
+        modelPickerButton.toolTip = shouldMakeModelPickerReadOnly ? nil : UserText.aiChatModelPickerButtonTooltip
+        modelPickerButton.setAccessibilityLabel(
+            shouldMakeModelPickerReadOnly ? persistedModelShortName : UserText.aiChatModelPickerButtonTooltip
+        )
         toolsButton.label = omnibarController.activeToolMode != nil ? nil : UserText.aiChatToolsButtonLabel
 
         // The carousel row's height is recomputed centrally via `updateAttachmentsCarouselLayout()`.

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -847,8 +847,7 @@ final class AIChatOmnibarController {
         if let selectedModel, selectedModel.supportsTool(.imageGeneration) {
             return selectedModel
         }
-        let candidates = models.filter { $0.entityHasAccess && $0.supportsTool(.imageGeneration) }
-        return candidates.first(where: \.isSuggestedForImageCreation) ?? candidates.first
+        return AIChatModel.preferredImageGenerationModel(in: models)
     }
 
     private func switchToImageGenerationModelIfNeeded() -> AIChatCreateImageModelSwitchNotice? {

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -64,6 +64,18 @@ enum AIChatToolMode: Equatable {
     }
 }
 
+struct AIChatCreateImageModelSwitchNotice: Equatable {
+    let previousModelShortName: String
+    let newModelShortName: String
+    let previousModelHasExtraPrivacyProtections: Bool
+
+    init(previousModel: AIChatModel, newModel: AIChatModel) {
+        previousModelShortName = previousModel.shortName
+        newModelShortName = newModel.shortName
+        previousModelHasExtraPrivacyProtections = previousModel.provider == .oss
+    }
+}
+
 /// Controller that manages the state and actions for the AI Chat omnibar.
 /// This controller is shared between AIChatOmnibarContainerViewController and AIChatOmnibarTextContainerViewController
 /// to coordinate text input and submission.
@@ -220,6 +232,10 @@ final class AIChatOmnibarController {
         featureFlagger.isFeatureOn(.aiChatOmnibarImageGeneration)
     }
 
+    var isUpdatedCreateImageEnabled: Bool {
+        featureFlagger.isFeatureOn(.updatedCreateImage)
+    }
+
     /// Whether the web search tool is available.
     var isWebSearchEnabled: Bool {
         featureFlagger.isFeatureOn(.aiChatOmnibarWebSearch)
@@ -268,8 +284,16 @@ final class AIChatOmnibarController {
             && featureFlagger.isFeatureOn(.aiChatOmnibarAttachMoreTabs)
     }
 
-    func toggleImageGenerationMode() {
-        activeToolMode = isImageGenerationMode ? nil : .imageGeneration
+    @discardableResult
+    func toggleImageGenerationMode() -> AIChatCreateImageModelSwitchNotice? {
+        guard !isImageGenerationMode else {
+            activeToolMode = nil
+            return nil
+        }
+
+        let notice = switchToImageGenerationModelIfNeeded()
+        activeToolMode = .imageGeneration
+        return notice
     }
 
     func toggleWebSearchMode() {
@@ -823,7 +847,20 @@ final class AIChatOmnibarController {
         if let selectedModel, selectedModel.supportsTool(.imageGeneration) {
             return selectedModel
         }
-        return models.first(where: { $0.entityHasAccess && $0.supportsTool(.imageGeneration) })
+        let candidates = models.filter { $0.entityHasAccess && $0.supportsTool(.imageGeneration) }
+        return candidates.first(where: \.isSuggestedForImageCreation) ?? candidates.first
+    }
+
+    private func switchToImageGenerationModelIfNeeded() -> AIChatCreateImageModelSwitchNotice? {
+        guard isUpdatedCreateImageEnabled,
+              let previousModel = selectedModel,
+              !previousModel.supportsTool(.imageGeneration),
+              let fallbackModel = imageGenerationModel else {
+            return nil
+        }
+
+        updateSelectedModel(fallbackModel.id)
+        return AIChatCreateImageModelSwitchNotice(previousModel: previousModel, newModel: fallbackModel)
     }
 
     /// The model ID to use for the current submission. In image-generation mode an

--- a/macOS/DuckDuckGo/AIChat/AIChatUsageWarningCardView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatUsageWarningCardView.swift
@@ -304,6 +304,7 @@ final class AIChatUsageWarningCardView: NSView {
     func update(with notice: DuckAiHighUsageModelNotice) {
         let text = UserText.aiChatUsageWarningsHighUsageModel(notice.modelShortName)
         applyInfoIcon()
+        titleLabel.maximumNumberOfLines = 1
         titleLabel.attributedStringValue = Self.attributedNotice(text)
         titleLabel.setAccessibilityLabel(text)
 
@@ -318,6 +319,7 @@ final class AIChatUsageWarningCardView: NSView {
     /// Lays the row out for `warning`. Whether the card shows at all is the host's call.
     func update(with warning: DuckAiUsageWarning) {
         applyIcon(for: warning)
+        titleLabel.maximumNumberOfLines = 1
         titleLabel.attributedStringValue = Self.attributedTitle(headline: warning.localizedHeadline,
                                                                 resetsIn: warning.localizedResetsIn)
         titleLabel.setAccessibilityLabel("\(warning.localizedHeadline). \(warning.localizedResetsIn)")
@@ -338,6 +340,25 @@ final class AIChatUsageWarningCardView: NSView {
         actionCloseSpacingConstraint?.constant = warning.isDismissible ? Constants.actionCloseSpacing : 0
     }
 
+    func update(with notice: AIChatCreateImageModelSwitchNotice) {
+        let title = UserText.aiChatCreateImageModelSwitchTitle(notice.newModelShortName)
+        let subtitle = notice.previousModelHasExtraPrivacyProtections
+            ? UserText.aiChatCreateImageModelSwitchPrivacySubtitle(notice.previousModelShortName)
+            : UserText.aiChatCreateImageModelSwitchSubtitle(notice.previousModelShortName)
+
+        applyModelSwitchIcon()
+        titleLabel.maximumNumberOfLines = 2
+        titleLabel.attributedStringValue = Self.attributedModelSwitch(title: title, subtitle: subtitle)
+        titleLabel.setAccessibilityLabel("\(title). \(subtitle)")
+
+        actionButton.isHidden = true
+        actionButton.collapse()
+
+        closeButton.isHidden = false
+        closeButtonWidthConstraint?.constant = Constants.closeButtonSize
+        actionCloseSpacingConstraint?.constant = Constants.actionCloseSpacing
+    }
+
     /// Bold headline, regular reset detail, one string so the two can never wrap apart.
     /// The ring tracks the percentage while the limit is only approaching; a reached limit reads as an
     /// alert, where a nearly-full ring would say less than the copy already does.
@@ -346,6 +367,16 @@ final class AIChatUsageWarningCardView: NSView {
         iconImageView.isHidden = false
         lastShownApproachingPercent = nil
         iconImageView.image = DesignSystemImages.Glyphs.Size16.info
+        NSAppearance.withAppearance(appearance) {
+            iconImageView.contentTintColor = NSColor(designSystemColor: .iconsPrimary)
+        }
+    }
+
+    private func applyModelSwitchIcon() {
+        ringView.isHidden = true
+        iconImageView.isHidden = false
+        lastShownApproachingPercent = nil
+        iconImageView.image = DesignSystemImages.Glyphs.Size12.swap
         NSAppearance.withAppearance(appearance) {
             iconImageView.contentTintColor = NSColor(designSystemColor: .iconsPrimary)
         }
@@ -386,6 +417,21 @@ final class AIChatUsageWarningCardView: NSView {
         result.append(NSAttributedString(
             string: " · \(resetsIn)",
             attributes: [.font: NSFont.systemFont(ofSize: Constants.fontSize, weight: .regular),
+                         .foregroundColor: textColor]
+        ))
+        return result
+    }
+
+    private static func attributedModelSwitch(title: String, subtitle: String) -> NSAttributedString {
+        let textColor = NSColor(designSystemColor: .textPrimary)
+        let result = NSMutableAttributedString(
+            string: title,
+            attributes: [.font: NSFont.systemFont(ofSize: Constants.fontSize, weight: .semibold),
+                         .foregroundColor: textColor]
+        )
+        result.append(NSAttributedString(
+            string: "\n\(subtitle)",
+            attributes: [.font: NSFont.systemFont(ofSize: 11, weight: .regular),
                          .foregroundColor: textColor]
         ))
         return result

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -991,6 +991,30 @@ struct UserText {
     static let aiChatUsageWarningsSubscribe = NotLocalizedString("aichat.usageWarnings.subscribe", value: "Subscribe", comment: "Button on the Duck.ai usage card taking a user who has already used their free trial to the subscription flow")
     static let aiChatUsageWarningsDismissAccessibilityLabel = NotLocalizedString("aichat.usageWarnings.dismiss.accessibility", value: "Dismiss", comment: "Accessibility label for the close button on the Duck.ai usage card")
     static let aiChatUsageWarningsModelPickerAccessibilityLabel = NotLocalizedString("aichat.usageWarnings.model-picker.accessibility", value: "Choose a model", comment: "Accessibility label for the chevron on the Duck.ai usage card, which opens the model picker")
+    static func aiChatCreateImageModelSwitchTitle(_ modelShortName: String) -> String {
+        let message = NotLocalizedString(
+            "aichat.createImage.modelSwitch.title",
+            value: "Now using %@",
+            comment: "Title of the Duck.ai input card shown after switching to an image-capable model. Parameter is the new model's short name."
+        )
+        return String(format: message, modelShortName)
+    }
+    static func aiChatCreateImageModelSwitchSubtitle(_ modelShortName: String) -> String {
+        let message = NotLocalizedString(
+            "aichat.createImage.modelSwitch.subtitle",
+            value: "%@ doesn't support image creation.",
+            comment: "Subtitle explaining why Duck.ai switched models. Parameter is the previous model's short name."
+        )
+        return String(format: message, modelShortName)
+    }
+    static func aiChatCreateImageModelSwitchPrivacySubtitle(_ modelShortName: String) -> String {
+        let message = NotLocalizedString(
+            "aichat.createImage.modelSwitch.privacy.subtitle",
+            value: "%@ can't create images. Its extra privacy protections won't apply until you switch back.",
+            comment: "Subtitle shown after switching away from an OSS model for image creation. Parameter is the previous model's short name."
+        )
+        return String(format: message, modelShortName)
+    }
     static let moreSearchSettings = NSLocalizedString("settings.more-search-settings", value: "More Search Settings", comment: "The button name in preferences for More Search Settings")
     static let moreSearchSettingsDescription = NSLocalizedString("settings.more-search-settings.description", value: "Customize your language, region, and more.", comment: "Subtitle of the 'More Search Settings' button")
     static let moreSearchSettingsLink = NSLocalizedString("settings.more-search-settings.link", value: "Open DuckDuckGo Search Settings", comment: "Button to open Search Settings on duckduckgo.com")

--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -325,6 +325,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enables the image generation mode toggle in the Duck.ai omnibar
     case aiChatOmnibarImageGeneration
 
+    /// Enables updated Create Image behavior, including switching unsupported models.
+    case updatedCreateImage
+
     /// Enables the web search tool in the Duck.ai omnibar
     case aiChatOmnibarWebSearch
 
@@ -730,6 +733,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.pdfPageContext), category: .duckAI)
         case .aiChatOmnibarImageGeneration:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.omnibarImageGeneration), category: .duckAI)
+        case .updatedCreateImage:
+            Config(source: .remoteReleasable(AIChatSubfeature.updatedCreateImage), category: .duckAI)
         case .aiChatOmnibarWebSearch:
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.omnibarWebSearch), category: .duckAI)
         case .aiChatOmnibarReasoningEffort:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1218029263916086
Tech Design URL:
CC:

### Description
Keeps Create Image available in the native macOS Duck.ai omnibar. Unsupported selections switch to a preferred accessible image-capable model and show native copy, including the OSS privacy explanation; the model remains visible but read-only while the tool is active. Gated by updatedCreateImage.

### Testing Steps
1. macOS, enable updatedCreateImage and select a model without image generation.
2. Activate Create Image — the model switches and the notice appears.
3. Repeat with an OSS model — the privacy explanation appears.
4. Confirm the model stays visible and read-only until Create Image is cleared.

### Impact
Medium. Changes model selection in the native Duck.ai omnibar behind a feature flag.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Feature-flagged changes to omnibar model selection and read-only picker state during Create Image; no auth or secrets in the diff.
> 
> **Overview**
> Introduces **updated Create Image** behavior on macOS Duck.ai omnibar, gated by the remote **`updatedCreateImage`** flag (privacy config + macOS feature flag).
> 
> When Create Image is turned on with a model that does not support image generation, the omnibar **auto-selects** an accessible image-capable model via shared **`AIChatModel.preferredImageGenerationModel`**, preferring models labeled for everyday use. A **usage card** explains the switch (“Now using …”) with a standard or **OSS privacy** subtitle, and takes priority over allowance warnings until dismissed.
> 
> While Create Image stays active, the **model picker stays visible** but **`isReadOnly`** (no menu, chevron hidden, static accessibility). Create Image can appear in the tools menu even when the current model lacks the tool. Notices clear when image mode ends, the user picks another model, or the panel tears down.
> 
> **`toggleImageGenerationMode()`** now returns an optional **`AIChatCreateImageModelSwitchNotice`** so the container can show the card; submissions still resolve **`imageGenerationModel`** through the shared preferred-model helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a723b10cf973d64507e723044cae75e565189565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->