### PR TITLE
[iOS] Fill the Duck.ai warning card CTA with control primary

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterCardView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterCardView.swift
@@ -284,7 +284,6 @@ final class UTIFooterActionButton: UIView {
     private enum Constants {
         static let height: CGFloat = 34
         static let titleHorizontalPadding: CGFloat = 14
-        static let strokeWidth: CGFloat = 0.5
     }
 
     var onPrimaryTap: (() -> Void)?
@@ -311,8 +310,7 @@ final class UTIFooterActionButton: UIView {
     }
 
     func applyColors() {
-        backgroundColor = UIColor(designSystemColor: .surfaceCanvas)
-        layer.borderColor = UIColor(designSystemColor: .lines).cgColor
+        backgroundColor = UIColor(designSystemColor: .controlsFillPrimary)
         primaryButton.configuration?.baseForegroundColor = UIColor(designSystemColor: .textPrimary)
     }
 
@@ -326,7 +324,6 @@ final class UTIFooterActionButton: UIView {
     private func setupUI() {
         clipsToBounds = true
         layer.cornerCurve = .continuous
-        layer.borderWidth = Constants.strokeWidth
 
         primaryButton.translatesAutoresizingMaskIntoConstraints = false
         primaryButton.accessibilityIdentifier = "AIChat.Footer.Button.Primary"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218089612306370?focus=true
Tech Design URL:
CC:

### Description
The CTA on the Duck.ai usage-warning card was drawn as an outlined pill, which does not match the design. It is now a filled pill using the control primary design-system color, with no stroke. Layout, sizing and copy are unchanged.

### Testing Steps
1. Enable the `utiDuckAIWarnings` flag and seed an approaching-limit warning from Debug ▸ AI Chat ▸ Duck.ai Usage Warnings.
2. Open a Duck.ai tab and tap the input bar so it expands → the warning card appears under the input.
3. Check the CTA is a filled light gray pill with no outline, in both light and dark mode.

### Impact and Risks
Low

#### What could go wrong?
The pill could look off against the card in dark mode → mitigated by using the design-system control fill token, which adapts per appearance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized visual styling on the footer CTA using an existing design-system fill token already used elsewhere in AI Chat controls.
> 
> **Overview**
> Updates the **Duck.ai usage-warning card** CTA (`UTIFooterActionButton`) so it matches design: a **filled pill** instead of an outlined one.
> 
> The pill background switches from `surfaceCanvas` with a `lines` border to **`controlsFillPrimary`**; border width and stroke styling are removed. Label color, height, padding, and tap behavior are unchanged, and colors still refresh on light/dark appearance changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ae3ebdc9ff5f673f9ce925eacebda58cc5c5103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->