### PR TITLE
Swap the close button's two placements without overlapping them

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatUsageWarningCardView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatUsageWarningCardView.swift
@@ -385,8 +385,16 @@ final class AIChatUsageWarningCardView: NSView {
         // the only rule there is.
         guard let closeAlignmentConstraint else { return }
 
-        closeAlignmentConstraint.isActive = isVisible
-        closeTrailingConstraint?.isActive = !isVisible
+        // Outgoing one first: these two place the button differently, so both being in the engine
+        // at once — even for the rest of this call — is a conflict Auto Layout reports and resolves
+        // by breaking whichever it likes, which here was the submit button's width.
+        if isVisible {
+            closeTrailingConstraint?.isActive = false
+            closeAlignmentConstraint.isActive = true
+        } else {
+            closeAlignmentConstraint.isActive = false
+            closeTrailingConstraint?.isActive = true
+        }
     }
 
     func update(with notice: AIChatCreateImageModelSwitchNotice) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1218084964759881
CC:

### Description

Fix of the UI constraint exception I experienced in Xcode a couple of times. The end state is unchanged, only the order the two are swapped in.

### Testing Steps

Needs `aiChatUsageWarnings` on in Debug → Feature Flags. Seeds are under Debug → AI Chat → Usage warnings.

1. Seed **Paid user → Approaching daily limit — 75%** (dismissible, so the close button shows) and focus the address bar in Duck.ai mode.
2. Watch the console → no `Unable to simultaneously satisfy constraints` block.
3. Switch between that and **Daily limit reached** (no close button) a few times, to exercise both directions of the swap.
4. Layout unchanged: close button under the voice button on the dismissible card, CTA on the card's trailing margin on the reached one.

### Impact

Low — same end state, behind `aiChatUsageWarnings` (internal only).

### Quality Considerations

No unit test: the conflict exists only during the call, and once it returns exactly one of the two constraints is active both before and after the fix, so a test asserting the final state would pass either way. Catching it would mean trapping the Auto Layout diagnostic itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Auto Layout ordering fix behind the internal `aiChatUsageWarnings` flag; no change to end-state UI or business logic.
> 
> **Overview**
> Fixes transient Auto Layout conflicts when the Duck.ai usage warning card toggles the close button between **card trailing margin** and **voice-button column** alignment.
> 
> `applyCloseButton` used to activate one placement while the other was still active for the rest of the call, which triggered `Unable to simultaneously satisfy constraints` and could break unrelated width constraints (e.g. the submit button). The change **deactivates the outgoing constraint first**, then activates the incoming one, with order depending on show vs hide so both transition directions stay safe. **Final layout is unchanged** — only the swap sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e475b7eb200254c420cfd53363b2c089ed9aaa31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->