### PR TITLE
Add on-site permission coordination and system gating

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -1677,6 +1677,7 @@
 		A17C00032F9A000100000003 /* ApplicationShortcutItemsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17C00042F9A000100000004 /* ApplicationShortcutItemsServiceTests.swift */; };
 		A17C00052F9A000100000005 /* ApplicationShortcutItemsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17C00062F9A000100000006 /* ApplicationShortcutItemsUITests.swift */; };
 		A1B2C3D40E1F202122232402 /* TabViewControllerGestureArbitrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40E1F202122232401 /* TabViewControllerGestureArbitrationTests.swift */; };
+		C0DE52010000000000000002 /* MediaCapturePermissionLegacyMatrixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE52010000000000000001 /* MediaCapturePermissionLegacyMatrixTests.swift */; };
 		A1B2C3D4E5F60001AABB0001 /* NTPAfterIdleInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */; };
 		A1B2C3D4E5F60002AABBA001 /* IdleReturnTabCountInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */; };
 		A1B2C3D4E5F60002AABBA0B1 /* AppReturnInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002AABBA0B2 /* AppReturnInstrumentationTests.swift */; };
@@ -4311,6 +4312,7 @@
 		A17C00042F9A000100000004 /* ApplicationShortcutItemsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationShortcutItemsServiceTests.swift; sourceTree = "<group>"; };
 		A17C00062F9A000100000006 /* ApplicationShortcutItemsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationShortcutItemsUITests.swift; sourceTree = "<group>"; };
 		A1B2C3D40E1F202122232401 /* TabViewControllerGestureArbitrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabViewControllerGestureArbitrationTests.swift; sourceTree = "<group>"; };
+		C0DE52010000000000000001 /* MediaCapturePermissionLegacyMatrixTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaCapturePermissionLegacyMatrixTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001AABB0002 /* NTPAfterIdleInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPAfterIdleInstrumentationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60002AABBA002 /* IdleReturnTabCountInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdleReturnTabCountInstrumentationTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60002AABBA0B2 /* AppReturnInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReturnInstrumentationTests.swift; sourceTree = "<group>"; };
@@ -7465,6 +7467,7 @@
 		84E341A91E2F7EFB00BDBA6F /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				C0DE52010000000000000001 /* MediaCapturePermissionLegacyMatrixTests.swift */,
 				BB82617030124E5100F8A80F /* MonthlyFreeTrialExperimentTests.swift */,
 				AA10B5012FA0000100AB12CD /* WebExtensionAvailabilityTests.swift */,
 				5B941E702FA29A1600AF2CE7 /* Widgets */,
@@ -13768,6 +13771,7 @@
 				98E564092DE8B32D00E6E75F /* ContextualOnboardingPresenterMock.swift in Sources */,
 				9F4CC5172C48B8D4006A96EB /* TabViewControllerDaxDialogTests.swift in Sources */,
 				A1B2C3D40E1F202122232402 /* TabViewControllerGestureArbitrationTests.swift in Sources */,
+				C0DE52010000000000000002 /* MediaCapturePermissionLegacyMatrixTests.swift in Sources */,
 				CB27DAE92FFFE6BC00EEEADB /* WebViewTransitionGeometryTests.swift in Sources */,
 				A8452A0101C0DE0000000004 /* HomeScreenTransitionGeometryTests.swift in Sources */,
 				A8452A0101C0DE0000000006 /* BrowserToolbarViewTests.swift in Sources */,

--- a/iOS/DuckDuckGoTests/MediaCapturePermissionLegacyMatrixTests.swift
+++ b/iOS/DuckDuckGoTests/MediaCapturePermissionLegacyMatrixTests.swift
@@ -1,0 +1,197 @@
+//
+//  MediaCapturePermissionLegacyMatrixTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AVFoundation
+import BrowserServicesKitTestsUtils
+import ObjectiveC
+import WebKit
+import XCTest
+@testable import DuckDuckGo
+@testable import AIChat
+
+@MainActor
+final class TabViewControllerMediaCapturePermissionLegacyMatrixTests: XCTestCase {
+
+    func testLegacyPermissionMatrix() throws {
+        let sut = TabViewController.fake()
+
+        try assertLegacyMatrix(fallthroughDecision: .prompt) { origin, frame, type, decisionHandler in
+            sut.webView(sut.webView,
+                        requestMediaCapturePermissionFor: origin,
+                        initiatedByFrame: frame,
+                        type: type,
+                        decisionHandler: decisionHandler)
+        }
+    }
+}
+
+@MainActor
+final class AIChatWebViewControllerMediaCapturePermissionLegacyMatrixTests: XCTestCase {
+
+    func testLegacyPermissionMatrix() throws {
+        let sut = AIChatWebViewController(chatModel: StubAIChatViewModel(), downloadHandler: StubDownloadHandler())
+        let webView = WKWebView()
+
+        try assertLegacyMatrix(fallthroughDecision: .deny) { origin, frame, type, decisionHandler in
+            sut.webView(webView,
+                        requestMediaCapturePermissionFor: origin,
+                        initiatedByFrame: frame,
+                        type: type,
+                        decisionHandler: decisionHandler)
+        }
+    }
+}
+
+@MainActor
+private func assertLegacyMatrix(
+    fallthroughDecision: WKPermissionDecision,
+    invoke: (WKSecurityOrigin, WKFrameInfo, WKMediaCaptureType, @escaping (WKPermissionDecision) -> Void) -> Void
+) throws {
+    for scenario in LegacyMediaCaptureScenario.matrix(fallthroughDecision: fallthroughDecision) {
+        try AVCaptureAuthorizationStatusStub.withStatuses(audio: scenario.audioStatus, video: scenario.videoStatus) {
+            var receivedDecision: WKPermissionDecision?
+            let origin = MockWKSecurityOrigin.new(host: scenario.host)
+            let frame = WKFrameInfo.mock(isMainFrame: true, securityOrigin: origin)
+
+            invoke(origin, frame, scenario.type) { receivedDecision = $0 }
+
+            XCTAssertEqual(receivedDecision, scenario.expectedDecision, scenario.name)
+            XCTAssertEqual(AVCaptureAuthorizationStatusStub.requestedMediaTypes, scenario.expectedRequestedMediaTypes, scenario.name)
+        }
+    }
+}
+
+private struct LegacyMediaCaptureScenario {
+    let name: String
+    let host: String
+    let type: WKMediaCaptureType
+    let audioStatus: AVAuthorizationStatus
+    let videoStatus: AVAuthorizationStatus
+    let expectedDecision: WKPermissionDecision
+    let expectedRequestedMediaTypes: [AVMediaType]
+
+    static func matrix(fallthroughDecision: WKPermissionDecision) -> [Self] {
+        let audioStatuses = [AVAuthorizationStatus.notDetermined, .restricted, .denied, .authorized]
+        let captureTypes = [WKMediaCaptureType.microphone, .camera, .cameraAndMicrophone]
+        let cartesianScenarios = ["example.com", "duck.ai"].flatMap { host in
+            captureTypes.flatMap { type in
+                audioStatuses.map { status in
+                    let consultsAudio = host == "duck.ai" && type != .camera
+                    return Self(name: "\(host) \(type) with audio status \(status)",
+                                host: host,
+                                type: type,
+                                audioStatus: status,
+                                videoStatus: .authorized,
+                                expectedDecision: consultsAudio ? (status == .authorized ? .grant : .deny) : fallthroughDecision,
+                                expectedRequestedMediaTypes: consultsAudio ? [.audio] : [])
+                }
+            }
+        }
+
+        return cartesianScenarios + [
+            Self(name: "duckduckgo.com is a Duck.ai host",
+                 host: "duckduckgo.com",
+                 type: .microphone,
+                 audioStatus: .authorized,
+                 videoStatus: .authorized,
+                 expectedDecision: .grant,
+                 expectedRequestedMediaTypes: [.audio]),
+            Self(name: "DuckDuckGo subdomain is a Duck.ai host",
+                 host: "subdomain.duckduckgo.com",
+                 type: .microphone,
+                 audioStatus: .authorized,
+                 videoStatus: .authorized,
+                 expectedDecision: .grant,
+                 expectedRequestedMediaTypes: [.audio]),
+            Self(name: "combined capture ignores denied video authorization",
+                 host: "duck.ai",
+                 type: .cameraAndMicrophone,
+                 audioStatus: .authorized,
+                 videoStatus: .denied,
+                 expectedDecision: .grant,
+                 expectedRequestedMediaTypes: [.audio])
+        ]
+    }
+}
+
+private enum AVCaptureAuthorizationStatusStub {
+    nonisolated(unsafe) private static var statuses: [AVMediaType: AVAuthorizationStatus] = [:]
+    nonisolated(unsafe) private(set) static var requestedMediaTypes: [AVMediaType] = []
+
+    static func withStatuses(audio: AVAuthorizationStatus, video: AVAuthorizationStatus, perform: () -> Void) throws {
+        statuses = [.audio: audio, .video: video]
+        requestedMediaTypes = []
+
+        let originalMethod = try XCTUnwrap(class_getClassMethod(
+            AVCaptureDevice.self,
+            #selector(AVCaptureDevice.authorizationStatus(for:))
+        ))
+        let stubMethod = try XCTUnwrap(class_getClassMethod(
+            AVCaptureDevice.self,
+            #selector(AVCaptureDevice.osp_authorizationStatus(for:))
+        ))
+
+        method_exchangeImplementations(originalMethod, stubMethod)
+        defer {
+            method_exchangeImplementations(stubMethod, originalMethod)
+            statuses = [:]
+            requestedMediaTypes = []
+        }
+
+        perform()
+    }
+
+    static func status(for mediaType: AVMediaType) -> AVAuthorizationStatus {
+        requestedMediaTypes.append(mediaType)
+        return statuses[mediaType] ?? .notDetermined
+    }
+}
+
+private extension AVCaptureDevice {
+    @objc class func osp_authorizationStatus(for mediaType: AVMediaType) -> AVAuthorizationStatus {
+        AVCaptureAuthorizationStatusStub.status(for: mediaType)
+    }
+}
+
+private final class StubAIChatViewModel: AIChatViewModeling {
+    let aiChatURL = URL(string: "https://duck.ai")!
+    let webViewConfiguration = WKWebViewConfiguration()
+    let requestAuthHandler: AIChatRequestAuthorizationHandling = StubAIChatRequestAuthorizationHandler()
+    let inspectableWebView = false
+    let downloadsPath = FileManager.default.temporaryDirectory
+    let userAgent = ""
+
+    func shouldAllowRequestWithNavigationAction(_ navigationAction: WKNavigationAction) -> Bool {
+        true
+    }
+}
+
+private struct StubAIChatRequestAuthorizationHandler: AIChatRequestAuthorizationHandling {
+    func shouldAllowRequestWithNavigationAction(_ navigationAction: WKNavigationAction) -> Bool {
+        true
+    }
+}
+
+private final class StubDownloadHandler: NSObject, DownloadHandling {
+    var onDownloadComplete: DownloadCompletionHandler?
+
+    func download(_ download: WKDownload, decideDestinationUsing response: URLResponse, suggestedFilename: String) async -> URL? {
+        nil
+    }
+}

--- a/iOS/DuckDuckGoTests/MediaCapturePermissionLegacyMatrixTests.swift
+++ b/iOS/DuckDuckGoTests/MediaCapturePermissionLegacyMatrixTests.swift
@@ -23,7 +23,6 @@ import ObjectiveC
 import WebKit
 import XCTest
 @testable import DuckDuckGo
