### PR TITLE
iOS: Remove Fire button from select mode and Delete Tab and Data action

### DIFF
--- a/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
+++ b/iOS/DuckDuckGo/FloatingTabSwitcherChrome.swift
@@ -357,7 +357,7 @@ final class FloatingTabSwitcherChrome: TabSwitcherChrome {
 
             closeTabsItem.title = UserText.tabSwitcherCloseTabsButtonTitle(withCount: params.selectedCount)
             closeTabsItem.isEnabled = params.selectedCount > 0
-            setToolbarItems([closeTabsItem, fireItem, .flexibleSpace(), doneItem])
+            setToolbarItems([closeTabsItem, .flexibleSpace(), doneItem])
         } else {
             navigationItem.title = nil
             navigationItem.titleView = centerTitleView()

--- a/iOS/DuckDuckGo/TabSwitcherMenuBuilder.swift
+++ b/iOS/DuckDuckGo/TabSwitcherMenuBuilder.swift
@@ -51,7 +51,6 @@ struct TabSwitcherLongPressMenuState {
     let pressedContainsWebPages: Bool
     let isEditing: Bool
     let title: String
-    var shouldShowDeleteTabAndData = false
 
     var canShare: Bool { pressedContainsWebPages }
     var canAddBookmarks: Bool { pressedContainsWebPages }
@@ -83,7 +82,6 @@ struct TabSwitcherLongPressMenuActions {
     var onSelect: () -> Void
     var onClose: () -> Void
     var onCloseOther: () -> Void
-    var onDeleteTabAndData: () -> Void = {}
 }
 
 struct TabSwitcherEditMenuActions {
@@ -214,12 +212,6 @@ class DefaultTabSwitcherMenuBuilder: TabSwitcherMenuBuilding {
                 state.canCloseOthers ? destructive(UserText.tabSwitcherCloseOtherTabs(withCount: 2),
                                                    imageForCloseTabs(2),
                                                    actions.onCloseOther) : nil,
-            ].compactMap { $0 }),
-
-            UIMenu(title: "", options: .displayInline, children: [
-                state.shouldShowDeleteTabAndData ? destructive(UserText.tabSwitcherDeleteTabAndData,
-                                                               DesignSystemImages.Glyphs.Size16.fireSolid,
-                                                               actions.onDeleteTabAndData) : nil,
             ].compactMap { $0 }),
         ].compactMap { $0 }
     }

--- a/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
+++ b/iOS/DuckDuckGo/TabSwitcherViewController+MultiSelect.swift
@@ -359,19 +359,14 @@ extension TabSwitcherViewController {
             totalCount: tabsModel.count,
             pressedContainsWebPages: containsWebPages,
             isEditing: isEditing,
-            title: title,
-            shouldShowDeleteTabAndData: floatingUIManager.isFloatingTabSwitcherEnabled && tabs.count == 1 && containsWebPages
+            title: title
         )
         return menuBuilder.longPressMenu(state: state, actions: TabSwitcherLongPressMenuActions(
             onShare: { [weak self] in self?.longPressMenuShareLinks(tabs: tabs) },
             onBookmark: { [weak self] in self?.longPressMenuBookmarkTabs(indexPaths: indexPaths) },
             onSelect: { [weak self] in self?.longPressMenuSelectTabs(indexPaths: indexPaths) },
             onClose: { [weak self] in self?.longPressMenuCloseTabs(indexPaths: indexPaths) },
-            onCloseOther: { [weak self] in self?.longPressMenuCloseOtherTabs(retainingIndexPaths: indexPaths) },
-            onDeleteTabAndData: { [weak self] in
-                guard let tab = tabs.first, let indexPath = indexPaths.first else { return }
-                self?.longPressMenuDeleteTabAndData(tab: tab, at: indexPath)
-            }
+            onCloseOther: { [weak self] in self?.longPressMenuCloseOtherTabs(retainingIndexPaths: indexPaths) }
         ))
     }
 
