### PR TITLE
macOS: Declare channel param on pixel defs failing live validation

### DIFF
--- a/macOS/PixelDefinitions/pixels/definitions/fire_window_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/fire_window_pixels.json5
@@ -5,7 +5,7 @@
         "owners": ["jotaemepereira"],
         "triggers": ["scheduled"],
         "suffixes": ["daily"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_fire_window_configuration_startup-fire-window_disabled": {
         "description": "Daily pixel fired when fire window is disabled for startup",

--- a/macOS/PixelDefinitions/pixels/definitions/memory_usage_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/memory_usage_pixels.json5
@@ -93,7 +93,8 @@
                 "key": "uptime",
                 "type": "integer",
                 "description": "Minutes elapsed since app launch (raw value, not bucketed)"
-            }
+            },
+            "channel"
         ]
     },
     "m_mac_memory_usage_16384_more": {
@@ -108,7 +109,8 @@
                 "key": "uptime",
                 "type": "integer",
                 "description": "Minutes elapsed since app launch (raw value, not bucketed)"
-            }
+            },
+            "channel"
         ]
     }
 }

--- a/macOS/PixelDefinitions/pixels/definitions/quit_survey_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/quit_survey_pixels.json5
@@ -5,21 +5,21 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_quit-survey-thumbs-up": {
         "description": "Fired when the user selects thumbs up (positive response) in the quit survey",
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_quit-survey-thumbs-down": {
         "description": "Fired when the user selects thumbs down (negative response) in the quit survey",
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_quit-survey-reasons-submission": {
         "description": "Fired when the user submits their reasons after selecting thumbs down. Format: 'reason-id=1' (selected), 'reason-id=0' (shown but not selected), 'reason-id=-1' (not shown)",
@@ -38,7 +38,8 @@
                 "key": "affected_domains",
                 "description": "Comma-separated list of domain hostnames the user identified as not working (e.g. 'example.com,another.com'). Only present when the user selected 'websites-didnt-work' and chose at least one domain.",
                 "type": "string"
-            }
+            },
+            "channel"
         ]
     },
     "m_mac_quit-survey-reasons-return": {
@@ -53,7 +54,8 @@
                 "key": "reasons",
                 "description": "Comma-separated list of reason IDs with their selection state: 1=selected, 0=not selected, -1=not shown (same as submission)",
                 "type": "string"
-            }
+            },
+            "channel"
         ]
     },
     "m_mac_quit-survey-thumbs-up-return": {

--- a/macOS/PixelDefinitions/pixels/definitions/serp_settings_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/serp_settings_pixels.json5
@@ -5,7 +5,7 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_serp_settings_keyvalue_store_read_error": {
         "description": "Fired when reading SERP settings from persistent storage fails",
@@ -33,7 +33,7 @@
         "owners": ["jotaemepereira"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource"]
+        "parameters": ["appVersion", "pixelSource", "channel"]
     },
     "m_mac_serp_settings_open_duck_ai_button_click": {
         "description": "Fired when the user taps the Open AI Features Setting button from the SERP",

--- a/macOS/PixelDefinitions/pixels/definitions/wc_memory_usage_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/wc_memory_usage_pixels.json5
@@ -141,7 +141,8 @@
                 "key": "uptime",
                 "type": "integer",
                 "description": "Minutes elapsed since app launch (raw value, not bucketed)"
-            }
+            },
+            "channel"
         ]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1217301108133637
Tech Design URL:
CC:

### Description

macOS PixelKit auto-injects `channel` on internal/alpha builds, so any definition that doesn't declare it fails live validation with "extra property 'channel'". Adds `channel` to the two reported pixels (`m_mac_memory_usage_8192_16383`, `m_mac_quit-survey-shown`) and to the other 9 defs under the same owner that were missing it, so the same report doesn't come back next release. Definitions only, no app code.

### Impact

Low. Pixel schema only; no behavior change.

#### What could go wrong?

Nothing at runtime — `channel` was already being sent, it just wasn't declared.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only pixel definition updates; channel was already sent at runtime and this only aligns declarations with validation.
> 
> **Overview**
> Adds the **`channel`** parameter to macOS pixel definitions that were missing it so live validation no longer reports an extra **`channel`** property.
> 
> PixelKit already injects **`channel`** on internal/alpha builds; these defs only listed **`appVersion`** and **`pixelSource`** (and custom params like **`uptime`** or **`reasons`**). Updates span fire window startup config, browser and WebContent memory usage buckets, quit survey events, SERP settings errors/clicks, and one WebContent memory threshold—**definitions only**, no runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce6451d0b7bfe832aa559582b60518a0adb9c6df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->