### PR TITLE
[iOS, macOS] fix screen time watchdog crash and fire pixel when there is data on launch

### DIFF
--- a/SharedPackages/ScreenTimeDataCleaner/Sources/ScreenTimeDataCleaner/ScreenTimeDataCleaner.swift
+++ b/SharedPackages/ScreenTimeDataCleaner/Sources/ScreenTimeDataCleaner/ScreenTimeDataCleaner.swift
@@ -16,17 +16,62 @@
 //  limitations under the License.
 //
 
+import ScreenTime
 import WebKit
 
 @available(iOS 26, macOS 26, *)
-public struct ScreenTimeDataCleaner {
+public struct ScreenTimeDataCleaner: Sendable {
 
     private static let removalTimeoutNanoseconds: UInt64 = 2_000_000_000
 
     public init() { }
 
-    @MainActor
+    public func hasScreenTimeData() async -> Bool {
+        if let history = makeWebHistory(), let hasHistory = await history.hasData(), hasHistory {
+            return true
+        }
+
+        // Cross-check WebKit when Screen Time reports no history.
+        return await hasScreenTimeDataInWebsiteDataStores()
+    }
+
     public func removeScreenTimeData() async {
+        if let history = makeWebHistory(), await history.removeData() {
+            return
+        }
+
+        await removeScreenTimeDataFromWebsiteDataStores()
+    }
+
+    private func makeWebHistory() -> ScreenTimeWebHistory? {
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return nil }
+
+        return ScreenTimeWebHistory(bundleIdentifier: bundleIdentifier)
+    }
+
+    @MainActor
+    private func hasScreenTimeDataInWebsiteDataStores() async -> Bool {
+        guard !Task.isCancelled else { return false }
+
+        let uids = await WKWebsiteDataStore.allDataStoreIdentifiers
+
+        guard !Task.isCancelled else { return false }
+        let defaultRecords = await WKWebsiteDataStore.default().dataRecords(ofTypes: [WKWebsiteDataTypeScreenTime])
+        guard defaultRecords.isEmpty else { return true }
+
+        for uid in uids {
+            guard !Task.isCancelled else { return false }
+            let records = await WKWebsiteDataStore(forIdentifier: uid).dataRecords(ofTypes: [WKWebsiteDataTypeScreenTime])
+            if !records.isEmpty {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    @MainActor
+    private func removeScreenTimeDataFromWebsiteDataStores() async {
         let uids = await WKWebsiteDataStore.allDataStoreIdentifiers
 
         guard !Task.isCancelled else { return }
@@ -70,6 +115,49 @@ public struct ScreenTimeDataCleaner {
             removalTask.cancel()
             return false
         }
+    }
+
+}
+
+@available(iOS 26, macOS 26, *)
+private actor ScreenTimeWebHistory {
+
+    private let bundleIdentifier: String
+    private var history: STWebHistory?
+
+    init(bundleIdentifier: String) {
+        self.bundleIdentifier = bundleIdentifier
+    }
+
+    func hasData() async -> Bool? {
+        guard let history = makeHistory() else { return nil }
+
+        return await withCheckedContinuation { continuation in
+            history.fetchAllHistory { urls, error in
+                guard error == nil else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                continuation.resume(returning: urls?.isEmpty == false)
+            }
+        }
+    }
+
+    func removeData() -> Bool {
+        guard let history = makeHistory() else { return false }
+
+        history.deleteAllHistory()
+        return true
+    }
+
+    private func makeHistory() -> STWebHistory? {
+        if let history {
+            return history
+        }
+
+        history = try? STWebHistory(bundleIdentifier: bundleIdentifier)
+        return history
     }
 
 }

--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -29,6 +29,7 @@ import PixelKit
 import BrowserServicesKit
 import Subscription
 import RemoteMessaging
+import ScreenTimeDataCleaner
 import WebExtensions
 import FeatureFlags_iOS
 
@@ -437,6 +438,16 @@ struct Launching: LaunchingHandling {
                 taskContext.finish()
             }
         })
+        if #available(iOS 26, *) {
+            launchTaskManager.register(task: BlockLaunchTask(name: "Report Screen Time Data") { taskContext in
+                Task { @MainActor in
+                    if await ScreenTimeDataCleaner().hasScreenTimeData() {
+                        PixelKit.fire(ScreenTimeDataPixel.recordsFound, frequency: .dailyAndCount)
+                    }
+                    taskContext.finish()
+                }
+            })
+        }
 
         // MARK: - Final Configuration
         // Complete the configuration process and set up the main window
