### PR TITLE
iOS: Hide Duck.ai usage warning after a manual model switch

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageSnapshot.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiUsageSnapshot.swift
@@ -68,6 +68,13 @@ public struct DuckAiUsageCta: Equatable {
         case switchToCheaper
         case switchToFree
         case subscribe
+
+        var asksForModelSwitch: Bool {
+            switch self {
+            case .switchToCheaper, .switchToFree: return true
+            case .bypassWeekly, .subscribe: return false
+            }
+        }
     }
 
     /// `modelIds` never includes the id it is keyed against.

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/UsageWarnings/DuckAiUsageWarningViewModel.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/UsageWarnings/DuckAiUsageWarningViewModel.swift
@@ -117,10 +117,11 @@ public final class DuckAiUsageWarningViewModel: ObservableObject {
         return recordActedOnCurrentSnapshot()
     }
 
-    /// A switch the user made from any picker stands the message down until web publishes against the
-    /// new model. Keyed on the CTA: iOS re-resolves first, and the cheapest model has no action left.
-    public func userSwitchedModel() {
-        guard lastReadSnapshot.cta?.id.asksForModelSwitch == true else { return }
+    /// A switch from the bar's own picker settles the message only if web offered that model as a step
+    /// down from the one the user was on. Read off the CTA: iOS re-resolves before reporting the switch.
+    public func userSwitchedModel(from previousModelId: String?, to modelId: String) {
+        guard let cta = lastReadSnapshot.cta, cta.id.asksForModelSwitch,
+              cta.target(forSelectedModelId: previousModelId).candidateModelIds.contains(modelId) else { return }
 
         Logger.aiChat.debug("Duck.ai usage warning stood down: user switched model")
         recordActedOnCurrentSnapshot()

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/UsageWarnings/DuckAiUsageWarningViewModel.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/UsageWarnings/DuckAiUsageWarningViewModel.swift
@@ -117,6 +117,15 @@ public final class DuckAiUsageWarningViewModel: ObservableObject {
         return recordActedOnCurrentSnapshot()
     }
 
+    /// A switch the user made from any picker stands the message down until web publishes against the
+    /// new model. Keyed on the CTA: iOS re-resolves first, and the cheapest model has no action left.
+    public func userSwitchedModel() {
+        guard lastReadSnapshot.cta?.id.asksForModelSwitch == true else { return }
+
+        Logger.aiChat.debug("Duck.ai usage warning stood down: user switched model")
+        recordActedOnCurrentSnapshot()
+    }
+
     @discardableResult
     private func recordActedOnCurrentSnapshot() -> Bool {
         guard let notice = lastReadSnapshot.notice,

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/UsageWarnings/DuckAiUsageWarningViewModel.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/UsageWarnings/DuckAiUsageWarningViewModel.swift
@@ -145,6 +145,13 @@ public final class DuckAiUsageWarningViewModel: ObservableObject {
         onOpenModelPicker?()
     }
 
+    /// Whether a switch was taken on the notice in the current snapshot, whatever web has published
+    /// since: the record outlives the signature match that hides the message.
+    public var hasActedOnCurrentNotice: Bool {
+        guard let notice = lastReadSnapshot.notice, let acted = dismissalStore.actedSnapshot() else { return false }
+        return acted.noticeID == notice.id.rawValue
+    }
+
     /// Teardown: drops the message without recording a dismissal.
     public func clear() {
         warning = nil

--- a/SharedPackages/AIChat/Tests/AIChatTests/UsageWarnings/DuckAiUsageWarningViewModelTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/UsageWarnings/DuckAiUsageWarningViewModelTests.swift
@@ -202,6 +202,50 @@ final class DuckAiUsageWarningViewModelTests: XCTestCase {
         XCTAssertEqual(dismissalStore.actedSnapshot()?.noticeID, "approaching")
     }
 
+    /// The bar's own picker applies the model itself, so a switch made there has to stand the message
+    /// down the same way the card's button does.
+    func testWhenTheUserSwitchesModelThenTheMessageIsStoodDown() {
+        snapshotProvider.snapshot = snapshot(notice(id: .approaching),
+                                             cta: DuckAiUsageCta(id: .switchToCheaper),
+                                             signature: "snapshot-1")
+        let sut = makeSUT(suggestion: .suggestion(DuckAiModelSuggestion(modelId: "haiku", modelShortName: "Haiku")))
+        sut.refresh()
+
+        sut.userSwitchedModel()
+
+        XCTAssertNil(sut.warning)
+        XCTAssertEqual(dismissalStore.actedSnapshot()?.noticeID, "approaching")
+    }
+
+    /// The picker re-resolves before reporting the switch, so by then a switch to the cheapest model
+    /// has already left the message with no button. It still asked for the switch the user just made.
+    func testWhenTheUserSwitchesToTheCheapestModelThenTheMessageIsStillStoodDown() {
+        snapshotProvider.snapshot = snapshot(notice(id: .approaching),
+                                             cta: DuckAiUsageCta(id: .switchToCheaper),
+                                             signature: "snapshot-1")
+        let sut = makeSUT(suggestion: .none(reason: .noTargetForSelectedModel))
+        sut.refresh()
+        XCTAssertNil(sut.warning?.action)
+
+        sut.userSwitchedModel()
+
+        XCTAssertNil(sut.warning)
+        XCTAssertEqual(dismissalStore.actedSnapshot()?.noticeID, "approaching")
+    }
+
+    /// Only a message that asked for a model switch is settled by one.
+    func testWhenTheUserSwitchesModelButTheMessageAskedForNoSwitchThenItStaysUp() {
+        snapshotProvider.snapshot = snapshot(notice(id: .freeReached, reached: true),
+                                             cta: DuckAiUsageCta(id: .subscribe))
+        let sut = makeSUT()
+        sut.refresh()
+
+        sut.userSwitchedModel()
+
+        XCTAssertEqual(sut.warning?.message, .freeReached)
+        XCTAssertNil(dismissalStore.actedSnapshot())
+    }
+
     /// A spent allowance takes the input with it: the card is the only thing left to act on.
     func testAReachedMessageBlocksTheInput() {
         for id in [DuckAiUsageNotice.ID.freeReached, .dailyReached, .weeklyReachedDegraded, .weeklyReached] {

--- a/SharedPackages/AIChat/Tests/AIChatTests/UsageWarnings/DuckAiUsageWarningViewModelTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/UsageWarnings/DuckAiUsageWarningViewModelTests.swift
@@ -202,16 +202,31 @@ final class DuckAiUsageWarningViewModelTests: XCTestCase {
         XCTAssertEqual(dismissalStore.actedSnapshot()?.noticeID, "approaching")
     }
 
-    /// The bar's own picker applies the model itself, so a switch made there has to stand the message
-    /// down the same way the card's button does.
-    func testWhenTheUserSwitchesModelThenTheMessageIsStoodDown() {
+    /// Only a message that offers the picker can be stood down by it.
+    func testAChevronSwitchIsIgnoredWhenTheMessageOffersNoPicker() {
+        snapshotProvider.snapshot = snapshot(notice(id: .freeReached, reached: true),
+                                             cta: DuckAiUsageCta(id: .subscribe))
+        let sut = makeSUT()
+        sut.refresh()
+
+        sut.modelSwitchedFromMessage()
+
+        XCTAssertEqual(sut.warning?.message, .freeReached)
+        XCTAssertNil(dismissalStore.actedSnapshot())
+    }
+
+    // MARK: - Switching from the bar's own picker
+
+    /// Picking a model the message offered is the same as taking its button.
+    func testWhenTheUserPicksAModelTheMessageOfferedThenItIsStoodDown() {
         snapshotProvider.snapshot = snapshot(notice(id: .approaching),
-                                             cta: DuckAiUsageCta(id: .switchToCheaper),
+                                             cta: DuckAiUsageCta(id: .switchToCheaper,
+                                                                 target: .init(modelId: "haiku", modelIds: ["mini"])),
                                              signature: "snapshot-1")
         let sut = makeSUT(suggestion: .suggestion(DuckAiModelSuggestion(modelId: "haiku", modelShortName: "Haiku")))
         sut.refresh()
 
-        sut.userSwitchedModel()
+        sut.userSwitchedModel(from: "sonnet", to: "mini")
 
         XCTAssertNil(sut.warning)
         XCTAssertEqual(dismissalStore.actedSnapshot()?.noticeID, "approaching")
@@ -219,28 +234,61 @@ final class DuckAiUsageWarningViewModelTests: XCTestCase {
 
     /// The picker re-resolves before reporting the switch, so by then a switch to the cheapest model
     /// has already left the message with no button. It still asked for the switch the user just made.
-    func testWhenTheUserSwitchesToTheCheapestModelThenTheMessageIsStillStoodDown() {
+    func testWhenTheUserPicksTheCheapestModelThenTheMessageIsStillStoodDown() {
         snapshotProvider.snapshot = snapshot(notice(id: .approaching),
-                                             cta: DuckAiUsageCta(id: .switchToCheaper),
+                                             cta: DuckAiUsageCta(id: .switchToCheaper,
+                                                                 target: .init(modelId: "haiku", modelIds: [])),
                                              signature: "snapshot-1")
         let sut = makeSUT(suggestion: .none(reason: .noTargetForSelectedModel))
         sut.refresh()
         XCTAssertNil(sut.warning?.action)
 
-        sut.userSwitchedModel()
+        sut.userSwitchedModel(from: "sonnet", to: "haiku")
 
         XCTAssertNil(sut.warning)
         XCTAssertEqual(dismissalStore.actedSnapshot()?.noticeID, "approaching")
     }
 
+    /// A sideways or heavier switch has not dealt with the message.
+    func testWhenTheUserPicksAModelTheMessageDidNotOfferThenItStaysUp() {
+        snapshotProvider.snapshot = snapshot(notice(id: .approaching),
+                                             cta: DuckAiUsageCta(id: .switchToCheaper,
+                                                                 target: .init(modelId: "haiku", modelIds: [])),
+                                             signature: "snapshot-1")
+        let sut = makeSUT(suggestion: .suggestion(DuckAiModelSuggestion(modelId: "haiku", modelShortName: "Haiku")))
+        sut.refresh()
+
+        sut.userSwitchedModel(from: "sonnet", to: "opus")
+
+        XCTAssertEqual(sut.warning?.message, .approaching)
+        XCTAssertNil(dismissalStore.actedSnapshot())
+    }
+
+    /// Web keys its offer to the model the picker is on, so that table decides, not the top-level one.
+    func testWhenTheOfferIsKeyedToThePickerModelThenThatTableDecides() {
+        snapshotProvider.snapshot = snapshot(notice(id: .approaching),
+                                             cta: DuckAiUsageCta(id: .switchToCheaper,
+                                                                 byModelId: ["sonnet": .init(modelId: "haiku", modelIds: [])]),
+                                             signature: "snapshot-1")
+        let sut = makeSUT(suggestion: .suggestion(DuckAiModelSuggestion(modelId: "haiku", modelShortName: "Haiku")))
+        sut.refresh()
+
+        sut.userSwitchedModel(from: "opus", to: "haiku")
+        XCTAssertEqual(sut.warning?.message, .approaching)
+
+        sut.userSwitchedModel(from: "sonnet", to: "haiku")
+        XCTAssertNil(sut.warning)
+    }
+
     /// Only a message that asked for a model switch is settled by one.
-    func testWhenTheUserSwitchesModelButTheMessageAskedForNoSwitchThenItStaysUp() {
+    func testWhenTheUserPicksAModelButTheMessageAskedForNoSwitchThenItStaysUp() {
         snapshotProvider.snapshot = snapshot(notice(id: .freeReached, reached: true),
-                                             cta: DuckAiUsageCta(id: .subscribe))
+                                             cta: DuckAiUsageCta(id: .subscribe,
+                                                                 target: .init(modelId: "haiku", modelIds: [])))
         let sut = makeSUT()
         sut.refresh()
 
-        sut.userSwitchedModel()
+        sut.userSwitchedModel(from: "sonnet", to: "haiku")
 
         XCTAssertEqual(sut.warning?.message, .freeReached)
         XCTAssertNil(dismissalStore.actedSnapshot())
@@ -322,19 +370,6 @@ final class DuckAiUsageWarningViewModelTests: XCTestCase {
         sut.refresh()
 
         XCTAssertFalse(sut.modelSwitchedToSuggestion("haiku"))
-
-        XCTAssertEqual(sut.warning?.message, .freeReached)
-        XCTAssertNil(dismissalStore.actedSnapshot())
-    }
-
-    /// Only a message that offers the picker can be stood down by it.
-    func testAChevronSwitchIsIgnoredWhenTheMessageOffersNoPicker() {
-        snapshotProvider.snapshot = snapshot(notice(id: .freeReached, reached: true),
-                                             cta: DuckAiUsageCta(id: .subscribe))
-        let sut = makeSUT()
-        sut.refresh()
-
-        sut.modelSwitchedFromMessage()
 
         XCTAssertEqual(sut.warning?.message, .freeReached)
         XCTAssertNil(dismissalStore.actedSnapshot())

--- a/SharedPackages/AIChat/Tests/AIChatTests/UsageWarnings/DuckAiUsageWarningViewModelTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/UsageWarnings/DuckAiUsageWarningViewModelTests.swift
@@ -215,6 +215,36 @@ final class DuckAiUsageWarningViewModelTests: XCTestCase {
         XCTAssertNil(dismissalStore.actedSnapshot())
     }
 
+    /// Platforms that keep their own copy of the acted-on message key it to this, so clearing the
+    /// record releases them too.
+    func testWhenASwitchWasTakenOnTheCurrentNoticeThenItSaysSoUntilTheRecordIsCleared() {
+        snapshotProvider.snapshot = snapshot(notice(id: .approaching),
+                                             cta: DuckAiUsageCta(id: .switchToCheaper),
+                                             signature: "snapshot-1")
+        let sut = makeSUT(suggestion: .suggestion(DuckAiModelSuggestion(modelId: "haiku", modelShortName: "Haiku")))
+        sut.refresh()
+        XCTAssertFalse(sut.hasActedOnCurrentNotice)
+
+        sut.performAction()
+        XCTAssertTrue(sut.hasActedOnCurrentNotice)
+
+        snapshotProvider.snapshot = snapshot(notice(id: .approaching), signature: "snapshot-2")
+        sut.refresh()
+        XCTAssertTrue(sut.hasActedOnCurrentNotice)
+
+        dismissalStore.setActedSnapshot(nil)
+        XCTAssertFalse(sut.hasActedOnCurrentNotice)
+    }
+
+    func testWhenTheActedRecordIsForAnotherNoticeThenItDoesNotCount() {
+        dismissalStore.setActedSnapshot(DuckAiUsageWarningActedSnapshot(noticeID: "dailyReached", signature: "snapshot-1"))
+        snapshotProvider.snapshot = snapshot(notice(id: .approaching), signature: "snapshot-1")
+        let sut = makeSUT()
+        sut.refresh()
+
+        XCTAssertFalse(sut.hasActedOnCurrentNotice)
+    }
+
     // MARK: - Switching from the bar's own picker
 
     /// Picking a model the message offered is the same as taking its button.

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIModelSelector.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIModelSelector.swift
@@ -63,8 +63,6 @@ final class UTIModelSelector {
         /// A model the user actually changed to, as opposed to a re-application of the current one,
         /// with the one they left.
         let onModelSelectionChanged: (_ previousModelId: String?, _ modelId: String) -> Void
-        /// The same switch, announced before it is applied, for listeners whose state it changes.
-        let onModelSelectionWillChange: (String) -> Void
     }
 
     private let modelStore: UTIModelStore
@@ -119,9 +117,6 @@ final class UTIModelSelector {
             // Supported model picked in the native picker — the recovery card's reason to block
             // submit is gone, so drop the block (no-op when it wasn't set).
             callbacks.clearSubmitRecoveryBlock()
-            if isNewSelection {
-                callbacks.onModelSelectionWillChange(modelId)
-            }
             updateSelectedModel(modelId)
             if isNewSelection {
                 pixelReporter.reportModelSelected(modelId: modelId)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIModelSelector.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Coordinator/UTIModelSelector.swift
@@ -60,8 +60,9 @@ final class UTIModelSelector {
         let onUserChoiceRecorded: () -> Void
         let clearSubmitRecoveryBlock: () -> Void
         let onModelApplied: (String) -> Void
-        /// A model the user actually changed to, as opposed to a re-application of the current one.
-        let onModelSelectionChanged: (String) -> Void
+        /// A model the user actually changed to, as opposed to a re-application of the current one,
+        /// with the one they left.
+        let onModelSelectionChanged: (_ previousModelId: String?, _ modelId: String) -> Void
         /// The same switch, announced before it is applied, for listeners whose state it changes.
         let onModelSelectionWillChange: (String) -> Void
     }
@@ -112,7 +113,8 @@ final class UTIModelSelector {
         }
 
         if model.entityHasAccess {
-            let isNewSelection = modelId != modelStore.persistedModelId
+            let previousModelId = modelStore.persistedModelId
+            let isNewSelection = modelId != previousModelId
             pendingGatedModelId = nil
             // Supported model picked in the native picker — the recovery card's reason to block
             // submit is gone, so drop the block (no-op when it wasn't set).
@@ -123,7 +125,7 @@ final class UTIModelSelector {
             updateSelectedModel(modelId)
             if isNewSelection {
                 pixelReporter.reportModelSelected(modelId: modelId)
-                callbacks.onModelSelectionChanged(modelId)
+                callbacks.onModelSelectionChanged(previousModelId, modelId)
             }
             callbacks.onModelApplied(modelId)
         } else {
@@ -164,7 +166,8 @@ final class UTIModelSelector {
             return false
         }
 
-        let isNewSelection = modelId != modelStore.persistedModelId
+        let previousModelId = modelStore.persistedModelId
+        let isNewSelection = modelId != previousModelId
         pendingGatedModelId = nil
         // Mirror the direct-selection path: the gated model in the recovery-card
         // is now accessible (post-purchase), so drop the recovery-card submit block.
@@ -172,7 +175,7 @@ final class UTIModelSelector {
         updateSelectedModel(modelId)
         if isNewSelection {
             pixelReporter.reportModelSelected(modelId: modelId)
-            callbacks.onModelSelectionChanged(modelId)
+            callbacks.onModelSelectionChanged(previousModelId, modelId)
         }
         callbacks.onModelApplied(modelId)
         return true

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
@@ -141,10 +141,11 @@ final class UTIFooterController {
         measurement.promptSubmitted()
     }
 
-    /// A switch the user made from the bar's picker; the card's own CTA reports and retires itself.
-    func userSwitchedModel() {
+    /// A switch from the bar's picker: always reported, but it only retires the message when it is the
+    /// step down the message asked for. The card's own CTA reports and retires itself.
+    func userSwitchedModel(from previousModelId: String?, to modelId: String) {
         measurement.modelSwitched()
-        viewModel.userSwitchedModel()
+        viewModel.userSwitchedModel(from: previousModelId, to: modelId)
         applyCurrentState()
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
@@ -245,9 +245,11 @@ final class UTIFooterController {
         return nil
     }
 
-    /// Releases as soon as the resolver produces a different message, so the next rung still shows.
+    /// Releases as soon as the resolver produces a different message, so the next rung still shows,
+    /// and once the acted-on record is gone, so clearing it is not undone by this copy.
     private func unlessActedOn(_ message: UTIFooterMessage) -> UTIFooterMessage? {
-        message == actedOnMessage ? nil : message
+        guard viewModel.hasActedOnCurrentNotice, message == actedOnMessage else { return message }
+        return nil
     }
 
     static let springAnimator: Animator = { changes in

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
@@ -149,13 +149,6 @@ final class UTIFooterController {
         applyCurrentState()
     }
 
-    /// Picking the model the card suggests is its CTA by another route, so it retires the card too.
-    /// Runs before the switch lands, while the suggestion still points at what the user picked.
-    func noteModelSelectionWillChange(to modelId: String) {
-        guard viewModel.modelSwitchedToSuggestion(modelId) else { return }
-        actedOnMessage = currentMessage
-    }
-
     func performPrimaryAction() {
         guard let message = currentMessage, message.primaryAction != nil else { return }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
@@ -141,9 +141,11 @@ final class UTIFooterController {
         measurement.promptSubmitted()
     }
 
-    /// A switch the user made themselves; the card's own switch CTA reports its own tap.
-    func recordModelSwitched() {
+    /// A switch the user made from the bar's picker; the card's own CTA reports and retires itself.
+    func userSwitchedModel() {
         measurement.modelSwitched()
+        viewModel.userSwitchedModel()
+        applyCurrentState()
     }
 
     /// Picking the model the card suggests is its CTA by another route, so it retires the card too.

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -448,7 +448,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
                 onUserChoiceRecorded: { [weak self] in self?.recordUserChoiceToStore() },
                 clearSubmitRecoveryBlock: { [weak self] in self?.isSubmitBlockedByRecoveryCard = false },
                 onModelApplied: { [weak self] in self?.notifyFrontendOfActiveChatModelChange($0) },
-                onModelSelectionChanged: { [weak self] _ in self?.footerController?.recordModelSwitched() },
+                onModelSelectionChanged: { [weak self] _ in self?.footerController?.userSwitchedModel() },
                 onModelSelectionWillChange: { [weak self] in self?.footerController?.noteModelSelectionWillChange(to: $0) }
             ),
             isUpdatedModelPickerEnabled: isUpdatedModelPickerEnabled,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -448,7 +448,9 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
                 onUserChoiceRecorded: { [weak self] in self?.recordUserChoiceToStore() },
                 clearSubmitRecoveryBlock: { [weak self] in self?.isSubmitBlockedByRecoveryCard = false },
                 onModelApplied: { [weak self] in self?.notifyFrontendOfActiveChatModelChange($0) },
-                onModelSelectionChanged: { [weak self] _ in self?.footerController?.userSwitchedModel() },
+                onModelSelectionChanged: { [weak self] previousModelId, modelId in
+                    self?.footerController?.userSwitchedModel(from: previousModelId, to: modelId)
+                },
                 onModelSelectionWillChange: { [weak self] in self?.footerController?.noteModelSelectionWillChange(to: $0) }
             ),
             isUpdatedModelPickerEnabled: isUpdatedModelPickerEnabled,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -450,8 +450,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
                 onModelApplied: { [weak self] in self?.notifyFrontendOfActiveChatModelChange($0) },
                 onModelSelectionChanged: { [weak self] previousModelId, modelId in
                     self?.footerController?.userSwitchedModel(from: previousModelId, to: modelId)
-                },
-                onModelSelectionWillChange: { [weak self] in self?.footerController?.noteModelSelectionWillChange(to: $0) }
+                }
             ),
             isUpdatedModelPickerEnabled: isUpdatedModelPickerEnabled,
             isUpdatedCreateImageEnabled: isUpdatedCreateImageEnabled

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterControllerTests.swift
@@ -25,6 +25,7 @@ import XCTest
 final class UTIFooterControllerTests: XCTestCase {
 
     private var limitsProvider: StubUsageLimitsProvider!
+    private var dismissalStore: InMemoryDuckAiUsageWarningDismissalStore!
     private var presenter: SpyUTIFooterPresenter!
     private var viewModel: DuckAiUsageWarningViewModel!
     private var measurementFiring: RecordingUsageWarningPixelFiring!
@@ -38,6 +39,7 @@ final class UTIFooterControllerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         limitsProvider = StubUsageLimitsProvider()
+        dismissalStore = InMemoryDuckAiUsageWarningDismissalStore()
         presenter = SpyUTIFooterPresenter()
         measurementFiring = RecordingUsageWarningPixelFiring()
         createImagePixelFiring = MockCreateImagePixelFiring()
@@ -61,6 +63,7 @@ final class UTIFooterControllerTests: XCTestCase {
         presenter = nil
         measurementFiring = nil
         createImagePixelFiring = nil
+        dismissalStore = nil
         limitsProvider = nil
         super.tearDown()
     }
@@ -323,6 +326,32 @@ final class UTIFooterControllerTests: XCTestCase {
         sut.refresh()
 
         XCTAssertTrue(presenter.appliedMessages.last??.title.contains("90%") ?? false)
+    }
+
+    /// Web republishing the same message under a new payload right after the switch must not read as
+    /// the button having done nothing.
+    func test_performPrimaryAction_keepsAnIdenticalRepublishedMessageHidden() {
+        limitsProvider.limits = weeklyUsage(50)
+        sut.refresh()
+        sut.performPrimaryAction()
+
+        limitsProvider.limits = weeklyUsage(50, signature: "snapshot-50-republished")
+        sut.refresh()
+
+        XCTAssertEqual(presenter.appliedMessages.last, .some(nil))
+    }
+
+    /// The debug menu clears the persisted record; the controller's own copy must not outlive it.
+    func test_performPrimaryAction_showsTheMessageAgainOnceTheActedRecordIsCleared() {
+        limitsProvider.limits = weeklyUsage(50)
+        sut.refresh()
+        sut.performPrimaryAction()
+        XCTAssertEqual(presenter.appliedMessages.last, .some(nil))
+
+        dismissalStore.setActedSnapshot(nil)
+        sut.refresh()
+
+        XCTAssertTrue(presenter.appliedMessages.last??.title.contains("50%") ?? false)
     }
 
     /// The upsell is not a switch: the user is still blocked, so the message stays up.
@@ -756,14 +785,14 @@ final class UTIFooterControllerTests: XCTestCase {
     private func makeViewModel() -> DuckAiUsageWarningViewModel {
         DuckAiUsageWarningViewModel(
             snapshotProvider: limitsProvider,
-            dismissalStore: InMemoryDuckAiUsageWarningDismissalStore(),
+            dismissalStore: dismissalStore,
             modelSuggester: StubCheaperModelSuggester(),
             dateProvider: { [unowned self] in now }
         )
     }
 
     /// An approaching notice with a cheaper-model CTA — what the footer shows most of the time.
-    private func weeklyUsage(_ percent: Int) -> DuckAiUsageSnapshot {
+    private func weeklyUsage(_ percent: Int, signature: String? = nil) -> DuckAiUsageSnapshot {
         DuckAiUsageSnapshot(
             notice: DuckAiUsageNotice(id: .approaching,
                                       window: .weekly,
@@ -773,7 +802,7 @@ final class UTIFooterControllerTests: XCTestCase {
                                       dismissible: true),
             cta: DuckAiUsageCta(id: .switchToCheaper,
                                 target: .init(modelId: "gpt-5.4-mini", modelIds: ["gpt-5.4-mini"])),
-            signature: "snapshot-\(percent)"
+            signature: signature ?? "snapshot-\(percent)"
         )
     }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterControllerTests.swift
@@ -152,6 +152,41 @@ final class UTIFooterControllerTests: XCTestCase {
         XCTAssertTrue(presenter.appliedMessages.last??.title.contains("Weekly usage limit reached") ?? false)
     }
 
+    // MARK: - Model switch
+
+    /// The message asked for a switch; one made from the bar's picker settles it as the CTA would.
+    func test_userSwitchedModel_hidesTheFooter() {
+        limitsProvider.limits = weeklyUsage(75)
+        sut.refresh()
+
+        sut.userSwitchedModel()
+
+        XCTAssertEqual(presenter.appliedMessages.last, .some(nil))
+    }
+
+    func test_userSwitchedModel_keepsTheMessageHiddenUntilWebPublishesAgain() {
+        limitsProvider.limits = weeklyUsage(75)
+        sut.refresh()
+        sut.userSwitchedModel()
+
+        sut.refresh()
+        XCTAssertEqual(presenter.appliedMessages.last, .some(nil))
+
+        limitsProvider.limits = weeklyUsage(80)
+        sut.refresh()
+        XCTAssertTrue(presenter.appliedMessages.last??.title.contains("80%") ?? false)
+    }
+
+    func test_userSwitchedModel_leavesAMessageThatAskedForNoSwitchUp() {
+        limitsProvider.limits = weeklyReachedWithUpsell()
+        sut.refresh()
+
+        sut.userSwitchedModel()
+
+        XCTAssertEqual(presenter.appliedMessages.count, 1)
+        XCTAssertNotNil(presenter.appliedMessages.last ?? nil)
+    }
+
     // MARK: - Suppression
 
     func test_setSuppressed_hidesTheFooterWithoutForgettingTheWarning() {
@@ -517,12 +552,12 @@ final class UTIFooterControllerTests: XCTestCase {
         XCTAssertEqual(measurementFiring.events.last, .promptSubmitted(approachingExposure(percentBucket: 75)))
     }
 
-    func test_recordModelSwitched_reportsAgainstTheWarningTheUserSaw() {
+    func test_userSwitchedModel_reportsAgainstTheWarningTheUserSaw() {
         limitsProvider.limits = weeklyUsage(75)
         sut.refresh()
         sut.footerVisibilityChanged(isVisible: true)
 
-        sut.recordModelSwitched()
+        sut.userSwitchedModel()
 
         XCTAssertEqual(measurementFiring.events.last, .modelSwitched(approachingExposure(percentBucket: 75)))
     }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterControllerTests.swift
@@ -154,12 +154,12 @@ final class UTIFooterControllerTests: XCTestCase {
 
     // MARK: - Model switch
 
-    /// The message asked for a switch; one made from the bar's picker settles it as the CTA would.
-    func test_userSwitchedModel_hidesTheFooter() {
+    /// Picking the model the message offered from the bar's picker settles it as the CTA would.
+    func test_userSwitchedModel_hidesTheFooterWhenTheModelIsTheOneOffered() {
         limitsProvider.limits = weeklyUsage(75)
         sut.refresh()
 
-        sut.userSwitchedModel()
+        sut.userSwitchedModel(from: "gpt-5.4", to: "gpt-5.4-mini")
 
         XCTAssertEqual(presenter.appliedMessages.last, .some(nil))
     }
@@ -167,7 +167,7 @@ final class UTIFooterControllerTests: XCTestCase {
     func test_userSwitchedModel_keepsTheMessageHiddenUntilWebPublishesAgain() {
         limitsProvider.limits = weeklyUsage(75)
         sut.refresh()
-        sut.userSwitchedModel()
+        sut.userSwitchedModel(from: "gpt-5.4", to: "gpt-5.4-mini")
 
         sut.refresh()
         XCTAssertEqual(presenter.appliedMessages.last, .some(nil))
@@ -177,11 +177,22 @@ final class UTIFooterControllerTests: XCTestCase {
         XCTAssertTrue(presenter.appliedMessages.last??.title.contains("80%") ?? false)
     }
 
+    /// A heavier or sideways switch has not dealt with the message.
+    func test_userSwitchedModel_leavesTheFooterUpWhenTheModelIsNotOneOffered() {
+        limitsProvider.limits = weeklyUsage(75)
+        sut.refresh()
+
+        sut.userSwitchedModel(from: "gpt-5.4", to: "claude-opus")
+
+        XCTAssertEqual(presenter.appliedMessages.count, 1)
+        XCTAssertNotNil(presenter.appliedMessages.last ?? nil)
+    }
+
     func test_userSwitchedModel_leavesAMessageThatAskedForNoSwitchUp() {
         limitsProvider.limits = weeklyReachedWithUpsell()
         sut.refresh()
 
-        sut.userSwitchedModel()
+        sut.userSwitchedModel(from: "gpt-5.4", to: "gpt-5.4-mini")
 
         XCTAssertEqual(presenter.appliedMessages.count, 1)
         XCTAssertNotNil(presenter.appliedMessages.last ?? nil)
@@ -557,7 +568,18 @@ final class UTIFooterControllerTests: XCTestCase {
         sut.refresh()
         sut.footerVisibilityChanged(isVisible: true)
 
-        sut.userSwitchedModel()
+        sut.userSwitchedModel(from: "gpt-5.4", to: "gpt-5.4-mini")
+
+        XCTAssertEqual(measurementFiring.events.last, .modelSwitched(approachingExposure(percentBucket: 75)))
+    }
+
+    /// The pixel is about what the user did, not whether it settled the message.
+    func test_userSwitchedModel_reportsASwitchThatLeavesTheMessageUp() {
+        limitsProvider.limits = weeklyUsage(75)
+        sut.refresh()
+        sut.footerVisibilityChanged(isVisible: true)
+
+        sut.userSwitchedModel(from: "gpt-5.4", to: "claude-opus")
 
         XCTAssertEqual(measurementFiring.events.last, .modelSwitched(approachingExposure(percentBucket: 75)))
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1218070823421574?focus=true
Tech Design URL:
CC:

### Description
The Duck.ai usage-limit card asks the user to switch to a lighter model, but switching from the bar's own model picker left the card up, still asking for the switch. A manual switch now settles the card the same way its Switch button does, but only when the picked model is one the card would have offered as a step down from the model the user was on; a heavier or sideways switch leaves it up. Separately, after taking the Switch button the card could never come back in the same app session, even after the debug menu cleared its record, because the footer kept its own copy of the acted-on message; that copy is now released with the record. iOS only; macOS is untouched.

### Testing Steps
1. On an internal build, open Settings → Debug → AI Chat, and under "Duck.ai Usage Warnings — Free" seed an approaching-limit case that offers a model switch → open a Duck.ai tab and focus the input; the usage card shows with a Switch button.
2. Open the model chip and pick the model the card suggests → the card hides without tapping its button.
3. Re-seed the case, then pick a heavier model instead → the card stays up.
4. Tap the card's Switch button → the card hides. In the debug menu tap "Clear dismissals", then collapse and re-expand the input → the card is back.
5. Back in the debug menu tap "Re-seed the last case (simulates a republish)" and focus the input again → the card returns.

### Impact
Low. Small behaviour fix to a card that is behind the internal-only `utiDuckAIWarnings` flag; the card's button, close and upsell paths are unchanged, and the model-switched pixel still fires for every manual switch.

#### What could go wrong?
Web's offer table names a model the picker does not list → the card stays up as today, since only a model actually picked from the list can match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> iOS-only UX fix behind internal usage-warnings flag; core submit, upsell, and dismiss paths unchanged, with added guardrails around CTA target matching.
> 
> **Overview**
> The Duck.ai usage-limit footer could stay visible after the user switched models from the **bar’s model chip**, even when they picked the lighter model the card was pushing. **Manual picker switches** now retire the warning the same way as the card’s Switch CTA, but only when the CTA is a model-switch type and the chosen model is among the step-down candidates for the model the user left (including per-model CTA tables from web).
> 
> **UTIModelSelector** reports selection changes as `(previousModelId, newModelId)` and drops the pre-apply `onModelSelectionWillChange` hook; the coordinator forwards that to the footer, which always fires the model-switched pixel while the view model decides whether to record “acted on” state.
> 
> **Footer hiding after acting** no longer depends only on a local `actedOnMessage` copy: **`hasActedOnCurrentNotice`** ties visibility to the shared dismissal store, so the card stays hidden across snapshot republishes with the same text and **reappears** when debug (or similar) clears the acted record.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf5de05c4ac2f3a3099e98830aa80e05ca3f6f8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->