### PR TITLE
Hide native Duck.ai usage warnings on iPad

### DIFF
--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -402,6 +402,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
 
         let supportsSuggestions = supportsContextualMode && featureFlagger.isFeatureOn(.contextualSuggestedPrompts)
         let supportsNativeUsageWarnings = featureFlagger.isFeatureOn(.utiDuckAIWarnings)
+            && devicePlatform.isIphone
             && supportsNativeChatInput
             && isNativeStorageBridgeAvailable
         let config = AIChatNativeConfigValues(

--- a/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -273,6 +273,20 @@ class AIChatUserScriptHandlerTests: XCTestCase {
         XCTAssertEqual(configValues?.supportsNativeUsageWarnings, false)
     }
 
+    /// The warning card is only designed for the iPhone input, so iPad keeps the FE banner.
+    func testWhenUsageWarningsFlagIsOnButDeviceIsIPadThenConfigDoesNotAdvertiseSupport() {
+        mockFeatureFlagger.enabledFeatureFlags = [.utiDuckAIWarnings]
+        MockDevicePlatform.isIphone = false
+        mockAIChatContextualModeFeature.isAvailable = true
+        mockUnifiedToggleInputFeature.isAvailable = true
+        aiChatUserScriptHandler = makeAIChatUserScriptHandler(isNativeStorageBridgeAvailable: true)
+
+        let configValues = aiChatUserScriptHandler.getAIChatNativeConfigValues(params: [], message: MockUserScriptMessage(name: "test", body: [:])) as? AIChatNativeConfigValues
+
+        XCTAssertEqual(configValues?.supportsNativeChatInput, true)
+        XCTAssertEqual(configValues?.supportsNativeUsageWarnings, false)
+    }
+
     func testWhenUsageWarningsFlagIsOffThenConfigDoesNotAdvertiseSupport() {
         mockFeatureFlagger.enabledFeatureFlags = []
         MockDevicePlatform.isIphone = true


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1218115273193323?focus=true
Tech Design URL:
CC:

### Description
The native Duck.ai usage-limit warning card is only designed for the iPhone input bar, but iPad was still being told the app could render it whenever contextual mode was on, so the warning went missing instead of falling back to the web banner. iPad now reports that it doesn't support native usage warnings, letting duck.ai show its own warning there.

### Testing Steps
1. On an iPad, enable the Duck.ai contextual mode and unified toggle input features, then open Duck.ai and reach the usage limit → the duck.ai web warning appears (no missing/blank warning).
2. On an iPhone with the same features enabled, reach the usage limit → the native warning card still appears in the input footer, unchanged.
3. Run `AIChatUserScriptHandlerTests` → all pass, including the new iPad case.

### Impact
Low

#### What could go wrong?
An iPad user could see no warning at all if duck.ai stops rendering its own banner → mitigated by the config value now matching what iPad can actually draw, plus a test pinning iPad to `false`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change for FE capability negotiation; iPhone path unchanged and iPad is covered by a new test.
> 
> **Overview**
> **iPad no longer advertises native Duck.ai usage-limit warnings** in `getAIChatNativeConfigValues`, so duck.ai keeps showing its web banner instead of suppressing it when the native card cannot render.
> 
> `supportsNativeUsageWarnings` now requires `devicePlatform.isIphone` in addition to the existing feature flag, native chat input, and storage bridge checks. iPhone behavior is unchanged.
> 
> A unit test locks iPad to `supportsNativeUsageWarnings: false` even when contextual mode, unified input, and the warnings flag are all enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbd8c247940067ab68c518af4639dd2d6c5a8c0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->