### PR TITLE
[macOS] Authenticate before opening V2 device details

### DIFF
--- a/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
@@ -43,9 +43,9 @@ protocol SyncSettingsViewHandling {
     /// Initiates the process to turn off sync for the current device
     func turnOffSyncPressed()
 
-    /// Presents the device details view for the specified sync device
+    /// Presents the device details view for the specified sync device, authenticating the user first when required
     /// - Parameter device: The sync device to display details for
-    func presentDeviceDetails(_ device: SyncDevice)
+    func presentDeviceDetails(_ device: SyncDevice) async
 
     /// Presents the remove device confirmation dialog for the specified device
     /// - Parameter device: The sync device to remove
@@ -638,12 +638,15 @@ extension SyncDialogController: SyncSettingsViewHandling {
     }
 
     @MainActor
-    func presentDeviceDetails(_ device: SyncDevice) {
-        if featureFlagger.isFeatureOn(.simplifiedSyncSetupV2) {
-            presentDialog(for: .deviceDetailsV2(device))
-        } else {
+    func presentDeviceDetails(_ device: SyncDevice) async {
+        guard featureFlagger.isFeatureOn(.simplifiedSyncSetupV2) else {
             presentDialog(for: .deviceDetails(device))
+            return
         }
+        guard await checkAuthenticated() else {
+            return
+        }
+        presentDialog(for: .deviceDetailsV2(device))
     }
 
     @MainActor

--- a/macOS/DuckDuckGo/Preferences/Model/SyncPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncPreferences.swift
@@ -413,8 +413,8 @@ final class SyncPreferences: ObservableObject, SyncUI_macOS.ManagementViewModel 
     }
 
     @MainActor
-    func presentDeviceDetails(_ device: SyncDevice) {
-        syncSettingsHandler.presentDeviceDetails(device)
+    func presentDeviceDetails(_ device: SyncDevice) async {
+        await syncSettingsHandler.presentDeviceDetails(device)
     }
 
     @MainActor

--- a/macOS/DuckDuckGo/Sync/DeviceSyncCoordinator.swift
+++ b/macOS/DuckDuckGo/Sync/DeviceSyncCoordinator.swift
@@ -136,9 +136,9 @@ extension DeviceSyncCoordinator: SyncSettingsViewHandling {
         dialogController.turnOffSyncPressed()
     }
 
-    func presentDeviceDetails(_ device: SyncUI_macOS.SyncDevice) {
+    func presentDeviceDetails(_ device: SyncUI_macOS.SyncDevice) async {
         presentDialog()
-        dialogController.presentDeviceDetails(device)
+        await dialogController.presentDeviceDetails(device)
     }
 
     func presentRemoveDevice(_ device: SyncUI_macOS.SyncDevice) {

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/ViewModels/ManagementViewModel.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/ViewModels/ManagementViewModel.swift
@@ -67,7 +67,7 @@ public protocol ManagementViewModel: ObservableObject {
     var isUnifiedFavoritesEnabled: Bool { get set }
 
     func presentDeleteAccount()
-    func presentDeviceDetails(_ device: SyncDevice)
+    func presentDeviceDetails(_ device: SyncDevice) async
     func presentRemoveDevice(_ device: SyncDevice)
 
     func saveRecoveryPDF()

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView/SyncedDevicesView.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView/SyncedDevicesView.swift
@@ -92,7 +92,7 @@ struct SyncedDevicesList: View {
 
     @State var hoveredDevice: SyncDevice?
 
-    var presentDeviceDetails: ((SyncDevice) -> Void)?
+    var presentDeviceDetails: ((SyncDevice) async -> Void)?
     var presentRemoveDevice: ((SyncDevice) -> Void)?
 
     var body: some View {
@@ -123,7 +123,9 @@ struct SyncedDevicesList: View {
                     } rightContent: {
                         if let presentDeviceDetails {
                             Button(UserText.currentDeviceDetails) {
-                                presentDeviceDetails(device)
+                                Task {
+                                    await presentDeviceDetails(device)
+                                }
                             }
                         }
                     }

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView/SyncedDevicesViewV2.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView/SyncedDevicesViewV2.swift
@@ -75,7 +75,7 @@ private struct SyncedDevicesListV2: View {
 
     @State var hoveredDevice: SyncDevice?
 
-    var presentDeviceDetails: ((SyncDevice) -> Void)?
+    var presentDeviceDetails: ((SyncDevice) async -> Void)?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -115,7 +115,9 @@ private struct SyncedDevicesListV2: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityAction(named: Text(UserText.currentDeviceDetails)) {
-            presentDeviceDetails?(device)
+            Task {
+                await presentDeviceDetails?(device)
+            }
         }
     }
 
@@ -123,7 +125,9 @@ private struct SyncedDevicesListV2: View {
     private func deviceAction(for device: SyncDevice) -> some View {
         if let presentDeviceDetails {
             Button(UserText.currentDeviceDetails) {
-                presentDeviceDetails(device)
+                Task {
+                    await presentDeviceDetails(device)
+                }
             }
             .accessibilityHidden(true)
             .visibility(hoveredDevice?.id == device.id ? .visible : .gone)

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView_PreviewMocks.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView_PreviewMocks.swift
@@ -93,7 +93,7 @@ final class PreviewManagementViewModel: ManagementViewModel {
     }
 
     func presentDeleteAccount() {}
-    func presentDeviceDetails(_ device: SyncDevice) {}
+    func presentDeviceDetails(_ device: SyncDevice) async {}
     func presentRemoveDevice(_ device: SyncDevice) {}
     func saveRecoveryPDF() {}
     func refreshDevices() {}

--- a/macOS/UnitTests/Sync/SyncDialogControllerTests.swift
+++ b/macOS/UnitTests/Sync/SyncDialogControllerTests.swift
@@ -283,23 +283,52 @@ final class SyncDialogControllerTests: XCTestCase {
     }
 
     @MainActor
-    func testPresentDeviceDetails_whenSimplifiedSyncSetupV2Disabled_showsDeviceDetails() {
+    func testPresentDeviceDetails_whenSimplifiedSyncSetupV2Disabled_showsDeviceDetailsWithoutAuthenticating() async {
         featureFlagger.isFeatureOn[FeatureFlag.simplifiedSyncSetupV2.rawValue] = false
+        authenticator.stubAuthenticateUser = .failure
         let device = SyncDevice(kind: .current, name: "test", id: "test")
 
-        syncDialogController.presentDeviceDetails(device)
+        await syncDialogController.presentDeviceDetails(device)
 
         XCTAssertEqual(managementDialogModel.currentDialog, .deviceDetails(device))
     }
 
     @MainActor
-    func testPresentDeviceDetails_whenSimplifiedSyncSetupV2Enabled_showsDeviceDetailsV2() {
+    func testPresentDeviceDetails_whenSimplifiedSyncSetupV2EnabledAndAuthenticated_showsDeviceDetailsV2() async {
         featureFlagger.isFeatureOn[FeatureFlag.simplifiedSyncSetupV2.rawValue] = true
         let device = SyncDevice(kind: .current, name: "test", id: "test")
 
-        syncDialogController.presentDeviceDetails(device)
+        await syncDialogController.presentDeviceDetails(device)
 
         XCTAssertEqual(managementDialogModel.currentDialog, .deviceDetailsV2(device))
+    }
+
+    @MainActor
+    func testPresentDeviceDetails_whenSimplifiedSyncSetupV2EnabledAndAuthenticationCancelled_doesNotShowDeviceDetailsV2AndEndsFlow() async {
+        featureFlagger.isFeatureOn[FeatureFlag.simplifiedSyncSetupV2.rawValue] = true
+        authenticator.stubAuthenticateUser = .failure
+        let coordinationDelegate = MockDeviceSyncCoordinationDelegate()
+        var didEndFlowCalled = false
+        coordinationDelegate.didEndFlowCalled = { didEndFlowCalled = true }
+        syncDialogController.coordinationDelegate = coordinationDelegate
+        let device = SyncDevice(kind: .current, name: "test", id: "test")
+
+        await syncDialogController.presentDeviceDetails(device)
+
+        XCTAssertNil(managementDialogModel.currentDialog)
+        XCTAssertTrue(didEndFlowCalled)
+    }
+
+    @MainActor
+    func testPresentDeviceDetails_whenSimplifiedSyncSetupV2EnabledAndNoAuthAvailable_showsUnableToAuthenticateError() async {
+        featureFlagger.isFeatureOn[FeatureFlag.simplifiedSyncSetupV2.rawValue] = true
+        authenticator.stubAuthenticateUser = .noAuthAvailable
+        let device = SyncDevice(kind: .current, name: "test", id: "test")
+
+        await syncDialogController.presentDeviceDetails(device)
+
+        XCTAssertEqual(managementDialogModel.currentDialog, .empty)
+        XCTAssertEqual(managementDialogModel.syncErrorMessage?.type, .unableToAuthenticateOnDevice)
     }
 
     @MainActor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217193470431159
Tech Design URL:
CC:

### Description

Behind the `simplifiedSyncSetupV2` flag, tapping Details in My Devices now runs the same `DeviceAuthenticator` check (password/Touch ID) already used by sync setup and recovery. 

### Testing Steps

1. Debug menu → Set Internal User State, then Feature Flag Overrides → Sync → enable `simplifiedSyncSetupV2`. Set up Sync so at least one device is listed.
2. Settings → Sync & Backup → hover a row in My Devices → Details. Confirm macOS asks for your password/Touch ID and the details dialog opens only after you authenticate.
3. Wait 15 seconds, repeat and cancel the auth prompt. Confirm the sheet closes and no details dialog appears.
4. Turn the feature flag off and press Details on the current device. Confirm the old dialog still opens with no auth prompt.

### Impact

Low — auth gate on new UI behind an off-by-default remote flag; the V1 dialog is untouched.

#### What could go wrong?

`presentDeviceDetails` is now `async`, so a missed `Task { await … }` at a call site would silently stop opening the dialog — mitigated by the compiler (all conformers updated) and unit tests covering the authenticated, cancelled, no-auth and flag-off paths.

#### Notes to Reviewer

The sync sheet is still presented by `DeviceSyncCoordinator` before auth runs, so an empty sheet sits behind the macOS prompt for a moment. That matches the existing "Sync with another device" sequence, but happy to reorder it if you'd rather not carry that over.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an authentication gate on a sensitive sync settings action; scope is limited to a remote flag and V2 UI, with async call-site updates and tests reducing regression risk.
> 
> **Overview**
> When **simplifiedSyncSetupV2** is on, opening **Details** in My Devices now runs the same **DeviceAuthenticator** step (password/Touch ID) used elsewhere in sync settings before showing the V2 device details dialog. The legacy V1 **deviceDetails** path still opens with no auth when the flag is off.
> 
> **presentDeviceDetails** is now **async** end-to-end (controller, coordinator, view model protocol, and SwiftUI device list buttons/accessibility actions use **Task { await … }**). Failed or unavailable auth follows existing **checkAuthenticated** behavior: dismiss the sheet via **didEndFlow**, or show the unable-to-authenticate error when no auth is available.
> 
> Unit tests cover flag-off, success, cancel, and no-auth paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa014a3bc649fa4395d8dad900e24d4862685720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->