### PR TITLE
iOS: Align Duck.ai usage warning card content with the input bar

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterCardView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterCardView.swift
@@ -29,7 +29,7 @@ final class UTIFooterCardView: UIView {
         static let cornerRadius: CGFloat = 28
         static let contentTopGap: CGFloat = 12
         static let contentBottom: CGFloat = 12
-        static let contentLeading: CGFloat = 16
+        static let contentLeading: CGFloat = 20
         static let contentTrailing: CGFloat = 12
         static let iconSize: CGFloat = 16
         static let iconTextGap: CGFloat = 10


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1218116567664266?focus=true
Tech Design URL:
CC:

### Description
Bumps the UTI footer card's content leading inset from 16pt to 20pt so the usage warning icon and text line up with the content of the input bar above it. Layout only — no behavior or copy changes.

### Testing Steps
1. Open a Duck.ai tab and trigger a usage warning card in the unified toggle input footer (or any footer message, e.g. the edit disclaimer).
2. Confirm the card's icon and text start at the same horizontal position as the input bar's content, with no clipping or overlap of the trailing dismiss button.
3. Repeat with a longer message and with Dynamic Type at a large size to confirm wrapping still looks right.

### Impact and Risks
Low

#### What could go wrong?
Longer footer messages have 4pt less horizontal room, so a borderline string could wrap onto an extra line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single layout constant with no logic changes; the only downside is slightly less text width, which could cause an extra wrap for very long messages.
> 
> **Overview**
> **Layout-only** change in `UTIFooterCardView`: the footer card’s content leading inset (`contentLeading`) moves from **16pt to 20pt**, so Duck.ai usage warnings and other footer messages (icon + text) sit on the same horizontal line as the unified toggle input bar above.
> 
> No behavior, copy, or trailing/dismiss layout changes—only the left inset on `contentView` via the existing constant used in constraints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7006a9374e259a6788e6c49872b4ba7f69d18436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->