### PR TITLE
macOS: Fixing Switch to Tab Style

### DIFF
--- a/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
+++ b/macOS/DuckDuckGo/NavigationBar/View/AddressBarViewController.swift
@@ -1022,7 +1022,6 @@ final class AddressBarViewController: NSViewController {
         bottomSeparatorView.isHidden = !themeManager.isAppRebranded
 
         let colorsProvider = theme.colorsProvider
-        let navigationBarBackgroundColor = colorsProvider.navigationBackgroundColor
 
         NSAppearance.withAppAppearance {
             // Keep selected appearance when AI chat is active (OR) isBurner, even if window loses key status
@@ -1038,7 +1037,7 @@ final class AddressBarViewController: NSViewController {
                     activeBackgroundView.borderColor = colorsProvider.addressBarActiveBorderColor(isBurner: isBurner)
                 }
                 activeBackgroundView.backgroundColor = colorsProvider.activeAddressBarBackgroundColor(isBurner: isBurner)
-                switchToTabBox.backgroundColor = navigationBarBackgroundColor.blended(with: .addressBarBackground)
+                switchToTabBox.backgroundColor = colorsProvider.activeSwitchToTabBackgroundColor
 
                 /// Important: `activeOuterBorderView` is hidden when `isAppRedesign` evaluates as true
                 activeOuterBorderView.isHidden = isToggleFocused || !theme.addressBarStyleProvider.shouldShowOutlineBorder(isHomePage: isHomePage) || selectionState == .activeWithAIChat
@@ -1053,7 +1052,7 @@ final class AddressBarViewController: NSViewController {
                 activeBackgroundView.borderColor = nil
                 activeBackgroundView.backgroundColor = colorsProvider.inactiveAddressBarBackgroundColor(isBurner: isBurner)
 
-                switchToTabBox.backgroundColor = navigationBarBackgroundColor.blended(with: .inactiveSearchBarBackground)
+                switchToTabBox.backgroundColor = colorsProvider.inactiveSwitchToTabBackgroundColor
 
                 activeOuterBorderView.isHidden = true
 

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
@@ -631,14 +631,6 @@
                                             <constraint firstItem="LBz-Pz-Fw5" firstAttribute="leading" secondItem="JKb-5c-xaD" secondAttribute="leading" constant="12" id="XGh-oj-HqL"/>
                                             <constraint firstItem="LBz-Pz-Fw5" firstAttribute="centerY" secondItem="JKb-5c-xaD" secondAttribute="centerY" id="bQo-e4-IPs"/>
                                         </constraints>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                                                <color key="value" name="ButtonMouseOverColor"/>
-                                            </userDefinedRuntimeAttribute>
-                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                <real key="value" value="6"/>
-                                            </userDefinedRuntimeAttribute>
-                                        </userDefinedRuntimeAttributes>
                                     </customView>
                                 </subviews>
                                 <constraints>
@@ -647,8 +639,8 @@
                                     <constraint firstAttribute="trailing" secondItem="JKb-5c-xaD" secondAttribute="trailing" id="bpq-Ui-dn5"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="backgroundColor">
-                                        <color key="value" name="AddressBarBackgroundColor"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="6"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </customView>

--- a/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
+++ b/macOS/DuckDuckGo/NavigationBar/View/NavigationBar.storyboard
@@ -600,10 +600,10 @@
                                 </connections>
                             </containerView>
                             <customView horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="JKb-5c-xaF" customClass="ColorView" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
-                                <rect key="frame" x="508" y="8" width="118" height="16"/>
+                                <rect key="frame" x="550" y="8" width="110" height="16"/>
                                 <subviews>
                                     <customView horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="JKb-5c-xaD" userLabel="Rounded Corners View" customClass="ColorView" customModule="DuckDuckGo_Privacy_Browser" customModuleProvider="target">
-                                        <rect key="frame" x="8" y="-3" width="110" height="22"/>
+                                        <rect key="frame" x="0.0" y="-3" width="110" height="22"/>
                                         <subviews>
                                             <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="LBz-Pz-Fw5">
                                                 <rect key="frame" x="10" y="4" width="75" height="14"/>
@@ -643,7 +643,7 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="JKb-5c-xaD" firstAttribute="centerY" secondItem="JKb-5c-xaF" secondAttribute="centerY" id="D2F-WV-eVc"/>
-                                    <constraint firstItem="JKb-5c-xaD" firstAttribute="leading" secondItem="JKb-5c-xaF" secondAttribute="leading" constant="8" id="ZHq-NY-UuQ"/>
+                                    <constraint firstItem="JKb-5c-xaD" firstAttribute="leading" secondItem="JKb-5c-xaF" secondAttribute="leading" id="ZHq-NY-UuQ"/>
                                     <constraint firstAttribute="trailing" secondItem="JKb-5c-xaD" secondAttribute="trailing" id="bpq-Ui-dn5"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>

--- a/macOS/DuckDuckGo/VisualRefresh/ColorsProviding.swift
+++ b/macOS/DuckDuckGo/VisualRefresh/ColorsProviding.swift
@@ -26,6 +26,8 @@ protocol ColorsProviding {
     var addressBarShadowColor: NSColor { get }
     var addressBarSuffixTextColor: NSColor { get }
     var addressBarTextFieldColor: NSColor { get }
+    var activeSwitchToTabBackgroundColor: NSColor { get }
+    var inactiveSwitchToTabBackgroundColor: NSColor { get }
     func addressBarActiveBorderColor(isBurner: Bool) -> NSColor
     func activeAddressBarBackgroundColor(isBurner: Bool) -> NSColor
     func inactiveAddressBarBackgroundColor(isBurner: Bool) -> NSColor
@@ -103,6 +105,8 @@ final class LegacyColorsProviding: ColorsProviding {
     var addressBarShadowColor: NSColor { palette.shadowTertiary }
     var addressBarSuffixTextColor: NSColor { palette.textSecondary }
     var addressBarTextFieldColor: NSColor { palette.textPrimary }
+    var activeSwitchToTabBackgroundColor: NSColor { navigationBackgroundColor.blended(with: .addressBarBackground) }
+    var inactiveSwitchToTabBackgroundColor: NSColor { navigationBackgroundColor.blended(with: .inactiveSearchBarBackground) }
 
     var settingsBackgroundColor: NSColor { palette.surfaceCanvas }
     var iconsColor: NSColor { palette.iconsPrimary }
@@ -148,6 +152,8 @@ final class CurrentColorsProviding: ColorsProviding {
     var addressBarShadowColor: NSColor { palette.shadowTertiary }
     var addressBarSuffixTextColor: NSColor { palette.textSecondary }
     var addressBarTextFieldColor: NSColor { palette.textPrimary }
+    var activeSwitchToTabBackgroundColor: NSColor { palette.unifiedInputControlFillSecondary }
+    var inactiveSwitchToTabBackgroundColor: NSColor { palette.unifiedInputControlFillSecondary }
 
     func addressBarActiveBorderColor(isBurner: Bool) -> NSColor {
         isBurner ? palette.accentFirePrimary : palette.accentPrimary


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211150618152277/task/1217497047574669
Tech Design URL:
CC:

### Description
This PR adjusts the `Switch to Tab` Address Bar component:

- Background color and Corner Radius were updated
- Removed an extra 6pt leading padding

### Testing Steps
1. Open githubstatus.com
2. Open a new Tab
3. Type `github` in the address bar
4. Highlight the Row Suggestion that has the `Switch to Tab` component

- [ ] Verify a new `Switch to Tab` label shows up in the Address Bar
- [ ] Verify the layout (and colors) looks great!

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features

#### What could go wrong?
We could introduce a regression in the `Switch to Tab` UI element

### Quality Considerations
Nothing in particular

### Screenshots

Before: Dark | Now: Dark
-|-
<img width="400" alt="Before Dark" src="https://github.com/user-attachments/assets/0be5323f-86ae-444a-b347-8433d6a32b0f" /> | <img width="400" alt="Now Dark" src="https://github.com/user-attachments/assets/f1a576b3-6691-4a40-8f71-b3386167b71d" />

Before: Light | Now: Light
-|-
<img width="400" alt="Before Light" src="https://github.com/user-attachments/assets/a5952b64-d702-4e4f-b551-992c64eb552c" /> | <img width="400" alt="Now Light" src="https://github.com/user-attachments/assets/ff205c53-b7e5-49d5-a1eb-3205e6bcd13b" />




---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only address bar styling and storyboard layout; behavior of Switch to Tab suggestions is unchanged, with minor regression risk in chip colors or alignment across themes.
> 
> **Overview**
> Updates the address bar **Switch to Tab** chip so its background and layout match the unified input / rebranded design instead of storyboard blends and nested color views.
> 
> **Switch to Tab** backgrounds are now driven through `ColorsProviding`: active and inactive states use `activeSwitchToTabBackgroundColor` and `inactiveSwitchToTabBackgroundColor` (legacy theme keeps the previous nav-bar blends; app rebrand uses `unifiedInputControlFillSecondary` for both). `AddressBarViewController` no longer blends `navigationBackgroundColor` inline when refreshing appearance.
> 
> Storyboard changes remove extra leading inset on the rounded label container, apply **6pt corner radius** on the outer `switchToTabBox`, and drop fixed `AddressBarBackgroundColor` / `ButtonMouseOverColor` runtime colors on the nested views so runtime theme updates own the look.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60884ab8d08e6fcb46731395c184dc1ad309fb2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->