### PR TITLE
[iOS/macOS][Pixel] Update Legacy Pixels

### DIFF
--- a/iOS/DuckDuckGo/Fire/Statistics/DataClearingPixels.swift
+++ b/iOS/DuckDuckGo/Fire/Statistics/DataClearingPixels.swift
@@ -36,9 +36,6 @@ enum DataClearingPixels {
 // MARK: - PixelKit.Event Protocol
 
 extension DataClearingPixels: PixelKit.Event {
-    /// This pixel signature is non-standard and not aligned to the current PixelKit defaults. This policy freezes the signature by not sending the platform marker suffix.
-    var platformSuffixPolicy: PixelKitPlatformSuffixPolicy { .legacyOmitted }
-
     var name: String {
         switch self {
         case .retriggerIn20s:
@@ -74,9 +71,8 @@ extension DataClearingPixels: PixelKit.Event {
 ///
 /// Kept separate from `DataClearingPixels` for two reasons, both of which would otherwise change
 /// pixels this type does not own:
-/// - these four have always sent the `_ios_phone` / `_ios_tablet` marker and `DataClearingPixels`
-///   never has, so the two need different `platformSuffixPolicy` values. Merging them would start
-///   marking `m_fire_retrigger_in_20s` and `m_fire_user_action_before_completion` too.
+/// - these four use `.legacyBeforeFrequencySuffix` (marker before the frequency suffix);
+///   `DataClearingPixels` uses PixelKit's default `.standard` (marker after it).
 /// - `DataClearingPixels` reports `pixelSource`, which these four do not declare in
 ///   `forget_all.json5`.
 enum DataClearingCompletionPixels {

--- a/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
@@ -19,7 +19,7 @@
         "description": "Fired when the app cannot enumerate the iOS app switcher snapshot directory, including when the expected private OS path is missing",
         "owners": ["bkunat"],
         "triggers": ["other"],
-        "suffixes": ["daily_count"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": ["appVersion", "pixelSource", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
     },
 

--- a/macOS/PixelDefinitions/pixels/definitions/data_import_wide_event.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/data_import_wide_event.json5
@@ -126,7 +126,8 @@
                 "type": "string",
                 "description": "Context name for the flow",
                 "enum": ["funnel_default_macos"]
-            }
+            },
+            "channel"
         ]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/subscription.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/subscription.json5
@@ -594,6 +594,11 @@
                 "description": "The funnel that led to the restore flow",
                 "pattern": "^funnel_"
             },
+            {
+                "key": "context.name",
+                "type": "string",
+                "description": "Legacy context name carried over from flows started on older app versions, prior to the funnel_name migration. New flows use feature.data.ext.funnel_name."
+            },
             "channel"
         ]
     },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218065547864023?focus=true

### Description
- Stop omitting the iOS form-factor suffix on fire-button pixels so they arrive as `m_fire_retrigger_in_20s_ios_phone` / `_ios_tablet` (and the daily variant), matching their definitions.
- Declare leftover macOS wide-event parameters still present in released traffic: `channel` on data import, and legacy `context.name` on subscription restore.
- App-switcher snapshot enumeration now also gets the form-factor suffix, because it shares the same PixelKit event type.

### Testing Steps
1. On iPhone, tap Fire twice within 20 seconds → pixel arrives as `m_fire_retrigger_in_20s_daily_ios_phone` and `m_fire_retrigger_in_20s_ios_phone`.
2. Repeat on iPad → same names with `_ios_tablet`.
3. Start a fire and interact before it finishes → `m_fire_user_action_before_completion_ios_phone` (or `_ios_tablet`).
4. Confirm dashboards that queried the bare names (`m_fire_retrigger_in_20s`, `m_fire_user_action_before_completion`) are updated to the suffixed names.

### Impact
**Impact Level: Medium**

Analytics/tracking names change for fire-button pixels (intentional) and for `app-switcher_snapshot_enumeration_failed` (side effect of sharing the event type). No user-facing behavior change.

#### What could go wrong?
- Existing dashboards that query the unsuffixed fire-button names will go quiet → mitigated by updating those queries after this ships.
- `app-switcher_snapshot_enumeration_failed` also starts sending `_ios_phone` / `_ios_tablet`. Confirm with the pixel owner if that split is unwanted.

### Quality Considerations
- Daily throttle keys are unchanged (PixelKit keys off the name without the trailing marker), so upgrading does not double-fire dailies.
- `DataClearingCompletionPixels` is unchanged and still uses the legacy marker-before-frequency order.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Analytics event names change for several iOS fire-related pixels, so dashboards querying unsuffixed names will go quiet until queries are updated; no user-facing or security behavior changes.
> 
> **Overview**
> **iOS fire / data-clearing pixels** now emit the platform and form-factor suffixes their definitions already declared. `DataClearingPixels` drops the custom `platformSuffixPolicy` that omitted those markers, so events like `m_fire_retrigger_in_20s` and `m_fire_user_action_before_completion` arrive as `…_ios_phone` / `…_ios_tablet` (including daily variants). The same event type change also suffixes `app-switcher_snapshot_enumeration_failed`, and its pixel definition is updated to list `platform` and `form_factor` alongside `daily_count`.
> 
> **`DataClearingCompletionPixels`** is unchanged and still uses legacy marker-before-frequency ordering; only the comment explaining why it stays separate is updated.
> 
> **macOS pixel definitions** are brought in line with traffic still on the wire: `m_mac_wide_data_import` now allows `channel`, and `m_mac_wide_subscription_restore` documents optional legacy `context.name` for restores started before the `funnel_name` migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a19995948e5928aa0fa4e66f50e685fa55ea81ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->