### PR TITLE
iOS: Add return-to-tab card and tab switcher Duck.ai entry sources

### DIFF
--- a/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
@@ -62,6 +62,7 @@ public enum AIChatEntryPointSource: String {
     case browsingMenuNTP = "browsing_menu_ntp"
     case browsingMenuWebpage = "browsing_menu_webpage"
     case tabSwitcher = "tab_switcher"
+    case tabSwitcherExistingChat = "tab_switcher_existing_chat"
     case tabsBarButton = "tabs_bar_button"
     case chatHistoryNewChat = "chat_history_new_chat"
     case chatHistoryOpenChat = "chat_history_open_chat"
@@ -78,6 +79,7 @@ public enum AIChatEntryPointSource: String {
     case widgetControlCenter = "widget_control_center"
     case siri
     case deepLinkOther = "deep_link_other"
+    case returnToChatCard = "return_to_chat_card"
 }
 
 extension AIChatEntryPointSource {

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6283,6 +6283,9 @@ extension MainViewController: EscapeHatchActionRouter {
         // row also reaches after already reporting its own terminal.
         recordNewTabPageSessionAction { $0.tapReturnToLast() }
         newTabPageSessionInstrumentation.visitEnded(terminalAction: .lastTabLoaded)
+        if tab.isAITab {
+            fireAIChatEntryPointPixel(source: .returnToChatCard, opensNewTab: false, hasPrompt: false)
+        }
 
         onSwitchToTab(tab)
     }
@@ -7118,6 +7121,9 @@ extension MainViewController: TabSwitcherDelegate {
             // Only a chosen tab is a terminal; dismissing with none selected creates a new tab,
             // which opens its own visit instead.
             newTabPageSessionInstrumentation.visitEnded(terminalAction: .selectOtherTab)
+            if tab.isAITab {
+                fireAIChatEntryPointPixel(source: .tabSwitcherExistingChat, opensNewTab: false, hasPrompt: false)
+            }
             tabManager.select(tab, dismissCurrent: false)
         }
 

--- a/iOS/DuckDuckGoTests/AIChatEntryPointSourceTests.swift
+++ b/iOS/DuckDuckGoTests/AIChatEntryPointSourceTests.swift
@@ -97,5 +97,7 @@ struct AIChatEntryPointSourceTests {
         #expect(AIChatEntryPointSource.deepLinkOther.rawValue == "deep_link_other")
         #expect(AIChatEntryPointSource.serp.rawValue == "serp")
         #expect(AIChatEntryPointSource.directURL.rawValue == "direct_url")
+        #expect(AIChatEntryPointSource.returnToChatCard.rawValue == "return_to_chat_card")
+        #expect(AIChatEntryPointSource.tabSwitcherExistingChat.rawValue == "tab_switcher_existing_chat")
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
@@ -9,7 +9,7 @@
             "appVersion",
             {
                 "key": "source",
-                "description": "The entry path into Duck.ai, one value per case of the AIChatEntryPointSource Swift enum. serp is any Duck.ai open the search results page asks native for, e.g. Search Assist, and covers every such SERP affordance because the request does not say which one it was. direct_url is a duck.ai navigation TabURLInterceptor saw with no other attribution, so it mixes a typed address with an in-page link. Resuming an already-open or restored Duck.ai tab is not an entry and does not fire.",
+                "description": "The entry path into Duck.ai, one value per case of the AIChatEntryPointSource Swift enum. serp is any Duck.ai open the search results page asks native for, e.g. Search Assist, and covers every such SERP affordance because the request does not say which one it was. direct_url is a duck.ai navigation TabURLInterceptor saw with no other attribution, so it mixes a typed address with an in-page link. Returning to an already-open Duck.ai tab fires only from the tab switcher (tab_switcher_existing_chat, distinct from the switcher's Duck.ai button, which creates a new chat and reports tab_switcher) and from the new tab page's return-to-tab card (return_to_chat_card); restoring a Duck.ai tab at launch is not an entry and does not fire.",
                 "type": "string",
                 "enum": [
                     "address_bar_prompt",
@@ -36,7 +36,9 @@
                     "widget_lock_screen",
                     "widget_control_center",
                     "siri",
-                    "deep_link_other"
+                    "deep_link_other",
+                    "return_to_chat_card",
+                    "tab_switcher_existing_chat"
                 ]
             },
             {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1218073816634377?focus=true
Tech Design URL:
CC:

### Description
The Duck.ai entry pixel now also fires when a user gets back to an existing chat, with two new source values: `return_to_chat_card` for the new tab page's return-to-tab card and `tab_switcher_existing_chat` for picking an open Duck.ai tab in the tab switcher. The switcher's Duck.ai button keeps reporting `tab_switcher`, since it opens a new chat. Returning to a regular page, dismissing the switcher without changing tabs, and restoring tabs at launch do not fire.

### Testing Steps
1. Open Duck.ai in a tab, open a second regular tab, then open the tab switcher and tap the Duck.ai tab's tile → `m_aichat_entry_point` fires with `source=tab_switcher_existing_chat`, `opens_new_tab=false`, `has_prompt=false`.
2. Open the tab switcher again and tap the Duck.ai button → fires with `source=tab_switcher`; tapping a regular tab's tile or Done fires nothing.
3. With a Duck.ai tab open, background the app long enough for the after-idle new tab page to show the return-to-tab card, then tap the card (or its menu's "Return to tab") → fires with `source=return_to_chat_card`; a card pointing at a regular page fires nothing.

### Impact
Low: measurement-only change adding source values to an existing pixel, with no UI or navigation changes.

#### What could go wrong?
The switcher could report an entry on a plain dismissal → mitigated by firing only after the existing check that the chosen tab differs from the current one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only additions to an existing pixel with narrow guards on `tab.isAITab`; no navigation or UI behavior changes.
> 
> **Overview**
> Extends **`m_aichat_entry_point`** so returning to an **already-open Duck.ai tab** is measured, not only fresh opens. Two new `AIChatEntryPointSource` values are added: **`return_to_chat_card`** (new tab page return-to-tab card / escape hatch) and **`tab_switcher_existing_chat`** (selecting an open Duck.ai tile in the tab switcher).
> 
> `MainViewController` calls **`fireAIChatEntryPointPixel`** with `opensNewTab: false` and `hasPrompt: false` when the target tab is an AI tab in those flows. The switcher’s Duck.ai button still reports **`tab_switcher`** for new chats; launch restore, dismissing the switcher without a tab change, and return cards for non-AI tabs do not fire.
> 
> Pixel definitions and unit tests are updated for the new `source` enum values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71021f4f6315341207a05f50acfe3eada8c9116e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->