### PR TITLE
iPad: Improve Create Image flow for Duck.ai users

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -414,6 +414,17 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         }
     }
 
+    var isAIChatModelPickerReadOnly: Bool = false {
+        didSet {
+            modelPickerButton.configuration?.image = isAIChatModelPickerReadOnly
+                ? nil
+                : UIImage(systemName: "chevron.down")?.withConfiguration(
+                    UIImage.SymbolConfiguration(pointSize: 10, weight: .medium)
+                )
+            modelPickerButton.showsMenuAsPrimaryAction = !isAIChatModelPickerReadOnly && modelPickerButton.menu != nil
+        }
+    }
+
     private var canShowModelPicker: Bool {
         isModelPickerEnabled && !(aiChatModelName?.isEmpty ?? true)
     }
@@ -502,6 +513,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
 
     /// Fired when the badge's clear (✕) button is tapped, so the host can deselect the tool.
     var onSelectedToolClearTapped: (() -> Void)?
+    var onCreateImageModelSwitchNoticeDismissed: (() -> Void)?
 
     private var canShowToolPicker: Bool {
         isToolPickerEnabled && toolPickerButton.menu != nil
@@ -624,6 +636,14 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         strip.translatesAutoresizingMaskIntoConstraints = false
         strip.isHidden = true
         return strip
+    }()
+
+    private let createImageModelSwitchCard: UTIFooterCardView = {
+        let card = UTIFooterCardView()
+        card.translatesAutoresizingMaskIntoConstraints = false
+        card.alpha = 0
+        card.isHidden = true
+        return card
     }()
 
     let aiChatTextView: ResignSuppressingTextView = {
@@ -1019,6 +1039,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         leadingButtonsContainer.addArrangedSubview(leadingBookmarksButtonView)
         leadingButtonsContainer.addArrangedSubview(passwordsButtonView)
 
+        searchAreaAlignmentView.addSubview(createImageModelSwitchCard)
         searchAreaAlignmentView.addSubview(searchAreaContainerView)
 
         if isFloatingUIEnabled {
@@ -1044,6 +1065,9 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         chromeContentContainerView.addSubview(selectedToolChipView)
         chromeContentContainerView.addSubview(attachButton)
         chromeContentContainerView.addSubview(attachmentsStripView)
+        createImageModelSwitchCard.onDismissTap = { [weak self] in
+            self?.onCreateImageModelSwitchNoticeDismissed?()
+        }
         addSubview(activeOutlineView)
         addLayoutGuide(fieldContainerLayoutGuide)
     }
@@ -1118,6 +1142,11 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
             // Grow the field as wide as possible; the leading/trailing bounds above plus the
             // centerX constraint below keep it centered within the available width.
             searchAreaContainerView.widthAnchor.constraint(equalTo: widthAnchor).withPriority(.defaultHigh),
+
+            createImageModelSwitchCard.leadingAnchor.constraint(equalTo: searchAreaContainerView.leadingAnchor),
+            createImageModelSwitchCard.trailingAnchor.constraint(equalTo: searchAreaContainerView.trailingAnchor),
+            createImageModelSwitchCard.topAnchor.constraint(equalTo: searchAreaContainerView.bottomAnchor,
+                                                            constant: -UTIFooterCardView.overlap),
 
             fieldContainerLayoutGuide.leadingAnchor.constraint(equalTo: chromeContentContainerView.leadingAnchor),
             fieldContainerLayoutGuide.trailingAnchor.constraint(equalTo: chromeContentContainerView.trailingAnchor),
@@ -1851,6 +1880,57 @@ extension DefaultOmniBarView {
 // MARK: - iPad Duck.ai Expanded Search Area
 
 extension DefaultOmniBarView {
+
+    func setCreateImageModelSwitchFooterMessage(_ message: UTIFooterMessage?, animated: Bool) {
+        guard let message, isSearchAreaExpanded else {
+            hideCreateImageModelSwitchCard(animated: animated)
+            return
+        }
+
+        createImageModelSwitchCard.configure(with: message, animateIcon: false)
+        createImageModelSwitchCard.isHidden = false
+        searchAreaAlignmentView.sendSubviewToBack(createImageModelSwitchCard)
+
+        guard animated else {
+            createImageModelSwitchCard.alpha = 1
+            layoutIfNeeded()
+            return
+        }
+
+        UIView.animate(withDuration: Metrics.expansionAnimationDuration,
+                       delay: 0,
+                       options: [.curveEaseInOut, .beginFromCurrentState]) {
+            self.createImageModelSwitchCard.alpha = 1
+            self.layoutIfNeeded()
+        }
+    }
+
+    func expandedContentMaxY(in view: UIView) -> CGFloat {
+        let isCardVisible = !createImageModelSwitchCard.isHidden && createImageModelSwitchCard.alpha > 0
+        let bottomView = isCardVisible ? createImageModelSwitchCard : searchAreaContainerView
+        return bottomView.convert(bottomView.bounds, to: view).maxY
+    }
+
+    private func hideCreateImageModelSwitchCard(animated: Bool) {
+        guard !createImageModelSwitchCard.isHidden else { return }
+
+        let completion: () -> Void = {
+            self.createImageModelSwitchCard.isHidden = true
+        }
+        guard animated else {
+            createImageModelSwitchCard.alpha = 0
+            completion()
+            return
+        }
+
+        UIView.animate(withDuration: Metrics.expansionAnimationDuration,
+                       delay: 0,
+                       options: [.curveEaseInOut, .beginFromCurrentState]) {
+            self.createImageModelSwitchCard.alpha = 0
+        } completion: { _ in
+            completion()
+        }
+    }
 
     func setSearchAreaExpanded(_ expanded: Bool, animated: Bool) {
         guard expanded != isSearchAreaExpanded else { return }

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -615,8 +615,13 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         didSet { refreshAttachButtonVisibility() }
     }
 
-    /// The menu offering photo / camera / file pickers. Setting it enables the button's primary
-    /// action; setting it nil hides the button — i.e. when the selected model accepts no attachments.
+    /// Whether the attach button should occupy its toolbar slot. Kept separate from the menu so an
+    /// unavailable button can remain visible but disabled.
+    var isAIChatAttachmentButtonVisible: Bool = false {
+        didSet { refreshAttachButtonVisibility() }
+    }
+
+    /// The menu offering photo / camera / file pickers. A nil menu disables the visible button.
     var aiChatAttachmentMenu: UIMenu? {
         get { attachButton.menu }
         set {
@@ -627,7 +632,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
     }
 
     private var canShowAttachButton: Bool {
-        isAttachButtonEnabled && attachButton.menu != nil
+        isAttachButtonEnabled && isAIChatAttachmentButtonVisible
     }
 
     /// The strip of pending attachments shown above the toolbar row when attachments are present.
@@ -2272,6 +2277,7 @@ extension DefaultOmniBarView {
     }
 
     private func refreshAttachButtonVisibility() {
+        attachButton.isEnabled = isAttachButtonEnabled && attachButton.menu != nil
         // Attach availability drives where the tool picker anchors, so re-evaluate it on every call
         // (including the early-return paths below).
         updateToolPickerLeadingConstraint()

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -1487,9 +1487,19 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
 
     private func overflowTarget(at point: CGPoint, with event: UIEvent?) -> UIView? {
         guard isSearchAreaExpanded else { return nil }
-        // The strip and attach button sit above the text view (which is brought to front for typing),
-        // so route taps to them before falling back to the text view.
-        let candidates: [UIView] = [aiChatSendButton, modelPickerButton, reasoningPickerButton, toolPickerButton, selectedToolChipView, attachButton, attachmentsStripView, aiChatTextView]
+        // Expanded controls sit above the text view, and the footer extends below the view's bounds,
+        // so route taps to them before falling back to the normal hierarchy.
+        let candidates: [UIView] = [
+            aiChatSendButton,
+            modelPickerButton,
+            reasoningPickerButton,
+            toolPickerButton,
+            selectedToolChipView,
+            attachButton,
+            attachmentsStripView,
+            aiChatTextView,
+            createImageModelSwitchCard
+        ]
         return candidates.first { candidate in
             guard !candidate.isHidden else { return false }
             let localPoint = candidate.convert(point, from: self)

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -1501,7 +1501,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
             createImageModelSwitchCard
         ]
         return candidates.first { candidate in
-            guard !candidate.isHidden else { return false }
+            guard !candidate.isHidden, candidate.alpha > 0 else { return false }
             let localPoint = candidate.convert(point, from: self)
             return candidate.point(inside: localPoint, with: event)
         }
@@ -1937,7 +1937,8 @@ extension DefaultOmniBarView {
                        delay: 0,
                        options: [.curveEaseInOut, .beginFromCurrentState]) {
             self.createImageModelSwitchCard.alpha = 0
-        } completion: { _ in
+        } completion: { finished in
+            guard finished else { return }
             completion()
         }
     }

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -558,7 +558,10 @@ extension DefaultOmniBarViewController {
 
         // The attach button shares the same store so its limits and accepted types track the selected
         // model. The strip view owns the pending attachments; the controller reads and mutates it.
-        let attachmentControllerInstance = IPadOmnibarAttachmentController(store: controller.modelStore)
+        let attachmentControllerInstance = IPadOmnibarAttachmentController(
+            store: controller.modelStore,
+            keepsUnavailableAttachmentButtonVisible: isUpdatedCreateImageEnabled
+        )
         attachmentController = attachmentControllerInstance
         attachmentControllerInstance.attachmentsStripView = omniBarView.attachmentsStripView
         attachmentControllerInstance.presenterProvider = { [weak self] in
@@ -675,8 +678,8 @@ extension DefaultOmniBarViewController {
     }
 
     private func refreshAttachButton() {
-        // A nil menu hides the button — i.e. when the selected model accepts no attachments.
         omniBarView.aiChatAttachmentMenu = attachmentController?.makeMenu()
+        omniBarView.isAIChatAttachmentButtonVisible = attachmentController?.isAttachButtonVisible ?? false
     }
 
     private func fireIPadUnifiedPromptSubmittedPixels(hasText: Bool, isFirstPromptNewInstall: Bool) {

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -555,7 +555,7 @@ extension DefaultOmniBarViewController {
             self?.toolPickerController?.resetSelection(isUserInitiated: true)
         }
         omniBarView.onCreateImageModelSwitchNoticeDismissed = { [weak self] in
-            self?.toolPickerController?.clearModelSwitchNotice()
+            self?.toolPickerController?.dismissModelSwitchNotice()
         }
 
         // The attach button shares the same store so its limits and accepted types track the selected
@@ -580,7 +580,7 @@ extension DefaultOmniBarViewController {
             // types apply).
             self.modelPickerController?.handleModelsUpdated()
             self.reasoningPickerController?.handleModelsUpdated()
-            self.toolPickerController?.handleModelChanged()
+            self.toolPickerController?.handleModelsUpdated()
             self.attachmentController?.handleModelChanged()
             self.refreshModelPicker()
             self.refreshReasoningPicker()

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -49,6 +49,7 @@ final class DefaultOmniBarViewController: OmniBarViewController {
     private var reasoningPickerController: IPadOmnibarReasoningPickerController?
     private var toolPickerController: IPadOmnibarToolPickerController?
     private var attachmentController: IPadOmnibarAttachmentController?
+    private var isUpdatedCreateImageEnabled = false
 
     override var iPadDuckAIControlValues: IPadDuckAIControlValues {
         IPadDuckAIControlValuesSnapshot(
@@ -134,6 +135,9 @@ final class DefaultOmniBarViewController: OmniBarViewController {
         omniBarView.onSearchAreaExpandedStateChanged = { [weak self] isExpanded in
             guard let self else { return }
             self.omniDelegate?.onOmniBarExpandedStateChanged(isExpanded: isExpanded)
+            if !isExpanded {
+                self.toolPickerController?.clearModelSwitchNotice()
+            }
             self.handleModelPickerExpansionChanged(isExpanded: isExpanded)
         }
 
@@ -526,14 +530,32 @@ extension DefaultOmniBarViewController {
             self?.refreshReasoningPicker()
         }
 
-        let toolController = IPadOmnibarToolPickerController(store: controller.modelStore)
+        isUpdatedCreateImageEnabled = dependencies.featureFlagger.isFeatureOn(.updatedCreateImage)
+        let toolController = IPadOmnibarToolPickerController(
+            store: controller.modelStore,
+            isUpdatedCreateImageEnabled: isUpdatedCreateImageEnabled
+        )
         toolPickerController = toolController
         toolController.onToolsUpdated = { [weak self] in
+            self?.refreshModelPicker()
             self?.refreshToolPicker()
             self?.refreshReasoningPicker()
+            self?.refreshAttachButton()
+        }
+        toolController.onModelSwitchNoticeUpdated = { [weak self] notice in
+            guard let self else { return }
+            if notice != nil {
+                self.attachmentController?.handleModelChanged()
+            }
+            let message = notice.map { UTIFooterMessageMapper().message(for: $0) }
+            self.omniBarView.setCreateImageModelSwitchFooterMessage(message, animated: true)
+            self.omniDelegate?.onOmniBarExpandedContentSizeChanged()
         }
         omniBarView.onSelectedToolClearTapped = { [weak self] in
             self?.toolPickerController?.resetSelection(isUserInitiated: true)
+        }
+        omniBarView.onCreateImageModelSwitchNoticeDismissed = { [weak self] in
+            self?.toolPickerController?.clearModelSwitchNotice()
         }
 
         // The attach button shares the same store so its limits and accepted types track the selected
@@ -601,9 +623,12 @@ extension DefaultOmniBarViewController {
             self.refreshToolPicker()
             self.refreshAttachButton()
         }
-        omniBarView.aiChatModelPickerMenu = menuFiringShownPixel(menu) {
+        let isReadOnly = isUpdatedCreateImageEnabled && toolPickerController?.selectedTool == .imageGeneration
+        omniBarView.isAIChatModelPickerReadOnly = isReadOnly
+        let menuWithShownPixel = menuFiringShownPixel(menu) {
             UnifiedToggleInputCoordinatorPixelHelper.fireModelPickerShownPixel(isAITabState: false)
         }
+        omniBarView.aiChatModelPickerMenu = isReadOnly ? nil : menuWithShownPixel
     }
 
     private func refreshReasoningPicker() {

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -547,9 +547,7 @@ extension DefaultOmniBarViewController {
             if notice != nil {
                 self.attachmentController?.handleModelChanged()
             }
-            let message = notice.map { UTIFooterMessageMapper().message(for: $0) }
-            self.omniBarView.setCreateImageModelSwitchFooterMessage(message, animated: true)
-            self.omniDelegate?.onOmniBarExpandedContentSizeChanged()
+            self.applyModelSwitchNotice(notice, animated: true)
         }
         omniBarView.onSelectedToolClearTapped = { [weak self] in
             self?.toolPickerController?.resetSelection(isUserInitiated: true)
@@ -605,6 +603,15 @@ extension DefaultOmniBarViewController {
         refreshReasoningPicker()
         refreshToolPicker()
         refreshAttachButton()
+        if let notice = toolPickerController?.currentModelSwitchNotice {
+            applyModelSwitchNotice(notice, animated: true)
+        }
+    }
+
+    private func applyModelSwitchNotice(_ notice: CreateImageModelSwitchNotice?, animated: Bool) {
+        let message = notice.map { UTIFooterMessageMapper().message(for: $0) }
+        omniBarView.setCreateImageModelSwitchFooterMessage(message, animated: animated)
+        omniDelegate?.onOmniBarExpandedContentSizeChanged()
     }
 
     private func refreshModelPicker() {

--- a/iOS/DuckDuckGo/IPadOmnibarAttachmentController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarAttachmentController.swift
@@ -33,6 +33,7 @@ import UniformTypeIdentifiers
 final class IPadOmnibarAttachmentController {
 
     private let store: UTIModelStore
+    private let keepsUnavailableAttachmentButtonVisible: Bool
     private let presenter = UnifiedToggleInputAttachmentPresenter()
 
     /// The strip that renders and owns the pending attachments. Set by the omnibar view controller
@@ -52,8 +53,9 @@ final class IPadOmnibarAttachmentController {
     /// Requested after a picker completes, so the omnibar can ensure it stays expanded.
     var onExpandRequested: (() -> Void)?
 
-    init(store: UTIModelStore) {
+    init(store: UTIModelStore, keepsUnavailableAttachmentButtonVisible: Bool = false) {
         self.store = store
+        self.keepsUnavailableAttachmentButtonVisible = keepsUnavailableAttachmentButtonVisible
 
         presenter.onExpandIfNeeded = { [weak self] in
             self?.onExpandRequested?()
@@ -77,6 +79,10 @@ final class IPadOmnibarAttachmentController {
     /// Whether the selected model accepts any attachment kind (so the button should be shown at all).
     var isAttachButtonAvailable: Bool {
         store.selectedModelSupportsImageUpload || !allowedFileUTTypes.isEmpty
+    }
+
+    var isAttachButtonVisible: Bool {
+        isAttachButtonAvailable || (store.selectedModel != nil && keepsUnavailableAttachmentButtonVisible)
     }
 
     /// Whether the current selection still allows attaching more (so the button should be enabled).

--- a/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
@@ -29,10 +29,13 @@ final class IPadOmnibarToolPickerController {
     private let store: UTIModelStore
     private let toolsController = UTIToolsController()
     private let menuFactory = UTIToolsMenuFactory()
+    private let isUpdatedCreateImageEnabled: Bool
     var onToolsUpdated: (() -> Void)?
+    var onModelSwitchNoticeUpdated: ((CreateImageModelSwitchNotice?) -> Void)?
 
-    init(store: UTIModelStore) {
+    init(store: UTIModelStore, isUpdatedCreateImageEnabled: Bool = false) {
         self.store = store
+        self.isUpdatedCreateImageEnabled = isUpdatedCreateImageEnabled
     }
 
     var isToolPickerAvailable: Bool {
@@ -77,17 +80,26 @@ final class IPadOmnibarToolPickerController {
         }
 
         let previousTool = toolsController.selectedTool
-        toolsController.toggleSelection(for: tool, modelStore: store)
+        let notice: CreateImageModelSwitchNotice?
+        if tool == .imageGeneration {
+            notice = toggleImageGenerationSelection()
+        } else {
+            toolsController.toggleSelection(for: tool, modelStore: store)
+            notice = nil
+        }
+        onModelSwitchNoticeUpdated?(notice)
         fireToggleTransitionPixel(previous: previousTool, current: toolsController.selectedTool)
         onToolsUpdated?()
     }
 
     func handleModelChanged() {
+        onModelSwitchNoticeUpdated?(nil)
         toolsController.clearSelectionIfUnsupported(for: store)
         onToolsUpdated?()
     }
 
     func resetSelection(isUserInitiated: Bool = false) {
+        onModelSwitchNoticeUpdated?(nil)
         guard let previousTool = toolsController.selectedTool else { return }
         toolsController.clearSelection()
         if isUserInitiated {
@@ -96,14 +108,43 @@ final class IPadOmnibarToolPickerController {
         onToolsUpdated?()
     }
 
+    func clearModelSwitchNotice() {
+        onModelSwitchNoticeUpdated?(nil)
+    }
+
     // MARK: - Private
 
     private var presentation: UTIToolsController.Presentation {
         toolsController.presentation(
             isActive: true,
             modelStore: store,
-            canShowCustomizeResponses: false
+            canShowCustomizeResponses: false,
+            createImagePolicy: createImageMenuPolicy
         )
+    }
+
+    private var createImageMenuPolicy: CreateImageMenuPolicy {
+        guard isUpdatedCreateImageEnabled else { return .legacy }
+        return .updated(canSwitchModel: store.imageGenerationFallbackModel != nil)
+    }
+
+    private func toggleImageGenerationSelection() -> CreateImageModelSwitchNotice? {
+        guard toolsController.selectedTool != .imageGeneration else {
+            toolsController.clearSelection()
+            return nil
+        }
+
+        var notice: CreateImageModelSwitchNotice?
+        if isUpdatedCreateImageEnabled,
+           !store.selectedModelSupports(tool: .imageGeneration),
+           let previousModel = store.selectedModel,
+           let fallbackModel = store.imageGenerationFallbackModel {
+            store.updateSelectedModel(fallbackModel.id, isNewChatContext: true)
+            notice = CreateImageModelSwitchNotice(previousModel: previousModel, newModel: fallbackModel)
+        }
+
+        toolsController.select(.imageGeneration, for: store)
+        return notice
     }
 
     private func fireToggleTransitionPixel(previous: AIChatRAGTool?, current: AIChatRAGTool?) {

--- a/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
@@ -69,6 +69,10 @@ final class IPadOmnibarToolPickerController {
         toolsController.selectedToolsForSubmission()
     }
 
+    var currentModelSwitchNotice: CreateImageModelSwitchNotice? {
+        modelSwitchNotice
+    }
+
     func makeMenu() -> UIMenu? {
         guard let toolsMenu = presentation.toolsMenu else { return nil }
         return menuFactory.makeMenu(toolsMenu) { [weak self] identifier in

--- a/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
+++ b/iOS/DuckDuckGo/IPadOmnibarToolPickerController.swift
@@ -30,12 +30,20 @@ final class IPadOmnibarToolPickerController {
     private let toolsController = UTIToolsController()
     private let menuFactory = UTIToolsMenuFactory()
     private let isUpdatedCreateImageEnabled: Bool
+    private let createImagePixelFiring: CreateImagePixelFiring
+    private lazy var createImageModelSwitcher = CreateImageModelSwitcher(
+        isFeatureEnabled: isUpdatedCreateImageEnabled,
+        pixelFiring: createImagePixelFiring)
+    private var modelSwitchNotice: CreateImageModelSwitchNotice?
     var onToolsUpdated: (() -> Void)?
     var onModelSwitchNoticeUpdated: ((CreateImageModelSwitchNotice?) -> Void)?
 
-    init(store: UTIModelStore, isUpdatedCreateImageEnabled: Bool = false) {
+    init(store: UTIModelStore,
+         isUpdatedCreateImageEnabled: Bool = false,
+         createImagePixelFiring: CreateImagePixelFiring = CreateImagePixelAdapter(surface: { .addressBar })) {
         self.store = store
         self.isUpdatedCreateImageEnabled = isUpdatedCreateImageEnabled
+        self.createImagePixelFiring = createImagePixelFiring
     }
 
     var isToolPickerAvailable: Bool {
@@ -87,19 +95,26 @@ final class IPadOmnibarToolPickerController {
             toolsController.toggleSelection(for: tool, modelStore: store)
             notice = nil
         }
-        onModelSwitchNoticeUpdated?(notice)
+        updateModelSwitchNotice(notice)
         fireToggleTransitionPixel(previous: previousTool, current: toolsController.selectedTool)
         onToolsUpdated?()
     }
 
     func handleModelChanged() {
-        onModelSwitchNoticeUpdated?(nil)
+        updateModelSwitchNotice(nil)
+        handleModelsUpdated()
+    }
+
+    func handleModelsUpdated() {
         toolsController.clearSelectionIfUnsupported(for: store)
+        if toolsController.selectedTool != .imageGeneration {
+            updateModelSwitchNotice(nil)
+        }
         onToolsUpdated?()
     }
 
     func resetSelection(isUserInitiated: Bool = false) {
-        onModelSwitchNoticeUpdated?(nil)
+        updateModelSwitchNotice(nil)
         guard let previousTool = toolsController.selectedTool else { return }
         toolsController.clearSelection()
         if isUserInitiated {
@@ -108,8 +123,14 @@ final class IPadOmnibarToolPickerController {
         onToolsUpdated?()
     }
 
+    func dismissModelSwitchNotice() {
+        guard modelSwitchNotice != nil else { return }
+        createImagePixelFiring.modelSwitchNoticeDismissed()
+        clearModelSwitchNotice()
+    }
+
     func clearModelSwitchNotice() {
-        onModelSwitchNoticeUpdated?(nil)
+        updateModelSwitchNotice(nil)
     }
 
     // MARK: - Private
@@ -125,26 +146,26 @@ final class IPadOmnibarToolPickerController {
 
     private var createImageMenuPolicy: CreateImageMenuPolicy {
         guard isUpdatedCreateImageEnabled else { return .legacy }
-        return .updated(canSwitchModel: store.imageGenerationFallbackModel != nil)
+        return .updated(canSwitchModel: canSwitchModelForImageGeneration)
+    }
+
+    private var canSwitchModelForImageGeneration: Bool {
+        store.imageGenerationFallbackModel != nil
     }
 
     private func toggleImageGenerationSelection() -> CreateImageModelSwitchNotice? {
-        guard toolsController.selectedTool != .imageGeneration else {
-            toolsController.clearSelection()
-            return nil
-        }
+        createImageModelSwitcher.toggle(
+            toolsController: toolsController,
+            modelStore: store,
+            canSwitchModel: canSwitchModelForImageGeneration,
+            entryPoint: .toolsMenu,
+            applyModel: { store.updateSelectedModel($0, isNewChatContext: true) })
+    }
 
-        var notice: CreateImageModelSwitchNotice?
-        if isUpdatedCreateImageEnabled,
-           !store.selectedModelSupports(tool: .imageGeneration),
-           let previousModel = store.selectedModel,
-           let fallbackModel = store.imageGenerationFallbackModel {
-            store.updateSelectedModel(fallbackModel.id, isNewChatContext: true)
-            notice = CreateImageModelSwitchNotice(previousModel: previousModel, newModel: fallbackModel)
-        }
-
-        toolsController.select(.imageGeneration, for: store)
-        return notice
+    private func updateModelSwitchNotice(_ notice: CreateImageModelSwitchNotice?) {
+        guard notice != modelSwitchNotice else { return }
+        modelSwitchNotice = notice
+        onModelSwitchNoticeUpdated?(notice)
     }
 
     private func fireToggleTransitionPixel(previous: AIChatRAGTool?, current: AIChatRAGTool?) {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6018,6 +6018,9 @@ extension MainViewController: OmniBarDelegate {
             return 0
         }
         let spacing: CGFloat = 12
+        if let omniBarView = viewCoordinator.omniBar.barView as? DefaultOmniBarView {
+            return max(0, omniBarView.expandedContentMaxY(in: viewCoordinator.contentContainer)) + spacing
+        }
         let containerFrame = searchContainer.convert(searchContainer.bounds, to: viewCoordinator.contentContainer)
         return max(0, containerFrame.maxY) + spacing
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UTIModelStore.swift
@@ -119,8 +119,7 @@ final class UTIModelStore {
     /// `resolve(modelId:)`, which drops an inaccessible model and falls back to `firstAccessibleModelId`
     /// — so switching to one would leave the user on a third model while the footer card names this one.
     var imageGenerationFallbackModel: AIChatModel? {
-        let candidates = models.filter { $0.entityHasAccess && $0.supportsTool(.imageGeneration) }
-        return candidates.first(where: \.isSuggestedForImageCreation) ?? candidates.first
+        AIChatModel.preferredImageGenerationModel(in: models)
     }
 
     private var firstAccessibleModelId: String? {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarAttachmentControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarAttachmentControllerTests.swift
@@ -64,6 +64,7 @@ final class IPadOmnibarAttachmentControllerTests: XCTestCase {
         store.models = [makeModel(id: "gpt-5.2", supportsImageUpload: true)]
 
         XCTAssertTrue(sut.isAttachButtonAvailable)
+        XCTAssertTrue(sut.isAttachButtonVisible)
         XCTAssertNotNil(sut.makeMenu())
     }
 
@@ -77,6 +78,27 @@ final class IPadOmnibarAttachmentControllerTests: XCTestCase {
         store.models = [makeModel(id: "gpt-oss", supportsImageUpload: false)]
 
         XCTAssertFalse(sut.isAttachButtonAvailable)
+        XCTAssertNil(sut.makeMenu())
+    }
+
+    func testWhenUnavailableButtonShouldRemainVisibleAndSelectedModelSupportsNoAttachmentsThenVisibleWithoutMenu() {
+        store.models = [makeModel(id: "gpt-oss", supportsImageUpload: false)]
+        sut = IPadOmnibarAttachmentController(store: store, keepsUnavailableAttachmentButtonVisible: true)
+
+        XCTAssertTrue(sut.isAttachButtonVisible)
+        XCTAssertNil(sut.makeMenu())
+    }
+
+    func testWhenUnavailableButtonShouldNotRemainVisibleAndSelectedModelSupportsNoAttachmentsThenHidden() {
+        store.models = [makeModel(id: "gpt-oss", supportsImageUpload: false)]
+
+        XCTAssertFalse(sut.isAttachButtonVisible)
+    }
+
+    func testWhenUnavailableButtonShouldRemainVisibleAndModelIsUnknownThenHidden() {
+        sut = IPadOmnibarAttachmentController(store: store, keepsUnavailableAttachmentButtonVisible: true)
+
+        XCTAssertFalse(sut.isAttachButtonVisible)
         XCTAssertNil(sut.makeMenu())
     }
 
@@ -195,6 +217,40 @@ final class IPadOmnibarAttachmentControllerTests: XCTestCase {
             fileName: "doc.pdf",
             mimeType: "application/pdf"
         )
+    }
+}
+
+@MainActor
+final class IPadOmnibarAttachmentButtonPresentationTests: XCTestCase {
+
+    func testWhenVisibleAttachmentButtonHasNoMenuThenItIsShownDisabled() {
+        let sut = DefaultOmniBarView.create(isFloatingUIEnabled: false)
+        sut.frame = CGRect(x: 0, y: 0, width: 1024, height: DefaultOmniBarView.expectedHeight)
+        sut.setLayoutMode(.expandedPad)
+        sut.isAttachButtonEnabled = true
+        sut.isAIChatAttachmentButtonVisible = true
+        sut.aiChatAttachmentMenu = nil
+
+        sut.setSearchAreaExpanded(true, animated: false)
+
+        XCTAssertFalse(sut.attachButton.isHidden)
+        XCTAssertFalse(sut.attachButton.isEnabled)
+        XCTAssertNil(sut.attachButton.menu)
+    }
+
+    func testWhenVisibleAttachmentButtonHasMenuThenItIsShownEnabled() {
+        let sut = DefaultOmniBarView.create(isFloatingUIEnabled: false)
+        sut.frame = CGRect(x: 0, y: 0, width: 1024, height: DefaultOmniBarView.expectedHeight)
+        sut.setLayoutMode(.expandedPad)
+        sut.isAttachButtonEnabled = true
+        sut.isAIChatAttachmentButtonVisible = true
+        sut.aiChatAttachmentMenu = UIMenu(children: [])
+
+        sut.setSearchAreaExpanded(true, animated: false)
+
+        XCTAssertFalse(sut.attachButton.isHidden)
+        XCTAssertTrue(sut.attachButton.isEnabled)
+        XCTAssertNotNil(sut.attachButton.menu)
     }
 }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarToolPickerControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/IPadOmnibarToolPickerControllerTests.swift
@@ -30,10 +30,12 @@ final class IPadOmnibarToolPickerControllerTests: XCTestCase {
     private var sut: IPadOmnibarToolPickerController!
     private var store: UTIModelStore!
     private var preferences: StubToolPreferences!
+    private var createImagePixelFiring: MockCreateImagePixelFiring!
 
     override func setUp() {
         super.setUp()
         preferences = StubToolPreferences()
+        createImagePixelFiring = MockCreateImagePixelFiring()
         store = UTIModelStore(
             modelsService: StubModelsService(),
             preferences: preferences,
@@ -47,6 +49,7 @@ final class IPadOmnibarToolPickerControllerTests: XCTestCase {
         sut = nil
         store = nil
         preferences = nil
+        createImagePixelFiring = nil
         super.tearDown()
     }
 
@@ -99,6 +102,67 @@ final class IPadOmnibarToolPickerControllerTests: XCTestCase {
         sut.handleToolSelection(.imageGeneration)
 
         XCTAssertEqual(sut.selectedToolsForSubmission, [.imageGeneration])
+    }
+
+    func testWhenUpdatedCreateImageSwitchesModelThenUsesSharedSwitcherAndReportsPixel() {
+        setUpUpdatedCreateImageModels()
+        var notices: [CreateImageModelSwitchNotice?] = []
+        sut.onModelSwitchNoticeUpdated = { notices.append($0) }
+
+        sut.handleToolSelection(.imageGeneration)
+
+        XCTAssertEqual(store.persistedModelId, "image-capable")
+        XCTAssertEqual(sut.selectedTool, .imageGeneration)
+        XCTAssertEqual(notices.last??.newModelShortName, "image-capable")
+        XCTAssertEqual(createImagePixelFiring.switches.first?.entryPoint, .toolsMenu)
+    }
+
+    func testWhenModelsRefreshAfterCreateImageSwitchThenNoticeRemainsVisible() {
+        setUpUpdatedCreateImageModels()
+        var notices: [CreateImageModelSwitchNotice?] = []
+        sut.onModelSwitchNoticeUpdated = { notices.append($0) }
+        sut.handleToolSelection(.imageGeneration)
+
+        sut.handleModelsUpdated()
+
+        XCTAssertEqual(notices.count, 1)
+        XCTAssertNotNil(notices.last ?? nil)
+    }
+
+    func testWhenUserChangesModelAfterCreateImageSwitchThenNoticeIsCleared() {
+        setUpUpdatedCreateImageModels()
+        var notices: [CreateImageModelSwitchNotice?] = []
+        sut.onModelSwitchNoticeUpdated = { notices.append($0) }
+        sut.handleToolSelection(.imageGeneration)
+
+        sut.handleModelChanged()
+
+        XCTAssertEqual(notices.count, 2)
+        XCTAssertNil(notices.last ?? nil)
+    }
+
+    func testWhenModelSwitchNoticeDismissedThenDismissPixelFiresOnce() {
+        setUpUpdatedCreateImageModels()
+        sut.handleToolSelection(.imageGeneration)
+
+        sut.dismissModelSwitchNotice()
+        sut.dismissModelSwitchNotice()
+
+        XCTAssertEqual(createImagePixelFiring.noticeDismissedCount, 1)
+    }
+
+    func testWhenUpdatedCreateImageHasNoFallbackThenUnavailablePixelFires() {
+        store.models = [makeModel(id: "unsupported", supportedTools: [])]
+        store.updateSelectedModel("unsupported", isNewChatContext: true)
+        sut = IPadOmnibarToolPickerController(
+            store: store,
+            isUpdatedCreateImageEnabled: true,
+            createImagePixelFiring: createImagePixelFiring)
+
+        sut.handleToolSelection(.imageGeneration)
+
+        XCTAssertEqual(createImagePixelFiring.unavailableCount, 1)
+        XCTAssertNil(sut.selectedTool)
     }
 
     func testWhenUnsupportedToolSelectedThenIgnored() {
@@ -247,6 +311,18 @@ final class IPadOmnibarToolPickerControllerTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    private func setUpUpdatedCreateImageModels() {
+        store.models = [
+            makeModel(id: "unsupported", supportedTools: []),
+            makeModel(id: "image-capable", supportedTools: [.imageGeneration])
+        ]
+        store.updateSelectedModel("unsupported", isNewChatContext: true)
+        sut = IPadOmnibarToolPickerController(
+            store: store,
+            isUpdatedCreateImageEnabled: true,
+            createImagePixelFiring: createImagePixelFiring)
+    }
 
     private func makeModel(id: String, supportedTools: [AIChatRAGTool]) -> AIChatModel {
         AIChatModel(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1218064605996648?focus=true
Tech Design URL:
CC:

### Description

Adds the updated Create Image flow to the native iPad omnibar. Create Image remains available across models; selecting it switches to an accessible image-capable model and shows the model/privacy notice, gated by updatedCreateImage.

### Testing Steps

1. On iPad, enable updatedCreateImage and open the native Duck.ai omnibar.
2. Select a model without image support, then choose Tools → Create Image → a compatible model is selected and the notice appears.
3. Verify the model picker remains visible and read-only while Create Image is active.
4. Repeat from an OSS model → the privacy-specific notice appears.

### Impact

Medium. Behind a feature flag; an incorrect fallback could switch users to the wrong model.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behind a feature flag but changes model selection and fallback logic on tool pick; a wrong fallback or notice state could leave users on an unexpected model or blocked controls.
> 
> **Overview**
> Brings the **updated Create Image** experience to the iPad Duck.ai omnibar when `updatedCreateImage` is on: choosing Create Image can auto-switch to an image-capable model and show a dismissible footer notice (model/privacy messaging via `UTIFooterCardView`), while the model chip stays visible but **read-only** for that tool.
> 
> The omnibar controller wires `IPadOmnibarToolPickerController` through the shared `CreateImageModelSwitcher`, refreshes model/reasoning/attach UI when tools change, clears the notice on collapse or dismiss, and notifies layout so suggestions/popover spacing follow the footer (`expandedContentMaxY` in `MainViewController`). Attachments can show a **disabled** attach button when the model accepts nothing (visibility vs menu is split); fallback model selection uses `AIChatModel.preferredImageGenerationModel`. Tests cover attachment presentation and Create Image switching/pixels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a4f7af4e5f2e8ddae7331eb3544e16d12ef4edc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->