### PR TITLE
Remove feature flag: iPadDuckAIBarControls

### DIFF
--- a/.maestro/ipad_duckai/ipad_duckai_bar_controls.yaml
+++ b/.maestro/ipad_duckai/ipad_duckai_bar_controls.yaml
@@ -1,18 +1,16 @@
 # ipad_duckai_bar_controls.yaml
 #
-# Validates the iPad Duck.ai omnibar controls that are gated behind the
-# `iPadDuckAIBarControls` feature flag: the model picker, reasoning picker, tool
-# picker and attach button that appear in the expanded Duck.ai input area.
+# Validates the iPad Duck.ai omnibar controls: the model picker, reasoning
+# picker, tool picker and attach button that appear in the expanded Duck.ai
+# input area.
 #
 # Coverage:
 #   1. State gating - the four chips are hidden while the omnibar is in Search
 #      mode, and only appear once it is switched to Duck.ai mode (expanded).
-#   2. Positive     - with the flag on, switching to Duck.ai mode renders them.
+#   2. Positive     - switching to Duck.ai mode renders them.
 #
 # Requirements / notes:
 #   * Runs on iPad only (the controls require the iPad idiom).
-#   * `iPadDuckAIBarControls` defaults to .internalOnly, so `isInternalUser` must
-#     be true for the `ff.` override to take effect.
 #   * The inline Search/Duck.ai mode toggle is gated by the AI Features
 #     "Search & Duck.ai" setting, so the flow enables it first. The picker sits
 #     at the bottom of the iPad Settings form sheet, so it must be scrolled fully
@@ -39,7 +37,6 @@ tags:
         currentAppVariant: ${APP_VARIANT}
         isRunningUITests: true
         isInternalUser: "true"
-        ff.iPadDuckAIBarControls: "true"
 
 # Enable the Search/Duck.ai mode toggle via AI Features -> "Search & Duck.ai".
 - tapOn:

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -495,10 +495,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// search-mode toggle and seeds the duckduckgo.com homepage. Off keeps the choice address-bar only.
     case onboardingToggleAffectsNtpAndDdg
 
-    /// Enables the native Duck.ai bar controls (model picker) in the iPad address bar's
-    /// expanded Duck.ai input area.
-    case iPadDuckAIBarControls
-
     /// Enables the macOS native "Customize Responses" UI (omnibar + New Tab Page entry points).
     case customizeResponses
 

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -392,7 +392,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         return button
     }()
 
-    /// Enables the model picker chip (driven by the `iPadDuckAIBarControls` flag).
+    /// Enables the model picker chip.
     var isModelPickerEnabled: Bool = false {
         didSet { refreshModelPickerVisibility() }
     }
@@ -432,7 +432,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         return button
     }()
 
-    /// Enables the reasoning picker chip (driven by the `iPadDuckAIBarControls` flag).
+    /// Enables the reasoning picker chip.
     var isReasoningPickerEnabled: Bool = false {
         didSet { refreshReasoningPickerVisibility() }
     }
@@ -475,7 +475,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         return button
     }()
 
-    /// Enables the tool picker chip (driven by the `iPadDuckAIBarControls` flag).
+    /// Enables the tool picker chip.
     var isToolPickerEnabled: Bool = false {
         didSet { refreshToolPickerVisibility() }
     }
@@ -598,7 +598,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         return button
     }()
 
-    /// Enables the attach button (driven by the `iPadDuckAIBarControls` flag).
+    /// Enables the attach button.
     var isAttachButtonEnabled: Bool = false {
         didSet { refreshAttachButtonVisibility() }
     }

