### PR TITLE
Push the weekly-limit hand-off to a live chat on iOS

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
@@ -111,6 +111,10 @@ public enum AIChatUserScriptMessages: String, CaseIterable {
     /// Pushed to the duck.ai page to open the Duck.ai Settings modal.
     case submitOpenSettingsAction
 
+    /// Pushed to the duck.ai page when the user opts to spend their weekly allowance after the
+    /// daily one is gone. Web owns what that means; native only reports the choice.
+    case submitStartUsingWeeklyLimitAction
+
     /// Posted by the Customize Responses card placement when the user dismisses it.
     case customizeResponsesModalClosed
 }

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -53,6 +53,7 @@ final class AIChatUserScript: NSObject, Subfeature {
         case newChatAction
         case promptInterruption
         case openSettingsAction
+        case startUsingWeeklyLimitAction
         case toggleSidebarAction
         case syncStatusChanged(AIChatSyncHandler.SyncStatus)
         case customizeResponsesAction
@@ -75,6 +76,8 @@ final class AIChatUserScript: NSObject, Subfeature {
                 return "submitPromptInterruption"
             case .openSettingsAction:
                 return "submitOpenSettingsAction"
+            case .startUsingWeeklyLimitAction:
+                return "submitStartUsingWeeklyLimitAction"
             case .toggleSidebarAction:
                 return "submitToggleSidebarAction"
             case .syncStatusChanged:
@@ -418,6 +421,12 @@ final class AIChatUserScript: NSObject, Subfeature {
     /// Submits an open settings action to the web content, opening the AI Chat settings.
     func submitOpenSettingsAction() {
         push(.openSettingsAction)
+    }
+
+    /// Reports that the user opted to spend their weekly allowance after the daily one ran out.
+    /// Web owns what that means; native only reports the choice.
+    func submitStartUsingWeeklyLimitAction() {
+        push(.startUsingWeeklyLimitAction)
     }
 
     /// Pushes a model-change action to the web content, switching the active chat's model.

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -969,8 +969,16 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
         case .tryForFree:
             subscriptionUpsellPresenter.presentPurchaseFlow(origin: usageWarningFunnelOrigin)
         case .startUsingWeeklyLimit(let entries):
-            // Web reads the entry before its next /status and /chat, so there is nothing to reload.
-            usageLimitsStore?.write(entries)
+            // Pushed to the live chat, the way a model change is. With no chat bound there is
+            // nothing to push to, so it falls back to the entry web reads on its next hydration —
+            // which is what macOS does throughout.
+            if let boundUserScript {
+                Logger.duckAIUsageWarnings.debug("[UsageWarnings] weekly-limit hand-off: chat is live, pushing the action")
+                boundUserScript.submitStartUsingWeeklyLimitAction()
+            } else {
+                Logger.duckAIUsageWarnings.debug("[UsageWarnings] weekly-limit hand-off: no chat bound, writing the entry")
+                usageLimitsStore?.write(entries)
+            }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1218085142464074?focus=true
CC:

### Description

"Start Using Weekly Limit" action is refactored for iOS in case Duck.ai is currently loaded. It pushes `submitStartUsingWeeklyLimitAction` directly.

### Testing Steps

On iOS
1. Set https://alavrenchuk.duck.ai/ as AI Chat URL
2. Visit https://staging.duck.ai/setup-aichat/
3. In duck.ai usage settings, set "Daily threshold"
4. Submit a prompt to reach the threshold
5. Observe the native usage warning, informing you about reaching the threshold 
6. Tap on "Start using weekly limit"
7. Submit a new prompt and make sure duck.ai responds

Optionally, smoke test the same scenario on macOS (setting custom AI chat URL as https://alavrenchuk.duck.ai/  isn't necessary)

### Impact

Low — behind `utiDuckAIWarnings`, internal only, and iOS-only. Until web handles the message and the payload field, the cta reports to a page that ignores it, where before it wrote an entry web acted on.

#### What could go wrong?

- The flag is consumed by a prompt other than the one the user was blocked on → it is read once, at the point the chat-opening prompt is built, and cleared.
- The push lands with no chat bound and is dropped → that case does not push; it takes the payload route instead.

### Quality Considerations

- `startUsingWeeklyLimit` is a new optional field on the prompt payload's `Query`, so this is a contract addition beyond the message itself. Omitted when unset, so nothing existing changes, but the name needs confirming with the frontend.
- The flag is read at the prompt-construction site by asking the coordinator, rather than threading a seventh parameter through `unifiedToggleInputDidSubmitPrompt` and `openAIChat` — both already long, with three conformers between them.
- No new tests. The push is a one-line mirror of the model-change path, and the payload half is covered by the existing prompt-encoding tests once the field is agreed; worth adding a round-trip test for the field if the name settles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes usage-limit UX behind feature flags and depends on a new web handler; mis-timed pushes could be dropped without the existing deferred-handshake gates described for settings.
> 
> **Overview**
> **Start Using Weekly Limit** no longer writes usage-limit entries into native storage; native tells duck.ai web that the user opted in, and web applies the weekly allowance.
> 
> When a duck.ai page is already bound, the coordinator pushes **`submitStartUsingWeeklyLimitAction`** (same pattern as open-settings / model change). If the CTA is taken with no chat loaded, the choice is held in memory and either consumed on the next bound page or encoded on the **first opening prompt** via new optional **`startUsingWeeklyLimit`** on `AIChatNativePrompt.Query` / `queryPrompt`, so web sees it before serving that prompt. Web-supplied entry payloads on the action are ignored on native.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c94b4920190722fdd83bc55893c2fcd5469518b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->