@@ -547,6 +558,17 @@ struct Launching: LaunchingHandling {
             backgroundTaskManager: BackgroundTaskManager(featureFlagger: featureFlagger)
         )
     }
+
+}
+
+private enum ScreenTimeDataPixel: PixelKit.Event {
+
+    case recordsFound
+
+    var name: String { "screen-time_records-present" }
+    var parameters: [String: String]? { nil }
+    var standardParameters: [PixelKitStandardParameter]? { nil }
+    var namePrefix: PixelKitNamePrefix { .none }
 
 }
 

--- a/iOS/PixelDefinitions/pixels/definitions/screen_time.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/screen_time.json5
@@ -1,0 +1,9 @@
+{
+    "screen-time_records-present": {
+        "description": "Fires when Screen Time records are found during an app launch.",
+        "owners": ["brindy"],
+        "triggers": ["startup"],
+        "suffixes": ["first_daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"],
+    },
+}

--- a/iOS/PixelDefinitions/pixels/definitions/screen_time.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/screen_time.json5
@@ -4,6 +4,6 @@
         "owners": ["brindy"],
         "triggers": ["startup"],
         "suffixes": ["first_daily_count", "platform", "form_factor"],
-        "parameters": ["appVersion"],
-    },
+        "parameters": ["appVersion"]
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1216744184761157?focus=true
Tech Design URL:
CC:

### Description
Improves Screen Time data cleanup on iOS/macOS 26 by using the dedicated system API while retaining the existing fallback. Adds daily and count telemetry when Screen Time records remain at launch, without reporting record counts or URLs.

### Testing Steps
1. On iOS 26, disable the Screen Time cleaning feature flag.
1. Launch the app and visit a website.
1. Background and relaunch the app → screen-time_records-present daily and count pixels are emitted.
1. Enable the Screen Time cleaning feature flag.
1. Background the app to trigger cleanup.
1. Relaunch the app → no Screen Time records pixel is emitted.
1. Build the iOS Browser scheme → build succeeds.

1. Smoke test macOS app

### Impact
High: A cleanup regression could leave browsing activity visible through Screen Time, affecting user privacy.

#### What could go wrong?
Screen Time records could remain after cleanup → mitigated by retaining the existing WebKit cleanup as a fallback.

The telemetry could report false positives → mitigated by checking both the dedicated Screen Time API and WebKit data stores.

### Quality Considerations
- The dedicated Screen Time work runs outside the main actor to reduce watchdog risk.
- The WebKit cross-check remains main-actor isolated as required by the SDK and includes cancellation checks.
- Telemetry reports only whether records exist. It does not include URLs, record counts, or other browsing information.
- The change applies only to  iOS/macOS 26 and later.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the Screen Time cleanup and detection path for privacy-sensitive browsing history; a regression could leave records visible or affect launch-time behavior, though WebKit fallback remains.
> 
> **Overview**
> On **iOS/macOS 26+**, `ScreenTimeDataCleaner` now tries the **Screen Time** `STWebHistory` path first for both **detecting** and **removing** browsing history, and only falls back to scanning/removing `WKWebsiteDataTypeScreenTime` across WebKit data stores when that path is unavailable or fails. Public cleanup/detection APIs are no longer fully `@MainActor`; WebKit work stays on the main actor with cancellation checks, and the cleaner is marked `Sendable`.
> 
> **Launch** registers an iOS 26+ startup task that calls `hasScreenTimeData()` and fires the **`screen-time_records-present`** pixel (daily + count) when records still exist—without URLs or counts. A matching **pixel definition** is added in `screen_time.json5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83b6e05e8b5f2b1a647ff88f1008832abca80798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->