--- a/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarViewController.swift
@@ -512,8 +512,7 @@ extension DefaultOmniBarViewController {
 extension DefaultOmniBarViewController {
 
     private func setUpModelPickerIfNeeded() {
-        guard dependencies.aiChatAddressBarExperience.isIPadAIToggleExperienceEnabled,
-              dependencies.featureFlagger.isFeatureOn(.iPadDuckAIBarControls) else { return }
+        guard dependencies.aiChatAddressBarExperience.isIPadAIToggleExperienceEnabled else { return }
 
         let controller = IPadOmnibarModelPickerController()
         modelPickerController = controller

--- a/iOS/DuckDuckGo/IPadDuckAIControlsFeature.swift
+++ b/iOS/DuckDuckGo/IPadDuckAIControlsFeature.swift
@@ -18,34 +18,27 @@
 //
 
 import Foundation
-import PrivacyConfig
 import Common
 import Core
-import FeatureFlags_iOS
 
 /// Provides access to the iPad Duck.ai bar controls (the address-bar model picker).
 protocol IPadDuckAIControlsFeatureProviding {
     /// Whether the iPad Duck.ai bar controls are available.
     ///
-    /// Returns `true` only when both conditions are met:
-    /// - The `iPadDuckAIBarControls` feature flag is enabled
-    /// - The device is NOT an iPhone (i.e. iPad or other large-screen devices)
+    /// Returns `true` when the device is NOT an iPhone (i.e. iPad or other large-screen devices).
     var isAvailable: Bool { get }
 }
 
 /// Determines availability of the iPad Duck.ai bar controls feature.
 struct IPadDuckAIControlsFeature: IPadDuckAIControlsFeatureProviding {
 
-    private let featureFlagger: any FeatureFlagger
     private let devicePlatform: DevicePlatformProviding.Type
 
-    init(featureFlagger: any FeatureFlagger = AppDependencyProvider.shared.featureFlagger,
-         devicePlatform: DevicePlatformProviding.Type = DevicePlatform.self) {
-        self.featureFlagger = featureFlagger
+    init(devicePlatform: DevicePlatformProviding.Type = DevicePlatform.self) {
         self.devicePlatform = devicePlatform
     }
 
     var isAvailable: Bool {
-        featureFlagger.isFeatureOn(.iPadDuckAIBarControls) && !devicePlatform.isIphone
+        !devicePlatform.isIphone
     }
 }

--- a/iOS/DuckDuckGoTests/AIChat/IPadDuckAIControlsFeatureTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/IPadDuckAIControlsFeatureTests.swift
@@ -31,50 +31,18 @@ final class IPadDuckAIControlsFeatureTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testWhenFeatureOnAndNotIphoneThenIsAvailable() {
-        let mockFlagger = MockFeatureFlagger(enabledFeatureFlags: [.iPadDuckAIBarControls])
+    func testWhenNotIphoneThenIsAvailable() {
         MockDevicePlatform.isIphone = false
 
-        let feature = IPadDuckAIControlsFeature(
-            featureFlagger: mockFlagger,
-            devicePlatform: MockDevicePlatform.self
-        )
+        let feature = IPadDuckAIControlsFeature(devicePlatform: MockDevicePlatform.self)
 
         XCTAssertTrue(feature.isAvailable)
     }
 
-    func testWhenFeatureOnAndIphoneThenIsNotAvailable() {
-        let mockFlagger = MockFeatureFlagger(enabledFeatureFlags: [.iPadDuckAIBarControls])
+    func testWhenIphoneThenIsNotAvailable() {
         MockDevicePlatform.isIphone = true
 
-        let feature = IPadDuckAIControlsFeature(
-            featureFlagger: mockFlagger,
-            devicePlatform: MockDevicePlatform.self
-        )
-
-        XCTAssertFalse(feature.isAvailable)
-    }
-
-    func testWhenFeatureOffAndNotIphoneThenIsNotAvailable() {
-        let mockFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
-        MockDevicePlatform.isIphone = false
-
-        let feature = IPadDuckAIControlsFeature(
-            featureFlagger: mockFlagger,
-            devicePlatform: MockDevicePlatform.self
-        )
-
-        XCTAssertFalse(feature.isAvailable)
-    }
-
-    func testWhenFeatureOffAndIphoneThenIsNotAvailable() {
-        let mockFlagger = MockFeatureFlagger(enabledFeatureFlags: [])
-        MockDevicePlatform.isIphone = true
-
-        let feature = IPadDuckAIControlsFeature(
-            featureFlagger: mockFlagger,
-            devicePlatform: MockDevicePlatform.self
-        )
+        let feature = IPadDuckAIControlsFeature(devicePlatform: MockDevicePlatform.self)
 
         XCTAssertFalse(feature.isAvailable)
     }

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -480,9 +480,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1204006570077678/task/1215105704317047
     case aiChatChromeShortcutIPad
 
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216000794365770?focus=true
-    case iPadDuckAIBarControls
-
     /// Warns Duck.ai users in the unified toggle input as they approach their usage limits, using the
     /// snapshot the web app writes into the reserved `usageLimits` native-storage entry.
     case utiDuckAIWarnings
@@ -729,8 +726,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .internalOnly, source: .remoteReleasable(NetworkProtectionSubfeature.strictRoutingToggle))
         case .forgetAllInSettings:
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.forgetAllInSettings))
-        case .iPadDuckAIBarControls:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.iPadDuckAIBarControls))
         case .utiDuckAIWarnings:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.usageWarnings))
         case .attributedMetrics:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1216000794365770
Tech Design URL:
CC:

### Description
Feature flag `iPadDuckAIBarControls` approved, removing conditional code. The iPad Duck.ai bar controls (model picker, reasoning picker, tool picker, and attach button in the expanded Duck.ai address-bar input) are now always available on non-iPhone devices, instead of being gated behind the remote feature flag.

### Testing Steps
1. On an iPad, focus the omnibar and switch to Duck.ai mode → the model picker, reasoning picker, tool picker, and attach button chips appear once the model list loads (as they already did with the flag on).
2. On an iPhone, verify no behavior change — these controls are still unavailable (gated by device idiom, not the removed flag).

### Impact
Low — this is a fully-approved flag removal with no user-facing behavior change; the previously-enabled code path is now unconditional (for non-iPhone devices).

### Quality Considerations
Removed the now-unused `featureFlagger` dependency from `IPadDuckAIControlsFeature` (its only use was this flag check) and the corresponding flag check at its one other call site in `DefaultOmniBarViewController`. Removed the flag case from `FeatureFlag` (iOS) and `AIChatSubfeature` (BrowserServicesKit), and the now-dead flag-off test cases. Updated the Maestro UI test to drop the now-unnecessary `ff.iPadDuckAIBarControls` override. Did not touch `iOS/Core/ios-config.json`, which is managed server-side.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193mtLexZk51RyGuZXo5xse

---
_Generated by [Claude Code](https://claude.ai/code/session_0193mtLexZk51RyGuZXo5xse)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Approved flag removal with no intended behavior change on iPad (controls stay on) or iPhone (still device-gated); only removes remote kill-switch for this UI.
> 
> **Overview**
> Removes the approved **`iPadDuckAIBarControls`** flag so iPad Duck.ai omnibar chips (model, reasoning, tool pickers, attach) are no longer gated remotely—**`IPadDuckAIControlsFeature`** now treats availability as non‑iPhone only, and **`DefaultOmniBarViewController`** sets up the model picker when the iPad AI toggle experience is enabled without an extra flag check.
> 
> The flag is dropped from **`FeatureFlag`** (iOS), **`AIChatSubfeature`** / **`PrivacyFeature`**, related **`FeatureFlag`** config, Maestro **`ipad_duckai_bar_controls.yaml`** (no `ff.` override), and simplified unit tests; omnibar comments no longer mention the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbbb64b2ccfbbd8999ef265879c79320c4c5de77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->