### PR TITLE
[iOS] fix contrast in dark mode for toolbar buttons

### DIFF
--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -18,6 +18,7 @@
 //
 
 import UIKit
+import DesignResourcesKit
 
 enum FloatingOmnibarSwipeDirection: Equatable {
     case left
@@ -1034,9 +1035,13 @@ final class BrowserToolbarView: UIView {
 
     private func materialEffect() -> UIVisualEffect {
         if #available(iOS 26.0, *) {
-            UIGlassEffect(style: .regular)
+            let effect = UIGlassEffect(style: .regular)
+            if materialInterfaceStyle == .dark {
+                effect.tintColor = UIColor(designSystemColor: .surfaceCanvas)
+            }
+            return effect
         } else {
-            UIBlurEffect(style: .systemThinMaterial)
+            return UIBlurEffect(style: .systemThinMaterial)
         }
     }
 

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -118,6 +118,20 @@ final class BrowserToolbarViewTests: XCTestCase {
         XCTAssertFalse(isInsideGlassContentView)
     }
 
+    func testWhenStandaloneGlassUsesDarkAppearanceThenItHasAContrastTint() throws {
+        guard #available(iOS 26.0, *) else { return }
+        let sut = makeSUT(embeddedOmnibar: false)
+
+        sut.refreshMaterialAppearance(interfaceStyle: .dark)
+
+        let glassView = try XCTUnwrap(firstVisualEffectView(in: sut))
+        XCTAssertNotNil((glassView.effect as? UIGlassEffect)?.tintColor)
+
+        sut.refreshMaterialAppearance(interfaceStyle: .light)
+
+        XCTAssertNil((glassView.effect as? UIGlassEffect)?.tintColor)
+    }
+
     func testWhenNotFloatingThenProgressIsANoOp() {
         let sut = makeSUT(floating: false)
         let legacyFullHeight = BrowserToolbarView.totalHeight(withOmnibarHeight: omnibarHeight, isFloating: false)
@@ -125,6 +139,11 @@ final class BrowserToolbarViewTests: XCTestCase {
         let height = sut.setButtonRowCollapseProgress(1, reduceMotion: false)
 
         XCTAssertEqual(height, legacyFullHeight, accuracy: 0.01)
+    }
+
+    private func firstVisualEffectView(in view: UIView) -> UIVisualEffectView? {
+        if let view = view as? UIVisualEffectView { return view }
+        return view.subviews.lazy.compactMap { self.firstVisualEffectView(in: $0) }.first
     }
 
     func testWhenButtonRowIsMidCollapseThenRestingCapsuleFrameStillReportsSingleRowHeight() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1218097691808544?focus=true
Tech Design URL:
CC: @kemiljk @bkunat 

### Description

Fixes floating toolbar icons becoming unreadable when dark mode is enabled over light webpage content.

### Testing Steps

1. Enable Floating UI.
2. Set the address bar position to Top.
3. Open Settings → Appearance → Theme and select Dark.
4. Load `https://news.ycombinator.com/?m=1` → the bottom toolbar uses a dark background and all icons remain clearly visible.
5. Select the Light theme → the toolbar returns to its light appearance and all icons remain clearly visible.

### Impact

Low: Visual fix limited to the floating toolbar on iOS 26.

#### What could go wrong?

The toolbar could retain the wrong appearance after switching themes → mitigated by automated coverage for transitions between dark and light appearances.

### Quality Considerations

Verified on an iOS 26 simulator against the reported webpage. The focused toolbar test suite passes with 28 tests. No privacy, security, or performance impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only change to iOS 26 floating toolbar glass tinting, scoped to dark appearance with test coverage for theme transitions.
> 
> **Overview**
> Fixes **floating toolbar icons becoming hard to read** when the app uses **dark appearance** over **light webpage content** on iOS 26. The Liquid Glass background was sampling the page and staying too light while icons stayed dark-theme styled.
> 
> **`BrowserToolbarView`** now applies a **design-system canvas tint** (`surfaceCanvas` via **DesignResourcesKit**) on **`UIGlassEffect`** when `materialInterfaceStyle` is **dark** inside `materialEffect()`. **Light** appearance keeps the untinted glass. Older iOS still uses **`UIBlurEffect`** unchanged.
> 
> Adds a unit test that **dark** `refreshMaterialAppearance` sets a non-nil glass tint and **light** clears it, plus a small helper to find the glass **`UIVisualEffectView`** in the hierarchy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f65872d9a7f990f1847d29a855e663f7612b64b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->