-@testable import AIChat
 
 @MainActor
 final class TabViewControllerMediaCapturePermissionLegacyMatrixTests: XCTestCase {
@@ -33,23 +32,6 @@ final class TabViewControllerMediaCapturePermissionLegacyMatrixTests: XCTestCase
 
         try assertLegacyMatrix(fallthroughDecision: .prompt) { origin, frame, type, decisionHandler in
             sut.webView(sut.webView,
-                        requestMediaCapturePermissionFor: origin,
-                        initiatedByFrame: frame,
-                        type: type,
-                        decisionHandler: decisionHandler)
-        }
-    }
-}
-
-@MainActor
-final class AIChatWebViewControllerMediaCapturePermissionLegacyMatrixTests: XCTestCase {
-
-    func testLegacyPermissionMatrix() throws {
-        let sut = AIChatWebViewController(chatModel: StubAIChatViewModel(), downloadHandler: StubDownloadHandler())
-        let webView = WKWebView()
-
-        try assertLegacyMatrix(fallthroughDecision: .deny) { origin, frame, type, decisionHandler in
-            sut.webView(webView,
                         requestMediaCapturePermissionFor: origin,
                         initiatedByFrame: frame,
                         type: type,
@@ -166,32 +148,5 @@ private enum AVCaptureAuthorizationStatusStub {
 private extension AVCaptureDevice {
     @objc class func osp_authorizationStatus(for mediaType: AVMediaType) -> AVAuthorizationStatus {
         AVCaptureAuthorizationStatusStub.status(for: mediaType)
-    }
-}
-
-private final class StubAIChatViewModel: AIChatViewModeling {
-    let aiChatURL = URL(string: "https://duck.ai")!
-    let webViewConfiguration = WKWebViewConfiguration()
-    let requestAuthHandler: AIChatRequestAuthorizationHandling = StubAIChatRequestAuthorizationHandler()
-    let inspectableWebView = false
-    let downloadsPath = FileManager.default.temporaryDirectory
-    let userAgent = ""
-
-    func shouldAllowRequestWithNavigationAction(_ navigationAction: WKNavigationAction) -> Bool {
-        true
-    }
-}
-
-private struct StubAIChatRequestAuthorizationHandler: AIChatRequestAuthorizationHandling {
-    func shouldAllowRequestWithNavigationAction(_ navigationAction: WKNavigationAction) -> Bool {
-        true
-    }
-}
-
-private final class StubDownloadHandler: NSObject, DownloadHandling {
-    var onDownloadComplete: DownloadCompletionHandler?
-
-    func download(_ download: WKDownload, decideDestinationUsing response: URLResponse, suggestedFilename: String) async -> URL? {
-        nil
     }
 }

--- a/iOS/LocalPackages/SitePermissions/Sources/SitePermissions/Coordinator/SitePermissionsCoordinator.swift
+++ b/iOS/LocalPackages/SitePermissions/Sources/SitePermissions/Coordinator/SitePermissionsCoordinator.swift
@@ -19,12 +19,18 @@
 
 import Foundation
 
+/// Identifies the page and frame that originated a site permission request.
+/// The coordinator uses this context to discard stale requests after navigation or process replacement.
 public struct SitePermissionRequestContext: Equatable, Sendable {
 
     public let tabID: String
+    /// The committed top-level site whose permission decision applies to the request.
     public let topLevelSite: SitePermissionKey
+    /// Identifies the web frame that initiated the permission request.
     public let requestingFrameID: UInt64
+    /// A counter that changes whenever WebKit replaces the tab's web content process.
     public let webContentProcessGeneration: UInt
+    /// A counter that changes whenever the tab starts a new main-frame navigation.
     public let navigationGeneration: UInt
 
     public init(tabID: String,
@@ -44,14 +50,11 @@ public struct SitePermissionRequest: Sendable {
 
     public let context: SitePermissionRequestContext
     public let permissionTypes: Set<SitePermissionType>
-    public let bypassesModel: Bool
 
     public init(context: SitePermissionRequestContext,
-                permissionTypes: Set<SitePermissionType>,
-                bypassesModel: Bool = false) {
+                permissionTypes: Set<SitePermissionType>) {
         self.context = context
         self.permissionTypes = permissionTypes
-        self.bypassesModel = bypassesModel
     }
 }
 
@@ -61,17 +64,26 @@ public struct SitePermissionPrompt: Equatable, Sendable {
     public let permissionTypes: Set<SitePermissionType>
 }
 
+/// The user's response to an on-site permission prompt.
 public enum SitePermissionPromptDecision: Equatable, Sendable {
+    /// Allows access until capture ends without storing a persistent site decision.
     case allowOnce
+    /// Grants access and stores an Allow decision for the site outside Fire mode.
     case allowWhileUsingSite
+    /// Denies access for the current page without storing a persistent site decision.
     case denyOnce
+    /// Denies access and stores a Deny decision for the site outside Fire mode.
     case neverAllow
 }
 
+/// Describes a system authorization state that prevented a site permission request from being granted.
 public struct SitePermissionSystemBlock: Equatable, Sendable {
 
+    /// Indicates when the blocking state was observed relative to a system authorization request.
     public enum Timing: Equatable, Sendable {
+        /// The blocking state existed before the coordinator could request authorization.
         case preexisting
+        /// The blocking state was observed after the coordinator requested authorization.
         case afterRequest
     }
 
@@ -80,12 +92,14 @@ public struct SitePermissionSystemBlock: Equatable, Sendable {
     public let timing: Timing
 }
 
+/// The result of evaluating site-level decisions and system authorization for a permission request.
 public enum SitePermissionResolution: Equatable, Sendable {
-    case bypass
     case grant
+    /// Denies access. An empty array means that a site-level decision blocked the request.
     case deny(systemBlocks: [SitePermissionSystemBlock])
 }
 
+/// Describes a page lifecycle change that can invalidate page-scoped permission state.
 public enum SitePermissionPageChange: Equatable, Sendable {
     case sameDocumentNavigation
     case reload
@@ -93,9 +107,12 @@ public enum SitePermissionPageChange: Equatable, Sendable {
     case webContentProcessReplacement
 }
 
+/// Coordinates a tab's site permission requests for camera, microphone, and location.
+/// It combines stored and page-scoped decisions with system authorization, serializes prompts, and discards stale requests.
 @MainActor
 public final class SitePermissionsCoordinator {
 
+    /// Returns the current context for a tab and requesting frame so the coordinator can reject stale requests.
     public typealias CurrentContextProvider = (_ tabID: String, _ requestingFrameID: UInt64) -> SitePermissionRequestContext?
     public typealias PromptHandler = (SitePermissionPrompt, @escaping (SitePermissionPromptDecision) -> Void) -> Void
     public typealias Completion = (SitePermissionResolution) -> Void
@@ -111,16 +128,13 @@ public final class SitePermissionsCoordinator {
 
     private final class PendingRequest {
         let request: SitePermissionRequest
-        let lifecycleGeneration: UInt
         let promptHandler: PromptHandler
         let completion: Completion
 
         init(request: SitePermissionRequest,
-             lifecycleGeneration: UInt,
              promptHandler: @escaping PromptHandler,
              completion: @escaping Completion) {
             self.request = request
-            self.lifecycleGeneration = lifecycleGeneration
             self.promptHandler = promptHandler
             self.completion = completion
         }
@@ -136,7 +150,6 @@ public final class SitePermissionsCoordinator {
     private var deniedForPage = Set<SitePermissionType>()
     private var queuedRequests = [PendingRequest]()
     private var activeRequest: PendingRequest?
-    private var lifecycleGeneration: UInt = 0
     private var isClosed = false
 
     public convenience init(store: SitePermissionsStore,
@@ -166,13 +179,7 @@ public final class SitePermissionsCoordinator {
                         promptHandler: @escaping PromptHandler,
                         completion: @escaping Completion) {
         guard !isClosed, !request.permissionTypes.isEmpty else { return }
-
-        if request.bypassesModel {
-            completion(.bypass)
-            return
-        }
-
-        guard isValid(request.context, lifecycleGeneration: lifecycleGeneration) else { return }
+        guard isValid(request.context) else { return }
 
         switch disposition(for: request) {
         case .deny:
@@ -185,34 +192,27 @@ public final class SitePermissionsCoordinator {
     }
 
     private func disposition(for request: SitePermissionRequest) -> RequestDisposition {
-        var hasDeniedPermission = false
-        var hasUnresolvedPermission = false
+        var disposition = RequestDisposition.allow
         for permissionType in ordered(request.permissionTypes) {
             switch store.decision(for: permissionType, at: request.context.topLevelSite) {
             case .deny:
-                hasDeniedPermission = true
+                return .deny
             case .allow:
                 continue
             case .ask, .none:
                 if deniedForPage.contains(permissionType) {
-                    hasDeniedPermission = true
-                } else if allowOnce.contains(permissionType) {
-                    continue
-                } else if store.globalDefault(for: permissionType) == .deny {
-                    hasDeniedPermission = true
-                } else {
-                    hasUnresolvedPermission = true
+                    return .deny
                 }
+                if allowOnce.contains(permissionType) {
+                    continue
+                }
+                if store.globalDefault(for: permissionType) == .deny {
+                    return .deny
+                }
+                disposition = .prompt
             }
         }
-
-        if hasDeniedPermission {
-            return .deny
-        } else if hasUnresolvedPermission {
-            return .prompt
-        } else {
-            return .allow
-        }
+        return disposition
     }
 
     public func captureDidEnd(_ permissionTypes: Set<SitePermissionType>) {
@@ -242,7 +242,6 @@ public final class SitePermissionsCoordinator {
                          promptHandler: @escaping PromptHandler,
                          completion: @escaping Completion) {
         queuedRequests.append(PendingRequest(request: request,
-                                             lifecycleGeneration: lifecycleGeneration,
                                              promptHandler: promptHandler,
                                              completion: completion))
         processNextRequestIfNeeded()
@@ -307,22 +306,29 @@ public final class SitePermissionsCoordinator {
         Task { @MainActor [weak self, weak pendingRequest] in
             guard let self, let pendingRequest else { return }
 
+            guard isActiveAndValid(pendingRequest) else {
+                drop(pendingRequest)
+                return
+            }
+
+            let permissionStates = ordered(pendingRequest.request.permissionTypes).map { permissionType in
+                (permissionType: permissionType, state: self.authorizationState(permissionType))
+            }
             var blocks = [SitePermissionSystemBlock]()
-            for permissionType in ordered(pendingRequest.request.permissionTypes) {
+            for (permissionType, state) in permissionStates where state != .authorized && state != .notDetermined {
+                blocks.append(SitePermissionSystemBlock(permissionType: permissionType,
+                                                        state: state,
+                                                        timing: .preexisting))
+            }
+            if !blocks.isEmpty {
+                finish(pendingRequest, with: .deny(systemBlocks: blocks))
+                return
+            }
+
+            for (permissionType, state) in permissionStates where state == .notDetermined {
                 guard isActiveAndValid(pendingRequest) else {
                     drop(pendingRequest)
                     return
-                }
-
-                let state = authorizationState(permissionType)
-                if state == .authorized {
-                    continue
-                }
-                if state != .notDetermined {
-                    blocks.append(SitePermissionSystemBlock(permissionType: permissionType,
-                                                            state: state,
-                                                            timing: .preexisting))
-                    continue
                 }
 
                 let requestedState = await requestAuthorization(permissionType)
@@ -368,7 +374,6 @@ public final class SitePermissionsCoordinator {
     }
 
     private func resetPageState() {
-        lifecycleGeneration &+= 1
         allowOnce.removeAll()
         deniedForPage.removeAll()
         queuedRequests.removeAll()
@@ -380,11 +385,11 @@ public final class SitePermissionsCoordinator {
     }
 
     private func isValid(_ pendingRequest: PendingRequest) -> Bool {
-        isValid(pendingRequest.request.context, lifecycleGeneration: pendingRequest.lifecycleGeneration)
+        isValid(pendingRequest.request.context)
     }
 
-    private func isValid(_ context: SitePermissionRequestContext, lifecycleGeneration: UInt) -> Bool {
-        !isClosed && self.lifecycleGeneration == lifecycleGeneration && currentContext(context.tabID, context.requestingFrameID) == context
+    private func isValid(_ context: SitePermissionRequestContext) -> Bool {
+        !isClosed && currentContext(context.tabID, context.requestingFrameID) == context
     }
 
     private func ordered(_ permissionTypes: Set<SitePermissionType>) -> [SitePermissionType] {

--- a/iOS/LocalPackages/SitePermissions/Sources/SitePermissions/Coordinator/SitePermissionsCoordinator.swift
+++ b/iOS/LocalPackages/SitePermissions/Sources/SitePermissions/Coordinator/SitePermissionsCoordinator.swift
@@ -1,0 +1,393 @@
+//
+//  SitePermissionsCoordinator.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public struct SitePermissionRequestContext: Equatable, Sendable {
+
+    public let tabID: String
+    public let topLevelSite: SitePermissionKey
+    public let requestingFrameID: UInt64
+    public let webContentProcessGeneration: UInt
+    public let navigationGeneration: UInt
+
+    public init(tabID: String,
+                topLevelSite: SitePermissionKey,
+                requestingFrameID: UInt64,
+                webContentProcessGeneration: UInt,
+                navigationGeneration: UInt) {
+        self.tabID = tabID
+        self.topLevelSite = topLevelSite
+        self.requestingFrameID = requestingFrameID
+        self.webContentProcessGeneration = webContentProcessGeneration
+        self.navigationGeneration = navigationGeneration
+    }
+}
+
+public struct SitePermissionRequest: Sendable {
+
+    public let context: SitePermissionRequestContext
+    public let permissionTypes: Set<SitePermissionType>
+    public let bypassesModel: Bool
+
+    public init(context: SitePermissionRequestContext,
+                permissionTypes: Set<SitePermissionType>,
+                bypassesModel: Bool = false) {
+        self.context = context
+        self.permissionTypes = permissionTypes
+        self.bypassesModel = bypassesModel
+    }
+}
+
+public struct SitePermissionPrompt: Equatable, Sendable {
+
+    public let site: SitePermissionKey
+    public let permissionTypes: Set<SitePermissionType>
+}
+
+public enum SitePermissionPromptDecision: Equatable, Sendable {
+    case allowOnce
+    case allowWhileUsingSite
+    case denyOnce
+    case neverAllow
+}
+
+public struct SitePermissionSystemBlock: Equatable, Sendable {
+
+    public enum Timing: Equatable, Sendable {
+        case preexisting
+        case afterRequest
+    }
+
+    public let permissionType: SitePermissionType
+    public let state: SystemPermissionAuthorizationState
+    public let timing: Timing
+}
+
+public enum SitePermissionResolution: Equatable, Sendable {
+    case bypass
+    case grant
+    case deny(systemBlocks: [SitePermissionSystemBlock])
+}
+
+public enum SitePermissionPageChange: Equatable, Sendable {
+    case sameDocumentNavigation
+    case reload
+    case navigation
+    case webContentProcessReplacement
+}
+
+@MainActor
+public final class SitePermissionsCoordinator {
+
+    public typealias CurrentContextProvider = (_ tabID: String, _ requestingFrameID: UInt64) -> SitePermissionRequestContext?
+    public typealias PromptHandler = (SitePermissionPrompt, @escaping (SitePermissionPromptDecision) -> Void) -> Void
+    public typealias Completion = (SitePermissionResolution) -> Void
+
+    typealias AuthorizationStateProvider = (SitePermissionType) -> SystemPermissionAuthorizationState
+    typealias AuthorizationRequester = (SitePermissionType) async -> SystemPermissionAuthorizationState
+
+    private enum RequestDisposition {
+        case deny
+        case allow
+        case prompt
+    }
+
+    private final class PendingRequest {
+        let request: SitePermissionRequest
+        let lifecycleGeneration: UInt
+        let promptHandler: PromptHandler
+        let completion: Completion
+
+        init(request: SitePermissionRequest,
+             lifecycleGeneration: UInt,
+             promptHandler: @escaping PromptHandler,
+             completion: @escaping Completion) {
+            self.request = request
+            self.lifecycleGeneration = lifecycleGeneration
+            self.promptHandler = promptHandler
+            self.completion = completion
+        }
+    }
+
+    private let store: SitePermissionsStore
+    private let isFireMode: Bool
+    private let currentContext: CurrentContextProvider
+    private let authorizationState: AuthorizationStateProvider
+    private let requestAuthorization: AuthorizationRequester
+
+    private var allowOnce = Set<SitePermissionType>()
+    private var deniedForPage = Set<SitePermissionType>()
+    private var queuedRequests = [PendingRequest]()
+    private var activeRequest: PendingRequest?
+    private var lifecycleGeneration: UInt = 0
+    private var isClosed = false
+
+    public convenience init(store: SitePermissionsStore,
+                            systemPermissionClient: SystemPermissionClient,
+                            isFireMode: Bool,
+                            currentContext: @escaping CurrentContextProvider) {
+        self.init(store: store,
+                  isFireMode: isFireMode,
+                  currentContext: currentContext,
+                  authorizationState: systemPermissionClient.authorizationState,
+                  requestAuthorization: systemPermissionClient.requestAuthorization)
+    }
+
+    init(store: SitePermissionsStore,
+         isFireMode: Bool,
+         currentContext: @escaping CurrentContextProvider,
+         authorizationState: @escaping AuthorizationStateProvider,
+         requestAuthorization: @escaping AuthorizationRequester) {
+        self.store = store
+        self.isFireMode = isFireMode
+        self.currentContext = currentContext
+        self.authorizationState = authorizationState
+        self.requestAuthorization = requestAuthorization
+    }
+
+    public func request(_ request: SitePermissionRequest,
+                        promptHandler: @escaping PromptHandler,
+                        completion: @escaping Completion) {
+        guard !isClosed, !request.permissionTypes.isEmpty else { return }
+
+        if request.bypassesModel {
+            completion(.bypass)
+            return
+        }
+
+        guard isValid(request.context, lifecycleGeneration: lifecycleGeneration) else { return }
+
+        switch disposition(for: request) {
+        case .deny:
+            completion(.deny(systemBlocks: []))
+        case .allow:
+            completion(systemResolution(for: request.permissionTypes))
+        case .prompt:
+            enqueue(request, promptHandler: promptHandler, completion: completion)
+        }
+    }
+
+    private func disposition(for request: SitePermissionRequest) -> RequestDisposition {
+        var hasDeniedPermission = false
+        var hasUnresolvedPermission = false
+        for permissionType in ordered(request.permissionTypes) {
+            switch store.decision(for: permissionType, at: request.context.topLevelSite) {
+            case .deny:
+                hasDeniedPermission = true
+            case .allow:
+                continue
+            case .ask, .none:
+                if deniedForPage.contains(permissionType) {
+                    hasDeniedPermission = true
+                } else if allowOnce.contains(permissionType) {
+                    continue
+                } else if store.globalDefault(for: permissionType) == .deny {
+                    hasDeniedPermission = true
+                } else {
+                    hasUnresolvedPermission = true
+                }
+            }
+        }
+
+        if hasDeniedPermission {
+            return .deny
+        } else if hasUnresolvedPermission {
+            return .prompt
+        } else {
+            return .allow
+        }
+    }
+
+    public func captureDidEnd(_ permissionTypes: Set<SitePermissionType>) {
+        allowOnce.subtract(permissionTypes)
+    }
+
+    public func pageDidChange(_ change: SitePermissionPageChange) {
+        guard change != .sameDocumentNavigation else { return }
+        resetPageState()
+    }
+
+    public func close() {
+        isClosed = true
+        resetPageState()
+    }
+
+    private func systemResolution(for permissionTypes: Set<SitePermissionType>) -> SitePermissionResolution {
+        let blocks = ordered(permissionTypes).compactMap { permissionType -> SitePermissionSystemBlock? in
+            let state = authorizationState(permissionType)
+            guard state != .authorized else { return nil }
+            return SitePermissionSystemBlock(permissionType: permissionType, state: state, timing: .preexisting)
+        }
+        return blocks.isEmpty ? .grant : .deny(systemBlocks: blocks)
+    }
+
+    private func enqueue(_ request: SitePermissionRequest,
+                         promptHandler: @escaping PromptHandler,
+                         completion: @escaping Completion) {
+        queuedRequests.append(PendingRequest(request: request,
+                                             lifecycleGeneration: lifecycleGeneration,
+                                             promptHandler: promptHandler,
+                                             completion: completion))
+        processNextRequestIfNeeded()
+    }
+
+    private func processNextRequestIfNeeded() {
+        guard activeRequest == nil else { return }
+
+        while !queuedRequests.isEmpty {
+            let pendingRequest = queuedRequests.removeFirst()
+            guard isValid(pendingRequest) else { continue }
+
+            activeRequest = pendingRequest
+            switch disposition(for: pendingRequest.request) {
+            case .deny:
+                finish(pendingRequest, with: .deny(systemBlocks: []))
+            case .allow:
+                finish(pendingRequest, with: systemResolution(for: pendingRequest.request.permissionTypes))
+            case .prompt:
+                let prompt = SitePermissionPrompt(site: pendingRequest.request.context.topLevelSite,
+                                                  permissionTypes: pendingRequest.request.permissionTypes)
+                pendingRequest.promptHandler(prompt) { [weak self, weak pendingRequest] decision in
+                    guard let self, let pendingRequest else { return }
+                    self.handle(decision, for: pendingRequest)
+                }
+            }
+            return
+        }
+    }
+
+    private func handle(_ decision: SitePermissionPromptDecision, for pendingRequest: PendingRequest) {
+        guard isActiveAndValid(pendingRequest) else {
+            drop(pendingRequest)
+            return
+        }
+
+        let permissionTypes = pendingRequest.request.permissionTypes
+        switch decision {
+        case .denyOnce:
+            allowOnce.subtract(permissionTypes)
+            deniedForPage.formUnion(permissionTypes)
+            finish(pendingRequest, with: .deny(systemBlocks: []))
+        case .neverAllow:
+            allowOnce.subtract(permissionTypes)
+            if isFireMode {
+                deniedForPage.formUnion(permissionTypes)
+            } else {
+                persist(.deny, for: pendingRequest.request)
+            }
+            finish(pendingRequest, with: .deny(systemBlocks: []))
+        case .allowOnce, .allowWhileUsingSite:
+            deniedForPage.subtract(permissionTypes)
+            if decision == .allowWhileUsingSite, !isFireMode {
+                persist(.allow, for: pendingRequest.request)
+            }
+            requestSystemAuthorization(for: pendingRequest,
+                                       activatesAllowOnce: decision == .allowOnce || isFireMode)
+        }
+    }
+
+    private func requestSystemAuthorization(for pendingRequest: PendingRequest, activatesAllowOnce: Bool) {
+        Task { @MainActor [weak self, weak pendingRequest] in
+            guard let self, let pendingRequest else { return }
+
+            var blocks = [SitePermissionSystemBlock]()
+            for permissionType in ordered(pendingRequest.request.permissionTypes) {
+                guard isActiveAndValid(pendingRequest) else {
+                    drop(pendingRequest)
+                    return
+                }
+
+                let state = authorizationState(permissionType)
+                if state == .authorized {
+                    continue
+                }
+                if state != .notDetermined {
+                    blocks.append(SitePermissionSystemBlock(permissionType: permissionType,
+                                                            state: state,
+                                                            timing: .preexisting))
+                    continue
+                }
+
+                let requestedState = await requestAuthorization(permissionType)
+                guard isActiveAndValid(pendingRequest) else {
+                    drop(pendingRequest)
+                    return
+                }
+                if requestedState != .authorized {
+                    blocks.append(SitePermissionSystemBlock(permissionType: permissionType,
+                                                            state: requestedState,
+                                                            timing: .afterRequest))
+                }
+            }
+
+            if blocks.isEmpty {
+                if activatesAllowOnce {
+                    allowOnce.formUnion(pendingRequest.request.permissionTypes)
+                }
+                finish(pendingRequest, with: .grant)
+            } else {
+                finish(pendingRequest, with: .deny(systemBlocks: blocks))
+            }
+        }
+    }
+
+    private func persist(_ decision: SitePermissionDecision, for request: SitePermissionRequest) {
+        for permissionType in ordered(request.permissionTypes) {
+            store.setPersistentDecision(decision, for: permissionType, at: request.context.topLevelSite)
+        }
+    }
+
+    private func finish(_ pendingRequest: PendingRequest, with resolution: SitePermissionResolution) {
+        guard activeRequest === pendingRequest else { return }
+        activeRequest = nil
+        pendingRequest.completion(resolution)
+        processNextRequestIfNeeded()
+    }
+
+    private func drop(_ pendingRequest: PendingRequest) {
+        guard activeRequest === pendingRequest else { return }
+        activeRequest = nil
+        processNextRequestIfNeeded()
+    }
+
+    private func resetPageState() {
+        lifecycleGeneration &+= 1
+        allowOnce.removeAll()
+        deniedForPage.removeAll()
+        queuedRequests.removeAll()
+        activeRequest = nil
+    }
+
+    private func isActiveAndValid(_ pendingRequest: PendingRequest) -> Bool {
+        activeRequest === pendingRequest && isValid(pendingRequest)
+    }
+
+    private func isValid(_ pendingRequest: PendingRequest) -> Bool {
+        isValid(pendingRequest.request.context, lifecycleGeneration: pendingRequest.lifecycleGeneration)
+    }
+
+    private func isValid(_ context: SitePermissionRequestContext, lifecycleGeneration: UInt) -> Bool {
+        !isClosed && self.lifecycleGeneration == lifecycleGeneration && currentContext(context.tabID, context.requestingFrameID) == context
+    }
+
+    private func ordered(_ permissionTypes: Set<SitePermissionType>) -> [SitePermissionType] {
+        SitePermissionType.allCases.filter(permissionTypes.contains)
+    }
+}

--- a/iOS/LocalPackages/SitePermissions/Sources/SitePermissions/System/SystemPermissionClient.swift
+++ b/iOS/LocalPackages/SitePermissions/Sources/SitePermissions/System/SystemPermissionClient.swift
@@ -21,22 +21,22 @@ import AVFoundation
 import CoreLocation
 import UIKit
 
+/// A common authorization state for camera, microphone, and location permissions.
 public enum SystemPermissionAuthorizationState: Equatable, Sendable {
     case notDetermined
     case authorized
     case denied
     case restricted
+    /// The service is disabled or the system returned an unsupported authorization state.
     case unavailable
 }
 
+/// Provides a unified interface to system authorization for camera, microphone, and location.
+/// It coalesces concurrent location authorization requests and forwards location updates.
 @MainActor
 public final class SystemPermissionClient: NSObject {
 
     public typealias LocationUpdate = Result<CLLocation, Error>
-
-    public var settingsURL: URL? {
-        URL(string: UIApplication.openSettingsURLString)
-    }
 
     public var locationUpdateHandler: ((LocationUpdate) -> Void)?
 
@@ -46,8 +46,6 @@ public final class SystemPermissionClient: NSObject {
     private let avRequestAccess: (AVMediaType, @escaping @Sendable (Bool) -> Void) -> Void
     private let notificationCenter: NotificationCenter
 
-    private var cameraState: SystemPermissionAuthorizationState = .notDetermined
-    private var microphoneState: SystemPermissionAuthorizationState = .notDetermined
     private var locationState: SystemPermissionAuthorizationState = .notDetermined
     private var locationAuthorizationContinuations = [CheckedContinuation<SystemPermissionAuthorizationState, Never>]()
 
@@ -90,9 +88,9 @@ public final class SystemPermissionClient: NSObject {
     public func authorizationState(for permissionType: SitePermissionType) -> SystemPermissionAuthorizationState {
         switch permissionType {
         case .camera:
-            cameraState
+            Self.state(from: avAuthorizationStatus(.video))
         case .microphone:
-            microphoneState
+            Self.state(from: avAuthorizationStatus(.audio))
         case .location:
             locationState
         }
@@ -101,17 +99,15 @@ public final class SystemPermissionClient: NSObject {
     public func requestAuthorization(for permissionType: SitePermissionType) async -> SystemPermissionAuthorizationState {
         switch permissionType {
         case .camera:
-            return await requestAVAuthorization(for: .video, permissionType: .camera)
+            return await requestAVAuthorization(for: .video)
         case .microphone:
-            return await requestAVAuthorization(for: .audio, permissionType: .microphone)
+            return await requestAVAuthorization(for: .audio)
         case .location:
             return await requestLocationAuthorization()
         }
     }
 
     public func refreshAuthorizationStates() {
-        refreshAVAuthorizationState(for: .camera, mediaType: .video)
-        refreshAVAuthorizationState(for: .microphone, mediaType: .audio)
         refreshLocationAuthorizationState()
     }
 
@@ -121,18 +117,6 @@ public final class SystemPermissionClient: NSObject {
 
     public func stopUpdatingLocation() {
         locationManager.stopUpdatingLocation()
-    }
-
-    private func refreshAVAuthorizationState(for permissionType: SitePermissionType, mediaType: AVMediaType) {
-        let state = Self.state(from: avAuthorizationStatus(mediaType))
-        switch permissionType {
-        case .camera:
-            cameraState = state
-        case .microphone:
-            microphoneState = state
-        case .location:
-            assertionFailure("Location does not use AV authorization")
-        }
     }
 
     private func refreshLocationAuthorizationState() {
@@ -148,9 +132,8 @@ public final class SystemPermissionClient: NSObject {
         continuations.forEach { $0.resume(returning: locationState) }
     }
 
-    private func requestAVAuthorization(for mediaType: AVMediaType,
-                                        permissionType: SitePermissionType) async -> SystemPermissionAuthorizationState {
-        let currentState = authorizationState(for: permissionType)
+    private func requestAVAuthorization(for mediaType: AVMediaType) async -> SystemPermissionAuthorizationState {
+        let currentState = Self.state(from: avAuthorizationStatus(mediaType))
         guard currentState == .notDetermined else { return currentState }
 
         return await withCheckedContinuation { continuation in
@@ -160,8 +143,7 @@ public final class SystemPermissionClient: NSObject {
                         continuation.resume(returning: .unavailable)
                         return
                     }
-                    self.refreshAVAuthorizationState(for: permissionType, mediaType: mediaType)
-                    continuation.resume(returning: self.authorizationState(for: permissionType))
+                    continuation.resume(returning: Self.state(from: self.avAuthorizationStatus(mediaType)))
                 }
             }
         }
@@ -181,6 +163,10 @@ public final class SystemPermissionClient: NSObject {
 
     @objc private func applicationDidBecomeActive() {
         refreshAuthorizationStates()
+        // Core Location ignores authorization requests made while the app is inactive, so retry when it returns.
+        if locationState == .notDetermined, !locationAuthorizationContinuations.isEmpty {
+            locationManager.requestWhenInUseAuthorization()
+        }
     }
 
     private static func state(from status: AVAuthorizationStatus) -> SystemPermissionAuthorizationState {

--- a/iOS/LocalPackages/SitePermissions/Sources/SitePermissions/System/SystemPermissionClient.swift
+++ b/iOS/LocalPackages/SitePermissions/Sources/SitePermissions/System/SystemPermissionClient.swift
@@ -1,0 +1,230 @@
+//
+//  SystemPermissionClient.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AVFoundation
+import CoreLocation
+import UIKit
+
+public enum SystemPermissionAuthorizationState: Equatable, Sendable {
+    case notDetermined
+    case authorized
+    case denied
+    case restricted
+    case unavailable
+}
+
+@MainActor
+public final class SystemPermissionClient: NSObject {
+
+    public typealias LocationUpdate = Result<CLLocation, Error>
+
+    public var settingsURL: URL? {
+        URL(string: UIApplication.openSettingsURLString)
+    }
+
+    public var locationUpdateHandler: ((LocationUpdate) -> Void)?
+
+    private let locationManager: CLLocationManager
+    private let locationServicesEnabled: () -> Bool
+    private let avAuthorizationStatus: (AVMediaType) -> AVAuthorizationStatus
+    private let avRequestAccess: (AVMediaType, @escaping @Sendable (Bool) -> Void) -> Void
+    private let notificationCenter: NotificationCenter
+
+    private var cameraState: SystemPermissionAuthorizationState = .notDetermined
+    private var microphoneState: SystemPermissionAuthorizationState = .notDetermined
+    private var locationState: SystemPermissionAuthorizationState = .notDetermined
+    private var locationAuthorizationContinuations = [CheckedContinuation<SystemPermissionAuthorizationState, Never>]()
+
+    var pendingLocationAuthorizationRequestCount: Int {
+        locationAuthorizationContinuations.count
+    }
+
+    public override convenience init() {
+        self.init(locationManager: CLLocationManager(),
+                  locationServicesEnabled: CLLocationManager.locationServicesEnabled,
+                  avAuthorizationStatus: AVCaptureDevice.authorizationStatus,
+                  avRequestAccess: AVCaptureDevice.requestAccess,
+                  notificationCenter: .default)
+    }
+
+    init(locationManager: CLLocationManager,
+         locationServicesEnabled: @escaping () -> Bool,
+         avAuthorizationStatus: @escaping (AVMediaType) -> AVAuthorizationStatus,
+         avRequestAccess: @escaping (AVMediaType, @escaping @Sendable (Bool) -> Void) -> Void,
+         notificationCenter: NotificationCenter) {
+        self.locationManager = locationManager
+        self.locationServicesEnabled = locationServicesEnabled
+        self.avAuthorizationStatus = avAuthorizationStatus
+        self.avRequestAccess = avRequestAccess
+        self.notificationCenter = notificationCenter
+        super.init()
+
+        locationManager.delegate = self
+        refreshAuthorizationStates()
+        notificationCenter.addObserver(self,
+                                       selector: #selector(applicationDidBecomeActive),
+                                       name: UIApplication.didBecomeActiveNotification,
+                                       object: nil)
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
+    }
+
+    public func authorizationState(for permissionType: SitePermissionType) -> SystemPermissionAuthorizationState {
+        switch permissionType {
+        case .camera:
+            cameraState
+        case .microphone:
+            microphoneState
+        case .location:
+            locationState
+        }
+    }
+
+    public func requestAuthorization(for permissionType: SitePermissionType) async -> SystemPermissionAuthorizationState {
+        switch permissionType {
+        case .camera:
+            return await requestAVAuthorization(for: .video, permissionType: .camera)
+        case .microphone:
+            return await requestAVAuthorization(for: .audio, permissionType: .microphone)
+        case .location:
+            return await requestLocationAuthorization()
+        }
+    }
+
+    public func refreshAuthorizationStates() {
+        refreshAVAuthorizationState(for: .camera, mediaType: .video)
+        refreshAVAuthorizationState(for: .microphone, mediaType: .audio)
+        refreshLocationAuthorizationState()
+    }
+
+    public func startUpdatingLocation() {
+        locationManager.startUpdatingLocation()
+    }
+
+    public func stopUpdatingLocation() {
+        locationManager.stopUpdatingLocation()
+    }
+
+    private func refreshAVAuthorizationState(for permissionType: SitePermissionType, mediaType: AVMediaType) {
+        let state = Self.state(from: avAuthorizationStatus(mediaType))
+        switch permissionType {
+        case .camera:
+            cameraState = state
+        case .microphone:
+            microphoneState = state
+        case .location:
+            assertionFailure("Location does not use AV authorization")
+        }
+    }
+
+    private func refreshLocationAuthorizationState() {
+        locationState = locationServicesEnabled() ? Self.state(from: locationManager.authorizationStatus) : .unavailable
+        completePendingLocationAuthorizationRequestsIfNeeded()
+    }
+
+    private func completePendingLocationAuthorizationRequestsIfNeeded() {
+        guard locationState != .notDetermined else { return }
+
+        let continuations = locationAuthorizationContinuations
+        locationAuthorizationContinuations.removeAll()
+        continuations.forEach { $0.resume(returning: locationState) }
+    }
+
+    private func requestAVAuthorization(for mediaType: AVMediaType,
+                                        permissionType: SitePermissionType) async -> SystemPermissionAuthorizationState {
+        let currentState = authorizationState(for: permissionType)
+        guard currentState == .notDetermined else { return currentState }
+
+        return await withCheckedContinuation { continuation in
+            avRequestAccess(mediaType) { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    guard let self else {
+                        continuation.resume(returning: .unavailable)
+                        return
+                    }
+                    self.refreshAVAuthorizationState(for: permissionType, mediaType: mediaType)
+                    continuation.resume(returning: self.authorizationState(for: permissionType))
+                }
+            }
+        }
+    }
+
+    private func requestLocationAuthorization() async -> SystemPermissionAuthorizationState {
+        guard locationState == .notDetermined else { return locationState }
+
+        return await withCheckedContinuation { continuation in
+            let shouldRequest = locationAuthorizationContinuations.isEmpty
+            locationAuthorizationContinuations.append(continuation)
+            if shouldRequest {
+                locationManager.requestWhenInUseAuthorization()
+            }
+        }
+    }
+
+    @objc private func applicationDidBecomeActive() {
+        refreshAuthorizationStates()
+    }
+
+    private static func state(from status: AVAuthorizationStatus) -> SystemPermissionAuthorizationState {
+        switch status {
+        case .notDetermined:
+            return .notDetermined
+        case .authorized:
+            return .authorized
+        case .denied:
+            return .denied
+        case .restricted:
+            return .restricted
+        @unknown default:
+            return .unavailable
+        }
+    }
+
+    private static func state(from status: CLAuthorizationStatus) -> SystemPermissionAuthorizationState {
+        switch status {
+        case .notDetermined:
+            return .notDetermined
+        case .authorizedAlways, .authorizedWhenInUse:
+            return .authorized
+        case .denied:
+            return .denied
+        case .restricted:
+            return .restricted
+        @unknown default:
+            return .unavailable
+        }
+    }
+}
+
+extension SystemPermissionClient: @preconcurrency CLLocationManagerDelegate {
+
+    public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        refreshLocationAuthorizationState()
+    }
+
+    public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        locations.forEach { locationUpdateHandler?(.success($0)) }
+    }
+
+    public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        locationUpdateHandler?(.failure(error))
+    }
+}

--- a/iOS/LocalPackages/SitePermissions/Tests/SitePermissionsTests/SitePermissionsCoordinatorTests.swift
+++ b/iOS/LocalPackages/SitePermissions/Tests/SitePermissionsTests/SitePermissionsCoordinatorTests.swift
@@ -25,22 +25,6 @@ import XCTest
 @MainActor
 final class SitePermissionsCoordinatorTests: XCTestCase {
 
-    func testWhenRequestBypassesModelThenStoreAndPromptAreIgnored() throws {
-        let harness = try Harness()
-        harness.store.setPersistentDecision(.deny, for: .camera, at: harness.site)
-        let request = harness.request([.camera], bypassesModel: true)
-        harness.context = harness.context(changingNavigationGenerationTo: 2)
-        var didPrompt = false
-        var resolution: SitePermissionResolution?
-
-        harness.coordinator.request(request, promptHandler: { _, _ in
-            didPrompt = true
-        }, completion: { resolution = $0 })
-
-        XCTAssertEqual(resolution, .bypass)
-        XCTAssertFalse(didPrompt)
-    }
-
     func testWhenStoredDenyExistsThenItWinsWithoutPrompting() throws {
         let harness = try Harness()
         harness.store.setPersistentDecision(.allow, for: .camera, at: harness.site)
@@ -235,27 +219,17 @@ final class SitePermissionsCoordinatorTests: XCTestCase {
         }
     }
 
-    func testWhenTabClosesOrIsRestoredThenNoPageDecisionSurvives() throws {
-        let closingHarness = try Harness()
-        closingHarness.coordinator.request(closingHarness.request([.camera]), promptHandler: { _, respond in
-            respond(.denyOnce)
-        }, completion: { _ in })
-        closingHarness.coordinator.close()
+    func testWhenTabClosesThenCoordinatorIgnoresRequests() throws {
+        let harness = try Harness()
+        harness.coordinator.close()
 
-        var closedTabDidRespond = false
-        closingHarness.coordinator.request(closingHarness.request([.camera]), promptHandler: { _, _ in
-            closedTabDidRespond = true
+        var didRespond = false
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, _ in
+            didRespond = true
         }, completion: { _ in
-            closedTabDidRespond = true
+            didRespond = true
         })
-        XCTAssertFalse(closedTabDidRespond)
-
-        let restoredHarness = try Harness()
-        var restoredTabDidPrompt = false
-        restoredHarness.coordinator.request(restoredHarness.request([.camera]), promptHandler: { _, _ in
-            restoredTabDidPrompt = true
-        }, completion: { _ in })
-        XCTAssertTrue(restoredTabDidPrompt)
+        XCTAssertFalse(didRespond)
     }
 
     func testWhenCoordinatorIsRestoredWithSameStoreThenAllowOnceIsNotRestored() async throws {
@@ -553,11 +527,34 @@ final class SitePermissionsCoordinatorTests: XCTestCase {
         XCTAssertEqual(requestedTypes, [.camera, .microphone])
     }
 
+    func testWhenFreshCombinedRequestHasPreexistingBlockThenUndeterminedTypesAreNotRequested() async throws {
+        let harness = try Harness()
+        harness.systemStates[.camera] = .denied
+        harness.systemStates[.microphone] = .notDetermined
+        var requestedTypes = [SitePermissionType]()
+        harness.authorizationRequester = { permissionType in
+            requestedTypes.append(permissionType)
+            return .authorized
+        }
+        let completion = expectation(description: "Combined request completes")
+
+        harness.coordinator.request(harness.request([.camera, .microphone]), promptHandler: { _, respond in
+            respond(.allowOnce)
+        }, completion: { resolution in
+            XCTAssertEqual(resolution, .deny(systemBlocks: [
+                SitePermissionSystemBlock(permissionType: .camera, state: .denied, timing: .preexisting)
+            ]))
+            completion.fulfill()
+        })
+
+        await fulfillment(of: [completion], timeout: 1)
+        XCTAssertTrue(requestedTypes.isEmpty)
+    }
+
     func testWhenFireModeUserChoosesPersistentOptionsThenOnlyMemoryChanges() async throws {
         let harness = try Harness(isFireMode: true)
         harness.store.setGlobalDefault(.deny, for: .microphone)
         harness.store.setPersistentDecision(.allow, for: .location, at: harness.site)
-        let originalGlobals = harness.rawGlobalDefaults
 
         var globalResolution: SitePermissionResolution?
         harness.coordinator.request(harness.request([.microphone]), promptHandler: { _, _ in
@@ -586,7 +583,6 @@ final class SitePermissionsCoordinatorTests: XCTestCase {
             respond(.neverAllow)
         }, completion: { _ in })
         XCTAssertNil(harness.store.decision(for: .camera, at: harness.site))
-        XCTAssertEqual(harness.rawGlobalDefaults, originalGlobals)
 
         var resolution: SitePermissionResolution?
         harness.coordinator.request(harness.request([.camera]), promptHandler: { _, _ in
@@ -594,24 +590,11 @@ final class SitePermissionsCoordinatorTests: XCTestCase {
         }, completion: { resolution = $0 })
         XCTAssertEqual(resolution, .deny(systemBlocks: []))
     }
-
-    func testWhenFireModeHasStoredDenyThenItIsReadWithoutPrompting() throws {
-        let harness = try Harness(isFireMode: true)
-        harness.store.setPersistentDecision(.deny, for: .camera, at: harness.site)
-        var resolution: SitePermissionResolution?
-
-        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, _ in
-            XCTFail("Fire mode must read stored site denial")
-        }, completion: { resolution = $0 })
-
-        XCTAssertEqual(resolution, .deny(systemBlocks: []))
-    }
 }
 
 @MainActor
 private final class Harness {
 
-    let keyValueStore: MockKeyValueStore
     let store: SitePermissionsStore
     let site: SitePermissionKey
     let isFireMode: Bool
@@ -640,23 +623,18 @@ private final class Harness {
             return await authorizationRequester(permissionType)
         })
 
-    var rawGlobalDefaults: [String: String]? {
-        keyValueStore.object(forKey: SitePermissionsStorageKeyNames.globalDefaults.rawValue) as? [String: String]
-    }
-
     init(isFireMode: Bool = false,
          context: SitePermissionRequestContext? = nil,
          keyValueStore: MockKeyValueStore = MockKeyValueStore()) throws {
         let context = try context ?? Self.makeContext()
-        self.keyValueStore = keyValueStore
         self.context = context
         site = context.topLevelSite
         self.isFireMode = isFireMode
         store = SitePermissionsStore(storage: keyValueStore.keyedStoring())
     }
 
-    func request(_ permissionTypes: Set<SitePermissionType>, bypassesModel: Bool = false) -> SitePermissionRequest {
-        SitePermissionRequest(context: context, permissionTypes: permissionTypes, bypassesModel: bypassesModel)
+    func request(_ permissionTypes: Set<SitePermissionType>) -> SitePermissionRequest {
+        SitePermissionRequest(context: context, permissionTypes: permissionTypes)
     }
 
     func context(changingNavigationGenerationTo generation: UInt) -> SitePermissionRequestContext {

--- a/iOS/LocalPackages/SitePermissions/Tests/SitePermissionsTests/SitePermissionsCoordinatorTests.swift
+++ b/iOS/LocalPackages/SitePermissions/Tests/SitePermissionsTests/SitePermissionsCoordinatorTests.swift
@@ -1,0 +1,678 @@
+//
+//  SitePermissionsCoordinatorTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@_spi(Testing) import Persistence
+import XCTest
+@testable import SitePermissions
+
+@MainActor
+final class SitePermissionsCoordinatorTests: XCTestCase {
+
+    func testWhenRequestBypassesModelThenStoreAndPromptAreIgnored() throws {
+        let harness = try Harness()
+        harness.store.setPersistentDecision(.deny, for: .camera, at: harness.site)
+        let request = harness.request([.camera], bypassesModel: true)
+        harness.context = harness.context(changingNavigationGenerationTo: 2)
+        var didPrompt = false
+        var resolution: SitePermissionResolution?
+
+        harness.coordinator.request(request, promptHandler: { _, _ in
+            didPrompt = true
+        }, completion: { resolution = $0 })
+
+        XCTAssertEqual(resolution, .bypass)
+        XCTAssertFalse(didPrompt)
+    }
+
+    func testWhenStoredDenyExistsThenItWinsWithoutPrompting() throws {
+        let harness = try Harness()
+        harness.store.setPersistentDecision(.allow, for: .camera, at: harness.site)
+        harness.store.setPersistentDecision(.deny, for: .microphone, at: harness.site)
+        var didPrompt = false
+        var resolution: SitePermissionResolution?
+
+        harness.coordinator.request(harness.request([.camera, .microphone]), promptHandler: { _, _ in
+            didPrompt = true
+        }, completion: { resolution = $0 })
+
+        XCTAssertEqual(resolution, .deny(systemBlocks: []))
+        XCTAssertFalse(didPrompt)
+    }
+
+    func testWhenStoredAllowExistsUnderGlobalNeverThenItStillGrants() throws {
+        let harness = try Harness()
+        harness.store.setPersistentDecision(.allow, for: .camera, at: harness.site)
+        harness.store.setGlobalDefault(.deny, for: .camera)
+        var resolution: SitePermissionResolution?
+
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, _ in
+            XCTFail("Stored Allow must not prompt")
+        }, completion: { resolution = $0 })
+
+        XCTAssertEqual(resolution, .grant)
+    }
+
+    func testWhenExplicitAskAndNoGlobalDenyExistThenRequestPrompts() throws {
+        let harness = try Harness()
+        harness.store.resetDecision(for: .camera, at: harness.site)
+        var receivedPrompt: SitePermissionPrompt?
+
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { prompt, _ in
+            receivedPrompt = prompt
+        }, completion: { _ in })
+
+        XCTAssertEqual(receivedPrompt, SitePermissionPrompt(site: harness.site, permissionTypes: [.camera]))
+    }
+
+    func testWhenGlobalNeverAppliesToUnresolvedTypeThenCombinedRequestDeclinesSilently() throws {
+        let harness = try Harness()
+        harness.store.setPersistentDecision(.allow, for: .camera, at: harness.site)
+        harness.store.setGlobalDefault(.deny, for: .microphone)
+        var didPrompt = false
+        var resolution: SitePermissionResolution?
+
+        harness.coordinator.request(harness.request([.camera, .microphone]), promptHandler: { _, _ in
+            didPrompt = true
+        }, completion: { resolution = $0 })
+
+        XCTAssertEqual(resolution, .deny(systemBlocks: []))
+        XCTAssertFalse(didPrompt)
+    }
+
+    func testWhenCombinedStoredStateIsPartialAllowAndAskThenOneCombinedPromptIsShown() throws {
+        let harness = try Harness()
+        harness.store.setPersistentDecision(.allow, for: .camera, at: harness.site)
+        var prompts = [SitePermissionPrompt]()
+
+        harness.coordinator.request(harness.request([.camera, .microphone]), promptHandler: { prompt, _ in
+            prompts.append(prompt)
+        }, completion: { _ in })
+
+        XCTAssertEqual(prompts, [SitePermissionPrompt(site: harness.site, permissionTypes: [.camera, .microphone])])
+    }
+
+    func testWhenAllowOnceCaptureEndsThenNextRequestPromptsAgain() async throws {
+        let harness = try Harness()
+        let firstCompletion = expectation(description: "First request grants")
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, respond in
+            respond(.allowOnce)
+        }, completion: { resolution in
+            XCTAssertEqual(resolution, .grant)
+            firstCompletion.fulfill()
+        })
+        await fulfillment(of: [firstCompletion], timeout: 1)
+
+        var promptCount = 0
+        var automaticResolution: SitePermissionResolution?
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, _ in
+            promptCount += 1
+        }, completion: { automaticResolution = $0 })
+        XCTAssertEqual(automaticResolution, .grant)
+        XCTAssertEqual(promptCount, 0)
+
+        harness.coordinator.captureDidEnd([.camera])
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, _ in
+            promptCount += 1
+        }, completion: { _ in })
+        XCTAssertEqual(promptCount, 1)
+        XCTAssertNil(harness.store.decision(for: .camera, at: harness.site))
+    }
+
+    func testWhenActiveAllowOnceAndStoredAllowCoverCombinedRequestThenTheyOverrideGlobalNever() async throws {
+        let harness = try Harness()
+        let firstCompletion = expectation(description: "Allow Once becomes active")
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, respond in
+            respond(.allowOnce)
+        }, completion: { resolution in
+            XCTAssertEqual(resolution, .grant)
+            firstCompletion.fulfill()
+        })
+        await fulfillment(of: [firstCompletion], timeout: 1)
+
+        harness.store.setGlobalDefault(.deny, for: .camera)
+        harness.store.setPersistentDecision(.allow, for: .microphone, at: harness.site)
+        var resolution: SitePermissionResolution?
+        harness.coordinator.request(harness.request([.camera, .microphone]), promptHandler: { _, _ in
+            XCTFail("Active and stored allows must satisfy the combined request")
+        }, completion: { resolution = $0 })
+
+        XCTAssertEqual(resolution, .grant)
+    }
+
+    func testWhenDenyOnceIsChosenThenItSuppressesReasksUntilReload() throws {
+        let harness = try Harness()
+        var firstResolution: SitePermissionResolution?
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, respond in
+            respond(.denyOnce)
+        }, completion: { firstResolution = $0 })
+        XCTAssertEqual(firstResolution, .deny(systemBlocks: []))
+
+        var promptCount = 0
+        var repeatedResolution: SitePermissionResolution?
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, _ in
+            promptCount += 1
+        }, completion: { repeatedResolution = $0 })
+        XCTAssertEqual(repeatedResolution, .deny(systemBlocks: []))
+        XCTAssertEqual(promptCount, 0)
+
+        harness.coordinator.pageDidChange(.reload)
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, _ in
+            promptCount += 1
+        }, completion: { _ in })
+        XCTAssertEqual(promptCount, 1)
+    }
+
+    func testWhenSameDocumentNavigationOccursThenPageDecisionSurvives() throws {
+        let harness = try Harness()
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, respond in
+            respond(.denyOnce)
+        }, completion: { _ in })
+
+        harness.coordinator.pageDidChange(.sameDocumentNavigation)
+        var resolution: SitePermissionResolution?
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, _ in
+            XCTFail("Same-document navigation must preserve the page decision")
+        }, completion: { resolution = $0 })
+
+        XCTAssertEqual(resolution, .deny(systemBlocks: []))
+    }
+
+    func testWhenSameDocumentNavigationOccursThenAllowOnceSurvives() async throws {
+        let harness = try Harness()
+        let firstCompletion = expectation(description: "Allow Once becomes active")
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, respond in
+            respond(.allowOnce)
+        }, completion: { resolution in
+            XCTAssertEqual(resolution, .grant)
+            firstCompletion.fulfill()
+        })
+        await fulfillment(of: [firstCompletion], timeout: 1)
+
+        harness.coordinator.pageDidChange(.sameDocumentNavigation)
+        var resolution: SitePermissionResolution?
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, _ in
+            XCTFail("Same-document navigation must preserve Allow Once")
+        }, completion: { resolution = $0 })
+
+        XCTAssertEqual(resolution, .grant)
+    }
+
+    func testWhenPageOrProcessEndsThenAllowOnceDoesNotSurvive() async throws {
+        for change in [SitePermissionPageChange.reload, .navigation, .webContentProcessReplacement] {
+            let harness = try Harness()
+            let grantCompletion = expectation(description: "Grant completes before \(change)")
+            harness.coordinator.request(harness.request([.camera]), promptHandler: { _, respond in
+                respond(.allowOnce)
+            }, completion: { resolution in
+                XCTAssertEqual(resolution, .grant)
+                grantCompletion.fulfill()
+            })
+            await fulfillment(of: [grantCompletion], timeout: 1)
+
+            harness.coordinator.pageDidChange(change)
+            var didPrompt = false
+            harness.coordinator.request(harness.request([.camera]), promptHandler: { _, _ in
+                didPrompt = true
+            }, completion: { _ in })
+            XCTAssertTrue(didPrompt)
+        }
+    }
+
+    func testWhenTabClosesOrIsRestoredThenNoPageDecisionSurvives() throws {
+        let closingHarness = try Harness()
+        closingHarness.coordinator.request(closingHarness.request([.camera]), promptHandler: { _, respond in
+            respond(.denyOnce)
+        }, completion: { _ in })
+        closingHarness.coordinator.close()
+
+        var closedTabDidRespond = false
+        closingHarness.coordinator.request(closingHarness.request([.camera]), promptHandler: { _, _ in
+            closedTabDidRespond = true
+        }, completion: { _ in
+            closedTabDidRespond = true
+        })
+        XCTAssertFalse(closedTabDidRespond)
+
+        let restoredHarness = try Harness()
+        var restoredTabDidPrompt = false
+        restoredHarness.coordinator.request(restoredHarness.request([.camera]), promptHandler: { _, _ in
+            restoredTabDidPrompt = true
+        }, completion: { _ in })
+        XCTAssertTrue(restoredTabDidPrompt)
+    }
+
+    func testWhenCoordinatorIsRestoredWithSameStoreThenAllowOnceIsNotRestored() async throws {
+        let keyValueStore = MockKeyValueStore()
+        let originalHarness = try Harness(keyValueStore: keyValueStore)
+        let firstCompletion = expectation(description: "Allow Once becomes active")
+        originalHarness.coordinator.request(originalHarness.request([.camera]), promptHandler: { _, respond in
+            respond(.allowOnce)
+        }, completion: { resolution in
+            XCTAssertEqual(resolution, .grant)
+            firstCompletion.fulfill()
+        })
+        await fulfillment(of: [firstCompletion], timeout: 1)
+
+        let restoredHarness = try Harness(keyValueStore: keyValueStore)
+        var didPrompt = false
+        restoredHarness.coordinator.request(restoredHarness.request([.camera]), promptHandler: { _, _ in
+            didPrompt = true
+        }, completion: { _ in })
+
+        XCTAssertTrue(didPrompt)
+        XCTAssertNil(restoredHarness.store.decision(for: .camera, at: restoredHarness.site))
+    }
+
+    func testWhenTwoPromptsArriveThenSecondWaitsForFirstCompleteFlow() async throws {
+        let harness = try Harness()
+        var responders = [(SitePermissionPromptDecision) -> Void]()
+        var promptedTypes = [Set<SitePermissionType>]()
+        let firstCompletion = expectation(description: "First request completes")
+        let secondCompletion = expectation(description: "Second request completes")
+
+        let promptHandler: SitePermissionsCoordinator.PromptHandler = { prompt, respond in
+            promptedTypes.append(prompt.permissionTypes)
+            responders.append(respond)
+        }
+        harness.coordinator.request(harness.request([.camera]), promptHandler: promptHandler) { resolution in
+            XCTAssertEqual(resolution, .grant)
+            firstCompletion.fulfill()
+        }
+        harness.coordinator.request(harness.request([.microphone]), promptHandler: promptHandler) { resolution in
+            XCTAssertEqual(resolution, .grant)
+            secondCompletion.fulfill()
+        }
+
+        XCTAssertEqual(promptedTypes, [[.camera]])
+        responders[0](.allowOnce)
+        await fulfillment(of: [firstCompletion], timeout: 1)
+        XCTAssertEqual(promptedTypes, [[.camera], [.microphone]])
+        responders[1](.allowOnce)
+        await fulfillment(of: [secondCompletion], timeout: 1)
+    }
+
+    func testWhenFirstQueuedRequestChoosesNeverAllowThenSecondIsSilentlyDenied() throws {
+        let harness = try Harness()
+        var responders = [(SitePermissionPromptDecision) -> Void]()
+        var resolutions = [SitePermissionResolution]()
+        let promptHandler: SitePermissionsCoordinator.PromptHandler = { _, respond in
+            responders.append(respond)
+        }
+
+        harness.coordinator.request(harness.request([.camera]), promptHandler: promptHandler) { resolutions.append($0) }
+        harness.coordinator.request(harness.request([.camera]), promptHandler: promptHandler) { resolutions.append($0) }
+        responders[0](.neverAllow)
+
+        XCTAssertEqual(responders.count, 1)
+        XCTAssertEqual(resolutions, [.deny(systemBlocks: []), .deny(systemBlocks: [])])
+        XCTAssertEqual(harness.store.decision(for: .camera, at: harness.site), .deny)
+    }
+
+    func testWhenFirstQueuedRequestChoosesAllowWhileUsingSiteThenSecondUsesStoredAllow() async throws {
+        let harness = try Harness()
+        var responders = [(SitePermissionPromptDecision) -> Void]()
+        var resolutions = [SitePermissionResolution]()
+        let promptHandler: SitePermissionsCoordinator.PromptHandler = { _, respond in
+            responders.append(respond)
+        }
+        let completions = expectation(description: "Both requests complete")
+        completions.expectedFulfillmentCount = 2
+
+        harness.coordinator.request(harness.request([.camera]), promptHandler: promptHandler) { resolution in
+            resolutions.append(resolution)
+            completions.fulfill()
+        }
+        harness.coordinator.request(harness.request([.camera]), promptHandler: promptHandler) { resolution in
+            resolutions.append(resolution)
+            completions.fulfill()
+        }
+        responders[0](.allowWhileUsingSite)
+        await fulfillment(of: [completions], timeout: 1)
+
+        XCTAssertEqual(responders.count, 1)
+        XCTAssertEqual(resolutions, [.grant, .grant])
+        XCTAssertEqual(harness.store.decision(for: .camera, at: harness.site), .allow)
+    }
+
+    func testWhenFirstQueuedRequestChoosesPageDecisionThenSecondUsesItWithoutPrompting() async throws {
+        let cases: [(SitePermissionPromptDecision, SitePermissionResolution)] = [
+            (.denyOnce, .deny(systemBlocks: [])),
+            (.allowOnce, .grant)
+        ]
+
+        for (decision, expectedResolution) in cases {
+            let harness = try Harness()
+            var responders = [(SitePermissionPromptDecision) -> Void]()
+            var resolutions = [SitePermissionResolution]()
+            let completions = expectation(description: "Both \(decision) requests complete")
+            completions.expectedFulfillmentCount = 2
+            let promptHandler: SitePermissionsCoordinator.PromptHandler = { _, respond in
+                responders.append(respond)
+            }
+
+            for _ in 0..<2 {
+                harness.coordinator.request(harness.request([.camera]), promptHandler: promptHandler) { resolution in
+                    resolutions.append(resolution)
+                    completions.fulfill()
+                }
+            }
+            responders[0](decision)
+            await fulfillment(of: [completions], timeout: 1)
+
+            XCTAssertEqual(responders.count, 1)
+            XCTAssertEqual(resolutions, [expectedResolution, expectedResolution])
+        }
+    }
+
+    func testWhenAnyContextFieldChangesBeforePromptResponseThenWorkIsDropped() throws {
+        let baseline = try Harness.makeContext()
+        let anotherSite = try XCTUnwrap(SitePermissionKey(committedURL: URL(string: "https://other.example")!))
+        let changedContexts = [
+            SitePermissionRequestContext(tabID: "other-tab",
+                                         topLevelSite: baseline.topLevelSite,
+                                         requestingFrameID: baseline.requestingFrameID,
+                                         webContentProcessGeneration: baseline.webContentProcessGeneration,
+                                         navigationGeneration: baseline.navigationGeneration),
+            SitePermissionRequestContext(tabID: baseline.tabID,
+                                         topLevelSite: anotherSite,
+                                         requestingFrameID: baseline.requestingFrameID,
+                                         webContentProcessGeneration: baseline.webContentProcessGeneration,
+                                         navigationGeneration: baseline.navigationGeneration),
+            SitePermissionRequestContext(tabID: baseline.tabID,
+                                         topLevelSite: baseline.topLevelSite,
+                                         requestingFrameID: 99,
+                                         webContentProcessGeneration: baseline.webContentProcessGeneration,
+                                         navigationGeneration: baseline.navigationGeneration),
+            SitePermissionRequestContext(tabID: baseline.tabID,
+                                         topLevelSite: baseline.topLevelSite,
+                                         requestingFrameID: baseline.requestingFrameID,
+                                         webContentProcessGeneration: 2,
+                                         navigationGeneration: baseline.navigationGeneration),
+            SitePermissionRequestContext(tabID: baseline.tabID,
+                                         topLevelSite: baseline.topLevelSite,
+                                         requestingFrameID: baseline.requestingFrameID,
+                                         webContentProcessGeneration: baseline.webContentProcessGeneration,
+                                         navigationGeneration: 2)
+        ]
+
+        for changedContext in changedContexts {
+            let harness = try Harness(context: baseline)
+            var responder: ((SitePermissionPromptDecision) -> Void)?
+            var resolution: SitePermissionResolution?
+            harness.coordinator.request(harness.request([.camera]), promptHandler: { _, respond in
+                responder = respond
+            }, completion: { resolution = $0 })
+
+            harness.context = changedContext
+            responder?(.allowWhileUsingSite)
+
+            XCTAssertNil(resolution)
+            XCTAssertNil(harness.store.decision(for: .camera, at: baseline.topLevelSite))
+        }
+    }
+
+    func testWhenNavigationOccursDuringOSRequestThenLateResultIsDroppedButCommittedAllowRemains() async throws {
+        let harness = try Harness()
+        harness.systemStates[.camera] = .notDetermined
+        let authorizationStarted = expectation(description: "OS authorization starts")
+        let staleCompletion = expectation(description: "Stale work does not complete")
+        staleCompletion.isInverted = true
+        var authorizationContinuation: CheckedContinuation<SystemPermissionAuthorizationState, Never>?
+        harness.authorizationRequester = { _ in
+            authorizationStarted.fulfill()
+            return await withCheckedContinuation { authorizationContinuation = $0 }
+        }
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, respond in
+            respond(.allowWhileUsingSite)
+        }, completion: { _ in staleCompletion.fulfill() })
+
+        XCTAssertEqual(harness.store.decision(for: .camera, at: harness.site), .allow)
+        await fulfillment(of: [authorizationStarted], timeout: 1)
+        harness.context = harness.context(changingNavigationGenerationTo: 2)
+        authorizationContinuation?.resume(returning: .authorized)
+        await fulfillment(of: [staleCompletion], timeout: 0.1)
+
+        XCTAssertEqual(harness.store.decision(for: .camera, at: harness.site), .allow)
+    }
+
+    func testWhenCombinedOSStatesDifferThenEveryTypeIsClassifiedSeparately() throws {
+        let harness = try Harness()
+        harness.store.setPersistentDecision(.allow, for: .camera, at: harness.site)
+        harness.store.setPersistentDecision(.allow, for: .microphone, at: harness.site)
+        harness.systemStates[.camera] = .denied
+        harness.systemStates[.microphone] = .restricted
+        var resolution: SitePermissionResolution?
+
+        harness.coordinator.request(harness.request([.camera, .microphone]), promptHandler: { _, _ in
+            XCTFail("Stored decisions must not prompt")
+        }, completion: { resolution = $0 })
+
+        XCTAssertEqual(resolution, .deny(systemBlocks: [
+            SitePermissionSystemBlock(permissionType: .camera, state: .denied, timing: .preexisting),
+            SitePermissionSystemBlock(permissionType: .microphone, state: .restricted, timing: .preexisting)
+        ]))
+    }
+
+    func testWhenStoredAllowHasUndeterminedSystemStateThenItDoesNotRequestAuthorization() throws {
+        let harness = try Harness()
+        harness.store.setPersistentDecision(.allow, for: .camera, at: harness.site)
+        harness.systemStates[.camera] = .notDetermined
+        harness.authorizationRequester = { _ in
+            XCTFail("Automatic Allow must not trigger the OS prompt")
+            return .authorized
+        }
+        var resolution: SitePermissionResolution?
+
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, _ in
+            XCTFail("Stored Allow must not show another site prompt")
+        }, completion: { resolution = $0 })
+
+        XCTAssertEqual(resolution, .deny(systemBlocks: [
+            SitePermissionSystemBlock(permissionType: .camera, state: .notDetermined, timing: .preexisting)
+        ]))
+    }
+
+    func testWhenFreshSystemRequestIsDeniedThenRecoveryMarksItAsAfterRequest() async throws {
+        let harness = try Harness()
+        harness.systemStates[.camera] = .notDetermined
+        harness.authorizationRequester = { permissionType in
+            XCTAssertEqual(permissionType, .camera)
+            return .denied
+        }
+        let completion = expectation(description: "Request completes")
+
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, respond in
+            respond(.allowOnce)
+        }, completion: { resolution in
+            XCTAssertEqual(resolution, .deny(systemBlocks: [
+                SitePermissionSystemBlock(permissionType: .camera, state: .denied, timing: .afterRequest)
+            ]))
+            completion.fulfill()
+        })
+
+        await fulfillment(of: [completion], timeout: 1)
+    }
+
+    func testWhenPersistentAllowIsFollowedBySystemDenialThenAllowRemainsStored() async throws {
+        let harness = try Harness()
+        harness.systemStates[.camera] = .notDetermined
+        harness.authorizationRequester = { _ in .denied }
+        let completion = expectation(description: "Request completes")
+
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, respond in
+            respond(.allowWhileUsingSite)
+        }, completion: { resolution in
+            XCTAssertEqual(resolution, .deny(systemBlocks: [
+                SitePermissionSystemBlock(permissionType: .camera, state: .denied, timing: .afterRequest)
+            ]))
+            completion.fulfill()
+        })
+
+        await fulfillment(of: [completion], timeout: 1)
+        XCTAssertEqual(harness.store.decision(for: .camera, at: harness.site), .allow)
+    }
+
+    func testWhenFreshCombinedRequestNeedsSystemAuthorizationThenEachTypeIsRequestedSeparately() async throws {
+        let harness = try Harness()
+        harness.systemStates[.camera] = .notDetermined
+        harness.systemStates[.microphone] = .notDetermined
+        var requestedTypes = [SitePermissionType]()
+        harness.authorizationRequester = { permissionType in
+            requestedTypes.append(permissionType)
+            return permissionType == .camera ? .authorized : .denied
+        }
+        let completion = expectation(description: "Combined request completes")
+
+        harness.coordinator.request(harness.request([.camera, .microphone]), promptHandler: { _, respond in
+            respond(.allowOnce)
+        }, completion: { resolution in
+            XCTAssertEqual(resolution, .deny(systemBlocks: [
+                SitePermissionSystemBlock(permissionType: .microphone, state: .denied, timing: .afterRequest)
+            ]))
+            completion.fulfill()
+        })
+
+        await fulfillment(of: [completion], timeout: 1)
+        XCTAssertEqual(requestedTypes, [.camera, .microphone])
+    }
+
+    func testWhenFireModeUserChoosesPersistentOptionsThenOnlyMemoryChanges() async throws {
+        let harness = try Harness(isFireMode: true)
+        harness.store.setGlobalDefault(.deny, for: .microphone)
+        harness.store.setPersistentDecision(.allow, for: .location, at: harness.site)
+        let originalGlobals = harness.rawGlobalDefaults
+
+        var globalResolution: SitePermissionResolution?
+        harness.coordinator.request(harness.request([.microphone]), promptHandler: { _, _ in
+            XCTFail("Fire mode must read the global default")
+        }, completion: { globalResolution = $0 })
+        XCTAssertEqual(globalResolution, .deny(systemBlocks: []))
+
+        var storedResolution: SitePermissionResolution?
+        harness.coordinator.request(harness.request([.location]), promptHandler: { _, _ in
+            XCTFail("Fire mode must read the stored site decision")
+        }, completion: { storedResolution = $0 })
+        XCTAssertEqual(storedResolution, .grant)
+
+        let grantCompletion = expectation(description: "Memory grant completes")
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, respond in
+            respond(.allowWhileUsingSite)
+        }, completion: { resolution in
+            XCTAssertEqual(resolution, .grant)
+            grantCompletion.fulfill()
+        })
+        await fulfillment(of: [grantCompletion], timeout: 1)
+        XCTAssertNil(harness.store.decision(for: .camera, at: harness.site))
+
+        harness.coordinator.captureDidEnd([.camera])
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, respond in
+            respond(.neverAllow)
+        }, completion: { _ in })
+        XCTAssertNil(harness.store.decision(for: .camera, at: harness.site))
+        XCTAssertEqual(harness.rawGlobalDefaults, originalGlobals)
+
+        var resolution: SitePermissionResolution?
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, _ in
+            XCTFail("Fire-mode Never must suppress for this page")
+        }, completion: { resolution = $0 })
+        XCTAssertEqual(resolution, .deny(systemBlocks: []))
+    }
+
+    func testWhenFireModeHasStoredDenyThenItIsReadWithoutPrompting() throws {
+        let harness = try Harness(isFireMode: true)
+        harness.store.setPersistentDecision(.deny, for: .camera, at: harness.site)
+        var resolution: SitePermissionResolution?
+
+        harness.coordinator.request(harness.request([.camera]), promptHandler: { _, _ in
+            XCTFail("Fire mode must read stored site denial")
+        }, completion: { resolution = $0 })
+
+        XCTAssertEqual(resolution, .deny(systemBlocks: []))
+    }
+}
+
+@MainActor
+private final class Harness {
+
+    let keyValueStore: MockKeyValueStore
+    let store: SitePermissionsStore
+    let site: SitePermissionKey
+    let isFireMode: Bool
+    var context: SitePermissionRequestContext
+    var systemStates: [SitePermissionType: SystemPermissionAuthorizationState] = [
+        .camera: .authorized,
+        .microphone: .authorized,
+        .location: .authorized
+    ]
+    var authorizationRequester: (SitePermissionType) async -> SystemPermissionAuthorizationState = { _ in .authorized }
+
+    lazy var coordinator = SitePermissionsCoordinator(
+        store: store,
+        isFireMode: isFireMode,
+        currentContext: { [weak self] tabID, frameID in
+            guard let self,
+                  context.tabID == tabID,
+                  context.requestingFrameID == frameID else { return nil }
+            return context
+        },
+        authorizationState: { [weak self] permissionType in
+            self?.systemStates[permissionType] ?? .unavailable
+        },
+        requestAuthorization: { [weak self] permissionType in
+            guard let self else { return .unavailable }
+            return await authorizationRequester(permissionType)
+        })
+
+    var rawGlobalDefaults: [String: String]? {
+        keyValueStore.object(forKey: SitePermissionsStorageKeyNames.globalDefaults.rawValue) as? [String: String]
+    }
+
+    init(isFireMode: Bool = false,
+         context: SitePermissionRequestContext? = nil,
+         keyValueStore: MockKeyValueStore = MockKeyValueStore()) throws {
+        let context = try context ?? Self.makeContext()
+        self.keyValueStore = keyValueStore
+        self.context = context
+        site = context.topLevelSite
+        self.isFireMode = isFireMode
+        store = SitePermissionsStore(storage: keyValueStore.keyedStoring())
+    }
+
+    func request(_ permissionTypes: Set<SitePermissionType>, bypassesModel: Bool = false) -> SitePermissionRequest {
+        SitePermissionRequest(context: context, permissionTypes: permissionTypes, bypassesModel: bypassesModel)
+    }
+
+    func context(changingNavigationGenerationTo generation: UInt) -> SitePermissionRequestContext {
+        SitePermissionRequestContext(tabID: context.tabID,
+                                     topLevelSite: context.topLevelSite,
+                                     requestingFrameID: context.requestingFrameID,
+                                     webContentProcessGeneration: context.webContentProcessGeneration,
+                                     navigationGeneration: generation)
+    }
+
+    static func makeContext() throws -> SitePermissionRequestContext {
+        let site = try XCTUnwrap(SitePermissionKey(committedURL: URL(string: "https://example.com")!))
+        return SitePermissionRequestContext(tabID: "tab-1",
+                                            topLevelSite: site,
+                                            requestingFrameID: 42,
+                                            webContentProcessGeneration: 1,
+                                            navigationGeneration: 1)
+    }
+}

