### PR TITLE
Feature flag onboardingRebranding approved, removing conditional code

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/xcshareddata/xcschemes/iOS Browser Alpha.xcscheme
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/xcshareddata/xcschemes/iOS Browser Alpha.xcscheme
@@ -53,10 +53,6 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "-ff.onboardingRebranding true"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
             argument = "-isOnboardingCompleted false"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/iOS/DuckDuckGo-iOS.xcodeproj/xcshareddata/xcschemes/iOS Browser.xcscheme
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/xcshareddata/xcschemes/iOS Browser.xcscheme
@@ -348,10 +348,6 @@
             argument = "-isOnboardingCompleted false"
             isEnabled = "NO">
          </CommandLineArgument>
-         <CommandLineArgument
-            argument = "-ff.onboardingRebranding true"
-            isEnabled = "NO">
-         </CommandLineArgument>
       </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
@@ -99,9 +99,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/414709148257752/task/1217605270508341
     case elementFullscreen
 
-    /// https://app.asana.com/1/137249556945/project/1206329551987282/task/1211806114021630?focus=true
-    case onboardingRebranding
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1214974217398704?focus=true
     case appRebranding
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1213683813965903
Tech Design URL:
CC:

### Description
Feature flag `onboardingRebranding` was Approved. The rebranded onboarding UI (`ContextualDaxDialogFactory`) is already unconditionally used with no remaining call sites gating on this flag, so the leftover flag declaration and its local-override launch arguments were dead code and have been removed.

### Testing Steps
1. Build the iOS app and confirm it compiles.
2. Open onboarding — behavior is unchanged (already using the rebranded dialogs unconditionally).

### Impact
None — this removes an already-dead flag declaration; no runtime behavior changes.

### Quality Considerations
Verified via a case-insensitive search that no code, tests, or scheme files reference `onboardingRebranding` after this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHwZcv9WHxSQe7NVYPzjsF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHwZcv9WHxSQe7NVYPzjsF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead feature-flag and scheme cleanup only; no functional onboarding or privacy-config logic changes in the diff.
> 
> **Overview**
> Removes the **`onboardingRebranding`** iOS browser config subfeature now that the rebranded onboarding path is always in use and nothing in the app still gates on that flag.
> 
> The **`onboardingRebranding`** case is deleted from `iOSBrowserConfigSubfeature`, and the disabled `-ff.onboardingRebranding true` launch argument is removed from the **iOS Browser** and **iOS Browser Alpha** Xcode schemes. Onboarding behavior should be unchanged—this is cleanup of an unused flag and dev overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cffa7f51eb67a95e7b30476348e98e1694806cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->