### PR TITLE
improve reliability of nightly quick actions test

### DIFF
--- a/iOS/AtbUITests/ApplicationShortcutItemsUITests.swift
+++ b/iOS/AtbUITests/ApplicationShortcutItemsUITests.swift
@@ -24,6 +24,9 @@ final class ApplicationShortcutItemsUITests: XCTestCase {
     private let app = XCUIApplication()
     private let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
     private let timeout: TimeInterval = 20
+    private let quickActionsMenuTimeout: TimeInterval = 5
+    private let transitionCount = 5
+    private let quickActionsMenuAttemptCount = 3
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -36,10 +39,13 @@ final class ApplicationShortcutItemsUITests: XCTestCase {
             "-AppleLanguages", "(en)",
             "-AppleLocale", "en_GB",
         ]
+        if ProcessInfo.processInfo.environment["INTERNAL_USER_MODE"] == "true" {
+            app.launchArguments += ["-isInternalUser", "true"]
+        }
         app.launchEnvironment = ["UITEST_MODE": "1"]
         app.launch()
 
-        XCTAssertTrue(searchEntry.waitForExistence(timeout: timeout))
+        XCTAssertTrue(searchEntry.waitForExistence(timeout: timeout), "Browser UI did not appear after launch.")
     }
 
     override func tearDownWithError() throws {
@@ -48,7 +54,7 @@ final class ApplicationShortcutItemsUITests: XCTestCase {
     }
 
     func testQuickActionsSurviveRepeatedBackgroundTransitions() {
-        for iteration in 1...20 {
+        for iteration in 1...transitionCount {
             XCUIDevice.shared.press(.home)
 
             XCTAssertTrue(waitForAppToLeaveForeground(), "App did not enter the background on iteration \(iteration).")
@@ -61,21 +67,65 @@ final class ApplicationShortcutItemsUITests: XCTestCase {
         }
 
         XCUIDevice.shared.press(.home)
-        XCTAssertTrue(waitForAppToLeaveForeground())
-        XCTAssertNotEqual(app.state, .notRunning)
+        XCTAssertTrue(waitForAppToLeaveForeground(), "App did not enter the background before inspecting Quick Actions.")
+        XCTAssertNotEqual(app.state, .notRunning, "App terminated before inspecting Quick Actions.")
+        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: timeout), "SpringBoard did not enter the foreground.")
 
-        let appIcon = springboard.icons["DuckDuckGo"]
-        XCTAssertTrue(appIcon.waitForExistence(timeout: timeout))
-        appIcon.press(forDuration: 1.2)
+        guard openQuickActionsMenu() else { return }
 
-        XCTAssertTrue(springboard.buttons["Duck.ai"].waitForExistence(timeout: timeout))
-        XCTAssertTrue(springboard.buttons["Paste from Clipboard"].exists)
-        XCTAssertFalse(springboard.buttons["Open VPN"].exists)
-        XCTAssertNotEqual(app.state, .notRunning)
+        XCTAssertTrue(springboard.buttons["Paste from Clipboard"].waitForExistence(timeout: quickActionsMenuTimeout),
+                      "Paste from Clipboard Quick Action did not appear.")
+        XCTAssertFalse(springboard.buttons["Open VPN"].exists, "Open VPN Quick Action appeared without a subscription.")
+        XCTAssertNotEqual(app.state, .notRunning, "App terminated while displaying Quick Actions.")
     }
 
     private var searchEntry: XCUIElement {
         app.descendants(matching: .any)["searchEntry"]
+    }
+
+    private func openQuickActionsMenu(file: StaticString = #filePath, line: UInt = #line) -> Bool {
+        let appIcon = springboard.icons["DuckDuckGo"]
+        let iconIsHittable = NSPredicate(format: "exists == true AND isHittable == true")
+
+        for attempt in 1...quickActionsMenuAttemptCount {
+            let iconExpectation = XCTNSPredicateExpectation(predicate: iconIsHittable, object: appIcon)
+            guard XCTWaiter.wait(for: [iconExpectation], timeout: timeout) == .completed else {
+                recordSpringboardDiagnostics()
+                XCTFail("DuckDuckGo app icon did not become hittable.", file: file, line: line)
+                return false
+            }
+
+            appIcon.press(forDuration: 1.2)
+
+            if springboard.buttons["Duck.ai"].waitForExistence(timeout: quickActionsMenuTimeout) {
+                return true
+            }
+
+            guard attempt < quickActionsMenuAttemptCount else { break }
+
+            XCUIDevice.shared.press(.home)
+            guard springboard.wait(for: .runningForeground, timeout: timeout) else {
+                recordSpringboardDiagnostics()
+                XCTFail("SpringBoard did not return to the foreground after Quick Actions attempt \(attempt).", file: file, line: line)
+                return false
+            }
+        }
+
+        recordSpringboardDiagnostics()
+        XCTFail("Duck.ai Quick Action did not appear after \(quickActionsMenuAttemptCount) attempts.", file: file, line: line)
+        return false
+    }
+
+    private func recordSpringboardDiagnostics() {
+        let screenshot = XCTAttachment(screenshot: springboard.screenshot())
+        screenshot.name = "SpringBoard Screenshot"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+
+        let hierarchy = XCTAttachment(string: springboard.debugDescription)
+        hierarchy.name = "SpringBoard Accessibility Hierarchy"
+        hierarchy.lifetime = .keepAlways
+        add(hierarchy)
     }
 
     private func waitForAppToLeaveForeground() -> Bool {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1218080651420681?focus=true
Tech Design URL:
CC:

### Description
Improve reliability of nightly quick actions test by setting expected conditions and reducing the number of times it runs.

### Testing Steps
1. Build is green.
2. Run the ATB UI Tests target in Xcode. No failures.

### Impact
Low: Minor visual changes, small bug fixes, improvement to existing features


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to UI test code with no production behavior impact.
> 
> **Overview**
> Strengthens the **Application Shortcut Items** UI test so nightly runs fail less often on flaky SpringBoard timing.
> 
> The background/foreground stress loop is reduced from **20** to **5** iterations via `transitionCount`. Launch setup now passes `-isInternalUser` when `INTERNAL_USER_MODE` is set, and assertions include clearer failure messages.
> 
> Opening the Quick Actions menu is centralized in **`openQuickActionsMenu()`**, which waits for the DuckDuckGo icon to be hittable, long-presses with retries (up to 3), and confirms **Duck.ai** appears before the test checks **Paste from Clipboard** and that **Open VPN** is absent. On failure, **`recordSpringboardDiagnostics()`** attaches a SpringBoard screenshot and accessibility hierarchy to the test report.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0322364702ca5df7ddfcfc694ba5c323cef7c8d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->