--- a/iOS/LocalPackages/SitePermissions/Tests/SitePermissionsTests/SystemPermissionClientTests.swift
+++ b/iOS/LocalPackages/SitePermissions/Tests/SitePermissionsTests/SystemPermissionClientTests.swift
@@ -47,11 +47,7 @@ final class SystemPermissionClientTests: XCTestCase {
     func testWhenCameraAndMicrophoneAreRequestedThenVideoAndAudioAreEvaluatedSeparately() async {
         var statuses: [AVMediaType: AVAuthorizationStatus] = [.video: .notDetermined, .audio: .notDetermined]
         var requestedMediaTypes = [AVMediaType]()
-        var locationServicesQueryCount = 0
-        let client = makeClient(locationServicesEnabled: {
-            locationServicesQueryCount += 1
-            return true
-        }, statuses: { statuses[$0] ?? .notDetermined }) { mediaType, completion in
+        let client = makeClient(statuses: { statuses[$0] ?? .notDetermined }) { mediaType, completion in
             requestedMediaTypes.append(mediaType)
             statuses[mediaType] = mediaType == .video ? .authorized : .denied
             completion(mediaType == .video)
@@ -63,7 +59,6 @@ final class SystemPermissionClientTests: XCTestCase {
         XCTAssertEqual(requestedMediaTypes, [.video, .audio])
         XCTAssertEqual(cameraState, .authorized)
         XCTAssertEqual(microphoneState, .denied)
-        XCTAssertEqual(locationServicesQueryCount, 1)
     }
 
     func testWhenLocationAuthorizationAndUpdatesAreRequestedThenOneManagerHandlesBoth() async {
@@ -113,6 +108,28 @@ final class SystemPermissionClientTests: XCTestCase {
         XCTAssertEqual(client.pendingLocationAuthorizationRequestCount, 0)
     }
 
+    func testWhenLocationRequestDoesNotChangeStateThenAppActivationRetriesIt() async {
+        let manager = MockLocationManager()
+        let notificationCenter = NotificationCenter()
+        let client = makeClient(locationManager: manager, notificationCenter: notificationCenter)
+
+        let authorizationTask = Task { await client.requestAuthorization(for: .location) }
+        let didEnqueueRequest = await waitUntil {
+            client.pendingLocationAuthorizationRequestCount == 1
+        }
+        XCTAssertTrue(didEnqueueRequest)
+        XCTAssertEqual(manager.requestAuthorizationCallCount, 1)
+
+        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        XCTAssertEqual(manager.requestAuthorizationCallCount, 2)
+
+        manager.authorizationStatusValue = .authorizedWhenInUse
+        manager.delegate?.locationManagerDidChangeAuthorization?(manager)
+
+        let authorizationState = await authorizationTask.value
+        XCTAssertEqual(authorizationState, .authorized)
+    }
+
     func testWhenTwoLocationAuthorizationRequestsArePendingThenOneNativeRequestCompletesBoth() async {
         let manager = MockLocationManager()
         let authorizationRequested = expectation(description: "Location authorization requested")
@@ -137,24 +154,6 @@ final class SystemPermissionClientTests: XCTestCase {
         XCTAssertEqual(firstState, .authorized)
         XCTAssertEqual(secondState, .authorized)
         XCTAssertEqual(client.pendingLocationAuthorizationRequestCount, 0)
-    }
-
-    func testWhenAppBecomesActiveThenAuthorizationStatesAreRefreshed() {
-        let notificationCenter = NotificationCenter()
-        var cameraStatus = AVAuthorizationStatus.denied
-        let client = makeClient(statuses: { _ in cameraStatus }, notificationCenter: notificationCenter)
-        XCTAssertEqual(client.authorizationState(for: .camera), .denied)
-
-        cameraStatus = .authorized
-        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-
-        XCTAssertEqual(client.authorizationState(for: .camera), .authorized)
-    }
-
-    func testSettingsURLUsesApplicationSettingsDeepLink() {
-        let client = makeClient()
-
-        XCTAssertEqual(client.settingsURL, URL(string: UIApplication.openSettingsURLString))
     }
 
     private func waitUntil(_ condition: @escaping @MainActor () -> Bool) async -> Bool {

--- a/iOS/LocalPackages/SitePermissions/Tests/SitePermissionsTests/SystemPermissionClientTests.swift
+++ b/iOS/LocalPackages/SitePermissions/Tests/SitePermissionsTests/SystemPermissionClientTests.swift
@@ -1,0 +1,207 @@
+//
+//  SystemPermissionClientTests.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AVFoundation
+import CoreLocation
+import UIKit
+import XCTest
+@testable import SitePermissions
+
+@MainActor
+final class SystemPermissionClientTests: XCTestCase {
+
+    func testWhenAuthorizationStatesAreReadThenAllFiveStatesRemainDistinct() {
+        let manager = MockLocationManager()
+        manager.authorizationStatusValue = .restricted
+        let statuses: [AVMediaType: AVAuthorizationStatus] = [.video: .authorized, .audio: .denied]
+        let client = makeClient(locationManager: manager, statuses: { statuses[$0] ?? .notDetermined })
+
+        XCTAssertEqual(client.authorizationState(for: .camera), .authorized)
+        XCTAssertEqual(client.authorizationState(for: .microphone), .denied)
+        XCTAssertEqual(client.authorizationState(for: .location), .restricted)
+
+        manager.authorizationStatusValue = .notDetermined
+        client.refreshAuthorizationStates()
+        XCTAssertEqual(client.authorizationState(for: .location), .notDetermined)
+
+        let unavailableClient = makeClient(locationServicesEnabled: { false })
+        XCTAssertEqual(unavailableClient.authorizationState(for: .location), .unavailable)
+    }
+
+    func testWhenCameraAndMicrophoneAreRequestedThenVideoAndAudioAreEvaluatedSeparately() async {
+        var statuses: [AVMediaType: AVAuthorizationStatus] = [.video: .notDetermined, .audio: .notDetermined]
+        var requestedMediaTypes = [AVMediaType]()
+        var locationServicesQueryCount = 0
+        let client = makeClient(locationServicesEnabled: {
+            locationServicesQueryCount += 1
+            return true
+        }, statuses: { statuses[$0] ?? .notDetermined }) { mediaType, completion in
+            requestedMediaTypes.append(mediaType)
+            statuses[mediaType] = mediaType == .video ? .authorized : .denied
+            completion(mediaType == .video)
+        }
+
+        let cameraState = await client.requestAuthorization(for: .camera)
+        let microphoneState = await client.requestAuthorization(for: .microphone)
+
+        XCTAssertEqual(requestedMediaTypes, [.video, .audio])
+        XCTAssertEqual(cameraState, .authorized)
+        XCTAssertEqual(microphoneState, .denied)
+        XCTAssertEqual(locationServicesQueryCount, 1)
+    }
+
+    func testWhenLocationAuthorizationAndUpdatesAreRequestedThenOneManagerHandlesBoth() async {
+        let manager = MockLocationManager()
+        let authorizationRequested = expectation(description: "Location authorization requested")
+        manager.requestAuthorizationHandler = { authorizationRequested.fulfill() }
+        let expectedLocation = CLLocation(latitude: 37.3317, longitude: -122.0301)
+        var receivedLocation: CLLocation?
+        let client = makeClient(locationManager: manager)
+        client.locationUpdateHandler = { result in
+            receivedLocation = try? result.get()
+        }
+
+        let authorizationTask = Task { await client.requestAuthorization(for: .location) }
+        await fulfillment(of: [authorizationRequested], timeout: 1.0)
+        XCTAssertEqual(manager.requestAuthorizationCallCount, 1)
+
+        manager.authorizationStatusValue = .authorizedWhenInUse
+        manager.delegate?.locationManagerDidChangeAuthorization?(manager)
+        let authorizationState = await authorizationTask.value
+        XCTAssertEqual(authorizationState, .authorized)
+
+        client.startUpdatingLocation()
+        manager.delegate?.locationManager?(manager, didUpdateLocations: [expectedLocation])
+        client.stopUpdatingLocation()
+
+        XCTAssertEqual(manager.startUpdatingCallCount, 1)
+        XCTAssertEqual(manager.stopUpdatingCallCount, 1)
+        XCTAssertEqual(receivedLocation, expectedLocation)
+    }
+
+    func testWhenAppBecomesActiveWithPendingLocationRequestThenRequestCompletesWithRefreshedState() async {
+        let manager = MockLocationManager()
+        let notificationCenter = NotificationCenter()
+        let authorizationRequested = expectation(description: "Location authorization requested")
+        manager.requestAuthorizationHandler = { authorizationRequested.fulfill() }
+        let client = makeClient(locationManager: manager, notificationCenter: notificationCenter)
+
+        let authorizationTask = Task { await client.requestAuthorization(for: .location) }
+        await fulfillment(of: [authorizationRequested], timeout: 1.0)
+
+        manager.authorizationStatusValue = .denied
+        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        let authorizationState = await authorizationTask.value
+        XCTAssertEqual(authorizationState, .denied)
+        XCTAssertEqual(client.pendingLocationAuthorizationRequestCount, 0)
+    }
+
+    func testWhenTwoLocationAuthorizationRequestsArePendingThenOneNativeRequestCompletesBoth() async {
+        let manager = MockLocationManager()
+        let authorizationRequested = expectation(description: "Location authorization requested")
+        authorizationRequested.assertForOverFulfill = true
+        manager.requestAuthorizationHandler = { authorizationRequested.fulfill() }
+        let client = makeClient(locationManager: manager)
+
+        let firstTask = Task { await client.requestAuthorization(for: .location) }
+        await fulfillment(of: [authorizationRequested], timeout: 1.0)
+        let secondTask = Task { await client.requestAuthorization(for: .location) }
+        let didEnqueueBothRequests = await waitUntil {
+            client.pendingLocationAuthorizationRequestCount == 2
+        }
+        XCTAssertTrue(didEnqueueBothRequests)
+        XCTAssertEqual(manager.requestAuthorizationCallCount, 1)
+
+        manager.authorizationStatusValue = .authorizedWhenInUse
+        manager.delegate?.locationManagerDidChangeAuthorization?(manager)
+
+        let firstState = await firstTask.value
+        let secondState = await secondTask.value
+        XCTAssertEqual(firstState, .authorized)
+        XCTAssertEqual(secondState, .authorized)
+        XCTAssertEqual(client.pendingLocationAuthorizationRequestCount, 0)
+    }
+
+    func testWhenAppBecomesActiveThenAuthorizationStatesAreRefreshed() {
+        let notificationCenter = NotificationCenter()
+        var cameraStatus = AVAuthorizationStatus.denied
+        let client = makeClient(statuses: { _ in cameraStatus }, notificationCenter: notificationCenter)
+        XCTAssertEqual(client.authorizationState(for: .camera), .denied)
+
+        cameraStatus = .authorized
+        notificationCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        XCTAssertEqual(client.authorizationState(for: .camera), .authorized)
+    }
+
+    func testSettingsURLUsesApplicationSettingsDeepLink() {
+        let client = makeClient()
+
+        XCTAssertEqual(client.settingsURL, URL(string: UIApplication.openSettingsURLString))
+    }
+
+    private func waitUntil(_ condition: @escaping @MainActor () -> Bool) async -> Bool {
+        for _ in 0..<100 {
+            if condition() {
+                return true
+            }
+            await Task.yield()
+        }
+        return condition()
+    }
+
+    private func makeClient(locationManager: MockLocationManager = MockLocationManager(),
+                            locationServicesEnabled: @escaping () -> Bool = { true },
+                            statuses: @escaping (AVMediaType) -> AVAuthorizationStatus = { _ in .notDetermined },
+                            requestAccess: @escaping (AVMediaType, @escaping @Sendable (Bool) -> Void) -> Void = { _, _ in },
+                            notificationCenter: NotificationCenter = NotificationCenter()) -> SystemPermissionClient {
+        SystemPermissionClient(locationManager: locationManager,
+                               locationServicesEnabled: locationServicesEnabled,
+                               avAuthorizationStatus: statuses,
+                               avRequestAccess: requestAccess,
+                               notificationCenter: notificationCenter)
+    }
+}
+
+private final class MockLocationManager: CLLocationManager {
+
+    var authorizationStatusValue = CLAuthorizationStatus.notDetermined
+    var requestAuthorizationHandler: (() -> Void)?
+    private(set) var requestAuthorizationCallCount = 0
+    private(set) var startUpdatingCallCount = 0
+    private(set) var stopUpdatingCallCount = 0
+
+    override var authorizationStatus: CLAuthorizationStatus {
+        authorizationStatusValue
+    }
+
+    override func requestWhenInUseAuthorization() {
+        requestAuthorizationCallCount += 1
+        requestAuthorizationHandler?()
+    }
+
+    override func startUpdatingLocation() {
+        startUpdatingCallCount += 1
+    }
+
+    override func stopUpdatingLocation() {
+        stopUpdatingCallCount += 1
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217863452475659
Tech Design URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216242282222619
CC:

### Description

Adds the decision and system-permission layers for on-site camera, microphone, and location access.

The feature is hidden behind `sitePermissions`, which is off by default.

### Testing Steps

- Check if sitePermissions is properly gated / no changes to the existing behavior

### Impact

Medium. This code will decide whether privacy-sensitive camera, microphone, and location requests proceed once later PRs connect it to the app.

#### What could go wrong?

- A queued request could use stale permission state → the coordinator re-evaluates stored and session choices when each request reaches the front of its per-tab FIFO.
- A callback could grant access to a navigated tab → every callback validates the tab, request URL, current main-frame URL, committed document identity, and active-tab identity.
- An iOS prompt could appear without the site prompt → undetermined native access returns the recovery path for automatic stored or session Allow requests.
- Concurrent location requests could hang or duplicate the native prompt → the system client coalesces callers and resumes every pending continuation.

### Quality Considerations

- Persistent Allow remains stored when iOS denies access so the manager continues to show the user’s site choice.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New logic governs privacy-sensitive grant/deny paths and async OS prompts, but it is not wired into production WebKit handlers in this diff; regressions are mainly future integration risk plus the legacy matrix guarding current media-capture behavior.
> 
> **Overview**
> Introduces the **SitePermissions** decision stack for on-site camera, microphone, and location: a per-tab `SitePermissionsCoordinator` that merges persisted site choices, page-scoped allow/deny-once state, global defaults, and Fire-mode rules; serializes prompts in a FIFO queue; and drops work when tab/navigation/process context goes stale.
> 
> Adds **`SystemPermissionClient`** as the shared bridge to iOS AV and Core Location authorization (including coalesced location prompts, app-active retries, and location update forwarding), with coordinator resolutions surfacing per-type system blocks (`preexisting` vs `afterRequest`).
> 
> Ships broad **unit coverage** for coordinator and system-client behavior, plus **`MediaCapturePermissionLegacyMatrixTests`** to lock in existing `TabViewController` WebKit media-capture outcomes (Duck.ai host audio gating vs `.prompt` fallthrough elsewhere). Xcode project updated to compile the new app test target file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5cf257c3951f43116760096ee0b4a3c3610e993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->