### PR TITLE
Reach the AI Chat debug row by filtering instead of scrolling

### DIFF
--- a/.maestro/shared/seed_duckai_usage_warning.yaml
+++ b/.maestro/shared/seed_duckai_usage_warning.yaml
@@ -20,18 +20,20 @@ appId: com.duckduckgo.mobile.ios
     centerElement: false
 - tapOn: "All debug options"
 
-# The debug screen is pushed asynchronously. Without this wait the scroll below can start while
-# Settings is still up, walk it to the bottom looking for a row it does not have, and fail with
-# `No visible element found: "AI Chat"`. Deliberately not anchored on a row: the first row sits
-# under the search bar, and asserting it failed on the second seed in a flow that seeds twice.
-- waitForAnimationToEnd:
-    timeout: 5000
-
-- scrollUntilVisible:
-    element:
-        text: "AI Chat"
-    direction: DOWN
-    centerElement: false
+# Filter rather than scroll. "AI Chat" is the first row of the Screens section but still sits below
+# the fold, and `scrollUntilVisible` only scrolls down: a fling that carries past the row cannot
+# recover, so it walks the remaining ~50 rows and fails with `No visible element found: "AI Chat"`.
+# That flaked on whichever warning flow drew it, and neither an animation wait nor a row assertion
+# helped, because the transition was never the problem. Filtering needs no scrolling at all.
+#
+# `tapOn` waits for its element, and "Filter" exists only on the debug screen, so this also covers
+# the screen transition that the previous animation wait was there for.
+#
+# "ai ch" rather than the full title: it matches exactly one of the 51 screen titles, it matches no
+# feature-flag rawValue (those are camelCase, so the space rules them out), and it keeps the text
+# we type from colliding with the row we tap next.
+- tapOn: "Filter"
+- inputText: "ai ch"
 - tapOn: "AI Chat"
 
 - scrollUntilVisible:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1218012549071850?focus=true

### Description

Third attempt at the same step, and the first that removes it rather than tuning it. The two before this were wrong; that history is below so a reviewer can judge the fix on evidence rather than on my argument for it.

`.maestro/shared/seed_duckai_usage_warning.yaml` reaches Debug ▸ AI Chat to seed a usage snapshot. Getting to the `AI Chat` row used `scrollUntilVisible`, which fails intermittently with `No visible element found: "AI Chat"` and takes whichever of the three `test_uti_duckai_warnings_*` flows happens to draw it.

`scrollUntilVisible` only scrolls **down**. `AI Chat` is the first row of the `Screens` section — `DebugScreensViewModel.sorter` compares raw `String`, so `AI` sorts before `Ad` — but it still sits below the fold, behind a toggle, a multi-line info row, three more toggles and another info row. A fling whose momentum carries past the row cannot recover: the scroll continues away from it through the remaining ~50 rows and gives up. Whether one gesture leaves the row visible is close to a coin flip, which is why the same commit passes and fails on identical builds.

The debug screen has a Filter field (`.searchable`, `DebugScreensViewController.swift:134`), so the row is reachable with no scrolling at all.

On the filter string: `ai ch` rather than the full title, because it matches exactly one of the 51 screen titles, matches no feature-flag rawValue (those are camelCase, so the space excludes them — `filteredFeatureFlags` would otherwise add rows for internal users), and keeps the text typed into the field from colliding with the row tapped next. `tapOn` waits for its element and `Filter` exists only on the debug screen, so this also covers the transition that #6597's `waitForAnimationToEnd` was there for — hence its removal.

### What came before

| Change | Result |
|---|---|
| #6597 `waitForAnimationToEnd` | nightly [33590186539](https://github.com/duckduckgo/apple-browsers/actions/runs/33590186539) failed on **both** legs, `disabled` and `limit_reached` |
| #6597 first attempt, `assertVisible` on the first debug row | failed the internal leg in `limit_reached`, the one flow that seeds twice |

Both were premised on the screen transition being the cause. The wait is on `main` and the step still fails, so it is not. No commit has touched the debug screens list or its root view since Aug 26, well before these flows existed, so nothing external moved underneath this.

### Testing Steps

Maestro YAML only, so no local build. Verification run on this branch is linked in a comment.

Worth stating plainly: one green run does **not** establish this. For a step that has been failing roughly half the time per leg, two green legs is about a 1-in-4 coincidence — I over-claimed on exactly that basis for #6597. `unified_toggle_input` is not a dispatchable suite, so each sample is the full 56-flow `release` suite, and the workflow's concurrency group cancels same-ref runs, so repeats have to be sequential. Treat a first green as necessary, not sufficient.

By hand on an internal build: Settings ▸ All debug options ▸ type `ai ch` in Filter → exactly one row, `AI Chat` → tap it.

### Impact

None — Maestro flows only, no shipping code.

#### What could go wrong?

The Filter field has to be selectable by its `Filter` prompt; no other flow in `.maestro` drives a `.searchable` field, so this is the one assumption the verification run is actually testing. If it does not hold, all three warning flows fail at `tapOn: "Filter"` with a message naming the string, which is a clearer signal than the flake it replaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Maestro YAML only; no app shipping code. Risk is test reliability and the assumption that the debug screen exposes a tappable "Filter" searchable field.
> 
> **Overview**
> Fixes intermittent Maestro failures in the Duck.ai usage-warning seed step (`seed_duckai_usage_warning.yaml`), which three `test_uti_duckai_warnings_*` flows depend on.
> 
> **Replaces** `waitForAnimationToEnd` plus `scrollUntilVisible` for **"AI Chat"** with **tap Filter → type `ai ch` → tap AI Chat**. Scrolling only downward could overshoot the first Screens row and never recover across ~50 rows; filtering avoids that flake. **`tapOn: "Filter"`** also waits for the debug screen without a separate animation wait.
> 
> The filter string **`ai ch`** is chosen to match a single screen title, avoid camelCase feature-flag rows, and not clash with the next tap target. Preset selection still uses scroll + tap on **`${PRESET}`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e301ac20c9acfc0cc140f2c508a36132a89c529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->