@@ -518,24 +513,6 @@ extension TabSwitcherViewController {
         closeOtherTabs(retainingIndexPaths: indexPaths,
                        pixel: .tabSwitcherLongPressCloseOtherTabs,
                        dailyPixel: .tabSwitcherLongPressCloseOtherTabsDaily)
-    }
-
-    func longPressMenuDeleteTabAndData(tab: Tab, at indexPath: IndexPath) {
-        guard tabsModel.tabs.contains(where: { $0 === tab }) else { return }
-
-        guard let sourceView = collectionView.cellForItem(at: indexPath) ?? view else { return }
-        let presenter = FireConfirmationPresenter()
-        presenter.presentFireConfirmation(
-            on: self,
-            attachPopoverTo: sourceView,
-            tabViewModel: tabManager.viewModel(for: tab),
-            pixelSource: .tabSwitcher,
-            fireContext: .singleTab,
-            browsingMode: tab.mode,
-            onConfirm: { [weak self] fireRequest in
-                self?.forgetAll(fireRequest)
-            },
-            onCancel: {})
     }
 
 }

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -464,11 +464,6 @@ public struct UserText {
 
     public static let tabSwitcherBookmarkAllTabs = NSLocalizedString("tab.switcher.bookmarkAll", value: "Bookmark All Tabs", comment: "Bookmark all tabs menu item")
 
-    public static let tabSwitcherDeleteTabAndData = NotLocalizedString(
-        "tab.switcher.delete.tab.and.data",
-        value: "Delete Tab and Data",
-        comment: "Delete a tab and its site data menu item")
-
     public static func tabSwitcherSelectTabs(withCount count: Int) -> String {
         let format = Bundle.main.localizedString(forKey: "tab.switcher.select-tabs.withCount", value: nil, table: nil)
         return String.localizedStringWithFormat(format, count)

--- a/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
+++ b/iOS/DuckDuckGoTests/FloatingTabSwitcherChromeTests.swift
@@ -118,7 +118,7 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(titleLabel.frame.width, titleLabel.intrinsicContentSize.width)
     }
 
-    func testWhenEditingThenBottomBarHasCloseTabsFireAndDone() {
+    func testWhenEditingThenBottomBarHasCloseTabsAndDone() {
         let chrome = makeInstalledChrome()
         chrome.actions.onMultiSelectMenuRequested = { UIMenu(children: []) }
 
@@ -132,20 +132,21 @@ final class FloatingTabSwitcherChromeTests: XCTestCase {
         let fireIndex = items.firstIndex { $0.accessibilityIdentifier == "Browser.Toolbar.Button.Fire" }
         let doneIndex = items.firstIndex { $0.accessibilityLabel == UserText.navigationTitleDone }
 
-        guard let closeTabsIndex, let fireIndex, let doneIndex else {
+        guard let closeTabsIndex, let doneIndex else {
             XCTFail("Missing selection toolbar items")
             return
         }
-        XCTAssertLessThan(closeTabsIndex, fireIndex)
-        XCTAssertLessThan(fireIndex, doneIndex)
+        // Single-tab burn is not implemented, so select mode must not offer the Fire button.
+        XCTAssertNil(fireIndex)
+        XCTAssertLessThan(closeTabsIndex, doneIndex)
         XCTAssertNotNil(chrome.navigationItem.leftBarButtonItems?.first?.menu)
 
         if #available(iOS 26.0, *) {
             // On iOS 26 Done is a title-less glyph; earlier versions still use the system Done item.
             XCTAssertNil(items[doneIndex].title)
             XCTAssertNotNil(items[doneIndex].image)
-            XCTAssertEqual(items.count, 4)
-            XCTAssertEqual([items[closeTabsIndex], items[fireIndex], items[doneIndex]].map(\.sharesBackground), [false, false, false])
+            XCTAssertEqual(items.count, 3)
+            XCTAssertEqual([items[closeTabsIndex], items[doneIndex]].map(\.sharesBackground), [false, false])
         }
     }
 

--- a/iOS/DuckDuckGoTests/TabSwitcherMenuBuilderTests.swift
+++ b/iOS/DuckDuckGoTests/TabSwitcherMenuBuilderTests.swift
@@ -268,28 +268,6 @@ class DefaultTabSwitcherMenuBuilderTests: XCTestCase {
         XCTAssertTrue(actions.contains(title: UserText.tabSwitcherSelectTabs(withCount: 1)))
         XCTAssertTrue(actions.contains(title: UserText.closeTabs(withCount: 1)))
         XCTAssertTrue(actions.contains(title: UserText.tabSwitcherCloseOtherTabs(withCount: 2)))
-        XCTAssertFalse(actions.contains(title: UserText.tabSwitcherDeleteTabAndData))
-    }
-
-    func testLongPressMenu_whenFloatingWebPageTab_showsDesignActionsInOrder() {
-        let state = TabSwitcherLongPressMenuState(
-            pressedCount: 1,
-            totalCount: 3,
-            pressedContainsWebPages: true,
-            isEditing: false,
-            title: "example.com",
-            shouldShowDeleteTabAndData: true)
-        let actions = flatActions(builder.longPressMenuItems(state: state, actions: noopLongPressActions))
-
-        XCTAssertEqual(actions.map(\.title), [
-            UserText.shareLinks(withCount: 1),
-            UserText.bookmarkSelectedTabs(withCount: 1),
-            UserText.tabSwitcherSelectTabs(withCount: 1),
-            UserText.closeTabs(withCount: 1),
-            UserText.tabSwitcherCloseOtherTabs(withCount: 2),
-            UserText.tabSwitcherDeleteTabAndData,
-        ])
-        XCTAssertTrue(actions.last?.attributes.contains(.destructive) == true)
     }
 
     func testLongPressMenu_homePageTab_hidesShareAndBookmarkButShowsSelect() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216033800174503/task/1216263720888074?focus=true
Tech Design URL: N/A
CC: N/A

### Description
Scoped single-tab burn is not implemented yet, but the floating Tab Manager (iOS 26 UI, behind the floating UI flag) offered two controls that implied it. Both actually burned every tab. This removes both until scoped burn exists:
- The Fire button in the select-mode bottom bar. Selecting tabs and tapping Fire burned all tabs, not the selection. Select mode now shows Close Tabs and Done.
- The “Delete Tab and Data” long-press action on a single tab. Its confirmation ran the full forget-all.

The Fire button is unchanged in the normal and large-size Tab Manager layouts. Unit tests updated to assert both controls are absent.

### Testing Steps
1. Enable the floating UI and open the Tab Manager with several tabs.
2. Open the overflow menu and tap “Select Tabs” → bottom bar shows Close Tabs and Done, with no Fire button.
3. Tap Done → the normal bottom bar still shows the Fire button.
4. Long-press a browsing tab → the menu shows Share, Bookmark, Select, Close, and Close Other Tabs, with no “Delete Tab and Data”.

### Impact
Low: Removes two controls from the flagged floating Tab Manager UI.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only removal behind the floating tab switcher flag; no change to global Fire behavior outside select mode or long-press delete.
> 
> **Overview**
> Removes two floating Tab Manager controls that suggested scoped “burn” but actually cleared **all** tabs, until single-tab burn exists.
> 
> **Select mode bottom bar** no longer includes the Fire button—only **Close Tabs** and **Done**. Fire stays on the normal (non–select-mode) toolbar.
> 
> **Long-press tab menu** drops **Delete Tab and Data** and the related state, menu builder section, `FireConfirmationPresenter` handler, and `UserText` string. Share, bookmark, select, close, and close-other remain.
> 
> Unit tests now assert Fire is absent in edit mode and remove coverage for the deleted long-press action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e685a7d78ca0e77a8be88b817e3124c2232efa97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->