### PR TITLE
iOS: Tighten floating chrome sizing and icon alignment

### DIFF
--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -105,8 +105,8 @@ final class BrowserToolbarView: UIView {
     /// buttons sit where the production `UIToolbar` placed them. Tuned to match production's
     /// end-button centres; the floating style keeps the tighter `horizontalEdgePadding`.
     private static let legacyButtonRowHorizontalPadding: CGFloat = 20
-    /// Mirrors `DefaultOmniBarView`'s embedded side padding.
-    private static let embeddedAddressBarTextAreaPadding = floatingEmbeddedVerticalContentPadding
+    /// Mirrors `DefaultOmniBarView`'s text-area padding.
+    private static let embeddedAddressBarTextAreaPadding: CGFloat = 16
 
     /// Distance from the glass edge to the centre of the outermost icon in either row of the
     /// combined bottom chrome.
@@ -164,7 +164,7 @@ final class BrowserToolbarView: UIView {
 
     /// Inner padding of the combined bottom floating chrome (address field + buttons). The standalone
     /// floating toolbar used in top-address-bar mode keeps the original 2pt padding.
-    private static let floatingEmbeddedVerticalContentPadding: CGFloat = 12
+    private static let floatingEmbeddedVerticalContentPadding: CGFloat = 16
     private static let floatingEmbeddedOmnibarToButtonsSpacing: CGFloat = 12
     private static let defaultVerticalContentPadding: CGFloat = 2
     private static let defaultOmnibarToButtonsSpacing: CGFloat = 2

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -105,10 +105,18 @@ final class BrowserToolbarView: UIView {
     /// buttons sit where the production `UIToolbar` placed them. Tuned to match production's
     /// end-button centres; the floating style keeps the tighter `horizontalEdgePadding`.
     private static let legacyButtonRowHorizontalPadding: CGFloat = 20
-    /// Inset for the combined (bottom) floating button row so the outer buttons' centres line up
-    /// with the embedded omnibar's leading/trailing icons. Separate from `horizontalEdgePadding`
-    /// so tuning it doesn't shift the omnibar field.
-    static let floatingEmbeddedButtonRowHorizontalPadding: CGFloat = 16
+    /// Mirrors `DefaultOmniBarView`'s text-area padding.
+    private static let embeddedAddressBarTextAreaPadding: CGFloat = 16
+
+    /// Distance from the glass edge to the centre of the outermost icon in either row of the
+    /// combined bottom chrome.
+    static let floatingEmbeddedAddressBarIconInset =
+        embeddedAddressBarTextAreaPadding + BrowserChromeButton.toolbarButtonSize / 2
+
+    /// Inset for the combined (bottom) floating button row, so its outer buttons' centres land on
+    /// `floatingEmbeddedAddressBarIconInset` alongside the embedded omnibar's icons.
+    static let floatingEmbeddedButtonRowHorizontalPadding =
+        floatingEmbeddedAddressBarIconInset - horizontalEdgePadding - BrowserChromeButton.toolbarButtonSize / 2
     /// Inner side inset of the standalone (top address bar) floating toolbar.
     static let floatingStandaloneButtonRowHorizontalPadding: CGFloat = 16
     // This is only used in floating UI

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -105,8 +105,8 @@ final class BrowserToolbarView: UIView {
     /// buttons sit where the production `UIToolbar` placed them. Tuned to match production's
     /// end-button centres; the floating style keeps the tighter `horizontalEdgePadding`.
     private static let legacyButtonRowHorizontalPadding: CGFloat = 20
-    /// Mirrors `DefaultOmniBarView`'s text-area padding.
-    private static let embeddedAddressBarTextAreaPadding: CGFloat = 16
+    /// Mirrors `DefaultOmniBarView`'s embedded side padding.
+    private static let embeddedAddressBarTextAreaPadding = floatingEmbeddedVerticalContentPadding
 
     /// Distance from the glass edge to the centre of the outermost icon in either row of the
     /// combined bottom chrome.

--- a/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
@@ -170,7 +170,8 @@ final class DefaultOmniBarSearchView: UIView {
             leftIconContainerPlaceholder.topAnchor.constraint(equalTo: leftIconContainer.topAnchor),
             leftIconContainerPlaceholder.bottomAnchor.constraint(equalTo: leftIconContainer.bottomAnchor),
 
-            privacyInfoContainer.leadingAnchor.constraint(equalTo: leftIconContainerPlaceholder.leadingAnchor, constant: 10),
+            // Shares a centre with the loupe it swaps in and out of the slot with.
+            privacyInfoContainer.centerXAnchor.constraint(equalTo: leftIconContainerPlaceholder.centerXAnchor),
             privacyInfoContainer.centerYAnchor.constraint(equalTo: textField.centerYAnchor),
             privacyInfoContainer.widthAnchor.constraint(equalToConstant: 28),
             privacyInfoContainer.heightAnchor.constraint(equalToConstant: 28),

--- a/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
@@ -68,12 +68,6 @@ final class DefaultOmniBarSearchView: UIView {
     private let mainStackView = UIStackView()
     private var mainStackLeadingConstraint: NSLayoutConstraint?
 
-    var contentVerticalOffset: CGFloat = 0 {
-        didSet {
-            mainStackView.transform = CGAffineTransform(translationX: 0, y: contentVerticalOffset)
-        }
-    }
-
     init() {
         super.init(frame: .zero)
 

--- a/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
@@ -157,8 +157,9 @@ final class DefaultOmniBarSearchView: UIView {
         NSLayoutConstraint.activate([
             leadingConstraint,
             mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            mainStackView.topAnchor.constraint(equalTo: topAnchor),
-            mainStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            mainStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            mainStackView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
+            mainStackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
 
             notificationContainer.leadingAnchor.constraint(equalTo: leftIconContainerPlaceholder.leadingAnchor, constant: 4),
             notificationContainer.trailingAnchor.constraint(equalTo: textField.trailingAnchor),
@@ -171,8 +172,8 @@ final class DefaultOmniBarSearchView: UIView {
             leftIconContainerPlaceholder.bottomAnchor.constraint(equalTo: leftIconContainer.bottomAnchor),
 
             // Shares a centre with the loupe it swaps in and out of the slot with.
-            privacyInfoContainer.centerXAnchor.constraint(equalTo: leftIconContainerPlaceholder.centerXAnchor),
-            privacyInfoContainer.centerYAnchor.constraint(equalTo: textField.centerYAnchor),
+            privacyInfoContainer.centerXAnchor.constraint(equalTo: leftIconContainer.centerXAnchor),
+            privacyInfoContainer.centerYAnchor.constraint(equalTo: leftIconContainer.centerYAnchor),
             privacyInfoContainer.widthAnchor.constraint(equalToConstant: 28),
             privacyInfoContainer.heightAnchor.constraint(equalToConstant: 28),
 

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -742,8 +742,8 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         var view = UIVisualEffectView()
         UITraitCollection(userInterfaceStyle: configuration.interfaceStyle).performAsCurrent {
             if #available(iOS 26.0, *) {
-                let style: UIGlassEffect.Style = configuration.kind == .embedded ? .clear : .regular
-                let effect = UIGlassEffect(style: style)
+                // The embedded field carries the same material blur as the rest of the chrome.
+                let effect = UIGlassEffect(style: .regular)
                 if configuration.fireMode {
                     effect.tintColor = UIColor(singleUseColor: .fireModeBackground)
                 }
@@ -1593,9 +1593,8 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         /// Height of the address field when it is hosted inside the floating bottom toolbar, matching
         /// the 48pt search pill in the chrome spec.
         static let floatingEmbeddedHeight: CGFloat = 48
-        /// Tight inner padding so the 44pt controls sit inside the 48pt embedded field (12 + 2 = 14
-        /// from the glass edge to the control, per spec).
-        static let floatingEmbeddedTextAreaPadding: CGFloat = 2
+        /// The embedded field fills its slot, so the glass matches the height in the chrome spec.
+        static let floatingEmbeddedTextAreaPadding: CGFloat = 0
         static let floatingTopInputHeight: CGFloat = 48
         static let floatingTopInputOuterPadding = (height - floatingTopInputHeight) / 2
         static let floatingTopContentVerticalOffset: CGFloat = -2

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -1418,7 +1418,19 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         textAreaTopPaddingConstraint?.constant = topPadding
         textAreaBottomPaddingConstraint?.constant = -bottomPadding
         searchAreaView.contentVerticalOffset = isTopFloatingField ? Metrics.floatingTopContentVerticalOffset : 0
+        updateHorizontalSpacing()
         updateFireModeAppearance()
+    }
+
+    /// The embedded field matches the combined chrome's vertical content padding on its sides, so
+    /// it sits the same distance from every edge of the glass.
+    private func updateHorizontalSpacing() {
+        guard layoutMode != .expandedPhone else { return }
+        let padding = isBottomFloatingField
+            ? Metrics.floatingEmbeddedHorizontalPadding
+            : Metrics.textAreaHorizontalPadding
+        stackViewLeadingConstraint?.constant = padding
+        stackViewTrailingConstraint?.constant = -padding
     }
 
     func refreshLongPressMenuAvailability() {
@@ -1605,6 +1617,10 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         static let activeBorderWidth: CGFloat = 2
 
         static let textAreaHorizontalPadding: CGFloat = 16
+
+        /// Side inset of the embedded field, matching `BrowserToolbarView`'s vertical content
+        /// padding so the glass keeps the same gap on every edge.
+        static let floatingEmbeddedHorizontalPadding: CGFloat = 12
         
         static let buttonToSearchContainerSpace: CGFloat = 4
 

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -1417,20 +1417,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         }
         textAreaTopPaddingConstraint?.constant = topPadding
         textAreaBottomPaddingConstraint?.constant = -bottomPadding
-        searchAreaView.contentVerticalOffset = isTopFloatingField ? Metrics.floatingTopContentVerticalOffset : 0
-        updateHorizontalSpacing()
         updateFireModeAppearance()
-    }
-
-    /// The embedded field matches the combined chrome's vertical content padding on its sides, so
-    /// it sits the same distance from every edge of the glass.
-    private func updateHorizontalSpacing() {
-        guard layoutMode != .expandedPhone else { return }
-        let padding = isBottomFloatingField
-            ? Metrics.floatingEmbeddedHorizontalPadding
-            : Metrics.textAreaHorizontalPadding
-        stackViewLeadingConstraint?.constant = padding
-        stackViewTrailingConstraint?.constant = -padding
     }
 
     func refreshLongPressMenuAvailability() {
@@ -1609,7 +1596,6 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         static let floatingEmbeddedTextAreaPadding: CGFloat = 0
         static let floatingTopInputHeight: CGFloat = 48
         static let floatingTopInputOuterPadding = (height - floatingTopInputHeight) / 2
-        static let floatingTopContentVerticalOffset: CGFloat = -2
         static var cornerRadius: CGFloat { OmniBarMetrics.cornerRadius }
 
         /// Sits 2pt outside `cornerRadius` so the active outline stays concentric with the field.
@@ -1617,10 +1603,6 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         static let activeBorderWidth: CGFloat = 2
 
         static let textAreaHorizontalPadding: CGFloat = 16
-
-        /// Side inset of the embedded field, matching `BrowserToolbarView`'s vertical content
-        /// padding so the glass keeps the same gap on every edge.
-        static let floatingEmbeddedHorizontalPadding: CGFloat = 12
         
         static let buttonToSearchContainerSpace: CGFloat = 4
 

--- a/iOS/DuckDuckGo/FloatingUI/FloatingDomainCapsuleController.swift
+++ b/iOS/DuckDuckGo/FloatingUI/FloatingDomainCapsuleController.swift
@@ -26,9 +26,8 @@ final class FloatingDomainCapsuleController {
 
     static let handoffBandHalfWidth: CGFloat = 0.02
 
-    /// Gap between the pill and the adjacent edge of its expanded chrome at its resting position.
-    /// The collapsed bottom capsule sits `restBottomInsetReduction` closer to the device bottom so
-    /// the chrome morphs down into the pill rather than gaining space above it.
+    /// Gap between the pill and the adjacent screen edge at rest. Used by the bottom capsule, and
+    /// by the top capsule only as a fallback before the expanded frame is known (see `restCenterY`).
     static let restEdgePadding: CGFloat = 8
 
     /// Extra downward shift of the collapsed bottom capsule, in points, relative to `restEdgePadding`
@@ -53,10 +52,11 @@ final class FloatingDomainCapsuleController {
         let halfHeight = capsuleHeight / 2
         switch addressBarPosition {
         case .top:
+            // The pill keeps the expanded bar's top edge, so the chrome morphs up into it.
             guard !expandedFrame.isEmpty else {
                 return safeAreaInsets.top + restEdgePadding + halfHeight
             }
-            return expandedFrame.maxY - restEdgePadding - halfHeight
+            return expandedFrame.minY + halfHeight
         case .bottom:
             return boundsMaxY - restPaddingFromPhysicalBottom(safeAreaBottom: safeAreaInsets.bottom) - halfHeight
         }
@@ -78,7 +78,7 @@ final class FloatingDomainCapsuleController {
             guard !expandedFrame.isEmpty else {
                 return safeAreaInsets.top + Self.restEdgePadding + capsuleHeight
             }
-            return expandedFrame.maxY - Self.restEdgePadding
+            return expandedFrame.minY + capsuleHeight
         case .bottom:
             return Self.restPaddingFromPhysicalBottom(safeAreaBottom: safeAreaInsets.bottom) + capsuleHeight
         }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -4490,6 +4490,10 @@ extension MainViewController: BrowserChromeDelegate {
         static let morphExpandCurve = ChromeMorphAnimator.Curve.spring(dampingRatio: 0.82, naturalFrequency: 8.84)
 
         static let minMorphDurationScale: CGFloat = 0.55
+
+        /// The top address bar collapses into the pill a little slower than the bottom one, so the
+        /// transformation reads as deliberate rather than a snap.
+        static let topMorphCollapseDurationMultiplier = 1.25
     }
 
     var tabBarContainer: UIView {
@@ -4553,9 +4557,13 @@ extension MainViewController: BrowserChromeDelegate {
         if useMorphScrub {
             let isExpanding = percent > fromPercent
             let durationScale = max(ChromeAnimationConstants.minMorphDurationScale, abs(percent - fromPercent))
+            let isTopAddressBar = appSettings.currentAddressBarPosition == .top
+            let collapseDuration = isTopAddressBar
+                ? ChromeAnimationConstants.morphCollapseDuration * ChromeAnimationConstants.topMorphCollapseDurationMultiplier
+                : ChromeAnimationConstants.morphCollapseDuration
             let baseDuration = isExpanding
                 ? ChromeAnimationConstants.morphExpandDuration
-                : ChromeAnimationConstants.morphCollapseDuration
+                : collapseDuration
 
             chromeMorphAnimator.animate(
                 from: fromPercent,

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -312,6 +312,13 @@ class MainViewController: UIViewController {
         guard isFloatingUIEnabled else { return }
         let interfaceStyle = settledFloatingGlassInterfaceStyle
         viewCoordinator.toolbar.refreshMaterialAppearance(interfaceStyle: interfaceStyle)
+        // The toolbar only refreshes an omnibar it hosts. With a top address bar the omnibar sits
+        // in the navigation bar container instead, so its glass keeps the style it was snapshotted
+        // with and lands opaque before flipping translucent a frame later.
+        if !viewCoordinator.isOmnibarInToolbar,
+           let barView = viewCoordinator.omniBar.barView as? DefaultOmniBarView {
+            barView.refreshMaterialAppearance(interfaceStyle: interfaceStyle)
+        }
     }
 
     private var settledFloatingGlassInterfaceStyle: UIUserInterfaceStyle {

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -337,6 +337,41 @@ final class BrowserToolbarViewTests: XCTestCase {
         }
     }
 
+    func testWhenEmbeddedFloatingThenToolbarIconsAlignWithTheAddressBarIcons() {
+        let sut = makeSUT(embeddedOmnibar: true)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        sut.translatesAutoresizingMaskIntoConstraints = false
+        window.addSubview(sut)
+        NSLayoutConstraint.activate([
+            sut.leadingAnchor.constraint(equalTo: window.leadingAnchor),
+            sut.trailingAnchor.constraint(equalTo: window.trailingAnchor),
+            sut.bottomAnchor.constraint(equalTo: window.bottomAnchor)
+        ])
+        sut.setToolbarButtons([
+            makeToolbarButton(identifier: "back", width: 44),
+            makeToolbarButton(identifier: "forward", width: 44),
+            makeToolbarButton(identifier: "Browser.Toolbar.Button.Fire", width: 44),
+            makeToolbarButton(identifier: "tabs", width: 44),
+            makeToolbarButton(identifier: "menu", width: 44)
+        ])
+        window.layoutIfNeeded()
+
+        let centers = sut.arrangedToolbarButtonViews.map { window.convert($0.center, from: $0.superview).x }
+        guard let first = centers.min(), let last = centers.max() else {
+            XCTFail("Missing toolbar buttons")
+            return
+        }
+        // The address field is hosted inside the same glass capsule, so its icons are inset from
+        // the capsule's edges rather than the toolbar view's.
+        let capsule = sut.restingCapsuleFrame(in: window)
+
+        // Both rows carry 44pt controls, so aligned centres mean the same distance from the glass
+        // edge as the address field's icons: its 16pt text-area padding plus half a control.
+        let expectedInset = BrowserToolbarView.floatingEmbeddedAddressBarIconInset
+        XCTAssertEqual(first - capsule.minX, expectedInset, accuracy: 0.5)
+        XCTAssertEqual(capsule.maxX - last, expectedInset, accuracy: 0.5)
+    }
+
     func testWhenStandaloneFloatingThenButtonsAreEvenlySpacedAndFireButtonIsCentered() {
         let sut = makeSUT(embeddedOmnibar: false)
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 800))

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -154,16 +154,17 @@ final class BrowserToolbarViewTests: XCTestCase {
         XCTAssertEqual(height, BrowserToolbarView.floatingButtonsHeight, accuracy: 0.01)
     }
 
-    func testWhenFloatingThenCombinedChromeHeightMatchesTheTwelvePointSpacingSpec() {
-        // 12 top + 48 field + 12 gap + 44 buttons + 12 bottom — bottom address bar only.
+    func testWhenFloatingThenCombinedChromeHeightMatchesTheSpacingSpec() {
+        // 16 top + 48 field + 12 gap + 44 buttons + 16 bottom — bottom address bar only. The outer
+        // padding matches the field's side inset so the glass keeps one gap on every edge.
         XCTAssertEqual(BrowserToolbarView.floatingEmbeddedButtonsHeight, 44)
         XCTAssertEqual(
             BrowserToolbarView.totalHeight(withOmnibarHeight: 48, isFloating: true),
-            128,
+            136,
             accuracy: 0.01)
         XCTAssertEqual(
             BrowserToolbarView.singleRowHeight(withOmnibarHeight: 48),
-            72,
+            80,
             accuracy: 0.01)
     }
 

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -622,7 +622,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
         XCTAssertEqual(searchContainerFrame.midY, barView.bounds.midY, accuracy: 0.01)
         XCTAssertEqual(searchView.bounds.height, 44, accuracy: 0.01)
         XCTAssertEqual((searchContainerFrame.height - searchView.bounds.height) / 2, 2, accuracy: 0.01)
-        XCTAssertEqual(loupeFrame.midY, searchView.bounds.midY - 2, accuracy: 0.01)
+        XCTAssertEqual(loupeFrame.midY, searchView.bounds.midY, accuracy: 0.01)
     }
 
     func testWhenTopFloatingLandscapeChromeThenInputHeightStaysUnchanged() {

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -415,6 +415,38 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
         }
     }
 
+    func testWhenShieldAndLoupeShareTheIconSlotThenTheyShareACentre() throws {
+        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        barView.isUsingSmallTopSpacing = true
+        barView.frame = CGRect(x: 0, y: 0, width: 390, height: barView.expectedHeight)
+        barView.layoutIfNeeded()
+
+        let shield = try XCTUnwrap(barView.privacyInfoContainer)
+        let slot = try XCTUnwrap(barView.leftIconContainerView)
+
+        // The shield and the loupe swap in and out of the same slot, so a shared centre keeps the
+        // icon from shifting sideways when the state changes.
+        XCTAssertEqual(barView.convert(shield.center, from: shield.superview).x,
+                       barView.convert(slot.center, from: slot.superview).x,
+                       accuracy: 0.5)
+    }
+
+    func testWhenFieldIsEmbeddedAtBottomThenItFillsTheFullSlotHeight() throws {
+        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        barView.isUsingSmallTopSpacing = true
+        barView.frame = CGRect(x: 0, y: 0, width: 390, height: barView.expectedHeight)
+        barView.layoutIfNeeded()
+
+        let searchContainer = try XCTUnwrap(barView.searchContainer)
+        let glassView = try XCTUnwrap(firstGlassView(in: searchContainer))
+
+        // The visible field is the glass, so it has to be the full 48pt rather than a 44pt pill
+        // floating inside the slot.
+        XCTAssertEqual(barView.expectedHeight, 48, accuracy: 0.01)
+        XCTAssertEqual(searchContainer.bounds.height, barView.expectedHeight, accuracy: 0.01)
+        XCTAssertEqual(glassView.frame.height, barView.expectedHeight, accuracy: 0.01)
+    }
+
     func testWhenToolbarMaterialAppearanceRefreshesThenHostedOmnibarUsesSettledStyle() {
         let toolbar = BrowserToolbarView(frame: CGRect(x: 0, y: 0, width: 390, height: 200))
         toolbar.overrideUserInterfaceStyle = .light
@@ -691,10 +723,24 @@ final class FloatingDomainCapsuleControllerTests: XCTestCase {
         XCTAssertLessThan(button?.bounds.width ?? .greatestFiniteMagnitude, expandedFrame.width / 2)
     }
 
-    func testWhenTopBarsHiddenThenPillKeepsEightPointsBelowIt() {
+    func testWhenTopBarsHiddenThenPillKeepsTheBarsTopEdge() {
         let button = update(barsVisibilityPercent: 0)
 
-        XCTAssertEqual(expandedFrame.maxY - (button?.frame.maxY ?? 0), FloatingDomainCapsuleController.restEdgePadding, accuracy: 0.5)
+        // The pill collapses upward into the bar's top edge, so no empty band is left above it.
+        XCTAssertEqual(button?.frame.minY ?? 0, expandedFrame.minY, accuracy: 0.5)
+    }
+
+    func testWhenTopCapsuleRestsThenObscuredHeightTracksThePillBottom() {
+        update(barsVisibilityPercent: 0)
+        let insets = UIEdgeInsets(top: 59, left: 0, bottom: 34, right: 0)
+
+        let obscured = controller.restObscuredHeightFromScreenEdge(for: .top,
+                                                                   safeAreaInsets: insets,
+                                                                   expandedFrame: expandedFrame)
+
+        // Tracks the moved pill, so page-fixed headers don't leave a dead band beneath it.
+        XCTAssertEqual(obscured, expandedFrame.minY + controller.capsuleHeight, accuracy: 0.001)
+        XCTAssertLessThan(obscured, expandedFrame.maxY)
     }
 
     func testWhenPartiallyVisibleThenPillWidthIsBetweenCapsuleAndBarAndFullyOpaque() {
@@ -775,7 +821,7 @@ final class FloatingDomainCapsuleGeometryTests: XCTestCase {
         XCTAssertEqual(restCenterY, previousRestCenterY + FloatingDomainCapsuleController.restBottomInsetReduction, accuracy: 0.001)
     }
 
-    func testWhenTopAddressBarThenCollapsedRestCenterKeepsEightPointsBelowCapsule() {
+    func testWhenTopAddressBarThenCollapsedRestCenterAlignsWithTheBarsTopEdge() {
         let insets = UIEdgeInsets(top: 59, left: 0, bottom: 34, right: 0)
         let capsuleHeight: CGFloat = 28
         let expandedFrame = CGRect(x: 16, y: insets.top, width: 358, height: 60)
@@ -786,10 +832,7 @@ final class FloatingDomainCapsuleGeometryTests: XCTestCase {
             safeAreaInsets: insets,
             capsuleHeight: capsuleHeight)
 
-        XCTAssertEqual(
-            expandedFrame.maxY - (restCenterY + capsuleHeight / 2),
-            FloatingDomainCapsuleController.restEdgePadding,
-            accuracy: 0.001)
+        XCTAssertEqual(restCenterY - capsuleHeight / 2, expandedFrame.minY, accuracy: 0.001)
     }
 }
 

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -419,16 +419,48 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
         let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
         barView.isUsingSmallTopSpacing = true
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: barView.expectedHeight)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        window.addSubview(barView)
+        window.makeKeyAndVisible()
         barView.layoutIfNeeded()
 
         let shield = try XCTUnwrap(barView.privacyInfoContainer)
         let slot = try XCTUnwrap(barView.leftIconContainerView)
 
+        func assertCentred(_ context: String, file: StaticString = #filePath, line: UInt = #line) {
+            let shieldCentre = barView.convert(shield.center, from: shield.superview)
+            let slotCentre = barView.convert(slot.center, from: slot.superview)
+            XCTAssertEqual(shieldCentre.x, slotCentre.x, accuracy: 0.5, context, file: file, line: line)
+            XCTAssertEqual(shieldCentre.y, slotCentre.y, accuracy: 0.5, context, file: file, line: line)
+        }
+
         // The shield and the loupe swap in and out of the same slot, so a shared centre keeps the
-        // icon from shifting sideways when the state changes.
-        XCTAssertEqual(barView.convert(shield.center, from: shield.superview).x,
-                       barView.convert(slot.center, from: slot.superview).x,
-                       accuracy: 0.5)
+        // icon from shifting when the state changes.
+        assertCentred("at rest")
+
+        barView.textField.becomeFirstResponder()
+        barView.layoutIfNeeded()
+        assertCentred("while focused")
+    }
+
+    func testWhenEmbeddedFieldIsTallerThanItsControlsThenTheRowStaysCentred() throws {
+        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        barView.isUsingSmallTopSpacing = true
+        barView.frame = CGRect(x: 0, y: 0, width: 390, height: barView.expectedHeight)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        window.addSubview(barView)
+        window.makeKeyAndVisible()
+        barView.layoutIfNeeded()
+
+        let field = try XCTUnwrap(barView.searchContainer)
+        let fieldMidY = barView.convert(field.bounds, from: field).midY
+
+        // The 44pt controls are shorter than the 48pt field, so the slack has to split evenly
+        // rather than settling the row against one edge.
+        for item in [barView.leftIconContainerView, barView.refreshButton, barView.textField] {
+            let view = try XCTUnwrap(item)
+            XCTAssertEqual(barView.convert(view.bounds, from: view).midY, fieldMidY, accuracy: 0.5)
+        }
     }
 
     func testWhenFieldIsEmbeddedAtBottomThenItFillsTheFullSlotHeight() throws {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1216782882404612?focus=true
Tech Design URL:
CC:

### Description

This also fixes a bug in another Asana task, but I’ve chosen to omit it to not break our flows.

Four sizing/alignment fixes in the floating chrome, from design feedback.

**Collapsed top capsule sat too low.** `restCenterY` for `.top` anchored the pill 8pt above the expanded bar's *bottom* edge, leaving ~14pt of empty space above it. It now keeps the bar's top edge. `restObscuredHeightFromScreenEdge` follows the move, so a page-fixed header still pins to the pill rather than to a gap beneath it.

**Embedded field rendered at 44pt, not 48pt.** The field inset its content 2pt on each side of its 48pt slot, so the glass — the part you actually see — came out at 44. Measured before and after; it now fills the slot and the 44pt controls centre inside it.

**Embedded field looked flat.** It was the only chrome built with `UIGlassEffect(style: .clear)`; everything else uses `.regular`. Now uniform, matching Safari's bottom address bar.

**Toolbar icons didn't line up with the address bar's.** Both rows carry 44pt controls, so aligned centres just means both sitting the same distance from the glass edge. The button row's inset is now derived from that shared distance instead of a hardcoded value that no longer matched its own comment (it promised centre alignment while sitting 8pt inboard). Separately, the privacy shield was pinned by a leading offset that placed it 2pt outboard of the loupe it shares a slot with — so the icon shifted sideways on state change. It is centred in the slot now, which settles shield-to-loupe, shield-to-trailing-icons and shield-to-toolbar together.

### Testing Steps

1. Enable Floating UI, address bar at top. Scroll to hide the bars → the collapsed capsule keeps the address bar's top edge, with no band of space above it.
1. On a page with a fixed header, scroll to collapse → the header pins to the capsule, no dead band.
1. Move the address bar to the bottom → the field fills the full height of its row and carries a material blur rather than a flat fill.
1. Compare the bottom platter's two rows → the outer toolbar icons and the address field's icons share the same distance from the glass edge.
1. Watch the leading icon as the field swaps between the loupe and the privacy shield → no sideways shift.

### Definition of Done

Unit tests cover each change: capsule rest position and obscured height, the 48pt field, cross-row icon-centre alignment measured from the laid-out capsule, and shield/loupe centring.

### Impact

Low: visual geometry only, scoped to the floating UI chrome, except the privacy shield centring which applies to every omnibar mode (a 2pt correction toward consistency in each).

#### What could go wrong?

The capsule move changes the web view's top obscured inset → covered by tests asserting the inset tracks the pill's bottom.
The shield constraint reaches beyond the floating UI → the omnibar state suites pass (235 tests).

### Quality Considerations

The field height was measured rather than inferred: the code comment and the constraints disagreed, and the constraints were right. The icon alignment is asserted against real laid-out icon centres, not against the constants, so it catches drift from either row.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual geometry and floating-UI chrome only; shield centering is a small omnibar layout tweak with broad test coverage.
> 
> **Overview**
> Tightens **floating UI** layout and animation from design feedback: collapsed top domain capsule, bottom embedded address field, glass material, and cross-row icon alignment.
> 
> **Top capsule** — When bars hide with a top address bar, the pill now rests on the **expanded bar’s top edge** (not ~8pt below its bottom), and **obscured height** tracks the pill so fixed headers don’t leave a dead band. Top chrome **collapse morph** is slightly slower for readability.
> 
> **Bottom embedded field** — The 48pt slot is filled by glass (**padding 2→0**, row **vertically centered**); embedded glass uses **`UIGlassEffect.regular`** like the rest of the chrome instead of `.clear`. Combined bottom chrome **outer vertical padding** goes **12→16** to match side inset.
> 
> **Icon alignment** — Toolbar button-row inset is **derived** from the same glass-edge-to-icon-center distance as the address field (16pt + half of 44pt control). The **privacy shield** is **centered** in the loupe slot so loupe/shield swaps don’t shift horizontally.
> 
> **Top address bar glass** — `MainViewController` now refreshes omnibar material when the bar isn’t hosted in the toolbar, avoiding a one-frame opaque flash before translucency.
> 
> Unit tests cover heights, capsule rest/obscured metrics, laid-out icon centers, and shield/loupe alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ebbff4674bf51aab27d1fa223c29f313ca2e7b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->